### PR TITLE
Bound the in-process custom rate-limit cache so distinct client IPs cannot grow it unbounded

### DIFF
--- a/backend/tests/unit/test_rate_limit_cache_cap.py
+++ b/backend/tests/unit/test_rate_limit_cache_cap.py
@@ -1,0 +1,36 @@
+"""Regression: the in-process custom rate-limit cache must stay bounded.
+
+utils.other.endpoints.rate_limit_custom stores per-request state in the module-level `cached` dict
+keyed by "{endpoint}:{ip}". It was get/set only with no eviction, so a stream of distinct client IPs
+(ordinary traffic, or an attacker rotating IPs) grew the map without bound. _store_rate_limit caps it.
+"""
+
+import pytest
+
+import utils.other.endpoints as endpoints
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    endpoints.cached.clear()
+    yield
+    endpoints.cached.clear()
+
+
+def test_rate_limit_cache_is_bounded_and_keeps_newest(monkeypatch):
+    monkeypatch.setattr(endpoints, "_MAX_RATE_LIMIT_ENTRIES", 10)
+    for i in range(40):
+        endpoints._store_rate_limit(f"rate_limit:ep:{i}", "{}")
+
+    assert len(endpoints.cached) <= 10
+    assert "rate_limit:ep:39" in endpoints.cached  # newest retained
+    assert "rate_limit:ep:0" not in endpoints.cached  # oldest evicted
+
+
+def test_updating_an_existing_key_does_not_grow(monkeypatch):
+    monkeypatch.setattr(endpoints, "_MAX_RATE_LIMIT_ENTRIES", 10)
+    endpoints._store_rate_limit("k", "v1")
+    endpoints._store_rate_limit("k", "v2")
+
+    assert len(endpoints.cached) == 1
+    assert endpoints.cached["k"] == "v2"

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -303,6 +303,17 @@ def get_current_user_uid_from_ws_message(message: Dict[str, Any]) -> str:
 
 cached: Dict[str, Any] = {}
 
+# This in-process rate-limit cache is keyed by "{endpoint}:{ip}", so a stream of distinct client IPs
+# would otherwise grow it without bound. Bound the map.
+_MAX_RATE_LIMIT_ENTRIES = 100000
+
+
+def _store_rate_limit(key: str, value: str) -> None:
+    cached[key] = value
+    if len(cached) > _MAX_RATE_LIMIT_ENTRIES:
+        for stale in list(cached)[: len(cached) - _MAX_RATE_LIMIT_ENTRIES]:
+            del cached[stale]
+
 
 def rate_limit_custom(endpoint: str, request: Request, requests_per_window: int, window_seconds: int) -> bool:
     ip = request.client.host if request.client else None
@@ -339,8 +350,8 @@ def rate_limit_custom(endpoint: str, request: Request, requests_per_window: int,
         remaining = requests_per_window - 1
         timestamp = int(time.time())
 
-    # Update the rate limit info in Redis
-    cached[key] = json.dumps({"timestamp": timestamp, "remaining": remaining})
+    # Update the rate limit info in the in-process cache
+    _store_rate_limit(key, json.dumps({"timestamp": timestamp, "remaining": remaining}))
 
     return True
 


### PR DESCRIPTION
## What

`utils.other.endpoints.rate_limit_custom` (used via `rate_limit_dependency` as a FastAPI per-endpoint dependency) keeps rate-limit state in a module-level dict:

```python
cached: Dict[str, Any] = {}

def rate_limit_custom(endpoint, request, requests_per_window, window_seconds):
    ip = request.client.host if request.client else None
    key = f"rate_limit:{endpoint}:{ip}"
    ...
    cached[key] = json.dumps({"timestamp": timestamp, "remaining": remaining})
    return True
```

The dict is keyed by `{endpoint}:{ip}` and is only ever read and written — there is no eviction, TTL, or size cap. The window-expiry logic resets the counter for an existing key but never deletes stale keys. So every distinct client IP that hits an endpoint using this dependency adds an entry that stays for the whole process lifetime. Ordinary traffic accumulates entries, and an attacker rotating source IPs can inflate it deliberately. This is exactly the case the backend guide calls out (gotcha #11: "Module-level dicts: add TTL-based eviction or cap size - they grow forever otherwise").

## Fix

Route the write through a small bounded helper that evicts the oldest entries once over a cap:

```python
_MAX_RATE_LIMIT_ENTRIES = 100000

def _store_rate_limit(key: str, value: str) -> None:
    cached[key] = value
    if len(cached) > _MAX_RATE_LIMIT_ENTRIES:
        for stale in list(cached)[: len(cached) - _MAX_RATE_LIMIT_ENTRIES]:
            del cached[stale]
```

```python
_store_rate_limit(key, json.dumps({"timestamp": timestamp, "remaining": remaining}))
```

Dict insertion order (Python 3.7+) makes the leading keys the oldest, so eviction drops the least-recently-inserted entries. The read path, window reset, and fail-open on a corrupt entry are all unchanged. (The pre-existing comment claimed the write went to Redis; it does not, so the comment is corrected to say in-process cache.)

## Tests

New `tests/unit/test_rate_limit_cache_cap.py`:

- writing many distinct keys keeps the map within the cap, retains the newest, and evicts the oldest
- updating an existing key does not grow the map

## Verification

```
cd backend && ENCRYPTION_SECRET=... python -m pytest tests/unit/test_rate_limit_cache_cap.py -q
  -> 2 passed
black --line-length 120 --skip-string-normalization --check utils/other/endpoints.py tests/unit/test_rate_limit_cache_cap.py
  -> unchanged
python -m pyright -p pyrightconfig.json utils/other/endpoints.py
  -> 0 errors
python scripts/check_module_stub_pollution.py
  -> Checked 661 test file(s); 0 violations
```

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

