### PR TITLE
fix(desktop): clear active conversations search on in-place account switch

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -849,6 +849,8 @@ extension Notification.Name {
   /// Posted by the local desktop automation bridge to open a specific conversation detail.
   static let desktopAutomationOpenConversationRequested = Notification.Name(
     "desktopAutomationOpenConversationRequested")
+  static let desktopAutomationSetConversationsSearchRequested = Notification.Name(
+    "desktopAutomationSetConversationsSearchRequested")
   /// Posted by the local desktop automation bridge to expand the transcript drawer.
   static let desktopAutomationShowConversationTranscriptRequested = Notification.Name(
     "desktopAutomationShowConversationTranscriptRequested")

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -2438,6 +2438,20 @@ final class DesktopAutomationActionRegistry {
     }
 
     register(
+      name: "set_conversations_search",
+      summary: "Set the Conversations page search query (drives the real debounced search path)",
+      params: ["query"]
+    ) { params in
+      try await ensureConversationsTabVisibleForAutomation()
+      NotificationCenter.default.post(
+        name: .desktopAutomationSetConversationsSearchRequested,
+        object: nil,
+        userInfo: ["query": params["query"] ?? ""]
+      )
+      return ["query": params["query"] ?? ""]
+    }
+
+    register(
       name: "open_latest_conversation",
       summary: "Open the most recently loaded conversation detail view",
       params: ["showTranscript", "timeoutMs"]

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -131,6 +131,32 @@ struct ConversationsPage: View {
       notification in
       handleAutomationOpenConversation(notification)
     }
+    .onReceive(
+      NotificationCenter.default.publisher(for: .desktopAutomationSetConversationsSearchRequested)
+    ) { notification in
+      searchQuery = (notification.userInfo?["query"] as? String) ?? ""
+    }
+    // Owner fencing: an in-place account switch posts only .runtimeOwnerDidChange;
+    // this page's local state (active search results, multi-select/merge state,
+    // folder sheets) otherwise keeps rendering the previous account's rows even
+    // after AppState and the repository reset.
+    .onReceive(NotificationCenter.default.publisher(for: .runtimeOwnerDidChange)) { _ in
+      searchQuery = ""
+      searchResults = []
+      isSearching = false
+      searchError = nil
+      showDatePicker = false
+      showCreateFolderSheet = false
+      editingFolder = nil
+      deletingFolder = nil
+      isFilteringStarred = false
+      isFilteringDate = false
+      isMultiSelectMode = false
+      selectedConversationIds = []
+      showMergeConfirmation = false
+      isMerging = false
+      mergeError = nil
+    }
     .dismissableSheet(isPresented: $showCreateFolderSheet) {
       FolderFormSheet(folder: nil, onDismiss: { showCreateFolderSheet = false })
         .environmentObject(appState)

--- a/desktop/macos/changelog/unreleased/20260715-account-switch-search-fence.json
+++ b/desktop/macos/changelog/unreleased/20260715-account-switch-search-fence.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed an active conversations search still showing the previous account's results after switching accounts"
+}


### PR DESCRIPTION
## What

Third and final residual of the account-switch owner fence (#9821, #9823): with a **search active** during an in-place account switch, the previous account's rows kept rendering from `ConversationsPage`'s view-local `searchResults` even after AppState and the repository reset.

The page now clears its owner-scoped local state (search query/results/flags, multi-select/merge state, folder sheets, filter-loading flags) on `.runtimeOwnerDidChange` — the same fence as the repository, AppState, and the detail host. Also adds a `set_conversations_search` automation-bridge action (same notification pattern as `open_conversation`) so the real debounced search path can be exercised in verification without synthetic keyboard/mouse input.

## Verification

Live on a named bundle signed into the real account: `set_conversations_search query=nik` rendered the account's search results; `swap_test_owner` (production `performEffectiveOwnerTransition` path) cleared the query and results to the empty state with the previous account's folder chips gone; `restore_test_owner` returned cleanly. Two-panel screenshot captured. Fence suites (`ConversationRepositoryTests` 26, `MemoriesViewModelOwnerFenceTests`, `AppStateOwnerFenceTests`) — 28 tests green; test-quality checker at baseline. (The cleared state is view-local `@State`, so coverage is the live bridge verification rather than a unit seam.)

## Product invariants affected

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

