### PR TITLE
fix(desktop): drop in-flight folder/people loads that finish after an account switch

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -464,12 +464,19 @@ class AppState: ObservableObject {
 
   private var ownerChangeObserver: NSObjectProtocol?
 
+  /// Bumped on every in-place account switch. Owner-scoped loads capture it
+  /// before awaiting and drop their result if it moved — a previous account's
+  /// in-flight response must never repopulate state after the reset (the
+  /// skip-while-non-empty reload guards would then pin the stale data).
+  private(set) var ownerScopeGeneration: UInt64 = 0
+
   /// Clear account-owned conversation UI state on an in-place account switch.
   /// The .userDidSignOut handler in DesktopHomeView covers full sign-out (and
   /// additionally resets onboarding and stops transcription); an in-place
   /// switch posts only .runtimeOwnerDidChange, so without this the previous
   /// account's folders, filters, counts, and people kept rendering.
   func resetOwnerScopedContent() {
+    ownerScopeGeneration &+= 1
     folders = []
     selectedFolderId = nil
     selectedDateFilter = nil

--- a/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
@@ -64,17 +64,27 @@ extension AppState {
 
   // MARK: - Folder Management
 
-  /// Load folders from API
-  func loadFolders() async {
+  /// Load folders from API. `fetch` is a test seam (production uses APIClient).
+  func loadFolders(fetch: (() async throws -> [Folder])? = nil) async {
     guard !isLoadingFolders else { return }
 
     isLoadingFolders = true
+    let generation = ownerScopeGeneration
 
     do {
-      let fetchedFolders = try await APIClient.shared.getFolders()
+      let fetchedFolders: [Folder]
+      if let fetch {
+        fetchedFolders = try await fetch()
+      } else {
+        fetchedFolders = try await APIClient.shared.getFolders()
+      }
+      // Owner fence: a previous account's in-flight response must not
+      // repopulate folders after an account switch reset them.
+      guard generation == ownerScopeGeneration else { return }
       folders = fetchedFolders
       log("Folders: Loaded \(fetchedFolders.count) folders")
     } catch {
+      guard generation == ownerScopeGeneration else { return }
       logError("Folders: Failed to load", error: error)
     }
 
@@ -174,13 +184,22 @@ extension AppState {
 
   // MARK: - People (Speaker Profiles)
 
-  /// Fetches all people from the OMI API
-  func fetchPeople() async {
+  /// Fetches all people from the OMI API. `fetch` is a test seam.
+  func fetchPeople(fetch: (() async throws -> [Person])? = nil) async {
+    let generation = ownerScopeGeneration
     do {
-      let fetchedPeople = try await APIClient.shared.getPeople()
+      let fetchedPeople: [Person]
+      if let fetch {
+        fetchedPeople = try await fetch()
+      } else {
+        fetchedPeople = try await APIClient.shared.getPeople()
+      }
+      // Owner fence: see loadFolders.
+      guard generation == ownerScopeGeneration else { return }
       people = fetchedPeople
       log("People: Loaded \(fetchedPeople.count) people")
     } catch {
+      guard generation == ownerScopeGeneration else { return }
       logError("People: Failed to load", error: error)
     }
   }

--- a/desktop/macos/Desktop/Tests/AppStateOwnerFenceTests.swift
+++ b/desktop/macos/Desktop/Tests/AppStateOwnerFenceTests.swift
@@ -2,6 +2,22 @@ import XCTest
 
 @testable import Omi_Computer
 
+private actor OwnerFencePauseGate {
+  private var released = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func pause() async {
+    if released { return }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+
+  func release() {
+    released = true
+    waiters.forEach { $0.resume() }
+    waiters = []
+  }
+}
+
 /// Regression: an in-place account switch posts only .runtimeOwnerDidChange
 /// (never .userDidSignOut), so AppState's account-owned conversation UI state
 /// (folders, filters, counts, people) must fence itself or the previous
@@ -36,5 +52,49 @@ final class AppStateOwnerFenceTests: XCTestCase {
     XCTAssertFalse(state.isLoadingConversations)
     XCTAssertFalse(state.isLoadingFolders)
     XCTAssertTrue(state.people.isEmpty, "previous account's people must clear on switch")
+  }
+
+  func testInFlightFolderLoadFromPreviousAccountIsDroppedAfterOwnerSwitch() async throws {
+    let state = AppState()
+    let previousFolder = try JSONDecoder().decode(
+      Folder.self,
+      from: Data(#"{"id":"previous-folder","name":"Previous account folder"}"#.utf8))
+    let gate = OwnerFencePauseGate()
+
+    let load = Task { @MainActor in
+      await state.loadFolders {
+        await gate.pause()
+        return [previousFolder]
+      }
+    }
+    // Let the load start and suspend on the gate, then switch accounts mid-flight.
+    await Task.yield()
+    NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+    await gate.release()
+    await load.value
+
+    XCTAssertTrue(
+      state.folders.isEmpty,
+      "a previous account's in-flight folder response must not repopulate after the switch")
+  }
+
+  func testInFlightPeopleFetchFromPreviousAccountIsDroppedAfterOwnerSwitch() async throws {
+    let state = AppState()
+    let gate = OwnerFencePauseGate()
+
+    let load = Task { @MainActor in
+      await state.fetchPeople {
+        await gate.pause()
+        return [Person(id: "previous-person", name: "Previous account person")]
+      }
+    }
+    await Task.yield()
+    NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+    await gate.release()
+    await load.value
+
+    XCTAssertTrue(
+      state.people.isEmpty,
+      "a previous account's in-flight people response must not repopulate after the switch")
   }
 }

--- a/desktop/macos/changelog/unreleased/20260715-account-switch-inflight-fence.json
+++ b/desktop/macos/changelog/unreleased/20260715-account-switch-inflight-fence.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed folders and people from the previous account briefly reappearing right after switching accounts"
+}


### PR DESCRIPTION
## What

Race residual of the account-switch fence series (#9821/#9823/#9826): `AppState` cleared folders/people on `.runtimeOwnerDidChange`, but `loadFolders()` / `fetchPeople()` had no owner fence — a previous account's **in-flight response landing after the reset** repopulated the cleared state, and the skip-while-non-empty reload guards then pinned the stale data for the new account.

Adds `ownerScopeGeneration` (bumped by `resetOwnerScopedContent()`); the loads capture it before awaiting and drop their result if it moved — same pattern as `ConversationRepository.requestGeneration`. Injectable fetch seams enable hermetic race coverage.

## Verification

- Two new behavioral regressions: a gate-suspended folder load and people fetch complete **after** `.runtimeOwnerDidChange` and are ignored (state stays empty). 30 tests green across the fence suites (`ConversationRepositoryTests` 26 incl. the owner-change regression, `MemoriesViewModelOwnerFenceTests`, `AppStateOwnerFenceTests` 3).
- Live account-switch round trip re-verified on the named bundle at this commit (real account's conversations render → `swap_test_owner` clears to the empty state → `restore_test_owner` returns cleanly); two-panel screenshot captured.

## Product invariants affected

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

