### PR TITLE
fix(desktop): batch staged-score sync at backend payload cap (#9814)

### DIFF
--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -3208,7 +3208,15 @@ extension APIClient {
     try await delete("v1/staged-tasks/\(id)")
   }
 
-  /// Batch update relevance scores for staged tasks
+  /// Maximum number of staged-task scores accepted per batch request.
+  /// Mirrors the backend `BatchScoreUpdate.scores` cap (`max_length=500`);
+  /// larger payloads are rejected with HTTP 422.
+  static let stagedScoresBatchMaxSize = 500
+
+  /// Batch update relevance scores for staged tasks.
+  /// Splits into ordered requests of at most `stagedScoresBatchMaxSize`
+  /// entries to stay under the backend payload cap, and fails fast if any
+  /// batch is rejected.
   func batchUpdateStagedScores(_ scores: [(id: String, score: Int)]) async throws {
     struct ScoreUpdate: Encodable {
       let id: String
@@ -3220,9 +3228,12 @@ extension APIClient {
     struct StatusResponse: Decodable {
       let status: String
     }
-    let request = BatchRequest(
-      scores: scores.map { ScoreUpdate(id: $0.id, relevance_score: $0.score) })
-    let _: StatusResponse = try await patch("v1/staged-tasks/batch-scores", body: request)
+    guard !scores.isEmpty else { return }
+    for chunk in scores.chunked(maxSize: Self.stagedScoresBatchMaxSize) {
+      let request = BatchRequest(
+        scores: chunk.map { ScoreUpdate(id: $0.id, relevance_score: $0.score) })
+      let _: StatusResponse = try await patch("v1/staged-tasks/batch-scores", body: request)
+    }
   }
 
   /// Promotes the top-ranked staged task to action_items

--- a/desktop/macos/Desktop/Tests/APIClientStagedScoresBatchTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientStagedScoresBatchTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import Omi_Computer
+
+private struct StagedScoresCapturedRequest {
+    let url: URL
+    let method: String
+    let body: Data?
+}
+
+private final class StagedScoresURLCapture: URLProtocol, @unchecked Sendable {
+    private static let lock = NSLock()
+    private static var _requests: [StagedScoresCapturedRequest] = []
+
+    /// Request ordinal (0-based) -> HTTP status to return. Missing = 200.
+    static var failStatusForRequestIndex: [Int: Int] = [:]
+
+    static var capturedRequests: [StagedScoresCapturedRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _requests
+    }
+
+    static func reset() {
+        lock.lock()
+        _requests.removeAll()
+        failStatusForRequestIndex.removeAll()
+        lock.unlock()
+    }
+
+    private static func record(_ request: StagedScoresCapturedRequest) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        _requests.append(request)
+        return _requests.count - 1
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        var index = 0
+        if request.url != nil {
+            index = StagedScoresURLCapture.record(
+                StagedScoresCapturedRequest(
+                    url: request.url!,
+                    method: request.httpMethod ?? "GET",
+                    body: Self.bodyData(from: request)))
+        }
+        let status = StagedScoresURLCapture.failStatusForRequestIndex[index] ?? 200
+        let response = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data((status == 200 ? "{\"status\":\"ok\"}" : "{}").utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func bodyData(from request: URLRequest) -> Data? {
+        if let httpBody = request.httpBody {
+            return httpBody
+        }
+        guard let stream = request.httpBodyStream else { return nil }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        let bufferSize = 65536
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}
+
+/// Regression coverage for #9814: desktop scored up to 10,000 staged tasks but
+/// sent every score in one request, exceeding the backend `scores` cap of 500
+/// (HTTP 422). Scores must now split into ordered requests of at most 500.
+final class APIClientStagedScoresBatchTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        StagedScoresURLCapture.reset()
+        setenv("OMI_PYTHON_API_URL", "http://python-test:9001", 1)
+    }
+
+    override func tearDown() {
+        unsetenv("OMI_PYTHON_API_URL")
+        StagedScoresURLCapture.reset()
+        super.tearDown()
+    }
+
+    private func makeClient() async -> APIClient {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StagedScoresURLCapture.self]
+        let session = URLSession(configuration: config)
+        let client = APIClient(session: session)
+        await client.setTestAuthHeader("Bearer test-token")
+        return client
+    }
+
+    private func scoreEntryCount(_ request: StagedScoresCapturedRequest) throws -> Int {
+        let body = try XCTUnwrap(request.body)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let entries = try XCTUnwrap(json["scores"] as? [[String: Any]])
+        return entries.count
+    }
+
+    func testBatchUpdateStagedScoresSplitsAtBackendCap() async throws {
+        let client = await makeClient()
+        let scores = (0..<(APIClient.stagedScoresBatchMaxSize + 1)).map { (id: "task-\($0)", score: $0) }
+
+        try await client.batchUpdateStagedScores(scores)
+
+        let requests = StagedScoresURLCapture.capturedRequests
+        XCTAssertEqual(requests.count, 2, "501 scores should produce 500 + 1 requests")
+        XCTAssertTrue(requests.allSatisfy { $0.method == "PATCH" })
+        XCTAssertTrue(requests.allSatisfy { $0.url.path == "/v1/staged-tasks/batch-scores" })
+
+        let counts = try requests.map { try scoreEntryCount($0) }
+        XCTAssertEqual(counts, [APIClient.stagedScoresBatchMaxSize, 1])
+    }
+
+    func testBatchUpdateStagedScoresSendsNoRequestForEmptyInput() async throws {
+        let client = await makeClient()
+
+        try await client.batchUpdateStagedScores([])
+
+        XCTAssertEqual(StagedScoresURLCapture.capturedRequests.count, 0)
+    }
+
+    func testBatchUpdateStagedScoresFailsFastWhenABatchIsRejected() async throws {
+        let client = await makeClient()
+        // Reject the second batch; the third must never be sent.
+        StagedScoresURLCapture.failStatusForRequestIndex = [1: 422]
+        let scores = (0..<(APIClient.stagedScoresBatchMaxSize * 2 + 1)).map { (id: "task-\($0)", score: $0) }
+
+        await XCTAssertThrowsErrorAsync({ try await client.batchUpdateStagedScores(scores) }) { error in
+            guard case let APIError.httpError(statusCode, _) = error, statusCode == 422 else {
+                XCTFail("Expected httpError 422, got \(error)")
+                return
+            }
+        }
+
+        XCTAssertEqual(
+            StagedScoresURLCapture.capturedRequests.count, 2,
+            "Fail-fast: the third batch must not be sent after the second is rejected")
+    }
+}
+
+private func XCTAssertThrowsErrorAsync<T>(
+    _ expression: () async throws -> T,
+    _ errorHandler: (Error) -> Void,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expected async expression to throw", file: file, line: line)
+    } catch {
+        errorHandler(error)
+    }
+}

--- a/desktop/macos/changelog/unreleased/20260715-staged-scores-batch-cap.json
+++ b/desktop/macos/changelog/unreleased/20260715-staged-scores-batch-cap.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed task prioritization failing to sync when many tasks were staged, by sending score updates in batches within the server limit"
+}


