### PR TITLE
Chunk memory deletes under the Firestore batch limit

### DIFF
--- a/backend/database/memories.py
+++ b/backend/database/memories.py
@@ -405,12 +405,22 @@ def _merge_evidence(  # type: ignore[reportUnusedFunction]  # reserved: thin ali
 
 def delete_memories(uid: str, *, firestore_client: Any = None) -> None:
     database = _get_db(firestore_client)
-    batch = database.batch()
     user_ref = database.collection(users_collection).document(uid)
     memories_ref = user_ref.collection(memories_collection)
+    # Chunk deletes to stay under the Firestore 500-writes-per-batch limit. A user with more than
+    # 500 memories would otherwise make the single batch.commit() raise and delete nothing. Mirrors
+    # the chunking in unlock_all_memories.
+    batch = database.batch()
+    count = 0
     for doc in memories_ref.stream():
         batch.delete(doc.reference)
-    batch.commit()
+        count += 1
+        if count >= 499:  # Firestore batch limit is 500
+            batch.commit()
+            batch = database.batch()
+            count = 0
+    if count > 0:
+        batch.commit()
 
 
 @prepare_for_read(decrypt_func=cast(_DecryptFunc, _prepare_memory_for_read))
@@ -725,10 +735,20 @@ def delete_all_memories(uid: str, *, firestore_client: Any = None) -> None:
     database = _get_db(firestore_client)
     user_ref = database.collection(users_collection).document(uid)
     memories_ref = user_ref.collection(memories_collection)
+    # Chunk deletes to stay under the Firestore 500-writes-per-batch limit. Account deletion and
+    # "delete all memories" hit this for any user with more than 500 memories: the single
+    # batch.commit() would raise and remove nothing. Mirrors the chunking in unlock_all_memories.
     batch = database.batch()
+    count = 0
     for doc in memories_ref.stream():
         batch.delete(doc.reference)
-    batch.commit()
+        count += 1
+        if count >= 499:  # Firestore batch limit is 500
+            batch.commit()
+            batch = database.batch()
+            count = 0
+    if count > 0:
+        batch.commit()
 
 
 def ripple_source_deletion(uid: str, source_id: str, *, firestore_client: Any = None) -> Dict[str, Any]:

--- a/backend/tests/unit/test_memories_delete_batch_chunk.py
+++ b/backend/tests/unit/test_memories_delete_batch_chunk.py
@@ -1,0 +1,90 @@
+"""Regression test: memory deletes must be chunked under the Firestore batch limit.
+
+database.memories.delete_memories and delete_all_memories accumulated every delete into a
+single WriteBatch and committed once. Firestore rejects a batch with more than 500 writes, so
+a user with more than 500 memories made batch.commit() raise, and the delete (including the
+account-deletion path) removed nothing. Both functions now chunk at 499, mirroring
+unlock_all_memories. The fake below models the real 500-write limit by raising on an oversized
+commit, so the pre-fix single-batch code fails here.
+"""
+
+import database.memories as memories
+
+_FIRESTORE_BATCH_LIMIT = 500
+
+
+class _FakeBatch:
+    def __init__(self, commit_sink):
+        self._commit_sink = commit_sink
+        self.deletes = 0
+
+    def delete(self, reference):
+        self.deletes += 1
+
+    def commit(self):
+        if self.deletes > _FIRESTORE_BATCH_LIMIT:
+            raise ValueError("Firestore batch too large: max 500 writes per commit")
+        self._commit_sink.append(self.deletes)
+
+
+class _FakeDoc:
+    def __init__(self, i):
+        self.reference = f"ref-{i}"
+        self.id = f"mem-{i}"
+
+
+class _FakeCollection:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def document(self, _uid):
+        return self
+
+    def collection(self, _name):
+        return self
+
+    def stream(self):
+        return iter(self._docs)
+
+
+class _FakeDb:
+    def __init__(self, n_docs, commit_sink):
+        self._docs = [_FakeDoc(i) for i in range(n_docs)]
+        self._commit_sink = commit_sink
+
+    def collection(self, _name):
+        return _FakeCollection(self._docs)
+
+    def batch(self):
+        return _FakeBatch(self._commit_sink)
+
+
+def test_delete_all_memories_chunks_over_firestore_batch_limit():
+    commit_sink = []
+    fake = _FakeDb(1000, commit_sink)
+
+    memories.delete_all_memories("u1", firestore_client=fake)  # must not raise
+
+    assert sum(commit_sink) == 1000  # every memory deleted
+    assert len(commit_sink) >= 2  # split across batches
+    assert all(c <= _FIRESTORE_BATCH_LIMIT for c in commit_sink)
+
+
+def test_delete_memories_chunks_over_firestore_batch_limit():
+    commit_sink = []
+    fake = _FakeDb(1000, commit_sink)
+
+    memories.delete_memories("u1", firestore_client=fake)  # must not raise
+
+    assert sum(commit_sink) == 1000
+    assert len(commit_sink) >= 2
+    assert all(c <= _FIRESTORE_BATCH_LIMIT for c in commit_sink)
+
+
+def test_delete_all_memories_small_count_single_commit():
+    commit_sink = []
+    fake = _FakeDb(3, commit_sink)
+
+    memories.delete_all_memories("u1", firestore_client=fake)
+
+    assert commit_sink == [3]


### PR DESCRIPTION
## What

`database/memories.py` `delete_memories` and `delete_all_memories` accumulated every delete into a single Firestore `WriteBatch` and committed once:

```python
batch = database.batch()
for doc in memories_ref.stream():
    batch.delete(doc.reference)
batch.commit()
```

Firestore rejects a batch with more than 500 writes. A user with more than 500 memories makes `batch.commit()` raise, and the delete removes nothing. `delete_all_memories` is on the account-deletion path, so a heavy user's memories could survive account deletion.

The same file already solved this in `unlock_all_memories`, which chunks at 499 per batch. These two delete helpers were missed.

## Fix

Chunk both delete loops at 499 per batch, committing and starting a fresh batch, exactly mirroring `unlock_all_memories`:

```python
batch = database.batch()
count = 0
for doc in memories_ref.stream():
    batch.delete(doc.reference)
    count += 1
    if count >= 499:  # Firestore batch limit is 500
        batch.commit()
        batch = database.batch()
        count = 0
if count > 0:
    batch.commit()
```

Small deletes still commit once.

## Tests

`tests/unit/test_memories_delete_batch_chunk.py` drives both functions through a fake Firestore client that raises on a commit of more than 500 writes (the real limit), via the module's built-in `firestore_client` injection point:

- deleting 1000 memories splits across multiple batches, each within the limit, and deletes all 1000
- the same for `delete_memories`
- a 3-memory delete still uses a single commit

The two 1000-memory cases raise against the pre-fix single-batch source and pass after.

## Verification

```
python -m pytest tests/unit/test_memories_delete_batch_chunk.py -q
  -> 3 passed  (2 fail with an oversized-commit error when the source fix is reverted, test kept)

black --line-length 120 --skip-string-normalization --check \
  database/memories.py tests/unit/test_memories_delete_batch_chunk.py
  -> clean

python -m pyright -p pyrightconfig.json database/memories.py
  -> 0 errors

python scripts/check_module_stub_pollution.py
  -> 0 violations
```

## Product invariants affected

- INV-MEM-1

This change touches the `database/memories.py` path glob locked by INV-MEM-1 (exactly three product memory tiers). It only chunks the delete batch and does not change tier vocabulary, tier count, or which memories are deleted, so the invariant's guarantee is unchanged and its guard test does not need updating.
