### PR TITLE
Align AudioRingBuffer.extract start to the PCM16 sample boundary

### DIFF
--- a/backend/tests/unit/test_audio_ring_buffer_alignment.py
+++ b/backend/tests/unit/test_audio_ring_buffer_alignment.py
@@ -1,0 +1,60 @@
+"""Regression test: AudioRingBuffer.extract must start on a PCM16 sample boundary.
+
+utils.audio.AudioRingBuffer stores PCM16 mono audio. extract() computed start_offset as
+int((actual_start - buffer_start_ts) * bytes_per_second), which is odd about half the time
+because actual_start is an arbitrary float timestamp. An odd byte offset begins the copy on a
+sample's high byte, so every returned int16 sample is byte-shifted into noise. This audio feeds
+speaker-embedding cuts, so the misalignment intermittently corrupts speaker identification.
+extract() now floors start_offset to the 2-byte sample boundary.
+"""
+
+import struct
+
+from utils.audio import AudioRingBuffer
+
+
+def _decode(pcm: bytes):
+    return list(struct.unpack("<" + "h" * (len(pcm) // 2), pcm))
+
+
+def _buffer_with_ascending_samples(sample_rate: int) -> AudioRingBuffer:
+    buf = AudioRingBuffer(1.0, sample_rate)
+    # 100 known ascending samples: 1000, 1001, ... 1099
+    buf.write(b"".join(struct.pack("<h", 1000 + i) for i in range(100)), 10.0)
+    return buf
+
+
+def test_extract_with_odd_start_offset_returns_aligned_samples():
+    sample_rate = 16000
+    buf = _buffer_with_ascending_samples(sample_rate)
+
+    time_range = buf.get_time_range()
+    assert time_range is not None
+    buffer_start_ts, buffer_end_ts = time_range
+
+    # 3.5 bytes worth of time -> start_offset computes to int(3.5) = 3 (odd).
+    out = buf.extract(buffer_start_ts + 3.5 / (sample_rate * 2), buffer_end_ts)
+    assert out is not None
+
+    samples = _decode(out)
+    assert samples  # non-empty
+    # Odd offset floored to 2 -> first whole sample is index 1 (value 1001), not byte-shifted noise.
+    assert samples[0] == 1001, samples[:5]
+    assert all(1000 <= s <= 1099 for s in samples), samples[:5]
+
+
+def test_extract_with_even_start_offset_still_correct():
+    sample_rate = 16000
+    buf = _buffer_with_ascending_samples(sample_rate)
+
+    time_range = buf.get_time_range()
+    assert time_range is not None
+    buffer_start_ts, buffer_end_ts = time_range
+
+    # 4.5 bytes worth of time -> start_offset computes to int(4.5) = 4 (already even).
+    out = buf.extract(buffer_start_ts + 4.5 / (sample_rate * 2), buffer_end_ts)
+    assert out is not None
+
+    samples = _decode(out)
+    assert samples[0] == 1002  # byte 4 = sample index 2
+    assert all(1000 <= s <= 1099 for s in samples), samples[:5]

--- a/backend/utils/audio.py
+++ b/backend/utils/audio.py
@@ -48,6 +48,12 @@ class AudioRingBuffer:
         start_offset = int((actual_start - buffer_start_ts) * self.bytes_per_second)
         end_offset = int((actual_end - buffer_start_ts) * self.bytes_per_second)
 
+        # Align the start to the PCM16 2-byte sample boundary. actual_start is an arbitrary float
+        # timestamp, so start_offset is odd roughly half the time; an odd offset begins the copy on a
+        # sample's high byte and byte-shifts every int16 sample into noise. length below is already
+        # forced even, so flooring the start to an even offset is what keeps whole samples intact.
+        start_offset -= start_offset % 2
+
         # Ensure even number of bytes (PCM16)
         length = ((end_offset - start_offset) // 2) * 2
         if length <= 0:


### PR DESCRIPTION
## What

`utils/audio.py` `AudioRingBuffer` stores PCM16 mono audio (2 bytes per sample). `extract()` computes the byte offset of the requested start as:

```python
start_offset = int((actual_start - buffer_start_ts) * self.bytes_per_second)
```

`actual_start` is an arbitrary float timestamp and `bytes_per_second = sample_rate * 2`, so `start_offset` is odd roughly half the time. The length is already forced even for PCM16 (`length = ((end_offset - start_offset) // 2) * 2`), but the start was never aligned. An odd start offset begins the copy on a sample's high byte, so every int16 sample in the returned buffer is byte-shifted into noise.

This is a real, execution-confirmed data-corruption bug. With 100 ascending samples (1000, 1001, ...) and a start that lands on an odd offset, `extract` returns `[-5629, -5373, -5117, ...]` instead of the written values. The extracted audio feeds speaker-embedding cuts, so the intermittent misalignment corrupts speaker identification. The existing test only checked output length parity, and its offsets happened to be even.

## Fix

Floor `start_offset` to the 2-byte sample boundary before computing length:

```python
start_offset -= start_offset % 2
```

The copy then always begins on a whole sample. The already-even path is unchanged.

## Tests

`tests/unit/test_audio_ring_buffer_alignment.py` (pure class, no monkeypatch):

- extract with a forced odd start offset (3) asserts the decoded int16 samples are the written values (first sample 1001), not byte-shifted noise
- extract with an already-even offset (4) still returns the correct samples (first sample 1002)

The odd-offset case fails against the pre-fix source (returns noise) and passes after.

## Verification

```
python -m pytest tests/unit/test_audio_ring_buffer_alignment.py -q
  -> 2 passed  (1 fail with byte-shifted noise when the source fix is reverted, test kept)

black --line-length 120 --skip-string-normalization --check \
  utils/audio.py tests/unit/test_audio_ring_buffer_alignment.py
  -> clean

python -m pyright -p pyrightconfig.json utils/audio.py
  -> 0 errors, 0 warnings

python scripts/check_module_stub_pollution.py
  -> 0 violations
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

