### PR TITLE
Tolerate malformed ISO date strings on action-item writes

### DIFF
--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -126,28 +126,19 @@ def _prepare_action_item_for_write(action_item_data: Dict[str, Any], *, partial:
         action_item_data.setdefault('provenance', [])
         action_item_data.setdefault('sort_order', 0)
         action_item_data.setdefault('indent_level', 0)
-    # Ensure timestamps are properly formatted
-    if 'created_at' in action_item_data and action_item_data['created_at']:
-        if isinstance(action_item_data['created_at'], str):
-            action_item_data['created_at'] = datetime.fromisoformat(
-                action_item_data['created_at'].replace('Z', '+00:00')
-            )
-
-    if 'updated_at' in action_item_data and action_item_data['updated_at']:
-        if isinstance(action_item_data['updated_at'], str):
-            action_item_data['updated_at'] = datetime.fromisoformat(
-                action_item_data['updated_at'].replace('Z', '+00:00')
-            )
-
-    if 'due_at' in action_item_data and action_item_data['due_at']:
-        if isinstance(action_item_data['due_at'], str):
-            action_item_data['due_at'] = datetime.fromisoformat(action_item_data['due_at'].replace('Z', '+00:00'))
-
-    if 'completed_at' in action_item_data and action_item_data['completed_at']:
-        if isinstance(action_item_data['completed_at'], str):
-            action_item_data['completed_at'] = datetime.fromisoformat(
-                action_item_data['completed_at'].replace('Z', '+00:00')
-            )
+    # Normalize any ISO date strings to aware datetimes. These fields can arrive as strings from
+    # tool- and LLM-created action items (not only from validated API models), so a single malformed
+    # string must not raise and 500 the whole create/update. Drop the bad value with a warning and let
+    # the field fall back to its default or stay unset, matching the tolerant date handling on the read
+    # path and in _coerce_utc_datetime.
+    for date_field in ('created_at', 'updated_at', 'due_at', 'completed_at'):
+        value = action_item_data.get(date_field)
+        if isinstance(value, str) and value:
+            try:
+                action_item_data[date_field] = datetime.fromisoformat(value.replace('Z', '+00:00'))
+            except ValueError:
+                logger.warning("Dropping malformed %s=%r on action item write", date_field, value)
+                action_item_data.pop(date_field, None)
 
     return action_item_data
 

--- a/backend/tests/unit/test_action_items_date_coercion.py
+++ b/backend/tests/unit/test_action_items_date_coercion.py
@@ -1,0 +1,46 @@
+"""Regression test: a malformed ISO date string must not 500 an action-item write.
+
+database.action_items._prepare_action_item_for_write normalizes created_at / updated_at /
+due_at / completed_at ISO strings to datetimes. These fields arrive as strings from tool-
+and LLM-created action items (not only from validated API models), so a single malformed
+value used to raise ValueError('Invalid isoformat string') out of create_action_item /
+update_action_item and 500 the request. The write path now drops a malformed date (with a
+warning) and keeps the rest of the item, mirroring the tolerant date handling on the read
+path and in _coerce_utc_datetime.
+"""
+
+from datetime import datetime
+
+from database.action_items import _prepare_action_item_for_write
+
+
+def test_malformed_due_at_is_dropped_not_raised():
+    out = _prepare_action_item_for_write({"description": "x", "due_at": "not-a-real-date"}, partial=True)
+
+    assert "due_at" not in out  # malformed value dropped, no ValueError raised
+    assert out["description"] == "x"
+
+
+def test_valid_iso_string_is_parsed():
+    out = _prepare_action_item_for_write({"description": "x", "due_at": "2024-01-01T00:00:00Z"}, partial=True)
+
+    assert isinstance(out["due_at"], datetime)
+    assert out["due_at"].year == 2024
+    assert out["due_at"].tzinfo is not None
+
+
+def test_datetime_value_passes_through_unchanged():
+    dt = datetime(2024, 5, 6, 7, 8, 9)
+    out = _prepare_action_item_for_write({"description": "x", "due_at": dt}, partial=True)
+
+    assert out["due_at"] is dt
+
+
+def test_one_malformed_field_does_not_drop_the_others():
+    out = _prepare_action_item_for_write(
+        {"description": "x", "created_at": "garbage", "due_at": "2024-01-01T00:00:00Z"},
+        partial=True,
+    )
+
+    assert "created_at" not in out  # malformed dropped
+    assert isinstance(out["due_at"], datetime)  # sibling good value preserved


### PR DESCRIPTION
## What

`database.action_items._prepare_action_item_for_write` normalizes `created_at` / `updated_at` / `due_at` / `completed_at` from ISO strings to `datetime` objects before writing to Firestore:

```python
if 'due_at' in action_item_data and action_item_data['due_at']:
    if isinstance(action_item_data['due_at'], str):
        action_item_data['due_at'] = datetime.fromisoformat(action_item_data['due_at'].replace('Z', '+00:00'))
```

The `isinstance(..., str)` guards exist because these fields arrive as strings, not only as pydantic-validated `datetime`s: tool- and LLM-created action items and internal callers pass ISO date strings. A single malformed string (for example a bad LLM-produced due date) makes `datetime.fromisoformat` raise `ValueError: Invalid isoformat string`, and this helper is the shared boundary for `create_action_item`, `update_action_item`, and the batch update path, so the whole request 500s.

Reproduction:

```
>>> _prepare_action_item_for_write({'description': 'x', 'due_at': 'not-a-real-date'}, partial=True)
ValueError: Invalid isoformat string: 'not-a-real-date'
```

## Fix

Coerce the four date fields in one tolerant loop. Valid ISO strings parse exactly as before; a malformed string is dropped with a warning instead of raising, so the field falls back to its default or stays unset and the rest of the item is written.

This matches the tolerant date handling the codebase already uses elsewhere:
- the read path `_prepare_action_item_for_read` uses `hasattr(..., 'timestamp')` / `fromtimestamp` and never raises on a bad stored value
- `database.api_key_metadata._coerce_utc_datetime` returns `None` on `ValueError`
- `models.app.ChatTool.deserialize_parameters` logs and drops malformed JSON rather than raising

The loop also collapses four copies of the same parse block into one.

## Tests

`tests/unit/test_action_items_date_coercion.py` (pure function, no DB):

- malformed `due_at` is dropped, not raised
- a valid ISO string is parsed to an aware datetime
- an existing `datetime` value passes through unchanged
- one malformed field does not drop a sibling valid field

The two malformed-input cases raise `ValueError` against the pre-fix source and pass after.

## Verification

```
python -m pytest tests/unit/test_action_items_date_coercion.py -q
  -> 4 passed  (2 fail with ValueError when the source fix is reverted, test kept)

black --line-length 120 --skip-string-normalization --check \
  database/action_items.py tests/unit/test_action_items_date_coercion.py
  -> clean

python -m pyright -p pyrightconfig.json database/action_items.py
  -> 0 errors

python scripts/check_module_stub_pollution.py
  -> 0 violations
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

