### PR TITLE
fix(desktop): reopen Rewind DB when indexer cache goes stale after self-recovery (#9790)

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -88,8 +88,20 @@ actor RewindIndexer {
     }
 
     /// Try to initialize with exponential backoff. Returns true if initialized.
-    private func ensureInitialized() async -> Bool {
-        if isInitialized { return true }
+    func ensureInitialized() async -> Bool {
+        if isInitialized {
+            // The database is the authoritative readiness signal. It closes its own
+            // pool after repeated I/O/corruption errors (RewindDatabase.reportQueryError);
+            // this cached flag then goes stale and every frame fails with
+            // databaseNotInitialized until periodic cleanup reopens it up to 6h later.
+            // Revalidate against the database and drop the stale flag so this frame
+            // reopens it through the normal backoff path below.
+            if await RewindDatabase.shared.isInitialized {
+                return true
+            }
+            isInitialized = false
+            log("RewindIndexer: Database closed after initialization (self-recovery); reinitializing")
+        }
 
         // Check backoff timer - skip if too soon after last failure
         if Date() < nextRetryTime {

--- a/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
@@ -66,4 +66,45 @@ final class RewindDatabaseLifecycleTests: XCTestCase {
     await RewindDatabase.shared.close()
     RewindDatabase.currentUserId = nil
   }
+
+  /// Regression for #9790: after the database self-closes (repeated I/O/corruption
+  /// errors close the pool), the indexer's cached `isInitialized` flag went stale and
+  /// it never reopened the database until periodic cleanup retried up to 6h later.
+  /// The indexer must revalidate against the authoritative database and reopen it.
+  func testIndexerReopensDatabaseAfterSelfRecoveryClose() async throws {
+    let testUserId = "rewind-indexer-reopen-\(UUID().uuidString)"
+    let userDir = FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(testUserId, isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: userDir) }
+
+    await RewindDatabase.shared.close()
+    await RewindIndexer.shared.reset()
+    RewindDatabase.currentUserId = testUserId
+    await RewindDatabase.shared.configure(userId: testUserId)
+
+    // Prime the indexer so its cached isInitialized flag is true.
+    let firstReady = await RewindIndexer.shared.ensureInitialized()
+    XCTAssertTrue(firstReady)
+    let openedAfterInit = await RewindDatabase.shared.isInitialized
+    XCTAssertTrue(openedAfterInit)
+
+    // Simulate the database self-closing after repeated I/O/corruption errors.
+    await RewindDatabase.shared.close()
+    let closedState = await RewindDatabase.shared.isInitialized
+    XCTAssertFalse(closedState)
+
+    // The indexer must notice the authoritative database closed and reopen it,
+    // instead of returning a stale "initialized" and emitting databaseNotInitialized.
+    let reready = await RewindIndexer.shared.ensureInitialized()
+    XCTAssertTrue(reready)
+    let reopened = await RewindDatabase.shared.isInitialized
+    XCTAssertTrue(reopened, "indexer must reopen a database that closed after it initialized")
+
+    await RewindDatabase.shared.close()
+    await RewindIndexer.shared.reset()
+    RewindDatabase.currentUserId = nil
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260715-rewind-reopen-after-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260715-rewind-reopen-after-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Rewind timeline silently stopping after a database recovery — the indexer now reopens the database immediately instead of waiting up to six hours"
+}


### PR DESCRIPTION
## Bug (#9790)

After the Rewind database self-closes following repeated SQLite I/O / corruption errors, the timeline silently stops recording. `RewindIndexer` retained its own `isInitialized = true` flag and kept processing frames, producing repeated `databaseNotInitialized` errors until the 6-hourly retention cleanup happened to reopen the database.

## Root cause

`RewindDatabase.reportQueryError` closes the pool (`close()`) after `maxQueryIOErrorsBeforeRecovery` (5) consecutive recoverable errors, so the next `initialize()` goes through the full WAL/corruption recovery path. But `RewindIndexer.ensureInitialized()` short-circuited on its **own** cached flag and never revalidated against the database's authoritative readiness. Once the DB closed, every frame's `insertScreenshot` threw `databaseNotInitialized`; the caught error routed back to `reportQueryError`, which early-returns when `dbQueue == nil`, so nothing ever re-triggered `initialize()`. Only `runCleanup` (≤ every 6h) called `RewindDatabase.shared.initialize()` directly and reopened it.

## Fix

`ensureInitialized()` now treats `RewindDatabase.shared.isInitialized` as the authoritative signal: when the cached flag is set but the database has closed, it drops the stale flag and reinitializes through the existing exponential-backoff path. Surgical — no new state or fallback booleans; the database stays the single owner of readiness.

## Test

Added `testIndexerReopensDatabaseAfterSelfRecoveryClose` (in `RewindDatabaseLifecycleTests`) which drives the production `ensureInitialized()`: initialize → `close()` (simulating self-recovery) → assert the next `ensureInitialized()` reopens the database. It fails on the stale-cache behavior and passes after the fix. Existing lifecycle tests remain green.

## Verification

- `xcrun swift build -c debug --package-path Desktop` → Build complete
- `xcrun swift test --package-path Desktop --filter RewindDatabaseLifecycleTests` → 3 tests, 0 failures

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

