### PR TITLE
build(devops): add offline OpenTofu foundation guard

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -72,6 +72,16 @@ checks:
     triggers: [".github/scripts/check_deployment_secret_boundary.py", ".github/scripts/test_check_deployment_secret_boundary.py"]
     lanes: ["local", "ci"]
     reason: "deployment secret-boundary fake-name fixtures must remain executable"
+  - id: opentofu-foundation-boundary
+    command: ["python3", ".github/scripts/check_opentofu_foundation.py"]
+    triggers: ["infrastructure/opentofu/**", ".github/scripts/check_opentofu_foundation.py", ".github/workflows/opentofu-foundation-validate.yml"]
+    lanes: ["local", "ci"]
+    reason: "OpenTofu remains limited to durable foundation resources and cannot carry secret values"
+  - id: opentofu-foundation-boundary-fixtures
+    command: ["python3", ".github/scripts/test_check_opentofu_foundation.py"]
+    triggers: ["infrastructure/opentofu/**", ".github/scripts/check_opentofu_foundation.py", ".github/scripts/test_check_opentofu_foundation.py", ".github/workflows/opentofu-foundation-validate.yml"]
+    lanes: ["local", "ci"]
+    reason: "OpenTofu foundation boundary fixtures must reject release and secret-value ownership"
   - id: public-build-contract
     command: ["python3", ".github/scripts/check_public_build_contract.py"]
     triggers: [".github/actions/prepare-public-build/**", ".github/actions/public-build-candidate-promotion/**", ".github/workflows/gcp_admin.yml", ".github/workflows/gcp_app.yml", ".github/workflows/gcp_frontend.yml", ".github/workflows/gcp_personas.yml", ".github/workflows/public-build-config-preflight.yml", ".github/scripts/check_public_build_contract.py", ".github/scripts/preflight_public_build_config.py", ".github/scripts/smoke_public_build_browser.py", ".github/scripts/test_check_public_build_contract.py", "config/public-build-contract.json", "config/public-build-values.json", "config/deployment-setting-classification.json", "web/admin/Dockerfile", "web/app/Dockerfile", "web/frontend/Dockerfile", "web/personas-open-source/Dockerfile", "web/admin/components/public-build-canary.tsx", "web/app/src/components/public-build-canary.tsx", "web/frontend/src/components/public-build-canary.tsx", "web/personas-open-source/src/components/public-build-canary.tsx"]

