### PR TITLE
fix(omiGlass): validate TLS cert on OTA firmware download

### DIFF
--- a/omiGlass/firmware/src/ota.cpp
+++ b/omiGlass/firmware/src/ota.cpp
@@ -1,5 +1,6 @@
 #include "ota.h"
 #include "config.h"
+#include "ota_certs.h"
 
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
@@ -265,8 +266,18 @@ static bool download_and_install_firmware() {
             ota_notify_status(OTA_STATUS_DOWNLOAD_FAILED);
             return false;
         }
-        // Skip certificate validation for testing (TODO: add proper certs for production)
+#ifdef OTA_ALLOW_INSECURE_TLS
+        // Opt-in insecure mode for local testing only. Never enable in shipped builds:
+        // it disables server authentication and allows a network MITM to serve a
+        // malicious firmware image.
+        Serial.println("OTA: WARNING - TLS certificate validation disabled (OTA_ALLOW_INSECURE_TLS)");
         secureClient->setInsecure();
+#else
+        // Validate the download server against the embedded root CA bundle so a MITM
+        // on the device's WiFi cannot substitute a malicious firmware image. Covers the
+        // github.com -> *.githubusercontent.com redirect used for release-asset downloads.
+        secureClient->setCACert(OTA_ROOT_CA_BUNDLE);
+#endif
         client = secureClient;
     } else {
         client = new WiFiClient;

--- a/omiGlass/firmware/src/ota_certs.h
+++ b/omiGlass/firmware/src/ota_certs.h
@@ -1,0 +1,71 @@
+#ifndef OTA_CERTS_H
+#define OTA_CERTS_H
+
+// =============================================================================
+// OTA TLS ROOT CA BUNDLE
+// =============================================================================
+// Root CAs required to validate the TLS chain for BLE-initiated OTA firmware
+// downloads. The firmware URL is a GitHub release asset, which redirects from
+// github.com to objects.githubusercontent.com / release-assets.githubusercontent.com,
+// so both roots below are needed to validate the full follow-redirect download:
+//
+//   * USERTrust ECC Certification Authority  -> github.com          (expires 2038-01-18)
+//   * ISRG Root X1                           -> *.githubusercontent.com (expires 2035-06-04)
+//
+// mbedTLS (WiFiClientSecure::setCACert) parses multiple concatenated PEM certs,
+// so this bundle is passed as a single string. If GitHub rotates its serving CA
+// out of these roots, OTA downloads will fail closed (rejected), not silently
+// downgrade to an unauthenticated download.
+
+static const char OTA_ROOT_CA_BUNDLE[] =
+    // USERTrust ECC Certification Authority (github.com)
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIICjzCCAhWgAwIBAgIQXIuZxVqUxdJxVt7NiYDMJjAKBggqhkjOPQQDAzCBiDEL\n"
+    "MAkGA1UEBhMCVVMxEzARBgNVBAgTCk5ldyBKZXJzZXkxFDASBgNVBAcTC0plcnNl\n"
+    "eSBDaXR5MR4wHAYDVQQKExVUaGUgVVNFUlRSVVNUIE5ldHdvcmsxLjAsBgNVBAMT\n"
+    "JVVTRVJUcnVzdCBFQ0MgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMTAwMjAx\n"
+    "MDAwMDAwWhcNMzgwMTE4MjM1OTU5WjCBiDELMAkGA1UEBhMCVVMxEzARBgNVBAgT\n"
+    "Ck5ldyBKZXJzZXkxFDASBgNVBAcTC0plcnNleSBDaXR5MR4wHAYDVQQKExVUaGUg\n"
+    "VVNFUlRSVVNUIE5ldHdvcmsxLjAsBgNVBAMTJVVTRVJUcnVzdCBFQ0MgQ2VydGlm\n"
+    "aWNhdGlvbiBBdXRob3JpdHkwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAQarFRaqflo\n"
+    "I+d61SRvU8Za2EurxtW20eZzca7dnNYMYf3boIkDuAUU7FfO7l0/4iGzzvfUinng\n"
+    "o4N+LZfQYcTxmdwlkWOrfzCjtHDix6EznPO/LlxTsV+zfTJ/ijTjeXmjQjBAMB0G\n"
+    "A1UdDgQWBBQ64QmG1M8ZwpZ2dEl23OA1xmNjmjAOBgNVHQ8BAf8EBAMCAQYwDwYD\n"
+    "VR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAwNoADBlAjA2Z6EWCNzklwBBHU6+4WMB\n"
+    "zzuqQhFkoJ2UOQIReVx7Hfpkue4WQrO/isIJxOzksU0CMQDpKmFHjFJKS04YcPbW\n"
+    "RNZu9YO6bVi9JNlWSOrvxKJGgYhqOkbRqZtNyWHa0V1Xahg=\n"
+    "-----END CERTIFICATE-----\n"
+    // ISRG Root X1 (objects.githubusercontent.com / release-assets.githubusercontent.com)
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw\n"
+    "TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh\n"
+    "cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4\n"
+    "WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu\n"
+    "ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY\n"
+    "MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc\n"
+    "h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+\n"
+    "0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U\n"
+    "A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW\n"
+    "T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH\n"
+    "B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC\n"
+    "B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv\n"
+    "KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn\n"
+    "OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn\n"
+    "jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw\n"
+    "qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI\n"
+    "rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV\n"
+    "HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq\n"
+    "hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL\n"
+    "ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ\n"
+    "3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK\n"
+    "NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5\n"
+    "ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur\n"
+    "TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC\n"
+    "jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc\n"
+    "oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq\n"
+    "4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA\n"
+    "mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d\n"
+    "emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=\n"
+    "-----END CERTIFICATE-----\n";
+
+#endif // OTA_CERTS_H


### PR DESCRIPTION
## What
The OmiGlass OTA updater downloaded firmware over HTTPS with certificate validation disabled. This PR makes it validate the download server's certificate against an embedded root CA bundle.

## Why
From #9589:
> `omiGlass/firmware/src/ota.cpp` uses `WiFiClientSecure::setInsecure()` for HTTPS firmware downloads — the device does not validate the server certificate. A man-in-the-middle on the device's WiFi network could serve a malicious firmware image during an OTA update.

The firmware URL points at a GitHub release asset, but nothing authenticated the download server, so a network MITM could substitute a malicious image (the ESP32 `Update` flow only validates image *structure*, not origin).

## Change
- New `src/ota_certs.h` — root CA bundle covering the full download chain. GitHub release URLs redirect from `github.com` to `objects.githubusercontent.com` / `release-assets.githubusercontent.com`, so two roots are embedded:
  - **USERTrust ECC Certification Authority** → `github.com` (expires 2038-01-18)
  - **ISRG Root X1** → `*.githubusercontent.com` (expires 2035-06-04)
- `src/ota.cpp` — replaced `setInsecure()` with `setCACert(OTA_ROOT_CA_BUNDLE)`. Downloads now **fail closed** if the chain doesn't validate rather than silently accepting any server. `setInsecure()` is retained only behind an opt-in `OTA_ALLOW_INSECURE_TLS` compile flag for local testing.

## Verified
- Confirmed the live cert chains via `openssl s_client`: `github.com` → USERTrust ECC root; `objects.githubusercontent.com` / `release-assets.githubusercontent.com` → ISRG Root X1.
- Extracted the PEM back out of `ota_certs.h` and confirmed it still validates all three live hosts (`openssl verify` return code 0).
- `ota_certs.h` compiles as C++ and parses to exactly 2 certs; `clang-format` clean.

## Not verified
- Full BLE-initiated OTA cycle (WiFi creds → URL → download → reboot) needs **on-device testing** — no ESP32 toolchain in this environment. The issue notes this is required before shipping.

Note on maintenance: if GitHub rotates its serving CA out of these two roots, OTA will fail closed (rejected) until the bundle is refreshed — a safe failure mode, but the bundle needs occasional updating.

Auto-generated from issue feedback by the mini issues-improver. Review before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

