### PR TITLE
fix(desktop): batch staged-score updates

### DIFF
--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -3220,9 +3220,11 @@ extension APIClient {
     struct StatusResponse: Decodable {
       let status: String
     }
-    let request = BatchRequest(
-      scores: scores.map { ScoreUpdate(id: $0.id, relevance_score: $0.score) })
-    let _: StatusResponse = try await patch("v1/staged-tasks/batch-scores", body: request)
+    for scoreBatch in scores.chunked(maxSize: 500) {
+      let request = BatchRequest(
+        scores: scoreBatch.map { ScoreUpdate(id: $0.id, relevance_score: $0.score) })
+      let _: StatusResponse = try await patch("v1/staged-tasks/batch-scores", body: request)
+    }
   }
 
   /// Promotes the top-ranked staged task to action_items

--- a/desktop/macos/Desktop/Tests/APIClientStagedScoreBatchTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientStagedScoreBatchTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import Omi_Computer
+
+private struct StagedScoreBatchRequest {
+  let url: URL
+  let method: String
+  let body: Data?
+}
+
+private final class StagedScoreBatchURLProtocol: URLProtocol, @unchecked Sendable {
+  private static let lock = NSLock()
+  private static var requests: [StagedScoreBatchRequest] = []
+
+  static func reset() {
+    lock.withLock { requests.removeAll() }
+  }
+
+  static var capturedRequests: [StagedScoreBatchRequest] {
+    lock.withLock { requests }
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    let captured = StagedScoreBatchRequest(
+      url: request.url!,
+      method: request.httpMethod ?? "GET",
+      body: Self.bodyData(from: request)
+    )
+    Self.lock.withLock { Self.requests.append(captured) }
+
+    let response = HTTPURLResponse(
+      url: request.url!,
+      statusCode: 200,
+      httpVersion: nil,
+      headerFields: nil
+    )!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: Data(#"{"status":"ok"}"#.utf8))
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+
+  private static func bodyData(from request: URLRequest) -> Data? {
+    if let body = request.httpBody {
+      return body
+    }
+    guard let stream = request.httpBodyStream else {
+      return nil
+    }
+
+    stream.open()
+    defer { stream.close() }
+    var body = Data()
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+    defer { buffer.deallocate() }
+    while stream.hasBytesAvailable {
+      let bytesRead = stream.read(buffer, maxLength: 4096)
+      if bytesRead <= 0 { break }
+      body.append(buffer, count: bytesRead)
+    }
+    return body.isEmpty ? nil : body
+  }
+}
+
+final class APIClientStagedScoreBatchTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    StagedScoreBatchURLProtocol.reset()
+    setenv("OMI_PYTHON_API_URL", "http://python-test:9001", 1)
+  }
+
+  override func tearDown() {
+    unsetenv("OMI_PYTHON_API_URL")
+    StagedScoreBatchURLProtocol.reset()
+    super.tearDown()
+  }
+
+  func testBatchUpdateStagedScoresSplitsMoreThanFiveHundredScoresIntoOrderedRequests() async throws {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [StagedScoreBatchURLProtocol.self]
+    let client = APIClient(session: URLSession(configuration: configuration))
+    await client.setTestAuthHeader("Bearer test-token")
+    let scores = (0...500).map { (id: "task-\($0)", score: $0) }
+
+    try await client.batchUpdateStagedScores(scores)
+
+    let requests = StagedScoreBatchURLProtocol.capturedRequests
+    XCTAssertEqual(requests.count, 2)
+    XCTAssertTrue(requests.allSatisfy {
+      $0.url.path == "/v1/staged-tasks/batch-scores" && $0.method == "PATCH"
+    })
+
+    let batches = try requests.map { request -> [[String: Any]] in
+      let body = try XCTUnwrap(request.body)
+      let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+      return try XCTUnwrap(json["scores"] as? [[String: Any]])
+    }
+    XCTAssertEqual(batches.map(\.count), [500, 1])
+    XCTAssertEqual(batches.flatMap { $0 }.map { $0["id"] as? String }, scores.map(\.id))
+    XCTAssertEqual(batches.flatMap { $0 }.map { $0["relevance_score"] as? Int }, scores.map(\.score))
+  }
+}

