### PR TITLE
Tolerate a malformed announcement sub-document instead of 500ing the list

### DIFF
--- a/backend/models/announcement.py
+++ b/backend/models/announcement.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, List, Mapping, Optional, cast
+from typing import Any, List, Mapping, Optional, TypeVar, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 
 class AnnouncementType(str, Enum):
@@ -107,6 +107,21 @@ class AnnouncementContent(BaseModel):
 
 
 # Main announcement model
+_SubModel = TypeVar("_SubModel", bound=BaseModel)
+
+
+def _optional_submodel(model_cls: type[_SubModel], sub_data: Optional[Mapping[str, Any]]) -> Optional[_SubModel]:
+    # Tolerate a malformed targeting/display sub-document (a bad enum, a bad datetime) the same way a
+    # bad top-level type is tolerated in from_dict: drop the sub-object rather than let one legacy
+    # announcement 500 the whole list (the DB helpers loop from_dict with no per-item guard).
+    if not sub_data:
+        return None
+    try:
+        return model_cls(**sub_data)
+    except ValidationError:
+        return None
+
+
 class Announcement(BaseModel):
     id: str
     type: AnnouncementType
@@ -187,8 +202,8 @@ class Announcement(BaseModel):
             firmware_version=data.get("firmware_version"),
             device_models=data.get("device_models"),
             expires_at=data.get("expires_at"),
-            targeting=Targeting(**targeting_data) if targeting_data else None,
-            display=Display(**display_data) if display_data else None,
+            targeting=_optional_submodel(Targeting, targeting_data),
+            display=_optional_submodel(Display, display_data),
             content=data.get("content", {}),
         )
 

--- a/backend/tests/unit/test_announcement_subdoc_guard.py
+++ b/backend/tests/unit/test_announcement_subdoc_guard.py
@@ -1,0 +1,43 @@
+"""Regression: a malformed announcement sub-document must not 500 the announcements list.
+
+models.announcement.Announcement.from_dict tolerates a bad top-level type/id/created_at, but built
+the targeting/display sub-models with an unguarded Targeting(**...) / Display(**...). A stored sub-dict
+with a bad enum or datetime raised pydantic ValidationError, and the database helpers loop from_dict
+over documents with no per-item try/except, so one malformed sub-document 500s the whole public list.
+from_dict now drops a malformed targeting/display sub-model and keeps the announcement.
+"""
+
+from models.announcement import Announcement, TriggerType
+
+
+def test_malformed_targeting_is_dropped_but_the_announcement_is_kept():
+    ann = Announcement.from_dict({"id": "a1", "type": "announcement", "targeting": {"trigger": "bogus-not-an-enum"}})
+    assert ann.targeting is None  # malformed sub-doc dropped, no raise
+    assert ann.id == "a1"  # announcement itself preserved
+
+
+def test_malformed_display_is_dropped():
+    ann = Announcement.from_dict({"id": "a2", "display": {"priority": "not-an-int", "start_at": "not-a-date"}})
+    assert ann.display is None
+
+
+def test_valid_targeting_and_display_are_kept():
+    ann = Announcement.from_dict(
+        {
+            "id": "a3",
+            "targeting": {"trigger": TriggerType.VERSION_UPGRADE.value, "device_models": ["Omi"]},
+            "display": {"priority": 3, "dismissible": False},
+        }
+    )
+    assert ann.targeting is not None
+    assert ann.targeting.trigger == TriggerType.VERSION_UPGRADE
+    assert ann.targeting.device_models == ["Omi"]
+    assert ann.display is not None
+    assert ann.display.priority == 3
+    assert ann.display.dismissible is False
+
+
+def test_missing_targeting_and_display_are_none():
+    ann = Announcement.from_dict({"id": "a4"})
+    assert ann.targeting is None
+    assert ann.display is None


### PR DESCRIPTION
## What

`models.announcement.Announcement.from_dict` was deliberately hardened so a single malformed or legacy announcement document cannot 500 the whole public announcements list. It tolerates a bad `type` (falls back to `ANNOUNCEMENT`), and a missing `id`/`created_at`:

```python
try:
    announcement_type = AnnouncementType(raw_type)
except ValueError:
    announcement_type = AnnouncementType.ANNOUNCEMENT
...
announcement_id = cast(str, data.get("id")) or ""
created_at = cast(datetime, data.get("created_at")) or datetime.fromtimestamp(0, tz=timezone.utc)
```

But the `targeting`/`display` sub-models were still built unguarded:

```python
targeting=Targeting(**targeting_data) if targeting_data else None,
display=Display(**display_data) if display_data else None,
```

`Targeting` and `Display` are pydantic models, so a stored sub-dict with a bad value (`targeting.trigger="foo"`, `display.priority="abc"`, `display.start_at="not-a-date"`) raises `ValidationError` out of `from_dict`. The `database.announcements` helpers loop `from_dict` over documents with no per-item try/except (`get_pending_announcements`, `get_general_announcements`, and others), so one malformed sub-document 500s the entire user-facing list for everyone.

## Fix

Extend the same tolerance already applied to `type` to the sub-models, via a small helper:

```python
def _optional_submodel(model_cls: type[_SubModel], sub_data: Optional[Mapping[str, Any]]) -> Optional[_SubModel]:
    if not sub_data:
        return None
    try:
        return model_cls(**sub_data)
    except ValidationError:
        return None
```

```python
targeting=_optional_submodel(Targeting, targeting_data),
display=_optional_submodel(Display, display_data),
```

On `ValidationError` the malformed sub-object is dropped (`None`) and the announcement is kept, matching the existing "one bad document must not 500 the list" intent. Valid sub-dicts parse exactly as before, and an empty/missing sub-dict stays `None`.

## Tests

New `tests/unit/test_announcement_subdoc_guard.py`:

- a malformed `targeting` (bad enum) or `display` (bad int/datetime) is dropped to `None` while the announcement is kept
- valid `targeting`/`display` are parsed unchanged
- missing sub-docs stay `None`

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_announcement_subdoc_guard.py -q
  -> 4 passed
black --line-length 120 --skip-string-normalization --check models/announcement.py tests/unit/test_announcement_subdoc_guard.py
  -> unchanged
python -m pyright -p pyrightconfig.json models/announcement.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 661 test file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

