### PR TITLE
Add Person.deserialize_many_safe and use it in memory extraction

### DIFF
--- a/backend/models/other.py
+++ b/backend/models/other.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, Callable, Iterable, List, Mapping, Optional
 
 from pydantic import BaseModel, Field
 
@@ -43,3 +43,21 @@ class Person(BaseModel):
     speech_samples: List[str] = []
     speech_sample_transcripts: Optional[List[str]] = None
     speech_samples_version: int = 3
+
+    @classmethod
+    def deserialize_many_safe(
+        cls,
+        records: Iterable[Mapping[str, Any]],
+        on_error: Optional[Callable[[Mapping[str, Any], Exception], None]] = None,
+    ) -> List['Person']:
+        """Build Person objects from raw stored records, skipping any that fail validation so one
+        malformed or legacy person document cannot break a whole people lookup. on_error(record,
+        exception), when provided, is called for each skip. Mirrors Message.deserialize_many_safe."""
+        parsed: List['Person'] = []
+        for record in records:
+            try:
+                parsed.append(cls(**record))
+            except Exception as exc:  # noqa: BLE001 - one bad record must not break the lookup
+                if on_error is not None:
+                    on_error(record, exc)
+        return parsed

--- a/backend/tests/unit/test_person_deserialize_many_safe.py
+++ b/backend/tests/unit/test_person_deserialize_many_safe.py
@@ -1,0 +1,47 @@
+"""Regression test for Person.deserialize_many_safe.
+
+Several LLM prompt builders load people with
+[Person(**p) for p in users_db.get_people_by_ids(...)]. A single malformed or legacy stored
+person document (for example one missing the required name field) raised a ValidationError that
+aborted the whole people lookup, which in turn broke memory extraction for that conversation.
+Person.deserialize_many_safe skips the bad record and keeps the rest, mirroring
+Message.deserialize_many_safe (#8882).
+"""
+
+from datetime import datetime, timezone
+
+from models.other import Person
+
+_GOOD = {"id": "p1", "name": "Alex"}
+_GOOD_2 = {"id": "p2", "name": "Sam", "created_at": datetime(2024, 1, 1, tzinfo=timezone.utc)}
+# Missing the required 'name' field -> Person(**record) raises ValidationError.
+_MALFORMED = {"id": "p3"}
+
+
+def test_skips_malformed_record_keeps_valid():
+    people = Person.deserialize_many_safe([_GOOD, _MALFORMED, _GOOD_2])
+
+    assert [p.id for p in people] == ["p1", "p2"]
+    assert all(isinstance(p, Person) for p in people)
+
+
+def test_on_error_called_for_each_skip():
+    skipped = []
+    people = Person.deserialize_many_safe(
+        [_GOOD, _MALFORMED], on_error=lambda record, exc: skipped.append((record, exc))
+    )
+
+    assert [p.id for p in people] == ["p1"]
+    assert len(skipped) == 1
+    assert skipped[0][0] == _MALFORMED
+    assert isinstance(skipped[0][1], Exception)
+
+
+def test_all_valid_preserves_order():
+    people = Person.deserialize_many_safe([_GOOD_2, _GOOD])
+
+    assert [p.id for p in people] == ["p2", "p1"]
+
+
+def test_empty_input_returns_empty_list():
+    assert Person.deserialize_many_safe([]) == []

--- a/backend/utils/llm/memories.py
+++ b/backend/utils/llm/memories.py
@@ -112,7 +112,7 @@ def new_memories_extractor(
         user_name, memories_str = get_prompt_memories(uid)
 
     person_ids = list(set([s.person_id for s in segments if s.person_id]))
-    people = [Person(**p) for p in users_db.get_people_by_ids(uid, person_ids)] if person_ids else []
+    people = Person.deserialize_many_safe(users_db.get_people_by_ids(uid, person_ids)) if person_ids else []
     content = TranscriptSegment.segments_as_string(segments, user_name=user_name, people=people)
     if not content or len(content) < 25:  # less than 5 words, probably nothing
         return []
@@ -210,7 +210,7 @@ def new_learnings_extractor(
         user_name, learnings_str = get_prompt_memories(uid)
 
     person_ids = list(set([s.person_id for s in segments if s.person_id]))
-    people = [Person(**p) for p in users_db.get_people_by_ids(uid, person_ids)] if person_ids else []
+    people = Person.deserialize_many_safe(users_db.get_people_by_ids(uid, person_ids)) if person_ids else []
     content = TranscriptSegment.segments_as_string(segments, user_name=user_name, people=people)
     if not content or len(content) < 100:
         return []


### PR DESCRIPTION
## What

Several LLM prompt builders load people with:

```python
people = [Person(**p) for p in users_db.get_people_by_ids(uid, person_ids)]
```

`get_people_by_ids` returns raw stored documents. One malformed or legacy person document (for example one missing the required `name` field) makes `Person(**p)` raise a `ValidationError`, which aborts the whole people lookup. In `utils/llm/memories.py` that lookup feeds memory extraction, so a single bad person row breaks memory extraction for that conversation.

This is the same failure class #8882 fixed for `Message` by adding `Message.deserialize_many_safe`. `Person` had no equivalent guard, so the raw comprehension pattern is repeated across the LLM prompt builders.

## Fix

Add `Person.deserialize_many_safe`, mirroring `Message.deserialize_many_safe`: it builds `Person` objects from raw records, skips any that fail validation, keeps the rest, and calls an optional `on_error(record, exception)` for each skip.

Adopt it in the two memory-extraction call sites in `utils/llm/memories.py`. The same one-line swap applies to the other `Person(**p)` call sites (chat, trends, retrieval, conversation processing). Following the guidance to land the enforceable guard now rather than broadening a safe fix into a wide migration, this PR keeps the diff to the model guard plus the memory-extraction subsystem so it stays reviewable; the remaining sites can adopt the helper incrementally.

## Tests

`tests/unit/test_person_deserialize_many_safe.py` exercises the guard directly (imports only `models.other`, so it is fast and hermetic):

- a good + malformed + good batch keeps the two valid people and drops the malformed one
- `on_error` is called once per skipped record with the record and the exception
- an all-valid batch preserves order
- empty input returns an empty list

## Verification

```
python -m pytest tests/unit/test_person_deserialize_many_safe.py -q
  -> 4 passed

black --line-length 120 --skip-string-normalization --check \
  models/other.py utils/llm/memories.py tests/unit/test_person_deserialize_many_safe.py
  -> clean

python -m pyright -p pyrightconfig.json models/other.py utils/llm/memories.py
  -> 0 errors

python scripts/check_module_stub_pollution.py
  -> 0 violations

import-verified utils/llm/memories.py after the swap (Person.deserialize_many_safe present)
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

