### PR TITLE
Tolerate a Hume success response missing job_id

### DIFF
--- a/backend/tests/unit/test_hume_job_response_model.py
+++ b/backend/tests/unit/test_hume_job_response_model.py
@@ -1,0 +1,25 @@
+"""Regression test: a Hume job-submit success response missing job_id must not raise.
+
+utils.other.hume.HumeJobResponseModel.from_dict is called on the success (HTTP 200) path
+with resp.json(). It read data["job_id"] with a required-key subscript, so a 200 response
+that omits job_id raised KeyError out of request_user_expression_mersurement, even though
+every error status is already turned into an error dict. HumeJobResponseModel.__init__ types
+id as Optional[str], so from_dict now reads job_id defensively and leaves id None when absent.
+"""
+
+from utils.other.hume import HumeJobResponseModel
+
+
+def test_from_dict_with_job_id():
+    model = HumeJobResponseModel.from_dict({"job_id": "abc123"})
+    assert model.id == "abc123"
+
+
+def test_from_dict_missing_job_id_does_not_raise():
+    model = HumeJobResponseModel.from_dict({})
+    assert model.id is None
+
+
+def test_from_dict_ignores_extra_keys():
+    model = HumeJobResponseModel.from_dict({"job_id": "j", "status": "queued"})
+    assert model.id == "j"

--- a/backend/utils/other/hume.py
+++ b/backend/utils/other/hume.py
@@ -148,7 +148,10 @@ class HumeJobResponseModel:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "HumeJobResponseModel":
-        model = cls(data["job_id"])
+        # Read job_id defensively: this runs on the success (HTTP 200) path from resp.json(),
+        # and a response missing job_id must not raise KeyError out of the caller while every
+        # error status is already turned into an error dict. id is Optional[str].
+        model = cls(data.get("job_id"))
         return model
 
 


### PR DESCRIPTION
## What

`utils/other/hume.py` `HumeJobResponseModel.from_dict` runs on the success (HTTP 200) path of `request_user_expression_mersurement`, parsing the response body with a required-key subscript:

```python
model = cls(data["job_id"])   # data is resp.json()
```

Every non-200 status and every request exception is already turned into an error dict earlier in the function. But a 200 response whose JSON body omits `job_id` makes this subscript raise `KeyError`, which propagates uncaught out of the caller. `HumeJobResponseModel.__init__` already types `id` as `Optional[str]`, so a missing id is a representable state, not an error.

## Fix

Read the field defensively with `data.get("job_id")` so a success response missing `job_id` yields a model with `id = None` instead of raising. One line, type-aligned with the existing `Optional[str]` field.

## Tests

`tests/unit/test_hume_job_response_model.py` (pure classmethod, no IO):

- present `job_id` parses to `id`
- missing `job_id` does not raise and leaves `id` None
- extra keys are ignored

The missing-key case raises `KeyError` against the pre-fix source and passes after.

## Verification

```
python -m pytest tests/unit/test_hume_job_response_model.py -q
  -> 3 passed  (1 fail with KeyError when the source fix is reverted, test kept)

black --line-length 120 --skip-string-normalization --check \
  utils/other/hume.py tests/unit/test_hume_job_response_model.py
  -> clean

python -m pyright -p pyrightconfig.json utils/other/hume.py
  -> 0 errors, 0 warnings

python scripts/check_module_stub_pollution.py
  -> 0 violations
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

