### PR TITLE
feat(observability): instrument real-traffic journey outcomes

### DIFF
--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -6838,5 +6838,495 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "omi-journey-chat-fail",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Chat response - terminal failure rate elevated",
+    "condition": "D",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=~\"success|failure\"}[30m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=~\"success|failure\"}[30m])), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A >= 20 && $B > 0.10",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "math"
+        }
+      },
+      {
+        "refId": "D",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "C",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "D",
+          "type": "reduce"
+        }
+      }
+    ],
+    "updated": "2026-07-15T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "7",
+      "summary": "Chat terminal failures exceed 10% with at least 20 terminal real requests in 30m",
+      "threshold": "failure share > 0.10; terminal outcomes >= 20"
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "ai-chat"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-journey-pusher-fail",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Pusher session - terminal failure rate elevated",
+    "condition": "D",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=~\"success|failure\"}[30m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=~\"success|failure\"}[30m])), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A >= 20 && $B > 0.10",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "math"
+        }
+      },
+      {
+        "refId": "D",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "C",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "D",
+          "type": "reduce"
+        }
+      }
+    ],
+    "updated": "2026-07-15T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "7",
+      "summary": "Pusher terminal failures exceed 10% with at least 20 terminal real sessions in 30m",
+      "threshold": "failure share > 0.10; terminal outcomes >= 20"
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "live-transcription"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-journey-capture-fail",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Capture finalization - terminal failure rate elevated",
+    "condition": "D",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[30m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[30m])), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A >= 20 && $B > 0.10",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "math"
+        }
+      },
+      {
+        "refId": "D",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "C",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "D",
+          "type": "reduce"
+        }
+      }
+    ],
+    "updated": "2026-07-15T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "9",
+      "summary": "Capture finalization terminal failures exceed 10% with at least 20 terminal real jobs in 30m",
+      "threshold": "failure share > 0.10; terminal outcomes >= 20"
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "speech-processing"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-journey-scrape-missing",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Journey outcomes - scrape source missing",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 300,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(count(count by (job) (up{job=~\"backend-listen-metrics|pusher-metrics\"})) < bool 2) or (min(up{job=~\"backend-listen-metrics|pusher-metrics\"}) < bool 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                  "params": [
+                    0
+                  ],
+                  "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      }
+    ],
+    "updated": "2026-07-15T00:00:00Z",
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "6",
+      "summary": "An expected real-traffic journey metrics scrape target is absent or unhealthy",
+      "threshold": "either named scrape job absent or any target up < 1"
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "observability"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
   }
 ]

