### PR TITLE
Skip malformed stored chat messages when building app proactive notifications

### DIFF
--- a/backend/tests/unit/test_app_integrations_safe_messages.py
+++ b/backend/tests/unit/test_app_integrations_safe_messages.py
@@ -1,0 +1,78 @@
+"""Regression test: one malformed stored chat message must not abort the whole
+proactive-notification build.
+
+utils.app_integrations._process_proactive_notification loads the last 10 app chat
+messages to substitute into the {{user_chat}} prompt slot. It used to build them with
+[Message(**msg) for msg in get_app_messages(...)], so a single legacy or malformed
+stored record raised a ValidationError. The only production caller wraps this in a broad
+except (fire-and-forget via run_blocking), so the failure was silent: the proactive
+notification was dropped on every run for that user until the bad row aged out of the
+last-10 window. The fix routes the batch through Message.deserialize_many_safe (the
+shared safe-deserialize helper added in #8882), which skips the bad record and keeps the
+rest, so the notification is still built and sent.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+import utils.app_integrations as app_int
+
+_GOOD_MESSAGE = {
+    "id": "good-1",
+    "text": "remember to drink water",
+    "created_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+    "sender": "human",
+    "type": "text",
+}
+# Missing text / created_at / sender / type -> Message(**record) raises ValidationError.
+_MALFORMED_MESSAGE = {"id": "legacy-broken"}
+
+
+@pytest.fixture
+def proactive_env(monkeypatch):
+    """Neutralize every dependency _process_proactive_notification touches except the real
+    Message deserialization this test is exercising (app_int.Message stays the real class)."""
+    monkeypatch.setattr(app_int, "_hit_proactive_notification_rate_limits", lambda uid, app: False)
+    monkeypatch.setattr(app_int, "_proactive_daily_cap_reached", lambda uid: False)
+    monkeypatch.setattr(app_int, "_set_proactive_noti_sent_at", MagicMock())
+    monkeypatch.setattr(app_int, "get_prompt_memories", lambda uid: ("Zach", "likes tea"))
+    monkeypatch.setattr(app_int, "send_app_notification", MagicMock())
+    monkeypatch.setattr(app_int, "incr_daily_notification_count", MagicMock())
+
+    llm = MagicMock()
+    llm.invoke.return_value.content = "Here is your nudge."
+    monkeypatch.setattr(app_int, "get_llm", MagicMock(return_value=llm))
+    return monkeypatch
+
+
+def _make_app():
+    app = MagicMock()
+    app.has_capability.return_value = True
+    app.id = "app-x"
+    app.name = "TestApp"
+    app.filter_proactive_notification_scopes.return_value = ["user_chat"]
+    return app
+
+
+def test_malformed_message_does_not_abort_proactive_notification(proactive_env):
+    proactive_env.setattr(
+        app_int, "get_app_messages", lambda uid, app_id, limit=10: [_GOOD_MESSAGE, _MALFORMED_MESSAGE]
+    )
+
+    result = app_int._process_proactive_notification(
+        "uid-1", _make_app(), {"prompt": "context: {{user_chat}}", "params": ["user_chat"]}
+    )
+
+    assert result == "Here is your nudge."
+
+
+def test_all_messages_malformed_still_sends(proactive_env):
+    proactive_env.setattr(app_int, "get_app_messages", lambda uid, app_id, limit=10: [_MALFORMED_MESSAGE])
+
+    result = app_int._process_proactive_notification(
+        "uid-2", _make_app(), {"prompt": "context: {{user_chat}}", "params": ["user_chat"]}
+    )
+
+    assert result == "Here is your nudge."

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -615,7 +615,12 @@ def _process_proactive_notification(uid: str, app: App, data):
 
     chat_messages = []
     if 'user_chat' in filter_scopes:
-        chat_messages = list(reversed([Message(**msg) for msg in get_app_messages(uid, app.id, limit=10)]))
+        # Skip any malformed/legacy stored message rather than letting one bad record raise a
+        # ValidationError that aborts the whole notification. The sole caller swallows exceptions
+        # from here, so an unguarded build silently dropped the proactive notification every run
+        # until the bad row aged out of the last-10 window. deserialize_many_safe (#8882) is the
+        # shared safe-deserialize path for exactly this class.
+        chat_messages = list(reversed(Message.deserialize_many_safe(get_app_messages(uid, app.id, limit=10))))
 
     # Build prompt with substitutions
     for param in filter_scopes:


### PR DESCRIPTION
## What

`_process_proactive_notification` in `utils/app_integrations.py` loads the last 10 app chat messages to fill the `{{user_chat}}` prompt slot, building them with:

```python
chat_messages = list(reversed([Message(**msg) for msg in get_app_messages(uid, app.id, limit=10)]))
```

One legacy or malformed stored record raises a `ValidationError`. The only caller runs this fire-and-forget through `run_blocking` and swallows exceptions, so the failure is silent: the proactive notification is dropped on every run for that user until the bad row ages out of the last-10 window. There is no 500 and no log at the drop site, so the user just stops getting notifications from that app.

## Fix

Route the batch through `Message.deserialize_many_safe`, the shared safe-deserialize helper added in #8882, which skips the bad record and keeps the rest. This closes the same failure class at its remaining reachable call site rather than patching one line: #8882 introduced the helper and converted the chat-history load, but this proactive-notification builder still did the unguarded comprehension.

## Tests

`tests/unit/test_app_integrations_safe_messages.py` drives `_process_proactive_notification` through two cases:

- a good record plus one malformed record (missing required fields)
- an all-malformed batch

Both assert the notification is still produced. Both fail against the pre-fix source with `ValidationError` and pass after the fix. The test keeps the real `Message` class (it does not stub `app_integrations.Message`), so it exercises the actual deserialization path.

## Verification

```
python -m pytest tests/unit/test_app_integrations_safe_messages.py -q
  -> 2 passed
  -> 2 failed (ValidationError) when the one-line source fix is reverted, test kept

black --line-length 120 --skip-string-normalization --check \
  utils/app_integrations.py tests/unit/test_app_integrations_safe_messages.py
  -> clean

python -m pyright -p pyrightconfig.json utils/app_integrations.py
  -> 0 errors, 0 warnings

python scripts/check_module_stub_pollution.py
  -> 0 violations
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

