### PR TITLE
fix(macos): isolate named dev bundles and add omi-macos-dev

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -2,6 +2,11 @@
 # Values use JSON scalars/lists within this stdlib-parsed YAML subset.
 # Add new checks here with both local and ci lanes; never hardcode them in workflow YAML.
 checks:
+  - id: pre-push-final-pr-diff
+    command: ["bash", "scripts/test-pre-push-diff-base.sh"]
+    triggers: ["scripts/pre-push", "scripts/pre-push-diff-base", "scripts/test-pre-push-diff-base.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "pre-push check selection must use the final PR diff rather than a stale remote feature tip"
   - id: check-manifest-contract
     command: ["python3", ".github/scripts/test_run_checks.py"]
     triggers: ["all"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -54,7 +54,7 @@ checks:
     reason: "desktop files changed"
   - id: omi-macos-dev-cli
     command: ["bash", "desktop/macos/tests/test-omi-macos-dev.sh"]
-    triggers: ["desktop/macos/scripts/omi-macos-dev", "desktop/macos/scripts/cleanup-omi-tcc.sh", "desktop/macos/tests/test-omi-macos-dev.sh"]
+    triggers: ["desktop/macos/scripts/omi-macos-dev", "desktop/macos/scripts/cleanup-omi-tcc.sh", "desktop/macos/tests/test-omi-macos-dev.sh", "desktop/macos/tests/test-cleanup-omi-tcc.sh"]
     lanes: ["local", "ci"]
     reason: "agent-facing macOS development hygiene CLI remains safe and deterministic"
   - id: desktop-e2e-flow-coverage

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -47,6 +47,11 @@ checks:
     triggers: ["desktop/macos/**"]
     lanes: ["local", "ci"]
     reason: "desktop files changed"
+  - id: omi-macos-dev-cli
+    command: ["bash", "desktop/macos/tests/test-omi-macos-dev.sh"]
+    triggers: ["desktop/macos/scripts/omi-macos-dev", "desktop/macos/scripts/cleanup-omi-tcc.sh", "desktop/macos/tests/test-omi-macos-dev.sh"]
+    lanes: ["local", "ci"]
+    reason: "agent-facing macOS development hygiene CLI remains safe and deterministic"
   - id: desktop-e2e-flow-coverage
     command: ["python3", "desktop/macos/scripts/check-e2e-flow-coverage.py", "--strict", "--base", "{base}"]
     triggers: ["desktop/macos/Desktop/Sources/**/*.swift"]

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -301,6 +301,8 @@ Fast path (skips web login and sidebar click-through):
 3. **Package boundary:** use `./run.sh --full` only for the first named launch, resource/entitlement/package/runtime input changes, or when `--fast-only` reports an expected fingerprint mismatch.
 4. **QA, commit, and PR readiness:** run `./scripts/omi-macos-dev doctor`, exercise the real user-facing path, then run the appropriate full component/PR contract.
 
+`omi-macos-dev` defaults to bounded JSON summaries so an agent can safely inspect a busy machine. Pass `--verbose` to the specific command for path-level records (for example, `clean plan --verbose`); cleanup always requires the exact current plan hash. The normal 14-day retention window can be deliberately bypassed with `--older-than 0` only when the operator has explicitly approved immediate cleanup.
+
 Never ask a user to test an unexercised path. A fast named-bundle launch plus a semantic bridge assertion is valid inner-loop evidence; a clean full bundle is release/QA evidence.
 
 ### After Implementing Changes

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -294,9 +294,18 @@ Fast path (skips web login and sidebar click-through):
    launch; per-user issues in Sentry/PostHog.
 4. **Verify the actual behavior**, not just that the app launched — exercise the feature and check the logs/UI reflect the change.
 
+### Default agent development loop
+
+1. **Edit or diagnose:** run the smallest relevant unit/static harness. Do not launch the app only to obtain compile evidence.
+2. **Swift/UI behavior:** reuse the existing named bundle with `OMI_APP_NAME=omi-<feature> ./run.sh --yolo --fast-only`, then use the local bridge (`omi-ctl action`, `state`, or a semantic snapshot) to assert the changed behavior.
+3. **Package boundary:** use `./run.sh --full` only for the first named launch, resource/entitlement/package/runtime input changes, or when `--fast-only` reports an expected fingerprint mismatch.
+4. **QA, commit, and PR readiness:** run `./scripts/omi-macos-dev doctor`, exercise the real user-facing path, then run the appropriate full component/PR contract.
+
+Never ask a user to test an unexercised path. A fast named-bundle launch plus a semantic bridge assertion is valid inner-loop evidence; a clean full bundle is release/QA evidence.
+
 ### After Implementing Changes
+
 - `xcrun swift build` is for **compile checks only** — it does NOT start the backend
-- To actually test, ALWAYS use `./run.sh` with `OMI_APP_NAME` — it starts Rust backend + Cloudflare tunnel + Swift app together
 - Voice-path verification means a natural authenticated PTT turn on a named bundle — signed-out, forced-transcript, or reducer-only runs do not count; provider mint or payload changes must also show the deploy-inline provider probe.
 - **When the user says "test it"**, use the `test-local` skill to build, run, and verify via macOS automation
 

--- a/desktop/macos/Desktop/Sources/AgentVMService.swift
+++ b/desktop/macos/Desktop/Sources/AgentVMService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OmiSupport
 
 /// Manages the cloud agent VM lifecycle: provisioning, status polling, and database upload.
 /// All operations are fire-and-forget from the caller's perspective.
@@ -174,10 +175,8 @@ actor AgentVMService {
         defer { Task { await AgentSyncService.shared.resume() } }
         // Find the local database path
         let dbPath = await MainActor.run {
-            let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
             let userId = RewindDatabase.currentUserId ?? "anonymous"
-            return appSupport
-                .appendingPathComponent("Omi", isDirectory: true)
+            return DesktopLocalProfile.applicationSupportURL()
                 .appendingPathComponent("users", isDirectory: true)
                 .appendingPathComponent(userId, isDirectory: true)
                 .appendingPathComponent("omi.db")

--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -15,15 +15,17 @@ enum OmiLogPathResolver {
       of: #"[^A-Za-z0-9._-]+"#,
       with: "-",
       options: .regularExpression)
-    return "/private/tmp/omi/\(safeBundleID)/\(launchID(processID: processID)).log"
+    return "/private/tmp/omi-dev-\(safeBundleID)-\(processID).log"
   }
 }
 
+private let logBundleIdentifier = Bundle.main.bundleIdentifier ?? "unknown"
+private let logProcessID = getpid()
 private let logFile: String = OmiLogPathResolver.logPath(
   isNonProduction: AppBuild.isNonProduction,
-  bundleIdentifier: Bundle.main.bundleIdentifier,
-  processID: getpid())
-private let logLaunchID = OmiLogPathResolver.launchID(processID: getpid())
+  bundleIdentifier: logBundleIdentifier,
+  processID: logProcessID)
+private let logLaunchID = OmiLogPathResolver.launchID(processID: logProcessID)
 /// The on-disk app-log path for the current build. Single source of truth for
 /// the log location so callers (feedback export, diagnostics bundle) don't
 /// re-derive it. Owner-only permissions are enforced by `ensureLogFileOwnerOnly`.
@@ -114,11 +116,13 @@ func ensureLogDirectoryOwnerOnly(atPath path: String) -> Bool {
 private var didEnsureLogFilePermissions = false
 
 private func ensureLogParentDirectories() -> Bool {
-  guard AppBuild.isNonProduction else { return true }
-  let bundleDirectory = (logFile as NSString).deletingLastPathComponent
-  let rootDirectory = (bundleDirectory as NSString).deletingLastPathComponent
-  return ensureLogDirectoryOwnerOnly(atPath: rootDirectory)
-    && ensureLogDirectoryOwnerOnly(atPath: bundleDirectory)
+  // Non-production logs live as owner-only files directly under private tmp.
+  // Do not chmod `/private/tmp`: it is shared infrastructure owned by macOS.
+  true
+}
+
+private func logLine(timestamp: String, category: String, message: String) -> String {
+  "[\(timestamp)] [\(category)] [bundle_id=\(logBundleIdentifier) pid=\(logProcessID)] \(message)"
 }
 
 /// Shared file-write implementation (must be called on logQueue)
@@ -148,7 +152,7 @@ private func writeToLogFile(_ data: Data) {
 /// Log a performance event with timing info - writes to omi.log with [perf] tag
 func logPerf(_ message: String, duration: Double? = nil, cpu: Bool = false) {
   let timestamp = dateFormatter.string(from: Date())
-  var parts = ["[\(timestamp)] [perf] \(message)"]
+  var parts = [logLine(timestamp: timestamp, category: "perf", message: message)]
 
   if let duration = duration {
     parts.append(String(format: "(%.1fms)", duration * 1000))
@@ -218,7 +222,7 @@ private let isDevBuild: Bool = AppBuild.isNonProduction
 /// Use sparingly (blocks the calling thread); prefer `log()` for normal logging.
 func logSync(_ message: String) {
   let timestamp = dateFormatter.string(from: Date())
-  let line = "[\(timestamp)] [app] \(message)"
+  let line = logLine(timestamp: timestamp, category: "app", message: message)
   print(line)
   fflush(stdout)
 
@@ -234,7 +238,7 @@ func logSync(_ message: String) {
 /// Write to log file, stdout, and Sentry breadcrumbs
 func log(_ message: String) {
   let timestamp = dateFormatter.string(from: Date())
-  let line = "[\(timestamp)] [app] \(message)"
+  let line = logLine(timestamp: timestamp, category: "app", message: message)
   print(line)
   fflush(stdout)
 
@@ -351,7 +355,7 @@ func logError(_ message: String, error: Error? = nil) {
   let timestamp = dateFormatter.string(from: Date())
   let errorDesc = error?.localizedDescription ?? ""
   let fullMessage = error != nil ? "\(message): \(errorDesc)" : message
-  let line = "[\(timestamp)] [error] \(fullMessage)"
+  let line = logLine(timestamp: timestamp, category: "error", message: fullMessage)
   print(line)
   fflush(stdout)
 

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -290,6 +290,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     DesktopAutomationBridge.shared.startIfNeeded()
     LocalAgentAPIServer.shared.startIfNeeded()
+    publishNamedBundleRuntimeManifest()
 
     // Strip com.apple.provenance xattrs that macOS adds when Sparkle extracts updates.
     // These break the code signature seal, causing the NEXT update to fail with
@@ -1250,6 +1251,32 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       return false
     }
     return true
+  }
+
+  /// Publish only token-free local diagnostics for a running named dev bundle.
+  /// The agent-facing doctor reads endpoint URLs from the loopback health route,
+  /// not from this durable file.
+  private func publishNamedBundleRuntimeManifest() {
+    guard DesktopLocalProfile.isNamedDevelopmentBundle,
+          let bundleID = Bundle.main.bundleIdentifier
+    else { return }
+
+    let manifest = DesktopDevRuntimeManifest(
+      bundleIdentifier: bundleID,
+      processID: ProcessInfo.processInfo.processIdentifier,
+      startedAt: Date(),
+      appPath: Bundle.main.bundleURL.path,
+      profileRoot: DesktopLocalProfile.applicationSupportURL().path,
+      logPath: omiLogFilePath(),
+      automationPort: Int(DesktopAutomationLaunchOptions.port))
+    do {
+      try DesktopDevRuntimeManifestStore.write(
+        manifest,
+        in: DesktopLocalProfile.applicationSupportURL())
+      log("AppDelegate: Published named-bundle runtime manifest")
+    } catch {
+      logError("AppDelegate: Failed to publish named-bundle runtime manifest", error: error)
+    }
   }
 
   func applicationWillTerminate(_ notification: Notification) {

--- a/desktop/macos/Desktop/Sources/OmiSupport/DesktopDevRuntimeManifest.swift
+++ b/desktop/macos/Desktop/Sources/OmiSupport/DesktopDevRuntimeManifest.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Token-free state published by a running named development bundle for local
+/// diagnostics. This is intentionally local-only: credentials, environment
+/// variables, and backend URLs must be obtained from the loopback health route
+/// rather than persisted to disk.
+package struct DesktopDevRuntimeManifest: Codable, Equatable {
+  package static let schemaVersion = 1
+
+  package let schemaVersion: Int
+  package let bundleIdentifier: String
+  package let processID: Int32
+  package let startedAt: Date
+  package let appPath: String
+  package let profileRoot: String
+  package let logPath: String
+  package let automationPort: Int
+
+  package init(
+    bundleIdentifier: String,
+    processID: Int32,
+    startedAt: Date,
+    appPath: String,
+    profileRoot: String,
+    logPath: String,
+    automationPort: Int
+  ) {
+    self.schemaVersion = Self.schemaVersion
+    self.bundleIdentifier = bundleIdentifier
+    self.processID = processID
+    self.startedAt = startedAt
+    self.appPath = appPath
+    self.profileRoot = profileRoot
+    self.logPath = logPath
+    self.automationPort = automationPort
+  }
+}
+
+package enum DesktopDevRuntimeManifestStore {
+  package static let filename = ".omi-dev-runtime.json"
+
+  package static func path(in profileRoot: URL) -> URL {
+    profileRoot.appendingPathComponent(filename, isDirectory: false)
+  }
+
+  package static func write(_ manifest: DesktopDevRuntimeManifest, in profileRoot: URL) throws {
+    let fileManager = FileManager.default
+    try fileManager.createDirectory(
+      at: profileRoot,
+      withIntermediateDirectories: true,
+      attributes: [.posixPermissions: 0o700])
+
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(manifest)
+    let destination = path(in: profileRoot)
+    let temporary = profileRoot.appendingPathComponent(".omi-dev-runtime-\(UUID().uuidString).tmp")
+
+    guard fileManager.createFile(
+      atPath: temporary.path,
+      contents: data,
+      attributes: [.posixPermissions: 0o600])
+    else {
+      throw CocoaError(.fileWriteUnknown)
+    }
+    try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: temporary.path)
+
+    if fileManager.fileExists(atPath: destination.path) {
+      _ = try fileManager.replaceItemAt(destination, withItemAt: temporary)
+    } else {
+      try fileManager.moveItem(at: temporary, to: destination)
+    }
+    try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: destination.path)
+  }
+}

--- a/desktop/macos/Desktop/Sources/OmiSupport/DesktopLocalProfile.swift
+++ b/desktop/macos/Desktop/Sources/OmiSupport/DesktopLocalProfile.swift
@@ -1,19 +1,79 @@
 import Foundation
 
-/// Runtime switches for the harness-owned Omi Dev local profile.
+/// The identity-derived storage boundary for a running desktop bundle.
 ///
-/// Production and beta keep their existing bundle identifiers. The local harness
-/// reuses the default ``Omi Dev`` bundle (`com.omi.desktop-dev`) so macOS
-/// permissions and storage paths are preserved; only API endpoints and Firebase
-/// Auth switch to localhost emulators when ``OMI_DESKTOP_LOCAL_PROFILE=1``.
+/// A regular named development build gets a separate root regardless of how it
+/// was launched. This is deliberately derived from the signed bundle ID instead
+/// of a launcher environment variable: macOS can reopen an installed app without
+/// `run.sh`, and that relaunch must remain isolated.
+package struct DesktopStorageIdentity: Equatable {
+  package static let namedDevelopmentBundlePrefix = "com.omi.omi-"
+
+  package let bundleIdentifier: String?
+  package let localProfileEnabled: Bool
+  package let localProfileStorageName: String?
+
+  package init(
+    bundleIdentifier: String?,
+    localProfileEnabled: Bool,
+    localProfileStorageName: String?
+  ) {
+    self.bundleIdentifier = bundleIdentifier
+    self.localProfileEnabled = localProfileEnabled
+    self.localProfileStorageName = localProfileStorageName
+  }
+
+  package var isNamedDevelopmentBundle: Bool {
+    guard let bundleIdentifier else { return false }
+    guard bundleIdentifier.hasPrefix(Self.namedDevelopmentBundlePrefix) else { return false }
+    let suffix = bundleIdentifier.dropFirst(Self.namedDevelopmentBundlePrefix.count)
+    guard !suffix.isEmpty else { return false }
+    return suffix.unicodeScalars.allSatisfy { scalar in
+      switch scalar.value {
+      case 48...57, 65...90, 97...122, 45, 46:
+        true
+      default:
+        false
+      }
+    }
+  }
+
+  package var usesIsolatedStorage: Bool {
+    localProfileEnabled || isNamedDevelopmentBundle
+  }
+
+  package var applicationSupportPathComponents: [String] {
+    if let bundleIdentifier, isNamedDevelopmentBundle {
+      return ["Omi Dev Bundles", bundleIdentifier]
+    }
+    if localProfileEnabled {
+      return [localProfileStorageName ?? "Omi"]
+    }
+    return ["Omi"]
+  }
+}
+
+/// Runtime switches for the harness-owned Omi Dev local profile and named
+/// development bundle storage. Production, beta, and canonical Omi Dev preserve
+/// their existing shared storage roots.
 package enum DesktopLocalProfile {
   package static var isEnabled: Bool {
     value("OMI_DESKTOP_LOCAL_PROFILE") == "1"
   }
 
   package static var storageDirectoryName: String {
-    guard isEnabled else { return "Omi" }
-    return nonEmpty(value("OMI_LOCAL_PROFILE_STORAGE_NAME")) ?? "Omi"
+    storageIdentity.applicationSupportPathComponents.joined(separator: "/")
+  }
+
+  package static var usesIsolatedStorage: Bool { storageIdentity.usesIsolatedStorage }
+  package static var isNamedDevelopmentBundle: Bool { storageIdentity.isNamedDevelopmentBundle }
+
+  package static var storageIdentity: DesktopStorageIdentity {
+    DesktopStorageIdentity(
+      bundleIdentifier: Bundle.main.bundleIdentifier,
+      localProfileEnabled: isEnabled,
+      localProfileStorageName: nonEmpty(value("OMI_LOCAL_PROFILE_STORAGE_NAME"))
+    )
   }
 
   package static var authEmulatorHost: String? {
@@ -28,12 +88,16 @@ package enum DesktopLocalProfile {
 
   package static func applicationSupportURL() -> URL {
     let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-    return base.appendingPathComponent(storageDirectoryName, isDirectory: true)
+    return storageIdentity.applicationSupportPathComponents.reduce(base) {
+      $0.appendingPathComponent($1, isDirectory: true)
+    }
   }
 
   package static func cachesURL() -> URL {
     let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
-    return base.appendingPathComponent(storageDirectoryName, isDirectory: true)
+    return storageIdentity.applicationSupportPathComponents.reduce(base) {
+      $0.appendingPathComponent($1, isDirectory: true)
+    }
   }
 
   private static func value(_ key: String) -> String? {

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -585,6 +585,11 @@ actor RewindDatabase {
     }
 
     private func migrateFromLegacyPathIfNeeded(to userDir: URL) {
+        // The legacy `Omi` root is shared historical state. A named bundle that
+        // now has an identity-derived profile must never claim it: the first
+        // bundle to launch would otherwise move data belonging to Omi/Omi Dev
+        // or another old named bundle into its isolated root.
+        guard Self.shouldMigrateLegacyStorage(isolatedStorage: DesktopLocalProfile.usesIsolatedStorage) else { return }
         let fileManager = FileManager.default
         let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let omiDir = appSupport.appendingPathComponent("Omi", isDirectory: true)
@@ -709,6 +714,10 @@ actor RewindDatabase {
         }
 
         log("RewindDatabase: Legacy migration complete")
+    }
+
+    static func shouldMigrateLegacyStorage(isolatedStorage: Bool) -> Bool {
+        !isolatedStorage
     }
 
     // MARK: - Corruption Detection & Recovery

--- a/desktop/macos/Desktop/Tests/DesktopStorageIdentityTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopStorageIdentityTests.swift
@@ -1,0 +1,90 @@
+import OmiSupport
+import XCTest
+
+@testable import Omi_Computer
+
+final class DesktopStorageIdentityTests: XCTestCase {
+  func testNamedDevelopmentBundlesHaveDistinctIdentityDerivedRoots() {
+    let first = DesktopStorageIdentity(
+      bundleIdentifier: "com.omi.omi-memory-atlas",
+      localProfileEnabled: false,
+      localProfileStorageName: nil)
+    let second = DesktopStorageIdentity(
+      bundleIdentifier: "com.omi.omi-rewind-fix",
+      localProfileEnabled: false,
+      localProfileStorageName: nil)
+
+    XCTAssertTrue(first.usesIsolatedStorage)
+    XCTAssertTrue(second.usesIsolatedStorage)
+    XCTAssertEqual(first.applicationSupportPathComponents, ["Omi Dev Bundles", "com.omi.omi-memory-atlas"])
+    XCTAssertEqual(second.applicationSupportPathComponents, ["Omi Dev Bundles", "com.omi.omi-rewind-fix"])
+    XCTAssertNotEqual(first.applicationSupportPathComponents, second.applicationSupportPathComponents)
+  }
+
+  func testProtectedAndReviewBundleIDsKeepLegacyStorage() {
+    let dev = DesktopStorageIdentity(
+      bundleIdentifier: "com.omi.desktop-dev",
+      localProfileEnabled: false,
+      localProfileStorageName: nil)
+    let review = DesktopStorageIdentity(
+      bundleIdentifier: "com.omi.review-build",
+      localProfileEnabled: false,
+      localProfileStorageName: nil)
+
+    XCTAssertFalse(dev.usesIsolatedStorage)
+    XCTAssertFalse(review.usesIsolatedStorage)
+    XCTAssertEqual(dev.applicationSupportPathComponents, ["Omi"])
+    XCTAssertEqual(review.applicationSupportPathComponents, ["Omi"])
+  }
+
+  func testNamedLocalProfileStillUsesTheBundleIDBoundary() {
+    let identity = DesktopStorageIdentity(
+      bundleIdentifier: "com.omi.omi-local-memory",
+      localProfileEnabled: true,
+      localProfileStorageName: "caller-controlled-name")
+
+    XCTAssertEqual(identity.applicationSupportPathComponents, ["Omi Dev Bundles", "com.omi.omi-local-memory"])
+  }
+
+  func testInvalidNamedBundleIDCannotSelectAnIsolatedPath() {
+    for bundleID in ["com.omi.omi-", "com.omi.omi-../escape", "com.omi.omi-测试"] {
+      let identity = DesktopStorageIdentity(
+        bundleIdentifier: bundleID,
+        localProfileEnabled: false,
+        localProfileStorageName: nil)
+
+      XCTAssertFalse(identity.isNamedDevelopmentBundle, "Unexpected named bundle ID: \(bundleID)")
+      XCTAssertEqual(identity.applicationSupportPathComponents, ["Omi"])
+    }
+  }
+
+  func testIsolatedStorageNeverMigratesTheSharedLegacyRoot() {
+    XCTAssertFalse(RewindDatabase.shouldMigrateLegacyStorage(isolatedStorage: true))
+    XCTAssertTrue(RewindDatabase.shouldMigrateLegacyStorage(isolatedStorage: false))
+  }
+
+  func testRuntimeManifestIsOwnerOnlyAndContainsNoCredentials() throws {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("omi-runtime-manifest-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let manifest = DesktopDevRuntimeManifest(
+      bundleIdentifier: "com.omi.omi-manifest-test",
+      processID: 42,
+      startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+      appPath: "/Applications/omi-manifest-test.app",
+      profileRoot: root.path,
+      logPath: "/private/tmp/omi-dev-com.omi.omi-manifest-test-42.log",
+      automationPort: 47777)
+    try DesktopDevRuntimeManifestStore.write(manifest, in: root)
+
+    let path = DesktopDevRuntimeManifestStore.path(in: root)
+    let attributes = try FileManager.default.attributesOfItem(atPath: path.path)
+    XCTAssertEqual((attributes[.posixPermissions] as? NSNumber)?.intValue, 0o600)
+
+    let contents = try String(contentsOf: path, encoding: .utf8)
+    XCTAssertFalse(contents.localizedCaseInsensitiveContains("token"))
+    XCTAssertFalse(contents.localizedCaseInsensitiveContains("credential"))
+    XCTAssertFalse(contents.localizedCaseInsensitiveContains("backend"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/LoggerPermissionsTests.swift
+++ b/desktop/macos/Desktop/Tests/LoggerPermissionsTests.swift
@@ -80,8 +80,8 @@ final class LoggerPermissionsTests: XCTestCase {
       processID: 202)
 
     XCTAssertNotEqual(first, second)
-    XCTAssertEqual(first, "/private/tmp/omi/com.omi.qa-one/pid-101.log")
-    XCTAssertEqual(second, "/private/tmp/omi/com.omi.qa-two/pid-202.log")
+    XCTAssertEqual(first, "/private/tmp/omi-dev-com.omi.qa-one-101.log")
+    XCTAssertEqual(second, "/private/tmp/omi-dev-com.omi.qa-two-202.log")
     XCTAssertEqual(
       OmiLogPathResolver.logPath(
         isNonProduction: false,

--- a/desktop/macos/changelog/unreleased/20260716-omi-macos-dev.json
+++ b/desktop/macos/changelog/unreleased/20260716-omi-macos-dev.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved macOS development bundle isolation and troubleshooting."
+}

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -23,6 +23,8 @@ covers:
   - desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
   - desktop/macos/Desktop/Sources/StartupWarmupCoordinator.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift
+  - desktop/macos/Desktop/Sources/OmiSupport/DesktopDevRuntimeManifest.swift
+  - desktop/macos/Desktop/Sources/OmiSupport/DesktopLocalProfile.swift
   - desktop/macos/Desktop/Sources/ViewModelContainer.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarDemoView.swift

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -9,6 +9,7 @@ export LC_NUMERIC=C
 # ─── Arguments ─────────────────────────────────────────────────────────
 YOLO_MODE=0
 FORCE_FULL_BUNDLE="${OMI_FORCE_FULL_BUNDLE:-0}"
+FAST_ONLY=0
 SHOW_HELP=0
 for arg in "$@"; do
     case "$arg" in
@@ -17,6 +18,9 @@ for arg in "$@"; do
             ;;
         --full)
             FORCE_FULL_BUNDLE=1
+            ;;
+        --fast-only)
+            FAST_ONLY=1
             ;;
         --help|-h)
             SHOW_HELP=1
@@ -27,6 +31,11 @@ for arg in "$@"; do
             ;;
     esac
 done
+
+if [ "$FAST_ONLY" = "1" ] && [ "$FORCE_FULL_BUNDLE" = "1" ]; then
+    echo "ERROR: --fast-only cannot be combined with --full or OMI_FORCE_FULL_BUNDLE=1" >&2
+    exit 2
+fi
 
 # ─── Help ──────────────────────────────────────────────────────────────
 if [ "$SHOW_HELP" = "1" ]; then
@@ -68,6 +77,7 @@ Examples:
   OMI_SKIP_TUNNEL=1 ./run.sh                # No Cloudflare tunnel (use direct URL)
   ./run.sh --yolo                            # Quick start: use dev backend, no local services
   ./run.sh --full                            # Rebuild every packaged dependency
+  ./run.sh --fast-only                       # Reuse an eligible installed bundle or fail without packaging
 USAGE
     exit 0
 fi
@@ -296,6 +306,65 @@ resolve_signing_identity() {
         substep "Using ad-hoc signing for named test bundle ($BUNDLE_ID)"
     fi
 }
+
+fast_bundle_fingerprint() {
+    omi_fast_bundle_fingerprint \
+        "$SCRIPT_DIR" \
+        "bundle-id=$BUNDLE_ID" \
+        "signing-identity=$SIGN_IDENTITY" \
+        "yolo=$YOLO_MODE" \
+        "skip-backend=${OMI_SKIP_BACKEND:-0}" \
+        "skip-tunnel=${OMI_SKIP_TUNNEL:-0}" \
+        "desktop-api-url=${OMI_DESKTOP_API_URL:-}" \
+        "python-api-url=${OMI_PYTHON_API_URL:-}" \
+        "backend-port=$BACKEND_PORT"
+}
+
+fast_bundle_profile_root() {
+    if [ "$IS_NAMED_BUNDLE" = true ]; then
+        printf '%s\n' "$HOME/Library/Application Support/Omi Dev Bundles/$BUNDLE_ID"
+    else
+        printf '%s\n' "$HOME/Library/Application Support/Omi"
+    fi
+}
+
+fail_fast_only() {
+    local reason="$1"
+    printf 'launch_mode=failed fast_reason=%s bundle_id=%s profile_root=%q\n' \
+        "$reason" "$BUNDLE_ID" "$(fast_bundle_profile_root)" >&2
+    exit 3
+}
+
+# `--fast-only` is an inspection-first agent operation. Read the same selected
+# configuration that a normal launch will use, but do it before killing an app,
+# clearing a build directory, starting a tunnel, or starting a backend. This
+# makes an ineligible fast launch safe to probe repeatedly.
+prepare_fast_only_configuration() {
+    if [ "$LOCAL_PROFILE" = false ] && [ -f "$BACKEND_DIR/.env" ]; then
+        set -a
+        # shellcheck disable=SC1090
+        source "$BACKEND_DIR/.env"
+        set +a
+    fi
+    if [ "$YOLO_MODE" = "1" ] || [ "$NAMED_BUNDLE_DEFAULT_DEV_BACKEND" = true ]; then
+        apply_yolo_env
+    fi
+}
+
+FAST_BUNDLE_STAMP="$OMI_DEV_DIR/fast-dev-bundles/$BUNDLE_ID.stamp"
+if [ "$FAST_ONLY" = "1" ]; then
+    prepare_fast_only_configuration
+    if [ "$LOCAL_PROFILE" = true ]; then
+        fail_fast_only "local_profile_requires_full"
+    fi
+
+    resolve_signing_identity
+    FAST_BUNDLE_FINGERPRINT="$(fast_bundle_fingerprint)"
+    FAST_BUNDLE_REASON="$(omi_fast_bundle_eligibility_reason "$APP_PATH" "$FAST_BUNDLE_STAMP" "$FAST_BUNDLE_FINGERPRINT")"
+    if [ "$FAST_BUNDLE_REASON" != "reusable" ]; then
+        fail_fast_only "$FAST_BUNDLE_REASON"
+    fi
+fi
 
 sign_app_bundle() {
     local bundle="$1"
@@ -701,33 +770,28 @@ while true; do
 done
 
 FAST_BUNDLE=0
-FAST_BUNDLE_STAMP="$OMI_DEV_DIR/fast-dev-bundles/$BUNDLE_ID.stamp"
-fast_bundle_fingerprint() {
-    omi_fast_bundle_fingerprint \
-        "$SCRIPT_DIR" \
-        "bundle-id=$BUNDLE_ID" \
-        "signing-identity=$SIGN_IDENTITY" \
-        "yolo=$YOLO_MODE" \
-        "skip-backend=${OMI_SKIP_BACKEND:-0}" \
-        "skip-tunnel=${OMI_SKIP_TUNNEL:-0}" \
-        "desktop-api-url=${OMI_DESKTOP_API_URL:-}" \
-        "python-api-url=${OMI_PYTHON_API_URL:-}" \
-        "backend-port=$BACKEND_PORT"
-}
+FAST_BUNDLE_REASON=""
 
 step "Checking reusable development bundle..."
 resolve_signing_identity
 FAST_BUNDLE_FINGERPRINT="$(fast_bundle_fingerprint)"
+FAST_BUNDLE_REASON="$(omi_fast_bundle_eligibility_reason "$APP_PATH" "$FAST_BUNDLE_STAMP" "$FAST_BUNDLE_FINGERPRINT")"
 if [ "$FORCE_FULL_BUNDLE" = "1" ]; then
+    FAST_BUNDLE_REASON="full_requested"
     substep "Full bundle requested (--full or OMI_FORCE_FULL_BUNDLE=1)"
 elif [ "$LOCAL_PROFILE" = true ]; then
     # The profile generates credential-bearing .env files. Keep that isolated
     # harness lane conservative until its configuration has a secret-free stamp.
+    FAST_BUNDLE_REASON="local_profile_requires_full"
     substep "Local profile requires a full bundle"
-elif [ ! -d "$APP_PATH/Contents" ]; then
-    substep "No installed bundle at $APP_PATH"
-elif ! omi_fast_bundle_stamp_matches "$FAST_BUNDLE_STAMP" "$FAST_BUNDLE_FINGERPRINT"; then
-    substep "Packaged inputs or launch configuration changed"
+    if [ "$FAST_ONLY" = "1" ]; then
+        fail_fast_only "$FAST_BUNDLE_REASON"
+    fi
+elif [ "$FAST_BUNDLE_REASON" != "reusable" ]; then
+    substep "Fast bundle unavailable: $FAST_BUNDLE_REASON"
+    if [ "$FAST_ONLY" = "1" ]; then
+        fail_fast_only "$FAST_BUNDLE_REASON"
+    fi
 else
     FAST_BUNDLE=1
     substep "Fast path: reusing installed bundle at $APP_PATH"
@@ -1103,6 +1167,15 @@ if [ "${#AUTOMATION_ARGS[@]}" -gt 0 ]; then
 fi
 echo "========================================"
 echo ""
+
+LAUNCH_MODE="full"
+[ "$FAST_BUNDLE" = "1" ] && LAUNCH_MODE="fast"
+PROFILE_ROOT="$HOME/Library/Application Support/Omi"
+if [ "$IS_NAMED_BUNDLE" = true ]; then
+    PROFILE_ROOT="$HOME/Library/Application Support/Omi Dev Bundles/$BUNDLE_ID"
+fi
+printf 'launch_mode=%s fast_reason=%s bundle_id=%s profile_root=%q\n' \
+    "$LAUNCH_MODE" "$FAST_BUNDLE_REASON" "$BUNDLE_ID" "$PROFILE_ROOT"
 
 auth_debug "BEFORE launch: $(defaults read "$BUNDLE_ID" auth_isSignedIn 2>&1 || true)"
 if [ "${#AUTOMATION_ARGS[@]}" -gt 0 ]; then

--- a/desktop/macos/scripts/app-config.sh
+++ b/desktop/macos/scripts/app-config.sh
@@ -28,6 +28,13 @@ derive_omi_app_config() {
             echo "ERROR: OMI_APP_NAME must contain at least one letter or number" >&2
             return 1
         fi
+        case "$app_slug" in
+            omi-*) ;;
+            *)
+                echo "ERROR: named OMI_APP_NAME values must use the omi- prefix (got '$app_name' -> '$app_slug')" >&2
+                return 1
+                ;;
+        esac
         expected_bundle_id="com.omi.$app_slug"
         expected_url_scheme="omi-$app_slug"
     fi

--- a/desktop/macos/scripts/cleanup-omi-tcc.sh
+++ b/desktop/macos/scripts/cleanup-omi-tcc.sh
@@ -6,7 +6,7 @@
 # bundle IDs; it never edits ~/Library/Application Support/com.apple.TCC/TCC.db.
 #
 # Usage:
-#   scripts/cleanup-omi-tcc.sh [--list] [--apply-tccutil] [--json]
+#   scripts/cleanup-omi-tcc.sh [--list] [--apply-tccutil] [--json] [--verbose]
 #
 # Keeps by default:
 #   com.omi.computer-macos  (Omi)
@@ -15,12 +15,13 @@ set -euo pipefail
 
 MODE="list"
 OUTPUT="text"
+VERBOSE="false"
 KEEP_BUNDLE_IDS="com.omi.computer-macos,com.omi.desktop-dev"
 CANDIDATE_PREFIXES="com.omi.omi-"
 
 usage() {
     cat <<'USAGE'
-Usage: cleanup-omi-tcc.sh [--list] [--apply-tccutil] [--json]
+Usage: cleanup-omi-tcc.sh [--list] [--apply-tccutil] [--json] [--verbose]
                           [--keep-bundle-id BUNDLE_ID]
                           [--candidate-prefix BUNDLE_ID_PREFIX] [--help]
 
@@ -34,6 +35,7 @@ Options:
   --list           List inventory only (default)
   --apply-tccutil  Reset TCC/privacy permissions for candidate bundle IDs
   --json           Emit deterministic JSON instead of human-readable text
+  --verbose        Include every matching app, preference, and TCC row
   --keep-bundle-id BUNDLE_ID
                    Preserve this Omi bundle ID. May be passed more than once.
   --candidate-prefix BUNDLE_ID_PREFIX
@@ -54,6 +56,9 @@ while [ "$#" -gt 0 ]; do
             ;;
         --json)
             OUTPUT="json"
+            ;;
+        --verbose)
+            VERBOSE="true"
             ;;
         --keep-bundle-id)
             if [ "$#" -lt 2 ] || [ -z "$2" ]; then
@@ -89,7 +94,7 @@ if [ "$MODE" != "list" ] && [ "$MODE" != "apply-tccutil" ]; then
     exit 2
 fi
 
-python3 - "$MODE" "$OUTPUT" "$KEEP_BUNDLE_IDS" "$CANDIDATE_PREFIXES" <<'PY'
+python3 - "$MODE" "$OUTPUT" "$VERBOSE" "$KEEP_BUNDLE_IDS" "$CANDIDATE_PREFIXES" <<'PY'
 import datetime as dt
 import json
 import os
@@ -101,8 +106,9 @@ from pathlib import Path
 
 MODE = sys.argv[1]
 OUTPUT = sys.argv[2]
-KEEP_BUNDLE_IDS = {item for item in sys.argv[3].split(",") if item}
-CANDIDATE_PREFIXES = tuple(item for item in sys.argv[4].split(",") if item)
+VERBOSE = sys.argv[3] == "true"
+KEEP_BUNDLE_IDS = {item for item in sys.argv[4].split(",") if item}
+CANDIDATE_PREFIXES = tuple(item for item in sys.argv[5].split(",") if item)
 HOME = Path(os.environ.get("OMI_TCC_HOME") or Path.home())
 TCC_DB = Path(
     os.environ.get("OMI_TCC_DB")
@@ -345,6 +351,51 @@ def status_counts(items):
     return dict(sorted(counts.items()))
 
 
+def limited(items, limit=20):
+    return items[:limit], max(0, len(items) - limit)
+
+
+def output_inventory(inventory):
+    if VERBOSE:
+        return {
+            **inventory,
+            "output_schema_version": 1,
+            "detail_mode": "full",
+            "details_available": False,
+        }
+
+    tcc = inventory["tcc"]
+    result = {
+        "output_schema_version": 1,
+        "detail_mode": "summary",
+        "details_available": True,
+        "keep_bundle_ids": inventory["keep_bundle_ids"],
+        "candidate_prefixes": inventory["candidate_prefixes"],
+        "candidate_rule": inventory["candidate_rule"],
+        "summary": inventory["summary"],
+        "candidate_bundle_ids_count": len(inventory["candidate_bundle_ids"]),
+        "tccutil_bundle_ids_count": len(inventory["tccutil_bundle_ids"]),
+        "tcc": {
+            "database": tcc["database"],
+            "readable": tcc["readable"],
+            "error": tcc["error"],
+            "row_count": len(tcc["rows"]),
+        },
+    }
+    if "apply" in inventory:
+        failed = [item["bundle_id"] for item in inventory["apply"]["results"] if item["status"] != "ok"]
+        visible_failed, omitted_failed = limited(failed)
+        result["apply"] = {
+            "mode": inventory["apply"]["mode"],
+            "tool": inventory["apply"]["tool"],
+            "summary": inventory["apply"]["summary"],
+            "result_count": len(inventory["apply"]["results"]),
+            "failed_bundle_ids": visible_failed,
+            "failed_bundle_ids_omitted_count": omitted_failed,
+        }
+    return result
+
+
 def candidate_bundle_ids(inventory):
     bundle_ids = set()
     for item in inventory["apps"]:
@@ -432,7 +483,13 @@ if MODE == "apply-tccutil":
     inventory["apply"]["summary"] = status_counts(inventory["apply"]["results"])
 
 if OUTPUT == "json":
-    print(json.dumps(inventory, indent=2, sort_keys=True))
+    print(json.dumps(output_inventory(inventory), indent=2, sort_keys=True))
+    sys.exit(0)
+
+if not VERBOSE:
+    print("Omi macOS permissions cleanup summary")
+    print("====================================")
+    print(json.dumps(output_inventory(inventory), indent=2, sort_keys=True))
     sys.exit(0)
 
 if MODE == "apply-tccutil":

--- a/desktop/macos/scripts/fast-dev-bundle.sh
+++ b/desktop/macos/scripts/fast-dev-bundle.sh
@@ -126,6 +126,24 @@ omi_fast_bundle_stamp_matches() {
   [ "$(sed -n 's/^fingerprint=//p' "$stamp" | head -1)" = "$expected_fingerprint" ]
 }
 
+# Emit one stable eligibility reason. Callers can safely surface this to agents
+# without attempting a full package build merely to discover why reuse failed.
+omi_fast_bundle_eligibility_reason() {
+  local app_path="$1"
+  local stamp="$2"
+  local expected_fingerprint="$3"
+
+  if [ ! -d "$app_path/Contents" ]; then
+    printf '%s\n' "no_installed_bundle"
+  elif [ ! -f "$stamp" ]; then
+    printf '%s\n' "missing_fast_fingerprint"
+  elif ! omi_fast_bundle_stamp_matches "$stamp" "$expected_fingerprint"; then
+    printf '%s\n' "fast_fingerprint_mismatch"
+  else
+    printf '%s\n' "reusable"
+  fi
+}
+
 omi_fast_bundle_write_stamp() {
   local stamp="$1"
   local fingerprint="$2"

--- a/desktop/macos/scripts/omi-macos-dev
+++ b/desktop/macos/scripts/omi-macos-dev
@@ -26,9 +26,11 @@ from typing import Any
 
 
 SCHEMA_VERSION = 1
+OUTPUT_SCHEMA_VERSION = 1
 NAMED_PREFIX = "com.omi.omi-"
 PROTECTED_BUNDLE_IDS = {"com.omi.computer-macos", "com.omi.desktop-dev"}
 MANIFEST_NAME = ".omi-dev-runtime.json"
+SUMMARY_ITEM_LIMIT = 20
 
 
 def home() -> Path:
@@ -229,6 +231,101 @@ def profile_databases(
     return entries
 
 
+def limited_entries(entries: list[Any]) -> tuple[list[Any], int]:
+    return entries[:SUMMARY_ITEM_LIMIT], max(0, len(entries) - SUMMARY_ITEM_LIMIT)
+
+
+def counts_by(items: list[dict[str, Any]], key: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in items:
+        value = str(item.get(key, "unknown"))
+        counts[value] = counts.get(value, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def database_summary(databases: list[dict[str, Any]]) -> dict[str, Any]:
+    holder_pids = sorted({pid for database in databases for pid in database["holders"]})
+    visible_pids, omitted_pids = limited_entries(holder_pids)
+    return {
+        "count": len(databases),
+        "bytes": sum(database["bytes"] for database in databases),
+        "holder_check_counts": counts_by(databases, "holder_check"),
+        "holder_pids": visible_pids,
+        "holder_pids_omitted_count": omitted_pids,
+    }
+
+
+def logs_summary(logs: list[dict[str, Any]]) -> dict[str, int]:
+    return {"count": len(logs), "bytes": sum(log["bytes"] for log in logs)}
+
+
+def actions_summary(actions: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "count": len(actions),
+        "bytes": sum(action["bytes"] for action in actions),
+        "kind_counts": counts_by(actions, "kind"),
+    }
+
+
+def bundle_summary(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "app_name": record["app_name"],
+        "bundle_id": record["bundle_id"],
+        "installed_app_path": record["installed_app_path"],
+        "pid": record["pid"],
+        "active": record["active"],
+        "automation_port": record["automation_port"],
+        "backend": record["backend"],
+        "profile_root": record["profile_root"],
+        "profile_root_expected": record["profile_root_expected"],
+        "profile_bytes": record["profile_bytes"],
+        "database_summary": database_summary(record["databases"]),
+        "isolation": record["isolation"],
+        "manifest": record["manifest"],
+        "log_summary": logs_summary(record["logs"]),
+    }
+
+
+def inventory_output(state: dict[str, Any], verbose: bool) -> dict[str, Any]:
+    if verbose:
+        return {
+            **state,
+            "output_schema_version": OUTPUT_SCHEMA_VERSION,
+            "detail_mode": "full",
+            "details_available": False,
+        }
+
+    bundles = [bundle_summary(record) for record in state["bundles"]]
+    visible_bundles, omitted_bundles = limited_entries(bundles)
+    legacy_databases = state["legacy_databases"]
+    visible_shared, omitted_shared = limited_entries(state["shared_storage_bundle_ids"])
+    all_bundle_databases = [database for record in state["bundles"] for database in record["databases"]]
+    all_bundle_logs = [log for record in state["bundles"] for log in record["logs"]]
+    return {
+        "schema_version": state["schema_version"],
+        "output_schema_version": OUTPUT_SCHEMA_VERSION,
+        "detail_mode": "summary",
+        "details_available": True,
+        "protected_bundle_ids": state["protected_bundle_ids"],
+        "legacy_shared_root": state["legacy_shared_root"],
+        "legacy_shared_bytes": state["legacy_shared_bytes"],
+        "legacy_database_summary": database_summary(legacy_databases),
+        "bundle_summary": {
+            "count": len(bundles),
+            "active_count": sum(record["active"] for record in state["bundles"]),
+            "isolation_counts": counts_by(state["bundles"], "isolation"),
+            "profile_bytes": sum(record["profile_bytes"] for record in state["bundles"]),
+            "database_summary": database_summary(all_bundle_databases),
+            "log_summary": logs_summary(all_bundle_logs),
+        },
+        "bundles": visible_bundles,
+        "bundles_omitted_count": omitted_bundles,
+        "shared_storage_bundle_ids": visible_shared,
+        "shared_storage_bundle_ids_omitted_count": omitted_shared,
+        "diagnostic": state["diagnostic"],
+    }
+
+
 def automation_health(port: object) -> dict[str, Any]:
     if not isinstance(port, int) or not 1 <= port <= 65535:
         return {"status": "unavailable", "reason": "invalid_port"}
@@ -417,6 +514,87 @@ def clean_plan(older_than_days: int) -> dict[str, Any]:
     }
 
 
+def clean_plan_output(plan: dict[str, Any], verbose: bool) -> dict[str, Any]:
+    if verbose:
+        return {
+            **plan,
+            "output_schema_version": OUTPUT_SCHEMA_VERSION,
+            "detail_mode": "full",
+            "details_available": False,
+        }
+    return {
+        **{key: value for key, value in plan.items() if key != "actions"},
+        "output_schema_version": OUTPUT_SCHEMA_VERSION,
+        "detail_mode": "summary",
+        "details_available": True,
+        "action_summary": actions_summary(plan["actions"]),
+    }
+
+
+def log_list_output(logs: list[dict[str, Any]], verbose: bool) -> dict[str, Any]:
+    if verbose:
+        return {
+            "output_schema_version": OUTPUT_SCHEMA_VERSION,
+            "detail_mode": "full",
+            "details_available": False,
+            "logs": logs,
+        }
+    return {
+        "output_schema_version": OUTPUT_SCHEMA_VERSION,
+        "detail_mode": "summary",
+        "details_available": True,
+        "log_summary": logs_summary(logs),
+    }
+
+
+def log_prune_output(
+    older_than_days: int,
+    actions: list[dict[str, Any]],
+    retained: list[dict[str, Any]],
+    applied: bool,
+    verbose: bool,
+) -> dict[str, Any]:
+    if verbose:
+        return {
+            "output_schema_version": OUTPUT_SCHEMA_VERSION,
+            "detail_mode": "full",
+            "details_available": False,
+            "older_than_days": older_than_days,
+            "actions": actions,
+            "retained": retained,
+            "applied": applied,
+        }
+    return {
+        "output_schema_version": OUTPUT_SCHEMA_VERSION,
+        "detail_mode": "summary",
+        "details_available": True,
+        "older_than_days": older_than_days,
+        "action_summary": actions_summary(actions),
+        "retained_summary": logs_summary(retained),
+        "applied": applied,
+    }
+
+
+def completed_cleanup_output(plan: str, completed: list[dict[str, Any]], verbose: bool) -> dict[str, Any]:
+    if verbose:
+        return {
+            "output_schema_version": OUTPUT_SCHEMA_VERSION,
+            "detail_mode": "full",
+            "details_available": False,
+            "plan": plan,
+            "completed": completed,
+            "reclaimed_bytes": sum(item["bytes"] for item in completed),
+        }
+    return {
+        "output_schema_version": OUTPUT_SCHEMA_VERSION,
+        "detail_mode": "summary",
+        "details_available": True,
+        "plan": plan,
+        "completed_summary": actions_summary(completed),
+        "reclaimed_bytes": sum(item["bytes"] for item in completed),
+    }
+
+
 def delete_action(action: dict[str, Any]) -> None:
     path = Path(action["path"])
     kind = action["kind"]
@@ -442,10 +620,12 @@ def delete_action(action: dict[str, Any]) -> None:
         raise RuntimeError("unknown_action")
 
 
-def cleanup_tcc(apply: bool) -> dict[str, Any]:
+def cleanup_tcc(apply: bool, verbose: bool) -> dict[str, Any]:
     command = [str(Path(__file__).with_name("cleanup-omi-tcc.sh")), "--json"]
     if apply:
         command.append("--apply-tccutil")
+    if verbose:
+        command.append("--verbose")
     environment = os.environ.copy()
     environment["OMI_TCC_HOME"] = str(home())
     environment["OMI_TCC_APP_ROOTS"] = os.pathsep.join(str(root) for root in app_roots())
@@ -454,7 +634,7 @@ def cleanup_tcc(apply: bool) -> dict[str, Any]:
         payload = json.loads(result.stdout)
     except json.JSONDecodeError:
         payload = {"raw_stdout": result.stdout.strip()}
-    return {"returncode": result.returncode, "inventory": payload, "stderr": result.stderr.strip()}
+    return {**payload, "returncode": result.returncode, "stderr": result.stderr.strip()}
 
 
 def emit(payload: dict[str, Any], human: bool) -> None:
@@ -468,54 +648,56 @@ def main() -> int:
     parser = argparse.ArgumentParser(prog="omi-macos-dev")
     parser.add_argument("--human", action="store_true", help="pretty-print JSON for interactive use")
     subparsers = parser.add_subparsers(dest="command", required=True)
-    doctor = subparsers.add_parser("doctor")
+    detail_parser = argparse.ArgumentParser(add_help=False)
+    detail_parser.add_argument("--verbose", action="store_true", help="include every path-level record")
+    doctor = subparsers.add_parser("doctor", parents=[detail_parser])
     doctor.add_argument("--bundle")
     bundle = subparsers.add_parser("bundle")
     bundle_subparsers = bundle.add_subparsers(dest="bundle_command", required=True)
-    bundle_subparsers.add_parser("list")
+    bundle_subparsers.add_parser("list", parents=[detail_parser])
     permissions = subparsers.add_parser("permissions")
     permission_subparsers = permissions.add_subparsers(dest="permission_command", required=True)
-    permission_subparsers.add_parser("list")
-    reset = permission_subparsers.add_parser("reset")
+    permission_subparsers.add_parser("list", parents=[detail_parser])
+    reset = permission_subparsers.add_parser("reset", parents=[detail_parser])
     reset.add_argument("--apply", action="store_true")
     reset.add_argument("--yes", action="store_true")
     logs = subparsers.add_parser("logs")
     logs_subparsers = logs.add_subparsers(dest="logs_command", required=True)
-    logs_subparsers.add_parser("list")
-    prune = logs_subparsers.add_parser("prune")
+    logs_subparsers.add_parser("list", parents=[detail_parser])
+    prune = logs_subparsers.add_parser("prune", parents=[detail_parser])
     prune.add_argument("--older-than", type=int, default=14)
     prune.add_argument("--apply", action="store_true")
     prune.add_argument("--yes", action="store_true")
     clean = subparsers.add_parser("clean")
     clean_subparsers = clean.add_subparsers(dest="clean_command", required=True)
-    plan = clean_subparsers.add_parser("plan")
+    plan = clean_subparsers.add_parser("plan", parents=[detail_parser])
     plan.add_argument("--older-than", type=int, default=14)
-    apply = clean_subparsers.add_parser("apply")
+    apply = clean_subparsers.add_parser("apply", parents=[detail_parser])
     apply.add_argument("--older-than", type=int, default=14)
     apply.add_argument("--plan", required=True)
     apply.add_argument("--yes", action="store_true")
     args = parser.parse_args()
 
     if args.command == "doctor":
-        payload = inventory(args.bundle)
+        payload = inventory_output(inventory(args.bundle), args.verbose)
         emit(payload, args.human)
         return 10 if payload["shared_storage_bundle_ids"] else 0
     if args.command == "bundle":
-        emit(inventory(), args.human)
+        emit(inventory_output(inventory(), args.verbose), args.human)
         return 0
     if args.command == "permissions":
         if args.permission_command == "reset" and (not args.apply or not args.yes):
             emit({"error": "permissions reset requires --apply --yes"}, args.human)
             return 2
-        result = cleanup_tcc(args.permission_command == "reset")
+        result = cleanup_tcc(args.permission_command == "reset", args.verbose)
         emit(result, args.human)
         return result["returncode"]
     if args.command == "logs":
         if args.logs_command == "list":
-            emit({"logs": all_logs()}, args.human)
+            emit(log_list_output(all_logs(), args.verbose), args.human)
             return 0
-        if args.older_than < 1:
-            emit({"error": "--older-than must be at least 1"}, args.human)
+        if args.older_than < 0:
+            emit({"error": "--older-than must be non-negative"}, args.human)
             return 2
         logs, retained = old_logs(args.older_than)
         if args.apply and args.yes:
@@ -524,15 +706,15 @@ def main() -> int:
         elif args.apply:
             emit({"error": "logs prune --apply requires --yes"}, args.human)
             return 2
-        emit({"older_than_days": args.older_than, "actions": logs, "retained": retained, "applied": bool(args.apply and args.yes)}, args.human)
+        emit(log_prune_output(args.older_than, logs, retained, bool(args.apply and args.yes), args.verbose), args.human)
         return 0
     if args.command == "clean":
-        if args.older_than < 1:
-            emit({"error": "--older-than must be at least 1"}, args.human)
+        if args.older_than < 0:
+            emit({"error": "--older-than must be non-negative"}, args.human)
             return 2
         planned = clean_plan(args.older_than)
         if args.clean_command == "plan":
-            emit(planned, args.human)
+            emit(clean_plan_output(planned, args.verbose), args.human)
             return 0
         if not args.yes:
             emit({"error": "clean apply requires --yes", "current_plan": planned["plan"]}, args.human)
@@ -544,7 +726,7 @@ def main() -> int:
         for action in planned["actions"]:
             delete_action(action)
             completed.append(action)
-        emit({"plan": planned["plan"], "completed": completed, "reclaimed_bytes": sum(item["bytes"] for item in completed)}, args.human)
+        emit(completed_cleanup_output(planned["plan"], completed, args.verbose), args.human)
         return 0
     raise AssertionError("unreachable")
 

--- a/desktop/macos/scripts/omi-macos-dev
+++ b/desktop/macos/scripts/omi-macos-dev
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+"""Agent-oriented diagnostics and safe cleanup for macOS Omi dev bundles.
+
+This tool intentionally manages only identity-derived `com.omi.omi-*` bundles.
+It never reads Keychain data, database content, or the shared legacy Omi root.
+JSON is the default stdout contract; use --human for interactive inspection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import plistlib
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+NAMED_PREFIX = "com.omi.omi-"
+PROTECTED_BUNDLE_IDS = {"com.omi.computer-macos", "com.omi.desktop-dev"}
+MANIFEST_NAME = ".omi-dev-runtime.json"
+
+
+def home() -> Path:
+    return Path(os.environ.get("OMI_MACOS_DEV_HOME", str(Path.home()))).expanduser()
+
+
+def app_roots() -> list[Path]:
+    configured = os.environ.get("OMI_MACOS_DEV_APP_ROOTS")
+    raw_roots = configured.split(os.pathsep) if configured else ["/Applications", str(home() / "Applications")]
+    return [Path(item).expanduser() for item in raw_roots if item]
+
+
+def support_root() -> Path:
+    return home() / "Library" / "Application Support" / "Omi Dev Bundles"
+
+
+def legacy_root() -> Path:
+    return home() / "Library" / "Application Support" / "Omi"
+
+
+def log_roots() -> list[Path]:
+    configured = os.environ.get("OMI_MACOS_DEV_LOG_ROOTS")
+    return [Path(item) for item in configured.split(os.pathsep)] if configured else [Path("/private/tmp"), Path("/private/tmp/omi")]
+
+
+def candidate(bundle_id: object) -> bool:
+    return isinstance(bundle_id, str) and re.fullmatch(r"com\.omi\.omi-[A-Za-z0-9.-]+", bundle_id) is not None
+
+
+def resolved(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def under(path: Path, root: Path) -> bool:
+    try:
+        resolved(path).relative_to(resolved(root))
+        return True
+    except ValueError:
+        return False
+
+
+def bytes_used(path: Path) -> int:
+    if not path.exists() or path.is_symlink():
+        return 0
+    if path.is_file():
+        return path.stat().st_size
+    total = 0
+    for current, directories, files in os.walk(path, followlinks=False):
+        directories[:] = [name for name in directories if not (Path(current) / name).is_symlink()]
+        for name in files:
+            file_path = Path(current) / name
+            try:
+                info = file_path.lstat()
+            except FileNotFoundError:
+                continue
+            if stat.S_ISREG(info.st_mode):
+                total += info.st_size
+    return total
+
+
+def safe_mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except FileNotFoundError:
+        return 0
+
+
+def process_alive(pid: object) -> bool:
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def app_info(path: Path) -> dict[str, Any] | None:
+    info_path = path / "Contents" / "Info.plist"
+    try:
+        with info_path.open("rb") as handle:
+            info = plistlib.load(handle)
+    except (FileNotFoundError, plistlib.InvalidFileException, OSError):
+        return None
+    bundle_id = info.get("CFBundleIdentifier")
+    if not candidate(bundle_id):
+        return None
+    return {
+        "app_name": info.get("CFBundleDisplayName") or info.get("CFBundleName") or path.stem,
+        "bundle_id": bundle_id,
+        "installed_app_path": str(path),
+        "app_bytes": bytes_used(path),
+        "app_mtime": safe_mtime(path),
+    }
+
+
+def iter_apps(root: Path):
+    if not root.is_dir():
+        return
+    try:
+        children = sorted(root.iterdir(), key=lambda item: item.name.lower())
+    except OSError:
+        return
+    for child in children:
+        if child.suffix == ".app":
+            yield child
+        elif child.is_dir() and not child.is_symlink():
+            try:
+                for grandchild in sorted(child.iterdir(), key=lambda item: item.name.lower()):
+                    if grandchild.suffix == ".app":
+                        yield grandchild
+            except OSError:
+                continue
+
+
+def apps() -> dict[str, dict[str, Any]]:
+    collected: dict[str, dict[str, Any]] = {}
+    for root in app_roots():
+        for path in iter_apps(root) or []:
+            info = app_info(path)
+            if info:
+                # Multiple installed copies of an identity are diagnostically useful.
+                key = f"{info['bundle_id']}:{info['installed_app_path']}"
+                collected[key] = info
+    return dict(sorted(collected.items()))
+
+
+def expected_profile(bundle_id: str) -> Path:
+    return support_root() / bundle_id
+
+
+def read_manifest(profile: Path, bundle_id: str) -> tuple[dict[str, Any] | None, str | None]:
+    path = profile / MANIFEST_NAME
+    if not path.is_file() or path.is_symlink():
+        return None, "missing"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None, "invalid_json"
+    required = {"schemaVersion", "bundleIdentifier", "processID", "appPath", "profileRoot", "logPath", "automationPort"}
+    if not isinstance(payload, dict) or not required.issubset(payload):
+        return None, "invalid_shape"
+    if payload["schemaVersion"] != SCHEMA_VERSION or payload["bundleIdentifier"] != bundle_id:
+        return None, "identity_mismatch"
+    return payload, None
+
+
+def lsof_holders(paths: list[Path]) -> tuple[dict[str, list[int]], str | None]:
+    if not paths:
+        return {}, None
+    executable = os.environ.get("OMI_MACOS_DEV_LSOF", "lsof")
+    normalized = {str(resolved(path)): [] for path in paths}
+    try:
+        result = subprocess.run(
+            [executable, "-Fpn", *normalized], text=True, capture_output=True, check=False, timeout=0.5)
+    except OSError as exc:
+        return normalized, f"unavailable:{exc.__class__.__name__}"
+    except subprocess.TimeoutExpired:
+        return normalized, "timed_out"
+    if result.returncode not in (0, 1):
+        return normalized, f"failed:{result.returncode}"
+
+    current_pid: int | None = None
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        if line.startswith("p") and line[1:].isdigit():
+            current_pid = int(line[1:])
+            continue
+        if line.startswith("n") and current_pid is not None:
+            path = str(resolved(Path(line[1:])))
+            if path in normalized:
+                normalized[path].append(current_pid)
+    return {path: sorted(set(holders)) for path, holders in normalized.items()}, None
+
+
+def database_paths(profile: Path) -> list[Path]:
+    if not profile.is_dir() or profile.is_symlink():
+        return []
+    return [path for path in [profile / "omi.db", *sorted(profile.glob("users/*/omi.db"))] if path.is_file()]
+
+
+def profile_databases(
+    profile: Path,
+    holder_map: dict[str, list[int]],
+    holder_error: str | None,
+) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for path in database_paths(profile):
+        entries.append({
+            "path": str(path),
+            "bytes": bytes_used(path),
+            "holders": holder_map.get(str(resolved(path)), []),
+            "holder_check": "ok" if holder_error is None else holder_error,
+        })
+    return entries
+
+
+def automation_health(port: object) -> dict[str, Any]:
+    if not isinstance(port, int) or not 1 <= port <= 65535:
+        return {"status": "unavailable", "reason": "invalid_port"}
+    request = urllib.request.Request(f"http://127.0.0.1:{port}/health", headers={"Host": f"127.0.0.1:{port}"})
+    try:
+        with urllib.request.urlopen(request, timeout=0.8) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
+        return {"status": "unavailable", "reason": exc.__class__.__name__}
+    return {
+        "status": "ok",
+        "desktop_backend_url": payload.get("rustBackendURL"),
+        "python_backend_url": payload.get("pythonBackendURL"),
+        "backend_environment": payload.get("backendEnvironment"),
+    }
+
+
+def logs_for_bundle(bundle_id: str) -> list[dict[str, Any]]:
+    safe_id = "".join(character if character.isalnum() or character in ".-_" else "-" for character in bundle_id)
+    found: list[dict[str, Any]] = []
+    for root in log_roots():
+        patterns = [f"omi-dev-{safe_id}-*.log", f"{safe_id}/pid-*.log"]
+        for pattern in patterns:
+            for path in sorted(root.glob(pattern)):
+                try:
+                    info = path.lstat()
+                except FileNotFoundError:
+                    continue
+                if stat.S_ISREG(info.st_mode) and info.st_uid == os.getuid():
+                    found.append({"bundle_id": bundle_id, "path": str(path), "bytes": info.st_size, "mtime": info.st_mtime})
+    return found
+
+
+def record_for(bundle_id: str, app: dict[str, Any] | None) -> dict[str, Any]:
+    profile = expected_profile(bundle_id)
+    manifest, manifest_error = read_manifest(profile, bundle_id)
+    active = process_alive(manifest.get("processID")) if manifest else False
+    manifest_profile = Path(manifest["profileRoot"]) if manifest else profile
+    isolated = manifest is not None and resolved(manifest_profile) == resolved(profile)
+    isolation_status = "isolated" if isolated else ("missing_manifest" if manifest_error == "missing" else "shared_or_invalid")
+    health = automation_health(manifest.get("automationPort")) if active and manifest else {"status": "unavailable", "reason": "inactive"}
+    return {
+        "app_name": app.get("app_name") if app else None,
+        "bundle_id": bundle_id,
+        "installed_app_path": app.get("installed_app_path") if app else None,
+        "pid": manifest.get("processID") if manifest else None,
+        "active": active,
+        "automation_port": manifest.get("automationPort") if manifest else None,
+        "backend": health,
+        "profile_root": str(manifest_profile if manifest else profile),
+        "profile_root_expected": str(profile),
+        "profile_bytes": bytes_used(profile),
+        "databases": [],
+        "isolation": isolation_status,
+        "manifest": {"path": str(profile / MANIFEST_NAME), "status": manifest_error or "ok"},
+        "logs": logs_for_bundle(bundle_id),
+    }
+
+
+def process_command(pid: int) -> str:
+    try:
+        result = subprocess.run(["ps", "-p", str(pid), "-o", "command="], text=True, capture_output=True, check=False)
+    except OSError:
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def inventory(selected_bundle: str | None = None) -> dict[str, Any]:
+    app_records = apps()
+    by_id: dict[str, dict[str, Any]] = {}
+    for app in app_records.values():
+        by_id.setdefault(app["bundle_id"], app)
+    if support_root().is_dir():
+        try:
+            profiles = list(support_root().iterdir())
+        except OSError:
+            profiles = []
+        for path in profiles:
+            if path.is_dir() and candidate(path.name):
+                by_id.setdefault(path.name, None)
+    bundle_ids = sorted(by_id)
+    if selected_bundle:
+        bundle_ids = [bundle_id for bundle_id in bundle_ids if bundle_id == selected_bundle or by_id[bundle_id] and by_id[bundle_id]["app_name"] == selected_bundle]
+    records = [record_for(bundle_id, by_id[bundle_id]) for bundle_id in bundle_ids]
+    profiles = [expected_profile(record["bundle_id"]) for record in records]
+    legacy_profile = legacy_root()
+    all_database_paths = [path for profile in [*profiles, legacy_profile] for path in database_paths(profile)]
+    holder_map, holder_error = lsof_holders(all_database_paths)
+    for record, profile in zip(records, profiles):
+        record["databases"] = profile_databases(profile, holder_map, holder_error)
+    legacy_databases = profile_databases(legacy_profile, holder_map, holder_error)
+    legacy_holders = {pid for database in legacy_databases for pid in database["holders"]}
+    for record in records:
+        app_path = record["installed_app_path"]
+        if app_path and any(app_path in process_command(pid) for pid in legacy_holders):
+            record["isolation"] = "shared_legacy_storage"
+    shared = [record["bundle_id"] for record in records if record["isolation"] in {"shared_or_invalid", "shared_legacy_storage"}]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "protected_bundle_ids": sorted(PROTECTED_BUNDLE_IDS),
+        "legacy_shared_root": str(legacy_root()),
+        "legacy_shared_bytes": bytes_used(legacy_root()),
+        "legacy_databases": legacy_databases,
+        "bundles": records,
+        "shared_storage_bundle_ids": shared,
+        "diagnostic": "shared_named_bundle_storage" if shared else None,
+    }
+
+
+def log_bundle_id(path: Path) -> str | None:
+    if path.name.startswith("omi-dev-") and path.suffix == ".log":
+        bundle_id, separator, pid = path.name[len("omi-dev-"):-len(".log")].rpartition("-")
+        if separator and pid.isdigit() and candidate(bundle_id):
+            return bundle_id
+    if re.fullmatch(r"pid-\d+\.log", path.name) and candidate(path.parent.name):
+        return path.parent.name
+    return None
+
+
+def all_logs() -> list[dict[str, Any]]:
+    found: dict[str, dict[str, Any]] = {}
+    for root in log_roots():
+        candidates = [*root.glob("omi-dev-*.log"), *root.glob("com.omi.omi-*/pid-*.log")]
+        for path in sorted(set(candidates)):
+            try:
+                info = path.lstat()
+            except FileNotFoundError:
+                continue
+            bundle_id = log_bundle_id(path)
+            if not bundle_id or not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid():
+                continue
+            found[str(path)] = {"bundle_id": bundle_id, "path": str(path), "bytes": info.st_size, "mtime": info.st_mtime}
+    return [found[path] for path in sorted(found)]
+
+
+def old_logs(older_than_days: int) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    cutoff = time.time() - older_than_days * 86400
+    active_log_paths = {
+        log["path"]
+        for record in inventory()["bundles"] if record["active"]
+        for log in record["logs"]
+    }
+    eligible: list[dict[str, Any]] = []
+    retained: list[dict[str, Any]] = []
+    for entry in all_logs():
+        if entry["mtime"] >= cutoff:
+            continue
+        # Retain a long-running bundle's current log even if it crosses the age threshold.
+        if entry["path"] in active_log_paths:
+            retained.append(entry)
+        else:
+            eligible.append(entry)
+    return eligible, retained
+
+
+def clean_plan(older_than_days: int) -> dict[str, Any]:
+    cutoff = time.time() - older_than_days * 86400
+    state = inventory()
+    actions: list[dict[str, Any]] = []
+    for record in state["bundles"]:
+        bundle_id = record["bundle_id"]
+        app_path = record["installed_app_path"]
+        profile = expected_profile(bundle_id)
+        if record["active"]:
+            continue
+        if any(database["holders"] or database["holder_check"] != "ok" for database in record["databases"]):
+            continue
+        if app_path and safe_mtime(Path(app_path)) < cutoff:
+            actions.append({"kind": "delete_bundle", "bundle_id": bundle_id, "path": app_path, "bytes": bytes_used(Path(app_path))})
+            if profile.exists() and safe_mtime(profile) < cutoff:
+                actions.append({"kind": "delete_profile", "bundle_id": bundle_id, "path": str(profile), "bytes": bytes_used(profile)})
+        elif not app_path and profile.exists() and safe_mtime(profile) < cutoff:
+            actions.append({"kind": "delete_profile", "bundle_id": bundle_id, "path": str(profile), "bytes": bytes_used(profile)})
+    logs, _ = old_logs(older_than_days)
+    actions.extend({"kind": "delete_log", **entry} for entry in logs)
+    actions.sort(key=lambda item: (item["kind"], item["path"]))
+    canonical = json.dumps(actions, sort_keys=True, separators=(",", ":"))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "older_than_days": older_than_days,
+        "actions": actions,
+        "reclaimable_bytes": sum(action["bytes"] for action in actions),
+        "plan": hashlib.sha256(canonical.encode()).hexdigest(),
+        "legacy_shared_root": str(legacy_root()),
+        "legacy_shared_root_touched": False,
+    }
+
+
+def delete_action(action: dict[str, Any]) -> None:
+    path = Path(action["path"])
+    kind = action["kind"]
+    if kind == "delete_profile":
+        if not candidate(action["bundle_id"]) or resolved(path) != resolved(expected_profile(action["bundle_id"])):
+            raise RuntimeError("unsafe_profile_path")
+        shutil.rmtree(path)
+    elif kind == "delete_bundle":
+        if not candidate(action["bundle_id"]) or not any(under(path, root) for root in app_roots()):
+            raise RuntimeError("unsafe_bundle_path")
+        shutil.rmtree(path)
+    elif kind == "delete_log":
+        if (
+            not candidate(action.get("bundle_id"))
+            or log_bundle_id(path) != action["bundle_id"]
+            or not any(under(path, root) for root in log_roots())
+            or not path.is_file()
+            or path.is_symlink()
+        ):
+            raise RuntimeError("unsafe_log_path")
+        path.unlink()
+    else:
+        raise RuntimeError("unknown_action")
+
+
+def cleanup_tcc(apply: bool) -> dict[str, Any]:
+    command = [str(Path(__file__).with_name("cleanup-omi-tcc.sh")), "--json"]
+    if apply:
+        command.append("--apply-tccutil")
+    environment = os.environ.copy()
+    environment["OMI_TCC_HOME"] = str(home())
+    environment["OMI_TCC_APP_ROOTS"] = os.pathsep.join(str(root) for root in app_roots())
+    result = subprocess.run(command, text=True, capture_output=True, env=environment, check=False)
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        payload = {"raw_stdout": result.stdout.strip()}
+    return {"returncode": result.returncode, "inventory": payload, "stderr": result.stderr.strip()}
+
+
+def emit(payload: dict[str, Any], human: bool) -> None:
+    if human:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="omi-macos-dev")
+    parser.add_argument("--human", action="store_true", help="pretty-print JSON for interactive use")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    doctor = subparsers.add_parser("doctor")
+    doctor.add_argument("--bundle")
+    bundle = subparsers.add_parser("bundle")
+    bundle_subparsers = bundle.add_subparsers(dest="bundle_command", required=True)
+    bundle_subparsers.add_parser("list")
+    permissions = subparsers.add_parser("permissions")
+    permission_subparsers = permissions.add_subparsers(dest="permission_command", required=True)
+    permission_subparsers.add_parser("list")
+    reset = permission_subparsers.add_parser("reset")
+    reset.add_argument("--apply", action="store_true")
+    reset.add_argument("--yes", action="store_true")
+    logs = subparsers.add_parser("logs")
+    logs_subparsers = logs.add_subparsers(dest="logs_command", required=True)
+    logs_subparsers.add_parser("list")
+    prune = logs_subparsers.add_parser("prune")
+    prune.add_argument("--older-than", type=int, default=14)
+    prune.add_argument("--apply", action="store_true")
+    prune.add_argument("--yes", action="store_true")
+    clean = subparsers.add_parser("clean")
+    clean_subparsers = clean.add_subparsers(dest="clean_command", required=True)
+    plan = clean_subparsers.add_parser("plan")
+    plan.add_argument("--older-than", type=int, default=14)
+    apply = clean_subparsers.add_parser("apply")
+    apply.add_argument("--older-than", type=int, default=14)
+    apply.add_argument("--plan", required=True)
+    apply.add_argument("--yes", action="store_true")
+    args = parser.parse_args()
+
+    if args.command == "doctor":
+        payload = inventory(args.bundle)
+        emit(payload, args.human)
+        return 10 if payload["shared_storage_bundle_ids"] else 0
+    if args.command == "bundle":
+        emit(inventory(), args.human)
+        return 0
+    if args.command == "permissions":
+        if args.permission_command == "reset" and (not args.apply or not args.yes):
+            emit({"error": "permissions reset requires --apply --yes"}, args.human)
+            return 2
+        result = cleanup_tcc(args.permission_command == "reset")
+        emit(result, args.human)
+        return result["returncode"]
+    if args.command == "logs":
+        if args.logs_command == "list":
+            emit({"logs": all_logs()}, args.human)
+            return 0
+        if args.older_than < 1:
+            emit({"error": "--older-than must be at least 1"}, args.human)
+            return 2
+        logs, retained = old_logs(args.older_than)
+        if args.apply and args.yes:
+            for entry in logs:
+                delete_action({"kind": "delete_log", **entry})
+        elif args.apply:
+            emit({"error": "logs prune --apply requires --yes"}, args.human)
+            return 2
+        emit({"older_than_days": args.older_than, "actions": logs, "retained": retained, "applied": bool(args.apply and args.yes)}, args.human)
+        return 0
+    if args.command == "clean":
+        if args.older_than < 1:
+            emit({"error": "--older-than must be at least 1"}, args.human)
+            return 2
+        planned = clean_plan(args.older_than)
+        if args.clean_command == "plan":
+            emit(planned, args.human)
+            return 0
+        if not args.yes:
+            emit({"error": "clean apply requires --yes", "current_plan": planned["plan"]}, args.human)
+            return 2
+        if args.plan != planned["plan"]:
+            emit({"error": "plan_mismatch", "provided_plan": args.plan, "current_plan": planned["plan"]}, args.human)
+            return 12
+        completed: list[dict[str, Any]] = []
+        for action in planned["actions"]:
+            delete_action(action)
+            completed.append(action)
+        emit({"plan": planned["plan"], "completed": completed, "reclaimed_bytes": sum(item["bytes"] for item in completed)}, args.human)
+        return 0
+    raise AssertionError("unreachable")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/desktop/macos/tests/test-app-config.sh
+++ b/desktop/macos/tests/test-app-config.sh
@@ -39,6 +39,13 @@ if ! grep -q "OMI_APP_NAME must contain at least one letter or number" /tmp/omi-
   fail "invalid app name did not explain the slug requirement"
 fi
 
+if derive_omi_app_config "feature-without-prefix" >/tmp/omi-app-config-prefix.out 2>/tmp/omi-app-config-prefix.err; then
+  fail "non-omi named app unexpectedly succeeded"
+fi
+if ! grep -q "must use the omi- prefix" /tmp/omi-app-config-prefix.err; then
+  fail "non-omi named app did not explain the required prefix"
+fi
+
 if OMI_BUNDLE_ID="com.omi.wrong" derive_omi_app_config "omi-subagent-test" >/tmp/omi-app-config-bundle.out 2>/tmp/omi-app-config-bundle.err; then
   fail "mismatched OMI_BUNDLE_ID unexpectedly succeeded"
 fi

--- a/desktop/macos/tests/test-cleanup-omi-tcc.sh
+++ b/desktop/macos/tests/test-cleanup-omi-tcc.sh
@@ -87,8 +87,25 @@ conn.commit()
 conn.close()
 PY
 
+summary_out="$TMPDIR/summary.json"
+OMI_TCC_HOME="$home" OMI_TCC_APP_ROOTS="$apps" "$SCRIPT" --json >"$summary_out"
+
+python3 - "$summary_out" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1]))
+assert data["detail_mode"] == "summary", data
+assert data["details_available"] is True, data
+assert data["candidate_bundle_ids_count"] == 2, data
+assert data["tccutil_bundle_ids_count"] == 1, data
+assert data["tcc"]["row_count"] == 7, data
+assert "apps" not in data, data
+assert "preferences" not in data, data
+PY
+
 json_out="$TMPDIR/inventory.json"
-OMI_TCC_HOME="$home" OMI_TCC_APP_ROOTS="$apps" "$SCRIPT" --json >"$json_out"
+OMI_TCC_HOME="$home" OMI_TCC_APP_ROOTS="$apps" "$SCRIPT" --json --verbose >"$json_out"
 
 python3 - "$json_out" <<'PY'
 import json
@@ -130,12 +147,34 @@ import sys
 data = json.load(open(sys.argv[1]))
 log = open(sys.argv[2]).read().splitlines()
 assert log == ["reset All com.omi.omi-test-one"], log
+assert data["detail_mode"] == "summary", data
+assert data["details_available"] is True, data
+assert data["apply"]["summary"] == {"ok": 1}, data["apply"]
+assert "results" not in data["apply"], data["apply"]
+PY
+
+apply_verbose_json="$TMPDIR/apply-verbose.json"
+TCCUTIL_LOG="$TMPDIR/tccutil-verbose.log" \
+PATH="$bin:$PATH" \
+OMI_TCC_HOME="$home" \
+OMI_TCC_APP_ROOTS="$apps" \
+  "$SCRIPT" --apply-tccutil --json --verbose >"$apply_verbose_json"
+
+python3 - "$apply_verbose_json" "$TMPDIR/tccutil-verbose.log" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1]))
+log = open(sys.argv[2]).read().splitlines()
+assert log == ["reset All com.omi.omi-test-one"], log
+assert data["detail_mode"] == "full", data
+assert len(data["apply"]["results"]) == 1, data["apply"]
 assert data["apply"]["summary"] == {"ok": 1}, data["apply"]
 PY
 
 custom_json="$TMPDIR/custom.json"
 OMI_TCC_HOME="$home" OMI_TCC_APP_ROOTS="$apps" \
-  "$SCRIPT" --json --candidate-prefix com.omi.review- --keep-bundle-id com.omi.review-build >"$custom_json"
+  "$SCRIPT" --json --verbose --candidate-prefix com.omi.review- --keep-bundle-id com.omi.review-build >"$custom_json"
 python3 - "$custom_json" <<'PY'
 import json
 import sys

--- a/desktop/macos/tests/test-fast-dev-bundle.sh
+++ b/desktop/macos/tests/test-fast-dev-bundle.sh
@@ -51,4 +51,28 @@ omi_fast_bundle_write_stamp "$stamp" "$agent_changed"
 omi_fast_bundle_stamp_matches "$stamp" "$agent_changed"
 ! omi_fast_bundle_stamp_matches "$stamp" "$first"
 
+test "$(omi_fast_bundle_eligibility_reason "$TMP_ROOT/missing.app" "$stamp" "$agent_changed")" = "no_installed_bundle"
+mkdir -p "$TMP_ROOT/installed.app/Contents"
+test "$(omi_fast_bundle_eligibility_reason "$TMP_ROOT/installed.app" "$TMP_ROOT/missing.stamp" "$agent_changed")" = "missing_fast_fingerprint"
+test "$(omi_fast_bundle_eligibility_reason "$TMP_ROOT/installed.app" "$stamp" "$first")" = "fast_fingerprint_mismatch"
+test "$(omi_fast_bundle_eligibility_reason "$TMP_ROOT/installed.app" "$stamp" "$agent_changed")" = "reusable"
+
+# An agent's failed --fast-only probe must not tear down a running app, clean
+# build output, or start services merely to discover that the named bundle does
+# not exist. Exercise the real launcher with a unique missing app name.
+fast_only_output="$TMP_ROOT/fast-only-launcher.log"
+fast_only_name="omi-fast-only-contract-$$"
+if HOME="$TMP_ROOT/home" OMI_APP_NAME="$fast_only_name" "$MACOS_DIR/run.sh" --yolo --fast-only >"$fast_only_output" 2>&1; then
+  echo "--fast-only unexpectedly succeeded for a missing bundle" >&2
+  exit 1
+else
+  fast_only_status=$?
+fi
+test "$fast_only_status" = "3"
+grep -q 'launch_mode=failed fast_reason=no_installed_bundle' "$fast_only_output"
+if grep -qE 'Killing existing instances|Cleaning up conflicting app bundles|Starting Cloudflare|Starting Rust backend|Preparing agent runtime' "$fast_only_output"; then
+  echo "--fast-only performed launch side effects before rejecting a missing bundle" >&2
+  exit 1
+fi
+
 echo "fast-dev-bundle fingerprint tests passed"

--- a/desktop/macos/tests/test-omi-macos-dev.sh
+++ b/desktop/macos/tests/test-omi-macos-dev.sh
@@ -13,7 +13,9 @@ home="$TMPDIR/home"
 apps="$TMPDIR/apps"
 logs="$TMPDIR/logs"
 bin="$TMPDIR/bin"
-mkdir -p "$home" "$apps" "$logs" "$bin"
+prefs="$home/Library/Preferences"
+tcc_dir="$home/Library/Application Support/com.apple.TCC"
+mkdir -p "$home" "$apps" "$logs" "$bin" "$prefs" "$tcc_dir"
 
 make_app() {
   local name="$1" bundle_id="$2"
@@ -68,8 +70,25 @@ make_manifest "$old_id" "$support/$old_id" "$support/$old_id"
 make_manifest "$shared_id" "$support/$shared_id" "$legacy"
 mkdir -p "$legacy"
 printf 'protected shared data' >"$legacy/omi.db"
+for ((index = 1; index <= 24; index++)); do
+  mkdir -p "$legacy/users/test-$index"
+  printf 'legacy test data' >"$legacy/users/test-$index/omi.db"
+  printf 'preference fixture' >"$prefs/com.omi.omi-preference-$index.plist"
+  printf 'recent log' >"$logs/omi-dev-com.omi.omi-extra-$index-321.log"
+done
 printf 'old log' >"$logs/omi-dev-$old_id-321.log"
 printf 'protected dev log' >"$logs/omi-dev-com.omi.desktop-dev-777.log"
+
+python3 - "$tcc_dir/TCC.db" <<'PY'
+import sqlite3
+import sys
+
+conn = sqlite3.connect(sys.argv[1])
+conn.execute("CREATE TABLE access (service TEXT, client TEXT, auth_value INTEGER)")
+conn.execute("INSERT INTO access VALUES (?, ?, ?)", ("kTCCServiceMicrophone", "com.omi.omi-good", 2))
+conn.commit()
+conn.close()
+PY
 
 python3 - "$apps/omi-old.app" "$support/$old_id" "$logs/omi-dev-$old_id-321.log" "$logs/omi-dev-com.omi.desktop-dev-777.log" <<'PY'
 import os
@@ -94,12 +113,49 @@ import json
 import sys
 payload = json.load(open(sys.argv[1]))
 assert payload["diagnostic"] is None, payload
+assert payload["detail_mode"] == "summary", payload
+assert payload["details_available"] is True, payload
+assert payload["legacy_database_summary"]["count"] == 25, payload
 record = payload["bundles"][0]
 assert record["bundle_id"] == sys.argv[2]
 assert record["isolation"] == "isolated", record
 assert record["profile_root"] == f"{sys.argv[3]}/{sys.argv[2]}"
-assert record["databases"][0]["holders"] == []
+assert record["database_summary"]["holder_pids"] == []
 assert record["backend"]["status"] == "unavailable"
+assert "databases" not in record, record
+assert "legacy_databases" not in payload, payload
+PY
+
+env "${env[@]}" "$CLI" doctor --bundle "$good_id" --verbose >"$TMPDIR/doctor-verbose.json"
+python3 - "$TMPDIR/doctor-verbose.json" "$good_id" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+assert payload["detail_mode"] == "full", payload
+assert len(payload["legacy_databases"]) == 25, payload
+record = payload["bundles"][0]
+assert record["bundle_id"] == sys.argv[2]
+assert record["databases"][0]["holders"] == []
+PY
+
+env "${env[@]}" "$CLI" bundle list >"$TMPDIR/bundles.json"
+python3 - "$TMPDIR/bundles.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+assert payload["detail_mode"] == "summary", payload
+assert payload["bundle_summary"]["count"] >= 3, payload
+assert "legacy_databases" not in payload, payload
+PY
+
+env "${env[@]}" "$CLI" bundle list --verbose >"$TMPDIR/bundles-verbose.json"
+python3 - "$TMPDIR/bundles-verbose.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+assert payload["detail_mode"] == "full", payload
+assert len(payload["legacy_databases"]) == 25, payload
+assert len(payload["bundles"]) >= 3, payload
 PY
 
 if env "${env[@]}" "$CLI" doctor --bundle "$shared_id" >"$TMPDIR/shared.json"; then
@@ -119,7 +175,59 @@ python3 - "$TMPDIR/logs.json" <<'PY'
 import json
 import sys
 payload = json.load(open(sys.argv[1]))
-assert len(payload["logs"]) == 1, payload
+assert payload["detail_mode"] == "summary", payload
+assert payload["log_summary"]["count"] == 25, payload
+assert "logs" not in payload, payload
+PY
+
+env "${env[@]}" "$CLI" logs list --verbose >"$TMPDIR/logs-verbose.json"
+python3 - "$TMPDIR/logs-verbose.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+assert payload["detail_mode"] == "full", payload
+assert len(payload["logs"]) == 25, payload
+PY
+
+env "${env[@]}" "$CLI" logs prune --older-than 14 >"$TMPDIR/log-prune.json"
+python3 - "$TMPDIR/log-prune.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+assert payload["detail_mode"] == "summary", payload
+assert payload["action_summary"]["count"] == 1, payload
+assert "actions" not in payload, payload
+PY
+
+env "${env[@]}" "$CLI" logs prune --older-than 14 --verbose >"$TMPDIR/log-prune-verbose.json"
+python3 - "$TMPDIR/log-prune-verbose.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+assert payload["detail_mode"] == "full", payload
+assert len(payload["actions"]) == 1, payload
+assert payload["retained"] == [], payload
+PY
+
+env "${env[@]}" "$CLI" permissions list >"$TMPDIR/permissions.json"
+python3 - "$TMPDIR/permissions.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+assert payload["detail_mode"] == "summary", payload
+assert payload["summary"]["preferences"]["candidate"] == 24, payload
+assert payload["tcc"]["row_count"] == 1, payload
+assert "preferences" not in payload, payload
+PY
+
+env "${env[@]}" "$CLI" permissions list --verbose >"$TMPDIR/permissions-verbose.json"
+python3 - "$TMPDIR/permissions-verbose.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+assert payload["detail_mode"] == "full", payload
+assert len(payload["preferences"]) == 24, payload
+assert len(payload["tcc"]["rows"]) == 1, payload
 PY
 
 env "${env[@]}" "$CLI" clean plan --older-than 14 >"$TMPDIR/plan.json"
@@ -127,12 +235,23 @@ plan="$(python3 - "$TMPDIR/plan.json" <<'PY'
 import json
 import sys
 payload = json.load(open(sys.argv[1]))
-kinds = {item["kind"] for item in payload["actions"]}
-assert {"delete_bundle", "delete_profile", "delete_log"}.issubset(kinds), payload
+assert payload["detail_mode"] == "summary", payload
+assert payload["action_summary"]["kind_counts"] == {"delete_bundle": 1, "delete_log": 1, "delete_profile": 1}, payload
 assert payload["legacy_shared_root_touched"] is False
 print(payload["plan"])
 PY
 )"
+
+env "${env[@]}" "$CLI" clean plan --older-than 14 --verbose >"$TMPDIR/plan-verbose.json"
+python3 - "$TMPDIR/plan-verbose.json" "$plan" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+kinds = {item["kind"] for item in payload["actions"]}
+assert payload["detail_mode"] == "full", payload
+assert payload["plan"] == sys.argv[2], payload
+assert {"delete_bundle", "delete_profile", "delete_log"}.issubset(kinds), payload
+PY
 
 if env "${env[@]}" "$CLI" clean apply --older-than 14 --plan not-the-plan --yes >/dev/null; then
   echo "FAIL: mismatched cleanup plan unexpectedly applied" >&2
@@ -140,6 +259,14 @@ if env "${env[@]}" "$CLI" clean apply --older-than 14 --plan not-the-plan --yes 
 fi
 
 env "${env[@]}" "$CLI" clean apply --older-than 14 --plan "$plan" --yes >"$TMPDIR/applied.json"
+python3 - "$TMPDIR/applied.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+assert payload["detail_mode"] == "summary", payload
+assert payload["completed_summary"]["count"] == 3, payload
+assert "completed" not in payload, payload
+PY
 test ! -e "$apps/omi-old.app"
 test ! -e "$support/$old_id"
 test ! -e "$logs/omi-dev-$old_id-321.log"
@@ -147,5 +274,57 @@ test -f "$legacy/omi.db"
 test -d "$apps/Omi Dev.app"
 test -d "$apps/invalid-named.app"
 test -f "$logs/omi-dev-com.omi.desktop-dev-777.log"
+
+if env "${env[@]}" "$CLI" clean plan --older-than -1 >/dev/null; then
+  echo "FAIL: negative cleanup age unexpectedly succeeded" >&2
+  exit 1
+fi
+recent_id="com.omi.omi-immediate"
+make_app "omi-immediate" "$recent_id"
+make_manifest "$recent_id" "$support/$recent_id" "$support/$recent_id"
+printf 'immediate cleanup log' >"$logs/omi-dev-$recent_id-321.log"
+
+env "${env[@]}" "$CLI" clean plan --older-than 0 >"$TMPDIR/immediate-plan.json"
+immediate_plan="$(python3 - "$TMPDIR/immediate-plan.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+assert payload["older_than_days"] == 0, payload
+assert payload["detail_mode"] == "summary", payload
+assert payload["action_summary"]["kind_counts"]["delete_bundle"] >= 2, payload
+assert payload["action_summary"]["kind_counts"]["delete_profile"] >= 2, payload
+assert payload["action_summary"]["kind_counts"]["delete_log"] >= 1, payload
+print(payload["plan"])
+PY
+)"
+
+env "${env[@]}" "$CLI" clean plan --older-than 0 --verbose >"$TMPDIR/immediate-plan-verbose.json"
+python3 - "$TMPDIR/immediate-plan-verbose.json" "$immediate_plan" "$apps/omi-immediate.app" "$support/$recent_id" "$logs/omi-dev-$recent_id-321.log" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+paths = {item["path"] for item in payload["actions"]}
+assert payload["detail_mode"] == "full", payload
+assert payload["plan"] == sys.argv[2], payload
+assert set(sys.argv[3:]).issubset(paths), payload
+PY
+
+env "${env[@]}" "$CLI" clean apply --older-than 0 --plan "$immediate_plan" --yes --verbose >"$TMPDIR/immediate-applied.json"
+python3 - "$TMPDIR/immediate-applied.json" "$apps/omi-immediate.app" "$support/$recent_id" "$logs/omi-dev-$recent_id-321.log" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+paths = {item["path"] for item in payload["completed"]}
+assert payload["detail_mode"] == "full", payload
+assert set(sys.argv[2:]).issubset(paths), payload
+PY
+test ! -e "$apps/omi-immediate.app"
+test ! -e "$support/$recent_id"
+test ! -e "$logs/omi-dev-$recent_id-321.log"
+test -f "$legacy/omi.db"
+test -d "$apps/Omi Dev.app"
+test -f "$logs/omi-dev-com.omi.desktop-dev-777.log"
+
+bash "$MACOS_DIR/tests/test-cleanup-omi-tcc.sh"
 
 echo "omi-macos-dev tests passed"

--- a/desktop/macos/tests/test-omi-macos-dev.sh
+++ b/desktop/macos/tests/test-omi-macos-dev.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLI="$MACOS_DIR/scripts/omi-macos-dev"
+
+TMPDIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+home="$TMPDIR/home"
+apps="$TMPDIR/apps"
+logs="$TMPDIR/logs"
+bin="$TMPDIR/bin"
+mkdir -p "$home" "$apps" "$logs" "$bin"
+
+make_app() {
+  local name="$1" bundle_id="$2"
+  mkdir -p "$apps/$name.app/Contents"
+  python3 - "$apps/$name.app/Contents/Info.plist" "$bundle_id" "$name" <<'PY'
+import plistlib
+import sys
+with open(sys.argv[1], "wb") as handle:
+    plistlib.dump({"CFBundleIdentifier": sys.argv[2], "CFBundleDisplayName": sys.argv[3]}, handle)
+PY
+}
+
+make_manifest() {
+  local bundle_id="$1" profile="$2" profile_root="$3"
+  mkdir -p "$profile/users/test-user"
+  printf 'sqlite-fixture' >"$profile/users/test-user/omi.db"
+  python3 - "$profile/.omi-dev-runtime.json" "$bundle_id" "$profile_root" <<'PY'
+import json
+import sys
+payload = {
+    "schemaVersion": 1,
+    "bundleIdentifier": sys.argv[2],
+    "processID": 999999,
+    "startedAt": "2026-01-01T00:00:00Z",
+    "appPath": "/Applications/fixture.app",
+    "profileRoot": sys.argv[3],
+    "logPath": "/private/tmp/fixture.log",
+    "automationPort": 47777,
+}
+json.dump(payload, open(sys.argv[1], "w"), sort_keys=True)
+PY
+}
+
+cat >"$bin/lsof" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+chmod +x "$bin/lsof"
+
+good_id="com.omi.omi-good"
+old_id="com.omi.omi-old"
+shared_id="com.omi.omi-shared"
+support="$home/Library/Application Support/Omi Dev Bundles"
+legacy="$home/Library/Application Support/Omi"
+
+make_app "omi-good" "$good_id"
+make_app "omi-old" "$old_id"
+make_app "Omi Dev" "com.omi.desktop-dev"
+make_app "invalid-named" "com.omi.omi-../escape"
+make_manifest "$good_id" "$support/$good_id" "$support/$good_id"
+make_manifest "$old_id" "$support/$old_id" "$support/$old_id"
+make_manifest "$shared_id" "$support/$shared_id" "$legacy"
+mkdir -p "$legacy"
+printf 'protected shared data' >"$legacy/omi.db"
+printf 'old log' >"$logs/omi-dev-$old_id-321.log"
+printf 'protected dev log' >"$logs/omi-dev-com.omi.desktop-dev-777.log"
+
+python3 - "$apps/omi-old.app" "$support/$old_id" "$logs/omi-dev-$old_id-321.log" "$logs/omi-dev-com.omi.desktop-dev-777.log" <<'PY'
+import os
+import sys
+import time
+then = time.time() - 40 * 86400
+for path in sys.argv[1:]:
+    os.utime(path, (then, then))
+PY
+
+env=(
+  OMI_MACOS_DEV_HOME="$home"
+  OMI_MACOS_DEV_APP_ROOTS="$apps"
+  OMI_MACOS_DEV_LOG_ROOTS="$logs"
+  OMI_MACOS_DEV_LSOF="$bin/lsof"
+)
+
+doctor="$TMPDIR/doctor.json"
+env "${env[@]}" "$CLI" doctor --bundle "$good_id" >"$doctor"
+python3 - "$doctor" "$good_id" "$support" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+assert payload["diagnostic"] is None, payload
+record = payload["bundles"][0]
+assert record["bundle_id"] == sys.argv[2]
+assert record["isolation"] == "isolated", record
+assert record["profile_root"] == f"{sys.argv[3]}/{sys.argv[2]}"
+assert record["databases"][0]["holders"] == []
+assert record["backend"]["status"] == "unavailable"
+PY
+
+if env "${env[@]}" "$CLI" doctor --bundle "$shared_id" >"$TMPDIR/shared.json"; then
+  echo "FAIL: shared legacy profile unexpectedly passed doctor" >&2
+  exit 1
+fi
+python3 - "$TMPDIR/shared.json" "$shared_id" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+assert payload["diagnostic"] == "shared_named_bundle_storage", payload
+assert payload["shared_storage_bundle_ids"] == [sys.argv[2]], payload
+PY
+
+env "${env[@]}" "$CLI" logs list >"$TMPDIR/logs.json"
+python3 - "$TMPDIR/logs.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+assert len(payload["logs"]) == 1, payload
+PY
+
+env "${env[@]}" "$CLI" clean plan --older-than 14 >"$TMPDIR/plan.json"
+plan="$(python3 - "$TMPDIR/plan.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+kinds = {item["kind"] for item in payload["actions"]}
+assert {"delete_bundle", "delete_profile", "delete_log"}.issubset(kinds), payload
+assert payload["legacy_shared_root_touched"] is False
+print(payload["plan"])
+PY
+)"
+
+if env "${env[@]}" "$CLI" clean apply --older-than 14 --plan not-the-plan --yes >/dev/null; then
+  echo "FAIL: mismatched cleanup plan unexpectedly applied" >&2
+  exit 1
+fi
+
+env "${env[@]}" "$CLI" clean apply --older-than 14 --plan "$plan" --yes >"$TMPDIR/applied.json"
+test ! -e "$apps/omi-old.app"
+test ! -e "$support/$old_id"
+test ! -e "$logs/omi-dev-$old_id-321.log"
+test -f "$legacy/omi.db"
+test -d "$apps/Omi Dev.app"
+test -d "$apps/invalid-named.app"
+test -f "$logs/omi-dev-com.omi.desktop-dev-777.log"
+
+echo "omi-macos-dev tests passed"

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -40,15 +40,9 @@ declare -a CHANGED_FILES=()
 if [ "${#PUSH_UPDATES[@]}" -gt 0 ]; then
   for update in "${PUSH_UPDATES[@]}"; do
     IFS=: read -r local_oid remote_oid remote_ref <<<"$update"
-    if [ -z "$remote_oid" ] || [ "$remote_oid" = "$ZERO_SHA" ]; then
-      DIFF_BASE=$(git merge-base "$BASE_REMOTE_REF" "$local_oid")
-    elif git cat-file -e "$remote_oid^{commit}" 2>/dev/null; then
-      DIFF_BASE="$remote_oid"
-    elif TRACKING_REF="refs/remotes/${PUSH_REMOTE}/${remote_ref#refs/heads/}" && git rev-parse --verify "$TRACKING_REF" >/dev/null 2>&1; then
-      DIFF_BASE=$(git rev-parse "$TRACKING_REF")
-    else
-      DIFF_BASE=$(git merge-base "$BASE_REMOTE_REF" "$local_oid")
-    fi
+    # Check selection describes the final review surface, not every historical
+    # commit needed to reconcile a stale remote PR branch.
+    DIFF_BASE=$(scripts/pre-push-diff-base "$BASE_REMOTE_REF" "$local_oid")
     changed_count=$(scripts/changed-files "$DIFF_BASE" "$local_oid" | wc -l | tr -d ' ')
     DIFF_SUMMARIES+=("${remote_ref:-$local_oid}: ${changed_count} changed file(s) since ${DIFF_BASE:0:12}")
     while IFS= read -r file; do

--- a/scripts/pre-push-diff-base
+++ b/scripts/pre-push-diff-base
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Print the base commit that represents a pushed ref's final review surface.
+set -euo pipefail
+
+base_remote_ref="${1:?usage: pre-push-diff-base <base-remote-ref> <local-oid>}"
+local_oid="${2:?usage: pre-push-diff-base <base-remote-ref> <local-oid>}"
+git merge-base "$base_remote_ref" "$local_oid"

--- a/scripts/test-pre-push-diff-base.sh
+++ b/scripts/test-pre-push-diff-base.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Git hooks export their own repository environment. This fixture creates a
+# separate temporary repository, so it must not inherit that hook context.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HELPER="$ROOT/scripts/pre-push-diff-base"
 TMPDIR="$(mktemp -d)"

--- a/scripts/test-pre-push-diff-base.sh
+++ b/scripts/test-pre-push-diff-base.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$ROOT/scripts/pre-push-diff-base"
+TMPDIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+git -C "$TMPDIR" init -q
+git -C "$TMPDIR" config user.email test@example.com
+git -C "$TMPDIR" config user.name test
+printf 'base\n' >"$TMPDIR/base.txt"
+git -C "$TMPDIR" add base.txt
+git -C "$TMPDIR" commit -qm base
+git -C "$TMPDIR" branch -M main
+printf 'main\n' >"$TMPDIR/main.txt"
+git -C "$TMPDIR" add main.txt
+git -C "$TMPDIR" commit -qm main
+git -C "$TMPDIR" branch feature HEAD~1
+git -C "$TMPDIR" switch -q feature
+printf 'desktop\n' >"$TMPDIR/desktop.txt"
+git -C "$TMPDIR" add desktop.txt
+git -C "$TMPDIR" commit -qm desktop
+git -C "$TMPDIR" merge -q --no-edit main
+
+base="$(cd "$TMPDIR" && "$HELPER" main HEAD)"
+selected="$(git -C "$TMPDIR" diff --name-only "$base" HEAD)"
+test "$selected" = "desktop.txt"
+test "$(cd "$TMPDIR" && "$HELPER" "$(git rev-parse main)" "$(git rev-parse HEAD)")" = "$base"
+
+echo "pre-push final-PR-diff selection tests passed"


### PR DESCRIPTION
## Summary

- Isolate every named `com.omi.omi-*` desktop bundle in an identity-derived Application Support and cache root, with per-bundle logs and a token-free runtime manifest.
- Add `omi-macos-dev`, an agent-oriented JSON CLI for doctor, bundle inventory, permission cleanup, log cleanup, and plan-confirmed stale-bundle cleanup.
- Make `run.sh --fast-only` fail before destructive launch work when reuse is ineligible, and make pre-push check selection use the final PR diff.

Closes #9833.

## Root cause and durable guard

Named bundles had distinct IDs but still resolved desktop data through the shared `Omi` root. That mixed Rewind data, could make a named launch migrate legacy state, and made diagnostics/cleanup ambiguous. Storage now derives from the signed named bundle ID; the legacy migration explicitly refuses isolated profiles; the CLI reports shared legacy storage rather than mutating it; and regression tests cover both boundaries.

## Product invariants affected

- INV-AUTH-1 — named bundles retain their own state boundary while Omi Dev and production/beta retain the established shared root.

## Verification

- `make preflight` with this PR body
- `bash desktop/macos/tests/test-omi-macos-dev.sh`
- `bash desktop/macos/tests/test-fast-dev-bundle.sh`
- `xcrun swift test --package-path Desktop --filter DesktopStorageIdentityTests`
- `xcrun swift test --package-path Desktop --filter LoggerPermissionsTests`
- `PATH="$PWD/Desktop/Sources/Resources:$PATH" ./scripts/agent-logic-harness.sh --cross-surface-smoke`
- Full and `--fast-only` launches of `omi-9833-macos-dev`; bridge health/state and `omi-macos-dev doctor` confirmed isolated storage and healthy development endpoints.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

