### PR TITLE
fix(desktop): recover Rewind after database self-close

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -57,7 +57,11 @@ actor RewindIndexer {
 
     /// Initialize all Rewind services
     func initialize() async throws {
-        guard !isInitialized, !isInitializing else { return }
+        let databaseIsInitialized = await RewindDatabase.shared.isInitialized
+        guard !(isInitialized && databaseIsInitialized), !isInitializing else { return }
+        // RewindDatabase can close itself after repeated I/O/corruption errors.
+        // Its readiness, not this cached flag, is authoritative.
+        isInitialized = false
         isInitializing = true
         defer { isInitializing = false }
 

--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -93,7 +93,12 @@ actor RewindIndexer {
 
     /// Try to initialize with exponential backoff. Returns true if initialized.
     private func ensureInitialized() async -> Bool {
-        if isInitialized { return true }
+        let databaseIsInitialized = await RewindDatabase.shared.isInitialized
+        if isInitialized && databaseIsInitialized { return true }
+
+        // RewindDatabase can close itself after recovery while this actor retains
+        // its cached initialized flag; only the database can confirm readiness.
+        if isInitialized { isInitialized = false }
 
         // Check backoff timer - skip if too soon after last failure
         if Date() < nextRetryTime {

--- a/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 
 @testable import Omi_Computer
@@ -98,5 +99,66 @@ final class RewindDatabaseLifecycleTests: XCTestCase {
     await RewindIndexer.shared.reset()
     await RewindDatabase.shared.close()
     RewindDatabase.currentUserId = nil
+  }
+
+  func testProcessFrameReopensDatabaseClosedAfterIndexerInitialization() async throws {
+    let testUserId = "rewind-indexer-process-frame-reinitialize-\(UUID().uuidString)"
+    let userDir = FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(testUserId, isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: userDir) }
+
+    await RewindIndexer.shared.reset()
+    await RewindDatabase.shared.close()
+    RewindDatabase.currentUserId = testUserId
+    await RewindDatabase.shared.configure(userId: testUserId)
+    try await RewindIndexer.shared.initialize()
+    let frame = try makeTestFrameImage()
+
+    // Prime the frame pipeline before simulating recovery so its first-frame
+    // retention cleanup cannot reopen the database independently of ensureInitialized.
+    await RewindIndexer.shared.processFrame(
+      cgImage: frame,
+      appName: "RewindDatabaseLifecycleTests",
+      windowTitle: "prime retention cleanup",
+      captureTime: Date())
+
+    // Runtime I/O/corruption recovery closes the pool without resetting the indexer.
+    await RewindDatabase.shared.close()
+    let initializedAfterClose = await RewindDatabase.shared.isInitialized
+    XCTAssertFalse(initializedAfterClose)
+
+    await RewindIndexer.shared.processFrame(
+      cgImage: frame,
+      appName: "RewindDatabaseLifecycleTests",
+      windowTitle: "reopen after close",
+      captureTime: Date())
+
+    let initializedAfterProcessFrame = await RewindDatabase.shared.isInitialized
+    XCTAssertTrue(
+      initializedAfterProcessFrame,
+      "processing a frame must reopen a database closed after the indexer was initialized")
+
+    await RewindIndexer.shared.reset()
+    await RewindDatabase.shared.close()
+    RewindDatabase.currentUserId = nil
+  }
+
+  private func makeTestFrameImage() throws -> CGImage {
+    let width = 96
+    let height = 64
+    let context = try XCTUnwrap(CGContext(
+      data: nil,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: width * 4,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+    context.setFillColor(NSColor.systemBlue.cgColor)
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    return try XCTUnwrap(context.makeImage())
   }
 }

--- a/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
@@ -66,4 +66,37 @@ final class RewindDatabaseLifecycleTests: XCTestCase {
     await RewindDatabase.shared.close()
     RewindDatabase.currentUserId = nil
   }
+
+  func testInitializeReopensDatabaseClosedAfterIndexerInitialization() async throws {
+    let testUserId = "rewind-indexer-reinitialize-\(UUID().uuidString)"
+    let userDir = FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(testUserId, isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: userDir) }
+
+    await RewindIndexer.shared.reset()
+    await RewindDatabase.shared.close()
+    RewindDatabase.currentUserId = testUserId
+    await RewindDatabase.shared.configure(userId: testUserId)
+    try await RewindIndexer.shared.initialize()
+    let initializedBeforeClose = await RewindDatabase.shared.isInitialized
+    XCTAssertTrue(initializedBeforeClose)
+
+    // Runtime I/O/corruption recovery closes the pool without resetting the indexer.
+    await RewindDatabase.shared.close()
+    let initializedAfterClose = await RewindDatabase.shared.isInitialized
+    XCTAssertFalse(initializedAfterClose)
+
+    try await RewindIndexer.shared.initialize()
+    let initializedAfterReinitialize = await RewindDatabase.shared.isInitialized
+    XCTAssertTrue(
+      initializedAfterReinitialize,
+      "initializing the indexer must reopen a database closed after the indexer was initialized")
+
+    await RewindIndexer.shared.reset()
+    await RewindDatabase.shared.close()
+    RewindDatabase.currentUserId = nil
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260715-rewind-database-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260715-rewind-database-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Rewind capture getting stuck after a recoverable local database failure instead of reopening its database automatically"
+}


### PR DESCRIPTION
## Summary

Fixes #9790.

RewindDatabase can close itself after repeated I/O or corruption failures while RewindIndexer retains a stale initialized flag. This change makes database readiness authoritative when the indexer initializes, so the next initialization reopens the database instead of continuing to emit `databaseNotInitialized` until scheduled cleanup.

## Durable guard

`RewindDatabaseLifecycleTests.testInitializeReopensDatabaseClosedAfterIndexerInitialization` reproduces the recovery-close sequence. It failed before the fix and passes after it.

## Verification

- `xcrun swift test -c debug --package-path Desktop --filter RewindDatabaseLifecycleTests/testInitializeReopensDatabaseClosedAfterIndexerInitialization` — passed
- `xcrun swift test -c debug --package-path Desktop --filter RewindDatabaseLifecycleTests` — 3 passed
- `make preflight` — pending this PR metadata


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

