### PR TITLE
harden(backend): centralize malformed Firestore reads

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -92,6 +92,11 @@ checks:
     triggers: ["backend/**/*.py", "backend/scripts/firestore_query_coverage_baseline.json", "backend/scripts/firestore_query_coverage_waivers.json"]
     lanes: ["local", "ci"]
     reason: "serving Firestore compound queries cannot add unregistered or unsupported debt"
+  - id: firestore-model-read-boundary
+    command: ["python3", ".github/scripts/check_firestore_model_read_boundary.py"]
+    triggers: ["backend/database/**/*.py", ".github/scripts/check_firestore_model_read_boundary.py", ".github/scripts/firestore_model_read_boundary_baseline.json"]
+    lanes: ["local", "ci"]
+    reason: "#9494 -> #9696 malformed Firestore documents must use the shared read boundary"
   - id: lifecycle-headers
     command: ["python3", ".github/scripts/check_lifecycle_headers.py", "--changed-files", "{changed_files}"]
     triggers: ["all"]

--- a/.github/scripts/check_firestore_model_read_boundary.py
+++ b/.github/scripts/check_firestore_model_read_boundary.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Prevent new direct Pydantic model construction in Firestore readers.
+
+Firestore documents must cross ``database.read_boundary`` so malformed or
+legacy data receives one safe logging, telemetry, and fail-open/fail-closed
+policy. This ratchet would have caught the repeated #9494 -> #9696 class of
+retail malformed-document fixes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCAN_ROOT = Path('backend/database')
+DEFAULT_BASELINE = Path('.github/scripts/firestore_model_read_boundary_baseline.json')
+EXCLUDED_FILES = frozenset({'read_boundary.py'})
+
+
+def _is_models_import(module: str | None) -> bool:
+    return module == 'models' or (module is not None and module.startswith('models.'))
+
+
+class _ModelConstructionVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.model_names: set[str] = set()
+        self.model_module_names: set[str] = set()
+        self.count = 0
+
+    def visit_Import(self, node: ast.Import) -> None:  # noqa: N802 - AST visitor name
+        for alias in node.names:
+            if _is_models_import(alias.name):
+                # ``import models.other`` binds ``models``; an alias binds itself.
+                self.model_module_names.add(alias.asname or alias.name.split('.', 1)[0])
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802 - AST visitor name
+        if _is_models_import(node.module):
+            self.model_names.update(alias.asname or alias.name for alias in node.names)
+            if node.module == 'models':
+                self.model_module_names.update(alias.asname or alias.name for alias in node.names)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802 - AST visitor name
+        if self._is_model_validate(node) or self._is_model_kwargs_constructor(node):
+            self.count += 1
+        self.generic_visit(node)
+
+    def _is_model_validate(self, node: ast.Call) -> bool:
+        return (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == 'model_validate'
+            and bool(node.args or node.keywords)
+            and self._is_model_reference(node.func.value)
+        )
+
+    def _is_model_kwargs_constructor(self, node: ast.Call) -> bool:
+        return (
+            self._is_model_reference(node.func)
+            and any(keyword.arg is None for keyword in node.keywords)
+        )
+
+    def _is_model_reference(self, node: ast.expr) -> bool:
+        if isinstance(node, ast.Name):
+            return node.id in self.model_names
+        dotted = self._dotted_name(node)
+        return dotted is not None and len(dotted) > 1 and dotted[0] in self.model_module_names
+
+    @staticmethod
+    def _dotted_name(node: ast.expr) -> tuple[str, ...] | None:
+        if isinstance(node, ast.Name):
+            return (node.id,)
+        if isinstance(node, ast.Attribute):
+            parent = _ModelConstructionVisitor._dotted_name(node.value)
+            return (*parent, node.attr) if parent is not None else None
+        return None
+
+
+def count_model_constructions(source: str, filename: str = '<unknown>') -> int:
+    visitor = _ModelConstructionVisitor()
+    visitor.visit(ast.parse(source, filename=filename))
+    return visitor.count
+
+
+def collect_counts(repository_root: Path, scan_root: Path) -> dict[str, int]:
+    root = repository_root / scan_root
+    counts: dict[str, int] = {}
+    for path in sorted(root.rglob('*.py')):
+        if path.name in EXCLUDED_FILES:
+            continue
+        count = count_model_constructions(path.read_text(encoding='utf-8'), str(path))
+        if count:
+            counts[path.relative_to(repository_root).as_posix()] = count
+    return counts
+
+
+def load_baseline(path: Path) -> dict[str, int]:
+    payload = json.loads(path.read_text(encoding='utf-8'))
+    if not isinstance(payload, dict) or not all(
+        isinstance(key, str) and isinstance(value, int) and value >= 0 for key, value in payload.items()
+    ):
+        raise ValueError(f'baseline must be a JSON object of path-to-nonnegative-count entries: {path}')
+    return payload
+
+
+def violations(counts: dict[str, int], baseline: dict[str, int]) -> list[str]:
+    return [
+        f'{path}: found {count}, baseline allows {baseline.get(path, 0)}'
+        for path, count in sorted(counts.items())
+        if count > baseline.get(path, 0)
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--root', type=Path, default=REPOSITORY_ROOT)
+    parser.add_argument('--scan-root', type=Path, default=DEFAULT_SCAN_ROOT)
+    parser.add_argument('--baseline', type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument('--print-counts', action='store_true')
+    args = parser.parse_args()
+
+    repository_root = args.root.resolve()
+    counts = collect_counts(repository_root, args.scan_root)
+    if args.print_counts:
+        print(json.dumps(counts, indent=2, sort_keys=True))
+        return 0
+
+    baseline_path = args.baseline if args.baseline.is_absolute() else repository_root / args.baseline
+    errors = violations(counts, load_baseline(baseline_path))
+    if not errors:
+        return 0
+    print('FAIL: direct Firestore model construction increased; use database.read_boundary instead.')
+    print('This guard closes the #9494 -> #9696 malformed-document failure class.')
+    print(*errors, sep='\n')
+    return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/.github/scripts/firestore_model_read_boundary_baseline.json
+++ b/.github/scripts/firestore_model_read_boundary_baseline.json
@@ -1,0 +1,10 @@
+{
+  "backend/database/candidates.py": 3,
+  "backend/database/dev_api_key.py": 1,
+  "backend/database/goals.py": 2,
+  "backend/database/mcp_api_key.py": 1,
+  "backend/database/memory_vector_repair_pinecone_adapter.py": 1,
+  "backend/database/task_recommendations.py": 7,
+  "backend/database/user_usage.py": 4,
+  "backend/database/workstreams.py": 10
+}

--- a/backend/database/candidates.py
+++ b/backend/database/candidates.py
@@ -2,7 +2,6 @@
 
 import hashlib
 import json
-import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, cast
@@ -10,10 +9,9 @@ from uuid import uuid4
 
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
-from pydantic import ValidationError
-
 import database.action_items as action_items_db
 from database._client import db
+from database.read_boundary import parse_snapshot_or_none, parse_snapshot_strict, parse_snapshots
 from models.action_item import EvidenceRef, TaskChangePayload, TaskCreatePayload, TaskOwner, TaskStatus
 from models.candidate import (
     CandidateAction,
@@ -24,8 +22,6 @@ from models.candidate import (
     CandidateSubjectKind,
 )
 from models.task_intelligence import TaskWorkflowControl, TaskWorkflowMode
-
-logger = logging.getLogger(__name__)
 
 CANDIDATES_COLLECTION = 'candidates'
 ACTION_ITEMS_COLLECTION = 'action_items'
@@ -140,7 +136,7 @@ def _task_control_ref(uid: str):
 def _validate_write_control(snapshot: Any, *, account_generation: int) -> None:
     control = TaskWorkflowControl()
     if snapshot.exists:
-        control = TaskWorkflowControl.model_validate(_snapshot_dict(snapshot))
+        control = parse_snapshot_strict(TaskWorkflowControl, snapshot)
     if control.account_generation != account_generation:
         raise CandidateGenerationMismatchError('account generation mismatch')
     if control.workflow_mode not in {TaskWorkflowMode.write, TaskWorkflowMode.read}:
@@ -415,14 +411,14 @@ def create_candidate(
             aliased_snapshot = _candidate_ref(uid, aliased_candidate_id).get(transaction=write_transaction)
             if not aliased_snapshot.exists:
                 raise CandidateConflictError('candidate idempotency alias target is missing')
-            aliased = CandidateRecord.from_storage(_snapshot_dict(aliased_snapshot))
+            aliased = parse_snapshot_strict(CandidateRecord, aliased_snapshot)
             if aliased.account_generation != account_generation:
                 raise CandidateConflictError('candidate idempotency alias generation mismatch')
             return aliased
 
         snapshot = ref.get(transaction=write_transaction)
         if snapshot.exists:
-            existing = CandidateRecord.from_storage(_snapshot_dict(snapshot))
+            existing = parse_snapshot_strict(CandidateRecord, snapshot)
             if existing.account_generation != account_generation or existing.idempotency_key != key_hash:
                 raise CandidateConflictError('candidate idempotency collision')
             existing_proposal = existing.as_proposal()
@@ -452,7 +448,7 @@ def create_candidate(
                     claimed_ref = _candidate_ref(uid, claimed_candidate_id)
                     claimed_snapshot = claimed_ref.get(transaction=write_transaction)
                     if claimed_snapshot.exists:
-                        candidate = CandidateRecord.from_storage(_snapshot_dict(claimed_snapshot))
+                        candidate = parse_snapshot_strict(CandidateRecord, claimed_snapshot)
                         if candidate.account_generation == account_generation:
                             claimed_candidate = candidate
                             if candidate.status == CandidateStatus.accepted and candidate.result_task_id:
@@ -547,22 +543,7 @@ def get_candidate(uid: str, candidate_id: str) -> Optional[CandidateRecord]:
     snapshot = _candidate_ref(uid, candidate_id).get()
     if not snapshot.exists:
         return None
-    try:
-        return CandidateRecord.from_storage(_snapshot_dict(snapshot))
-    except ValidationError as e:
-        # A malformed/legacy candidate doc must not 500 the read; return None (the router maps that to
-        # 404), mirroring the skip in list_candidates. Catch only ValidationError so unexpected runtime
-        # errors still surface, and log bounded structural error types only since the rendered pydantic
-        # error can contain private task text.
-        errors = e.errors(include_input=False, include_url=False)
-        bounded_error_types = [str(error.get('type', 'unknown')) for error in errors[:5]]
-        logger.warning(
-            'Ignoring malformed candidate record %s: error_count=%s validation_types=%s',
-            getattr(snapshot, 'id', None),
-            e.error_count(),
-            bounded_error_types,
-        )
-        return None
+    return parse_snapshot_or_none(CandidateRecord, snapshot)
 
 
 def list_candidates(
@@ -582,24 +563,7 @@ def list_candidates(
     if offset:
         query = query.offset(offset)
     query = query.limit(limit)
-    records: list[CandidateRecord] = []
-    for snapshot in query.stream():
-        try:
-            records.append(CandidateRecord.from_storage(_snapshot_dict(snapshot)))
-        except ValidationError as e:
-            # One malformed/legacy candidate doc must not 500 the whole list. Catch only the pydantic
-            # validation failure (from_storage is model_validate) so unexpected runtime errors still
-            # surface. Pydantic's rendered error includes input_value, which may contain private task
-            # text, so retain only a bounded structural error-type summary.
-            errors = e.errors(include_input=False, include_url=False)
-            bounded_error_types = [str(error.get('type', 'unknown')) for error in errors[:5]]
-            logger.warning(
-                'Skipping malformed candidate record %s: error_count=%s validation_types=%s',
-                getattr(snapshot, 'id', None),
-                e.error_count(),
-                bounded_error_types,
-            )
-    return records
+    return parse_snapshots(CandidateRecord, query.stream())
 
 
 def _task_create_storage(candidate: CandidateRecord, *, task_id: str, now: datetime) -> dict[str, Any]:
@@ -675,7 +639,7 @@ def resolve_task_candidate(
         snapshot = candidate_ref.get(transaction=write_transaction)
         if not snapshot.exists:
             raise CandidateNotFoundError(candidate_id)
-        candidate = CandidateRecord.from_storage(_snapshot_dict(snapshot))
+        candidate = parse_snapshot_strict(CandidateRecord, snapshot)
         if candidate.account_generation != account_generation:
             raise CandidateGenerationMismatchError(candidate_id)
         if candidate.status == CandidateStatus.accepted:
@@ -807,7 +771,7 @@ def claim_candidate_integration_dispatch(
         control_snapshot = _task_control_ref(uid).get(transaction=write_transaction)
         control = TaskWorkflowControl()
         if control_snapshot.exists:
-            control = TaskWorkflowControl.model_validate(_snapshot_dict(control_snapshot))
+            control = parse_snapshot_strict(TaskWorkflowControl, control_snapshot)
         if payload.get('account_generation') != account_generation or control.account_generation != account_generation:
             write_transaction.update(
                 outbox_ref,
@@ -872,7 +836,7 @@ def complete_candidate_integration_dispatch(
         control_snapshot = _task_control_ref(uid).get(transaction=write_transaction)
         control = TaskWorkflowControl()
         if control_snapshot.exists:
-            control = TaskWorkflowControl.model_validate(_snapshot_dict(control_snapshot))
+            control = parse_snapshot_strict(TaskWorkflowControl, control_snapshot)
         if payload.get('account_generation') != account_generation or control.account_generation != account_generation:
             write_transaction.update(
                 outbox_ref,
@@ -948,7 +912,7 @@ def resolve_candidate_without_mutation(
         snapshot = candidate_ref.get(transaction=write_transaction)
         if not snapshot.exists:
             raise CandidateNotFoundError(candidate_id)
-        candidate = CandidateRecord.from_storage(_snapshot_dict(snapshot))
+        candidate = parse_snapshot_strict(CandidateRecord, snapshot)
         if candidate.account_generation != account_generation:
             raise CandidateGenerationMismatchError(candidate_id)
         if candidate.status == status:
@@ -1007,7 +971,7 @@ def reconcile_migrated_candidate(
         snapshot = candidate_ref.get(transaction=write_transaction)
         if not snapshot.exists:
             raise CandidateNotFoundError(candidate_id)
-        candidate = CandidateRecord.from_storage(_snapshot_dict(snapshot))
+        candidate = parse_snapshot_strict(CandidateRecord, snapshot)
         if candidate.account_generation != account_generation:
             raise CandidateGenerationMismatchError(candidate_id)
         if candidate.status == status:
@@ -1075,7 +1039,7 @@ def claim_candidate_for_legacy_promotion(
         candidate_snapshot = candidate_ref.get(transaction=write_transaction)
         if not candidate_snapshot.exists:
             raise CandidateNotFoundError(candidate_id)
-        candidate = CandidateRecord.from_storage(_snapshot_dict(candidate_snapshot))
+        candidate = parse_snapshot_strict(CandidateRecord, candidate_snapshot)
         if candidate.account_generation != account_generation:
             raise CandidateGenerationMismatchError(candidate_id)
         if candidate.status != CandidateStatus.pending:
@@ -1149,7 +1113,7 @@ def begin_candidate_legacy_promotion(
         candidate_snapshot = candidate_ref.get(transaction=write_transaction)
         if not candidate_snapshot.exists:
             raise CandidateNotFoundError(candidate_id)
-        candidate = CandidateRecord.from_storage(_snapshot_dict(candidate_snapshot))
+        candidate = parse_snapshot_strict(CandidateRecord, candidate_snapshot)
         if candidate.account_generation != account_generation:
             raise CandidateGenerationMismatchError(candidate_id)
         if candidate.status != CandidateStatus.pending:

--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -14,6 +14,7 @@ from models.chat import Message
 from utils import encryption
 from ._client import db
 from .helpers import prepare_for_read, prepare_for_write, set_data_protection_level
+from database.read_boundary import parse_snapshot_or_none
 
 logger = logging.getLogger(__name__)
 
@@ -396,12 +397,13 @@ def get_message(uid: str, message_id: str) -> tuple[Message, str] | None:
     if not message_doc:
         return None
 
-    message_data: Dict[str, Any] = _typed_doc(message_doc)
-    if not message_data:
+    message = parse_snapshot_or_none(
+        Message,
+        message_doc,
+        payload_from_snapshot=lambda snapshot: _prepare_message_for_read(_typed_doc(snapshot), uid),
+    )
+    if message is None:
         return None
-
-    decrypted_data: Dict[str, Any] = _prepare_message_for_read(message_data, uid)
-    message = Message(**decrypted_data)
 
     return message, message_doc.id
 

--- a/backend/database/goals.py
+++ b/backend/database/goals.py
@@ -12,6 +12,7 @@ from google.cloud.firestore_v1 import FieldFilter
 from pydantic import ValidationError
 
 from database import _client
+from database.read_boundary import parse_snapshot_strict, parse_snapshots
 from models.goal import (
     GoalMetric,
     GoalProgressEvent,
@@ -86,7 +87,7 @@ def _goal_control_ref(uid: str, *, firestore_client: Any):
 def _validate_canonical_write(snapshot: Any, *, account_generation: int) -> None:
     control = TaskWorkflowControl()
     if snapshot.exists:
-        control = TaskWorkflowControl.model_validate(_snapshot_dict(snapshot))
+        control = parse_snapshot_strict(TaskWorkflowControl, snapshot)
     if control.account_generation != account_generation:
         raise GoalConflictError('account generation mismatch')
     if control.workflow_mode not in {TaskWorkflowMode.write, TaskWorkflowMode.read}:
@@ -371,7 +372,7 @@ def create_goal(
             .get(transaction=write_transaction)
         )
         account_generation = (
-            TaskWorkflowControl.model_validate(_snapshot_dict(control_snapshot)).account_generation
+            parse_snapshot_strict(TaskWorkflowControl, control_snapshot).account_generation
             if control_snapshot.exists
             else 0
         )
@@ -750,8 +751,7 @@ def _append_goal_progress_event(
             raise GoalNotFoundError(goal_id)
         existing = event_ref.get(transaction=write_transaction)
         if existing.exists:
-            stored = _snapshot_dict(existing)
-            record = GoalProgressEvent.model_validate(stored)
+            record = parse_snapshot_strict(GoalProgressEvent, existing)
             stored_proposal = GoalProgressEventCreate(
                 kind=record.kind,
                 summary=record.summary,
@@ -816,14 +816,7 @@ def list_goal_progress_events(
         .order_by('sequence', direction=firestore.Query.DESCENDING)
         .limit(limit)
     )
-    events: list[GoalProgressEvent] = []
-    for snapshot in query.stream():
-        try:
-            events.append(GoalProgressEvent.model_validate(_snapshot_dict(snapshot)))
-        except ValidationError as e:
-            # Skip a malformed/legacy progress event rather than 500 the whole detail page.
-            logger.warning('Skipping malformed goal progress event %s: %s', getattr(snapshot, 'id', None), e)
-    return events
+    return parse_snapshots(GoalProgressEvent, query.stream())
 
 
 def update_goal_progress(

--- a/backend/database/memory_apply_store.py
+++ b/backend/database/memory_apply_store.py
@@ -16,6 +16,7 @@ except ImportError:  # pragma: no cover - local unit tests mock Firestore.
 
 from database._client import db
 from database.memory_collections import MemoryCollections
+from database.read_boundary import parse_snapshot_strict
 from models.memory_evidence import MemoryEvidence
 from models.memory_contracts import DurablePatchDecision
 from models.memory_apply import (
@@ -227,8 +228,7 @@ def _atomic_bump_source_generation_transaction(
             updated_at=now,
         )
     else:
-        data: Dict[str, Any] = _typed_doc(snapshot)
-        control = MemoryControlState(**data)
+        control = parse_snapshot_strict(MemoryControlState, snapshot, payload_from_snapshot=_typed_doc)
     bumped = control.model_copy(
         update={
             "source_generation": control.source_generation + 1,
@@ -363,8 +363,7 @@ def _read_authoritative_target_item(
     snapshot = target_ref.get(transaction=transaction)
     if not snapshot.exists:
         return None
-    data: Dict[str, Any] = _typed_doc(snapshot)
-    return MemoryItem(**data)
+    return parse_snapshot_strict(MemoryItem, snapshot, payload_from_snapshot=_typed_doc)
 
 
 def _validate_authoritative_targets(
@@ -381,8 +380,7 @@ def _validate_authoritative_targets(
         snapshot = target_ref.get(transaction=transaction)
         if not snapshot.exists:
             return _target_not_active(control_state, operation, f"missing target memory item: {target_id}")
-        data: Dict[str, Any] = _typed_doc(snapshot)
-        target = MemoryItem(**data)
+        target = parse_snapshot_strict(MemoryItem, snapshot, payload_from_snapshot=_typed_doc)
         if target.uid != operation.uid:
             return _target_not_active(control_state, operation, "target memory uid mismatch")
         if target.account_generation != control_state.account_generation:
@@ -464,8 +462,7 @@ def _required_model(*, ref: Any, transaction: Any, model: type[M], label: str) -
     snapshot = ref.get(transaction=transaction)
     if not snapshot.exists:
         raise MissingMemoryDocument(f"missing {label}: {ref.path}")
-    data: Dict[str, Any] = _typed_doc(snapshot)
-    return model(**data)
+    return parse_snapshot_strict(model, snapshot, payload_from_snapshot=_typed_doc)
 
 
 def _firestore_data(value: object) -> Any:

--- a/backend/database/memory_non_active_routes.py
+++ b/backend/database/memory_non_active_routes.py
@@ -36,6 +36,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from database._client import db
 from database.memory_collections import MemoryCollections
+from database.read_boundary import parse_snapshot_strict
 
 
 class NonActiveRoute(str, Enum):
@@ -118,7 +119,7 @@ def _persist_non_active_route_outcome_transaction(
     outcome_ref = db_client.document(f"{collections.non_active_memory_routes}/{persisted.outcome_id}")
     snapshot = outcome_ref.get(transaction=transaction)
     if snapshot.exists:
-        existing = PersistedNonActiveRouteOutcome(**(snapshot.to_dict() or {}))
+        existing = parse_snapshot_strict(PersistedNonActiveRouteOutcome, snapshot)
         if existing.payload_fingerprint != persisted.payload_fingerprint:
             raise NonActiveRouteStoreConflict("idempotency key payload mismatch")
         return existing

--- a/backend/database/read_boundary.py
+++ b/backend/database/read_boundary.py
@@ -1,0 +1,248 @@
+"""Shared Firestore snapshot-to-model read boundary.
+
+Malformed or legacy Firestore documents are untrusted input. Presentation
+readers can use the fail-open entry points below to preserve the rest of a
+response, while idempotency and canonical-state readers use the strict entry
+point so corruption cannot create a duplicate side effect.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from typing import Any, TypeVar, cast
+
+from pydantic import ValidationError
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T', covariant=True)
+
+
+# Pydantic's classmethod accepts ``obj`` plus optional keyword controls, which
+# cannot be expressed by a narrow protocol without rejecting normal BaseModels.
+ModelParser = type[Any] | Callable[[Mapping[str, Any]], T]
+SnapshotPayload = Callable[[Any], Mapping[str, Any]]
+
+
+_fallback_recorder: Callable[..., None] | None
+try:
+    # Bind eagerly in real backend processes so the first malformed document
+    # stays within fast-reader latency budgets. Some strict-only router import
+    # tests intentionally stub FastAPI incompletely; they defer this safely.
+    from utils.observability.fallback import record_fallback as _shared_record_fallback
+except ImportError:
+    _fallback_recorder = None
+else:
+    _fallback_recorder = _shared_record_fallback
+
+
+def record_fallback(**kwargs: Any) -> None:
+    """Import telemetry only when a fail-open reader actually drops a document.
+
+    Strict-only stores are imported by lightweight router tests that intentionally
+    stub FastAPI. Their deferred first use preserves that import isolation.
+    """
+    global _fallback_recorder
+    if _fallback_recorder is None:
+        from utils.observability.fallback import record_fallback as shared_record_fallback
+
+        _fallback_recorder = shared_record_fallback
+    _fallback_recorder(**kwargs)
+
+
+class MalformedDocError(RuntimeError):
+    """A strict Firestore reader encountered a structurally invalid document."""
+
+    def __init__(self, *, document_path: str, error_types: tuple[str, ...], error_fields: tuple[str, ...]):
+        self.document_path = document_path
+        self.error_types = error_types
+        self.error_fields = error_fields
+        super().__init__(
+            f'malformed Firestore document path={document_path} '
+            f'validation_fields={list(error_fields)} validation_types={list(error_types)}'
+        )
+
+
+def _snapshot_path(snapshot: Any) -> str:
+    reference = getattr(snapshot, 'reference', None)
+    reference_path = getattr(reference, 'path', None)
+    if isinstance(reference_path, str) and reference_path:
+        return reference_path
+    path = getattr(snapshot, 'path', None)
+    if isinstance(path, str) and path:
+        return path
+    document_id = getattr(snapshot, 'id', None)
+    if isinstance(document_id, str) and document_id:
+        return f'<unknown>/{document_id}'
+    return '<unknown>'
+
+
+def _error_types(error: ValidationError | TypeError) -> tuple[str, ...]:
+    if not isinstance(error, ValidationError):
+        return (type(error).__name__,)
+    return tuple(str(item.get('type', 'unknown')) for item in error.errors(include_input=False, include_url=False)[:5])
+
+
+def _error_fields(error: ValidationError | TypeError) -> tuple[str, ...]:
+    """Return only structural field paths, never rejected input values."""
+    if not isinstance(error, ValidationError):
+        return ('<payload>',)
+    fields: list[str] = []
+    for item in error.errors(include_input=False, include_url=False)[:5]:
+        location = item.get('loc', ())
+        fields.append('.'.join(str(part) for part in location) or '<payload>')
+    return tuple(fields)
+
+
+def _default_payload(snapshot: Any) -> Mapping[str, Any]:
+    payload = snapshot.to_dict()
+    if not isinstance(payload, Mapping):
+        raise TypeError('Firestore snapshot payload must be a mapping')
+    return cast(Mapping[str, Any], payload)
+
+
+def _payload_for(
+    snapshot: Any,
+    *,
+    payload_from_snapshot: SnapshotPayload | None,
+    document_id_field: str | None,
+) -> Mapping[str, Any]:
+    payload = dict((payload_from_snapshot or _default_payload)(snapshot))
+    if document_id_field is not None:
+        document_id = getattr(snapshot, 'id', None)
+        if isinstance(document_id, str) and document_id:
+            payload.setdefault(document_id_field, document_id)
+    return payload
+
+
+def _parse(model: ModelParser[T], payload: Mapping[str, Any]) -> T:
+    validator = getattr(model, 'model_validate', None)
+    if callable(validator):
+        return cast(T, validator(payload))
+    return cast(Callable[[Mapping[str, Any]], T], model)(payload)
+
+
+def _parse_strict(
+    model: ModelParser[T],
+    snapshot: Any,
+    *,
+    payload_from_snapshot: SnapshotPayload | None,
+    document_id_field: str | None,
+) -> T:
+    try:
+        return _parse(
+            model,
+            _payload_for(
+                snapshot,
+                payload_from_snapshot=payload_from_snapshot,
+                document_id_field=document_id_field,
+            ),
+        )
+    except (ValidationError, TypeError) as error:
+        document_path = _snapshot_path(snapshot)
+        error_types = _error_types(error)
+        error_fields = _error_fields(error)
+        # Never render ValidationError: its input_value can contain Firestore PII.
+        logger.warning(
+            'Malformed Firestore document path=%s validation_fields=%s validation_types=%s',
+            document_path,
+            error_fields,
+            error_types,
+        )
+        raise MalformedDocError(
+            document_path=document_path,
+            error_types=error_types,
+            error_fields=error_fields,
+        ) from error
+
+
+def _record_drop() -> None:
+    record_fallback(
+        component='firestore_read',
+        from_mode='firestore_document',
+        to_mode='skip_malformed_document',
+        reason='malformed_doc',
+        outcome='degraded',
+        log=logger,
+    )
+
+
+def parse_snapshot_or_none(
+    model: ModelParser[T],
+    snapshot: Any,
+    *,
+    payload_from_snapshot: SnapshotPayload | None = None,
+    document_id_field: str | None = None,
+) -> T | None:
+    """Parse one presentation snapshot, returning ``None`` for malformed data."""
+    if not getattr(snapshot, 'exists', True):
+        return None
+    try:
+        return _parse_strict(
+            model,
+            snapshot,
+            payload_from_snapshot=payload_from_snapshot,
+            document_id_field=document_id_field,
+        )
+    except MalformedDocError:
+        _record_drop()
+        return None
+
+
+def parse_snapshots(
+    model: ModelParser[T],
+    snapshots: Iterable[Any],
+    *,
+    payload_from_snapshot: SnapshotPayload | None = None,
+    document_id_field: str | None = None,
+) -> list[T]:
+    """Parse materialized presentation snapshots, dropping malformed entries."""
+    return [
+        parsed
+        for snapshot in snapshots
+        if (
+            parsed := parse_snapshot_or_none(
+                model,
+                snapshot,
+                payload_from_snapshot=payload_from_snapshot,
+                document_id_field=document_id_field,
+            )
+        )
+        is not None
+    ]
+
+
+def iter_parsed_snapshots(
+    model: ModelParser[T],
+    snapshot_iter: Iterable[Any],
+    *,
+    payload_from_snapshot: SnapshotPayload | None = None,
+    document_id_field: str | None = None,
+) -> Iterator[T]:
+    """Lazily parse presentation snapshots, dropping malformed entries."""
+    for snapshot in snapshot_iter:
+        parsed = parse_snapshot_or_none(
+            model,
+            snapshot,
+            payload_from_snapshot=payload_from_snapshot,
+            document_id_field=document_id_field,
+        )
+        if parsed is not None:
+            yield parsed
+
+
+def parse_snapshot_strict(
+    model: ModelParser[T],
+    snapshot: Any,
+    *,
+    payload_from_snapshot: SnapshotPayload | None = None,
+    document_id_field: str | None = None,
+) -> T:
+    """Parse a correctness-critical snapshot or raise a typed corruption error."""
+    return _parse_strict(
+        model,
+        snapshot,
+        payload_from_snapshot=payload_from_snapshot,
+        document_id_field=document_id_field,
+    )

--- a/backend/database/recurrence_inbox.py
+++ b/backend/database/recurrence_inbox.py
@@ -1,15 +1,14 @@
 """Durable workflow-owned handoff for canonical recurrence signals."""
 
 import hashlib
-import logging
 from datetime import datetime, timezone
 from typing import Any
 
 from google.cloud import firestore
 from google.cloud.firestore_v1.base_query import FieldFilter
-from pydantic import ValidationError
 
 from database._client import db as default_db
+from database.read_boundary import MalformedDocError, parse_snapshot_strict, parse_snapshots
 from models.memory_recurrence import CanonicalRecurrenceSignal
 from models.workstream_association import (
     RecurrenceInboxReceipt,
@@ -17,8 +16,6 @@ from models.workstream_association import (
     RecurrenceOutcomeKind,
 )
 from models.task_intelligence import TaskWorkflowControl, TaskWorkflowMode
-
-logger = logging.getLogger(__name__)
 
 RECURRENCE_INBOX_COLLECTION = 'task_recurrence_inbox'
 TASK_INTELLIGENCE_CONTROL_COLLECTION = 'task_intelligence_control'
@@ -59,20 +56,13 @@ def _control_ref(uid: str, *, firestore_client: Any = None):
 
 
 def _validate_generation(snapshot: Any, account_generation: int) -> None:
-    try:
-        control = (
-            TaskWorkflowControl.model_validate(snapshot.to_dict() or {}) if snapshot.exists else TaskWorkflowControl()
-        )
-    except ValidationError as e:
-        # A drifted control doc (extra='forbid' plus a renamed/removed field, a bad enum) must not crash the
-        # recurrence handoff. Fall back to the legacy-safe default (workflow_mode=off, account_generation=0),
-        # which fails the checks below, so a malformed control is treated as a generation mismatch (fail-closed)
-        # rather than raising ValidationError. Log bounded error types only, never input_value (task text).
-        logger.warning(
-            'Ignoring malformed task workflow control in recurrence inbox: %s',
-            [str(err.get('type', 'unknown')) for err in e.errors(include_input=False, include_url=False)[:5]],
-        )
+    if not snapshot.exists:
         control = TaskWorkflowControl()
+    else:
+        try:
+            control = parse_snapshot_strict(TaskWorkflowControl, snapshot)
+        except MalformedDocError as error:
+            raise RecurrenceGenerationMismatchError('task workflow control is malformed') from error
     if control.account_generation != account_generation:
         raise RecurrenceGenerationMismatchError('account generation mismatch')
     if control.workflow_mode not in {TaskWorkflowMode.write, TaskWorkflowMode.read}:
@@ -80,7 +70,7 @@ def _validate_generation(snapshot: Any, account_generation: int) -> None:
 
 
 def _from_snapshot(snapshot: Any) -> RecurrenceInboxReceipt:
-    return RecurrenceInboxReceipt.model_validate(snapshot.to_dict() or {})
+    return parse_snapshot_strict(RecurrenceInboxReceipt, snapshot)
 
 
 def _storage(receipt: RecurrenceInboxReceipt) -> dict[str, Any]:
@@ -147,7 +137,7 @@ def list_pending_recurrence_receipts(
         .where(filter=FieldFilter('account_generation', '==', account_generation))
         .limit(limit)
     )
-    return [_from_snapshot(snapshot) for snapshot in query.stream()]
+    return parse_snapshots(RecurrenceInboxReceipt, query.stream())
 
 
 def complete_recurrence_receipt(

--- a/backend/database/task_intelligence_control.py
+++ b/backend/database/task_intelligence_control.py
@@ -1,16 +1,11 @@
 """Firestore persistence for per-user task workflow migration controls."""
 
-import logging
-from typing import Any, cast
-
 from google.api_core.exceptions import AlreadyExists, Conflict
-from pydantic import ValidationError
 
 from config.what_matters_now_smoke_fixture import WHAT_MATTERS_NOW_SMOKE_UID, is_development_smoke_fixture
 from database._client import db
+from database.read_boundary import parse_snapshot_or_none
 from models.task_intelligence import TaskWorkflowControl, TaskWorkflowMode
-
-logger = logging.getLogger(__name__)
 
 CONTROL_COLLECTION = 'task_intelligence_control'
 CONTROL_DOCUMENT = 'state'
@@ -30,22 +25,7 @@ def get_task_workflow_control(uid: str) -> TaskWorkflowControl:
     snapshot = ref.get()
     if snapshot.exists is not True:
         return TaskWorkflowControl()
-    payload = snapshot.to_dict()
-    if not isinstance(payload, dict):
-        return TaskWorkflowControl()
-    try:
-        return TaskWorkflowControl.model_validate(cast(dict[str, Any], payload))
-    except ValidationError as e:
-        # A single drifted control doc (extra='forbid' plus a removed/renamed field, a bad enum) must not
-        # 500 every candidate/staged-task read that gates on it. Fall back to the default, which the model
-        # defines as legacy-safe (workflow_mode=off, account_generation=0) so writes stay disabled, never
-        # silently enabled. Log only bounded error types -- never input_value, which can carry task text.
-        logger.warning(
-            'Ignoring malformed task workflow control for %s: %s',
-            uid,
-            [str(err.get('type', 'unknown')) for err in e.errors(include_input=False, include_url=False)[:5]],
-        )
-        return TaskWorkflowControl()
+    return parse_snapshot_or_none(TaskWorkflowControl, snapshot) or TaskWorkflowControl()
 
 
 def set_task_workflow_control(uid: str, control: TaskWorkflowControl) -> None:

--- a/backend/database/task_recommendations.py
+++ b/backend/database/task_recommendations.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 
 from database._client import get_firestore_client
 from database.firestore_index_registry import ACTIVE_ATTENTION_OVERRIDE_QUERY
+from database.read_boundary import parse_snapshot_or_none, parse_snapshot_strict
 from models.task_recommendation import (
     DecisionRecord,
     FeedbackCreate,
@@ -26,6 +27,7 @@ from models.task_recommendation import (
     WhatMattersNowProjection,
 )
 from models.task_intelligence import TaskWorkflowControl, TaskWorkflowMode
+from utils.observability.fallback import record_fallback
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +93,7 @@ def _validate_generation(
 ) -> None:
     control = TaskWorkflowControl()
     if snapshot.exists:
-        control = TaskWorkflowControl.model_validate(_snapshot_dict(snapshot))
+        control = parse_snapshot_strict(TaskWorkflowControl, snapshot)
     if control.account_generation != account_generation:
         raise RecommendationGenerationMismatchError('account generation mismatch')
     if control.workflow_mode not in (allowed_modes or {TaskWorkflowMode.read}):
@@ -109,6 +111,23 @@ def _without_generation(payload: dict[str, Any]) -> dict[str, Any]:
 def _snapshot_dict(snapshot: Any) -> dict[str, Any]:
     payload = snapshot.to_dict()
     return cast(dict[str, Any], payload) if isinstance(payload, dict) else {}
+
+
+def _record_malformed_embedded_payload(*, evaluation_id: str, error: ValidationError) -> None:
+    error_types = [
+        str(item.get('type', 'unknown')) for item in error.errors(include_input=False, include_url=False)[:5]
+    ]
+    logger.warning(
+        'Malformed embedded Firestore payload evaluation_id=%s validation_types=%s', evaluation_id, error_types
+    )
+    record_fallback(
+        component='firestore_read',
+        from_mode='firestore_document',
+        to_mode='skip_malformed_document',
+        reason='malformed_doc',
+        outcome='degraded',
+        log=logger,
+    )
 
 
 def _stable_id(prefix: str, *parts: object) -> str:
@@ -181,7 +200,12 @@ def create_intervention(
         if stored.get('_request_hash') != payload['_request_hash']:
             raise IdempotencyConflictError('idempotency key was used for a different intervention')
         stored.pop('_request_hash', None)
-        return InterventionRecord.model_validate(_without_generation(stored)), False
+        return (
+            parse_snapshot_strict(
+                InterventionRecord, existing, payload_from_snapshot=lambda _snapshot: _without_generation(stored)
+            ),
+            False,
+        )
 
     return apply(transaction)
 
@@ -213,7 +237,11 @@ def save_projection(
         )
         current_snapshot = projection_ref.get(transaction=write_transaction)
         if current_snapshot.exists:
-            current = WhatMattersNowProjection.model_validate(_without_generation(_snapshot_dict(current_snapshot)))
+            current = parse_snapshot_strict(
+                WhatMattersNowProjection,
+                current_snapshot,
+                payload_from_snapshot=lambda _snapshot: _without_generation(_snapshot_dict(current_snapshot)),
+            )
             if current.generated_at > projection.generated_at or (
                 current.material_version == projection.material_version and current.expires_at > projection.generated_at
             ):
@@ -310,7 +338,13 @@ def get_projection(
     payload = _snapshot_dict(snapshot)
     if payload.get('account_generation') != account_generation:
         return None
-    projection = WhatMattersNowProjection.model_validate(_without_generation(payload))
+    projection = parse_snapshot_or_none(
+        WhatMattersNowProjection,
+        snapshot,
+        payload_from_snapshot=lambda _snapshot: _without_generation(payload),
+    )
+    if projection is None:
+        return None
     return projection if include_expired or projection.expires_at > now else None
 
 
@@ -326,7 +360,7 @@ def _decision_records(raw_records: list[Any], evaluation_id: str) -> list[Decisi
         try:
             records.append(DecisionRecord.model_validate(record))
         except ValidationError as e:
-            logger.warning('Skipping malformed decision record in evaluation %s: %s', evaluation_id, e)
+            _record_malformed_embedded_payload(evaluation_id=evaluation_id, error=e)
     records.sort(key=lambda record: record.subject_id)
     return records
 
@@ -380,7 +414,7 @@ def _valid_evaluation_projection(
     try:
         projection = WhatMattersNowProjection.model_validate(raw_projection)
     except ValidationError as e:
-        logger.warning('Ignoring malformed stored projection for evaluation %s: %s', evaluation_id, e)
+        _record_malformed_embedded_payload(evaluation_id=evaluation_id, error=e)
         return None
     if projection.evaluation_id != evaluation_id or projection.expires_at <= now:
         return None
@@ -505,7 +539,12 @@ def create_feedback(
                         },
                     )
             stored.pop('_request_hash', None)
-            return FeedbackRecord.model_validate(_without_generation(stored)), False
+            return (
+                parse_snapshot_strict(
+                    FeedbackRecord, existing, payload_from_snapshot=lambda _snapshot: _without_generation(stored)
+                ),
+                False,
+            )
         write_transaction.set(ref, payload)
         if override_expires_at is not None and dedupe_key is not None:
             override_id = _stable_id('override', uid, account_generation, dedupe_key)
@@ -682,7 +721,12 @@ def create_outcome(
         if stored.get('_request_hash') != payload['_request_hash']:
             raise IdempotencyConflictError('idempotency key was used for a different outcome')
         stored.pop('_request_hash', None)
-        return OutcomeRecord.model_validate(_without_generation(stored)), False
+        return (
+            parse_snapshot_strict(
+                OutcomeRecord, existing, payload_from_snapshot=lambda _snapshot: _without_generation(stored)
+            ),
+            False,
+        )
 
     return apply(transaction)
 
@@ -727,7 +771,11 @@ def replace_context_snapshot(
         replaced = stored_snapshot.exists
         if replaced:
             stored_payload = _snapshot_dict(stored_snapshot)
-            stored = NormalizedContextSnapshot.model_validate(_without_generation(stored_payload))
+            stored = parse_snapshot_strict(
+                NormalizedContextSnapshot,
+                stored_snapshot,
+                payload_from_snapshot=lambda _snapshot: _without_generation(stored_payload),
+            )
             if snapshot.generated_at < stored.generated_at:
                 raise StaleSnapshotError('context snapshot is older than stored state')
             if snapshot.generated_at == stored.generated_at and snapshot != stored:
@@ -772,7 +820,13 @@ def get_context_snapshot(
     payload = _snapshot_dict(snapshot)
     if payload.get('account_generation') != account_generation:
         return None
-    record = NormalizedContextSnapshot.model_validate(_without_generation(payload))
+    record = parse_snapshot_or_none(
+        NormalizedContextSnapshot,
+        snapshot,
+        payload_from_snapshot=lambda _snapshot: _without_generation(payload),
+    )
+    if record is None:
+        return None
     if record.expires_at <= now:
         ref.delete()
         receipt_id = payload.get('_receipt_id')
@@ -824,7 +878,11 @@ def replace_open_loop_snapshot(
         replaced = stored_snapshot.exists
         if replaced:
             stored_payload = _snapshot_dict(stored_snapshot)
-            stored = OpenLoopSnapshot.model_validate(_without_generation(stored_payload))
+            stored = parse_snapshot_strict(
+                OpenLoopSnapshot,
+                stored_snapshot,
+                payload_from_snapshot=lambda _snapshot: _without_generation(stored_payload),
+            )
             if snapshot.generated_at < stored.generated_at:
                 raise StaleSnapshotError('open-loop snapshot is older than stored state')
             if snapshot.generated_at == stored.generated_at and snapshot != stored:
@@ -863,7 +921,13 @@ def list_open_loop_snapshots(
     records: list[OpenLoopSnapshot] = []
     for snapshot in query.stream():
         payload = _snapshot_dict(snapshot)
-        record = OpenLoopSnapshot.model_validate(_without_generation(payload))
+        record = parse_snapshot_or_none(
+            OpenLoopSnapshot,
+            snapshot,
+            payload_from_snapshot=lambda _snapshot: _without_generation(payload),
+        )
+        if record is None:
+            continue
         if record.expires_at <= now:
             snapshot.reference.delete()
             receipt_id = payload.get('_receipt_id')

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -4,10 +4,9 @@ from typing import Literal, Optional, TypedDict
 
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter, transactional
-from pydantic import ValidationError
-
 from ._client import db, document_id_from_seed
 from database.firestore_cache import CachePolicy, get_or_fetch, invalidate
+from database.read_boundary import parse_snapshot_or_none, parse_snapshot_strict
 from database.redis_db import try_acquire_client_device_write_lock, try_acquire_user_platform_write_lock
 from models.users import Subscription, PlanLimits, PlanType, SubscriptionStatus
 from models.other import Person
@@ -757,14 +756,8 @@ def get_people_by_ids(uid: str, person_ids: list[str]):
         if doc.exists:
             data = doc.to_dict()
             data.setdefault('id', doc.id)
-            try:
-                # Validate at the boundary: every caller builds Person(**p) from these dicts, so a
-                # legacy or partial doc (e.g. missing name) would 500 the read. Skip it instead.
-                Person(**data)
-            except ValidationError as e:
-                logger.warning('Skipping malformed person doc %s: %s', doc.id, e)
-                continue
-            all_people.append(data)
+            if parse_snapshot_or_none(Person, doc, document_id_field='id') is not None:
+                all_people.append(data)
     return all_people
 
 
@@ -1419,11 +1412,22 @@ def get_user_subscription(uid: str) -> Subscription:
         user_data = user_doc.to_dict()
         if 'subscription' in user_data:
             sub_data = user_data['subscription']
-            # Handle migration for old 'free' plan identifier
-            if sub_data.get('plan') == 'free':
+            legacy_free_plan = isinstance(sub_data, dict) and sub_data.get('plan') == 'free'
+
+            def subscription_payload(_snapshot: object) -> dict:
+                if not isinstance(sub_data, dict):
+                    raise TypeError('Firestore subscription payload must be a mapping')
+                payload = dict(sub_data)
+                if legacy_free_plan:
+                    payload['plan'] = PlanType.basic.value
+                return payload
+
+            subscription = parse_snapshot_strict(Subscription, user_doc, payload_from_snapshot=subscription_payload)
+            # Handle migration for old 'free' plan identifier after validating the normalized payload.
+            if legacy_free_plan:
                 sub_data['plan'] = PlanType.basic.value
                 update_user_subscription(uid, sub_data)
-            return Subscription(**sub_data)
+            return subscription
 
     # If subscription doesn't exist for the user, create and return a default free plan.
     default_subscription = get_default_basic_subscription()
@@ -1447,9 +1451,16 @@ def get_existing_user_subscription(uid: str) -> Optional[Subscription]:
         return None
 
     sub_data = user_data['subscription']
-    if sub_data.get('plan') == 'free':
-        sub_data['plan'] = PlanType.basic.value
-    return Subscription(**sub_data)
+
+    def subscription_payload(_snapshot: object) -> dict:
+        if not isinstance(sub_data, dict):
+            raise TypeError('Firestore subscription payload must be a mapping')
+        payload = dict(sub_data)
+        if payload.get('plan') == 'free':
+            payload['plan'] = PlanType.basic.value
+        return payload
+
+    return parse_snapshot_strict(Subscription, user_doc, payload_from_snapshot=subscription_payload)
 
 
 def get_user_training_data_opt_in(uid: str) -> Optional[dict]:

--- a/backend/database/workstreams.py
+++ b/backend/database/workstreams.py
@@ -2,16 +2,14 @@
 
 import hashlib
 import json
-import logging
 from datetime import datetime, timezone
 from typing import Any, Optional, cast
 
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
-from pydantic import ValidationError
-
 import database.goals as goals_db
 from database._client import get_firestore_client
+from database.read_boundary import parse_snapshot_or_none, parse_snapshot_strict, parse_snapshots
 from models.action_item import ActionItemResponse, TaskOwner, TaskPriority, TaskStatus
 from models.candidate import CandidateRecord, CandidateResolutionReceipt, CandidateStatus, CandidateSubjectKind
 from models.goal import GoalResponse, GoalStatus
@@ -38,8 +36,6 @@ from models.workstream import (
     WorkstreamStatus,
     WorkstreamUpdate,
 )
-
-logger = logging.getLogger(__name__)
 
 WORKSTREAMS_COLLECTION = 'workstreams'
 EVENTS_COLLECTION = 'events'
@@ -86,19 +82,9 @@ def _snapshot_dict(snapshot: Any) -> dict[str, Any]:
 
 
 def _task_responses_from_snapshots(snapshots: Any, *, context: str) -> list[ActionItemResponse]:
-    # Skip a malformed/legacy action item doc rather than 500 the whole detail page,
-    # mirroring routers.action_items._safe_action_item_responses for the same model.
-    tasks: list[ActionItemResponse] = []
-    for snapshot in snapshots:
-        payload = _snapshot_dict(snapshot)
-        if payload.get('deleted'):
-            continue
-        payload.setdefault('id', snapshot.id)
-        try:
-            tasks.append(ActionItemResponse.model_validate(payload))
-        except ValidationError as e:
-            logger.warning('Skipping malformed action item %s (%s): %s', payload.get('id'), context, e)
-    return tasks
+    del context  # The shared boundary logs a structural summary and document path instead.
+    active_snapshots = (snapshot for snapshot in snapshots if not _snapshot_dict(snapshot).get('deleted'))
+    return parse_snapshots(ActionItemResponse, active_snapshots, document_id_field='id')
 
 
 def _user_ref(uid: str, *, firestore_client: Any = None):
@@ -202,7 +188,7 @@ def _finish_mutation(
 def _validate_control(snapshot: Any, *, account_generation: int) -> None:
     control = TaskWorkflowControl()
     if snapshot.exists:
-        control = TaskWorkflowControl.model_validate(_snapshot_dict(snapshot))
+        control = parse_snapshot_strict(TaskWorkflowControl, snapshot)
     if control.account_generation != account_generation:
         raise WorkstreamGenerationMismatchError('account generation mismatch')
     if control.workflow_mode not in {TaskWorkflowMode.write, TaskWorkflowMode.read}:
@@ -215,10 +201,14 @@ def _assert_workstream_generation(snapshot: Any, *, account_generation: int) -> 
         raise WorkstreamGenerationMismatchError('workstream account generation mismatch')
 
 
-def _workstream_from_snapshot(snapshot: Any) -> Workstream:
+def _workstream_payload(snapshot: Any) -> dict[str, Any]:
     payload = _snapshot_dict(snapshot)
     payload.pop('account_generation', None)
-    return Workstream.model_validate(payload)
+    return payload
+
+
+def _workstream_from_snapshot(snapshot: Any) -> Workstream:
+    return parse_snapshot_strict(Workstream, snapshot, payload_from_snapshot=_workstream_payload)
 
 
 def _task_storage(
@@ -345,7 +335,7 @@ def get_workstream(
     payload = _snapshot_dict(snapshot)
     if account_generation is not None and payload.get('account_generation', 0) != account_generation:
         return None
-    return _workstream_from_snapshot(snapshot)
+    return parse_snapshot_or_none(Workstream, snapshot, payload_from_snapshot=_workstream_payload)
 
 
 def get_workstream_goal_id(uid: str, workstream_id: str, *, firestore_client: Any = None) -> Optional[str]:
@@ -359,7 +349,7 @@ def get_task_workflow_control(uid: str, *, firestore_client: Any = None) -> Task
     snapshot = _control_ref(uid, firestore_client=firestore_client).get()
     if not snapshot.exists:
         return TaskWorkflowControl()
-    return TaskWorkflowControl.model_validate(_snapshot_dict(snapshot))
+    return parse_snapshot_strict(TaskWorkflowControl, snapshot)
 
 
 def list_open_workstreams(
@@ -380,7 +370,7 @@ def list_open_workstreams(
     snapshots = list(query.stream())
     if account_generation == 0:
         snapshots = [snapshot for snapshot in snapshots if _snapshot_dict(snapshot).get('account_generation', 0) == 0]
-    records = [_workstream_from_snapshot(snapshot) for snapshot in snapshots]
+    records = parse_snapshots(Workstream, snapshots, payload_from_snapshot=_workstream_payload)
     records.sort(key=lambda record: record.updated_at, reverse=True)
     return records
 
@@ -399,7 +389,7 @@ def list_workstreams_for_goal(
         .where(filter=FieldFilter('goal_id', '==', goal_id))
         .limit(limit)
     )
-    records = [_workstream_from_snapshot(snapshot) for snapshot in query.stream()]
+    records = parse_snapshots(Workstream, query.stream(), payload_from_snapshot=_workstream_payload)
     if not include_archived:
         records = [record for record in records if record.status != WorkstreamStatus.archived]
     records.sort(key=lambda record: record.updated_at, reverse=True)
@@ -480,7 +470,7 @@ def append_workstream_event(
         _assert_workstream_generation(workstream_snapshot, account_generation=account_generation)
         existing = event_ref.get(transaction=write_transaction)
         if existing.exists:
-            stored = WorkstreamEvent.model_validate(_snapshot_dict(existing))
+            stored = parse_snapshot_strict(WorkstreamEvent, existing)
             stored_proposal = WorkstreamEventCreate(
                 kind=stored.kind,
                 summary=stored.summary,
@@ -529,14 +519,7 @@ def list_workstream_events(
         .order_by('sequence', direction=firestore.Query.ASCENDING)
         .limit(limit)
     )
-    events: list[WorkstreamEvent] = []
-    for snapshot in query.stream():
-        try:
-            events.append(WorkstreamEvent.model_validate(_snapshot_dict(snapshot)))
-        except Exception:
-            # One malformed/legacy event must not 500 the whole workstream event stream.
-            logger.warning('Skipping malformed workstream event %s', getattr(snapshot, 'id', None))
-    return events
+    return parse_snapshots(WorkstreamEvent, query.stream())
 
 
 def create_artifact_descriptor(
@@ -584,7 +567,7 @@ def create_artifact_descriptor(
             created_at=now,
         )
         if existing.exists:
-            stored = ArtifactDescriptor.model_validate(_snapshot_dict(existing))
+            stored = parse_snapshot_strict(ArtifactDescriptor, existing)
             proposal_fields = set(ArtifactDescriptorCreate.model_fields)
             if stored.model_dump(mode='python', include=proposal_fields) != proposal.model_dump(mode='python'):
                 raise WorkstreamConflictError('artifact version already exists with different content')
@@ -608,7 +591,7 @@ def create_artifact_descriptor(
             superseded_snapshot = superseded_ref.get(transaction=write_transaction)
             if not superseded_snapshot.exists:
                 raise WorkstreamConflictError('artifact head points to a missing descriptor')
-            superseded = ArtifactDescriptor.model_validate(_snapshot_dict(superseded_snapshot))
+            superseded = parse_snapshot_strict(ArtifactDescriptor, superseded_snapshot)
             if superseded.logical_key != proposal.logical_key or superseded.status == ArtifactStatus.superseded:
                 raise WorkstreamConflictError('artifact head is not a live version of this logical artifact')
         elif proposal.version != 1 or proposal.supersedes_artifact_id is not None:
@@ -706,7 +689,7 @@ def transition_artifact_status(
         artifact_snapshot = artifact_ref.get(transaction=write_transaction)
         if not artifact_snapshot.exists:
             raise WorkstreamNotFoundError(artifact_id)
-        artifact = ArtifactDescriptor.model_validate(_snapshot_dict(artifact_snapshot))
+        artifact = parse_snapshot_strict(ArtifactDescriptor, artifact_snapshot)
         if artifact.status == request.status:
             _finish_mutation(
                 write_transaction,
@@ -764,14 +747,7 @@ def list_artifact_descriptors(
         .order_by('created_at', direction=firestore.Query.DESCENDING)
         .limit(limit)
     )
-    descriptors: list[ArtifactDescriptor] = []
-    for snapshot in query.stream():
-        try:
-            descriptors.append(ArtifactDescriptor.model_validate(_snapshot_dict(snapshot)))
-        except ValidationError as e:
-            # Skip a malformed/legacy artifact doc rather than 500 the whole page.
-            logger.warning('Skipping malformed artifact descriptor %s: %s', getattr(snapshot, 'id', None), e)
-    return descriptors
+    return parse_snapshots(ArtifactDescriptor, query.stream())
 
 
 def upsert_continuation_checkpoint(
@@ -812,7 +788,7 @@ def upsert_continuation_checkpoint(
             raise WorkstreamConflictError('checkpoint cannot advance beyond the workstream journal')
         checkpoint_snapshot = checkpoint_ref.get(transaction=write_transaction)
         if checkpoint_snapshot.exists:
-            existing = ContinuationCheckpoint.model_validate(_snapshot_dict(checkpoint_snapshot))
+            existing = parse_snapshot_strict(ContinuationCheckpoint, checkpoint_snapshot)
             if checkpoint.last_event_sequence < existing.last_event_sequence:
                 raise WorkstreamConflictError('checkpoint sequence cannot move backwards')
             if checkpoint.last_event_sequence == existing.last_event_sequence:
@@ -861,14 +837,7 @@ def list_continuation_checkpoints(
         .collection(CHECKPOINTS_COLLECTION)
         .stream()
     )
-    checkpoints: list[ContinuationCheckpoint] = []
-    for snapshot in snapshots:
-        try:
-            checkpoints.append(ContinuationCheckpoint.model_validate(_snapshot_dict(snapshot)))
-        except ValidationError as e:
-            # Skip a malformed/legacy checkpoint doc rather than 500 the whole page.
-            logger.warning('Skipping malformed continuation checkpoint %s: %s', getattr(snapshot, 'id', None), e)
-    return checkpoints
+    return parse_snapshots(ContinuationCheckpoint, snapshots)
 
 
 def resolve_workstream_candidate(
@@ -896,7 +865,7 @@ def resolve_workstream_candidate(
         candidate_snapshot = candidate_ref.get(transaction=write_transaction)
         if not candidate_snapshot.exists:
             raise WorkstreamNotFoundError(candidate.candidate_id)
-        stored_candidate = CandidateRecord.from_storage(_snapshot_dict(candidate_snapshot))
+        stored_candidate = parse_snapshot_strict(CandidateRecord, candidate_snapshot)
         if stored_candidate.account_generation != account_generation:
             raise WorkstreamGenerationMismatchError('Candidate account generation mismatch')
         if stored_candidate.status == CandidateStatus.accepted:

--- a/backend/tests/unit/test_candidates_skip_malformed.py
+++ b/backend/tests/unit/test_candidates_skip_malformed.py
@@ -42,13 +42,12 @@ def test_list_candidates_skips_malformed_without_logging_private_input(monkeypat
     bad.id = "bad"
     bad.to_dict.return_value = {"bad": True, "description": secret, secret: "private-value"}
 
-    def fake_from_storage(data):
+    def fake_validate(data):
         if data.get("bad"):
             _Probe(x=data)  # a dict is not an int -> raises a genuine pydantic ValidationError
         return data  # stand-in for a parsed CandidateRecord
 
-    monkeypatch.setattr(candidates_db, "_snapshot_dict", lambda snap: snap.to_dict())
-    monkeypatch.setattr(candidates_db.CandidateRecord, "from_storage", staticmethod(fake_from_storage))
+    monkeypatch.setattr(candidates_db.CandidateRecord, "model_validate", staticmethod(fake_validate))
 
     with patch.object(candidates_db, "db", _fake_candidates_db([good, bad])):
         result = candidates_db.list_candidates("u1")
@@ -68,8 +67,7 @@ def test_list_candidates_does_not_swallow_unexpected_error(monkeypatch):
     def boom(_data):
         raise RuntimeError("unexpected parsing failure")
 
-    monkeypatch.setattr(candidates_db, "_snapshot_dict", lambda snap: snap.to_dict())
-    monkeypatch.setattr(candidates_db.CandidateRecord, "from_storage", staticmethod(boom))
+    monkeypatch.setattr(candidates_db.CandidateRecord, "model_validate", staticmethod(boom))
 
     with patch.object(candidates_db, "db", _fake_candidates_db([good])):
         with pytest.raises(RuntimeError):

--- a/backend/tests/unit/test_check_firestore_model_read_boundary.py
+++ b/backend/tests/unit/test_check_firestore_model_read_boundary.py
@@ -1,0 +1,61 @@
+"""Tests for the Firestore model-read boundary AST ratchet."""
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[3] / '.github' / 'scripts' / 'check_firestore_model_read_boundary.py'
+_SPEC = importlib.util.spec_from_file_location('check_firestore_model_read_boundary', _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+def test_counts_direct_assigned_and_model_validate_construction():
+    source = '''
+from models.other import Person
+
+payload = {'id': 'p1'}
+direct = Person(**payload)
+assigned_payload = payload
+assigned = Person(**assigned_payload)
+validated = Person.model_validate(assigned_payload)
+'''
+
+    assert _MODULE.count_model_constructions(source) == 3
+
+
+def test_counts_qualified_model_imports_and_keyword_model_validate():
+    source = '''
+import models.other as other
+from models import another
+
+first = other.Person(**payload)
+second = other.Person.model_validate(obj=payload)
+third = another.Person(**payload)
+fourth = another.Person.model_validate(obj=payload)
+'''
+
+    assert _MODULE.count_model_constructions(source) == 4
+
+
+def test_ignores_non_model_kwargs_and_excludes_boundary_file(tmp_path):
+    source = '''
+from google.cloud import firestore
+
+client = firestore.Client(**kwargs)
+'''
+    assert _MODULE.count_model_constructions(source) == 0
+
+    scan_root = tmp_path / 'backend' / 'database'
+    scan_root.mkdir(parents=True)
+    (scan_root / 'read_boundary.py').write_text('from models.other import Person\nrecord = Person(**payload)\n')
+    (scan_root / 'reader.py').write_text('from models.other import Person\nrecord = Person(**payload)\n')
+
+    assert _MODULE.collect_counts(tmp_path, Path('backend/database')) == {'backend/database/reader.py': 1}
+
+
+def test_reports_only_count_increases():
+    assert _MODULE.violations({'backend/database/readers.py': 2}, {'backend/database/readers.py': 1}) == [
+        'backend/database/readers.py: found 2, baseline allows 1'
+    ]
+    assert _MODULE.violations({'backend/database/readers.py': 1}, {'backend/database/readers.py': 2}) == []

--- a/backend/tests/unit/test_fallback_observability.py
+++ b/backend/tests/unit/test_fallback_observability.py
@@ -89,6 +89,11 @@ def test_llm_gateway_is_a_bounded_fallback_component():
     assert fallback_mod.bucket_component('llm_gateway') == 'llm_gateway'
 
 
+def test_firestore_malformed_document_labels_are_bounded():
+    assert fallback_mod.bucket_component('firestore_read') == 'firestore_read'
+    assert fallback_mod.bucket_reason('malformed_doc') == 'malformed_doc'
+
+
 def test_record_fallback_never_raises_on_metric_or_log_failure(monkeypatch):
     class BoomCounter:
         def labels(self, **_labels):

--- a/backend/tests/unit/test_get_candidate_skip_malformed.py
+++ b/backend/tests/unit/test_get_candidate_skip_malformed.py
@@ -56,7 +56,7 @@ def test_get_candidate_skips_malformed(monkeypatch):
     def raise_err(data):
         raise err
 
-    monkeypatch.setattr(candidates.CandidateRecord, 'from_storage', staticmethod(raise_err))
+    monkeypatch.setattr(candidates.CandidateRecord, 'model_validate', staticmethod(raise_err))
     _patch_db(monkeypatch, _snap(True, {'bad': 'doc'}))
     assert candidates.get_candidate('u1', 'c1') is None  # malformed -> None (router 404s), not a 500
 
@@ -71,7 +71,7 @@ def test_get_candidate_unexpected_error_propagates(monkeypatch):
     def boom(data):
         raise RuntimeError('unexpected')
 
-    monkeypatch.setattr(candidates.CandidateRecord, 'from_storage', staticmethod(boom))
+    monkeypatch.setattr(candidates.CandidateRecord, 'model_validate', staticmethod(boom))
     _patch_db(monkeypatch, _snap(True, {'x': 1}))
     with pytest.raises(RuntimeError):
         candidates.get_candidate('u1', 'c1')

--- a/backend/tests/unit/test_read_boundary.py
+++ b/backend/tests/unit/test_read_boundary.py
@@ -1,0 +1,105 @@
+"""Behavioral contracts for the shared Firestore read boundary."""
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel
+
+import database.read_boundary as read_boundary
+
+
+class _Record(BaseModel):
+    id: str
+    count: int
+
+
+@dataclass
+class _Reference:
+    path: str
+
+
+class _Snapshot:
+    def __init__(self, document_id: str, payload: object, *, exists: bool = True):
+        self.id = document_id
+        self._payload = payload
+        self.exists = exists
+        self.reference = _Reference(f'users/test/items/{document_id}')
+
+    def to_dict(self):
+        return self._payload
+
+
+def test_parse_snapshot_or_none_injects_document_id_and_redacts_input(caplog, monkeypatch):
+    secret = 'private task description must never be logged'
+
+    with patch.object(read_boundary, 'record_fallback') as fallback:
+        parsed = read_boundary.parse_snapshot_or_none(_Record, _Snapshot('valid', {'count': 1}), document_id_field='id')
+        malformed = read_boundary.parse_snapshot_or_none(_Record, _Snapshot('bad', {'description': secret}))
+
+    assert parsed == _Record(id='valid', count=1)
+    assert malformed is None
+    assert fallback.call_count == 1
+    assert fallback.call_args.kwargs == {
+        'component': 'firestore_read',
+        'from_mode': 'firestore_document',
+        'to_mode': 'skip_malformed_document',
+        'reason': 'malformed_doc',
+        'outcome': 'degraded',
+        'log': read_boundary.logger,
+    }
+    assert 'users/test/items/bad' in caplog.text
+    assert secret not in caplog.text
+    assert 'validation_fields=' in caplog.text
+    assert 'validation_types=' in caplog.text
+
+
+def test_parse_snapshots_drops_each_malformed_snapshot_and_keeps_valid_entries(monkeypatch):
+    with patch.object(read_boundary, 'record_fallback') as fallback:
+        parsed = read_boundary.parse_snapshots(
+            _Record,
+            [
+                _Snapshot('one', {'id': 'one', 'count': 1}),
+                _Snapshot('bad', {'id': 'bad'}),
+                _Snapshot('two', {'id': 'two', 'count': 2}),
+            ],
+        )
+
+    assert parsed == [_Record(id='one', count=1), _Record(id='two', count=2)]
+    assert fallback.call_count == 1
+
+
+def test_iter_parsed_snapshots_is_lazy_and_drops_malformed_entries(monkeypatch):
+    snapshots = iter([_Snapshot('one', {'id': 'one', 'count': 1}), _Snapshot('bad', {'id': 'bad'})])
+
+    with patch.object(read_boundary, 'record_fallback') as fallback:
+        parsed = read_boundary.iter_parsed_snapshots(_Record, snapshots)
+
+        assert isinstance(parsed, Iterator)
+        assert next(parsed) == _Record(id='one', count=1)
+        assert fallback.call_count == 0
+        assert list(parsed) == []
+        assert fallback.call_count == 1
+
+
+def test_parse_snapshot_strict_raises_typed_error_without_fallback(monkeypatch):
+    with patch.object(read_boundary, 'record_fallback') as fallback:
+        with pytest.raises(read_boundary.MalformedDocError, match='users/test/items/bad') as error:
+            read_boundary.parse_snapshot_strict(_Record, _Snapshot('bad', {'id': 'bad'}))
+
+    assert error.value.error_types == ('missing',)
+    assert error.value.error_fields == ('count',)
+    assert fallback.call_count == 0
+
+
+def test_boundary_converts_type_error_from_payload_transform_to_fail_open(monkeypatch):
+    with patch.object(read_boundary, 'record_fallback') as fallback:
+        result = read_boundary.parse_snapshot_or_none(
+            _Record,
+            _Snapshot('bad', {'id': 'bad', 'count': 1}),
+            payload_from_snapshot=lambda _snapshot: None,  # type: ignore[return-value]
+        )
+
+    assert result is None
+    assert fallback.call_count == 1

--- a/backend/tests/unit/test_recurrence_inbox_control_skip_malformed.py
+++ b/backend/tests/unit/test_recurrence_inbox_control_skip_malformed.py
@@ -1,15 +1,15 @@
-"""Regression: a malformed task_intelligence_control doc must not crash the recurrence handoff.
+"""Regression: a malformed task_intelligence_control doc must fail closed in the recurrence transaction.
 
-recurrence_inbox._validate_generation loads the per-user control doc with
-TaskWorkflowControl.model_validate. The model is extra='forbid', so a drifted document raised
-ValidationError straight out of the recurrence enqueue/transaction paths. The guard falls back to
-the legacy-safe default, which fails the generation/mode checks, so a malformed control is treated
-as a RecurrenceGenerationMismatchError (an outcome callers already handle) rather than crashing.
+recurrence_inbox._validate_generation loads the per-user control document inside an idempotent
+transaction. A malformed control must not be silently treated as a default: it now parses strictly
+and translates the typed boundary error to the existing caller-facing generation-mismatch outcome.
 """
 
 import pytest
+from unittest.mock import patch
 
 import database.recurrence_inbox as recurrence_inbox_db
+import database.read_boundary as read_boundary
 from database.recurrence_inbox import _validate_generation, RecurrenceGenerationMismatchError
 
 
@@ -22,17 +22,17 @@ class _FakeSnapshot:
         return self._data
 
 
-def test_malformed_control_is_treated_as_generation_mismatch():
+def test_malformed_control_is_treated_as_generation_mismatch_without_fail_open():
     # extra='forbid': an unknown persisted field fails to load with ValidationError.
     snapshot = _FakeSnapshot(
         exists=True,
         data={'workflow_mode': 'write', 'account_generation': 1, 'legacy_extra': True},
     )
 
-    # Falls back to the default (account_generation=0), so it fails the generation check -- a handled
-    # mismatch, not a ValidationError bubbling out of the recurrence handoff.
-    with pytest.raises(RecurrenceGenerationMismatchError):
-        _validate_generation(snapshot, account_generation=1)
+    with patch.object(read_boundary, 'record_fallback') as fallback:
+        with pytest.raises(RecurrenceGenerationMismatchError, match='malformed'):
+            _validate_generation(snapshot, account_generation=1)
+    fallback.assert_not_called()
 
 
 def test_valid_matching_control_passes():

--- a/backend/tests/unit/test_users_missing_doc_guards.py
+++ b/backend/tests/unit/test_users_missing_doc_guards.py
@@ -9,14 +9,14 @@ race). These getters now use the file's existing `.to_dict() or {}` guard so a m
 the same default as a missing field instead of crashing. These cover the pure getter behavior.
 """
 
-import importlib.util
 import os
-import sys
-import types
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from testing.import_isolation import load_module_fresh, stub_modules
 
 BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
 
@@ -26,59 +26,42 @@ os.environ.setdefault(
 )
 
 
-def _pkg(name):
-    mod = sys.modules.get(name)
-    if mod is None or not hasattr(mod, "__path__"):
-        mod = types.ModuleType(name)
-        mod.__path__ = []
-        sys.modules[name] = mod
-    return mod
-
-
-def _mod(name, **attrs):
-    mod = types.ModuleType(name)
+def _module(name: str, **attrs: object) -> ModuleType:
+    mod = ModuleType(name)
     for key, value in attrs.items():
         setattr(mod, key, value)
-    sys.modules[name] = mod
     return mod
 
 
-# Stub the heavy leaves database/users.py imports so the real module loads; the @transactional /
-# CachePolicy module-level constructs become harmless mocks. None are exercised by the getters here.
-for _p in ["google", "google.cloud", "database", "models", "utils"]:
-    _pkg(_p)
-_mod("google.cloud.firestore", SERVER_TIMESTAMP=MagicMock())
-_mod("google.cloud.firestore_v1", FieldFilter=MagicMock(), transactional=lambda fn: fn)
-_mod("database._client", db=MagicMock(), document_id_from_seed=lambda seed: "id")
-_mod("database.read_boundary", parse_snapshot_or_none=MagicMock(), parse_snapshot_strict=MagicMock())
-_mod("database.firestore_cache", CachePolicy=MagicMock(), get_or_fetch=MagicMock(), invalidate=MagicMock())
-_mod(
-    "database.redis_db",
-    try_acquire_client_device_write_lock=MagicMock(return_value=True),
-    try_acquire_user_platform_write_lock=MagicMock(return_value=True),
-)
-_mod(
-    "models.users",
-    Subscription=MagicMock(),
-    PlanLimits=MagicMock(),
-    PlanType=MagicMock(),
-    SubscriptionStatus=MagicMock(),
-)
-_mod("utils.subscription", get_default_basic_subscription=MagicMock())
-_mod("models.other", Person=MagicMock())
-
-
-def _load():
-    # Load under the real package-qualified name so the module's `from ._client import ...` relative
-    # import resolves against the stubbed `database` package above.
-    spec = importlib.util.spec_from_file_location("database.users", str(BACKEND_DIR / "database" / "users.py"))
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules["database.users"] = mod
-    spec.loader.exec_module(mod)
-    return mod
-
-
-users = _load()
+@pytest.fixture(scope="module")
+def users():
+    """Load database.users with import-time leaves faked in a restoring context."""
+    firestore = _module("google.cloud.firestore", SERVER_TIMESTAMP=MagicMock())
+    firestore_v1 = _module("google.cloud.firestore_v1", FieldFilter=MagicMock(), transactional=lambda fn: fn)
+    fakes = {
+        "google.cloud.firestore": firestore,
+        "google.cloud.firestore_v1": firestore_v1,
+        "database._client": _module("database._client", db=MagicMock(), document_id_from_seed=lambda seed: "id"),
+        "database.firestore_cache": _module(
+            "database.firestore_cache", CachePolicy=MagicMock(), get_or_fetch=MagicMock(), invalidate=MagicMock()
+        ),
+        "database.redis_db": _module(
+            "database.redis_db",
+            try_acquire_client_device_write_lock=MagicMock(return_value=True),
+            try_acquire_user_platform_write_lock=MagicMock(return_value=True),
+        ),
+        "models.users": _module(
+            "models.users",
+            Subscription=MagicMock(),
+            PlanLimits=MagicMock(),
+            PlanType=MagicMock(),
+            SubscriptionStatus=MagicMock(),
+        ),
+        "utils.subscription": _module("utils.subscription", get_default_basic_subscription=MagicMock()),
+        "models.other": _module("models.other", Person=MagicMock()),
+    }
+    with stub_modules(fakes):
+        yield load_module_fresh("database.users", str(BACKEND_DIR / "database" / "users.py"))
 
 
 def _db_for(to_dict_result):
@@ -102,7 +85,7 @@ CASES = [
 
 
 @pytest.mark.parametrize("fn,field,default,present", CASES)
-def test_missing_user_doc_returns_default_not_crash(fn, field, default, present):
+def test_missing_user_doc_returns_default_not_crash(users, fn, field, default, present):
     # to_dict() is None when the user document does not exist; the getter must return the default
     # rather than raising AttributeError (which previously became a 500).
     func = getattr(users, fn)
@@ -111,7 +94,7 @@ def test_missing_user_doc_returns_default_not_crash(fn, field, default, present)
 
 
 @pytest.mark.parametrize("fn,field,default,present", CASES)
-def test_existing_user_doc_returns_field_value(fn, field, default, present):
+def test_existing_user_doc_returns_field_value(users, fn, field, default, present):
     # Happy path is unchanged: a present field is returned as-is.
     func = getattr(users, fn)
     with patch.object(users, "db", _db_for({field: present})):
@@ -119,7 +102,7 @@ def test_existing_user_doc_returns_field_value(fn, field, default, present):
 
 
 @pytest.mark.parametrize("fn,field,default,present", CASES)
-def test_doc_present_but_field_absent_returns_default(fn, field, default, present):
+def test_doc_present_but_field_absent_returns_default(users, fn, field, default, present):
     # A doc that exists but lacks the field still yields the default (also unchanged behavior).
     func = getattr(users, fn)
     with patch.object(users, "db", _db_for({"unrelated": 1})):

--- a/backend/tests/unit/test_users_missing_doc_guards.py
+++ b/backend/tests/unit/test_users_missing_doc_guards.py
@@ -50,6 +50,7 @@ for _p in ["google", "google.cloud", "database", "models", "utils"]:
 _mod("google.cloud.firestore", SERVER_TIMESTAMP=MagicMock())
 _mod("google.cloud.firestore_v1", FieldFilter=MagicMock(), transactional=lambda fn: fn)
 _mod("database._client", db=MagicMock(), document_id_from_seed=lambda seed: "id")
+_mod("database.read_boundary", parse_snapshot_or_none=MagicMock(), parse_snapshot_strict=MagicMock())
 _mod("database.firestore_cache", CachePolicy=MagicMock(), get_or_fetch=MagicMock(), invalidate=MagicMock())
 _mod(
     "database.redis_db",

--- a/backend/tests/unit/test_users_subscription_read_boundary.py
+++ b/backend/tests/unit/test_users_subscription_read_boundary.py
@@ -1,0 +1,37 @@
+"""Subscriptions preserve strict corruption semantics at the Firestore read boundary."""
+
+from unittest.mock import patch
+
+import pytest
+
+import database.read_boundary as read_boundary
+import database.users as users_db
+
+
+class _Snapshot:
+    exists = True
+    id = 'user-1'
+
+    def to_dict(self):
+        return {'subscription': ['not-a-mapping']}
+
+
+class _Database:
+    def collection(self, *_args):
+        return self
+
+    def document(self, *_args):
+        return self
+
+    def get(self, *_args, **_kwargs):
+        return _Snapshot()
+
+
+def test_existing_subscription_with_malformed_payload_raises_typed_error(monkeypatch):
+    monkeypatch.setattr(users_db, 'db', _Database())
+
+    with patch.object(read_boundary, 'record_fallback') as fallback:
+        with pytest.raises(read_boundary.MalformedDocError):
+            users_db.get_existing_user_subscription('user-1')
+
+    fallback.assert_not_called()

--- a/backend/tests/unit/test_workstream_events_skip_malformed.py
+++ b/backend/tests/unit/test_workstream_events_skip_malformed.py
@@ -8,12 +8,18 @@ rest still return. No live services.
 import os
 from unittest.mock import MagicMock
 
+from pydantic import BaseModel
+
 os.environ.setdefault(
     "ENCRYPTION_SECRET",
     "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
 )
 
 import database.workstreams as workstreams_db  # noqa: E402
+
+
+class _Probe(BaseModel):
+    x: int
 
 
 def test_list_workstream_events_skips_malformed(monkeypatch):
@@ -31,7 +37,7 @@ def test_list_workstream_events_skips_malformed(monkeypatch):
 
     def fake_validate(data):
         if data.get("bad"):
-            raise ValueError("malformed workstream event")
+            _Probe.model_validate({})  # raises a genuine pydantic ValidationError
         return data  # stand-in for a parsed WorkstreamEvent
 
     monkeypatch.setattr(workstreams_db, "_snapshot_dict", lambda snap: snap.to_dict())

--- a/backend/tests/unit/test_workstream_list_skip_malformed.py
+++ b/backend/tests/unit/test_workstream_list_skip_malformed.py
@@ -19,7 +19,7 @@ os.environ.setdefault(
     'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
 )
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import BaseModel, ValidationError
@@ -118,3 +118,17 @@ def test_task_responses_unexpected_error_propagates(monkeypatch):
     monkeypatch.setattr(ws.ActionItemResponse, 'model_validate', staticmethod(boom))
     with pytest.raises(RuntimeError):
         ws._task_responses_from_snapshots([_snapshot({'id': 't1'})], context='goal_detail')
+
+
+def test_workstream_presentation_read_skips_malformed_snapshot(monkeypatch):
+    _stub_validate(monkeypatch, 'Workstream')
+    snapshot = _snapshot({'id': 'bad', '_bad': True})
+    snapshot.exists = True
+    client = _fake_client([])
+    client.get.return_value = snapshot
+
+    with patch('database.read_boundary.record_fallback') as fallback:
+        result = ws.get_workstream('u1', 'bad', firestore_client=client)
+
+    assert result is None
+    fallback.assert_called_once()

--- a/backend/utils/observability/fallback.py
+++ b/backend/utils/observability/fallback.py
@@ -40,6 +40,7 @@ ALLOWED_REASONS = frozenset(
         'policy',
         'dispatch_disabled',
         'byok',
+        'malformed_doc',
         'other',
         'none',
     }
@@ -61,6 +62,7 @@ ALLOWED_COMPONENTS = frozenset(
         'llm_gateway',
         'redis_ratelimit',
         'silent_mic',
+        'firestore_read',
         'other',
     }
 )

--- a/docs/product/failure-classes.md
+++ b/docs/product/failure-classes.md
@@ -1,0 +1,5 @@
+# Failure-class registry
+
+| Class | Violated contract | Canonical fix primitive | Status |
+| --- | --- | --- | --- |
+| FC-1 | A malformed or legacy Firestore document must not bypass the reader's explicit fail-open or fail-closed policy. | `backend/database/read_boundary.py` | Open — the 14-day closure observation starts when #9827 merges. |


### PR DESCRIPTION
## Summary

- Add one snapshot-native Firestore model-read boundary with explicit presentation fail-open and correctness-critical strict APIs.
- Migrate Firestore readers across candidate, goal, workstream, task-intelligence, chat, subscription, and memory paths; malformed presentation records are skipped with safe telemetry, while transaction, idempotency, ledger, and canonical-state reads fail closed with `MalformedDocError`.
- Log only a document path plus structural field paths/types, register the `firestore_read` / `malformed_doc` telemetry labels, and document FC-1's 14-day post-merge observation window.
- Add the CI/local AST no-increase ratchet for direct model construction outside the boundary. The ratchet complements the shared primitive by preventing future bypasses at the remaining direct-construction boundary.

## Failure-class closure

Root cause: Firestore snapshots bypassed a common untrusted-data boundary, so malformed legacy documents could raise raw Pydantic errors and 500 read paths.

Durable guard: all migrated snapshot-to-model paths now choose the shared fail-open or strict policy, per-document fallback telemetry is bounded and PII-safe, strict paths raise a typed error, and the AST ratchet prevents the direct-construction forms behind the prior #9494 -> #9696 fixes from increasing.

## Product invariants affected

- INV-MEM-1 — memory reads remain in the existing three-tier/canonical-collection model; only malformed-document handling changed.

## Verification

- `cd backend && .venv/bin/python -m pytest -q tests/unit/test_read_boundary.py tests/unit/test_check_firestore_model_read_boundary.py tests/unit/test_recurrence_inbox_control_skip_malformed.py tests/unit/test_workstream_list_skip_malformed.py tests/unit/test_fallback_observability.py tests/unit/test_users_subscription_read_boundary.py` — 28 passed.
- `cd backend && .venv/bin/python ../.github/scripts/check_firestore_model_read_boundary.py` — passed.
- `backend/.venv/bin/python -m pyright --pythonpath backend/.venv/bin/python backend/database/read_boundary.py` and `compileall` — passed.
- `bash backend/test.sh` exercised the component suite. All changed-path tests passed; the suite remains blocked by an unchanged `tests/unit/test_tools_rest_memory_runtime_adapter.py` CPU duration guard (0.34s > 0.12s) despite its four assertions passing. The same isolated runner reproduces that pre-existing guard failure.
- Sol reviewed the implementation twice, including the final lazy-telemetry/import-isolation follow-up, with no blocking findings.

I exercised the snapshot-facing application read paths through injectable Firestore fakes. A live malformed Firestore document was not used because local development has no safe malformed-data fixture/emulator configured.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

