### PR TITLE
fix(desktop): polish Settings controls

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/AppRuleEditorView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/AppRuleEditorView.swift
@@ -58,7 +58,7 @@ struct AppRuleEditorView: View {
 
       HStack(spacing: OmiSpacing.sm) {
         TextField(placeholder, text: $newAppName)
-          .textFieldStyle(.roundedBorder)
+          .settingsTextInputStyle()
           .onSubmit { addApp() }
 
         Button(addButtonTitle) { addApp() }
@@ -189,8 +189,7 @@ struct BrowserKeywordListView: View {
       // Add new keyword
       HStack(spacing: OmiSpacing.sm) {
         TextField("Add keyword...", text: $newKeyword)
-          .textFieldStyle(.roundedBorder)
-          .scaledFont(size: OmiType.caption)
+          .settingsTextInputStyle()
           .onSubmit { addKeyword() }
 
         Button("Add") { addKeyword() }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
@@ -391,8 +391,7 @@ extension SettingsContentView {
             if isPromoCodeExpanded {
               VStack(alignment: .leading, spacing: OmiSpacing.xs) {
                 TextField("Enter promo code", text: $upgradePromotionCode)
-                  .textFieldStyle(.roundedBorder)
-                  .scaledFont(size: OmiType.body)
+                  .settingsTextInputStyle()
                   .disabled(activeCheckoutPriceId != nil)
                   .onChange(of: upgradePromotionCode) {
                     subscriptionError = nil

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+Controls.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+Controls.swift
@@ -1,8 +1,92 @@
+import AppKit
 import Sparkle
 import SwiftUI
 import UniformTypeIdentifiers
 import WebKit
 import OmiTheme
+
+enum SettingsControlMetrics {
+  static let steppedSliderThumbDiameter: CGFloat = 22
+
+  static func steppedSliderInset(in containerWidth: CGFloat) -> CGFloat {
+    min(steppedSliderThumbDiameter / 2, max(0, containerWidth / 2))
+  }
+
+  static func steppedSliderTrackWidth(in containerWidth: CGFloat) -> CGFloat {
+    max(0, containerWidth - (2 * steppedSliderInset(in: containerWidth)))
+  }
+
+  static func steppedSliderPosition(index: Int, stepCount: Int, containerWidth: CGFloat) -> CGFloat {
+    let inset = steppedSliderInset(in: containerWidth)
+    guard stepCount > 1 else { return inset }
+
+    let clampedIndex = max(0, min(stepCount - 1, index))
+    let fraction = CGFloat(clampedIndex) / CGFloat(stepCount - 1)
+    return inset + (steppedSliderTrackWidth(in: containerWidth) * fraction)
+  }
+
+  static func steppedSliderIndex(locationX: CGFloat, stepCount: Int, containerWidth: CGFloat) -> Int {
+    let trackWidth = steppedSliderTrackWidth(in: containerWidth)
+    guard stepCount > 1, trackWidth > 0 else { return 0 }
+
+    let fraction = max(0, min(1, (locationX - steppedSliderInset(in: containerWidth)) / trackWidth))
+    return Int(round(fraction * CGFloat(stepCount - 1)))
+  }
+
+  static func dailySummaryDate(forHour hour: Int, referenceDate: Date, calendar: Calendar = .current) -> Date {
+    let normalizedHour = max(0, min(23, hour))
+    return calendar.date(bySettingHour: normalizedHour, minute: 0, second: 0, of: referenceDate)
+      ?? referenceDate
+  }
+
+  static func dailySummaryHour(from date: Date, calendar: Calendar = .current) -> Int {
+    calendar.component(.hour, from: date)
+  }
+}
+
+struct SettingsMenuPicker<SelectionValue: Hashable, Content: View>: View {
+  @Binding private var selection: SelectionValue
+  private let content: Content
+
+  init(selection: Binding<SelectionValue>, @ViewBuilder content: () -> Content) {
+    _selection = selection
+    self.content = content()
+  }
+
+  var body: some View {
+    Picker("", selection: $selection) {
+      content
+    }
+    .pickerStyle(.menu)
+    .labelsHidden()
+    .fixedSize()
+  }
+}
+
+private struct SettingsTextInputStyle: ViewModifier {
+  func body(content: Content) -> some View {
+    content
+      .textFieldStyle(.plain)
+      .scaledFont(size: OmiType.body)
+      .foregroundColor(OmiColors.textPrimary)
+      .padding(.horizontal, OmiSpacing.sm)
+      .padding(.vertical, OmiSpacing.sm)
+      .background(
+        RoundedRectangle(cornerRadius: OmiChrome.elementRadius, style: .continuous)
+          .fill(OmiColors.backgroundTertiary)
+          .overlay(
+            RoundedRectangle(cornerRadius: OmiChrome.elementRadius, style: .continuous)
+              .stroke(OmiColors.backgroundQuaternary, lineWidth: 1)
+          )
+      )
+  }
+}
+
+extension View {
+  func settingsTextInputStyle() -> some View {
+    modifier(SettingsTextInputStyle())
+  }
+}
 
 extension SettingsContentView {
   var floatingBarTypedVoiceAnswersBinding: Binding<Bool> {
@@ -46,19 +130,22 @@ extension SettingsContentView {
         VStack(spacing: OmiSpacing.xs) {
           // Stepped slider
           GeometryReader { geo in
-            let trackWidth = geo.size.width
             let segmentCount = CGFloat(steps.count - 1)
+            let trackWidth = SettingsControlMetrics.steppedSliderTrackWidth(in: geo.size.width)
+            let trackInset = SettingsControlMetrics.steppedSliderInset(in: geo.size.width)
 
             ZStack(alignment: .leading) {
               // Track background
               RoundedRectangle(cornerRadius: OmiChrome.stripRadius)
                 .fill(OmiColors.backgroundQuaternary)
-                .frame(height: 6)
+                .frame(width: trackWidth, height: 6)
+                .offset(x: trackInset)
 
               // Filled track
               RoundedRectangle(cornerRadius: OmiChrome.stripRadius)
                 .fill(OmiColors.accent)
                 .frame(width: trackWidth * CGFloat(currentIndex) / segmentCount, height: 6)
+                .offset(x: trackInset)
 
               // Step dots
               ForEach(0..<steps.count, id: \.self) { i in
@@ -68,7 +155,8 @@ extension SettingsContentView {
                   )
                   .frame(width: 12, height: 12)
                   .position(
-                    x: trackWidth * CGFloat(i) / segmentCount,
+                    x: SettingsControlMetrics.steppedSliderPosition(
+                      index: i, stepCount: steps.count, containerWidth: geo.size.width),
                     y: geo.size.height / 2
                   )
               }
@@ -79,20 +167,25 @@ extension SettingsContentView {
                 .frame(width: 22, height: 22)
                 .shadow(color: .black.opacity(0.25), radius: 3, y: 1)
                 .position(
-                  x: trackWidth * CGFloat(currentIndex) / segmentCount,
+                  x: SettingsControlMetrics.steppedSliderPosition(
+                    index: currentIndex, stepCount: steps.count, containerWidth: geo.size.width),
                   y: geo.size.height / 2
                 )
                 .gesture(
-                  DragGesture(minimumDistance: 0)
+                  DragGesture(minimumDistance: 0, coordinateSpace: .named("voiceSpeedSlider"))
                     .onChanged { value in
-                      let fraction = max(0, min(1, value.location.x / trackWidth))
-                      let nearestIndex = Int(round(fraction * segmentCount))
-                      let clamped = max(0, min(steps.count - 1, nearestIndex))
-                      shortcutSettings.voicePlaybackSpeed = steps[clamped]
+                      let clamped = SettingsControlMetrics.steppedSliderIndex(
+                        locationX: value.location.x, stepCount: steps.count,
+                        containerWidth: geo.size.width)
+                      if shortcutSettings.voicePlaybackSpeed != steps[clamped] {
+                        performStepHaptic()
+                        shortcutSettings.voicePlaybackSpeed = steps[clamped]
+                      }
                     }
                 )
             }
           }
+          .coordinateSpace(name: "voiceSpeedSlider")
           .frame(height: 22)
 
           HStack {
@@ -142,16 +235,19 @@ extension SettingsContentView {
       }
 
       GeometryReader { geo in
-        let trackWidth = geo.size.width
+        let trackWidth = SettingsControlMetrics.steppedSliderTrackWidth(in: geo.size.width)
+        let trackInset = SettingsControlMetrics.steppedSliderInset(in: geo.size.width)
 
         ZStack(alignment: .leading) {
           RoundedRectangle(cornerRadius: OmiChrome.stripRadius)
             .fill(OmiColors.backgroundQuaternary)
-            .frame(height: 6)
+            .frame(width: trackWidth, height: 6)
+            .offset(x: trackInset)
 
           RoundedRectangle(cornerRadius: OmiChrome.stripRadius)
             .fill(OmiColors.accent)
             .frame(width: trackWidth * CGFloat(currentIndex) / segmentCount, height: 6)
+            .offset(x: trackInset)
 
           ForEach(0..<stepCount, id: \.self) { i in
             Circle()
@@ -160,7 +256,8 @@ extension SettingsContentView {
               )
               .frame(width: 12, height: 12)
               .position(
-                x: trackWidth * CGFloat(i) / segmentCount,
+                x: SettingsControlMetrics.steppedSliderPosition(
+                  index: i, stepCount: stepCount, containerWidth: geo.size.width),
                 y: geo.size.height / 2
               )
           }
@@ -170,16 +267,17 @@ extension SettingsContentView {
             .frame(width: 22, height: 22)
             .shadow(color: .black.opacity(0.25), radius: 3, y: 1)
             .position(
-              x: trackWidth * CGFloat(currentIndex) / segmentCount,
+              x: SettingsControlMetrics.steppedSliderPosition(
+                index: currentIndex, stepCount: stepCount, containerWidth: geo.size.width),
               y: geo.size.height / 2
             )
             .gesture(
-              DragGesture(minimumDistance: 0)
+              DragGesture(minimumDistance: 0, coordinateSpace: .named("notificationFrequencySlider"))
                 .onChanged { value in
-                  let fraction = max(0, min(1, value.location.x / trackWidth))
-                  let nearestIndex = Int(round(fraction * segmentCount))
-                  let clamped = max(0, min(stepCount - 1, nearestIndex))
+                  let clamped = SettingsControlMetrics.steppedSliderIndex(
+                    locationX: value.location.x, stepCount: stepCount, containerWidth: geo.size.width)
                   if clamped != notificationFrequency {
+                    performStepHaptic()
                     notificationFrequency = clamped
                     updateNotificationSettings(frequency: clamped)
                   }
@@ -187,6 +285,7 @@ extension SettingsContentView {
             )
         }
       }
+      .coordinateSpace(name: "notificationFrequencySlider")
       .frame(height: 22)
 
       HStack {
@@ -556,8 +655,7 @@ extension SettingsContentView {
             title: "Update Channel", subtitle: updaterViewModel.updateChannel.description,
             settingId: "about.channel"
           ) {
-            Picker(
-              "",
+            SettingsMenuPicker(
               selection: Binding(
                 get: { updaterViewModel.updateChannel },
                 set: { newChannel in
@@ -576,9 +674,6 @@ extension SettingsContentView {
                 Text(channel.displayName).tag(channel)
               }
             }
-            .pickerStyle(.menu)
-            .labelsHidden()
-            .frame(width: 200)
           }
         }
       }
@@ -693,6 +788,22 @@ extension SettingsContentView {
         row
       }
     }
+  }
+
+  func settingsCardHeader(icon: String, title: String) -> some View {
+    HStack(spacing: OmiSpacing.sm) {
+      Image(systemName: icon)
+        .scaledFont(size: OmiType.subheading)
+        .foregroundColor(OmiColors.textSecondary)
+
+      Text(title)
+        .scaledFont(size: OmiType.subheading, weight: .medium)
+        .foregroundColor(OmiColors.textPrimary)
+    }
+  }
+
+  func performStepHaptic() {
+    NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
   }
 
   func linkRow(title: String, url: String) -> some View {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
@@ -121,39 +121,39 @@ extension SettingsContentView {
               .scaledFont(size: OmiType.subheading)
               .foregroundColor(OmiColors.textTertiary)
 
-            Text("AI Provider")
-              .scaledFont(size: OmiType.subheading, weight: .semibold)
-              .foregroundColor(OmiColors.textPrimary)
+            VStack(alignment: .leading, spacing: OmiSpacing.hairline) {
+              Text("AI Provider")
+                .scaledFont(size: OmiType.body)
+                .foregroundColor(OmiColors.textSecondary)
+
+              if let provider = AIProvider.from(bridgeMode: chatBridgeMode) {
+                if let url = provider.attributionURL {
+                  Link(destination: url) {
+                    Text("\(provider.tagline) · \(url.host ?? "")")
+                      .scaledFont(size: OmiType.caption)
+                      .foregroundColor(OmiColors.textTertiary)
+                  }
+                } else {
+                  Text(provider.tagline)
+                    .scaledFont(size: OmiType.caption)
+                    .foregroundColor(OmiColors.textTertiary)
+                }
+              }
+            }
 
             Spacer()
 
-            Picker("", selection: $chatBridgeMode) {
+            SettingsMenuPicker(selection: $chatBridgeMode) {
               ForEach(AIProvider.all) { provider in
                 Text(provider.displayName).tag(provider.bridgeModeRawValue)
               }
             }
-            .pickerStyle(.menu)
-            .frame(width: 200)
             .onChange(of: chatBridgeMode) { _, newMode in
               if let mode = ChatProvider.BridgeMode(rawValue: newMode) {
                 Task {
                   await chatProvider?.switchBridgeMode(to: mode)
                 }
               }
-            }
-          }
-
-          if let provider = AIProvider.from(bridgeMode: chatBridgeMode) {
-            if let url = provider.attributionURL {
-              Link(destination: url) {
-                Text("\(provider.tagline) · \(url.host ?? "")")
-                  .scaledFont(size: OmiType.caption)
-                  .foregroundColor(OmiColors.textTertiary)
-              }
-            } else {
-              Text(provider.tagline)
-                .scaledFont(size: OmiType.caption)
-                .foregroundColor(OmiColors.textTertiary)
             }
           }
 
@@ -433,7 +433,7 @@ extension SettingsContentView {
                 .scaledFont(size: OmiType.body, design: .monospaced)
                 .foregroundColor(OmiColors.textSecondary)
                 .scrollContentBackground(.hidden)
-                .frame(maxHeight: 200)
+                .frame(minHeight: 120, maxHeight: 300)
 
               HStack {
                 Button("Cancel") {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Assistants.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Assistants.swift
@@ -309,6 +309,7 @@ extension SettingsContentView {
               )
               .tint(OmiColors.accent)
               .onChange(of: taskExtractionInterval) { _, newValue in
+                performStepHaptic()
                 TaskAssistantSettings.shared.extractionInterval = newValue
                 SettingsSyncManager.shared.pushPartialUpdate(
                   AssistantSettingsResponse(
@@ -339,6 +340,7 @@ extension SettingsContentView {
               Slider(value: $taskMinConfidence, in: 0.3...0.9, step: 0.1)
                 .tint(OmiColors.accent)
                 .onChange(of: taskMinConfidence) { _, newValue in
+                  performStepHaptic()
                   TaskAssistantSettings.shared.minConfidence = newValue
                   SettingsSyncManager.shared.pushPartialUpdate(
                     AssistantSettingsResponse(task: TaskSettingsResponse(minConfidence: newValue)))
@@ -575,6 +577,7 @@ extension SettingsContentView {
               )
               .tint(OmiColors.accent)
               .onChange(of: insightExtractionInterval) { _, newValue in
+                performStepHaptic()
                 InsightAssistantSettings.shared.extractionInterval = newValue
                 SettingsSyncManager.shared.pushPartialUpdate(
                   AssistantSettingsResponse(
@@ -605,6 +608,7 @@ extension SettingsContentView {
               Slider(value: $insightMinConfidence, in: 0.5...0.95, step: 0.05)
                 .tint(OmiColors.accent)
                 .onChange(of: insightMinConfidence) { _, newValue in
+                  performStepHaptic()
                   InsightAssistantSettings.shared.minConfidence = newValue
                   SettingsSyncManager.shared.pushPartialUpdate(
                     AssistantSettingsResponse(
@@ -777,6 +781,7 @@ extension SettingsContentView {
               )
               .tint(OmiColors.accent)
               .onChange(of: memoryExtractionInterval) { _, newValue in
+                performStepHaptic()
                 MemoryAssistantSettings.shared.extractionInterval = newValue
                 SettingsSyncManager.shared.pushPartialUpdate(
                   AssistantSettingsResponse(
@@ -807,6 +812,7 @@ extension SettingsContentView {
               Slider(value: $memoryMinConfidence, in: 0.5...0.95, step: 0.05)
                 .tint(OmiColors.accent)
                 .onChange(of: memoryMinConfidence) { _, newValue in
+                  performStepHaptic()
                   MemoryAssistantSettings.shared.minConfidence = newValue
                   SettingsSyncManager.shared.pushPartialUpdate(
                     AssistantSettingsResponse(
@@ -935,6 +941,7 @@ extension SettingsContentView {
           )
           .tint(OmiColors.accent)
           .onChange(of: analysisDelay) { _, newValue in
+            performStepHaptic()
             AssistantSettings.shared.analysisDelay = newValue
             SettingsSyncManager.shared.pushPartialUpdate(
               AssistantSettingsResponse(

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
@@ -265,6 +265,9 @@ extension SettingsContentView {
 
             Slider(value: $fontScaleSettings.scale, in: 0.5...2.0, step: 0.05)
               .tint(OmiColors.info)
+              .onChange(of: fontScaleSettings.scale) { _, _ in
+                performStepHaptic()
+              }
 
             Text("A")
               .scaledFont(size: 18, weight: .medium)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+NotificationsPrivacy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+NotificationsPrivacy.swift
@@ -11,13 +11,7 @@ extension SettingsContentView {
       settingsCard(settingId: "notifications.settings") {
         VStack(alignment: .leading, spacing: OmiSpacing.lg) {
           HStack {
-            Image(systemName: "bell.badge.fill")
-              .scaledFont(size: OmiType.subheading)
-              .foregroundColor(OmiColors.textSecondary)
-
-            Text("Notifications")
-              .scaledFont(size: OmiType.subheading, weight: .medium)
-              .foregroundColor(OmiColors.textPrimary)
+            settingsCardHeader(icon: "bell.badge.fill", title: "Notifications")
 
             Spacer()
 
@@ -109,13 +103,7 @@ extension SettingsContentView {
       settingsCard(settingId: "notifications.dailysummary") {
         VStack(alignment: .leading, spacing: OmiSpacing.lg) {
           HStack {
-            Image(systemName: "text.badge.checkmark")
-              .scaledFont(size: OmiType.subheading)
-              .foregroundColor(OmiColors.textSecondary)
-
-            Text("Daily Summary")
-              .scaledFont(size: OmiType.subheading, weight: .medium)
-              .foregroundColor(OmiColors.textPrimary)
+            settingsCardHeader(icon: "text.badge.checkmark", title: "Daily Summary")
 
             Spacer()
 
@@ -139,16 +127,24 @@ extension SettingsContentView {
               title: "Summary Time", subtitle: "When to send your daily summary",
               settingId: "notifications.summarytime"
             ) {
-              Picker("", selection: $dailySummaryHour) {
-                ForEach(hourOptions, id: \.self) { hour in
-                  Text(formatHour(hour)).tag(hour)
-                }
-              }
-              .pickerStyle(.menu)
-              .frame(width: 200)
-              .onChange(of: dailySummaryHour) { _, newValue in
-                updateDailySummarySettings(hour: newValue)
-              }
+              DatePicker(
+                "",
+                selection: Binding(
+                  get: {
+                    SettingsControlMetrics.dailySummaryDate(
+                      forHour: dailySummaryHour, referenceDate: Date())
+                  },
+                  set: { selectedTime in
+                    let hour = SettingsControlMetrics.dailySummaryHour(from: selectedTime)
+                    dailySummaryHour = hour
+                    updateDailySummarySettings(hour: hour)
+                  }
+                ),
+                displayedComponents: .hourAndMinute
+              )
+              .datePickerStyle(.field)
+              .labelsHidden()
+              .fixedSize()
             }
           }
         }
@@ -164,9 +160,7 @@ extension SettingsContentView {
       // Data Controls
       settingsCard(settingId: "privacy.storerecordings") {
         VStack(alignment: .leading, spacing: OmiSpacing.lg) {
-          Text("Data Controls")
-            .scaledFont(size: OmiType.heading, weight: .semibold)
-            .foregroundColor(OmiColors.textPrimary)
+          settingsCardHeader(icon: "shield", title: "Data Controls")
 
           privacyToggleRow(
             icon: "mic.fill",
@@ -193,16 +187,7 @@ extension SettingsContentView {
       // Encryption
       settingsCard(settingId: "privacy.encryption") {
         VStack(alignment: .leading, spacing: OmiSpacing.md) {
-          HStack(spacing: OmiSpacing.sm) {
-            Image(systemName: "shield.lefthalf.filled")
-              .scaledFont(size: OmiType.body)
-              .foregroundColor(OmiColors.textSecondary)
-              .frame(width: 20)
-
-            Text("Encryption")
-              .scaledFont(size: OmiType.body, weight: .medium)
-              .foregroundColor(OmiColors.textPrimary)
-          }
+          settingsCardHeader(icon: "shield.lefthalf.filled", title: "Encryption")
 
           HStack(spacing: OmiSpacing.sm) {
             Image(systemName: "checkmark.circle.fill")

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Rewind.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Rewind.swift
@@ -162,14 +162,12 @@ extension SettingsContentView {
 
             Spacer()
 
-            Picker("", selection: $rewindSettings.retentionDays) {
+            SettingsMenuPicker(selection: $rewindSettings.retentionDays) {
               Text("3 days").tag(3)
               Text("7 days").tag(7)
               Text("14 days").tag(14)
               Text("30 days").tag(30)
             }
-            .pickerStyle(.menu)
-            .frame(width: 200)
           }
         }
       }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Transcription.swift
@@ -67,6 +67,7 @@ extension SettingsContentView {
                       lineWidth: 1)
                 )
             )
+            .contentShape(RoundedRectangle(cornerRadius: OmiChrome.elementRadius))
           }
           .buttonStyle(.plain)
 
@@ -109,10 +110,7 @@ extension SettingsContentView {
                     ) { option in
                       transcriptionLanguage = option.id
                       AssistantSettings.shared.transcriptionLanguage = option.id
-                      let supportsMulti = AssistantSettings.supportsAutoDetect(option.id)
-                      transcriptionAutoDetect = supportsMulti
-                      AssistantSettings.shared.transcriptionAutoDetect = supportsMulti
-                      updateTranscriptionPreferences(singleLanguageMode: !supportsMulti)
+                      updateTranscriptionPreferences(singleLanguageMode: true)
                       updateLanguage(option.id)
                       restartTranscriptionIfNeeded()
                     }
@@ -135,6 +133,7 @@ extension SettingsContentView {
                       lineWidth: 1)
                 )
             )
+            .contentShape(RoundedRectangle(cornerRadius: OmiChrome.elementRadius))
           }
           .buttonStyle(.plain)
 
@@ -219,7 +218,7 @@ extension SettingsContentView {
           // Add new word input
           HStack(spacing: OmiSpacing.sm) {
             TextField("Add a word...", text: $newVocabularyWord)
-              .textFieldStyle(.roundedBorder)
+              .settingsTextInputStyle()
               .onSubmit {
                 addVocabularyWord()
               }

--- a/desktop/macos/Desktop/Sources/MainWindow/RewindOnlyView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/RewindOnlyView.swift
@@ -224,15 +224,13 @@ struct RewindSettingsView: View {
                     title: "Keep Screenshots For",
                     subtitle: "Older screenshots will be automatically deleted"
                 ) {
-                    Picker("", selection: $retentionDays) {
+                    SettingsMenuPicker(selection: $retentionDays) {
                         Text("1 day").tag(1)
                         Text("3 days").tag(3)
                         Text("7 days").tag(7)
                         Text("14 days").tag(14)
                         Text("30 days").tag(30)
                     }
-                    .pickerStyle(.menu)
-                    .frame(width: 120)
                 }
 
                 // Storage Info

--- a/desktop/macos/Desktop/Tests/SettingsControlMetricsTests.swift
+++ b/desktop/macos/Desktop/Tests/SettingsControlMetricsTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class SettingsControlMetricsTests: XCTestCase {
+  func testSteppedSliderEndpointsKeepThumbInsideContainer() {
+    let containerWidth: CGFloat = 200
+    let thumbRadius = SettingsControlMetrics.steppedSliderThumbDiameter / 2
+
+    let firstPosition = SettingsControlMetrics.steppedSliderPosition(
+      index: 0, stepCount: 6, containerWidth: containerWidth)
+    let lastPosition = SettingsControlMetrics.steppedSliderPosition(
+      index: 5, stepCount: 6, containerWidth: containerWidth)
+
+    XCTAssertEqual(firstPosition - thumbRadius, 0)
+    XCTAssertEqual(lastPosition + thumbRadius, containerWidth)
+  }
+
+  func testSteppedSliderMapsInsetTrackToFirstAndLastSteps() {
+    let containerWidth: CGFloat = 200
+    let firstPosition = SettingsControlMetrics.steppedSliderPosition(
+      index: 0, stepCount: 6, containerWidth: containerWidth)
+    let lastPosition = SettingsControlMetrics.steppedSliderPosition(
+      index: 5, stepCount: 6, containerWidth: containerWidth)
+
+    XCTAssertEqual(
+      SettingsControlMetrics.steppedSliderIndex(
+        locationX: firstPosition, stepCount: 6, containerWidth: containerWidth), 0)
+    XCTAssertEqual(
+      SettingsControlMetrics.steppedSliderIndex(
+        locationX: lastPosition, stepCount: 6, containerWidth: containerWidth), 5)
+  }
+
+  func testDailySummaryDateAlwaysUsesWholeHour() {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    let referenceDate = Date(timeIntervalSince1970: 1_784_020_500)
+
+    let summaryDate = SettingsControlMetrics.dailySummaryDate(
+      forHour: 20, referenceDate: referenceDate, calendar: calendar)
+
+    XCTAssertEqual(calendar.component(.hour, from: summaryDate), 20)
+    XCTAssertEqual(calendar.component(.minute, from: summaryDate), 0)
+    XCTAssertEqual(SettingsControlMetrics.dailySummaryHour(from: summaryDate, calendar: calendar), 20)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260715-settings-ui-polish.json
+++ b/desktop/macos/changelog/unreleased/20260715-settings-ui-polish.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved macOS Settings controls with better alignment, larger inputs, and more responsive interactions"
+}


### PR DESCRIPTION
## Summary
- Resolve the nine reported macOS Settings visual and interaction issues, including aligned pickers, consistent headers, stable language selection, larger typed inputs, and responsive stepped sliders.
- Consolidate shared Settings menu, text-input, header, and slider-metric behavior while preserving existing update-channel and provider flows.
- Add deterministic regression coverage for whole-hour daily summaries and slider endpoint mapping.

## Root cause and durable guard
Settings controls had diverged into per-screen implementations, including fixed-width menus and raw slider geometry. Shared control primitives and `SettingsControlMetricsTests` now enforce the common boundary behavior.

## Verification
- `xcrun swift test -c debug --package-path Desktop --filter SettingsControlMetricsTests` (3 passed)
- `make preflight` (13 applicable checks passed)
- Named development bundle built and launch health checked. Settings navigation could not be exercised because this machine had no source Omi Dev session and the available local emulator was a foreign test harness.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

