### PR TITLE
fix(desktop): clear previous account's conversations and memories on in-place account switch

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Conversations/ConversationRepository.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Conversations/ConversationRepository.swift
@@ -260,10 +260,29 @@ final class ConversationRepository {
   private(set) var isLoading = false
   private(set) var error: String?
   var onSnapshot: ((ConversationRepositorySnapshot) -> Void)?
+  private var ownerChangeObserver: NSObjectProtocol?
 
   init(remote: ConversationRemoteDataSource, local: ConversationLocalDataSource) {
     self.remote = remote
     self.local = local
+    // Owner fencing: an in-place account switch posts only
+    // .runtimeOwnerDidChange (never .userDidSignOut), so without this reset the
+    // previous owner's conversations keep rendering for the next account and
+    // ConversationsPage.onAppear skips its reload because the array is
+    // non-empty. Mirrors TasksStore.resetSessionState's subscription.
+    ownerChangeObserver = NotificationCenter.default.addObserver(
+      forName: .runtimeOwnerDidChange, object: nil, queue: nil
+    ) { [weak self] _ in
+      MainActor.assumeIsolated {
+        self?.reset()
+      }
+    }
+  }
+
+  deinit {
+    if let ownerChangeObserver {
+      NotificationCenter.default.removeObserver(ownerChangeObserver)
+    }
   }
 
   convenience init() {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -394,6 +394,18 @@ class MemoriesViewModel: ObservableObject {
   // MARK: - Initialization
 
   init() {
+    // Owner fencing: an in-place account switch posts only
+    // .runtimeOwnerDidChange (never .userDidSignOut), so without this reset the
+    // previous owner's memories keep rendering until the container's deferred
+    // startup reset runs. Mirrors TasksStore.resetSessionState's subscription.
+    NotificationCenter.default.publisher(for: .runtimeOwnerDidChange)
+      .sink { [weak self] _ in
+        MainActor.assumeIsolated {
+          self?.resetSessionState()
+        }
+      }
+      .store(in: &cancellables)
+
     // Refresh memories when app becomes active
     NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
       .sink { [weak self] _ in

--- a/desktop/macos/Desktop/Tests/ConversationRepositoryTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationRepositoryTests.swift
@@ -715,6 +715,34 @@ final class ConversationRepositoryTests: XCTestCase {
     }
   }
 
+  func testRuntimeOwnerChangeClearsThePreviousAccountsConversations() async {
+    // Regression: an in-place account switch posts only .runtimeOwnerDidChange
+    // (never .userDidSignOut). Without the repository's own owner fence, the
+    // previous account's conversations kept rendering for the next account and
+    // ConversationsPage.onAppear skipped its reload because the array was
+    // non-empty.
+    let previousOwners = makeConversation(title: "Previous account's conversation", revision: 1)
+    let remote = FakeConversationRemote(
+      listResult: .success([previousOwners]), countResult: .success(1))
+    let repository = ConversationRepository(
+      remote: remote,
+      local: FakeConversationLocal(listResult: [], count: 0)
+    )
+    var snapshots: [ConversationRepositorySnapshot] = []
+    repository.onSnapshot = { snapshots.append($0) }
+    await repository.load(query: .all)
+    XCTAssertFalse(repository.conversations.isEmpty, "precondition: previous account's rows are loaded")
+
+    NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+
+    XCTAssertTrue(
+      repository.conversations.isEmpty,
+      "an in-place account switch must clear the previous account's conversations")
+    XCTAssertEqual(
+      snapshots.last?.conversations.count, 0,
+      "the cleared state must be published so the UI empties and the page reloads")
+  }
+
   private func makeConversation(
     id: String = "conversation-1",
     title: String = "Title",

--- a/desktop/macos/Desktop/Tests/MemoriesViewModelOwnerFenceTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoriesViewModelOwnerFenceTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression: an in-place account switch posts only .runtimeOwnerDidChange
+/// (never .userDidSignOut), so owner-bound view models must fence themselves
+/// or the previous account's rows keep rendering for the next account.
+@MainActor
+final class MemoriesViewModelOwnerFenceTests: XCTestCase {
+  func testRuntimeOwnerChangeClearsThePreviousAccountsMemories() {
+    let vm = MemoriesViewModel()
+    vm.memories = [
+      ServerMemory(
+        id: "previous-account-memory",
+        content: "Previous account's memory",
+        category: .system,
+        tier: .shortTerm,
+        tierIsExplicit: false,
+        createdAt: Date(timeIntervalSince1970: 1),
+        updatedAt: Date(timeIntervalSince1970: 1),
+        conversationId: nil,
+        reviewed: false,
+        userReview: nil,
+        visibility: "private",
+        manuallyAdded: false,
+        scoring: nil,
+        source: "desktop",
+        confidence: nil,
+        sourceApp: nil,
+        contextSummary: nil,
+        isRead: false,
+        isDismissed: false,
+        tags: [],
+        reasoning: nil,
+        currentActivity: nil,
+        inputDeviceName: nil,
+        windowTitle: nil,
+        headline: nil
+      )
+    ]
+
+    NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+
+    XCTAssertTrue(
+      vm.memories.isEmpty,
+      "an in-place account switch must clear the previous account's memories")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260715-account-switch-conversations-fence.json
+++ b/desktop/macos/changelog/unreleased/20260715-account-switch-conversations-fence.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed switching accounts showing the previous account's conversations and memories until the app was restarted"
+}


### PR DESCRIPTION
## Bug (reproduced live)

Signing out of account A and into account B in the running app left **A's conversations rendering for B** (and A's memories until the deferred container reset). Verified data-side: the rendered rows existed only in A's cloud while the app's RewindDatabase had already retargeted to B's per-uid store.

## Root cause

An in-place account switch re-auths through `commitSignedInSession → performEffectiveOwnerTransition`, which posts only `.runtimeOwnerDidChange` — never `.userDidSignOut`. `ConversationRepository` was absent from every owner-change reset path (its only reset hung off the `signOut()`-only `.userDidSignOut` view handler), and `ConversationsPage.onAppear` skips its reload while the array is non-empty. `MemoriesViewModel` had the same gap (deferred-only reset).

## Fix

Both now subscribe to `.runtimeOwnerDidChange` and reset themselves — mirroring `TasksStore`'s existing owner fence. `repository.reset()` already advances `requestGeneration`/`cacheWriteScope` (cancels in-flight loads/mutations fail-closed) and publishes an empty snapshot so the page reloads the new account.

## Verification

- Regression tests: repository clears + publishes an empty snapshot on the notification; memories clear likewise. Full `ConversationRepositoryTests` (26) + `TasksStoreOwnerBoundaryTests` (14) + new memories fence test = **41 green**.
- Real path on a named bundle signed into the real account: Conversations showed the account's rows → `swap_test_owner` (drives the production `performEffectiveOwnerTransition` path — the exact vector of the reported re-login) cleared the list to "No Conversations" instead of leaking the previous owner's rows → `restore_test_owner` reloaded the correct account's conversations. Three-panel screenshot captured.
- Independent agent review: approved (MainActor post-site audit, reset-mid-mutation fail-closed semantics, deinit observer removal, deterministic synchronous test delivery).

## Named follow-ups (same failure class, not fenced here)

- `AppState.folders` + folder/date/starred filter selections: cleared only in the `.userDidSignOut` handler; reload sites skip while non-empty (same mechanism as this bug, same page).
- `AppState.people`: never cleared on any auth path.
- `DashboardViewModel` / `HomeStatusStore` / `AppProvider` / `MemoryGraphViewModel`: deferred-only reset via `ViewModelContainer.resetStartupState`.

## Product invariants affected

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

