### PR TITLE
Enforce the webhook-disabled cache size cap on every write path

### DIFF
--- a/backend/database/webhook_health.py
+++ b/backend/database/webhook_health.py
@@ -36,6 +36,18 @@ def _evict_oldest(d: Dict[str, Any]) -> None:
         del d[k]
 
 
+def _set_disabled_state(app_id: str, value: bool) -> None:
+    """Record a disabled-state write and enforce the size cap. Caller must hold _cache_lock.
+
+    The is_app_webhook_disabled read path already caps the cache; the record/re-enable write paths
+    did not, so routing every write through here keeps the cache within _CACHE_MAX_SIZE on all paths.
+    """
+    gen = _disabled_cache.get(app_id, (False, 0, 0))[2] + 1
+    _disabled_cache[app_id] = (value, time.monotonic(), gen)
+    if len(_disabled_cache) > _CACHE_MAX_SIZE:
+        _evict_oldest(_disabled_cache)
+
+
 # Lua script: atomically record a failure and return graduated response action.
 # Returns: 0 = no action, 1 = day1 warn, 2 = day2 warn, 3 = disable
 _RECORD_FAILURE_LUA = """
@@ -143,8 +155,7 @@ def record_app_webhook_failure(app_id: str, status_code: int, error: str, endpoi
         if action == 3:
             r.setex(f'app_webhook_disabled:{app_id}', _HEALTH_TTL, '1')
             with _cache_lock:
-                gen = _disabled_cache.get(app_id, (False, 0, 0))[2] + 1
-                _disabled_cache[app_id] = (True, time.monotonic(), gen)
+                _set_disabled_state(app_id, True)
         return action
     except Exception as e:
         logger.warning(f'record_app_webhook_failure redis error app_id={app_id}: {e}')
@@ -212,8 +223,7 @@ def record_app_webhook_success(app_id: str, endpoint: str = ENDPOINT_REALTIME):
 def clear_app_webhook_health(app_id: str):
     """Clear all webhook health state for an app. Used on re-enable."""
     with _cache_lock:
-        gen = _disabled_cache.get(app_id, (False, 0, 0))[2] + 1
-        _disabled_cache[app_id] = (False, time.monotonic(), gen)
+        _set_disabled_state(app_id, False)
     try:
         keys_to_delete = [f'app_webhook_disabled:{app_id}']
         for ep in _ALL_ENDPOINTS:
@@ -272,8 +282,7 @@ def get_app_webhook_health(app_id: str, endpoint: Optional[str] = None) -> Optio
 def disable_app_in_firestore(app_id: str, error: str, failure_hours: int):
     """Mark an app as disabled in Firestore due to webhook failures."""
     with _cache_lock:
-        gen = _disabled_cache.get(app_id, (False, 0, 0))[2] + 1
-        _disabled_cache[app_id] = (True, time.monotonic(), gen)
+        _set_disabled_state(app_id, True)
     try:
         apps_collection = 'plugins_data'
         app_ref = db.collection(apps_collection).document(app_id)

--- a/backend/tests/unit/test_webhook_health_cache_cap.py
+++ b/backend/tests/unit/test_webhook_health_cache_cap.py
@@ -1,0 +1,40 @@
+"""Regression: the disabled-app cache size cap must hold on every write path.
+
+database.webhook_health caches disabled-app state in _disabled_cache with a _CACHE_MAX_SIZE safety
+cap, but the cap was enforced only on the is_app_webhook_disabled read path; the record/re-enable
+write paths set the cache without it. _set_disabled_state centralizes the write so every path stays
+within the cap.
+"""
+
+import pytest
+
+import database.webhook_health as wh
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    wh._disabled_cache.clear()
+    yield
+    wh._disabled_cache.clear()
+
+
+def test_cap_is_enforced_on_the_write_paths(monkeypatch):
+    monkeypatch.setattr(wh, "_CACHE_MAX_SIZE", 10)
+    for i in range(30):
+        wh._set_disabled_state(f"app-{i}", True)
+
+    # Before the fix these write paths never evicted, so the cache would hold all 30 entries.
+    assert len(wh._disabled_cache) <= 10
+    assert len(wh._disabled_cache) >= 1
+
+
+def test_rewriting_a_key_increments_generation_without_growth():
+    wh._set_disabled_state("a", True)
+    gen1 = wh._disabled_cache["a"][2]
+
+    wh._set_disabled_state("a", False)
+
+    value, _ts, gen2 = wh._disabled_cache["a"]
+    assert gen2 == gen1 + 1
+    assert value is False
+    assert len(wh._disabled_cache) == 1  # same key, no growth


### PR DESCRIPTION
## What

`database.webhook_health` caches disabled-app state in a module-level dict with a safety size cap:

```python
_CACHE_MAX_SIZE = 10000
_disabled_cache: dict[str, tuple[bool, float, int]] = {}  # (value, timestamp, generation)
```

The cap is enforced in one place, the read path `is_app_webhook_disabled`:

```python
_disabled_cache[app_id] = (result, now, pre_gen)
if len(_disabled_cache) > _CACHE_MAX_SIZE:
    _evict_oldest(_disabled_cache)
```

But three other write paths set the cache directly without the cap: the failure/disable path in `record_app_webhook_failure`, the re-enable path, and the second disable path. Each does:

```python
gen = _disabled_cache.get(app_id, (False, 0, 0))[2] + 1
_disabled_cache[app_id] = (True, time.monotonic(), gen)
```

So a burst of disables/re-enables can push `_disabled_cache` past `_CACHE_MAX_SIZE` even though the author added the cap to keep it bounded.

## Fix

Centralize the write in a helper that bumps the generation, stores the entry, and enforces the cap, then route the three uncapped sites through it:

```python
def _set_disabled_state(app_id: str, value: bool) -> None:
    """Record a disabled-state write and enforce the size cap. Caller must hold _cache_lock."""
    gen = _disabled_cache.get(app_id, (False, 0, 0))[2] + 1
    _disabled_cache[app_id] = (value, time.monotonic(), gen)
    if len(_disabled_cache) > _CACHE_MAX_SIZE:
        _evict_oldest(_disabled_cache)
```

The helper is called inside the existing `with _cache_lock:` sections, so it does not lock (same contract as `_evict_oldest`). The read path is left as-is (it already caps and uses its own timestamp/generation).

Scope, stated plainly: `_disabled_cache` is keyed by `app_id`, so it is bounded by the number of apps and this is not a live unbounded leak. It closes the gap where the author's own `_CACHE_MAX_SIZE` cap was enforced on only one of four write paths. Same module-dict cap class as #9713 and #9778.

## Tests

New `tests/unit/test_webhook_health_cache_cap.py`:

- with a small cap, writing many distinct app ids keeps the cache within the cap (before the fix these paths never evicted)
- re-writing an existing app id increments its generation and updates the value without growing the map

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_webhook_health_cache_cap.py -q
  -> 2 passed
black --line-length 120 --skip-string-normalization --check database/webhook_health.py tests/unit/test_webhook_health_cache_cap.py
  -> unchanged
python -m pyright -p pyrightconfig.json database/webhook_health.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 660 test file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

