### PR TITLE
fix(desktop): classify retired-socket ENOTCONN as expected teardown (#9666)

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
@@ -4,10 +4,12 @@ import Foundation
 ///
 /// Gemini can idle-close warm sessions with WebSocket 1008 after the socket has
 /// lived for a while, and OpenAI has a known maximum-session-duration close.
-/// Both expected lifecycle paths should re-warm quietly rather than page Sentry
-/// as production errors. Fast 1008 closes are different: they usually mean
-/// provider policy/auth/config rejection and should still be reported, but with
-/// a stable category instead of raw provider text.
+/// OpenAI's transport can also surface an already-retired socket as an ENOTCONN
+/// ("Socket is not connected") write race, typically right after the 60-minute
+/// rotation. All of these expected lifecycle paths should re-warm quietly rather
+/// than page Sentry as production errors. Fast 1008 closes are different: they
+/// usually mean provider policy/auth/config rejection and should still be
+/// reported, but with a stable category instead of raw provider text.
 enum RealtimeHubCloseCategory: String {
   case expectedIdleTeardown = "expected_idle_teardown"
   case expectedSessionRotation = "expected_session_rotation"
@@ -40,6 +42,17 @@ enum RealtimeHubCloseClassifier {
       && lower.contains("60 minutes")
     {
       return .expectedSessionRotation
+    }
+    // A retired socket surfaces later writes as ENOTCONN. On an aged socket with
+    // no active turn (e.g. the window right after a 60-minute rotation) this is
+    // an expected transport teardown, not a provider error: re-warm quietly. A
+    // fast ENOTCONN, or one during an active turn, falls through and stays a
+    // reportable error so genuine transport failures remain observable.
+    if !hasActiveTurn,
+      aliveFor >= idleTeardownThreshold,
+      lower.contains("socket is not connected")
+    {
+      return .expectedIdleTeardown
     }
     guard lower.contains("websocket closed (1008)") else { return nil }
     if CredentialHealthManager.classifyProviderClose(

--- a/desktop/macos/Desktop/Tests/RealtimeHubCloseClassifierTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubCloseClassifierTests.swift
@@ -60,6 +60,37 @@ final class RealtimeHubCloseClassifierTests: XCTestCase {
     XCTAssertNil(category)
   }
 
+  func testClassifiesAgedIdleSocketNotConnectedAsExpectedTeardown() {
+    let category = RealtimeHubCloseClassifier.category(
+      message: "The operation couldn’t be completed. Socket is not connected",
+      aliveFor: 60 * 60,
+      provider: .openai)
+
+    XCTAssertEqual(category, .expectedIdleTeardown)
+    XCTAssertFalse(RealtimeHubCloseClassifier.shouldReportToSentry(category))
+  }
+
+  func testClassifiesActiveTurnSocketNotConnectedAsReportableError() {
+    let category = RealtimeHubCloseClassifier.category(
+      message: "The operation couldn’t be completed. Socket is not connected",
+      aliveFor: 60 * 60,
+      hasActiveTurn: true,
+      provider: .openai)
+
+    XCTAssertNil(category)
+    XCTAssertTrue(RealtimeHubCloseClassifier.shouldReportToSentry(category))
+  }
+
+  func testClassifiesFastSocketNotConnectedAsReportableError() {
+    let category = RealtimeHubCloseClassifier.category(
+      message: "The operation couldn’t be completed. Socket is not connected",
+      aliveFor: 3,
+      provider: .openai)
+
+    XCTAssertNil(category)
+    XCTAssertTrue(RealtimeHubCloseClassifier.shouldReportToSentry(category))
+  }
+
   func testClassifiesFastWebSocket1008AsProviderPolicyClose() {
     let category = RealtimeHubCloseClassifier.category(
       message: "WebSocket closed (1008) policy violation",


### PR DESCRIPTION
## Bug
Issue #9666: macOS RealtimeHub should treat OpenAI's 60-minute session rotation as normal lifecycle without surfacing an error. After the rotation classifier landed (#9672), production still records a `Socket is not connected` Sentry cluster on the stable/beta cohorts (per the 2026-07-15 recurrence comments).

## Root cause
When a write races the provider close, the retired OpenAI socket surfaces the failure as ENOTCONN — `The operation couldn't be completed. Socket is not connected`. That text matched **no** lifecycle category in `RealtimeHubCloseClassifier`, so `shouldReportToSentry` returned `true` and it was logged **error-level**. On an aged, idle socket (the window right after a 60-minute rotation) this is an expected transport teardown, not a provider error. The re-warm already happens on the nil-category aged path — only the classification, and thus the error-level Sentry event, was wrong.

## Fix
Recognize ENOTCONN on an aged idle socket (`aliveFor >= idleTeardownThreshold`, no active turn) as `.expectedIdleTeardown`, mirroring the existing WebSocket-1008 idle-close gate: quiet re-warm, no Sentry error. A **fast** ENOTCONN, or one **during an active turn**, falls through and stays a reportable error, so genuine transport failures remain observable. Scope is the typed classifier boundary only — no call-site booleans, no send-path change.

## Verification
- `xcrun swift build -c debug --package-path Desktop` → Build complete.
- `xcrun swift test --filter RealtimeHubCloseClassifierTests` → 13/13 pass, including 3 new cases:
  - aged idle ENOTCONN → `.expectedIdleTeardown`, not reported
  - active-turn ENOTCONN → nil, reported
  - fast ENOTCONN → nil, reported

## Scope note
This eliminates the error-level Sentry noise for the expected rotation/teardown (acceptance criterion: "the known expiry no longer creates an error-level Sentry event; unexpected close/reconnect failure remains observable"). It does not add new send-path guards; the active-turn/fast ENOTCONN paths remain visible for further lifecycle work.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