--- a/desktop/macos/Desktop/Tests/APIClientStagedScoreBatchTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientStagedScoreBatchTests.swift
@@ -11,8 +11,17 @@ private final class StagedScoreBatchURLProtocol: URLProtocol, @unchecked Sendabl
   private static let lock = NSLock()
   private static var requests: [StagedScoreBatchRequest] = []
 
+  private static var failingRequestNumber: Int?
+
   static func reset() {
-    lock.withLock { requests.removeAll() }
+    lock.withLock {
+      requests.removeAll()
+      failingRequestNumber = nil
+    }
+  }
+
+  static func failRequest(number: Int) {
+    lock.withLock { failingRequestNumber = number }
   }
 
   static var capturedRequests: [StagedScoreBatchRequest] {
@@ -28,17 +37,28 @@ private final class StagedScoreBatchURLProtocol: URLProtocol, @unchecked Sendabl
       method: request.httpMethod ?? "GET",
       body: Self.bodyData(from: request)
     )
-    Self.lock.withLock { Self.requests.append(captured) }
+    let requestNumber = Self.lock.withLock {
+      Self.requests.append(captured)
+      return Self.requests.count
+    }
 
+    let statusCode = Self.lock.withLock {
+      Self.failingRequestNumber == requestNumber ? 500 : 200
+    }
     let response = HTTPURLResponse(
       url: request.url!,
-      statusCode: 200,
+      statusCode: statusCode,
       httpVersion: nil,
       headerFields: nil
     )!
     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-    client?.urlProtocol(self, didLoad: Data(#"{"status":"ok"}"#.utf8))
-    client?.urlProtocolDidFinishLoading(self)
+    if statusCode == 200 {
+      client?.urlProtocol(self, didLoad: Data(#"{"status":"ok"}"#.utf8))
+      client?.urlProtocolDidFinishLoading(self)
+    } else {
+      client?.urlProtocol(self, didLoad: Data(#"{"detail":"batch failed"}"#.utf8))
+      client?.urlProtocolDidFinishLoading(self)
+    }
   }
 
   override func stopLoading() {}
@@ -76,6 +96,31 @@ final class APIClientStagedScoreBatchTests: XCTestCase {
     unsetenv("OMI_PYTHON_API_URL")
     StagedScoreBatchURLProtocol.reset()
     super.tearDown()
+  }
+
+  func testBatchUpdateStagedScoresStopsAfterSecondBatchFailsWhileFirstBatchMayAlreadyBeApplied() async throws {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [StagedScoreBatchURLProtocol.self]
+    let client = APIClient(session: URLSession(configuration: configuration))
+    await client.setTestAuthHeader("Bearer test-token")
+    StagedScoreBatchURLProtocol.failRequest(number: 2)
+    let scores = (0...1000).map { (id: "task-\($0)", score: $0) }
+
+    do {
+      try await client.batchUpdateStagedScores(scores)
+      XCTFail("Expected the second batch failure to be thrown")
+    } catch {
+      // Requests are intentionally non-atomic: batch one may already have been applied.
+    }
+
+    let requests = StagedScoreBatchURLProtocol.capturedRequests
+    XCTAssertEqual(requests.count, 2, "The third batch must not be sent after batch two fails")
+    let batchSizes = try requests.map { request -> Int in
+      let body = try XCTUnwrap(request.body)
+      let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+      return try XCTUnwrap(json["scores"] as? [[String: Any]]).count
+    }
+    XCTAssertEqual(batchSizes, [500, 500])
   }
 
   func testBatchUpdateStagedScoresSplitsMoreThanFiveHundredScoresIntoOrderedRequests() async throws {

--- a/desktop/macos/changelog/unreleased/20260715-task-prioritization-score-batching.json
+++ b/desktop/macos/changelog/unreleased/20260715-task-prioritization-score-batching.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed task prioritization syncing large score updates by sending them in backend-safe batches"
+}


### PR DESCRIPTION
## Summary

Fixes #9814.

Desktop could score thousands of staged tasks but sent them in one request even though the backend contract accepts at most 500 scores. This splits score updates into ordered, sequential batches of at most 500 while retaining fail-fast behavior.

## Root cause and durable guard

The authoritative API-client boundary did not enforce the server payload limit. A URLSession-backed regression test sends 501 scores and verifies two ordered PATCH requests with payload sizes `500` and `1`.

## Verification

- `xcrun swift test --package-path Desktop --filter APIClient` — 116 passed
- `make preflight` with this PR body — passed

## Product invariants affected

- INV-AUTH-1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

