### PR TITLE
fix(desktop): preserve Rewind writer error classification

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -421,7 +421,7 @@ public class ProactiveAssistantsPlugin: NSObject {
                     do {
                         _ = try await VideoChunkEncoder.shared.flushCurrentChunk()
                     } catch {
-                        logError("ProactiveAssistantsPlugin: Failed to flush video chunk before power cadence switch: \(error)")
+                        logError("ProactiveAssistantsPlugin: Failed to flush video chunk before power cadence switch", error: error)
                     }
 
                     await MainActor.run {

--- a/desktop/macos/Desktop/Sources/ResourceMonitor.swift
+++ b/desktop/macos/Desktop/Sources/ResourceMonitor.swift
@@ -370,7 +370,11 @@ class ResourceMonitor {
       // Flush VideoChunkEncoder and await completion; ResourceMonitor records
       // reset counters in component diagnostics so hang/memory Sentry events can
       // be correlated.
-      _ = try? await VideoChunkEncoder.shared.flushCurrentChunk()
+      do {
+        _ = try await VideoChunkEncoder.shared.flushCurrentChunk()
+      } catch {
+        logError("ResourceMonitor: Failed to flush video chunk during memory remediation", error: error)
+      }
 
       // Clear focus assistant pending tasks specifically
       if let focusAssistant = ProactiveAssistantsPlugin.shared.currentFocusAssistant {

--- a/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
@@ -489,7 +489,11 @@ actor VideoChunkEncoder {
         ]
         SentrySDK.addBreadcrumb(breadcrumb)
 
-        try? await finalizeCurrentChunk()
+        do {
+            try await finalizeCurrentChunk()
+        } catch {
+            logError("VideoChunkEncoder: Failed to finalize stale video chunk", error: error)
+        }
     }
 
     // MARK: - Helpers

--- a/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
@@ -188,7 +188,7 @@ actor VideoChunkEncoder {
                 encoderRestartCount += 1
             } catch {
                 consecutiveWriteFailures += 1
-                logError("VideoChunkEncoder: Failed to start video writer (\(consecutiveWriteFailures)/\(maxConsecutiveFailures)): \(error)")
+                logError("VideoChunkEncoder: Failed to start video writer (\(consecutiveWriteFailures)/\(maxConsecutiveFailures))", error: error)
 
                 // Reset the half-initialized chunk state so the NEXT frame cleanly retries
                 // starting the writer. Without this, currentChunkStartTime stays set while
@@ -222,7 +222,7 @@ actor VideoChunkEncoder {
             resetStalenessTimer()
         } catch {
             consecutiveWriteFailures += 1
-            logError("VideoChunkEncoder: Failed to write frame (\(consecutiveWriteFailures)/\(maxConsecutiveFailures)): \(error)")
+            logError("VideoChunkEncoder: Failed to write frame (\(consecutiveWriteFailures)/\(maxConsecutiveFailures))", error: error)
 
             if consecutiveWriteFailures >= maxConsecutiveFailures {
                 logError("VideoChunkEncoder: Too many write failures, performing emergency reset")

--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -281,7 +281,7 @@ actor RewindIndexer {
             }
 
         } catch {
-            logError("RewindIndexer: Failed to process frame: \(error)")
+            logError("RewindIndexer: Failed to process frame", error: error)
             await RewindDatabase.shared.reportQueryError(error)
         }
     }
@@ -362,7 +362,7 @@ actor RewindIndexer {
             }
 
         } catch {
-            logError("RewindIndexer: Failed to process CGImage frame: \(error)")
+            logError("RewindIndexer: Failed to process CGImage frame", error: error)
             await RewindDatabase.shared.reportQueryError(error)
         }
     }
@@ -472,7 +472,7 @@ actor RewindIndexer {
             }
 
         } catch {
-            logError("RewindIndexer: Failed to process frame with metadata: \(error)")
+            logError("RewindIndexer: Failed to process frame with metadata", error: error)
             await RewindDatabase.shared.reportQueryError(error)
         }
     }