--- a/.github/scripts/check_opentofu_foundation.py
+++ b/.github/scripts/check_opentofu_foundation.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Enforce the no-mutation OpenTofu foundation boundary for issue #9842."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MODULE_DIR = ROOT / "infrastructure" / "opentofu" / "foundation"
+DEFAULT_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "opentofu-foundation-validate.yml"
+
+RESOURCE_BLOCK = re.compile(r'^\s*resource\s+"(?P<type>[^"]+)"\s+"[^"]+"', re.MULTILINE)
+DATA_BLOCK = re.compile(r'^\s*data\s+"(?P<type>[^"]+)"\s+"[^"]+"', re.MULTILINE)
+GCS_BACKEND = re.compile(r'backend\s+"gcs"\s*\{\s*\}', re.DOTALL)
+GCS_BACKEND_BLOCK = re.compile(r'^\s*backend\s+"gcs"\s*\{\s*\}\s*$', re.MULTILINE)
+
+ALLOWED_RESOURCE_TYPES = frozenset(
+    {
+        "google_iam_workload_identity_pool",
+        "google_iam_workload_identity_pool_provider",
+        "google_project_iam_member",
+        "google_secret_manager_secret",
+        "google_secret_manager_secret_iam_member",
+        "google_service_account",
+        "google_service_account_iam_member",
+        "google_storage_bucket",
+        "google_storage_bucket_iam_member",
+    }
+)
+
+FORBIDDEN_REFERENCES = (
+    re.compile(r"\bgoogle_artifact_registry_"),
+    re.compile(r"\bgoogle_cloud_run_"),
+    re.compile(r"\bgoogle_container_"),
+    re.compile(r"\bgoogle_secret_manager_secret_version\b"),
+    re.compile(r"\bsecret_data\s*="),
+    re.compile(r"\bsecret_string\s*="),
+)
+
+FORBIDDEN_WORKFLOW_REFERENCES = (
+    re.compile(r"\bcredentials_json\b"),
+    re.compile(r"\bgcloud\b"),
+    re.compile(r"\bgoogle-github-actions/auth\b"),
+    re.compile(r"\bid-token\s*:\s*"),
+    re.compile(r"\btofu\b[^\n]*\bapply\b"),
+    re.compile(r"\bworkload_identity_provider\b"),
+)
+
+REQUIRED_WORKFLOW_REFERENCES = (
+    "contents: read",
+    "-backend=false",
+    "--prepare-offline-plan-module",
+    "-refresh=false",
+)
+
+
+def module_files(module_dir: Path) -> list[Path]:
+    return sorted(path for path in module_dir.rglob("*.tf") if path.is_file())
+
+
+def check_module(module_dir: Path) -> list[str]:
+    errors: list[str] = []
+    files = module_files(module_dir)
+    if not files:
+        return [f"{module_dir}: no OpenTofu files found"]
+
+    source = "\n".join(path.read_text(encoding="utf-8") for path in files)
+    if not GCS_BACKEND.search(source):
+        errors.append("foundation module must declare an empty gcs backend block")
+    if 'required_providers' not in source or 'hashicorp/google' not in source:
+        errors.append("foundation module must pin the hashicorp/google provider")
+
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        for match in RESOURCE_BLOCK.finditer(text):
+            resource_type = match.group("type")
+            if resource_type not in ALLOWED_RESOURCE_TYPES:
+                errors.append(f"{path}: resource type {resource_type} is outside the foundation boundary")
+        for match in DATA_BLOCK.finditer(text):
+            errors.append(f"{path}: data source {match.group('type')} is outside the foundation boundary")
+        for pattern in FORBIDDEN_REFERENCES:
+            if pattern.search(text):
+                errors.append(f"{path}: forbidden release or secret-value reference {pattern.pattern!r}")
+
+    return errors
+
+
+def prepare_offline_plan_module(module_dir: Path, destination: Path) -> None:
+    """Copy the module with its GCS backend removed for an offline empty-plan check."""
+    if destination.exists():
+        shutil.rmtree(destination)
+    shutil.copytree(module_dir, destination)
+
+    removed_backends = 0
+    for path in module_files(destination):
+        text = path.read_text(encoding="utf-8")
+        updated, count = GCS_BACKEND_BLOCK.subn("", text)
+        if count:
+            path.write_text(updated, encoding="utf-8")
+            removed_backends += count
+
+    if removed_backends != 1:
+        raise ValueError(f"expected one gcs backend block in {module_dir}, found {removed_backends}")
+
+
+def check_workflow_text(text: str) -> list[str]:
+    errors: list[str] = []
+    for pattern in FORBIDDEN_WORKFLOW_REFERENCES:
+        if pattern.search(text):
+            errors.append(f"validation workflow contains forbidden cloud mutation or credential reference {pattern.pattern!r}")
+    for reference in REQUIRED_WORKFLOW_REFERENCES:
+        if reference not in text:
+            errors.append(f"validation workflow is missing required no-mutation reference {reference!r}")
+    return errors
+
+
+def check_workflow(workflow_path: Path) -> list[str]:
+    try:
+        return check_workflow_text(workflow_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return [f"could not read validation workflow {workflow_path}: {exc}"]
+
+
+def check_plan(plan: dict[str, Any], *, require_empty: bool) -> list[str]:
+    errors: list[str] = []
+    changes = plan.get("resource_changes", [])
+    if not isinstance(changes, list):
+        return ["plan resource_changes must be a list"]
+
+    for change in changes:
+        if not isinstance(change, dict):
+            errors.append("plan contains a malformed resource change")
+            continue
+        resource_type = change.get("type")
+        address = change.get("address", "<unknown>")
+        if resource_type not in ALLOWED_RESOURCE_TYPES:
+            errors.append(f"plan resource {address} ({resource_type}) is outside the foundation boundary")
+        if require_empty:
+            errors.append(f"initial no-mutation slice must have an empty plan; found {address}")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--module-dir", type=Path, default=DEFAULT_MODULE_DIR)
+    parser.add_argument("--plan-json", type=Path)
+    parser.add_argument("--prepare-offline-plan-module", type=Path)
+    parser.add_argument("--workflow-path", type=Path, default=DEFAULT_WORKFLOW_PATH)
+    args = parser.parse_args()
+
+    errors = check_module(args.module_dir)
+    errors.extend(check_workflow(args.workflow_path))
+    if args.prepare_offline_plan_module is not None and not errors:
+        try:
+            prepare_offline_plan_module(args.module_dir, args.prepare_offline_plan_module)
+        except (OSError, ValueError) as exc:
+            errors.append(f"could not prepare offline plan module: {exc}")
+    if args.plan_json is not None:
+        try:
+            plan = json.loads(args.plan_json.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"could not read plan JSON {args.plan_json}: {exc}")
+        else:
+            if not isinstance(plan, dict):
+                errors.append(f"plan JSON {args.plan_json} must be an object")
+            else:
+                errors.extend(check_plan(plan, require_empty=True))
+
+    if errors:
+        print("OpenTofu foundation boundary check failed:", file=sys.stderr)
+        print("\n".join(f"- {error}" for error in errors), file=sys.stderr)
+        return 1
+
+    print("OpenTofu foundation boundary check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_check_opentofu_foundation.py
+++ b/.github/scripts/test_check_opentofu_foundation.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Fixture tests for the OpenTofu foundation boundary checker."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECKER_PATH = REPO_ROOT / ".github" / "scripts" / "check_opentofu_foundation.py"
+SPEC = importlib.util.spec_from_file_location("opentofu_foundation", CHECKER_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load {CHECKER_PATH}")
+CHECKER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CHECKER
+SPEC.loader.exec_module(CHECKER)
+
+
+MODULE_HEADER = '''terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+
+  backend "gcs" {}
+}
+'''
+
+
+class OpenTofuFoundationFixture(unittest.TestCase):
+    def module_errors(self, contents: str) -> list[str]:
+        with tempfile.TemporaryDirectory(prefix="omi-opentofu-foundation-") as temp_dir:
+            module_dir = Path(temp_dir)
+            (module_dir / "main.tf").write_text(contents, encoding="utf-8")
+            return CHECKER.check_module(module_dir)
+
+    def test_allows_empty_foundation_module(self) -> None:
+        self.assertEqual(self.module_errors(MODULE_HEADER), [])
+
+    def test_allows_future_foundation_service_account(self) -> None:
+        contents = MODULE_HEADER + '''
+resource "google_service_account" "ci_plan" {
+  account_id = "omi-tofu-plan"
+}
+'''
+        self.assertEqual(self.module_errors(contents), [])
+
+    def test_rejects_cloud_run_resources(self) -> None:
+        contents = MODULE_HEADER + '''
+resource "google_cloud_run_v2_service" "backend" {}
+'''
+        errors = self.module_errors(contents)
+        self.assertIn("outside the foundation boundary", "\n".join(errors))
+        self.assertIn("forbidden release or secret-value reference", "\n".join(errors))
+
+    def test_rejects_secret_versions_and_payloads(self) -> None:
+        contents = MODULE_HEADER + '''
+resource "google_secret_manager_secret_version" "api_key" {
+  secret_data = "not-allowed"
+}
+'''
+        errors = self.module_errors(contents)
+        self.assertIn("google_secret_manager_secret_version", "\n".join(errors))
+        self.assertIn("secret_data", "\n".join(errors))
+
+    def test_rejects_non_foundation_resources_and_all_data_sources(self) -> None:
+        contents = MODULE_HEADER + '''
+resource "google_compute_network" "network" {}
+data "google_secret_manager_secret_version" "api_key" {}
+'''
+        errors = self.module_errors(contents)
+        self.assertIn("google_compute_network", "\n".join(errors))
+        self.assertIn("data source google_secret_manager_secret_version", "\n".join(errors))
+
+    def test_prepares_an_offline_plan_copy_without_mutating_the_source(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="omi-opentofu-foundation-") as temp_dir:
+            source_dir = Path(temp_dir) / "source"
+            plan_dir = Path(temp_dir) / "plan"
+            source_dir.mkdir()
+            source_file = source_dir / "main.tf"
+            source_file.write_text(MODULE_HEADER, encoding="utf-8")
+
+            CHECKER.prepare_offline_plan_module(source_dir, plan_dir)
+
+            self.assertIn('backend "gcs" {}', source_file.read_text(encoding="utf-8"))
+            self.assertNotIn('backend "gcs" {}', (plan_dir / "main.tf").read_text(encoding="utf-8"))
+
+    def test_validation_workflow_remains_credentials_free_and_apply_free(self) -> None:
+        self.assertEqual(CHECKER.check_workflow(CHECKER.DEFAULT_WORKFLOW_PATH), [])
+
+    def test_validation_workflow_rejects_cloud_auth_and_apply(self) -> None:
+        errors = CHECKER.check_workflow_text(
+            """permissions:
+  contents: read
+  id-token: write
+tofu apply
+"""
+        )
+        self.assertIn("forbidden cloud mutation or credential reference", "\n".join(errors))
+        self.assertIn("missing required no-mutation reference", "\n".join(errors))
+
+    def test_plan_accepts_only_foundation_resource_types(self) -> None:
+        plan = {"resource_changes": [{"address": "google_service_account.ci", "type": "google_service_account"}]}
+        self.assertEqual(CHECKER.check_plan(plan, require_empty=False), [])
+
+    def test_initial_plan_must_remain_empty_and_rejects_cloud_run(self) -> None:
+        plan = {
+            "resource_changes": [
+                {"address": "google_cloud_run_v2_service.backend", "type": "google_cloud_run_v2_service"}
+            ]
+        }
+        errors = CHECKER.check_plan(plan, require_empty=True)
+        self.assertIn("outside the foundation boundary", "\n".join(errors))
+        self.assertIn("initial no-mutation slice must have an empty plan", "\n".join(errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/opentofu-foundation-validate.yml
+++ b/.github/workflows/opentofu-foundation-validate.yml
@@ -1,0 +1,68 @@
+name: OpenTofu Foundation Validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/scripts/check_opentofu_foundation.py"
+      - ".github/scripts/test_check_opentofu_foundation.py"
+      - ".github/workflows/opentofu-foundation-validate.yml"
+      - "infrastructure/opentofu/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/scripts/check_opentofu_foundation.py"
+      - ".github/scripts/test_check_opentofu_foundation.py"
+      - ".github/workflows/opentofu-foundation-validate.yml"
+      - "infrastructure/opentofu/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: opentofu-foundation-validate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-no-mutation-slice:
+    runs-on: ubuntu-latest
+    env:
+      TF_IN_AUTOMATION: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: 1.12.4
+          tofu_wrapper: false
+
+      - name: Test foundation boundary checker
+        run: python3 .github/scripts/test_check_opentofu_foundation.py
+
+      - name: Check foundation source boundary
+        run: python3 .github/scripts/check_opentofu_foundation.py
+
+      - name: Validate source without a remote backend
+        run: |
+          export TF_DATA_DIR="${RUNNER_TEMP}/opentofu-foundation-validate-data"
+          tofu -chdir=infrastructure/opentofu/foundation init -backend=false -input=false -no-color
+          tofu -chdir=infrastructure/opentofu/foundation validate -no-color
+
+      - name: Generate and check an offline empty plan
+        run: |
+          OFFLINE_MODULE="${RUNNER_TEMP}/opentofu-foundation-offline-plan"
+          python3 .github/scripts/check_opentofu_foundation.py \
+            --prepare-offline-plan-module "$OFFLINE_MODULE"
+          export TF_DATA_DIR="${RUNNER_TEMP}/opentofu-foundation-plan-data"
+          tofu -chdir="$OFFLINE_MODULE" init -backend=false -input=false -no-color
+          tofu -chdir="$OFFLINE_MODULE" validate -no-color
+          tofu -chdir="$OFFLINE_MODULE" plan \
+            -input=false \
+            -lock=false \
+            -refresh=false \
+            -no-color \
+            -out="${RUNNER_TEMP}/foundation.tfplan"
+          tofu -chdir="$OFFLINE_MODULE" show \
+            -json "${RUNNER_TEMP}/foundation.tfplan" > "${RUNNER_TEMP}/foundation-plan.json"
+          python3 .github/scripts/check_opentofu_foundation.py \
+            --plan-json "${RUNNER_TEMP}/foundation-plan.json"

--- a/infrastructure/opentofu/README.md
+++ b/infrastructure/opentofu/README.md
@@ -1,0 +1,29 @@
+# OpenTofu foundation
+
+This directory is the future source of truth for durable GCP foundation resources only:
+
+- GitHub Workload Identity Federation pools, providers, and CI service accounts;
+- dedicated runtime service accounts and additive IAM grants;
+- Secret Manager containers and Secret Accessor bindings, never secret payloads or versions; and
+- GCS state-bucket metadata and narrowly scoped state access.
+
+Cloud Run and GKE releases remain owned by GitHub release workflows. OpenTofu must never write images, service or job templates, revisions, tags, traffic, runtime environment variables, secret references, GKE workloads, or secret values.
+
+## Initial no-mutation slice
+
+`foundation/main.tf` deliberately declares no resources. The backend shape and Google provider constraint are checked in now so the module can be validated without a GCP identity, a remote state bucket, a project ID, or an API call.
+
+The CI workflow uses only `contents: read`. It validates the source with the backend disabled, then copies the module to a temporary directory with the backend block removed before generating an offline empty plan:
+
+```sh
+tofu -chdir=infrastructure/opentofu/foundation init -backend=false -input=false
+tofu -chdir=infrastructure/opentofu/foundation validate
+python3 .github/scripts/check_opentofu_foundation.py --prepare-offline-plan-module /tmp/opentofu-foundation-plan
+tofu -chdir=/tmp/opentofu-foundation-plan plan -refresh=false -lock=false
+```
+
+It then checks the generated plan is empty. `check_opentofu_foundation.py` allows only the foundation resource families above and rejects all data sources, Cloud Run, GKE, release artifacts, arbitrary resources, and Secret Manager version/payload paths.
+
+## State bootstrap and live pilot
+
+The `.backend.hcl.example` files are placeholders, not executable configuration. Follow the staged manual work recorded in [issue #9842](https://github.com/BasedHardware/omi/issues/9842) before initializing a real backend or authenticating a plan. Keep development and production state isolated, and never add secret payloads, secret-version resources, or secret-value data sources to this module.

--- a/infrastructure/opentofu/environments/development.backend.hcl.example
+++ b/infrastructure/opentofu/environments/development.backend.hcl.example
@@ -1,0 +1,3 @@
+# Replace only during the approved state-backend bootstrap in based-hardware-dev.
+bucket = "REPLACE_WITH_APPROVED_DEVELOPMENT_STATE_BUCKET"
+prefix = "opentofu/foundation/development"

--- a/infrastructure/opentofu/environments/production.backend.hcl.example
+++ b/infrastructure/opentofu/environments/production.backend.hcl.example
@@ -1,0 +1,3 @@
+# Replace only during the approved state-backend bootstrap in based-hardware.
+bucket = "REPLACE_WITH_APPROVED_PRODUCTION_STATE_BUCKET"
+prefix = "opentofu/foundation/production"

--- a/infrastructure/opentofu/foundation/.terraform.lock.hcl
+++ b/infrastructure/opentofu/foundation/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:0qkP2yFo87EamHXoV0cK2w6hADP2grd+ZfzAixUPDSw=",
+    "h1:22CAxZ/tGKrnH+5+Cg3DM18S/OvpJZrVMRzp3A40h7Y=",
+    "h1:IH3uigEekXZECc3XgxC771MS1u32uWq5RHmZtVBsau8=",
+    "h1:Jw+wqWmsOFONn1I4BVShIkywBAu25VXfTvPBiQJRYYA=",
+    "h1:LxtuVWb0Y6r8I3RsQ8dgXozVzeG1rzFDnCav5EkZCoc=",
+    "h1:MAAe4zFFdqS9M5rpmJK/vKgdb6ZMD/s/0Xd97yTDipA=",
+    "h1:O5jnIJXJcM6QWNYDPJAeR/yD01GfvrX4q4X6yLg9Afg=",
+    "h1:ULGxKibTy8Z9F3roMLNFiPgw+MDs7FYuOdiy+Oispi8=",
+    "h1:WO2Jt6hHnY9lvpUdUdhnZ318vq4xPq3R4WYmQ2u7QpU=",
+    "h1:YS1XbzFYWp1xFGo8XyI6TrDrKoz4Ka4CVaeTpPI6xOY=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}

--- a/infrastructure/opentofu/foundation/main.tf
+++ b/infrastructure/opentofu/foundation/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.12.4, < 2.0.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+
+  # The bucket and prefix are intentionally supplied only at initialization
+  # time from a reviewed, environment-specific backend config file.
+  backend "gcs" {}
+}


### PR DESCRIPTION
## Summary

- add an intentionally empty OpenTofu foundation module, locked Google provider, and isolated dev/prod backend examples;
- enforce the ownership boundary in source and plan fixtures: foundation identity/IAM/state metadata only, never Cloud Run/GKE releases or secret values; and
- add a credentials-free GitHub workflow that validates the source and produces an offline empty plan from a temporary backend-free copy.

## Why

Omi's durable identity and IAM control plane needs a reviewable source of truth, while GitHub workflows remain the sole Cloud Run/GKE release writers. This establishes that boundary before a development WIF pilot.

## Scope and safety

No GCP resource, state bucket, IAM binding, WIF provider, secret, Cloud Run/GKE release surface, or GitHub environment was changed. The workflow has `contents: read` only; the repository guard rejects GCP auth, OIDC tokens, `gcloud`, `tofu apply`, Cloud Run/GKE resources, data sources, and Secret Manager payload/version paths.

## Verification

- `python3 .github/scripts/test_check_opentofu_foundation.py` — 10 fixture tests passed.
- `python3 .github/scripts/check_opentofu_foundation.py --plan-json /tmp/omi-opentofu.wkAqDX/foundation-clean-plan.json` — source and empty-plan boundary passed.
- Checksum-verified OpenTofu 1.12.4: `init -backend=false`, `validate`, and a credentials-free offline `plan -refresh=false -lock=false` — passed with `No changes`.
- `actionlint -shellcheck '' .github/workflows/opentofu-foundation-validate.yml` — passed.
- `make preflight` and pre-push deterministic checks — passed (12 manifest checks selected).

No product invariants apply to these paths.

Refs #9842.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

