### PR TITLE
Guard sync-job Redis reads against a corrupt or legacy blob

### DIFF
--- a/backend/database/sync_jobs.py
+++ b/backend/database/sync_jobs.py
@@ -198,7 +198,13 @@ def get_sync_job(job_id: str) -> Optional[Dict[str, Any]]:
     data = r.get(key)
     if not data:
         return None
-    raw = json.loads(data)
+    try:
+        raw = json.loads(data)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        # A corrupt or legacy blob must not 500 the status poll. redis_db is fail-open and the
+        # fenced mutation paths below already guard the identical json.loads; an unparseable job
+        # is treated as an unknown job.
+        return None
     job: Dict[str, Any] = cast(Dict[str, Any], raw) if isinstance(raw, dict) else {}
 
     return job
@@ -284,7 +290,12 @@ def update_sync_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, 
     if not data:
         return None
     current_raw = _as_redis_text(data)
-    decoded = json.loads(current_raw)
+    try:
+        decoded = json.loads(current_raw)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        # Corrupt/legacy blob: treat as an unresolvable job and skip the mutation, matching the
+        # isinstance(dict) guard just below and the fenced paths' json.loads handling.
+        return None
     if not isinstance(decoded, dict):
         return None
     current_job = cast(Dict[str, Any], decoded)

--- a/backend/tests/unit/test_sync_jobs_corrupt_blob.py
+++ b/backend/tests/unit/test_sync_jobs_corrupt_blob.py
@@ -1,0 +1,38 @@
+"""Regression test: a corrupt Redis sync-job blob must not 500 the sync-status poll.
+
+database.sync_jobs reads job documents from Redis with json.loads. The redis_db layer is
+documented as fail-open (all errors caught and logged, requests proceed), and the fenced
+mutation paths in this same module already guard json.loads with
+except (TypeError, ValueError, json.JSONDecodeError). get_sync_job and update_sync_job did
+not, so a corrupt or legacy sync_job:{id} blob raised JSONDecodeError out of the status
+poll / update path. Both now return None (unknown job) on unparseable data, matching the
+sibling fenced paths and the fail-open contract.
+"""
+
+import database.sync_jobs as sync_jobs
+
+
+class _FakeRedis:
+    def __init__(self, value):
+        self._value = value
+
+    def get(self, key):
+        return self._value
+
+
+def test_get_sync_job_returns_none_on_corrupt_blob(monkeypatch):
+    monkeypatch.setattr(sync_jobs, "r", _FakeRedis(b"{not valid json"))
+
+    assert sync_jobs.get_sync_job("job-1") is None
+
+
+def test_get_sync_job_parses_valid_blob(monkeypatch):
+    monkeypatch.setattr(sync_jobs, "r", _FakeRedis(b'{"id": "job-2", "status": "processing"}'))
+
+    assert sync_jobs.get_sync_job("job-2") == {"id": "job-2", "status": "processing"}
+
+
+def test_update_sync_job_returns_none_on_corrupt_blob(monkeypatch):
+    monkeypatch.setattr(sync_jobs, "r", _FakeRedis(b"{not valid json"))
+
+    assert sync_jobs.update_sync_job("job-3", {"status": "completed"}) is None


### PR DESCRIPTION
## What

`database/sync_jobs.py` reads the `sync_job:{id}` document from Redis and parses it with `json.loads`, unguarded, in two places:

- `get_sync_job` (line 201): `raw = json.loads(data)`
- `update_sync_job` (line 287): `decoded = json.loads(current_raw)`

A corrupt or legacy blob raises `JSONDecodeError`, which 500s the sync-status poll (`get_sync_job`) and the legacy update path (`update_sync_job`).

Two things make this a clear defect rather than a judgment call:

1. `backend/AGENTS.md` documents the redis layer as fail-open: "`from database import redis_db` - fail-open (all errors caught and logged, requests proceed)."
2. The fenced mutation paths in this same module already guard the identical call. `_decode_legacy_job_mutation` (261-265), the reset path (362-365), and the reclaim path (429-432) all wrap `json.loads` in `except (TypeError, ValueError, json.JSONDecodeError)`. `get_sync_job` and `update_sync_job` are the two read paths that were missed.

## Fix

Wrap both reads in the same guard the sibling paths use and return `None` on unparseable data.

`None` already means "unknown job" on both paths: `get_sync_job` returns `None` for a missing key just above, and `update_sync_job` returns `None` immediately below when the decoded value is not a dict. So a corrupt blob now surfaces as an unknown job and callers follow the documented safe re-upload path, instead of a 500.

## Tests

`tests/unit/test_sync_jobs_corrupt_blob.py` uses the sanctioned module-singleton monkeypatch seam (`monkeypatch.setattr(sync_jobs, "r", fake)`):

- `get_sync_job` with a corrupt blob returns `None`
- `get_sync_job` with a valid blob parses normally
- `update_sync_job` with a corrupt blob returns `None`

The two corrupt cases raise `JSONDecodeError` against the pre-fix source and pass after.

## Verification

```
python -m pytest tests/unit/test_sync_jobs_corrupt_blob.py -q
  -> 3 passed  (2 fail with JSONDecodeError when the source fix is reverted, test kept)

black --line-length 120 --skip-string-normalization --check \
  database/sync_jobs.py tests/unit/test_sync_jobs_corrupt_blob.py
  -> clean

python -m pyright -p pyrightconfig.json database/sync_jobs.py
  -> 0 errors

python scripts/check_module_stub_pollution.py
  -> 0 violations
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

