### PR TITLE
Bound the in-memory proactive-notification cache so it cannot grow unbounded

### DIFF
--- a/backend/database/mem_db.py
+++ b/backend/database/mem_db.py
@@ -3,10 +3,28 @@ import time
 # In-memory proactive notification sent cache: maps "<uid>:<app_id>" -> (sent_ts, expiry_ts).
 proactive_noti_sent_at: dict[str, tuple[int, float]] = {}
 
+# Safety cap: expired entries are only deleted when their own key is read again, so keys for churned
+# users or uninstalled apps would otherwise accumulate on the long-lived process. Bound the map.
+_MAX_PROACTIVE_NOTI_ENTRIES = 50000
+
+
+def _prune_proactive_noti(now: float) -> None:
+    # Sweep already-expired entries first (get() already treats them as gone), then, if still over the
+    # cap, drop the entries nearest to expiry so the map stays bounded.
+    for key in [k for k, (_ts, ex) in proactive_noti_sent_at.items() if ex < now]:
+        del proactive_noti_sent_at[key]
+    if len(proactive_noti_sent_at) > _MAX_PROACTIVE_NOTI_ENTRIES:
+        overflow = len(proactive_noti_sent_at) - _MAX_PROACTIVE_NOTI_ENTRIES
+        for key in sorted(proactive_noti_sent_at, key=lambda k: proactive_noti_sent_at[k][1])[:overflow]:
+            del proactive_noti_sent_at[key]
+
 
 def set_proactive_noti_sent_at(uid: str, *, app_id: str, ts: int, ttl: int = 30) -> None:
     k = f'{uid}:{app_id}'
-    proactive_noti_sent_at[k] = (ts, ttl + time.time())
+    now = time.time()
+    proactive_noti_sent_at[k] = (ts, ttl + now)
+    if len(proactive_noti_sent_at) > _MAX_PROACTIVE_NOTI_ENTRIES:
+        _prune_proactive_noti(now)
 
 
 def get_proactive_noti_sent_at(uid: str, app_id: str) -> int | None:

--- a/backend/tests/unit/test_mem_db_proactive_noti_cap.py
+++ b/backend/tests/unit/test_mem_db_proactive_noti_cap.py
@@ -1,0 +1,44 @@
+"""Regression: the in-memory proactive-notification cache must stay bounded.
+
+database.mem_db.proactive_noti_sent_at maps "<uid>:<app_id>" -> (sent_ts, expiry_ts). An expired
+entry is deleted only when its OWN key is read again (get_proactive_noti_sent_at), so keys for
+churned users or uninstalled apps are never revisited and accumulate for the process lifetime (the
+repo's rule requires module-level dicts to cap or TTL). set_proactive_noti_sent_at now sweeps expired
+entries and caps the map.
+"""
+
+import pytest
+
+import database.mem_db as mem_db
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    mem_db.proactive_noti_sent_at.clear()
+    yield
+    mem_db.proactive_noti_sent_at.clear()
+
+
+def test_expired_entries_are_swept_when_over_cap(monkeypatch):
+    monkeypatch.setattr(mem_db, "_MAX_PROACTIVE_NOTI_ENTRIES", 5)
+    # All already expired (negative ttl); before the fix these would never be evicted (never re-read).
+    for i in range(20):
+        mem_db.set_proactive_noti_sent_at(f"u{i}", app_id="a", ts=1, ttl=-100)
+
+    assert len(mem_db.proactive_noti_sent_at) <= 5
+
+
+def test_cap_holds_even_when_all_entries_are_live(monkeypatch):
+    monkeypatch.setattr(mem_db, "_MAX_PROACTIVE_NOTI_ENTRIES", 5)
+    for i in range(20):
+        mem_db.set_proactive_noti_sent_at(f"u{i}", app_id="a", ts=i, ttl=3600)
+
+    assert len(mem_db.proactive_noti_sent_at) <= 5
+
+
+def test_get_still_returns_live_and_none_for_expired():
+    mem_db.set_proactive_noti_sent_at("u", app_id="a", ts=42, ttl=3600)
+    assert mem_db.get_proactive_noti_sent_at("u", "a") == 42
+
+    mem_db.set_proactive_noti_sent_at("u", app_id="b", ts=7, ttl=-100)
+    assert mem_db.get_proactive_noti_sent_at("u", "b") is None


### PR DESCRIPTION
## What

`database.mem_db` keeps an in-memory cache of when a proactive notification was last sent:

```python
proactive_noti_sent_at: dict[str, tuple[int, float]] = {}

def set_proactive_noti_sent_at(uid, *, app_id, ts, ttl=30):
    k = f'{uid}:{app_id}'
    proactive_noti_sent_at[k] = (ts, ttl + time.time())

def get_proactive_noti_sent_at(uid, app_id):
    ...
    ts, ex = proactive_noti_sent_at[k]
    if ex < time.time():
        del proactive_noti_sent_at[k]   # only place an entry is ever removed
        return None
    return ts
```

An expired entry is deleted only when its own key is read again. So a key for a user who churns, or an app that is uninstalled, is written once and never revisited, and it stays in the dict for the whole process lifetime. The map grows without bound. This is exactly the case the backend guide calls out (gotcha #11: "Module-level dicts: add TTL-based eviction or cap size - they grow forever otherwise").

Called from the proactive/mentor notification path (`utils/app_integrations.py`), so distinct `{uid}:{app_id}` keys accumulate over time.

## Fix

Sweep expired entries and cap the map on write:

```python
_MAX_PROACTIVE_NOTI_ENTRIES = 50000

def _prune_proactive_noti(now: float) -> None:
    for key in [k for k, (_ts, ex) in proactive_noti_sent_at.items() if ex < now]:
        del proactive_noti_sent_at[key]
    if len(proactive_noti_sent_at) > _MAX_PROACTIVE_NOTI_ENTRIES:
        overflow = len(proactive_noti_sent_at) - _MAX_PROACTIVE_NOTI_ENTRIES
        for key in sorted(proactive_noti_sent_at, key=lambda k: proactive_noti_sent_at[k][1])[:overflow]:
            del proactive_noti_sent_at[key]

def set_proactive_noti_sent_at(uid, *, app_id, ts, ttl=30):
    k = f'{uid}:{app_id}'
    now = time.time()
    proactive_noti_sent_at[k] = (ts, ttl + now)
    if len(proactive_noti_sent_at) > _MAX_PROACTIVE_NOTI_ENTRIES:
        _prune_proactive_noti(now)
```

The prune drops already-expired entries first (semantically gone -- `get()` already returns `None` for them), and only if still over the cap does it drop the entries nearest to expiry. It runs only when the map exceeds the cap, so the common path is a single dict write as before. The read path and the 30s TTL semantics are unchanged.

## Tests

New `tests/unit/test_mem_db_proactive_noti_cap.py` (direct calls, no heavy import):

- writing many already-expired entries past the cap sweeps them and keeps the map within the cap
- the cap holds even when every entry is still live (nearest-to-expiry eviction)
- `get` still returns a live value and `None` for an expired entry

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_mem_db_proactive_noti_cap.py -q
  -> 3 passed
black --line-length 120 --skip-string-normalization --check database/mem_db.py tests/unit/test_mem_db_proactive_noti_cap.py
  -> unchanged
python -m pyright -p pyrightconfig.json database/mem_db.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 661 test file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

