### PR TITLE
fix(desktop): clear account-scoped conversation UI state and open detail on in-place account switch

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -462,9 +462,36 @@ class AppState: ObservableObject {
     set { servicesCoordinator.bluetoothStateCancellable = newValue }
   }
 
+  private var ownerChangeObserver: NSObjectProtocol?
+
+  /// Clear account-owned conversation UI state on an in-place account switch.
+  /// The .userDidSignOut handler in DesktopHomeView covers full sign-out (and
+  /// additionally resets onboarding and stops transcription); an in-place
+  /// switch posts only .runtimeOwnerDidChange, so without this the previous
+  /// account's folders, filters, counts, and people kept rendering.
+  func resetOwnerScopedContent() {
+    folders = []
+    selectedFolderId = nil
+    selectedDateFilter = nil
+    showStarredOnly = false
+    totalConversationsCount = nil
+    filteredConversationsCount = nil
+    conversationsError = nil
+    isLoadingConversations = false
+    isLoadingFolders = false
+    people = []
+  }
+
   init() {
     // Register as the current instance so background services can check recording state
     AppState.current = self
+    ownerChangeObserver = NotificationCenter.default.addObserver(
+      forName: .runtimeOwnerDidChange, object: nil, queue: nil
+    ) { [weak self] _ in
+      MainActor.assumeIsolated {
+        self?.resetOwnerScopedContent()
+      }
+    }
     conversationRepository.onSnapshot = { [weak self] snapshot in
       guard let self else { return }
       self.conversations = snapshot.conversations
@@ -741,6 +768,9 @@ class AppState: ObservableObject {
 
   deinit {
     servicesCoordinator.removeLifecycleObservers()
+    if let ownerChangeObserver {
+      NotificationCenter.default.removeObserver(ownerChangeObserver)
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1217,6 +1217,11 @@ private struct ConversationsPageHost: View {
 
   var body: some View {
     ConversationsPage(appState: appState, selectedConversation: $selectedConversation)
+      // Owner fencing: an open detail view must not keep showing the previous
+      // account's conversation after an in-place account switch.
+      .onReceive(NotificationCenter.default.publisher(for: .runtimeOwnerDidChange)) { _ in
+        selectedConversation = nil
+      }
   }
 }
 

--- a/desktop/macos/Desktop/Tests/AppStateOwnerFenceTests.swift
+++ b/desktop/macos/Desktop/Tests/AppStateOwnerFenceTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression: an in-place account switch posts only .runtimeOwnerDidChange
+/// (never .userDidSignOut), so AppState's account-owned conversation UI state
+/// (folders, filters, counts, people) must fence itself or the previous
+/// account's values keep rendering — and the reload sites skip while non-empty.
+@MainActor
+final class AppStateOwnerFenceTests: XCTestCase {
+  func testRuntimeOwnerChangeClearsAccountScopedConversationState() throws {
+    let state = AppState()
+    let folder = try JSONDecoder().decode(
+      Folder.self,
+      from: Data(#"{"id":"previous-folder","name":"Previous account folder"}"#.utf8))
+    state.folders = [folder]
+    state.selectedFolderId = "previous-folder"
+    state.selectedDateFilter = Date(timeIntervalSince1970: 1)
+    state.showStarredOnly = true
+    state.totalConversationsCount = 42
+    state.filteredConversationsCount = 7
+    state.conversationsError = "stale error"
+    state.isLoadingConversations = true
+    state.isLoadingFolders = true
+    state.people = [Person(id: "previous-person", name: "Previous account person")]
+
+    NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+
+    XCTAssertTrue(state.folders.isEmpty, "previous account's folders must clear on switch")
+    XCTAssertNil(state.selectedFolderId)
+    XCTAssertNil(state.selectedDateFilter)
+    XCTAssertFalse(state.showStarredOnly)
+    XCTAssertNil(state.totalConversationsCount)
+    XCTAssertNil(state.filteredConversationsCount)
+    XCTAssertNil(state.conversationsError)
+    XCTAssertFalse(state.isLoadingConversations)
+    XCTAssertFalse(state.isLoadingFolders)
+    XCTAssertTrue(state.people.isEmpty, "previous account's people must clear on switch")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260715-account-switch-detail-folders-fence.json
+++ b/desktop/macos/changelog/unreleased/20260715-account-switch-detail-folders-fence.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed an open conversation and the folder filters still showing the previous account's data after switching accounts"
+}


### PR DESCRIPTION
## What

Completes the owner fence from #9821 (reviewer-identified residuals): an **open conversation detail** (`ConversationsPageHost` keeps `selectedConversation` in view-local `@State`) kept showing the previous account's conversation after an in-place account switch, and **folders / folder-date-starred filters / counts / loading-error flags / people** were cleared only by the `signOut()`-only `.userDidSignOut` handler.

- `AppState` now subscribes to `.runtimeOwnerDidChange` → `resetOwnerScopedContent()` (mirrors the sign-out handler's conversation subset; people were never cleared on any auth path before).
- `ConversationsPageHost` dismisses any open detail on the same signal.

## Verification

- New `AppStateOwnerFenceTests` regression: folders, filter selections, counts, flags, and people all clear on the notification. 31 tests green across the fence suites (`ConversationRepositoryTests`, `MemoriesViewModelOwnerFenceTests`, `AppStateOwnership`/`OwnerFence`).
- Real path on a named bundle signed into the real account: opened a conversation detail (`open_latest_conversation`), ran `swap_test_owner` (production `performEffectiveOwnerTransition` path) — the detail dismissed and the list showed the empty state with the previous account's folder chips gone (All/Starred/Work/Personal/Social/Test → All/Starred); `restore_test_owner` returned cleanly. Two-panel screenshot captured.

## Still-deferred (named)

`DashboardViewModel` / `HomeStatusStore` / `AppProvider` / `MemoryGraphViewModel` remain deferred-only via `ViewModelContainer.resetStartupState`.

## Product invariants affected

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