### PR DESCRIPTION
Closes #9814

## Bug
`TaskPrioritizationService` re-ranks up to 10,000 staged tasks hourly, then syncs **all** scores to the backend in a single `PATCH /v1/staged-tasks/batch-scores` request.

## Root cause
The backend caps the request `scores` array at `max_length=500` (`backend/routers/staged_tasks.py:256`). Any full rescore with more than 500 staged tasks is rejected with **HTTP 422**, so none of the scores sync. Surfaced in beta Sentry as `TaskPrioritize HTTP 422` events.

## Fix
`APIClient.batchUpdateStagedScores` now splits the scores into ordered requests of at most `stagedScoresBatchMaxSize` (500) — mirroring the existing `memoriesBatchMaxSize` / `chunked(maxSize:)` pattern already used for memory batches. Requests are issued sequentially, so **fail-fast** is preserved: the loop throws on the first rejected batch and does not send the rest.

## Test
`APIClientStagedScoresBatchTests` (URLProtocol capture):
- 501 entries → **500 + 1** requests, both `PATCH /v1/staged-tasks/batch-scores`
- empty input → no request sent
- second batch rejected (422) → third batch never sent (fail-fast)

## Verification
- `xcrun swift build -c debug --package-path Desktop` — clean
- `xcrun swift test --filter APIClientStagedScoresBatchTests` — 3/3 pass

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

