### PR TITLE
feat: add real-traffic product health outcomes

### DIFF
--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -6838,5 +6838,79 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "product_health_capture_finalization_outage",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Product health",
+    "title": "Product health — capture finalization outage",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 900, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "(sum(increase(omi_product_journey_accepted_total{journey=\"capture_finalization\"}[15m])) > 5) and ((sum(increase(omi_product_journey_terminal_total{journey=\"capture_finalization\",outcome=\"succeeded\"}[15m])) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"capture_finalization\"}[15m])), 1)) < ((sum(increase(omi_product_journey_terminal_total{journey=\"capture_finalization\",outcome=\"succeeded\"}[15m] offset 24h)) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"capture_finalization\"}[15m] offset 24h)), 1)) - 0.20))",
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "refId": "B", "type": "threshold", "conditions": [{"type": "query", "evaluator": {"type": "gt", "params": [0]}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"type": "last", "params": []}}]}
+      }
+    ],
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {"__dashboardUid__": "omi-product-health-real-traffic", "__panelId__": "3", "runbook": "backend/docs/runbooks/resilience-dashboards.md"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "record": null,
+    "labels": {"severity": "critical", "instatus_component": "capture-finalization"}
+  },
+  {
+    "uid": "product_health_pusher_regression",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Product health",
+    "title": "Product health — pusher session regression",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 900, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "(sum(increase(omi_product_journey_accepted_total{journey=\"realtime_pusher_session\"}[15m])) > 10) and ((sum(increase(omi_product_journey_terminal_total{journey=\"realtime_pusher_session\",outcome=\"succeeded\"}[15m])) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"realtime_pusher_session\"}[15m])), 1)) < ((sum(increase(omi_product_journey_terminal_total{journey=\"realtime_pusher_session\",outcome=\"succeeded\"}[15m] offset 24h)) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"realtime_pusher_session\"}[15m] offset 24h)), 1)) - 0.10))",
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "refId": "B", "type": "threshold", "conditions": [{"type": "query", "evaluator": {"type": "gt", "params": [0]}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"type": "last", "params": []}}]}
+      }
+    ],
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {"__dashboardUid__": "omi-product-health-real-traffic", "__panelId__": "2", "runbook": "backend/docs/runbooks/pusher-degraded.md"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "record": null,
+    "labels": {"severity": "critical", "instatus_component": "live-transcription"}
   }
 ]

--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -6877,6 +6877,43 @@
     "labels": {"severity": "critical", "instatus_component": "capture-finalization"}
   },
   {
+    "uid": "product_health_chat_response_regression",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Product health",
+    "title": "Product health — chat response outage or regression",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 900, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "(sum(increase(omi_product_journey_accepted_total{journey=\"chat_response\"}[15m])) > 20) and ((sum(increase(omi_product_journey_terminal_total{journey=\"chat_response\",outcome=\"succeeded\"}[15m])) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"chat_response\"}[15m])), 1)) < 0.80) and ((sum(increase(omi_product_journey_terminal_total{journey=\"chat_response\",outcome=\"succeeded\"}[15m])) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"chat_response\"}[15m])), 1)) < ((sum(increase(omi_product_journey_terminal_total{journey=\"chat_response\",outcome=\"succeeded\"}[15m] offset 24h)) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"chat_response\"}[15m] offset 24h)), 1)) - 0.20))",
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "refId": "B", "type": "threshold", "conditions": [{"type": "query", "evaluator": {"type": "gt", "params": [0]}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"type": "last", "params": []}}]}
+      }
+    ],
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {"__dashboardUid__": "omi-product-health-real-traffic", "__panelId__": "4", "runbook": "backend/docs/runbooks/product-health-real-traffic.md"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "record": null,
+    "labels": {"severity": "critical", "instatus_component": "chat"}
+  },
+  {
     "uid": "product_health_pusher_regression",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",

--- a/backend/charts/monitoring/alerts/product-health.json
+++ b/backend/charts/monitoring/alerts/product-health.json
@@ -1,0 +1,76 @@
+[
+  {
+    "uid": "product_health_capture_finalization_outage",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Product health",
+    "title": "Product health — capture finalization outage",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 900, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "(sum(increase(omi_product_journey_accepted_total{journey=\"capture_finalization\"}[15m])) > 5) and ((sum(increase(omi_product_journey_terminal_total{journey=\"capture_finalization\",outcome=\"succeeded\"}[15m])) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"capture_finalization\"}[15m])), 1)) < ((sum(increase(omi_product_journey_terminal_total{journey=\"capture_finalization\",outcome=\"succeeded\"}[15m] offset 24h)) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"capture_finalization\"}[15m] offset 24h)), 1)) - 0.20))",
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "refId": "B", "type": "threshold", "conditions": [{"type": "query", "evaluator": {"type": "gt", "params": [0]}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"type": "last", "params": []}}]}
+      }
+    ],
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {"__dashboardUid__": "omi-product-health-real-traffic", "__panelId__": "3", "runbook": "backend/docs/runbooks/resilience-dashboards.md"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "record": null,
+    "labels": {"severity": "critical", "instatus_component": "capture-finalization"}
+  },
+  {
+    "uid": "product_health_pusher_regression",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Product health",
+    "title": "Product health — pusher session regression",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 900, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "(sum(increase(omi_product_journey_accepted_total{journey=\"realtime_pusher_session\"}[15m])) > 10) and ((sum(increase(omi_product_journey_terminal_total{journey=\"realtime_pusher_session\",outcome=\"succeeded\"}[15m])) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"realtime_pusher_session\"}[15m])), 1)) < ((sum(increase(omi_product_journey_terminal_total{journey=\"realtime_pusher_session\",outcome=\"succeeded\"}[15m] offset 24h)) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"realtime_pusher_session\"}[15m] offset 24h)), 1)) - 0.10))",
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "refId": "B", "type": "threshold", "conditions": [{"type": "query", "evaluator": {"type": "gt", "params": [0]}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"type": "last", "params": []}}]}
+      }
+    ],
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {"__dashboardUid__": "omi-product-health-real-traffic", "__panelId__": "2", "runbook": "backend/docs/runbooks/pusher-degraded.md"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "record": null,
+    "labels": {"severity": "critical", "instatus_component": "live-transcription"}
+  }
+]