--- a/backend/charts/monitoring/alerts/resilience.json
+++ b/backend/charts/monitoring/alerts/resilience.json
@@ -114,5 +114,183 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "omi-journey-chat-fail",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Chat response - terminal failure rate elevated",
+    "condition": "D",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 1800, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=~\"success|failure\"}[30m]))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 1800, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=~\"success|failure\"}[30m])), 1)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B"}
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "$A >= 20 && $B > 0.10", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "math"}
+      },
+      {
+        "refId": "D",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["D"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "C", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "D", "type": "reduce"}
+      }
+    ],
+    "updated": "2026-07-15T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {"__dashboardUid__": "omi-resilience-fallbacks", "__panelId__": "7", "summary": "Chat terminal failures exceed 10% with at least 20 terminal real requests in 30m", "threshold": "failure share > 0.10; terminal outcomes >= 20"},
+    "labels": {"severity": "warning", "instatus_component": "ai-chat"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "record": null
+  },
+  {
+    "uid": "omi-journey-pusher-fail",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Pusher session - terminal failure rate elevated",
+    "condition": "D",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 1800, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=~\"success|failure\"}[30m]))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 1800, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=~\"success|failure\"}[30m])), 1)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B"}
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "$A >= 20 && $B > 0.10", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "math"}
+      },
+      {
+        "refId": "D",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["D"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "C", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "D", "type": "reduce"}
+      }
+    ],
+    "updated": "2026-07-15T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {"__dashboardUid__": "omi-resilience-fallbacks", "__panelId__": "7", "summary": "Pusher terminal failures exceed 10% with at least 20 terminal real sessions in 30m", "threshold": "failure share > 0.10; terminal outcomes >= 20"},
+    "labels": {"severity": "warning", "instatus_component": "live-transcription"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "record": null
+  },
+  {
+    "uid": "omi-journey-capture-fail",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Capture finalization - terminal failure rate elevated",
+    "condition": "D",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 1800, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[30m]))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 1800, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[30m])), 1)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B"}
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "$A >= 20 && $B > 0.10", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "math"}
+      },
+      {
+        "refId": "D",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["D"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "C", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "D", "type": "reduce"}
+      }
+    ],
+    "updated": "2026-07-15T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {"__dashboardUid__": "omi-resilience-fallbacks", "__panelId__": "9", "summary": "Capture finalization terminal failures exceed 10% with at least 20 terminal real jobs in 30m", "threshold": "failure share > 0.10; terminal outcomes >= 20"},
+    "labels": {"severity": "warning", "instatus_component": "speech-processing"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "record": null
+  },
+  {
+    "uid": "omi-journey-scrape-missing",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Journey outcomes - scrape source missing",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 300, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "(count(count by (job) (up{job=~\"backend-listen-metrics|pusher-metrics\"})) < bool 2) or (min(up{job=~\"backend-listen-metrics|pusher-metrics\"}) < bool 1)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"conditions": [{"evaluator": {"params": [0], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "B", "type": "reduce"}
+      }
+    ],
+    "updated": "2026-07-15T00:00:00Z",
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {"__dashboardUid__": "omi-resilience-fallbacks", "__panelId__": "6", "summary": "An expected real-traffic journey metrics scrape target is absent or unhealthy", "threshold": "either named scrape job absent or any target up < 1"},
+    "labels": {"severity": "warning", "instatus_component": "observability"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "record": null
   }
 ]

--- a/backend/charts/monitoring/dashboards/omi-services/resilience-fallbacks.json
+++ b/backend/charts/monitoring/dashboards/omi-services/resilience-fallbacks.json
@@ -488,6 +488,209 @@
       ],
       "title": "LLM gateway fallback rate (ticket tier)",
       "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 6,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "**Real-traffic journeys:** chat, pusher, and capture-finalization measure accepted work through a server-observable terminal boundary. Product-failure alerts require real traffic; cancelled client/transport endings and fenced stale work remain visible without counting as product failures. An absent source is scrape health, not zero traffic. Semantics: `backend/docs/runbooks/real-traffic-journeys.md`.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.1.0",
+      "title": "Journey outcome contract",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(sum by (journey) (increase(omi_journey_terminal_total{outcome=\"success\"}[$__rate_interval])) / sum by (journey) (increase(omi_journey_terminal_total{outcome=~\"success|failure\"}[$__rate_interval]))) and on (journey) (sum by (journey) (increase(omi_journey_terminal_total{outcome=~\"success|failure\"}[$__rate_interval])) > 0)",
+          "legendFormat": "{{journey}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Journey terminal success rate (success / success + failure)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (journey, le) (rate(omi_journey_latency_seconds_bucket[15m])))",
+          "legendFormat": "{{journey}} p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Journey acceptance-to-terminal latency (p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "oldest nonterminal age"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(omi_journey_accepted_total{journey=\"capture_finalization\"}[6h])) - sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\"}[6h]))",
+          "legendFormat": "accepted minus terminal (6h)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(omi_capture_finalization_reconciliations_total[15m]))",
+          "legendFormat": "stale reconciliations / second",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max(listen_finalization_oldest_nonterminal_age_seconds)",
+          "legendFormat": "oldest nonterminal age",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Capture finalization reconciliation and nonterminal work",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/backend/database/conversation_finalization_jobs.py
+++ b/backend/database/conversation_finalization_jobs.py
@@ -31,6 +31,7 @@ class FinalizationIntent(TypedDict):
     dispatch_generation: int | None
     requires_byok: bool
     fanout_key: str | None
+    created: bool
 
 
 class FinalizationAdmission(TypedDict):
@@ -55,6 +56,7 @@ class FinalizationClaim(TypedDict):
     status: str
     lease_epoch: int | None
     attempt_count: int
+    created_at: datetime | None
 
 
 def _now() -> datetime:
@@ -70,8 +72,13 @@ def get_finalization_reconcile_stale_after() -> timedelta:
     return timedelta(seconds=max(30, seconds))
 
 
-def _claim_result(status: str, lease_epoch: int | None = None, attempt_count: int = 0) -> FinalizationClaim:
-    return {'status': status, 'lease_epoch': lease_epoch, 'attempt_count': attempt_count}
+def _claim_result(
+    status: str,
+    lease_epoch: int | None = None,
+    attempt_count: int = 0,
+    created_at: datetime | None = None,
+) -> FinalizationClaim:
+    return {'status': status, 'lease_epoch': lease_epoch, 'attempt_count': attempt_count, 'created_at': created_at}
 
 
 def _is_current_lease(job: dict[str, Any], dispatch_generation: int, lease_epoch: int) -> bool:
@@ -98,13 +105,14 @@ def _job_id(uid: str, conversation_id: str, revision: int) -> str:
     return document_id_from_seed(f'listen-finalization:{uid}:{conversation_id}:{revision}')
 
 
-def _intent_from_job(job_id: str, data: dict[str, Any]) -> FinalizationIntent:
+def _intent_from_job(job_id: str, data: dict[str, Any], *, created: bool = False) -> FinalizationIntent:
     return {
         'job_id': job_id,
         'status': str(data.get('status') or 'queued'),
         'dispatch_generation': int(data.get('dispatch_generation') or 1),
         'requires_byok': bool(data.get('requires_byok')),
         'fanout_key': data.get('fanout_key') if isinstance(data.get('fanout_key'), str) else None,
+        'created': created,
     }
 
 
@@ -115,6 +123,7 @@ def _no_finalization_intent(status: str) -> FinalizationIntent:
         'dispatch_generation': None,
         'requires_byok': False,
         'fanout_key': None,
+        'created': False,
     }
 
 
@@ -216,7 +225,7 @@ def _create_or_get_finalization_intent_txn(
             'finalization_status': status,
         },
     )
-    return _intent_from_job(job_id, job)
+    return _intent_from_job(job_id, job, created=True)
 
 
 def create_or_get_finalization_intent(
@@ -252,6 +261,7 @@ def _resume_blocked_byok_job_txn(transaction: Any, job_ref: Any, now: datetime) 
             'dispatch_generation': None,
             'requires_byok': False,
             'fanout_key': None,
+            'created': False,
         }
     job = snapshot.to_dict() or {}
     if job.get('status') == 'blocked_byok' and job.get('requires_byok'):
@@ -333,7 +343,13 @@ def _claim_finalization_job_txn(
             'attempt_count': attempt_count,
         },
     )
-    return _claim_result('claimed', lease_epoch, attempt_count)
+    created_at = job.get('created_at')
+    return _claim_result(
+        'claimed',
+        lease_epoch,
+        attempt_count,
+        created_at if isinstance(created_at, datetime) else None,
+    )
 
 
 def claim_finalization_job(
@@ -671,6 +687,7 @@ def _claim_finalization_replay_txn(
             'dispatch_generation': None,
             'requires_byok': False,
             'fanout_key': None,
+            'created': False,
         }
     job = snapshot.to_dict() or {}
     status = str(job.get('status') or '')

--- a/backend/docs/runbooks/real-traffic-journeys.md
+++ b/backend/docs/runbooks/real-traffic-journeys.md
@@ -1,0 +1,73 @@
+# Real-Traffic Journey Outcomes
+
+`omi_journey_*` measures user-originated traffic only. It does not create test
+accounts, synthetic canaries, or generated requests. Dev/beta and production
+are intentionally isolated: each Prometheus instance evaluates only the
+traffic it scrapes, with no cross-environment comparison or labels.
+
+## Closed metric contract
+
+| Metric | Labels | Meaning |
+| --- | --- | --- |
+| `omi_journey_accepted_total` | `journey` | A production boundary accepted work. |
+| `omi_journey_terminal_total` | `journey`, `outcome` | A one-shot terminal outcome for accepted work. |
+| `omi_journey_latency_seconds` | `journey`, `outcome` | Acceptance-to-terminal latency. |
+| `omi_capture_finalization_reconciliations_total` | `outcome` | A stale durable capture job was requeued, or its requeue handoff failed. |
+| `listen_finalization_oldest_nonterminal_age_seconds` | none | Age of the oldest queued, leased, or BYOK-blocked capture finalization job. |
+
+`journey` is exactly `chat_response`, `pusher_session`, or
+`capture_finalization`. `outcome` is exactly `success`, `failure`,
+`cancelled`, or `stale`; reconciliation `outcome` is exactly `requeued` or
+`enqueue_failed`. There are no user, conversation, request, error-text,
+provider, or content labels.
+
+## Boundary semantics
+
+- `chat_response` is accepted after `/v2/messages` has persisted the human
+  message and prepared its SSE response. `success` is recorded when the server
+  yields the terminal `done:` frame. `failure` means the server-side stream
+  raised; `cancelled` means the stream ended before a terminal frame because
+  its consumer disconnected or cancelled it. This cannot prove a client
+  rendered the response after the server yielded it.
+- `pusher_session` is accepted only after `/v1/trigger/listen` completes its
+  WebSocket accept. Close codes `1000` and `1001` are `success` unless the
+  server has already identified an application failure. A `1011` or stronger
+  application failure is `failure`; other transport/client endings are
+  `cancelled`, not product failures.
+- `capture_finalization` is accepted only once, when the Firestore finalization
+  outbox creates a new durable job. Successful completion is `success`, a
+  dead-letter is `failure`, and a lifecycle-fenced durable job is `stale`.
+  Existing job re-dispatches do not increment acceptance. A nonterminal job is
+  reconciled after its bounded stale delay; use the reconciliation counter and
+  oldest-nonterminal-age gauge to interpret accepted minus terminal work.
+
+## Dashboard, alerts, and scrape health
+
+The **Resilience / Fallbacks** dashboard includes all three journey success
+rates and p95 latencies. Success rate intentionally uses only terminal
+`success` and `failure` outcomes: cancelled client/transport endings and
+stale fenced capture jobs stay visible but do not masquerade as application
+failures.
+
+The terminal-success-rate panel stays empty (N/A) until a journey has a terminal
+success-or-failure outcome; it never presents idle traffic as a 0% success rate.
+
+Product-failure alerts require at least 20 terminal success-or-failure outcomes in 30 minutes,
+then alert only when the terminal failure share is above 10% for 10 minutes.
+No traffic produces a zero accepted count and does not page. The separate
+scrape-source alert requires both Prometheus jobs, `backend-listen-metrics` and
+`pusher-metrics`, to be present and every target to be up; it distinguishes an absent metric source from a healthy,
+idle product. Grafana query errors remain errors rather than product-outcome
+alerts.
+
+The expected authenticated `/metrics` scrape targets in both dev/beta and prod
+are `backend-listen-metrics` (chat plus Cloud Tasks capture-finalization
+worker) and `pusher-metrics` (pusher sessions plus inline capture finalization).
+The metric children are initialized at process startup, so a scraped idle
+target exports zeros; an absent series should be investigated as scrape or
+deployment health, not read as zero traffic.
+
+Known blind spots: a server can only observe the SSE/WS boundary it controls,
+not client rendering; process restarts may defer a terminal metric until the
+durable worker/reconciler resumes; and a durable job still within its bounded
+reconcile delay is deliberately nonterminal rather than an immediate failure.

--- a/backend/docs/runbooks/resilience-dashboards.md
+++ b/backend/docs/runbooks/resilience-dashboards.md
@@ -19,6 +19,7 @@ Cross-platform view of backend Prometheus fallbacks, desktop PostHog heals, and 
 | Fallback rate by component & outcome | `sum by (component, outcome) (rate(omi_fallback_total[5m]))` | Dashboard only (`recovered` is expected) |
 | Sync enqueue uncertainty share | `sum(rate(omi_sync_dispatch_attempts_total{mode="enqueue_uncertain"}[10m])) / clamp_min(sum(rate(omi_sync_dispatch_attempts_total[10m])), 1e-9)` | Dashboard only until Cloud Run scrape — see [sync-dispatch-fallback.md](./sync-dispatch-fallback.md) |
 | Pusher degraded sessions & ratio | `pusher_sessions_degraded`, `pusher_active_ws_connections`, ratio | **PAGE** — see [pusher-degraded.md](./pusher-degraded.md) |
+| Real-traffic journey outcomes | `omi_journey_*`, `omi_capture_finalization_reconciliations_total`, `listen_finalization_oldest_nonterminal_age_seconds` | Traffic-gated product alerts plus separate scrape-source health — see [real-traffic-journeys.md](./real-traffic-journeys.md) |
 | LLM gateway fallback rate | `sum(rate(llm_gateway_requests_total{fallback_used="true"}[30m])) / clamp_min(sum(rate(llm_gateway_requests_total[30m])), 1e-9)` | **Ticket** — see [llm-gateway-fallback.md](./llm-gateway-fallback.md) |
 
 The dashboard text panel repeats paging policy: page only on exhausted outcomes, sync enqueue uncertainty, and pusher degraded ratio. Successful `outcome=recovered` heals are dashboard-only.

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -72,6 +72,7 @@ from utils.llm.usage_tracker import set_usage_context, reset_usage_context, Feat
 from utils.users import get_user_display_name
 from utils.log_sanitizer import sanitize_pii
 from utils.observability import submit_langsmith_feedback
+from utils.observability.journeys import JourneyAttempt
 from utils.voice_duration_limiter import (
     compute_pcm_duration_ms,
     read_wav_duration_ms,
@@ -413,8 +414,11 @@ def send_message(
 
         return ai_message, ask_for_nps
 
+    journey_attempt = JourneyAttempt('chat_response')
+
     async def generate_stream():
         callback_data = {}
+        stream_exhausted = False
         # Set usage context for streaming (can't use 'with' across yields)
         usage_token = set_usage_context(uid, Features.CHAT)
         try:
@@ -440,9 +444,21 @@ def send_message(
                         encoded_response = base64.b64encode(bytes(response_message.model_dump_json(), 'utf-8')).decode(
                             'utf-8'
                         )
+                        # This is the furthest server-observable client boundary:
+                        # a yielded terminal frame is not a client-render acknowledgement.
+                        journey_attempt.finish('success')
                         yield f"done: {encoded_response}\n\n"
+            stream_exhausted = True
+        except asyncio.CancelledError:
+            journey_attempt.finish('cancelled')
+            raise
+        except Exception:
+            journey_attempt.finish('failure')
+            raise
         finally:
             reset_usage_context(usage_token)
+            if not journey_attempt.finished:
+                journey_attempt.finish('failure' if stream_exhausted else 'cancelled')
 
     return StreamingResponse(generate_stream(), media_type="text/event-stream")
 

--- a/backend/routers/conversation_finalization.py
+++ b/backend/routers/conversation_finalization.py
@@ -24,6 +24,7 @@ from utils.conversations.finalizer import (
 )
 from utils.executors import db_executor, run_blocking
 from utils.metrics import LISTEN_FINALIZATION_RETRIES_TOTAL
+from utils.observability.journeys import record_capture_finalization_terminal
 
 logger = logging.getLogger(__name__)
 
@@ -179,6 +180,11 @@ async def run_listen_finalization_job(
             )
         if not completed:
             return JSONResponse(status_code=409, content={'status': 'completion_conflict'})
+        accepted_at = job.get('created_at') if job else None
+        if disposition == ConversationFinalizationDisposition.fenced:
+            record_capture_finalization_terminal('stale', accepted_at)
+        else:
+            record_capture_finalization_terminal('success', accepted_at)
         return JSONResponse(status_code=200, content={'status': 'done'})
     except asyncio.CancelledError:
         release_lock = False

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -40,6 +40,7 @@ from utils.webhooks import (
 from utils.cloud_tasks import get_listen_finalization_tasks_max_attempts, is_audio_merge_dispatch_enabled
 from utils.other.storage import maybe_invalidate_conversation_playback, upload_audio_chunks_batch
 from utils.metrics import PUSHER_ACTIVE_WS_CONNECTIONS
+from utils.observability.journeys import JourneyAttempt, JourneyOutcome, record_capture_finalization_terminal
 from utils.speaker_identification import extract_speaker_samples
 import logging
 
@@ -78,6 +79,15 @@ WS_RECEIVE_TIMEOUT = 300.0  # seconds
 # before being force-cancelled.  Prevents hung GCS uploads or webhook calls from
 # blocking cleanup indefinitely.
 BG_DRAIN_TIMEOUT = 30.0  # seconds
+
+
+def pusher_session_outcome(close_code: int, *, application_failed: bool = False) -> JourneyOutcome:
+    """Classify accepted sessions without counting normal disconnects as failures."""
+    if application_failed or close_code == 1011:
+        return 'failure'
+    if close_code in {1000, 1001}:
+        return 'success'
+    return 'cancelled'
 
 
 class _SpeakerSampleRequest(TypedDict):
@@ -256,8 +266,10 @@ async def _process_conversation_task(
             await send_result({'conversation_id': conversation_id, 'error': 'job_completion_conflict'})
             return
         if disposition == ConversationFinalizationDisposition.fenced:
+            record_capture_finalization_terminal('stale', claim.get('created_at'))
             await send_result({'conversation_id': conversation_id, 'fenced': True})
             return
+        record_capture_finalization_terminal('success', claim.get('created_at'))
         await send_result({'conversation_id': conversation_id, 'success': True})
     except ConversationFinalizationError:
         terminal = await record_failure('processing_failed')
@@ -299,20 +311,29 @@ async def _websocket_util_trigger(
         await websocket.close(code=1011, reason="Dirty state")
         return
 
+    journey_attempt = JourneyAttempt('pusher_session')
     websocket_active = True
     shutdown_event = asyncio.Event()
     websocket_close_code = 1000
+    application_failed = False
 
-    # audio bytes
-    audio_bytes_webhook_delay_seconds = get_audio_bytes_webhook_seconds(uid)
-    audio_bytes_trigger_delay_seconds = 4
-    has_audio_apps_enabled = await run_blocking(db_executor, is_audio_bytes_app_enabled, uid)
-    private_cloud_sync_enabled = await run_blocking(db_executor, users_db.get_user_private_cloud_sync_enabled, uid)
-    cached_protection_level = (
-        (await run_blocking(db_executor, users_db.get_data_protection_level, uid))
-        if private_cloud_sync_enabled
-        else None
-    )
+    try:
+        # audio bytes
+        audio_bytes_webhook_delay_seconds = get_audio_bytes_webhook_seconds(uid)
+        audio_bytes_trigger_delay_seconds = 4
+        has_audio_apps_enabled = await run_blocking(db_executor, is_audio_bytes_app_enabled, uid)
+        private_cloud_sync_enabled = await run_blocking(db_executor, users_db.get_user_private_cloud_sync_enabled, uid)
+        cached_protection_level = (
+            (await run_blocking(db_executor, users_db.get_data_protection_level, uid))
+            if private_cloud_sync_enabled
+            else None
+        )
+    except asyncio.CancelledError:
+        journey_attempt.finish('cancelled')
+        raise
+    except Exception:
+        journey_attempt.finish('failure')
+        raise
 
     # Track background tasks to cancel on cleanup (prevents memory leaks from fire-and-forget tasks)
     bg_tasks: Set[asyncio.Task[Any]] = set()
@@ -566,6 +587,7 @@ async def _websocket_util_trigger(
     async def receive_tasks() -> None:
         nonlocal websocket_active
         nonlocal websocket_close_code
+        nonlocal application_failed
         nonlocal speaker_sample_queue
         nonlocal transcript_queue
         nonlocal audio_bytes_queue
@@ -582,7 +604,10 @@ async def _websocket_util_trigger(
                     data = await asyncio.wait_for(websocket.receive_bytes(), timeout=WS_RECEIVE_TIMEOUT)
                 except asyncio.TimeoutError:
                     logger.warning(f"WebSocket receive timeout ({WS_RECEIVE_TIMEOUT}s), closing connection {uid}")
-                    websocket_close_code = 1000
+                    # This is a dead upstream, not a normal remote close. Keep its
+                    # terminal outcome distinct from protocol close codes 1000/1001.
+                    websocket_close_code = 1011
+                    application_failed = True
                     break
                 header_type = struct.unpack('<I', data[:4])[0]
 
@@ -755,11 +780,13 @@ async def _websocket_util_trigger(
                         audiobuffer = bytearray()
                     continue
 
-        except WebSocketDisconnect:
+        except WebSocketDisconnect as exc:
+            websocket_close_code = exc.code or 1006
             logger.info("WebSocket disconnected")
         except Exception as e:
             logger.error(f'Could not process audio: error {e}')
             websocket_close_code = 1011
+            application_failed = True
         finally:
             # Flush any remaining private cloud sync buffer before shutdown
             if private_cloud_sync_enabled and current_conversation_id and len(private_cloud_sync_buffer) > 0:
@@ -797,6 +824,11 @@ async def _websocket_util_trigger(
             label="pusher",
         )
         logger.info(f"Supervisor exited: reason={exit_result.reason} task={exit_result.task_name} {uid}")
+        if exit_result.reason in {'crash', 'lifetime_done'}:
+            # A background worker dying or unexpectedly returning ends an accepted
+            # session abnormally even though the socket itself has no close frame.
+            websocket_close_code = 1011
+            application_failed = True
 
         if receive_task.done() and not receive_task.cancelled():
             exc = receive_task.exception()
@@ -814,8 +846,13 @@ async def _websocket_util_trigger(
         shutdown_event.set()
         await drain_tasks(bg_main_tasks, timeout=BG_DRAIN_TIMEOUT, label="pusher_bg", cancel=False)
 
+    except asyncio.CancelledError:
+        websocket_close_code = 1006
+        raise
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e}")
+        websocket_close_code = 1011
+        application_failed = True
     finally:
         shutdown_event.set()
         websocket_active = False
@@ -825,6 +862,8 @@ async def _websocket_util_trigger(
         bg_tasks.clear()
 
         PUSHER_ACTIVE_WS_CONNECTIONS.dec()
+
+        journey_attempt.finish(pusher_session_outcome(websocket_close_code, application_failed=application_failed))
 
         if websocket.client_state == WebSocketState.CONNECTED:
             try:

--- a/backend/services/conversation_finalization.py
+++ b/backend/services/conversation_finalization.py
@@ -24,6 +24,10 @@ from utils.metrics import (
     LISTEN_FINALIZATION_RETRIES_TOTAL,
 )
 from utils.observability.fallback import record_fallback
+from utils.observability.journeys import (
+    record_capture_finalization_reconciliation,
+    record_capture_finalization_terminal,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +68,7 @@ def reconcile_listen_finalization_jobs(limit: int = 100, *, firestore_client: An
         try:
             enqueue_listen_finalization_job(job_id, int(claimed['dispatch_generation']))
         except Exception:
+            record_capture_finalization_reconciliation('enqueue_failed')
             record_fallback(
                 component='pusher',
                 from_mode='cloud_tasks',
@@ -76,6 +81,7 @@ def reconcile_listen_finalization_jobs(limit: int = 100, *, firestore_client: An
             result['enqueue_failed'] += 1
             continue
         result['requeued'] += 1
+        record_capture_finalization_reconciliation('requeued')
         LISTEN_FINALIZATION_RETRIES_TOTAL.inc()
 
     _publish_job_metrics(firestore_client=firestore_client)
@@ -94,6 +100,14 @@ def final_attempt_failed(
     )
     if marked:
         LISTEN_FINALIZATION_DEAD_LETTER_TOTAL.inc()
+        try:
+            job = jobs_db.get_finalization_job(job_id, firestore_client=firestore_client)
+            accepted_at = job.get('created_at') if job else None
+            record_capture_finalization_terminal('failure', accepted_at)
+        except Exception:
+            # Dead-lettering is authoritative; a best-effort metric lookup must
+            # never prevent the caller from discarding the terminal conversation.
+            logger.exception('listen finalization terminal metric lookup failed job=%s', job_id)
     return marked
 
 

--- a/backend/tests/unit/test_chat_quota_counting_router.py
+++ b/backend/tests/unit/test_chat_quota_counting_router.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+import pytest
 
 BACKEND_DIR = Path(__file__).resolve().parents[2]
 
@@ -108,6 +109,24 @@ def _make_chat_client():
     sanitizer.sanitize_pii = lambda value: value
     observability = _install_package('utils.observability', BACKEND_DIR / 'utils' / 'observability')
     observability.submit_langsmith_feedback = MagicMock()
+    journey_observability = _install_module('utils.observability.journeys', ModuleType('utils.observability.journeys'))
+
+    class JourneyAttempt:
+        instances = []
+
+        def __init__(self, journey):
+            self.journey = journey
+            self.finished = False
+            self.outcomes = []
+            self.__class__.instances.append(self)
+
+        def finish(self, outcome):
+            if self.finished:
+                return
+            self.finished = True
+            self.outcomes.append(outcome)
+
+    journey_observability.JourneyAttempt = JourneyAttempt
     transcription_observability = _install_module(
         'utils.observability.transcription',
         ModuleType('utils.observability.transcription'),
@@ -266,6 +285,39 @@ def test_v2_messages_quota_exceeded_reply_does_not_record_quota_question():
         assert response.status_code == 200
         assert 'done: ' in response.text
         module.llm_usage_db.record_chat_quota_question.assert_not_called()
+    finally:
+        _cleanup(saved)
+
+
+def test_v2_messages_records_success_when_the_terminal_sse_frame_is_yielded():
+    client, module, saved = _make_chat_client()
+    try:
+        response = client.post('/v2/messages', json={'text': 'hello', 'file_ids': []})
+
+        assert response.status_code == 200
+        assert 'done: ' in response.text
+        assert len(module.JourneyAttempt.instances) == 1
+        assert module.JourneyAttempt.instances[0].journey == 'chat_response'
+        assert module.JourneyAttempt.instances[0].outcomes == ['success']
+    finally:
+        _cleanup(saved)
+
+
+def test_v2_messages_records_failure_when_the_production_stream_errors():
+    client, module, saved = _make_chat_client()
+    try:
+
+        async def failing_stream(*_args, **_kwargs):
+            raise RuntimeError('provider unavailable')
+            yield ''
+
+        module.execute_chat_stream = failing_stream
+
+        with pytest.raises(RuntimeError, match='provider unavailable'):
+            client.post('/v2/messages', json={'text': 'hello', 'file_ids': []})
+
+        assert len(module.JourneyAttempt.instances) == 1
+        assert module.JourneyAttempt.instances[0].outcomes == ['failure']
     finally:
         _cleanup(saved)
 

--- a/backend/tests/unit/test_conversation_finalization_jobs.py
+++ b/backend/tests/unit/test_conversation_finalization_jobs.py
@@ -201,6 +201,7 @@ def test_duplicate_reconnect_reuses_the_same_outbox_job():
         'dispatch_generation': 1,
         'requires_byok': False,
         'fanout_key': None,
+        'created': False,
     }
     assert transaction.sets == []
     assert transaction.updates == []
@@ -304,7 +305,7 @@ def test_duplicate_task_delivery_claims_only_once_until_lease_expires():
     first = _Transaction()
 
     claim = jobs._claim_finalization_job_txn(first, ref, 2, False, 1500, now)
-    assert claim == {'status': 'claimed', 'lease_epoch': 1, 'attempt_count': 1}
+    assert claim == {'status': 'claimed', 'lease_epoch': 1, 'attempt_count': 1, 'created_at': None}
     claim_update = first.updates[0][1]
     assert claim_update['status'] == 'leased'
     assert claim_update['attempt_count'] == 1
@@ -315,6 +316,7 @@ def test_duplicate_task_delivery_claims_only_once_until_lease_expires():
         'status': 'leased',
         'lease_epoch': None,
         'attempt_count': 0,
+        'created_at': None,
     }
     assert duplicate.updates == []
 
@@ -333,7 +335,7 @@ def test_expired_worker_lease_can_be_safely_reclaimed():
     transaction = _Transaction()
 
     claim = jobs._claim_finalization_job_txn(transaction, ref, 2, False, 1500, now)
-    assert claim == {'status': 'claimed', 'lease_epoch': 1, 'attempt_count': 2}
+    assert claim == {'status': 'claimed', 'lease_epoch': 1, 'attempt_count': 2, 'created_at': None}
     assert transaction.updates[0][1]['attempt_count'] == 2
     assert transaction.updates[0][1]['lease_epoch'] == 1
 
@@ -470,7 +472,7 @@ def test_completed_fenced_job_replays_as_a_fenced_result():
 
     claim = jobs._claim_finalization_job_txn(_Transaction(), ref, 1, False, 1500, _now())
 
-    assert claim == {'status': 'fenced', 'lease_epoch': None, 'attempt_count': 0}
+    assert claim == {'status': 'fenced', 'lease_epoch': None, 'attempt_count': 0, 'created_at': None}
 
 
 def test_live_pusher_claim_cannot_use_another_conversations_job():
@@ -496,7 +498,7 @@ def test_live_pusher_claim_cannot_use_another_conversations_job():
         expected_conversation_id='other-conversation',
     )
 
-    assert status == {'status': 'identity_mismatch', 'lease_epoch': None, 'attempt_count': 0}
+    assert status == {'status': 'identity_mismatch', 'lease_epoch': None, 'attempt_count': 0, 'created_at': None}
     assert transaction.updates == []
 
 
@@ -508,6 +510,7 @@ def test_completed_and_dead_letter_jobs_never_execute_again():
             'status': status,
             'lease_epoch': None,
             'attempt_count': 0,
+            'created_at': None,
         }
         assert transaction.updates == []
 
@@ -547,7 +550,7 @@ def test_expired_lease_reclaim_fences_a_stale_worker_terminal_write():
 
     reclaim = _Transaction()
     new_claim = jobs._claim_finalization_job_txn(reclaim, ref, 3, False, 1500, now)
-    assert new_claim == {'status': 'claimed', 'lease_epoch': 5, 'attempt_count': 1}
+    assert new_claim == {'status': 'claimed', 'lease_epoch': 5, 'attempt_count': 1, 'created_at': None}
     ref.data = ref.data | reclaim.updates[0][1]
 
     stale_completion = _Transaction()

--- a/backend/tests/unit/test_journey_observability.py
+++ b/backend/tests/unit/test_journey_observability.py
@@ -1,0 +1,117 @@
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from services import conversation_finalization
+from utils import metrics
+from utils.observability import journeys
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+def _install_journey_metrics(monkeypatch):
+    accepted = MagicMock()
+    terminal = MagicMock()
+    latency = MagicMock()
+    reconciliations = MagicMock()
+    monkeypatch.setattr(journeys, 'OMI_JOURNEY_ACCEPTED_TOTAL', accepted)
+    monkeypatch.setattr(journeys, 'OMI_JOURNEY_TERMINAL_TOTAL', terminal)
+    monkeypatch.setattr(journeys, 'OMI_JOURNEY_LATENCY_SECONDS', latency)
+    monkeypatch.setattr(journeys, 'OMI_CAPTURE_FINALIZATION_RECONCILIATIONS_TOTAL', reconciliations)
+    accepted.labels.return_value = MagicMock()
+    terminal.labels.return_value = MagicMock()
+    latency.labels.return_value = MagicMock()
+    reconciliations.labels.return_value = MagicMock()
+    return accepted, terminal, latency, reconciliations
+
+
+def test_journey_contract_uses_only_closed_privacy_safe_labels(monkeypatch):
+    accepted, terminal, latency, reconciliations = _install_journey_metrics(monkeypatch)
+
+    journeys.record_journey_accepted('chat_response')
+    journeys.record_journey_terminal('pusher_session', 'cancelled', 1.5)
+    journeys.record_capture_finalization_reconciliation('requeued')
+
+    accepted.labels.assert_called_once_with(journey='chat_response')
+    terminal.labels.assert_called_once_with(journey='pusher_session', outcome='cancelled')
+    latency.labels.assert_called_once_with(journey='pusher_session', outcome='cancelled')
+    reconciliations.labels.assert_called_once_with(outcome='requeued')
+    with pytest.raises(ValueError, match='unknown journey'):
+        journeys.record_journey_accepted('user-123')
+    with pytest.raises(ValueError, match='unknown journey outcome'):
+        journeys.record_journey_terminal('chat_response', 'raw exception text', 1.0)
+
+
+def test_capture_terminal_uses_persisted_acceptance_time(monkeypatch):
+    _accepted, terminal, latency, _reconciliations = _install_journey_metrics(monkeypatch)
+    accepted_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+
+    journeys.record_capture_finalization_terminal('success', accepted_at)
+
+    terminal.labels.assert_called_once_with(journey='capture_finalization', outcome='success')
+    latency.labels.assert_called_once_with(journey='capture_finalization', outcome='success')
+    observed = latency.labels.return_value.observe.call_args.args[0]
+    assert 4.0 <= observed <= 6.0
+
+
+def test_terminal_finalization_failure_records_once_after_dead_letter(monkeypatch):
+    dead_letter = MagicMock(return_value=True)
+    accepted_at = datetime.now(timezone.utc) - timedelta(seconds=12)
+    terminal = MagicMock()
+    monkeypatch.setattr(conversation_finalization.jobs_db, 'mark_finalization_dead_letter', dead_letter)
+    monkeypatch.setattr(
+        conversation_finalization.jobs_db,
+        'get_finalization_job',
+        MagicMock(return_value={'created_at': accepted_at}),
+    )
+    monkeypatch.setattr(conversation_finalization, 'LISTEN_FINALIZATION_DEAD_LETTER_TOTAL', MagicMock())
+    monkeypatch.setattr(conversation_finalization, 'record_capture_finalization_terminal', terminal)
+
+    assert conversation_finalization.final_attempt_failed('job-1', 2, 3, 4) is True
+
+    dead_letter.assert_called_once_with('job-1', 2, 3, 4, firestore_client=None)
+    terminal.assert_called_once_with('failure', accepted_at)
+
+
+def test_idle_metrics_and_monitoring_contract_distinguish_traffic_from_a_missing_scrape_source():
+    exported = metrics.generate_latest().decode()
+    assert 'omi_journey_accepted_total{journey="chat_response"}' in exported
+    assert 'omi_journey_terminal_total{journey="pusher_session",outcome="success"}' in exported
+    assert 'omi_capture_finalization_reconciliations_total{outcome="requeued"}' in exported
+
+    monitoring = REPO / 'backend/charts/monitoring'
+    split_alerts = json.loads((monitoring / 'alerts/resilience.json').read_text(encoding='utf-8'))
+    combined_alerts = json.loads((monitoring / 'alert-rules.json').read_text(encoding='utf-8'))
+    expected_ids = {
+        'omi-journey-chat-fail',
+        'omi-journey-pusher-fail',
+        'omi-journey-capture-fail',
+        'omi-journey-scrape-missing',
+    }
+    assert expected_ids <= {rule['uid'] for rule in split_alerts}
+    assert expected_ids <= {rule['uid'] for rule in combined_alerts}
+
+    product_rules = [rule for rule in split_alerts if rule['uid'] in expected_ids - {'omi-journey-scrape-missing'}]
+    assert {rule['noDataState'] for rule in product_rules} == {'NoData'}
+    for rule in product_rules:
+        assert 'outcome=~"success|failure"' in rule['data'][0]['model']['expr']
+        assert '$A >= 20 && $B > 0.10' in rule['data'][2]['model']['expression']
+    scrape_rule = next(rule for rule in split_alerts if rule['uid'] == 'omi-journey-scrape-missing')
+    assert scrape_rule['noDataState'] == 'Alerting'
+    assert 'count by (job)' in scrape_rule['data'][0]['model']['expr']
+    assert 'backend-listen-metrics|pusher-metrics' in scrape_rule['data'][0]['model']['expr']
+
+    dashboard = json.loads(
+        (monitoring / 'dashboards/omi-services/resilience-fallbacks.json').read_text(encoding='utf-8')
+    )
+    panel_titles = {panel['title'] for panel in dashboard['panels']}
+    assert 'Journey terminal success rate (success / success + failure)' in panel_titles
+    assert 'Journey acceptance-to-terminal latency (p95)' in panel_titles
+    assert 'Capture finalization reconciliation and nonterminal work' in panel_titles
+    success_panel = next(
+        panel for panel in dashboard['panels'] if panel['title'].startswith('Journey terminal success')
+    )
+    assert 'and on (journey)' in success_panel['targets'][0]['expr']

--- a/backend/tests/unit/test_listen_finalization_cloud_tasks.py
+++ b/backend/tests/unit/test_listen_finalization_cloud_tasks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -58,6 +59,33 @@ def test_platform_key_job_dispatches_to_cloud_tasks(monkeypatch):
 
     assert result['route'] == 'cloud_tasks'
     enqueue.assert_called_once_with('job-1', 2)
+
+
+def test_durable_finalization_acceptance_counts_only_a_new_outbox_job(monkeypatch):
+    intent = {'job_id': 'job-1', 'status': 'queued', 'dispatch_generation': 2, 'requires_byok': False, 'created': True}
+    accepted = MagicMock()
+    _mock_lifecycle_conversation(monkeypatch)
+    monkeypatch.setattr(lifecycle_service.jobs_db, 'create_or_get_finalization_intent', MagicMock(return_value=intent))
+    monkeypatch.setattr(lifecycle_service, 'is_listen_finalization_dispatch_enabled', lambda: False)
+    monkeypatch.setattr(lifecycle_service, 'record_journey_accepted', accepted)
+
+    result = lifecycle_service.request_finalization('uid-1', 'conversation-1', has_byok_keys=False)
+
+    assert result['route'] == 'pusher'
+    accepted.assert_called_once_with('capture_finalization')
+
+
+def test_durable_finalization_redelivery_does_not_count_as_new_traffic(monkeypatch):
+    intent = {'job_id': 'job-1', 'status': 'queued', 'dispatch_generation': 2, 'requires_byok': False, 'created': False}
+    accepted = MagicMock()
+    _mock_lifecycle_conversation(monkeypatch)
+    monkeypatch.setattr(lifecycle_service.jobs_db, 'create_or_get_finalization_intent', MagicMock(return_value=intent))
+    monkeypatch.setattr(lifecycle_service, 'is_listen_finalization_dispatch_enabled', lambda: False)
+    monkeypatch.setattr(lifecycle_service, 'record_journey_accepted', accepted)
+
+    lifecycle_service.request_finalization('uid-1', 'conversation-1', has_byok_keys=False)
+
+    accepted.assert_not_called()
 
 
 def test_enqueue_failure_leaves_job_queued_for_reconciler(monkeypatch):
@@ -188,6 +216,49 @@ class _PusherWebSocket:
         self.sent.append(payload)
 
 
+class _PusherLifecycleWebSocket:
+    def __init__(self, receive_bytes):
+        self._receive_bytes = receive_bytes
+        self.accepted = False
+        self.client_state = pusher_router.WebSocketState.DISCONNECTED
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def receive_bytes(self) -> bytes:
+        return await self._receive_bytes()
+
+
+class _PusherJourneyAttempt:
+    outcomes: list[str] = []
+
+    def __init__(self, journey: str) -> None:
+        assert journey == 'pusher_session'
+
+    def finish(self, outcome: str) -> None:
+        self.outcomes.append(outcome)
+
+
+def _patch_pusher_session_dependencies(monkeypatch) -> None:
+    monkeypatch.setattr(pusher_router, 'get_audio_bytes_webhook_seconds', lambda _uid: None)
+    monkeypatch.setattr(pusher_router, 'is_audio_bytes_app_enabled', lambda _uid: False)
+    monkeypatch.setattr(pusher_router.users_db, 'get_user_private_cloud_sync_enabled', lambda _uid: False)
+    monkeypatch.setattr(pusher_router, 'run_blocking', _inline_run_blocking)
+    monkeypatch.setattr(pusher_router, 'PUSHER_ACTIVE_WS_CONNECTIONS', MagicMock())
+    monkeypatch.setattr(pusher_router, 'JourneyAttempt', _PusherJourneyAttempt)
+    monkeypatch.setattr(pusher_router, 'create_named_task', lambda coro, *, name: asyncio.create_task(coro, name=name))
+
+    async def drain(tasks, *, cancel, **_kwargs):
+        if not cancel:
+            return
+        tasks = list(tasks)
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    monkeypatch.setattr(pusher_router, 'drain_tasks', drain)
+
+
 async def _inline_run_blocking(_executor, func, *args, **kwargs):
     return func(*args, **kwargs)
 
@@ -262,11 +333,15 @@ async def test_worker_completes_claimed_job(monkeypatch):
         jobs_db, 'claim_finalization_job', lambda *args, **kwargs: {'status': 'claimed', 'lease_epoch': 1}
     )
     monkeypatch.setattr(
-        jobs_db, 'get_finalization_job', lambda job_id: {'uid': 'uid-1', 'conversation_id': 'conversation-1'}
+        jobs_db,
+        'get_finalization_job',
+        lambda job_id: {'uid': 'uid-1', 'conversation_id': 'conversation-1', 'created_at': 'accepted-at'},
     )
     monkeypatch.setattr(finalization_router, 'finalize_persisted_conversation', AsyncMock())
     completed = MagicMock(return_value=True)
+    terminal = MagicMock()
     monkeypatch.setattr(jobs_db, 'mark_finalization_completed', completed)
+    monkeypatch.setattr(finalization_router, 'record_capture_finalization_terminal', terminal)
 
     response = await finalization_router.run_listen_finalization_job(
         _Request({'job_id': 'job-1', 'dispatch_generation': 1}), task_retry_count=0
@@ -275,6 +350,7 @@ async def test_worker_completes_claimed_job(monkeypatch):
     assert response.status_code == 200
     assert json.loads(response.body) == {'status': 'done'}
     completed.assert_called_once_with('job-1', 1, 1)
+    terminal.assert_called_once_with('success', 'accepted-at')
 
 
 @pytest.mark.anyio
@@ -286,7 +362,9 @@ async def test_worker_closes_a_fenced_finalization_without_fanout(monkeypatch):
         jobs_db, 'claim_finalization_job', lambda *args, **kwargs: {'status': 'claimed', 'lease_epoch': 1}
     )
     monkeypatch.setattr(
-        jobs_db, 'get_finalization_job', lambda job_id: {'uid': 'uid-1', 'conversation_id': 'conversation-1'}
+        jobs_db,
+        'get_finalization_job',
+        lambda job_id: {'uid': 'uid-1', 'conversation_id': 'conversation-1', 'created_at': 'accepted-at'},
     )
     monkeypatch.setattr(
         finalization_router,
@@ -297,10 +375,12 @@ async def test_worker_closes_a_fenced_finalization_without_fanout(monkeypatch):
     fenced_completion = MagicMock(return_value=True)
     retryable = MagicMock()
     dead_letter = MagicMock()
+    terminal = MagicMock()
     monkeypatch.setattr(jobs_db, 'mark_finalization_completed', normal_completion)
     monkeypatch.setattr(jobs_db, 'mark_finalization_retryable', retryable)
     monkeypatch.setattr(finalization_router, 'final_attempt_failed', dead_letter)
     monkeypatch.setattr(finalization_router.lifecycle_service, 'complete_fenced_finalization', fenced_completion)
+    monkeypatch.setattr(finalization_router, 'record_capture_finalization_terminal', terminal)
 
     response = await finalization_router.run_listen_finalization_job(
         _Request({'job_id': 'job-1', 'dispatch_generation': 1}), task_retry_count=0
@@ -312,6 +392,7 @@ async def test_worker_closes_a_fenced_finalization_without_fanout(monkeypatch):
     fenced_completion.assert_called_once_with('job-1', 1, 1)
     retryable.assert_not_called()
     dead_letter.assert_not_called()
+    terminal.assert_called_once_with('stale', 'accepted-at')
 
 
 @pytest.mark.anyio
@@ -351,6 +432,78 @@ async def test_pusher_rejects_legacy_finalization_without_a_durable_job():
     result = json.loads(websocket.sent[0][4:])
     assert frame_type == 201
     assert result == {'conversation_id': 'conversation-1', 'error': 'durable_job_required'}
+
+
+@pytest.mark.parametrize(
+    ('close_code', 'application_failed', 'outcome'),
+    [
+        (1000, False, 'success'),
+        (1001, False, 'success'),
+        (1006, False, 'cancelled'),
+        (1011, False, 'failure'),
+        (1000, True, 'failure'),
+    ],
+)
+def test_pusher_session_outcome_keeps_normal_disconnects_out_of_failures(close_code, application_failed, outcome):
+    assert pusher_router.pusher_session_outcome(close_code, application_failed=application_failed) == outcome
+
+
+@pytest.mark.anyio
+async def test_pusher_setup_cancellation_terminalizes_an_accepted_session(monkeypatch):
+    _PusherJourneyAttempt.outcomes = []
+
+    async def cancel_during_setup(*_args, **_kwargs):
+        raise asyncio.CancelledError
+
+    websocket = _PusherLifecycleWebSocket(receive_bytes=AsyncMock())
+    monkeypatch.setattr(pusher_router, 'get_audio_bytes_webhook_seconds', lambda _uid: None)
+    monkeypatch.setattr(pusher_router, 'run_blocking', cancel_during_setup)
+    monkeypatch.setattr(pusher_router, 'JourneyAttempt', _PusherJourneyAttempt)
+
+    with pytest.raises(asyncio.CancelledError):
+        await pusher_router._websocket_util_trigger(websocket, 'uid-1')
+
+    assert websocket.accepted is True
+    assert _PusherJourneyAttempt.outcomes == ['cancelled']
+
+
+@pytest.mark.anyio
+async def test_pusher_background_task_crash_terminalizes_as_failure(monkeypatch):
+    _PusherJourneyAttempt.outcomes = []
+    _patch_pusher_session_dependencies(monkeypatch)
+    websocket = _PusherLifecycleWebSocket(receive_bytes=AsyncMock())
+
+    async def supervisor(**_kwargs):
+        return SimpleNamespace(reason='crash', task_name='ws:uid-1:transcripts')
+
+    monkeypatch.setattr(pusher_router, 'supervise_tasks', supervisor)
+
+    await pusher_router._websocket_util_trigger(websocket, 'uid-1')
+
+    assert websocket.accepted is True
+    assert _PusherJourneyAttempt.outcomes == ['failure']
+
+
+@pytest.mark.anyio
+async def test_pusher_dead_peer_timeout_terminalizes_as_failure(monkeypatch):
+    _PusherJourneyAttempt.outcomes = []
+    _patch_pusher_session_dependencies(monkeypatch)
+
+    async def timeout() -> bytes:
+        raise asyncio.TimeoutError
+
+    websocket = _PusherLifecycleWebSocket(receive_bytes=timeout)
+
+    async def supervisor(*, receive_task, **_kwargs):
+        await receive_task
+        return SimpleNamespace(reason='disconnect', task_name='ws:uid-1:receive')
+
+    monkeypatch.setattr(pusher_router, 'supervise_tasks', supervisor)
+
+    await pusher_router._websocket_util_trigger(websocket, 'uid-1')
+
+    assert websocket.accepted is True
+    assert _PusherJourneyAttempt.outcomes == ['failure']
 
 
 @pytest.mark.anyio

--- a/backend/utils/conversations/lifecycle.py
+++ b/backend/utils/conversations/lifecycle.py
@@ -24,6 +24,7 @@ from utils.conversations.finalization_decision import (
     decide_finalization,
 )
 from utils.observability.fallback import record_fallback
+from utils.observability.journeys import record_journey_accepted
 
 logger = logging.getLogger(__name__)
 
@@ -525,6 +526,10 @@ def request_finalization(
         finalization_admission=lambda conversation: _finalization_admission(conversation, conversation_id),
         firestore_client=firestore_client,
     )
+    # The outbox transaction is the authoritative acceptance boundary. Count
+    # only newly-created jobs so an idempotent re-dispatch cannot inflate traffic.
+    if intent.get('created'):
+        record_journey_accepted('capture_finalization')
     status = intent['status']
     if intent['job_id'] is None or status in {'missing', 'no_content', 'deferred', 'completed', 'dead_letter'}:
         return dict(intent) | {'route': 'noop'}

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -26,6 +26,41 @@ PUSHER_SESSION_DEGRADED = Gauge(
     'Number of sessions currently in degraded mode (pusher unavailable)',
 )
 
+OMI_JOURNEY_ACCEPTED_TOTAL = Counter(
+    'omi_journey_accepted_total',
+    'Accepted real-traffic product journeys by closed journey name',
+    ['journey'],
+)
+
+OMI_JOURNEY_TERMINAL_TOTAL = Counter(
+    'omi_journey_terminal_total',
+    'Terminal real-traffic product journey outcomes by closed journey and outcome names',
+    ['journey', 'outcome'],
+)
+
+OMI_JOURNEY_LATENCY_SECONDS = Histogram(
+    'omi_journey_latency_seconds',
+    'Elapsed time from accepted real-traffic journey to terminal outcome',
+    ['journey', 'outcome'],
+    buckets=(0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 900, 3600, 21600, 86400),
+)
+
+OMI_CAPTURE_FINALIZATION_RECONCILIATIONS_TOTAL = Counter(
+    'omi_capture_finalization_reconciliations_total',
+    'Reconciliation attempts for stale nonterminal capture finalization jobs',
+    ['outcome'],
+)
+
+# Export zero-valued children from a healthy but idle process. This lets
+# Prometheus/Grafana distinguish no user traffic from an absent scrape target.
+for _journey in ('chat_response', 'pusher_session', 'capture_finalization'):
+    OMI_JOURNEY_ACCEPTED_TOTAL.labels(journey=_journey)
+    for _outcome in ('success', 'failure', 'cancelled', 'stale'):
+        OMI_JOURNEY_TERMINAL_TOTAL.labels(journey=_journey, outcome=_outcome)
+        OMI_JOURNEY_LATENCY_SECONDS.labels(journey=_journey, outcome=_outcome)
+for _outcome in ('requeued', 'enqueue_failed'):
+    OMI_CAPTURE_FINALIZATION_RECONCILIATIONS_TOTAL.labels(outcome=_outcome)
+
 LISTEN_FINALIZATION_OLDEST_NONTERMINAL_AGE_SECONDS = Gauge(
     'listen_finalization_oldest_nonterminal_age_seconds',
     'Age of the oldest queued, leased, or blocked listen finalization job',

--- a/backend/utils/observability/journeys.py
+++ b/backend/utils/observability/journeys.py
@@ -1,0 +1,87 @@
+"""Closed, privacy-safe outcome metrics for real product traffic journeys."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from time import monotonic
+from typing import Literal, cast
+
+from utils.metrics import (
+    OMI_CAPTURE_FINALIZATION_RECONCILIATIONS_TOTAL,
+    OMI_JOURNEY_ACCEPTED_TOTAL,
+    OMI_JOURNEY_LATENCY_SECONDS,
+    OMI_JOURNEY_TERMINAL_TOTAL,
+)
+
+JourneyName = Literal['chat_response', 'pusher_session', 'capture_finalization']
+JourneyOutcome = Literal['success', 'failure', 'cancelled', 'stale']
+ReconciliationOutcome = Literal['requeued', 'enqueue_failed']
+
+_JOURNEYS = frozenset({'chat_response', 'pusher_session', 'capture_finalization'})
+_OUTCOMES = frozenset({'success', 'failure', 'cancelled', 'stale'})
+_RECONCILIATION_OUTCOMES = frozenset({'requeued', 'enqueue_failed'})
+
+
+def _journey(value: str) -> JourneyName:
+    if value not in _JOURNEYS:
+        raise ValueError(f'unknown journey: {value}')
+    return cast(JourneyName, value)
+
+
+def _outcome(value: str) -> JourneyOutcome:
+    if value not in _OUTCOMES:
+        raise ValueError(f'unknown journey outcome: {value}')
+    return cast(JourneyOutcome, value)
+
+
+def record_journey_accepted(journey: JourneyName) -> None:
+    """Record an accepted journey after its authoritative durable/protocol boundary."""
+    OMI_JOURNEY_ACCEPTED_TOTAL.labels(journey=_journey(journey)).inc()
+
+
+def record_journey_terminal(journey: JourneyName, outcome: JourneyOutcome, elapsed_seconds: float) -> None:
+    """Record exactly one terminal outcome and its elapsed time for one journey."""
+    labels = {'journey': _journey(journey), 'outcome': _outcome(outcome)}
+    OMI_JOURNEY_TERMINAL_TOTAL.labels(**labels).inc()
+    OMI_JOURNEY_LATENCY_SECONDS.labels(**labels).observe(max(0.0, elapsed_seconds))
+
+
+class JourneyAttempt:
+    """In-process accepted journey with a one-shot terminal outcome."""
+
+    def __init__(self, journey: JourneyName) -> None:
+        self.journey: JourneyName = _journey(journey)
+        self.started_at = monotonic()
+        self._finished = False
+        record_journey_accepted(self.journey)
+
+    @property
+    def finished(self) -> bool:
+        return self._finished
+
+    def finish(self, outcome: JourneyOutcome) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        record_journey_terminal(self.journey, outcome, monotonic() - self.started_at)
+
+
+def record_capture_finalization_terminal(outcome: JourneyOutcome, accepted_at: datetime | None) -> None:
+    """Terminalize a durable capture job using its persisted acceptance time."""
+    if accepted_at is None:
+        # Legacy jobs can predate created_at. Keep the outcome visible without
+        # fabricating a latency value.
+        labels = {'journey': _journey('capture_finalization'), 'outcome': _outcome(outcome)}
+        OMI_JOURNEY_TERMINAL_TOTAL.labels(**labels).inc()
+        return
+    if accepted_at.tzinfo is None:
+        accepted_at = accepted_at.replace(tzinfo=timezone.utc)
+    elapsed_seconds = (datetime.now(timezone.utc) - accepted_at).total_seconds()
+    record_journey_terminal('capture_finalization', outcome, elapsed_seconds)
+
+
+def record_capture_finalization_reconciliation(outcome: ReconciliationOutcome) -> None:
+    """Record a bounded reconciliation event for stale capture work."""
+    if outcome not in _RECONCILIATION_OUTCOMES:
+        raise ValueError(f'unknown finalization reconciliation outcome: {outcome}')
+    OMI_CAPTURE_FINALIZATION_RECONCILIATIONS_TOTAL.labels(outcome=outcome).inc()


### PR DESCRIPTION
Closes #9786

## Summary

- Add closed, privacy-safe accepted/terminal/latency metrics for chat SSE, pusher sessions, and durable capture finalization.
- Classify normal pusher closes separately from cancellation and application failures; include setup cancellation, dead-peer timeout, and supervised task crashes.
- Add reconciliation visibility plus traffic-gated Grafana panels, scrape-health and outcome alerts, and an operational runbook.

## Root cause and durable guard

Outcome boundaries were previously inferred from logs and process-local signals rather than one shared, bounded metric contract. The new journey helper validates its closed labels, terminalizes attempts once, tracks durable finalization from persisted job creation through fenced/dead-letter outcomes, and has route/lifecycle regressions for terminal paths.

## Verification

- `BACKEND_PYTEST_WORKERS=1 bash backend/test.sh` (full backend suite, passed)
- Focused journey/route/lifecycle suite: 92 passed
- `pyright` on changed production files: 0 errors
- `make preflight` (15 applicable checks, passed)
- JSON parse, alert UID uniqueness, and split/combined alert equivalence checks passed

## Review

- Independent Sol subagent review: approved after identifying and verifying fixes for pusher cancellation/crash classification and idle dashboard semantics.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

