### PR TITLE
fix(desktop): keep floating bar above third-party overlay apps (Clicky)

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -123,6 +123,14 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     /// Readable status strip under chrome/pill for too-short PTT / mic errors.
     static let pttHintRowHeight: CGFloat = 30
     private static let maxBarSize = NSSize(width: 1200, height: 1000)
+    /// The bar must never be buried under third-party overlay apps: notch
+    /// companions (e.g. Clicky) park windows at .popUpMenu (101) and full-screen
+    /// overlays at .screenSaver (1000), so .statusBar (25) lost the notch to
+    /// them. Assistive-tech-high (1500) beats every common overlay level while
+    /// staying below the system cursor and the screen-lock shield.
+    static let alwaysOnTopLevel = NSWindow.Level(
+        rawValue: Int(CGWindowLevelForKey(.assistiveTechHighWindow))
+    )
     static let notchExpandedWidth: CGFloat = 382
     private static let notificationWidth: CGFloat = 430
     private static let notificationHeight: CGFloat = 108
@@ -191,6 +199,12 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     private var frameAnimationToken: Int = 0
     private var pendingFrameAnimationTarget: NSRect?
     private var startupDisplayRevalidationWorkItems: [DispatchWorkItem] = []
+    /// In-process NSMenus (bar context menus, the model picker) render at
+    /// .popUpMenu (101); while one is tracking, the bar drops to that level so
+    /// the island cannot occlude its own menus. Depth-counted because nested
+    /// submenus emit their own begin/end tracking notifications.
+    private var menuTrackingDepth = 0
+    private var menuTrackingObservers: [NSObjectProtocol] = []
 
     /// The bar adopts the notch-island presentation whenever it is actively
     /// engaged — PTT listening, thinking, or speaking a reply — on ANY display,
@@ -409,7 +423,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         self.isOpaque = false
         self.backgroundColor = .clear
         self.hasShadow = false
-        self.level = initialUsesNotchIsland ? .statusBar : .floating
+        self.level = Self.alwaysOnTopLevel
         self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         self.isMovableByWindowBackground = false
         self.acceptsMouseMovedEvents = true
@@ -419,6 +433,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
         setupViews()
         updateNotchIslandState()
+        registerMenuTrackingObservers()
 
         if ShortcutSettings.shared.draggableBarEnabled,
            !notchModeEnabled,
@@ -439,6 +454,36 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             centerOnMainScreen()
         }
         scheduleStartupDisplayRevalidation()
+    }
+
+    deinit {
+        menuTrackingObservers.forEach(NotificationCenter.default.removeObserver)
+    }
+
+    // MARK: - Window Level
+
+    /// Reasserts the bar's always-on-top level, yielding only while one of our
+    /// own menus is open (menus render at .popUpMenu and must stay clickable).
+    private func applySurfaceLevel() {
+        level = menuTrackingDepth > 0 ? .popUpMenu : Self.alwaysOnTopLevel
+    }
+
+    private func registerMenuTrackingObservers() {
+        let center = NotificationCenter.default
+        menuTrackingObservers.append(center.addObserver(
+            forName: NSMenu.didBeginTrackingNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.menuTrackingDepth += 1
+            self.applySurfaceLevel()
+        })
+        menuTrackingObservers.append(center.addObserver(
+            forName: NSMenu.didEndTrackingNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.menuTrackingDepth = max(0, self.menuTrackingDepth - 1)
+            self.applySurfaceLevel()
+        })
     }
 
     /// Clamp `rect` so it stays entirely inside `visible`. visibleFrame already
@@ -549,7 +594,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         if !usesNotch {
             state.notchRevealProgress = 1
         }