@@ -541,7 +541,7 @@ actor RewindIndexer {
         do {
             _ = try await VideoChunkEncoder.shared.flushCurrentChunk()
         } catch {
-            logError("RewindIndexer: Failed to flush video chunk: \(error)")
+            logError("RewindIndexer: Failed to flush video chunk", error: error)
             return false
         }
 

--- a/desktop/macos/Desktop/Tests/RewindStorageErrorClassificationTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindStorageErrorClassificationTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import XCTest
 
 @testable import Omi_Computer
@@ -42,6 +43,14 @@ final class RewindStorageErrorClassificationTests: XCTestCase {
     XCTAssertTrue(isNonActionableTransient(rewindError))
   }
 
+  func testRewindStorageWriteFailureWrappingUnknownAVFoundationErrorIsActionable() {
+    let avFoundationError = NSError(domain: AVFoundationErrorDomain, code: AVError.unknown.rawValue)
+    let rewindError = RewindError.storageWriteFailed(
+      "Failed to finalize HEVC writer", underlying: avFoundationError)
+
+    XCTAssertFalse(isNonActionableTransient(rewindError))
+  }
+
   func testStorageWriterFailuresPassStructuredErrorsToLogger() throws {
     let testFile = URL(fileURLWithPath: #filePath)
     let desktopDir = testFile.deletingLastPathComponent().deletingLastPathComponent()
@@ -55,6 +64,16 @@ final class RewindStorageErrorClassificationTests: XCTestCase {
       contentsOf: desktopDir.appendingPathComponent("Sources/Rewind/Services/RewindIndexer.swift"),
       encoding: .utf8
     )
+    // omi-test-quality: source-inspection -- static contract: all fire-and-forget Rewind writer flushes preserve errors for classification
+    let resourceMonitor = try String(
+      contentsOf: desktopDir.appendingPathComponent("Sources/ResourceMonitor.swift"),
+      encoding: .utf8
+    )
+    // omi-test-quality: source-inspection -- static contract: all fire-and-forget Rewind writer flushes preserve errors for classification
+    let proactiveAssistantsPlugin = try String(
+      contentsOf: desktopDir.appendingPathComponent("Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift"),
+      encoding: .utf8
+    )
 
     XCTAssertTrue(encoder.contains(#"logError("VideoChunkEncoder: Failed to start video writer (\(consecutiveWriteFailures)/\(maxConsecutiveFailures))", error: error)"#))
     XCTAssertTrue(encoder.contains(#"logError("VideoChunkEncoder: Failed to write frame (\(consecutiveWriteFailures)/\(maxConsecutiveFailures))", error: error)"#))
@@ -62,6 +81,11 @@ final class RewindStorageErrorClassificationTests: XCTestCase {
     XCTAssertTrue(indexer.contains(#"logError("RewindIndexer: Failed to process CGImage frame", error: error)"#))
     XCTAssertTrue(indexer.contains(#"logError("RewindIndexer: Failed to process frame with metadata", error: error)"#))
     XCTAssertTrue(indexer.contains(#"logError("RewindIndexer: Failed to flush video chunk", error: error)"#))
+    XCTAssertTrue(encoder.contains(#"logError("VideoChunkEncoder: Failed to finalize stale video chunk", error: error)"#))
+    XCTAssertFalse(encoder.contains("try? await finalizeCurrentChunk()"))
+    XCTAssertTrue(resourceMonitor.contains(#"logError("ResourceMonitor: Failed to flush video chunk during memory remediation", error: error)"#))
+    XCTAssertFalse(resourceMonitor.contains("try? await VideoChunkEncoder.shared.flushCurrentChunk()"))
+    XCTAssertTrue(proactiveAssistantsPlugin.contains(#"logError("ProactiveAssistantsPlugin: Failed to flush video chunk before power cadence switch", error: error)"#))
   }
 
   func testGenericStorageErrorStillCaptured() {

--- a/desktop/macos/Desktop/Tests/RewindStorageErrorClassificationTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindStorageErrorClassificationTests.swift
@@ -42,6 +42,28 @@ final class RewindStorageErrorClassificationTests: XCTestCase {
     XCTAssertTrue(isNonActionableTransient(rewindError))
   }
 
+  func testStorageWriterFailuresPassStructuredErrorsToLogger() throws {
+    let testFile = URL(fileURLWithPath: #filePath)
+    let desktopDir = testFile.deletingLastPathComponent().deletingLastPathComponent()
+    // omi-test-quality: source-inspection -- static contract: structured Rewind storage-writer errors must reach logError
+    let encoder = try String(
+      contentsOf: desktopDir.appendingPathComponent("Sources/Rewind/Core/VideoChunkEncoder.swift"),
+      encoding: .utf8
+    )
+    // omi-test-quality: source-inspection -- static contract: structured Rewind storage-writer errors must reach logError
+    let indexer = try String(
+      contentsOf: desktopDir.appendingPathComponent("Sources/Rewind/Services/RewindIndexer.swift"),
+      encoding: .utf8
+    )
+
+    XCTAssertTrue(encoder.contains(#"logError("VideoChunkEncoder: Failed to start video writer (\(consecutiveWriteFailures)/\(maxConsecutiveFailures))", error: error)"#))
+    XCTAssertTrue(encoder.contains(#"logError("VideoChunkEncoder: Failed to write frame (\(consecutiveWriteFailures)/\(maxConsecutiveFailures))", error: error)"#))
+    XCTAssertTrue(indexer.contains(#"logError("RewindIndexer: Failed to process frame", error: error)"#))
+    XCTAssertTrue(indexer.contains(#"logError("RewindIndexer: Failed to process CGImage frame", error: error)"#))
+    XCTAssertTrue(indexer.contains(#"logError("RewindIndexer: Failed to process frame with metadata", error: error)"#))
+    XCTAssertTrue(indexer.contains(#"logError("RewindIndexer: Failed to flush video chunk", error: error)"#))
+  }
+
   func testGenericStorageErrorStillCaptured() {
     // A plain storage error with no underlying OS cause may be a real bug — keep it.
     XCTAssertFalse(isNonActionableTransient(RewindError.storageError("Cannot add HEVC writer input")))

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -18,6 +18,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+  - desktop/macos/Desktop/Sources/ResourceMonitor.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/ProactiveStorage.swift

--- a/desktop/macos/scripts/check_desktop_test_quality.py
+++ b/desktop/macos/scripts/check_desktop_test_quality.py
@@ -43,7 +43,7 @@ TEST_ROOT = "desktop/macos/Desktop/Tests"
 # Pinned debt ceilings. These may only decrease. Escaped sites are not counted.
 # Run with --print after improving tests, then lower both relevant values.
 SOURCE_INSPECTION_FILE_BASELINE = 57
-SOURCE_INSPECTION_SITE_BASELINE = 165
+SOURCE_INSPECTION_SITE_BASELINE = 162
 WALL_CLOCK_WAIT_BASELINE = 19
 
 MIN_REASON_LENGTH = 12


### PR DESCRIPTION
## Summary

Follow-up to #9193.

Preserves structured Rewind writer errors when logging writer-start, frame-write, frame-processing, and chunk-flush failures, allowing the existing storage-write classifier to inspect the real wrapped error rather than only an interpolated string.

## Root cause and durable guard

Relevant catch paths called `logError` without the caught error, bypassing established disk-write classification. A narrow wiring regression test covers every affected logging site. This does not suppress or alter unknown AVFoundation failures; writer retry/reset behavior is unchanged.

## Verification

- `xcrun swift test --package-path Desktop --filter RewindStorageErrorClassificationTests` — 9 passed
- targeted encoder diagnostics tests — 5 passed
- desktop test-quality check — passed
- `git diff --check` — passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

