### PR TITLE
Skip a topic missing its 'topic' field instead of dropping the whole trends category

### DIFF
--- a/backend/database/trends.py
+++ b/backend/database/trends.py
@@ -42,7 +42,10 @@ def get_trends_data() -> List[Dict[str, Any]]:
             # KeyError and drop the entire category from the public /v1/trends response.
             topics = sorted(topics_docs, key=lambda e: len(e.get('memory_ids') or []), reverse=True)
             for topic in topics:
-                if topic['topic'] not in valid_items:
+                # A topic doc can be missing 'topic' the same way it can be missing 'memory_ids'
+                # (guarded above); use .get so one such topic is skipped rather than raising KeyError
+                # and dropping the entire category from the public /v1/trends response.
+                if topic.get('topic') not in valid_items:
                     continue
                 topic['memories_count'] = len(topic.get('memory_ids') or [])
                 topic.pop('memory_ids', None)

--- a/backend/tests/unit/test_trends_topic_key_guard.py
+++ b/backend/tests/unit/test_trends_topic_key_guard.py
@@ -1,0 +1,71 @@
+"""Regression: a topic doc missing its 'topic' field must not drop the whole trends category.
+
+database.trends.get_trends_data guards a missing 'memory_ids' on a topic (two-phase save can leave it
+absent), but still did a required-key lookup topic['topic']. A topic missing 'topic' raised KeyError,
+caught by the per-category try/except, which dropped the entire category from the public /v1/trends
+response. The lookup now uses .get so only the malformed topic is skipped.
+"""
+
+import database.trends as trends
+from models.trend import valid_items
+
+
+class _Doc:
+    def __init__(self, data):
+        self._data = data
+
+    def to_dict(self):
+        return self._data
+
+
+class _DocRef:
+    def __init__(self, topics):
+        self._topics = topics
+
+    def collection(self, _name):
+        return _TopicsCollection(self._topics)
+
+
+class _TopicsCollection:
+    def __init__(self, topics):
+        self._topics = topics
+
+    def stream(self, retry=None):
+        return iter(self._topics)
+
+
+class _TrendsCollection:
+    def __init__(self, categories, topics_by_cat):
+        self._categories = categories
+        self._topics_by_cat = topics_by_cat
+
+    def stream(self, retry=None):
+        return iter(self._categories)
+
+    def document(self, cat_id):
+        return _DocRef(self._topics_by_cat.get(cat_id, []))
+
+
+class _FakeDb:
+    def __init__(self, collection):
+        self._collection = collection
+
+    def collection(self, _name):
+        return self._collection
+
+
+def test_topic_missing_topic_key_does_not_drop_the_category(monkeypatch):
+    good = next(iter(valid_items))
+    category = _Doc({'category': 'ceo', 'id': 'cat1'})
+    topic_missing = _Doc({'memory_ids': ['m1']})  # no 'topic' key -> KeyError before the fix
+    topic_good = _Doc({'topic': good, 'memory_ids': ['m2', 'm3']})
+    coll = _TrendsCollection([category], {'cat1': [topic_missing, topic_good]})
+    monkeypatch.setattr(trends, 'db', _FakeDb(coll))
+
+    result = trends.get_trends_data()
+
+    # The category survives (before the fix the missing-topic KeyError dropped the whole category).
+    assert len(result) == 1
+    topics = result[0]['topics']
+    assert [t['topic'] for t in topics] == [good]  # malformed topic skipped, valid one kept
+    assert topics[0]['memories_count'] == 2


### PR DESCRIPTION
## What

`database.trends.get_trends_data` builds the public `/v1/trends` response by looping categories and their topics. It was hardened so a topic doc missing `memory_ids` (the two-phase `save_trends` writes the doc, then updates `memory_ids` with `ArrayUnion`, so an interrupted second write leaves it absent) does not raise:

```python
topics = sorted(topics_docs, key=lambda e: len(e.get('memory_ids') or []), reverse=True)
for topic in topics:
    if topic['topic'] not in valid_items:   # required-key lookup
        continue
    topic['memories_count'] = len(topic.get('memory_ids') or [])
```

But `topic['topic']` is still a required-key lookup. A topic document missing the `topic` field raises `KeyError`, which the per-category `try/except` catches by `continue`-ing, so the **entire category** is silently dropped from `/v1/trends` (not a 500, but the whole category vanishes for every user).

## Fix

Use `.get`, mirroring the `memory_ids` treatment directly above:

```python
if topic.get('topic') not in valid_items:
    continue
```

A topic missing `topic` yields `None`, which is not in `valid_items`, so that one topic is skipped and the rest of the category survives. Valid topics are unaffected.

## Tests

New `tests/unit/test_trends_topic_key_guard.py` (monkeypatches the module `db` proxy with a fake trends store, since `get_trends_data` takes no injectable client):

- a category with one topic missing `topic` and one valid topic is still returned, with the valid topic kept and the malformed one skipped (before the fix the `KeyError` dropped the whole category)

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_trends_topic_key_guard.py -q
  -> 1 passed
black --line-length 120 --skip-string-normalization --check database/trends.py tests/unit/test_trends_topic_key_guard.py
  -> unchanged
python -m pyright -p pyrightconfig.json database/trends.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 661 test file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

