### PR TITLE
fix(desktop): follow-up polish for Settings controls

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
@@ -756,6 +756,8 @@ extension SettingsContentView {
         await MainActor.run {
           dailySummaryEnabled = dailySummary.enabled
           dailySummaryHour = dailySummary.hour
+          dailySummaryTime = SettingsControlMetrics.dailySummaryDate(
+            forHour: dailySummary.hour, referenceDate: Date())
           notificationsEnabled = notifications.enabled
           notificationFrequency = notifications.frequency
           // Mirror to UserDefaults so NotificationService can gate/throttle without a backend roundtrip.

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+Controls.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+Controls.swift
@@ -118,13 +118,8 @@ extension SettingsContentView {
           }
           Spacer()
           Text("\(String(format: "%.1f", currentSpeed))×")
-            .font(.system(size: 22, weight: .bold, design: .rounded))
+            .scaledFont(size: OmiType.subheading, weight: .semibold)
             .foregroundColor(OmiColors.accent)
-            .frame(width: 52, height: 52)
-            .background(
-              RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius, style: .continuous)
-                .fill(OmiColors.accent.opacity(0.15))
-            )
         }
 
         VStack(spacing: OmiSpacing.xs) {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
@@ -84,13 +84,11 @@ extension SettingsContentView {
 
             Spacer()
 
-            Picker("", selection: $realtimeOmniProvider) {
+            SettingsMenuPicker(selection: $realtimeOmniProvider) {
               ForEach(RealtimeOmniProvider.allCases, id: \.rawValue) { p in
                 Text(p.displayName).tag(p.rawValue)
               }
             }
-            .pickerStyle(.menu)
-            .frame(width: 200)
             .onChange(of: realtimeOmniProvider) { _, newValue in
               if newValue == RealtimeOmniProvider.auto.rawValue {
                 AutoModelSelector.shared.refreshIfStale()

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Assistants.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Assistants.swift
@@ -61,13 +61,11 @@ extension SettingsContentView {
               title: "Focus Cooldown", subtitle: "Minimum time between distraction alerts",
               settingId: "advanced.focusassistant.cooldown"
             ) {
-              Picker("", selection: $cooldownInterval) {
+              SettingsMenuPicker(selection: $cooldownInterval) {
                 ForEach(cooldownOptions, id: \.self) { minutes in
                   Text(formatMinutes(minutes)).tag(minutes)
                 }
               }
-              .pickerStyle(.menu)
-              .frame(width: 200)
               .onChange(of: cooldownInterval) { _, newValue in
                 FocusAssistantSettings.shared.cooldownInterval = newValue
                 SettingsSyncManager.shared.pushPartialUpdate(

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+FloatingBarAndChat.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+FloatingBarAndChat.swift
@@ -127,14 +127,11 @@ extension SettingsContentView {
           .foregroundColor(OmiColors.textSecondary)
         }
         Spacer()
-        Picker("", selection: $shortcutSettings.selectedVoiceID) {
+        SettingsMenuPicker(selection: $shortcutSettings.selectedVoiceID) {
           ForEach(ShortcutSettings.availableVoices) { voice in
             Text(voice.name).tag(voice.id)
           }
         }
-        .pickerStyle(.menu)
-        .labelsHidden()
-        .frame(width: 200)
       }
     }
   }
@@ -159,13 +156,11 @@ extension SettingsContentView {
 
             Spacer()
 
-            Picker("", selection: $chatBridgeMode) {
+            SettingsMenuPicker(selection: $chatBridgeMode) {
               ForEach(AIProvider.all) { provider in
                 Text(provider.displayName).tag(provider.bridgeModeRawValue)
               }
             }
-            .pickerStyle(.menu)
-            .frame(width: 200)
             .onChange(of: chatBridgeMode) { _, newMode in
               if let mode = ChatProvider.BridgeMode(rawValue: newMode) {
                 Task {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
@@ -195,8 +195,7 @@ extension SettingsContentView {
 
               Spacer()
 
-              Picker(
-                "",
+              SettingsMenuPicker(
                 selection: Binding(
                   get: { systemAudioCaptureMode },
                   set: { newValue in
@@ -210,9 +209,6 @@ extension SettingsContentView {
                   AssistantSettings.SystemAudioCaptureMode.onlyDuringMeetings)
                 Text("Never").tag(AssistantSettings.SystemAudioCaptureMode.never)
               }
-              .pickerStyle(.menu)
-              .labelsHidden()
-              .frame(width: 200)
             }
 
             if systemAudioCaptureMode == .onlyDuringMeetings {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+NotificationsPrivacy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+NotificationsPrivacy.swift
@@ -129,22 +129,18 @@ extension SettingsContentView {
             ) {
               DatePicker(
                 "",
-                selection: Binding(
-                  get: {
-                    SettingsControlMetrics.dailySummaryDate(
-                      forHour: dailySummaryHour, referenceDate: Date())
-                  },
-                  set: { selectedTime in
-                    let hour = SettingsControlMetrics.dailySummaryHour(from: selectedTime)
-                    dailySummaryHour = hour
-                    updateDailySummarySettings(hour: hour)
-                  }
-                ),
+                selection: $dailySummaryTime,
                 displayedComponents: .hourAndMinute
               )
-              .datePickerStyle(.field)
+              .datePickerStyle(.stepperField)
               .labelsHidden()
               .fixedSize()
+              .onChange(of: dailySummaryTime) { _, selectedTime in
+                let hour = SettingsControlMetrics.dailySummaryHour(from: selectedTime)
+                guard hour != dailySummaryHour else { return }
+                dailySummaryHour = hour
+                updateDailySummarySettings(hour: hour)
+              }
             }
           }
         }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -213,6 +213,10 @@ struct SettingsContentView: View {
   // Notification settings (from backend)
   @State var dailySummaryEnabled: Bool = true
   @State var dailySummaryHour: Int = 22
+  // UI-only date for the Summary Time stepper field; the backend stores whole hours,
+  // so this glides freely while only the hour component is persisted.
+  @State var dailySummaryTime: Date = SettingsControlMetrics.dailySummaryDate(
+    forHour: 22, referenceDate: Date())
   @State var notificationsEnabled: Bool = true
   @State var notificationFrequency: Int = 3
 

--- a/desktop/macos/changelog/unreleased/20260715-settings-ui-polish-followups.json
+++ b/desktop/macos/changelog/unreleased/20260715-settings-ui-polish-followups.json
@@ -1,0 +1,3 @@
+{
+  "change": "Right-aligned the remaining Settings dropdowns (voice, voice model, AI provider, system audio, focus cooldown), made the daily summary time picker glide with a native stepper, and slimmed the voice speed value label"
+}


### PR DESCRIPTION
Follow-up polish on top of #9813, catching the settings controls that pass missed and refining two of its changes.

## Changes

**Right-align the five pickers #9813 missed** — the polish pass converted most menu pickers to the shared `SettingsMenuPicker` (hug-content, trailing edge aligned with toggles) but left five on the old fixed `.frame(width: 200)`, so their values floated mid-row:
- Voice ("Shimmer") — Settings → Floating Bar
- Voice Model — Settings → AI Chat
- AI Provider — Settings → AI Chat
- System Audio capture mode — Settings → General
- Focus Cooldown — Settings → Advanced → Focus Assistant

**Summary Time glides like the native control** — Settings → Notifications & Privacy → Daily Summary. The `.field`-style `DatePicker` had no steppers, and its inline binding re-derived the date (minutes forced to `:00`) on every change, snapping the field back mid-edit. Now bound to a dedicated UI date state with `.stepperField` (repeat-on-hold arrows, System Settings feel); only the whole hour the backend supports is persisted, and the state re-syncs from the backend on settings load.

**Slim the voice speed value label** — Settings → Floating Bar → Voice Speed. Dropped the 52pt tinted box behind the current-speed number; it now renders as plain 15pt semibold accent text.

## Verification

Built and ran a named bundle (`omi-settings-ui-polish.app`) signed in against the dev backend. Confirmed via macOS accessibility frames that every converted popup's right edge now sits at x=1292 — identical to the toggle column — across Floating Bar, AI Chat, and General, and that the Summary Time row renders a real stepper (`AXIncrementor`). Full-image screenshots weren't available in the headless shell (no Screen Recording grant), so alignment was verified numerically.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

