### PR TITLE
fix(desktop): prevent terminal realtime session resurrection

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
@@ -218,6 +218,7 @@ final class RealtimeHubSession: NSObject {
   }
 
   private func _start() {
+    guard !terminated else { return }
     guard let request = makeRequest(), let url = request.url else {
       notifyError("Could not build \(provider.displayName) request URL")
       return
@@ -228,6 +229,7 @@ final class RealtimeHubSession: NSObject {
       rawWS = ws
       ws.onOpen = { [weak self] in
         guard let self else { return }
+        guard !self.terminated else { return }
         log("RealtimeHub: raw WS open (\(self.provider.displayName))")
         self.sendSessionSetup()
       }
@@ -834,7 +836,7 @@ final class RealtimeHubSession: NSObject {
   }
 
   private func markReady() {
-    guard !isOpen else { return }
+    guard !terminated, !isOpen else { return }
     isOpen = true
     log("\(tag): ready")
     // Open the speech window if a turn started before we connected (Gemini).
@@ -1290,6 +1292,7 @@ extension RealtimeHubSession: URLSessionWebSocketDelegate {
   ) {
     log("RealtimeHub: WS didOpen (OpenAI)")
     q.async {
+      guard !self.terminated else { return }
       self.receiveLoop()
       self.sendSessionSetup()
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
@@ -296,6 +296,11 @@ final class RealtimeHubSession: NSObject {
   private func notifyError(_ message: String) {
     guard !terminated else { return }
     terminated = true
+    // Make this physical session non-sendable on q before the main-actor
+    // controller observes the error and schedules teardown.
+    isOpen = false
+    task = nil
+    rawWS = nil
     let d = delegate
     Task { @MainActor in d?.hubDidError(message, source: self) }
   }

--- a/desktop/macos/Desktop/Tests/RealtimeHubSessionInputLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSessionInputLifecycleTests.swift
@@ -189,6 +189,29 @@ final class RealtimeHubSessionInputLifecycleTests: XCTestCase {
     XCTAssertFalse(closed.isOpen, "a closed transport must become non-sendable before its controller handles the error")
   }
 
+  func testTerminalOpenAISessionDoesNotResurrectFromLateReadiness() async {
+    let delegate = RealtimeHubSessionDelegateSpy()
+    let session = makeSession(provider: .openai, delegate: delegate)
+    let transport = URLSession.shared.webSocketTask(with: URL(string: "wss://example.com")!)
+
+    session.sendAudio(Data([1, 2, 3, 4]))
+    session.commitInputTurn()
+    let buffered = await session.inputLifecycleSnapshot()
+    XCTAssertEqual(buffered.pendingAudioChunkCount, 1)
+    XCTAssertTrue(buffered.pendingCommit)
+
+    session.urlSession(URLSession.shared, webSocketTask: transport, didCloseWith: .normalClosure, reason: nil)
+    _ = await session.inputLifecycleSnapshot()
+    await session.receiveOpenAIEventForTesting(["type": "session.updated"])
+    await Task.yield()
+
+    let afterLateReadiness = await session.inputLifecycleSnapshot()
+    XCTAssertFalse(afterLateReadiness.isOpen)
+    XCTAssertEqual(afterLateReadiness.pendingAudioChunkCount, 1, "a terminal session must not flush buffered audio")
+    XCTAssertTrue(afterLateReadiness.pendingCommit, "a terminal session must not commit buffered input")
+    XCTAssertEqual(delegate.connectCount, 0, "a terminal session must not report a late connection")
+  }
+
   func testOpenAICancelReclaimsActiveResponseIdentity() async {
     let delegate = RealtimeHubSessionDelegateSpy()
     let session = makeSession(provider: .openai, delegate: delegate)
@@ -242,7 +265,9 @@ final class RealtimeHubSessionInputLifecycleTests: XCTestCase {
 
 @MainActor
 private final class RealtimeHubSessionDelegateSpy: RealtimeHubSessionDelegate {
-  func hubDidConnect(source: RealtimeHubSession) {}
+  private(set) var connectCount = 0
+
+  func hubDidConnect(source: RealtimeHubSession) { connectCount += 1 }
   func hubDidReceiveInputTranscript(
     _ text: String, isFinal: Bool, identity: RealtimeHubEventIdentity?, source: RealtimeHubSession
   ) {}

--- a/desktop/macos/Desktop/Tests/RealtimeHubSessionInputLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSessionInputLifecycleTests.swift
@@ -176,6 +176,19 @@ final class RealtimeHubSessionInputLifecycleTests: XCTestCase {
     XCTAssertFalse(committed.pendingCommit)
   }
 
+  func testOpenAITransportCloseImmediatelyMakesSessionNonSendableBeforeControllerTeardown() async {
+    let delegate = RealtimeHubSessionDelegateSpy()
+    let session = makeSession(provider: .openai, delegate: delegate)
+    session.markReadyForTesting()
+    _ = await session.inputLifecycleSnapshot()
+    let transport = URLSession.shared.webSocketTask(with: URL(string: "wss://example.com")!)
+
+    session.urlSession(URLSession.shared, webSocketTask: transport, didCloseWith: .normalClosure, reason: nil)
+
+    let closed = await session.inputLifecycleSnapshot()
+    XCTAssertFalse(closed.isOpen, "a closed transport must become non-sendable before its controller handles the error")
+  }
+
   func testOpenAICancelReclaimsActiveResponseIdentity() async {
     let delegate = RealtimeHubSessionDelegateSpy()
     let session = makeSession(provider: .openai, delegate: delegate)

--- a/desktop/macos/changelog/unreleased/20260715-realtime-closed-session-send.json
+++ b/desktop/macos/changelog/unreleased/20260715-realtime-closed-session-send.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed voice input attempting to use a connection that had already closed"
+}


### PR DESCRIPTION
## Summary

Fixes #9666.

A terminal RealtimeHub transport error previously posted to the main-actor controller before the physical session was made non-sendable. Queued audio or commit work could therefore attempt a WebSocket send during the close-to-controller-teardown window.

This change clears transport readiness and detaches the task on the session queue before delivering the controller callback.

## Product invariants affected

- INV-CHAT-1

## Durable guard

`RealtimeHubSessionInputLifecycleTests.testOpenAITransportCloseImmediatelyMakesSessionNonSendableBeforeControllerTeardown` failed before the repair and passes after it.

## Verification

- focused lifecycle regression test — passed
- `xcrun swift test --package-path Desktop --filter Realtime` — 117 passed
- `make preflight` — pending this PR metadata


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

