### PR TITLE
fix(ci): complete Windows pre-push launch path

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -19,9 +19,9 @@ checks:
     reason: "advisory desktop release evidence and drift report"
   - id: preflight-runner-portability
     command: ["python3", ".github/scripts/test_preflight_runner.py"]
-    triggers: [".github/scripts/preflight_runner.py", ".github/scripts/test_preflight_runner.py"]
+    triggers: [".github/scripts/preflight_runner.py", ".github/scripts/test_preflight_runner.py", "scripts/pre-push-singleflight"]
     lanes: ["local", "ci"]
-    reason: "single-flight pre-push runner must start on hosts without POSIX signal APIs"
+    reason: "single-flight pre-push runner must start and launch its Bash checks portably"
   - id: diff-hygiene
     command: ["python3", ".github/scripts/check_diff_hygiene.py", "--changed-files", "{changed_files}", "--base", "{base}", "--head", "{head}"]
     triggers: ["all"]

--- a/.github/scripts/test_preflight_runner.py
+++ b/.github/scripts/test_preflight_runner.py
@@ -7,6 +7,10 @@ import importlib.util
 import os
 from pathlib import Path
 import signal
+import shutil
+import subprocess
+import sys
+import tempfile
 import types
 import unittest
 from unittest import mock
@@ -14,10 +18,24 @@ from unittest import mock
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 MODULE_PATH = SCRIPT_DIR / "preflight_runner.py"
+REPO_ROOT = SCRIPT_DIR.parents[1]
+WRAPPER_PATH = REPO_ROOT / "scripts" / "pre-push-singleflight"
 SPEC = importlib.util.spec_from_file_location("preflight_runner", MODULE_PATH)
 assert SPEC and SPEC.loader
 runner = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(runner)
+
+
+def find_hook_bash() -> str | None:
+    if os.name == "nt":
+        git = shutil.which("git")
+        if git:
+            git_root = Path(git).resolve().parent.parent
+            for relative_path in (Path("bin/bash.exe"), Path("usr/bin/bash.exe")):
+                candidate = git_root / relative_path
+                if candidate.is_file():
+                    return str(candidate)
+    return shutil.which("bash")
 
 
 class FakeChild:
@@ -55,7 +73,7 @@ class SignalChildTests(unittest.TestCase):
         child = FakeChild()
 
         with mock.patch.object(runner, "HAS_PROCESS_GROUPS", True):
-            with mock.patch.object(runner.os, "killpg") as killpg:
+            with mock.patch.object(runner.os, "killpg", create=True) as killpg:
                 runner.signal_child(child, signal.SIGINT)
 
         killpg.assert_called_once_with(child.pid, signal.SIGINT)
@@ -81,7 +99,7 @@ class SignalChildTests(unittest.TestCase):
         child = FakeChild()
 
         with mock.patch.object(runner, "HAS_PROCESS_GROUPS", True):
-            with mock.patch.object(runner.os, "killpg", side_effect=ProcessLookupError):
+            with mock.patch.object(runner.os, "killpg", side_effect=ProcessLookupError, create=True):
                 runner.signal_child(child, signal.SIGTERM)
 
 
@@ -97,6 +115,32 @@ class ProcessExistsTests(unittest.TestCase):
     def test_live_and_dead_pids(self) -> None:
         self.assertTrue(runner.process_exists(os.getpid()))
         self.assertFalse(runner.process_exists(0))
+
+
+class WrapperContractTests(unittest.TestCase):
+    def test_launches_extensionless_pre_push_through_active_bash(self) -> None:
+        wrapper = WRAPPER_PATH.read_text(encoding="utf-8")
+
+        self.assertIn(' -- "$BASH" scripts/pre-push "$@"', wrapper)
+
+    def test_runner_launches_bash_on_this_host(self) -> None:
+        bash = find_hook_bash()
+        self.assertIsNotNone(bash)
+
+        with tempfile.TemporaryDirectory() as state_dir:
+            env = {**os.environ, "OMI_PREFLIGHT_STATE_DIR": state_dir}
+            completed = subprocess.run(
+                [sys.executable, str(MODULE_PATH), "--name", "bash-launch", "--", bash, "-c", "printf bash-ok"],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=False,
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("bash-ok", completed.stdout)
 
 
 if __name__ == "__main__":

--- a/scripts/pre-push-singleflight
+++ b/scripts/pre-push-singleflight
@@ -4,4 +4,4 @@ set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
-exec python3 .github/scripts/preflight_runner.py --name pre-push -- scripts/pre-push "$@"
+exec python3 .github/scripts/preflight_runner.py --name pre-push -- "$BASH" scripts/pre-push "$@"


### PR DESCRIPTION
## Summary

Completes the native-Windows launch path in #9730:

- pass the active Bash executable to `preflight_runner.py` before the extensionless `scripts/pre-push` path
- add a wrapper contract plus a real host-Bash launch test
- let the POSIX `killpg` simulations construct that missing API on Windows
- select the portability check whenever the wrapper changes

## Root cause and guard

After #9730 avoids the missing `signal.SIGHUP`, Python 3.11 on Windows reaches `subprocess.Popen` but `CreateProcess` cannot execute the extensionless Bash script directly. Binding the wrapper to its already-running `$BASH` preserves POSIX behavior and gives Windows an executable entrypoint. The manifest-backed regression test keeps that argv contract attached to future wrapper edits.

## Verification

- Before the wrapper change, the regression test failed because the first command after `--` was `pre-push`, not Bash.
- `python .github/scripts/test_preflight_runner.py` -> 11 tests OK on native Windows
- `python .github/scripts/test_run_checks.py` -> 9 tests OK
- Direct runner proof -> `windows-bash-launch-ok`
- Local PR preflight -> 9 selected checks passed
- Real `git push` reached and passed the portability/preflight/deployment-policy checks; the older #9730 base then stopped at its pre-existing `backend/.venv/bin/python` requirement.

Product invariants: none.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

