### PR TITLE
fix(desktop): reopen Rewind database after self-recovery close (#9790)

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -87,8 +87,21 @@ actor RewindIndexer {
         }
     }
 
+    /// Reconcile the cached `isInitialized` flag against the authoritative
+    /// database readiness. `RewindDatabase` self-recovers by closing its pool
+    /// after repeated I/O or corruption errors; when it does, our cached flag is
+    /// stale and would otherwise short-circuit reinitialization, leaving frames
+    /// to emit repeated `databaseNotInitialized` errors until the 6-hourly
+    /// cleanup happens to call `RewindDatabase.initialize()` again.
+    private func reconcileDatabaseReadiness() async {
+        guard isInitialized, await !RewindDatabase.shared.isInitialized else { return }
+        log("RewindIndexer: Database closed after self-recovery; reinitializing")
+        isInitialized = false
+    }
+
     /// Try to initialize with exponential backoff. Returns true if initialized.
-    private func ensureInitialized() async -> Bool {
+    func ensureInitialized() async -> Bool {
+        await reconcileDatabaseReadiness()
         if isInitialized { return true }
 
         // Check backoff timer - skip if too soon after last failure
@@ -645,7 +658,8 @@ actor RewindIndexer {
     func rebuildFromVideoFiles(progressCallback: @escaping (Double) -> Void) async throws {
         log("RewindIndexer: Starting database rebuild from video files...")
 
-        // Ensure initialized
+        // Ensure initialized (reopen if the database self-recovered/closed).
+        await reconcileDatabaseReadiness()
         if !isInitialized {
             try await initialize()
         }

--- a/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
@@ -66,4 +66,48 @@ final class RewindDatabaseLifecycleTests: XCTestCase {
     await RewindDatabase.shared.close()
     RewindDatabase.currentUserId = nil
   }
+
+  /// Regression for the stale indexer cache: after the database self-recovers by
+  /// closing its pool, the indexer must reopen it on the next frame instead of
+  /// trusting its own cached `isInitialized` flag and emitting repeated
+  /// `databaseNotInitialized` errors until the 6-hourly cleanup retries.
+  func testIndexerReopensDatabaseAfterSelfRecoveryClose() async throws {
+    let testUserId = "rewind-indexer-reopen-\(UUID().uuidString)"
+    let userDir = FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(testUserId, isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: userDir) }
+
+    await RewindDatabase.shared.close()
+    RewindDatabase.currentUserId = testUserId
+    await RewindDatabase.shared.configure(userId: testUserId)
+    await RewindIndexer.shared.reset()
+
+    // First initialization: indexer + database both ready.
+    let firstReady = await RewindIndexer.shared.ensureInitialized()
+    XCTAssertTrue(firstReady)
+    let dbReadyAfterInit = await RewindDatabase.shared.isInitialized
+    XCTAssertTrue(dbReadyAfterInit)
+
+    // Simulate self-recovery: repeated I/O errors close the pool.
+    await RewindDatabase.shared.close()
+    let dbReadyAfterClose = await RewindDatabase.shared.isInitialized
+    XCTAssertFalse(dbReadyAfterClose)
+
+    // The indexer's cached flag is now stale. It must reconcile against the
+    // authoritative database readiness and reopen the pool.
+    let reopened = await RewindIndexer.shared.ensureInitialized()
+    XCTAssertTrue(reopened, "indexer must reinitialize after the database self-recovers")
+    let dbReadyAfterReopen = await RewindDatabase.shared.isInitialized
+    XCTAssertTrue(
+      dbReadyAfterReopen,
+      "stale indexer cache must reopen the closed database instead of leaving it closed"
+    )
+
+    await RewindIndexer.shared.reset()
+    await RewindDatabase.shared.close()
+    RewindDatabase.currentUserId = nil
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260715-rewind-indexer-reopen-db.json
+++ b/desktop/macos/changelog/unreleased/20260715-rewind-indexer-reopen-db.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Rewind timeline going stale for hours after a database self-recovery — the indexer now reopens the database on the next frame instead of waiting for periodic cleanup"
+}


### PR DESCRIPTION
Fixes #9790

## Bug
After repeated SQLite I/O or corruption errors, `RewindDatabase` self-recovers by closing its pool (`dbQueue = nil`, `isInitialized` → false). `RewindIndexer`, however, keeps its own cached `isInitialized = true` flag, so `ensureInitialized()` short-circuits and never reopens the database. Every captured frame then emits repeated `databaseNotInitialized` errors until the 6-hourly retention cleanup happens to call `RewindDatabase.initialize()` again — up to six hours of a dead Rewind timeline.

## Root cause
The indexer's cached readiness flag was not reconciled against the authoritative source, `RewindDatabase.shared.isInitialized`, after the database self-recovered/closed.

## Fix
Add `reconcileDatabaseReadiness()`: if the indexer thinks it's initialized but the database pool is actually closed, clear the stale flag so the next call reinitializes. It's invoked before both:
- `ensureInitialized()` — the per-frame indexing path (the hot path in the issue), and
- `rebuildFromVideoFiles()` — which had the same stale-flag exposure.

This reopens the pool on the very next frame instead of waiting for periodic cleanup.

## Test
`RewindDatabaseLifecycleTests.testIndexerReopensDatabaseAfterSelfRecoveryClose` drives the real `ensureInitialized()` through a self-recovery close and asserts the database reopens.
- Fails without the fix (DB stays closed) ✅ verified
- Passes with the fix ✅
- Full `RewindDatabaseLifecycleTests` suite green (3/3), `xcrun swift build` clean, `check_desktop_test_quality.py` OK.

🤖 automated by hourly watchdog; opened for review.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