-        level = usesNotch ? .statusBar : .floating
+        applySurfaceLevel()
     }
 
     private func refreshPresentationForDraggableBarPreference() {
@@ -829,7 +874,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
     private func growOutFromNotch(on targetScreen: NSScreen) {
         state.usesNotchIsland = true
-        level = .statusBar
+        applySurfaceLevel()
         styleMask.remove(.resizable)
 
         let targetFrame = frameForCurrentState(on: targetScreen, usesNotchIsland: true)
@@ -1508,7 +1553,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         resizeWorkItem?.cancel()
         resizeWorkItem = nil
         updateNotchIslandState()
-        self.level = notchModeEnabled ? .statusBar : .floating
+        applySurfaceLevel()
 
         let windowSize = responseGlowWindowSizeForCurrentScreen(forSurfaceSize: size)
         let constrainedSize = NSSize(
@@ -1551,7 +1596,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         resizeWorkItem?.cancel()
         resizeWorkItem = nil
         updateNotchIslandState()
-        level = notchModeEnabled ? .statusBar : .floating
+        applySurfaceLevel()
 
         let windowSize = responseGlowWindowSizeForCurrentScreen(forSurfaceSize: size)
         let constrainedSize = NSSize(

--- a/desktop/macos/Desktop/Tests/FloatingBarWindowLevelTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarWindowLevelTests.swift
@@ -1,0 +1,22 @@
+import AppKit
+import XCTest
+@testable import Omi_Computer
+
+/// Regression guard for the bar's always-on-top contract: third-party notch
+/// companions (e.g. Clicky) park windows at .popUpMenu (101) and full-screen
+/// overlays at .screenSaver (1000). The bar buried at .statusBar (25) is the
+/// bug this pins down — its level must clear every common overlay level.
+final class FloatingBarWindowLevelTests: XCTestCase {
+    func testBarLevelClearsCommonOverlayLevels() {
+        let level = FloatingControlBarWindow.alwaysOnTopLevel
+        XCTAssertGreaterThan(level.rawValue, NSWindow.Level.statusBar.rawValue)
+        XCTAssertGreaterThan(level.rawValue, NSWindow.Level.popUpMenu.rawValue)
+        XCTAssertGreaterThan(level.rawValue, NSWindow.Level.screenSaver.rawValue)
+    }
+
+    func testBarLevelStaysBelowCursorAndShield() {
+        let level = FloatingControlBarWindow.alwaysOnTopLevel
+        XCTAssertLessThan(level.rawValue, Int(CGWindowLevelForKey(.cursorWindow)))
+        XCTAssertLessThan(level.rawValue, Int(CGShieldingWindowLevel()))
+    }
+}

--- a/desktop/macos/changelog/unreleased/20260715-floating-bar-always-on-top.json
+++ b/desktop/macos/changelog/unreleased/20260715-floating-bar-always-on-top.json
@@ -1,0 +1,3 @@
+{
+  "change": "The floating bar and notch island now stay above other overlay apps (e.g. Clicky) instead of being buried under them"
+}


### PR DESCRIPTION
## Problem

With a notch companion app installed (e.g. Clicky), the Omi floating bar was always buried under it. Clicky parks its notch bar at `.popUpMenu` (101) and a full-screen overlay at `.screenSaver` (1000), while the Omi island ran at `.statusBar` (25) and the pill at `.floating` (3) — so Clicky always drew on top of Omi at the notch.

## Fix

Root cause: the bar's window level was chosen for "above normal windows", not "above other overlay apps" — any overlay app picking a higher common level wins the notch. Durable guard: a single always-on-top constant plus a regression test pinning the contract.

- Both bar surfaces (notch island and pill) now use one always-on-top level: `kCGAssistiveTechHighWindowLevel` (1500) — above every common overlay level (`.popUpMenu` 101, `.statusBar` 25, `.screenSaver` 1000), below the system cursor and screen-lock shield.
- While one of our own NSMenus is tracking (bar context menus, model picker — NSMenu windows render at `.popUpMenu`), the bar temporarily yields to `.popUpMenu` so it cannot occlude its own menus, then reasserts 1500 when tracking ends (`NSMenu.didBeginTracking`/`didEndTracking`, depth-counted for submenus).
- New `FloatingBarWindowLevelTests` pins the level contract (clears popUpMenu/screenSaver, stays below cursor/shield).

## Verification

On a named bundle (`omi-clicky-top`) with Clicky (HeyClicky) running:

- Before (prod omi, front-to-back CGWindowList near the notch): `HeyClicky layer 1000` → `HeyClicky layer 101` → `omi layer 25` (buried — matches the user screenshot).
- After: `omi-clicky-top layer 1500` frontmost, above both HeyClicky windows.
- `debug_bar_state answering`: island keeps 1500 through the resize paths.
- Status-item menu opened via AX (no cursor): bar dropped to 101 while the menu tracked, menu rendered and dismissed normally, bar restored to 1500 after tracking ended.
- `xcrun swift test --filter FloatingBarWindowLevelTests` — 2/2 passed.
- `make preflight` — 8 checks passed.
- User confirmed visually on the live setup ("works").

## Product invariants affected

- INV-CHAT-1 — path-matched only (`FloatingControlBar/` glob); no transcript/chat behavior changes, window layering only. Guard test unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