--- a/backend/charts/monitoring/alerts/product-health.json
+++ b/backend/charts/monitoring/alerts/product-health.json
@@ -37,6 +37,43 @@
     "labels": {"severity": "critical", "instatus_component": "capture-finalization"}
   },
   {
+    "uid": "product_health_chat_response_regression",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Product health",
+    "title": "Product health — chat response outage or regression",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 900, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "(sum(increase(omi_product_journey_accepted_total{journey=\"chat_response\"}[15m])) > 20) and ((sum(increase(omi_product_journey_terminal_total{journey=\"chat_response\",outcome=\"succeeded\"}[15m])) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"chat_response\"}[15m])), 1)) < 0.80) and ((sum(increase(omi_product_journey_terminal_total{journey=\"chat_response\",outcome=\"succeeded\"}[15m])) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"chat_response\"}[15m])), 1)) < ((sum(increase(omi_product_journey_terminal_total{journey=\"chat_response\",outcome=\"succeeded\"}[15m] offset 24h)) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"chat_response\"}[15m] offset 24h)), 1)) - 0.20))",
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "refId": "B", "type": "threshold", "conditions": [{"type": "query", "evaluator": {"type": "gt", "params": [0]}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"type": "last", "params": []}}]}
+      }
+    ],
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {"__dashboardUid__": "omi-product-health-real-traffic", "__panelId__": "4", "runbook": "backend/docs/runbooks/product-health-real-traffic.md"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "record": null,
+    "labels": {"severity": "critical", "instatus_component": "chat"}
+  },
+  {
     "uid": "product_health_pusher_regression",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",

--- a/backend/charts/monitoring/dashboards/omi-services/product-health-real-traffic.json
+++ b/backend/charts/monitoring/dashboards/omi-services/product-health-real-traffic.json
@@ -14,7 +14,7 @@
       "gridPos": {"h": 4, "w": 24, "x": 0, "y": 0},
       "options": {
         "mode": "markdown",
-        "content": "**No synthetic canaries.** These are accepted user journeys only. Compare a current rate with the same environment's own 24-hour baseline; do not compare dev and production. A Cloud Run scrape gap can make a quiet service look healthy, so check scrape targets before treating no data as recovery."
+        "content": "**No synthetic canaries.** These are accepted user journeys only. Dev and production are isolated by Prometheus instance, not an environment label: compare a current rate only with that Prometheus instance's own 24-hour baseline. A Cloud Run scrape gap can make a quiet service look healthy, so check scrape targets before treating no data as recovery. Traffic gates and a missing baseline intentionally suppress alerts; see `backend/docs/runbooks/product-health-real-traffic.md` for the current false-negative limits."
       }
     },
     {
@@ -56,6 +56,29 @@
         {
           "refId": "B",
           "expr": "sum(increase(omi_product_journey_terminal_total{journey=\"capture_finalization\",outcome=\"succeeded\"}[15m] offset 24h)) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"capture_finalization\"}[15m] offset 24h)), 1)",
+          "legendFormat": "24h baseline",
+          "range": true
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "percentunit", "min": 0, "max": 1}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi"}}
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Chat success rate vs. own baseline",
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 13},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(omi_product_journey_terminal_total{journey=\"chat_response\",outcome=\"succeeded\"}[15m])) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"chat_response\"}[15m])), 1)",
+          "legendFormat": "current",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "sum(increase(omi_product_journey_terminal_total{journey=\"chat_response\",outcome=\"succeeded\"}[15m] offset 24h)) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"chat_response\"}[15m] offset 24h)), 1)",
           "legendFormat": "24h baseline",
           "range": true
         }

--- a/backend/charts/monitoring/dashboards/omi-services/product-health-real-traffic.json
+++ b/backend/charts/monitoring/dashboards/omi-services/product-health-real-traffic.json
@@ -1,0 +1,67 @@
+{
+  "uid": "omi-product-health-real-traffic",
+  "title": "Product health — real traffic",
+  "tags": ["product-health", "real-traffic"],
+  "timezone": "browser",
+  "schemaVersion": 41,
+  "version": 1,
+  "refresh": "1m",
+  "panels": [
+    {
+      "id": 1,
+      "type": "text",
+      "title": "Scope and interpretation",
+      "gridPos": {"h": 4, "w": 24, "x": 0, "y": 0},
+      "options": {
+        "mode": "markdown",
+        "content": "**No synthetic canaries.** These are accepted user journeys only. Compare a current rate with the same environment's own 24-hour baseline; do not compare dev and production. A Cloud Run scrape gap can make a quiet service look healthy, so check scrape targets before treating no data as recovery."
+      }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Accepted and terminal journeys",
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (journey) (rate(omi_product_journey_accepted_total[5m]))",
+          "legendFormat": "{{journey}} accepted/s",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "sum by (journey, outcome) (rate(omi_product_journey_terminal_total[5m]))",
+          "legendFormat": "{{journey}} {{outcome}}/s",
+          "range": true
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi"}}
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Capture finalization success rate vs. own baseline",
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(omi_product_journey_terminal_total{journey=\"capture_finalization\",outcome=\"succeeded\"}[15m])) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"capture_finalization\"}[15m])), 1)",
+          "legendFormat": "current",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "sum(increase(omi_product_journey_terminal_total{journey=\"capture_finalization\",outcome=\"succeeded\"}[15m] offset 24h)) / clamp_min(sum(increase(omi_product_journey_accepted_total{journey=\"capture_finalization\"}[15m] offset 24h)), 1)",
+          "legendFormat": "24h baseline",
+          "range": true
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "percentunit", "min": 0, "max": 1}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi"}}
+    }
+  ]
+}

--- a/backend/database/conversation_finalization_jobs.py
+++ b/backend/database/conversation_finalization_jobs.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Literal, Mapping, TypedDict
+from typing import Any, Callable, Literal, Mapping, NotRequired, TypedDict
 
 from google.cloud import firestore
 
@@ -31,6 +31,7 @@ class FinalizationIntent(TypedDict):
     dispatch_generation: int | None
     requires_byok: bool
     fanout_key: str | None
+    newly_created: NotRequired[bool]
 
 
 class FinalizationAdmission(TypedDict):
@@ -227,7 +228,9 @@ def _create_or_get_finalization_intent_txn(
             'finalization_status': status,
         },
     )
-    return _intent_from_job(job_id, job) | {'newly_created': True}
+    intent = _intent_from_job(job_id, job)
+    intent['newly_created'] = True
+    return intent
 
 
 def create_or_get_finalization_intent(

--- a/backend/database/conversation_finalization_jobs.py
+++ b/backend/database/conversation_finalization_jobs.py
@@ -55,6 +55,7 @@ class FinalizationClaim(TypedDict):
     status: str
     lease_epoch: int | None
     attempt_count: int
+    accepted_at_epoch_seconds: float | None
 
 
 def _now() -> datetime:
@@ -70,8 +71,18 @@ def get_finalization_reconcile_stale_after() -> timedelta:
     return timedelta(seconds=max(30, seconds))
 
 
-def _claim_result(status: str, lease_epoch: int | None = None, attempt_count: int = 0) -> FinalizationClaim:
-    return {'status': status, 'lease_epoch': lease_epoch, 'attempt_count': attempt_count}
+def _claim_result(
+    status: str,
+    lease_epoch: int | None = None,
+    attempt_count: int = 0,
+    accepted_at_epoch_seconds: float | None = None,
+) -> FinalizationClaim:
+    return {
+        'status': status,
+        'lease_epoch': lease_epoch,
+        'attempt_count': attempt_count,
+        'accepted_at_epoch_seconds': accepted_at_epoch_seconds,
+    }
 
 
 def _is_current_lease(job: dict[str, Any], dispatch_generation: int, lease_epoch: int) -> bool:
@@ -216,7 +227,7 @@ def _create_or_get_finalization_intent_txn(
             'finalization_status': status,
         },
     )
-    return _intent_from_job(job_id, job)
+    return _intent_from_job(job_id, job) | {'newly_created': True}
 
 
 def create_or_get_finalization_intent(
@@ -333,7 +344,9 @@ def _claim_finalization_job_txn(
             'attempt_count': attempt_count,
         },
     )
-    return _claim_result('claimed', lease_epoch, attempt_count)
+    created_at = job.get('created_at')
+    accepted_at_epoch_seconds = created_at.timestamp() if isinstance(created_at, datetime) else None
+    return _claim_result('claimed', lease_epoch, attempt_count, accepted_at_epoch_seconds)
 
 
 def claim_finalization_job(

--- a/backend/docs/runbooks/product-health-real-traffic.md
+++ b/backend/docs/runbooks/product-health-real-traffic.md
@@ -1,0 +1,28 @@
+# Product health — real traffic
+
+## Scope
+
+This dashboard and its alert rules use accepted user traffic only; they do not
+generate synthetic traffic. Dev and production are isolated by Prometheus
+instance, not by an environment label. Each current success rate is compared
+only with the 24-hour offset data held by that same Prometheus instance.
+
+## Chat response regression alert
+
+`product_health_chat_response_regression` pages only when more than 20 chat
+streams were accepted in 15 minutes, the current success rate is below 80%,
+and it is at least 20 percentage points below its own 24-hour baseline for 15
+minutes. Check the Product health — real traffic dashboard panel before
+triaging provider, application, or scrape failures.
+
+## Current false-negative limits
+
+- Low traffic is intentionally gated and will not alert, including a complete
+  outage with 20 or fewer accepted chat streams in a 15-minute window.
+- A missing 24-hour baseline, such as after a new Prometheus instance or
+  retention gap, suppresses the regression comparison.
+- `noDataState: OK` means a scrape gap can look healthy; verify targets before
+  declaring recovery.
+- This measures only streams accepted by the backend. Requests rejected before
+  the stream boundary and clients that never reach the service are out of
+  scope.

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -60,6 +60,7 @@ from utils.stt.pre_recorded import get_prerecorded_service
 from config.prerecorded_stt import TranscriptionOutcome
 from utils.stt.outcomes import TranscriptionFailure, failure_from_exception
 from utils.observability.transcription import TranscriptionAttempt
+from utils.observability.product_health import ProductJourney, ProductJourneyAttempt, ProductJourneyOutcome
 from utils.llm.goals import extract_and_update_goal_progress
 from database.redis_db import try_acquire_goal_extraction_lock, check_rate_limit, store_chat_share, get_chat_share
 from database.users import set_chat_message_rating_score
@@ -413,7 +414,20 @@ def send_message(
 
         return ai_message, ask_for_nps
 
+    # The journey starts only after all admission work has completed and this
+    # request is committed to returning the real LLM stream. Quota-exceeded
+    # canned replies return above and intentionally do not contribute.
+    journey_attempt = ProductJourneyAttempt.accepted(ProductJourney.chat_response)
+
     async def generate_stream():
+        terminal_outcome: ProductJourneyOutcome | None = None
+
+        def finish_journey(outcome: ProductJourneyOutcome) -> None:
+            nonlocal terminal_outcome
+            if terminal_outcome is None:
+                terminal_outcome = outcome
+                journey_attempt.finish(outcome)
+
         callback_data = {}
         # Set usage context for streaming (can't use 'with' across yields)
         usage_token = set_usage_context(uid, Features.CHAT)
@@ -441,7 +455,19 @@ def send_message(
                             'utf-8'
                         )
                         yield f"done: {encoded_response}\n\n"
+                        # This runs only after the terminal SSE chunk has been
+                        # handed to StreamingResponse. A cancelled send reaches
+                        # the cancellation handler instead.
+                        finish_journey(ProductJourneyOutcome.succeeded)
+        except asyncio.CancelledError:
+            finish_journey(ProductJourneyOutcome.failed)
+            raise
+        except Exception:
+            finish_journey(ProductJourneyOutcome.failed)
+            raise
         finally:
+            # A stream ending without a terminal response is a failed journey.
+            finish_journey(ProductJourneyOutcome.failed)
             reset_usage_context(usage_token)
 
     return StreamingResponse(generate_stream(), media_type="text/event-stream")

--- a/backend/routers/conversation_finalization.py
+++ b/backend/routers/conversation_finalization.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, Request
@@ -24,10 +25,28 @@ from utils.conversations.finalizer import (
 )
 from utils.executors import db_executor, run_blocking
 from utils.metrics import LISTEN_FINALIZATION_RETRIES_TOTAL
+from utils.observability.product_health import ProductJourney, ProductJourneyOutcome, record_durable_journey_terminal
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _accepted_at_epoch_seconds(job: dict[str, Any] | None) -> float | None:
+    created_at = job.get('created_at') if job else None
+    return created_at.timestamp() if isinstance(created_at, datetime) else None
+
+
+def _record_capture_finalization_terminal(
+    outcome: ProductJourneyOutcome, accepted_at_epoch_seconds: float | None
+) -> None:
+    if accepted_at_epoch_seconds is None:
+        return
+    record_durable_journey_terminal(
+        ProductJourney.capture_finalization,
+        outcome,
+        accepted_at_epoch_seconds=accepted_at_epoch_seconds,
+    )
 
 
 def _parse_task_payload(payload: Any) -> tuple[str, int] | None:
@@ -52,6 +71,7 @@ async def _retry_or_dead_letter(
     *,
     uid: str | None = None,
     conversation_id: str | None = None,
+    accepted_at_epoch_seconds: float | None = None,
 ) -> bool:
     """Record a task failure; return whether this was the terminal delivery."""
     max_attempts = get_listen_finalization_tasks_max_attempts_for_worker()
@@ -66,6 +86,7 @@ async def _retry_or_dead_letter(
         )
         if not marked_dead_letter:
             return False
+        _record_capture_finalization_terminal(ProductJourneyOutcome.failed, accepted_at_epoch_seconds)
         if uid is not None and conversation_id is not None:
             await run_blocking(
                 db_executor,
@@ -109,6 +130,7 @@ async def run_listen_finalization_job(
     release_lock = True
     claimed_lease_epoch: int | None = None
     job: dict[str, Any] | None = None
+    accepted_at_epoch_seconds: float | None = None
     try:
         claim = await run_blocking(
             db_executor,
@@ -129,9 +151,15 @@ async def run_listen_finalization_job(
             return JSONResponse(status_code=500, content={'status': 'retry'})
 
         job = await run_blocking(db_executor, jobs_db.get_finalization_job, job_id)
+        accepted_at_epoch_seconds = _accepted_at_epoch_seconds(job)
         if not job or not isinstance(job.get('uid'), str) or not isinstance(job.get('conversation_id'), str):
             terminal = await _retry_or_dead_letter(
-                job_id, dispatch_generation, claimed_lease_epoch, task_retry_count, 'invalid_job'
+                job_id,
+                dispatch_generation,
+                claimed_lease_epoch,
+                task_retry_count,
+                'invalid_job',
+                accepted_at_epoch_seconds=accepted_at_epoch_seconds,
             )
             if terminal:
                 logger.error('listen finalization final attempt failed job=%s error=invalid_job', job_id)
@@ -155,6 +183,7 @@ async def run_listen_finalization_job(
                 'processing_failed',
                 uid=job['uid'],
                 conversation_id=job['conversation_id'],
+                accepted_at_epoch_seconds=accepted_at_epoch_seconds,
             )
             if terminal:
                 logger.error('listen finalization final attempt failed job=%s failure=processing_failed', job_id)
@@ -179,6 +208,7 @@ async def run_listen_finalization_job(
             )
         if not completed:
             return JSONResponse(status_code=409, content={'status': 'completion_conflict'})
+        _record_capture_finalization_terminal(ProductJourneyOutcome.succeeded, accepted_at_epoch_seconds)
         return JSONResponse(status_code=200, content={'status': 'done'})
     except asyncio.CancelledError:
         release_lock = False
@@ -195,6 +225,7 @@ async def run_listen_finalization_job(
                     'worker_failed',
                     uid=job.get('uid') if job else None,
                     conversation_id=job.get('conversation_id') if job else None,
+                    accepted_at_epoch_seconds=accepted_at_epoch_seconds,
                 )
             except Exception:
                 logger.error('listen finalization recovery update failed job=%s failure=worker_failed', job_id)

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -26,6 +26,12 @@ from utils.conversations.finalizer import (
     finalize_persisted_conversation,
 )
 from utils.executors import db_executor, storage_executor, run_blocking
+from utils.observability.product_health import (
+    ProductJourney,
+    ProductJourneyAttempt,
+    ProductJourneyOutcome,
+    record_durable_journey_terminal,
+)
 from utils.async_tasks import (
     supervise_tasks,
     drain_tasks,
@@ -78,6 +84,18 @@ WS_RECEIVE_TIMEOUT = 300.0  # seconds
 # before being force-cancelled.  Prevents hung GCS uploads or webhook calls from
 # blocking cleanup indefinitely.
 BG_DRAIN_TIMEOUT = 30.0  # seconds
+
+
+def _record_capture_finalization_terminal(
+    outcome: ProductJourneyOutcome, accepted_at_epoch_seconds: float | None
+) -> None:
+    if accepted_at_epoch_seconds is None:
+        return
+    record_durable_journey_terminal(
+        ProductJourney.capture_finalization,
+        outcome,
+        accepted_at_epoch_seconds=accepted_at_epoch_seconds,
+    )
 
 
 class _SpeakerSampleRequest(TypedDict):
@@ -134,6 +152,7 @@ async def _process_conversation_task(
     generation: Optional[int] = None
     lease_epoch: Optional[int] = None
     attempt_count: int = 0
+    accepted_at_epoch_seconds: float | None = None
 
     async def record_failure(failure_code: str) -> bool:
         """Release the lease. Returns whether this was the terminal attempt.
@@ -158,6 +177,7 @@ async def _process_conversation_task(
                 )
                 if not marked_dead_letter:
                     return False
+                _record_capture_finalization_terminal(ProductJourneyOutcome.failed, accepted_at_epoch_seconds)
                 return await run_blocking(
                     db_executor, lifecycle_service.fail_and_discard_processing, uid, conversation_id
                 )
@@ -220,6 +240,7 @@ async def _process_conversation_task(
             return
         attempt_count = claim['attempt_count']
         lease_epoch = claim['lease_epoch']
+        accepted_at_epoch_seconds = claim.get('accepted_at_epoch_seconds')
         if lease_epoch is None:
             logger.error(
                 'pusher finalization claim returned no lease epoch uid=%s conversation=%s', uid, conversation_id
@@ -255,6 +276,7 @@ async def _process_conversation_task(
         if not completed:
             await send_result({'conversation_id': conversation_id, 'error': 'job_completion_conflict'})
             return
+        _record_capture_finalization_terminal(ProductJourneyOutcome.succeeded, accepted_at_epoch_seconds)
         if disposition == ConversationFinalizationDisposition.fenced:
             await send_result({'conversation_id': conversation_id, 'fenced': True})
             return
@@ -302,6 +324,7 @@ async def _websocket_util_trigger(
     websocket_active = True
     shutdown_event = asyncio.Event()
     websocket_close_code = 1000
+    journey_attempt: ProductJourneyAttempt | None = None
 
     # audio bytes
     audio_bytes_webhook_delay_seconds = get_audio_bytes_webhook_seconds(uid)
@@ -782,6 +805,7 @@ async def _websocket_util_trigger(
     bg_main_tasks: List[asyncio.Task[Any]] = []
     try:
         PUSHER_ACTIVE_WS_CONNECTIONS.inc()
+        journey_attempt = ProductJourneyAttempt.accepted(ProductJourney.realtime_pusher_session)
         receive_task = create_named_task(receive_tasks(), name=f"ws:{uid}:receive")
         bg_main_tasks = [
             create_named_task(process_speaker_sample_queue(), name=f"ws:{uid}:speaker_samples"),
@@ -816,6 +840,7 @@ async def _websocket_util_trigger(
 
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e}")
+        websocket_close_code = 1011
     finally:
         shutdown_event.set()
         websocket_active = False
@@ -825,6 +850,9 @@ async def _websocket_util_trigger(
         bg_tasks.clear()
 
         PUSHER_ACTIVE_WS_CONNECTIONS.dec()
+        if journey_attempt is not None:
+            outcome = ProductJourneyOutcome.succeeded if websocket_close_code == 1000 else ProductJourneyOutcome.failed
+            journey_attempt.finish(outcome)
 
         if websocket.client_state == WebSocketState.CONNECTED:
             try:

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -30,6 +30,7 @@ from utils.observability.product_health import (
     ProductJourney,
     ProductJourneyAttempt,
     ProductJourneyOutcome,
+    finish_pusher_session_attempt,
     record_durable_journey_terminal,
 )
 from utils.async_tasks import (
@@ -324,6 +325,7 @@ async def _websocket_util_trigger(
     websocket_active = True
     shutdown_event = asyncio.Event()
     websocket_close_code = 1000
+    client_disconnect_code: int | None = None
     journey_attempt: ProductJourneyAttempt | None = None
 
     # audio bytes
@@ -587,6 +589,7 @@ async def _websocket_util_trigger(
                     logger.error(f"Error processing audio bytes: {e} {uid}")
 
     async def receive_tasks() -> None:
+        nonlocal client_disconnect_code
         nonlocal websocket_active
         nonlocal websocket_close_code
         nonlocal speaker_sample_queue
@@ -778,7 +781,8 @@ async def _websocket_util_trigger(
                         audiobuffer = bytearray()
                     continue
 
-        except WebSocketDisconnect:
+        except WebSocketDisconnect as disconnect:
+            client_disconnect_code = disconnect.code
             logger.info("WebSocket disconnected")
         except Exception as e:
             logger.error(f'Could not process audio: error {e}')
@@ -822,6 +826,9 @@ async def _websocket_util_trigger(
         )
         logger.info(f"Supervisor exited: reason={exit_result.reason} task={exit_result.task_name} {uid}")
 
+        if exit_result.reason != 'disconnect':
+            websocket_close_code = 1011
+
         if receive_task.done() and not receive_task.cancelled():
             exc = receive_task.exception()
             if exc is not None:
@@ -841,6 +848,7 @@ async def _websocket_util_trigger(
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e}")
         websocket_close_code = 1011
+        client_disconnect_code = None
     finally:
         shutdown_event.set()
         websocket_active = False
@@ -851,8 +859,7 @@ async def _websocket_util_trigger(
 
         PUSHER_ACTIVE_WS_CONNECTIONS.dec()
         if journey_attempt is not None:
-            outcome = ProductJourneyOutcome.succeeded if websocket_close_code == 1000 else ProductJourneyOutcome.failed
-            journey_attempt.finish(outcome)
+            finish_pusher_session_attempt(journey_attempt, client_disconnect_code=client_disconnect_code)
 
         if websocket.client_state == WebSocketState.CONNECTED:
             try:

--- a/backend/scripts/typecheck.sh
+++ b/backend/scripts/typecheck.sh
@@ -7,10 +7,10 @@ cd "$ROOT_DIR"
 
 PYRIGHT_PYTHON="${PYRIGHT_PYTHON:-}"
 if [[ -z "$PYRIGHT_PYTHON" ]]; then
-  if [[ -n "${VIRTUAL_ENV:-}" && -x "$VIRTUAL_ENV/bin/python" ]]; then
-    PYRIGHT_PYTHON="$VIRTUAL_ENV/bin/python"
-  elif [[ -x ".venv/bin/python" ]]; then
+  if [[ -x ".venv/bin/python" ]]; then
     PYRIGHT_PYTHON=".venv/bin/python"
+  elif [[ -n "${VIRTUAL_ENV:-}" && -x "$VIRTUAL_ENV/bin/python" ]]; then
+    PYRIGHT_PYTHON="$VIRTUAL_ENV/bin/python"
   else
     PYRIGHT_PYTHON="python3"
   fi

--- a/backend/tests/unit/test_chat_quota_counting_router.py
+++ b/backend/tests/unit/test_chat_quota_counting_router.py
@@ -1,5 +1,6 @@
 """Router tests for explicit backend chat quota question counting."""
 
+import asyncio
 import base64
 import importlib.util
 import io
@@ -11,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+import pytest
 
 BACKEND_DIR = Path(__file__).resolve().parents[2]
 
@@ -268,6 +270,50 @@ def test_v2_messages_quota_exceeded_reply_does_not_record_quota_question():
         module.llm_usage_db.record_chat_quota_question.assert_not_called()
     finally:
         _cleanup(saved)
+
+
+def test_v2_messages_records_chat_journey_at_stream_acceptance_then_success():
+    client, module, saved = _make_chat_client()
+    try:
+        attempt = MagicMock()
+        with patch.object(module.ProductJourneyAttempt, 'accepted', return_value=attempt) as accepted:
+            response = module.send_message(module.SendMessageRequest(text='private user content'), uid='test-uid')
+
+            # The real stream is accepted when the StreamingResponse is returned, before it is consumed.
+            accepted.assert_called_once_with(module.ProductJourney.chat_response)
+            assert attempt.finish.call_count == 0
+            asyncio.run(_consume_stream(response.body_iterator))
+
+        attempt.finish.assert_called_once_with(module.ProductJourneyOutcome.succeeded)
+    finally:
+        _cleanup(saved)
+
+
+@pytest.mark.parametrize('failure', (RuntimeError('upstream error'), asyncio.CancelledError()))
+def test_v2_messages_records_chat_stream_error_and_cancellation_as_failed(failure):
+    client, module, saved = _make_chat_client()
+    try:
+        attempt = MagicMock()
+
+        async def failed_chat_stream(*_args, **_kwargs):
+            if False:
+                yield ''
+            raise failure
+
+        module.execute_chat_stream = failed_chat_stream
+        with patch.object(module.ProductJourneyAttempt, 'accepted', return_value=attempt):
+            response = module.send_message(module.SendMessageRequest(text='private user content'), uid='test-uid')
+            with pytest.raises(type(failure)):
+                asyncio.run(_consume_stream(response.body_iterator))
+
+        attempt.finish.assert_called_once_with(module.ProductJourneyOutcome.failed)
+    finally:
+        _cleanup(saved)
+
+
+async def _consume_stream(stream):
+    async for _chunk in stream:
+        pass
 
 
 def test_v2_voice_messages_records_quota_question_from_visible_message_chunk():

--- a/backend/tests/unit/test_conversation_finalization_jobs.py
+++ b/backend/tests/unit/test_conversation_finalization_jobs.py
@@ -114,6 +114,7 @@ def test_intent_persists_outbox_before_any_live_handoff_and_omits_byok_material(
 
     assert intent['status'] == 'queued'
     assert intent['job_id']
+    assert intent['newly_created'] is True
     assert len(transaction.sets) == 1
     job = transaction.sets[0][1]
     assert job['uid'] == 'uid-1'
@@ -300,11 +301,20 @@ def test_atomic_admission_rejects_terminal_snapshot_before_any_outbox_write():
 
 def test_duplicate_task_delivery_claims_only_once_until_lease_expires():
     now = _now()
-    ref = _Ref('job-1', {'status': 'queued', 'dispatch_generation': 2, 'attempt_count': 0})
+    accepted_at = now - timedelta(seconds=30)
+    ref = _Ref(
+        'job-1',
+        {'status': 'queued', 'dispatch_generation': 2, 'attempt_count': 0, 'created_at': accepted_at},
+    )
     first = _Transaction()
 
     claim = jobs._claim_finalization_job_txn(first, ref, 2, False, 1500, now)
-    assert claim == {'status': 'claimed', 'lease_epoch': 1, 'attempt_count': 1}
+    assert claim == {
+        'status': 'claimed',
+        'lease_epoch': 1,
+        'attempt_count': 1,
+        'accepted_at_epoch_seconds': accepted_at.timestamp(),
+    }
     claim_update = first.updates[0][1]
     assert claim_update['status'] == 'leased'
     assert claim_update['attempt_count'] == 1
@@ -315,6 +325,7 @@ def test_duplicate_task_delivery_claims_only_once_until_lease_expires():
         'status': 'leased',
         'lease_epoch': None,
         'attempt_count': 0,
+        'accepted_at_epoch_seconds': None,
     }
     assert duplicate.updates == []
 
@@ -333,7 +344,7 @@ def test_expired_worker_lease_can_be_safely_reclaimed():
     transaction = _Transaction()
 
     claim = jobs._claim_finalization_job_txn(transaction, ref, 2, False, 1500, now)
-    assert claim == {'status': 'claimed', 'lease_epoch': 1, 'attempt_count': 2}
+    assert claim == {'status': 'claimed', 'lease_epoch': 1, 'attempt_count': 2, 'accepted_at_epoch_seconds': None}
     assert transaction.updates[0][1]['attempt_count'] == 2
     assert transaction.updates[0][1]['lease_epoch'] == 1
 
@@ -470,7 +481,7 @@ def test_completed_fenced_job_replays_as_a_fenced_result():
 
     claim = jobs._claim_finalization_job_txn(_Transaction(), ref, 1, False, 1500, _now())
 
-    assert claim == {'status': 'fenced', 'lease_epoch': None, 'attempt_count': 0}
+    assert claim == {'status': 'fenced', 'lease_epoch': None, 'attempt_count': 0, 'accepted_at_epoch_seconds': None}
 
 
 def test_live_pusher_claim_cannot_use_another_conversations_job():
@@ -496,7 +507,12 @@ def test_live_pusher_claim_cannot_use_another_conversations_job():
         expected_conversation_id='other-conversation',
     )
 
-    assert status == {'status': 'identity_mismatch', 'lease_epoch': None, 'attempt_count': 0}
+    assert status == {
+        'status': 'identity_mismatch',
+        'lease_epoch': None,
+        'attempt_count': 0,
+        'accepted_at_epoch_seconds': None,
+    }
     assert transaction.updates == []
 
 
@@ -508,6 +524,7 @@ def test_completed_and_dead_letter_jobs_never_execute_again():
             'status': status,
             'lease_epoch': None,
             'attempt_count': 0,
+            'accepted_at_epoch_seconds': None,
         }
         assert transaction.updates == []
 
@@ -547,7 +564,7 @@ def test_expired_lease_reclaim_fences_a_stale_worker_terminal_write():
 
     reclaim = _Transaction()
     new_claim = jobs._claim_finalization_job_txn(reclaim, ref, 3, False, 1500, now)
-    assert new_claim == {'status': 'claimed', 'lease_epoch': 5, 'attempt_count': 1}
+    assert new_claim == {'status': 'claimed', 'lease_epoch': 5, 'attempt_count': 1, 'accepted_at_epoch_seconds': None}
     ref.data = ref.data | reclaim.updates[0][1]
 
     stale_completion = _Transaction()

--- a/backend/tests/unit/test_listen_finalization_cloud_tasks.py
+++ b/backend/tests/unit/test_listen_finalization_cloud_tasks.py
@@ -16,6 +16,7 @@ import routers.pusher as pusher_router
 from utils.conversations import lifecycle as lifecycle_service
 from utils import cloud_tasks
 from utils.conversations.finalizer import ConversationFinalizationDisposition, ConversationFinalizationError
+from utils.observability.product_health import ProductJourney, ProductJourneyOutcome
 import utils.conversations.finalizer as persisted_finalizer
 
 
@@ -58,6 +59,26 @@ def test_platform_key_job_dispatches_to_cloud_tasks(monkeypatch):
 
     assert result['route'] == 'cloud_tasks'
     enqueue.assert_called_once_with('job-1', 2)
+
+
+def test_lifecycle_records_capture_acceptance_only_for_a_new_durable_job(monkeypatch):
+    intent = {
+        'job_id': 'job-1',
+        'status': 'queued',
+        'dispatch_generation': 1,
+        'requires_byok': False,
+        'newly_created': True,
+    }
+    accepted = MagicMock()
+    _mock_lifecycle_conversation(monkeypatch)
+    monkeypatch.setattr(lifecycle_service.jobs_db, 'create_or_get_finalization_intent', MagicMock(return_value=intent))
+    monkeypatch.setattr(lifecycle_service, 'is_listen_finalization_dispatch_enabled', lambda: False)
+    monkeypatch.setattr(lifecycle_service.ProductJourneyAttempt, 'accepted', accepted)
+
+    result = lifecycle_service.request_finalization('uid-1', 'conversation-1', has_byok_keys=False)
+
+    assert result['route'] == 'pusher'
+    accepted.assert_called_once_with(ProductJourney.capture_finalization)
 
 
 def test_enqueue_failure_leaves_job_queued_for_reconciler(monkeypatch):
@@ -356,13 +377,17 @@ async def test_pusher_rejects_legacy_finalization_without_a_durable_job():
 @pytest.mark.anyio
 async def test_pusher_claims_the_durable_job_before_finalizing(monkeypatch):
     websocket = _PusherWebSocket()
-    claim = MagicMock(return_value={'status': 'claimed', 'lease_epoch': 7, 'attempt_count': 1})
+    claim = MagicMock(
+        return_value={'status': 'claimed', 'lease_epoch': 7, 'attempt_count': 1, 'accepted_at_epoch_seconds': 123.0}
+    )
     completed = MagicMock(return_value=True)
     finalizer = AsyncMock()
+    terminal = MagicMock()
     monkeypatch.setattr(pusher_router, 'run_blocking', _inline_run_blocking)
     monkeypatch.setattr(jobs_db, 'claim_finalization_job', claim)
     monkeypatch.setattr(jobs_db, 'mark_finalization_completed', completed)
     monkeypatch.setattr(pusher_router, 'finalize_persisted_conversation', finalizer)
+    monkeypatch.setattr(pusher_router, 'record_durable_journey_terminal', terminal)
 
     await pusher_router._process_conversation_task(
         'uid-1', 'conversation-1', 'en', websocket, finalization_job_id='job-1', dispatch_generation=3
@@ -384,6 +409,11 @@ async def test_pusher_claims_the_durable_job_before_finalizing(monkeypatch):
         lease_epoch=7,
     )
     completed.assert_called_once_with('job-1', 3, 7)
+    terminal.assert_called_once_with(
+        ProductJourney.capture_finalization,
+        ProductJourneyOutcome.succeeded,
+        accepted_at_epoch_seconds=123.0,
+    )
     assert json.loads(websocket.sent[0][4:]) == {'conversation_id': 'conversation-1', 'success': True}
 
 

--- a/backend/tests/unit/test_product_health_monitoring_contract.py
+++ b/backend/tests/unit/test_product_health_monitoring_contract.py
@@ -1,0 +1,65 @@
+"""Static safety contract for the real-traffic product-health monitoring artifacts."""
+
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+MONITORING = REPO / 'backend/charts/monitoring'
+METRIC = 'omi_product_journey_terminal_total'
+DASHBOARD = MONITORING / 'dashboards/omi-services/product-health-real-traffic.json'
+ALERTS = MONITORING / 'alerts/product-health.json'
+
+
+def _rules(path: Path) -> dict[str, dict]:
+    return {rule['uid']: rule for rule in json.loads(path.read_text(encoding='utf-8'))}
+
+
+def _promql(rule: dict) -> str:
+    return rule['data'][0]['model']['expr']
+
+
+def test_dashboard_declares_real_traffic_only_scope_and_self_baseline():
+    dashboard = json.loads(DASHBOARD.read_text(encoding='utf-8'))
+    assert dashboard['uid'] == 'omi-product-health-real-traffic'
+
+    text_panels = [panel['options']['content'] for panel in dashboard['panels'] if panel['type'] == 'text']
+    assert any('No synthetic canaries' in content for content in text_panels)
+    assert any('same environment' in content for content in text_panels)
+    assert any('Cloud Run scrape gap' in content for content in text_panels)
+
+    expressions = [
+        target.get('expr', '')
+        for panel in dashboard['panels']
+        for target in panel.get('targets', [])
+        if isinstance(target, dict)
+    ]
+    assert any(METRIC in expression for expression in expressions)
+    assert all('environment=' not in expression and 'env=' not in expression for expression in expressions)
+
+
+def test_alerts_are_traffic_gated_and_compare_only_to_their_own_baseline():
+    combined = _rules(MONITORING / 'alert-rules.json')
+    split = _rules(ALERTS)
+    required = {'product_health_capture_finalization_outage', 'product_health_pusher_regression'}
+
+    assert required <= combined.keys()
+    assert required <= split.keys()
+    for uid in required:
+        assert combined[uid]['noDataState'] == split[uid]['noDataState'] == 'OK'
+        assert combined[uid]['for'] == split[uid]['for'] == '15m'
+        expression = _promql(combined[uid])
+        assert METRIC in expression
+        assert 'increase(omi_product_journey_accepted_total' in expression
+        assert 'offset 24h' in expression
+        assert 'environment=' not in expression and 'env=' not in expression
+        assert combined[uid]['labels']['severity'] == 'critical'
+
+
+def test_dev_and_prod_scrape_the_same_real_traffic_targets():
+    for environment in ('dev', 'prod'):
+        values = (MONITORING / 'kube-prometheus-stack' / f'{environment}_omi_monitoring_values.yaml').read_text(
+            encoding='utf-8'
+        )
+        assert 'job_name: backend-listen-metrics' in values
+        assert 'job_name: pusher-metrics' in values
+        assert 'scrape_interval: 15s' in values

--- a/backend/tests/unit/test_product_health_monitoring_contract.py
+++ b/backend/tests/unit/test_product_health_monitoring_contract.py
@@ -8,6 +8,7 @@ MONITORING = REPO / 'backend/charts/monitoring'
 METRIC = 'omi_product_journey_terminal_total'
 DASHBOARD = MONITORING / 'dashboards/omi-services/product-health-real-traffic.json'
 ALERTS = MONITORING / 'alerts/product-health.json'
+RUNBOOK = REPO / 'backend/docs/runbooks/product-health-real-traffic.md'
 
 
 def _rules(path: Path) -> dict[str, dict]:
@@ -24,7 +25,8 @@ def test_dashboard_declares_real_traffic_only_scope_and_self_baseline():
 
     text_panels = [panel['options']['content'] for panel in dashboard['panels'] if panel['type'] == 'text']
     assert any('No synthetic canaries' in content for content in text_panels)
-    assert any('same environment' in content for content in text_panels)
+    assert any('own 24-hour baseline' in content for content in text_panels)
+    assert any('Prometheus instance' in content for content in text_panels)
     assert any('Cloud Run scrape gap' in content for content in text_panels)
 
     expressions = [
@@ -36,11 +38,21 @@ def test_dashboard_declares_real_traffic_only_scope_and_self_baseline():
     assert any(METRIC in expression for expression in expressions)
     assert all('environment=' not in expression and 'env=' not in expression for expression in expressions)
 
+    chat_panels = [panel for panel in dashboard['panels'] if panel.get('title') == 'Chat success rate vs. own baseline']
+    assert len(chat_panels) == 1
+    chat_expressions = [target['expr'] for target in chat_panels[0]['targets']]
+    assert all('journey="chat_response"' in expression for expression in chat_expressions)
+    assert any('offset 24h' in expression for expression in chat_expressions)
+
 
 def test_alerts_are_traffic_gated_and_compare_only_to_their_own_baseline():
     combined = _rules(MONITORING / 'alert-rules.json')
     split = _rules(ALERTS)
-    required = {'product_health_capture_finalization_outage', 'product_health_pusher_regression'}
+    required = {
+        'product_health_capture_finalization_outage',
+        'product_health_chat_response_regression',
+        'product_health_pusher_regression',
+    }
 
     assert required <= combined.keys()
     assert required <= split.keys()
@@ -53,6 +65,20 @@ def test_alerts_are_traffic_gated_and_compare_only_to_their_own_baseline():
         assert 'offset 24h' in expression
         assert 'environment=' not in expression and 'env=' not in expression
         assert combined[uid]['labels']['severity'] == 'critical'
+
+    chat_expression = _promql(combined['product_health_chat_response_regression'])
+    assert 'journey="chat_response"' in chat_expression
+    assert '> 20' in chat_expression
+
+
+def test_runbook_documents_prometheus_instance_isolation_and_false_negative_limits():
+    runbook = RUNBOOK.read_text(encoding='utf-8')
+
+    assert 'Prometheus instance' in runbook
+    assert 'environment label' in runbook
+    assert 'low traffic' in runbook.lower()
+    assert 'scrape gap' in runbook
+    assert 'missing 24-hour baseline' in runbook
 
 
 def test_dev_and_prod_scrape_the_same_real_traffic_targets():

--- a/backend/tests/unit/test_product_health_observability.py
+++ b/backend/tests/unit/test_product_health_observability.py
@@ -11,6 +11,7 @@ from utils.observability.product_health import (
     ProductJourney,
     ProductJourneyAttempt,
     ProductJourneyOutcome,
+    finish_pusher_session_attempt,
     record_durable_journey_terminal,
 )
 
@@ -88,4 +89,22 @@ def test_metric_contract_has_only_closed_journey_and_outcome_labels():
         'realtime_pusher_session',
         'capture_finalization',
     }
+
+
+@pytest.mark.parametrize('client_disconnect_code', (1000, 1001))
+def test_pusher_normal_client_disconnects_are_terminal_successes(client_disconnect_code):
+    attempt = MagicMock()
+
+    finish_pusher_session_attempt(attempt, client_disconnect_code=client_disconnect_code)
+
+    attempt.finish.assert_called_once_with(ProductJourneyOutcome.succeeded)
+
+
+@pytest.mark.parametrize('client_disconnect_code', (None, 1006, 1011))
+def test_pusher_server_and_error_closes_are_terminal_failures(client_disconnect_code):
+    attempt = MagicMock()
+
+    finish_pusher_session_attempt(attempt, client_disconnect_code=client_disconnect_code)
+
+    attempt.finish.assert_called_once_with(ProductJourneyOutcome.failed)
     assert {outcome.value for outcome in ProductJourneyOutcome} == {'succeeded', 'failed'}

--- a/backend/tests/unit/test_product_health_observability.py
+++ b/backend/tests/unit/test_product_health_observability.py
@@ -1,0 +1,91 @@
+"""Behavioral contract for the real-traffic product-health metric slice."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from utils.observability.product_health import (
+    PRODUCT_JOURNEY_ACCEPTED_TOTAL,
+    PRODUCT_JOURNEY_LATENCY_SECONDS,
+    PRODUCT_JOURNEY_TERMINAL_TOTAL,
+    ProductJourney,
+    ProductJourneyAttempt,
+    ProductJourneyOutcome,
+    record_durable_journey_terminal,
+)
+
+
+@patch('utils.observability.product_health.monotonic', side_effect=[10.0, 13.5])
+@patch('utils.observability.product_health.PRODUCT_JOURNEY_LATENCY_SECONDS')
+@patch('utils.observability.product_health.PRODUCT_JOURNEY_TERMINAL_TOTAL')
+@patch('utils.observability.product_health.PRODUCT_JOURNEY_ACCEPTED_TOTAL')
+def test_attempt_records_one_accepted_and_one_success_terminal(
+    accepted_metric,
+    terminal_metric,
+    latency_metric,
+    _monotonic,
+):
+    accepted_child = MagicMock()
+    terminal_child = MagicMock()
+    latency_child = MagicMock()
+    accepted_metric.labels.return_value = accepted_child
+    terminal_metric.labels.return_value = terminal_child
+    latency_metric.labels.return_value = latency_child
+
+    attempt = ProductJourneyAttempt.accepted(ProductJourney.chat_response)
+    attempt.finish(ProductJourneyOutcome.succeeded)
+    attempt.finish(ProductJourneyOutcome.failed)
+
+    accepted_metric.labels.assert_called_once_with(journey='chat_response')
+    terminal_metric.labels.assert_called_once_with(journey='chat_response', outcome='succeeded')
+    latency_metric.labels.assert_called_once_with(journey='chat_response', outcome='succeeded')
+    accepted_child.inc.assert_called_once_with()
+    terminal_child.inc.assert_called_once_with()
+    latency_child.observe.assert_called_once_with(3.5)
+
+
+def test_contract_rejects_non_allowlisted_labels():
+    with pytest.raises(ValueError, match='ProductJourney'):
+        ProductJourneyAttempt.accepted('user-123')  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match='ProductJourneyOutcome'):
+        record_durable_journey_terminal(
+            ProductJourney.capture_finalization,
+            'raw provider response',  # type: ignore[arg-type]
+            accepted_at_epoch_seconds=1.0,
+            now_epoch_seconds=2.0,
+        )
+
+
+@patch('utils.observability.product_health.PRODUCT_JOURNEY_LATENCY_SECONDS')
+@patch('utils.observability.product_health.PRODUCT_JOURNEY_TERMINAL_TOTAL')
+def test_durable_terminal_uses_persisted_acceptance_time_without_identity_labels(terminal_metric, latency_metric):
+    terminal_child = MagicMock()
+    latency_child = MagicMock()
+    terminal_metric.labels.return_value = terminal_child
+    latency_metric.labels.return_value = latency_child
+
+    record_durable_journey_terminal(
+        ProductJourney.capture_finalization,
+        ProductJourneyOutcome.failed,
+        accepted_at_epoch_seconds=100.0,
+        now_epoch_seconds=121.25,
+    )
+
+    expected_labels = {'journey': 'capture_finalization', 'outcome': 'failed'}
+    assert terminal_metric.labels.call_args.kwargs == expected_labels
+    assert latency_metric.labels.call_args.kwargs == expected_labels
+    terminal_child.inc.assert_called_once_with()
+    latency_child.observe.assert_called_once_with(21.25)
+
+
+def test_metric_contract_has_only_closed_journey_and_outcome_labels():
+    assert PRODUCT_JOURNEY_ACCEPTED_TOTAL._labelnames == ('journey',)
+    assert PRODUCT_JOURNEY_TERMINAL_TOTAL._labelnames == ('journey', 'outcome')
+    assert PRODUCT_JOURNEY_LATENCY_SECONDS._labelnames == ('journey', 'outcome')
+    assert {journey.value for journey in ProductJourney} == {
+        'chat_response',
+        'realtime_pusher_session',
+        'capture_finalization',
+    }
+    assert {outcome.value for outcome in ProductJourneyOutcome} == {'succeeded', 'failed'}

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -195,6 +195,15 @@ def test_backend_test_runner_defaults_python_to_utf8():
     assert runner.index(utf8_export) < runner.index('PYTHON_BIN="${PYTHON:-}"')
 
 
+def test_typecheck_prefers_the_project_venv_over_an_active_environment():
+    """Static tripwire for pre-push: Hermes must not select its own interpreter."""
+    typecheck = (BACKEND_DIR / 'scripts/typecheck.sh').read_text(encoding='utf-8')
+
+    project_venv = 'if [[ -x ".venv/bin/python" ]]; then'
+    active_venv = 'elif [[ -n "${VIRTUAL_ENV:-}" && -x "$VIRTUAL_ENV/bin/python" ]]; then'
+    assert typecheck.index(project_venv) < typecheck.index(active_venv)
+
+
 def test_pre_push_requires_backend_python_lazily():
     pre_push = (BACKEND_DIR.parent / "scripts/pre-push").read_text(encoding="utf-8")
     setup_prefix = pre_push[: pre_push.index("run_step()")]

--- a/backend/utils/conversations/lifecycle.py
+++ b/backend/utils/conversations/lifecycle.py
@@ -24,6 +24,7 @@ from utils.conversations.finalization_decision import (
     decide_finalization,
 )
 from utils.observability.fallback import record_fallback
+from utils.observability.product_health import ProductJourney, ProductJourneyAttempt
 
 logger = logging.getLogger(__name__)
 
@@ -525,6 +526,8 @@ def request_finalization(
         finalization_admission=lambda conversation: _finalization_admission(conversation, conversation_id),
         firestore_client=firestore_client,
     )
+    if intent.get('newly_created'):
+        ProductJourneyAttempt.accepted(ProductJourney.capture_finalization)
     status = intent['status']
     if intent['job_id'] is None or status in {'missing', 'no_content', 'deferred', 'completed', 'dead_letter'}:
         return dict(intent) | {'route': 'noop'}

--- a/backend/utils/observability/product_health.py
+++ b/backend/utils/observability/product_health.py
@@ -1,0 +1,95 @@
+"""Privacy-safe product health metrics for real user traffic journeys."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from time import monotonic, time
+
+from prometheus_client import Counter, Histogram
+
+
+class ProductJourney(str, Enum):
+    chat_response = 'chat_response'
+    realtime_pusher_session = 'realtime_pusher_session'
+    capture_finalization = 'capture_finalization'
+
+
+class ProductJourneyOutcome(str, Enum):
+    succeeded = 'succeeded'
+    failed = 'failed'
+
+
+PRODUCT_JOURNEY_ACCEPTED_TOTAL = Counter(
+    'omi_product_journey_accepted_total',
+    'Accepted real-traffic product journeys by closed journey name',
+    ['journey'],
+)
+
+PRODUCT_JOURNEY_TERMINAL_TOTAL = Counter(
+    'omi_product_journey_terminal_total',
+    'Terminal real-traffic product journeys by closed journey name and outcome',
+    ['journey', 'outcome'],
+)
+
+PRODUCT_JOURNEY_LATENCY_SECONDS = Histogram(
+    'omi_product_journey_latency_seconds',
+    'End-to-end latency for terminal real-traffic product journeys',
+    ['journey', 'outcome'],
+    buckets=(0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 900, 3600),
+)
+
+
+def _require_journey(journey: ProductJourney) -> ProductJourney:
+    if not isinstance(journey, ProductJourney):
+        raise ValueError('journey must be a ProductJourney')
+    return journey
+
+
+def _require_outcome(outcome: ProductJourneyOutcome) -> ProductJourneyOutcome:
+    if not isinstance(outcome, ProductJourneyOutcome):
+        raise ValueError('outcome must be a ProductJourneyOutcome')
+    return outcome
+
+
+def _record_terminal(journey: ProductJourney, outcome: ProductJourneyOutcome, latency_seconds: float) -> None:
+    labels = {'journey': journey.value, 'outcome': outcome.value}
+    PRODUCT_JOURNEY_TERMINAL_TOTAL.labels(**labels).inc()
+    PRODUCT_JOURNEY_LATENCY_SECONDS.labels(**labels).observe(max(0.0, latency_seconds))
+
+
+@dataclass
+class ProductJourneyAttempt:
+    """An in-memory attempt for a request or WebSocket session lifecycle."""
+
+    journey: ProductJourney
+    accepted_at_monotonic: float
+    _finished: bool = False
+
+    @classmethod
+    def accepted(cls, journey: ProductJourney) -> 'ProductJourneyAttempt':
+        journey = _require_journey(journey)
+        PRODUCT_JOURNEY_ACCEPTED_TOTAL.labels(journey=journey.value).inc()
+        return cls(journey=journey, accepted_at_monotonic=monotonic())
+
+    def finish(self, outcome: ProductJourneyOutcome) -> None:
+        outcome = _require_outcome(outcome)
+        if self._finished:
+            return
+        self._finished = True
+        _record_terminal(self.journey, outcome, monotonic() - self.accepted_at_monotonic)
+
+
+def record_durable_journey_terminal(
+    journey: ProductJourney,
+    outcome: ProductJourneyOutcome,
+    *,
+    accepted_at_epoch_seconds: float,
+    now_epoch_seconds: float | None = None,
+) -> None:
+    """Record a terminal event for a journey whose acceptance is persisted."""
+
+    journey = _require_journey(journey)
+    outcome = _require_outcome(outcome)
+    terminal_at = time() if now_epoch_seconds is None else now_epoch_seconds
+    _record_terminal(journey, outcome, terminal_at - accepted_at_epoch_seconds)

--- a/backend/utils/observability/product_health.py
+++ b/backend/utils/observability/product_health.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from time import monotonic, time
-from typing import Callable
-
-from prometheus_client import REGISTRY, Counter, Histogram
+from prometheus_client import Counter, Histogram
 
 
 class ProductJourney(str, Enum):
@@ -21,54 +19,33 @@ class ProductJourneyOutcome(str, Enum):
     failed = 'failed'
 
 
-def _registered_metric_or_create(name: str, factory: Callable[[], Counter | Histogram]) -> Counter | Histogram:
-    """Reuse collectors when isolated router tests reload this module."""
-
-    try:
-        return factory()
-    except ValueError:
-        collector = REGISTRY._names_to_collectors.get(name)
-        if collector is None:
-            raise
-        return collector
-
-
-PRODUCT_JOURNEY_ACCEPTED_TOTAL = _registered_metric_or_create(
+PRODUCT_JOURNEY_ACCEPTED_TOTAL = Counter(
     'omi_product_journey_accepted_total',
-    lambda: Counter(
-        'omi_product_journey_accepted_total',
-        'Accepted real-traffic product journeys by closed journey name',
-        ['journey'],
-    ),
+    'Accepted real-traffic product journeys by closed journey name',
+    ['journey'],
 )
 
-PRODUCT_JOURNEY_TERMINAL_TOTAL = _registered_metric_or_create(
+PRODUCT_JOURNEY_TERMINAL_TOTAL = Counter(
     'omi_product_journey_terminal_total',
-    lambda: Counter(
-        'omi_product_journey_terminal_total',
-        'Terminal real-traffic product journeys by closed journey name and outcome',
-        ['journey', 'outcome'],
-    ),
+    'Terminal real-traffic product journeys by closed journey name and outcome',
+    ['journey', 'outcome'],
 )
 
-PRODUCT_JOURNEY_LATENCY_SECONDS = _registered_metric_or_create(
+PRODUCT_JOURNEY_LATENCY_SECONDS = Histogram(
     'omi_product_journey_latency_seconds',
-    lambda: Histogram(
-        'omi_product_journey_latency_seconds',
-        'End-to-end latency for terminal real-traffic product journeys',
-        ['journey', 'outcome'],
-        buckets=(0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 900, 3600),
-    ),
+    'End-to-end latency for terminal real-traffic product journeys',
+    ['journey', 'outcome'],
+    buckets=(0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 900, 3600),
 )
 
 
-def _require_journey(journey: ProductJourney) -> ProductJourney:
+def _require_journey(journey: object) -> ProductJourney:
     if not isinstance(journey, ProductJourney):
         raise ValueError('journey must be a ProductJourney')
     return journey
 
 
-def _require_outcome(outcome: ProductJourneyOutcome) -> ProductJourneyOutcome:
+def _require_outcome(outcome: object) -> ProductJourneyOutcome:
     if not isinstance(outcome, ProductJourneyOutcome):
         raise ValueError('outcome must be a ProductJourneyOutcome')
     return outcome

--- a/backend/utils/observability/product_health.py
+++ b/backend/utils/observability/product_health.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from time import monotonic, time
+from typing import Callable
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import REGISTRY, Counter, Histogram
 
 
 class ProductJourney(str, Enum):
@@ -20,23 +21,44 @@ class ProductJourneyOutcome(str, Enum):
     failed = 'failed'
 
 
-PRODUCT_JOURNEY_ACCEPTED_TOTAL = Counter(
+def _registered_metric_or_create(name: str, factory: Callable[[], Counter | Histogram]) -> Counter | Histogram:
+    """Reuse collectors when isolated router tests reload this module."""
+
+    try:
+        return factory()
+    except ValueError:
+        collector = REGISTRY._names_to_collectors.get(name)
+        if collector is None:
+            raise
+        return collector
+
+
+PRODUCT_JOURNEY_ACCEPTED_TOTAL = _registered_metric_or_create(
     'omi_product_journey_accepted_total',
-    'Accepted real-traffic product journeys by closed journey name',
-    ['journey'],
+    lambda: Counter(
+        'omi_product_journey_accepted_total',
+        'Accepted real-traffic product journeys by closed journey name',
+        ['journey'],
+    ),
 )
 
-PRODUCT_JOURNEY_TERMINAL_TOTAL = Counter(
+PRODUCT_JOURNEY_TERMINAL_TOTAL = _registered_metric_or_create(
     'omi_product_journey_terminal_total',
-    'Terminal real-traffic product journeys by closed journey name and outcome',
-    ['journey', 'outcome'],
+    lambda: Counter(
+        'omi_product_journey_terminal_total',
+        'Terminal real-traffic product journeys by closed journey name and outcome',
+        ['journey', 'outcome'],
+    ),
 )
 
-PRODUCT_JOURNEY_LATENCY_SECONDS = Histogram(
+PRODUCT_JOURNEY_LATENCY_SECONDS = _registered_metric_or_create(
     'omi_product_journey_latency_seconds',
-    'End-to-end latency for terminal real-traffic product journeys',
-    ['journey', 'outcome'],
-    buckets=(0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 900, 3600),
+    lambda: Histogram(
+        'omi_product_journey_latency_seconds',
+        'End-to-end latency for terminal real-traffic product journeys',
+        ['journey', 'outcome'],
+        buckets=(0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 900, 3600),
+    ),
 )
 
 
@@ -93,3 +115,17 @@ def record_durable_journey_terminal(
     outcome = _require_outcome(outcome)
     terminal_at = time() if now_epoch_seconds is None else now_epoch_seconds
     _record_terminal(journey, outcome, terminal_at - accepted_at_epoch_seconds)
+
+
+def finish_pusher_session_attempt(attempt: ProductJourneyAttempt, *, client_disconnect_code: int | None) -> None:
+    """Finish a pusher session using the peer's close frame, when present.
+
+    A normal close is only successful when it came from the client. Server
+    timeouts and error closes have no client close frame and are failures even
+    if the server happens to use close code 1000 while cleaning up.
+    """
+
+    outcome = (
+        ProductJourneyOutcome.succeeded if client_disconnect_code in {1000, 1001} else ProductJourneyOutcome.failed
+    )
+    attempt.finish(outcome)


### PR DESCRIPTION
## Summary

Adds the first real-traffic product-health outcome slice without synthetic canaries:

- privacy-safe accepted/terminal/latency metrics for chat, Pusher sessions, and durable capture finalization;
- chat streaming instrumentation at the actual backend stream boundary;
- normal client Pusher disconnects (`1000` / `1001`) treated as successful sessions;
- per-Prometheus-instance, traffic-gated dashboard and alerts with 24-hour self-baselines;
- documented no-data and low-volume false-negative limits.

Dev/beta and production remain isolated by Prometheus instance. No metric uses customer IDs, content, raw errors, request IDs, or conversation IDs as labels.

## Verification

- `make preflight` — passed all 15 selected checks
- Focused backend unit suite — 68 passed
- Monitoring dashboard and alert JSON parsed successfully

## Follow-up

Partial delivery toward #9786. Durable finalization reconciliation/stale-work semantics and broader latency SLO alerting remain tracked there; this PR does not claim to close it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

