### PR TITLE
build(devops): add dev WIF read-only plan pilot

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -92,6 +92,16 @@ checks:
     triggers: ["infrastructure/opentofu/**", ".github/scripts/check_opentofu_foundation.py", ".github/scripts/test_check_opentofu_foundation.py", ".github/workflows/opentofu-foundation-validate.yml"]
     lanes: ["local", "ci"]
     reason: "OpenTofu foundation boundary fixtures must reject release and secret-value ownership"
+  - id: opentofu-development-wif-pilot
+    command: ["python3", ".github/scripts/check_opentofu_development_wif_pilot.py"]
+    triggers: ["infrastructure/opentofu/pilots/development-wif-plan/**", "infrastructure/opentofu/probes/development-project-read/**", ".github/scripts/check_opentofu_development_wif_pilot.py", ".github/workflows/opentofu-development-wif-pilot.yml", ".github/workflows/opentofu-development-wif-pilot-validate.yml"]
+    lanes: ["local", "ci"]
+    reason: "development WIF pilot stays read-only, GitHub-main-scoped, and outside release ownership"
+  - id: opentofu-development-wif-pilot-fixtures
+    command: ["python3", ".github/scripts/test_check_opentofu_development_wif_pilot.py"]
+    triggers: ["infrastructure/opentofu/pilots/development-wif-plan/**", "infrastructure/opentofu/probes/development-project-read/**", ".github/scripts/check_opentofu_development_wif_pilot.py", ".github/scripts/test_check_opentofu_development_wif_pilot.py", ".github/workflows/opentofu-development-wif-pilot.yml", ".github/workflows/opentofu-development-wif-pilot-validate.yml"]
+    lanes: ["local", "ci"]
+    reason: "development WIF pilot fixtures must reject secret access, apply, and scope expansion"
   - id: public-build-contract
     command: ["python3", ".github/scripts/check_public_build_contract.py"]
     triggers: [".github/actions/deploy-public-build/**", ".github/actions/prepare-public-build/**", ".github/actions/public-build-candidate-promotion/**", ".github/workflows/gcp_admin.yml", ".github/workflows/gcp_app.yml", ".github/workflows/gcp_frontend.yml", ".github/workflows/gcp_personas.yml", ".github/workflows/public-build-config-preflight.yml", ".github/scripts/check_public_build_contract.py", ".github/scripts/preflight_public_build_config.py", ".github/scripts/preflight_public_build_runtime.py", ".github/scripts/smoke_public_build_browser.py", ".github/scripts/test_check_public_build_contract.py", "config/public-build-contract.json", "config/public-build-values.json", "config/deployment-setting-classification.json", "web/admin/Dockerfile", "web/app/Dockerfile", "web/frontend/Dockerfile", "web/personas-open-source/Dockerfile", "web/admin/components/public-build-canary.tsx", "web/app/src/components/public-build-canary.tsx", "web/frontend/src/components/public-build-canary.tsx", "web/personas-open-source/src/components/public-build-canary.tsx"]

--- a/.github/scripts/check_opentofu_development_wif_pilot.py
+++ b/.github/scripts/check_opentofu_development_wif_pilot.py
@@ -3,26 +3,66 @@
 
 from __future__ import annotations
 
+import argparse
+import json
 import re
 import sys
 from pathlib import Path
+from typing import Any, Sequence
 
 
 ROOT = Path(__file__).resolve().parents[2]
-BOOTSTRAP = ROOT / "infrastructure" / "opentofu" / "pilots" / "development-wif-plan" / "main.tf"
-BOOTSTRAP_VARIABLES = ROOT / "infrastructure" / "opentofu" / "pilots" / "development-wif-plan" / "variables.tf"
-PROBE = ROOT / "infrastructure" / "opentofu" / "probes" / "development-project-read" / "main.tf"
+PILOT_DIR = ROOT / "infrastructure" / "opentofu" / "pilots" / "development-wif-plan"
+PROBE_DIR = ROOT / "infrastructure" / "opentofu" / "probes" / "development-project-read"
+BOOTSTRAP = PILOT_DIR / "main.tf"
+BOOTSTRAP_VARIABLES = PILOT_DIR / "variables.tf"
+PROBE = PROBE_DIR / "main.tf"
 WORKFLOW = ROOT / ".github" / "workflows" / "opentofu-development-wif-pilot.yml"
 VALIDATION_WORKFLOW = ROOT / ".github" / "workflows" / "opentofu-development-wif-pilot-validate.yml"
 
-EXPECTED_BOOTSTRAP_RESOURCES = {
-    "google_service_account.plan",
-    "google_iam_workload_identity_pool.github",
-    "google_iam_workload_identity_pool_provider.github",
-    "google_service_account_iam_member.github_plan_impersonation",
-    "google_project_iam_member.plan_project_browser",
-}
+EXPECTED_PILOT_FILES = frozenset({"main.tf", "variables.tf"})
+EXPECTED_PROBE_FILES = frozenset({"main.tf"})
+EXPECTED_BOOTSTRAP_RESOURCES = frozenset(
+    {
+        "google_service_account.plan",
+        "google_iam_workload_identity_pool.github",
+        "google_iam_workload_identity_pool_provider.github",
+        "google_service_account_iam_member.github_plan_impersonation",
+        "google_project_iam_member.plan_project_browser",
+    }
+)
 RESOURCE = re.compile(r'^\s*resource\s+"(?P<type>[^"]+)"\s+"(?P<name>[^"]+)"', re.MULTILINE)
+DATA = re.compile(r'^\s*data\s+"(?P<type>[^"]+)"\s+"(?P<name>[^"]+)"', re.MULTILINE)
+MODULE = re.compile(r'^\s*module\s+"(?P<name>[^"]+)"', re.MULTILINE)
+PROVIDER = re.compile(r'^\s*provider\s+"(?P<name>[^"]+)"', re.MULTILINE)
+PROVISIONER = re.compile(r'^\s*provisioner\s+"(?P<name>[^"]+)"', re.MULTILINE)
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def module_files(module_dir: Path) -> list[Path]:
+    return sorted(path for path in module_dir.rglob("*.tf") if path.is_file())
+
+
+def module_config_files(module_dir: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in module_dir.rglob("*")
+        if path.is_file() and (path.name.endswith(".tf") or path.name.endswith(".tf.json"))
+    )
+
+
+def check_module_files(module_dir: Path, expected_names: frozenset[str], label: str) -> list[str]:
+    names = {path.relative_to(module_dir).as_posix() for path in module_config_files(module_dir)}
+    if names != expected_names:
+        return [f"{label} files must be exactly {sorted(expected_names)}, found {sorted(names)}"]
+    return []
+
+
+def module_source(module_dir: Path) -> str:
+    return "\n".join(read(path) for path in module_files(module_dir))
 
 
 def resource_body(text: str, address: str) -> str | None:
@@ -35,24 +75,31 @@ def resource_body(text: str, address: str) -> str | None:
     return None if match is None else match.group("body")
 
 
-def read(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
-
-
 def check_bootstrap(text: str) -> list[str]:
     errors: list[str] = []
     resources = {f"{match.group('type')}.{match.group('name')}" for match in RESOURCE.finditer(text)}
     if resources != EXPECTED_BOOTSTRAP_RESOURCES:
         errors.append(f"bootstrap resources must be exactly {sorted(EXPECTED_BOOTSTRAP_RESOURCES)}")
-    if re.search(r"^\s*data\s+", text, re.MULTILINE):
+    if DATA.search(text):
         errors.append("bootstrap must not declare data sources")
+    if MODULE.search(text):
+        errors.append("bootstrap must not declare modules")
+    if PROVISIONER.search(text):
+        errors.append("bootstrap must not declare provisioners")
+    providers = {match.group("name") for match in PROVIDER.finditer(text)}
+    if providers != {"google"}:
+        errors.append("bootstrap must declare exactly one google provider")
     for required in (
         'backend "gcs" {}',
-        'project = var.project_id',
-        'roles/iam.workloadIdentityUser',
-        'roles/browser',
-        'assertion.ref == \'refs/heads/main\'',
-        'https://token.actions.githubusercontent.com',
+        "project = var.project_id",
+        "roles/iam.workloadIdentityUser",
+        "roles/browser",
+        "assertion.repository_id == '${var.github_repository_id}'",
+        "assertion.repository_owner_id == '${var.github_repository_owner_id}'",
+        "assertion.ref == 'refs/heads/main'",
+        "assertion.workflow_ref == '${var.github_workflow_ref}'",
+        "assertion.environment == 'development'",
+        "https://token.actions.githubusercontent.com",
     ):
         if required not in text:
             errors.append(f"bootstrap is missing required pilot contract {required!r}")
@@ -74,19 +121,21 @@ def check_bootstrap(text: str) -> list[str]:
             errors.append(f"bootstrap contains forbidden permission or release/secret-value reference {forbidden!r}")
 
     expected_blocks = {
-        "google_service_account.plan": ('account_id   = var.plan_service_account_id',),
-        "google_iam_workload_identity_pool.github": ('workload_identity_pool_id = var.workload_identity_pool_id',),
+        "google_service_account.plan": ("account_id   = var.plan_service_account_id",),
+        "google_iam_workload_identity_pool.github": ("workload_identity_pool_id = var.workload_identity_pool_id",),
         "google_iam_workload_identity_pool_provider.github": (
             "workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id",
             'workload_identity_pool_provider_id = "github"',
-            '"google.subject"       = "assertion.sub"',
-            '"attribute.repository" = "assertion.repository"',
-            "attribute_condition = \"assertion.repository == '${var.github_repository}' && assertion.ref == 'refs/heads/main'\"",
+            '"google.subject"                = "assertion.sub"',
+            '"attribute.repository_id"       = "assertion.repository_id"',
+            '"attribute.repository_owner_id" = "assertion.repository_owner_id"',
+            '"attribute.workflow_ref"        = "assertion.workflow_ref"',
+            '"attribute.environment"         = "assertion.environment"',
         ),
         "google_service_account_iam_member.github_plan_impersonation": (
             "service_account_id = google_service_account.plan.name",
             'role               = "roles/iam.workloadIdentityUser"',
-            "attribute.repository/${var.github_repository}",
+            "attribute.repository_id/${var.github_repository_id}",
         ),
         "google_project_iam_member.plan_project_browser": (
             "project = var.project_id",
@@ -106,11 +155,19 @@ def check_bootstrap(text: str) -> list[str]:
 
 def check_probe(text: str) -> list[str]:
     errors: list[str] = []
-    if re.search(r"^\s*resource\s+", text, re.MULTILINE):
+    if RESOURCE.search(text):
         errors.append("development probe must not declare resources")
+    if MODULE.search(text):
+        errors.append("development probe must not declare modules")
+    if PROVISIONER.search(text):
+        errors.append("development probe must not declare provisioners")
+    if {match.group("name") for match in PROVIDER.finditer(text)} != {"google"}:
+        errors.append("development probe must declare exactly one google provider")
     if len(re.findall(r'^\s*data\s+"google_project"\s+"development"', text, re.MULTILINE)) != 1:
         errors.append("development probe must contain exactly one google_project development data source")
-    for required in ('default     = "based-hardware-dev"', 'project = var.project_id', 'project_id = var.project_id'):
+    if len(list(DATA.finditer(text))) != 1:
+        errors.append("development probe must not contain other data sources")
+    for required in ('default     = "based-hardware-dev"', "project = var.project_id", "project_id = var.project_id"):
         if required not in text:
             errors.append(f"development probe is missing required contract {required!r}")
     if 'backend "gcs"' in text:
@@ -125,8 +182,12 @@ def check_bootstrap_variables(text: str) -> list[str]:
         'condition     = var.project_id == "based-hardware-dev"',
         'default     = "1031333818730"',
         'condition     = var.project_number == "1031333818730"',
-        'default     = "BasedHardware/omi"',
-        'condition     = var.github_repository == "BasedHardware/omi"',
+        'default     = "776121034"',
+        'condition     = var.github_repository_id == "776121034"',
+        'default     = "162546372"',
+        'condition     = var.github_repository_owner_id == "162546372"',
+        'default     = "BasedHardware/omi/.github/workflows/opentofu-development-wif-pilot.yml@refs/heads/main"',
+        'condition     = var.github_workflow_ref == "BasedHardware/omi/.github/workflows/opentofu-development-wif-pilot.yml@refs/heads/main"',
         'default     = "omi-opentofu-9842-dev"',
         'condition     = var.workload_identity_pool_id == "omi-opentofu-9842-dev"',
         'default     = "omi-tofu-plan-dev-9842"',
@@ -134,6 +195,34 @@ def check_bootstrap_variables(text: str) -> list[str]:
     ):
         if required not in text:
             errors.append(f"bootstrap variables are missing immutable pilot contract {required!r}")
+    return errors
+
+
+def check_plan(plan: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    changes = plan.get("resource_changes")
+    if not isinstance(changes, list):
+        return ["bootstrap plan resource_changes must be a list"]
+
+    actual: dict[str, list[str]] = {}
+    for change in changes:
+        if not isinstance(change, dict):
+            errors.append("bootstrap plan contains a malformed resource change")
+            continue
+        address = change.get("address")
+        action = change.get("change", {}).get("actions") if isinstance(change.get("change"), dict) else None
+        if not isinstance(address, str) or not isinstance(action, list) or not all(isinstance(item, str) for item in action):
+            errors.append("bootstrap plan contains a malformed address or action")
+            continue
+        if address in actual:
+            errors.append(f"bootstrap plan contains duplicate change {address}")
+        actual[address] = action
+
+    if set(actual) != EXPECTED_BOOTSTRAP_RESOURCES:
+        errors.append(f"bootstrap plan resources must be exactly {sorted(EXPECTED_BOOTSTRAP_RESOURCES)}")
+    for address, actions in actual.items():
+        if actions != ["create"]:
+            errors.append(f"bootstrap plan {address} must have only a create action, found {actions}")
     return errors
 
 
@@ -169,9 +258,13 @@ def check_validation_workflow(text: str) -> list[str]:
         "-backend=false",
         "-lock=false",
         "-refresh=false",
+        "-out=",
+        "--plan-json",
     ):
         if required not in text:
             errors.append(f"pilot validation workflow is missing required offline contract {required!r}")
+    if not re.search(r"tofu\s+-chdir=[^\n]+\s+show\s+-json", text):
+        errors.append("pilot validation workflow is missing required offline plan JSON rendering")
     token_values = re.findall(r"^\s*GOOGLE_OAUTH_ACCESS_TOKEN:\s*(?P<value>\S.*)$", text, re.MULTILINE)
     if token_values != ["offline-validation-only"]:
         errors.append("pilot validation workflow may contain only the invalid offline-validation-only token literal")
@@ -191,14 +284,33 @@ def check_validation_workflow(text: str) -> list[str]:
     return errors
 
 
-def main() -> int:
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan-json", type=Path)
+    args = parser.parse_args(argv)
+
+    bootstrap = module_source(PILOT_DIR)
+    probe = module_source(PROBE_DIR)
     errors = (
-        check_bootstrap(read(BOOTSTRAP))
+        check_module_files(PILOT_DIR, EXPECTED_PILOT_FILES, "bootstrap")
+        + check_bootstrap(bootstrap)
         + check_bootstrap_variables(read(BOOTSTRAP_VARIABLES))
-        + check_probe(read(PROBE))
+        + check_module_files(PROBE_DIR, EXPECTED_PROBE_FILES, "development probe")
+        + check_probe(probe)
         + check_workflow(read(WORKFLOW))
         + check_validation_workflow(read(VALIDATION_WORKFLOW))
     )
+    if args.plan_json is not None:
+        try:
+            plan = json.loads(read(args.plan_json))
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"could not read bootstrap plan JSON {args.plan_json}: {exc}")
+        else:
+            if not isinstance(plan, dict):
+                errors.append(f"bootstrap plan JSON {args.plan_json} must be an object")
+            else:
+                errors.extend(check_plan(plan))
+
     if errors:
         print("Development WIF pilot check failed:", file=sys.stderr)
         print("\n".join(f"- {error}" for error in errors), file=sys.stderr)

--- a/.github/scripts/check_opentofu_development_wif_pilot.py
+++ b/.github/scripts/check_opentofu_development_wif_pilot.py
@@ -13,6 +13,7 @@ BOOTSTRAP = ROOT / "infrastructure" / "opentofu" / "pilots" / "development-wif-p
 BOOTSTRAP_VARIABLES = ROOT / "infrastructure" / "opentofu" / "pilots" / "development-wif-plan" / "variables.tf"
 PROBE = ROOT / "infrastructure" / "opentofu" / "probes" / "development-project-read" / "main.tf"
 WORKFLOW = ROOT / ".github" / "workflows" / "opentofu-development-wif-pilot.yml"
+VALIDATION_WORKFLOW = ROOT / ".github" / "workflows" / "opentofu-development-wif-pilot-validate.yml"
 
 EXPECTED_BOOTSTRAP_RESOURCES = {
     "google_service_account.plan",
@@ -159,12 +160,44 @@ def check_workflow(text: str) -> list[str]:
     return errors
 
 
+def check_validation_workflow(text: str) -> list[str]:
+    errors: list[str] = []
+    for required in (
+        "contents: read",
+        "GOOGLE_OAUTH_ACCESS_TOKEN: offline-validation-only",
+        "--prepare-offline-plan-module",
+        "-backend=false",
+        "-lock=false",
+        "-refresh=false",
+    ):
+        if required not in text:
+            errors.append(f"pilot validation workflow is missing required offline contract {required!r}")
+    token_values = re.findall(r"^\s*GOOGLE_OAUTH_ACCESS_TOKEN:\s*(?P<value>\S.*)$", text, re.MULTILINE)
+    if token_values != ["offline-validation-only"]:
+        errors.append("pilot validation workflow may contain only the invalid offline-validation-only token literal")
+    for forbidden in (
+        "credentials_json",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CREDENTIALS",
+        "google-github-actions/auth",
+        "id-token: write",
+        "workload_identity_provider",
+        "gcloud",
+        "tofu apply",
+        "backend-config",
+    ):
+        if forbidden in text:
+            errors.append(f"pilot validation workflow contains forbidden credential or mutation reference {forbidden!r}")
+    return errors
+
+
 def main() -> int:
     errors = (
         check_bootstrap(read(BOOTSTRAP))
         + check_bootstrap_variables(read(BOOTSTRAP_VARIABLES))
         + check_probe(read(PROBE))
         + check_workflow(read(WORKFLOW))
+        + check_validation_workflow(read(VALIDATION_WORKFLOW))
     )
     if errors:
         print("Development WIF pilot check failed:", file=sys.stderr)

--- a/.github/scripts/check_opentofu_development_wif_pilot.py
+++ b/.github/scripts/check_opentofu_development_wif_pilot.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Keep the #9842 development WIF plan pilot development-only and read-only."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BOOTSTRAP = ROOT / "infrastructure" / "opentofu" / "pilots" / "development-wif-plan" / "main.tf"
+BOOTSTRAP_VARIABLES = ROOT / "infrastructure" / "opentofu" / "pilots" / "development-wif-plan" / "variables.tf"
+PROBE = ROOT / "infrastructure" / "opentofu" / "probes" / "development-project-read" / "main.tf"
+WORKFLOW = ROOT / ".github" / "workflows" / "opentofu-development-wif-pilot.yml"
+
+EXPECTED_BOOTSTRAP_RESOURCES = {
+    "google_service_account.plan",
+    "google_iam_workload_identity_pool.github",
+    "google_iam_workload_identity_pool_provider.github",
+    "google_service_account_iam_member.github_plan_impersonation",
+    "google_project_iam_member.plan_project_browser",
+}
+RESOURCE = re.compile(r'^\s*resource\s+"(?P<type>[^"]+)"\s+"(?P<name>[^"]+)"', re.MULTILINE)
+
+
+def resource_body(text: str, address: str) -> str | None:
+    resource_type, name = address.split(".", maxsplit=1)
+    match = re.search(
+        rf'^\s*resource\s+"{re.escape(resource_type)}"\s+"{re.escape(name)}"\s*\{{(?P<body>.*?)(?=^\s*resource\s+|\Z)',
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    return None if match is None else match.group("body")
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def check_bootstrap(text: str) -> list[str]:
+    errors: list[str] = []
+    resources = {f"{match.group('type')}.{match.group('name')}" for match in RESOURCE.finditer(text)}
+    if resources != EXPECTED_BOOTSTRAP_RESOURCES:
+        errors.append(f"bootstrap resources must be exactly {sorted(EXPECTED_BOOTSTRAP_RESOURCES)}")
+    if re.search(r"^\s*data\s+", text, re.MULTILINE):
+        errors.append("bootstrap must not declare data sources")
+    for required in (
+        'backend "gcs" {}',
+        'project = var.project_id',
+        'roles/iam.workloadIdentityUser',
+        'roles/browser',
+        'assertion.ref == \'refs/heads/main\'',
+        'https://token.actions.githubusercontent.com',
+    ):
+        if required not in text:
+            errors.append(f"bootstrap is missing required pilot contract {required!r}")
+    for forbidden in (
+        "roles/owner",
+        "roles/editor",
+        "roles/viewer",
+        "roles/iam.securityReviewer",
+        "roles/secretmanager.viewer",
+        "roles/secretmanager.secretAccessor",
+        "roles/iam.serviceAccountTokenCreator",
+        "google_cloud_run_",
+        "google_container_",
+        "google_secret_manager_secret_version",
+        "secret_data",
+        "secret_string",
+    ):
+        if forbidden in text:
+            errors.append(f"bootstrap contains forbidden permission or release/secret-value reference {forbidden!r}")
+
+    expected_blocks = {
+        "google_service_account.plan": ('account_id   = var.plan_service_account_id',),
+        "google_iam_workload_identity_pool.github": ('workload_identity_pool_id = var.workload_identity_pool_id',),
+        "google_iam_workload_identity_pool_provider.github": (
+            "workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id",
+            'workload_identity_pool_provider_id = "github"',
+            '"google.subject"       = "assertion.sub"',
+            '"attribute.repository" = "assertion.repository"',
+            "attribute_condition = \"assertion.repository == '${var.github_repository}' && assertion.ref == 'refs/heads/main'\"",
+        ),
+        "google_service_account_iam_member.github_plan_impersonation": (
+            "service_account_id = google_service_account.plan.name",
+            'role               = "roles/iam.workloadIdentityUser"',
+            "attribute.repository/${var.github_repository}",
+        ),
+        "google_project_iam_member.plan_project_browser": (
+            "project = var.project_id",
+            'role    = "roles/browser"',
+            "member  = \"serviceAccount:${google_service_account.plan.email}\"",
+        ),
+    }
+    for address, required in expected_blocks.items():
+        body = resource_body(text, address)
+        if body is None:
+            continue
+        for expected in required:
+            if expected not in body:
+                errors.append(f"bootstrap {address} is missing required contract {expected!r}")
+    return errors
+
+
+def check_probe(text: str) -> list[str]:
+    errors: list[str] = []
+    if re.search(r"^\s*resource\s+", text, re.MULTILINE):
+        errors.append("development probe must not declare resources")
+    if len(re.findall(r'^\s*data\s+"google_project"\s+"development"', text, re.MULTILINE)) != 1:
+        errors.append("development probe must contain exactly one google_project development data source")
+    for required in ('default     = "based-hardware-dev"', 'project = var.project_id', 'project_id = var.project_id'):
+        if required not in text:
+            errors.append(f"development probe is missing required contract {required!r}")
+    if 'backend "gcs"' in text:
+        errors.append("development probe must not use a remote backend")
+    return errors
+
+
+def check_bootstrap_variables(text: str) -> list[str]:
+    errors: list[str] = []
+    for required in (
+        'default     = "based-hardware-dev"',
+        'condition     = var.project_id == "based-hardware-dev"',
+        'default     = "1031333818730"',
+        'condition     = var.project_number == "1031333818730"',
+        'default     = "BasedHardware/omi"',
+        'condition     = var.github_repository == "BasedHardware/omi"',
+        'default     = "omi-opentofu-9842-dev"',
+        'condition     = var.workload_identity_pool_id == "omi-opentofu-9842-dev"',
+        'default     = "omi-tofu-plan-dev-9842"',
+        'condition     = var.plan_service_account_id == "omi-tofu-plan-dev-9842"',
+    ):
+        if required not in text:
+            errors.append(f"bootstrap variables are missing immutable pilot contract {required!r}")
+    return errors
+
+
+def check_workflow(text: str) -> list[str]:
+    errors: list[str] = []
+    for required in (
+        "workflow_dispatch:",
+        "environment: development",
+        "contents: read",
+        "id-token: write",
+        "google-github-actions/auth@v2",
+        "workload_identity_provider: projects/1031333818730/locations/global/workloadIdentityPools/omi-opentofu-9842-dev/providers/github",
+        "service_account: omi-tofu-plan-dev-9842@based-hardware-dev.iam.gserviceaccount.com",
+        "ref: main",
+        "-backend=false",
+        "-lock=false",
+        "-refresh=false",
+    ):
+        if required not in text:
+            errors.append(f"pilot workflow is missing required read-only development contract {required!r}")
+    for forbidden in ("credentials_json", "gcloud", "tofu apply", "backend-config", "environment: prod"):
+        if forbidden in text:
+            errors.append(f"pilot workflow contains forbidden reference {forbidden!r}")
+    return errors
+
+
+def main() -> int:
+    errors = (
+        check_bootstrap(read(BOOTSTRAP))
+        + check_bootstrap_variables(read(BOOTSTRAP_VARIABLES))
+        + check_probe(read(PROBE))
+        + check_workflow(read(WORKFLOW))
+    )
+    if errors:
+        print("Development WIF pilot check failed:", file=sys.stderr)
+        print("\n".join(f"- {error}" for error in errors), file=sys.stderr)
+        return 1
+    print("Development WIF pilot check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_check_opentofu_development_wif_pilot.py
+++ b/.github/scripts/test_check_opentofu_development_wif_pilot.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -41,6 +42,35 @@ class DevelopmentWifPilotFixture(unittest.TestCase):
         source = CHECKER.read(CHECKER.BOOTSTRAP_VARIABLES)
         errors = CHECKER.check_bootstrap_variables(source.replace('default     = "based-hardware-dev"', 'default     = "based-hardware"'))
         self.assertIn("based-hardware-dev", "\n".join(errors))
+
+    def test_bootstrap_rejects_non_immutable_github_identity(self) -> None:
+        source = CHECKER.read(CHECKER.BOOTSTRAP)
+        errors = CHECKER.check_bootstrap(source.replace("assertion.repository_id", "assertion.repository", 1))
+        self.assertIn("repository_id", "\n".join(errors))
+
+    def test_bootstrap_rejects_extra_open_tofu_files(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="omi-opentofu-pilot-") as temp_dir:
+            module_dir = Path(temp_dir)
+            for name in ("main.tf", "variables.tf", "elevated.tf", "hidden.tf.json"):
+                (module_dir / name).touch()
+            errors = CHECKER.check_module_files(module_dir, CHECKER.EXPECTED_PILOT_FILES, "bootstrap")
+        self.assertIn("elevated.tf", "\n".join(errors))
+        self.assertIn("hidden.tf.json", "\n".join(errors))
+
+    def test_bootstrap_plan_requires_exact_creates(self) -> None:
+        plan = {
+            "resource_changes": [
+                {"address": address, "change": {"actions": ["create"]}}
+                for address in sorted(CHECKER.EXPECTED_BOOTSTRAP_RESOURCES)
+            ]
+        }
+        self.assertEqual(CHECKER.check_plan(plan), [])
+
+        plan["resource_changes"].append(
+            {"address": "google_project_iam_member.escalation", "change": {"actions": ["create"]}}
+        )
+        errors = CHECKER.check_plan(plan)
+        self.assertIn("must be exactly", "\n".join(errors))
 
     def test_probe_rejects_resources_and_remote_state(self) -> None:
         source = CHECKER.read(CHECKER.PROBE)

--- a/.github/scripts/test_check_opentofu_development_wif_pilot.py
+++ b/.github/scripts/test_check_opentofu_development_wif_pilot.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Fixture tests for the development WIF plan pilot guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER_PATH = ROOT / ".github" / "scripts" / "check_opentofu_development_wif_pilot.py"
+SPEC = importlib.util.spec_from_file_location("opentofu_development_wif_pilot", CHECKER_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load {CHECKER_PATH}")
+CHECKER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CHECKER
+SPEC.loader.exec_module(CHECKER)
+
+
+class DevelopmentWifPilotFixture(unittest.TestCase):
+    def test_checked_in_pilot_contract_passes(self) -> None:
+        self.assertEqual(CHECKER.main(), 0)
+
+    def test_bootstrap_rejects_broad_or_secret_access(self) -> None:
+        source = CHECKER.read(CHECKER.BOOTSTRAP)
+        self.assertIn("roles/owner", "\n".join(CHECKER.check_bootstrap(source + '\nrole = "roles/owner"\n')))
+        self.assertIn(
+            "roles/secretmanager.secretAccessor",
+            "\n".join(CHECKER.check_bootstrap(source + '\nrole = "roles/secretmanager.secretAccessor"\n')),
+        )
+
+    def test_bootstrap_rejects_a_broadened_browser_binding(self) -> None:
+        source = CHECKER.read(CHECKER.BOOTSTRAP)
+        errors = CHECKER.check_bootstrap(source.replace('role    = "roles/browser"', 'role    = "roles/viewer"'))
+        self.assertIn("roles/viewer", "\n".join(errors))
+        self.assertIn("plan_project_browser", "\n".join(errors))
+
+    def test_bootstrap_variables_reject_production_project(self) -> None:
+        source = CHECKER.read(CHECKER.BOOTSTRAP_VARIABLES)
+        errors = CHECKER.check_bootstrap_variables(source.replace('default     = "based-hardware-dev"', 'default     = "based-hardware"'))
+        self.assertIn("based-hardware-dev", "\n".join(errors))
+
+    def test_probe_rejects_resources_and_remote_state(self) -> None:
+        source = CHECKER.read(CHECKER.PROBE)
+        errors = CHECKER.check_probe(source + '\nresource "google_cloud_run_v2_service" "forbidden" {}\nbackend "gcs" {}\n')
+        self.assertIn("must not declare resources", "\n".join(errors))
+        self.assertIn("must not use a remote backend", "\n".join(errors))
+
+    def test_workflow_rejects_apply_and_key_credentials(self) -> None:
+        source = CHECKER.read(CHECKER.WORKFLOW)
+        errors = CHECKER.check_workflow(source + "\ntofu apply\ncredentials_json: ${{ secrets.GCP_CREDENTIALS }}\n")
+        self.assertIn("tofu apply", "\n".join(errors))
+        self.assertIn("credentials_json", "\n".join(errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_check_opentofu_development_wif_pilot.py
+++ b/.github/scripts/test_check_opentofu_development_wif_pilot.py
@@ -54,6 +54,13 @@ class DevelopmentWifPilotFixture(unittest.TestCase):
         self.assertIn("tofu apply", "\n".join(errors))
         self.assertIn("credentials_json", "\n".join(errors))
 
+    def test_validation_workflow_rejects_real_or_extra_credentials(self) -> None:
+        source = CHECKER.read(CHECKER.VALIDATION_WORKFLOW)
+        errors = CHECKER.check_validation_workflow(source.replace("offline-validation-only", "not-a-sentinel"))
+        self.assertIn("offline-validation-only", "\n".join(errors))
+        errors = CHECKER.check_validation_workflow(source + "\nGOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}\n")
+        self.assertIn("GOOGLE_APPLICATION_CREDENTIALS", "\n".join(errors))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/opentofu-development-wif-pilot-validate.yml
+++ b/.github/workflows/opentofu-development-wif-pilot-validate.yml
@@ -43,6 +43,10 @@ jobs:
         run: python3 .github/scripts/check_opentofu_development_wif_pilot.py
 
       - name: Validate bootstrap source without a remote backend
+        env:
+          # This invalid literal satisfies provider initialization only. The
+          # backend-free, no-refresh plan has no API path and cannot mutate GCP.
+          GOOGLE_OAUTH_ACCESS_TOKEN: offline-validation-only
         run: |
           export TF_DATA_DIR="${RUNNER_TEMP}/opentofu-development-wif-bootstrap"
           python3 .github/scripts/check_opentofu_foundation.py \

--- a/.github/workflows/opentofu-development-wif-pilot-validate.yml
+++ b/.github/workflows/opentofu-development-wif-pilot-validate.yml
@@ -58,7 +58,13 @@ jobs:
             -input=false \
             -lock=false \
             -refresh=false \
+            -out="${RUNNER_TEMP}/opentofu-development-wif-bootstrap.tfplan" \
             -no-color
+          tofu -chdir="${RUNNER_TEMP}/opentofu-development-wif-bootstrap-copy" show -json \
+            "${RUNNER_TEMP}/opentofu-development-wif-bootstrap.tfplan" \
+            > "${RUNNER_TEMP}/opentofu-development-wif-bootstrap.json"
+          python3 .github/scripts/check_opentofu_development_wif_pilot.py \
+            --plan-json "${RUNNER_TEMP}/opentofu-development-wif-bootstrap.json"
 
       - name: Validate read-only probe source
         run: |

--- a/.github/workflows/opentofu-development-wif-pilot-validate.yml
+++ b/.github/workflows/opentofu-development-wif-pilot-validate.yml
@@ -1,0 +1,63 @@
+name: OpenTofu Development WIF Pilot Validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/scripts/check_opentofu_development_wif_pilot.py"
+      - ".github/scripts/test_check_opentofu_development_wif_pilot.py"
+      - ".github/workflows/opentofu-development-wif-pilot.yml"
+      - ".github/workflows/opentofu-development-wif-pilot-validate.yml"
+      - "infrastructure/opentofu/pilots/development-wif-plan/**"
+      - "infrastructure/opentofu/probes/development-project-read/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/scripts/check_opentofu_development_wif_pilot.py"
+      - ".github/scripts/test_check_opentofu_development_wif_pilot.py"
+      - ".github/workflows/opentofu-development-wif-pilot.yml"
+      - ".github/workflows/opentofu-development-wif-pilot-validate.yml"
+      - "infrastructure/opentofu/pilots/development-wif-plan/**"
+      - "infrastructure/opentofu/probes/development-project-read/**"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-development-pilot:
+    runs-on: ubuntu-latest
+    env:
+      TF_IN_AUTOMATION: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: 1.12.4
+          tofu_wrapper: false
+
+      - name: Test development pilot guard
+        run: python3 .github/scripts/test_check_opentofu_development_wif_pilot.py
+
+      - name: Check development pilot boundary
+        run: python3 .github/scripts/check_opentofu_development_wif_pilot.py
+
+      - name: Validate bootstrap source without a remote backend
+        run: |
+          export TF_DATA_DIR="${RUNNER_TEMP}/opentofu-development-wif-bootstrap"
+          python3 .github/scripts/check_opentofu_foundation.py \
+            --module-dir infrastructure/opentofu/pilots/development-wif-plan \
+            --prepare-offline-plan-module "${RUNNER_TEMP}/opentofu-development-wif-bootstrap-copy"
+          tofu -chdir="${RUNNER_TEMP}/opentofu-development-wif-bootstrap-copy" init -backend=false -input=false -no-color
+          tofu -chdir="${RUNNER_TEMP}/opentofu-development-wif-bootstrap-copy" validate -no-color
+          tofu -chdir="${RUNNER_TEMP}/opentofu-development-wif-bootstrap-copy" plan \
+            -input=false \
+            -lock=false \
+            -refresh=false \
+            -no-color
+
+      - name: Validate read-only probe source
+        run: |
+          export TF_DATA_DIR="${RUNNER_TEMP}/opentofu-development-wif-probe"
+          tofu -chdir=infrastructure/opentofu/probes/development-project-read init -backend=false -input=false -no-color
+          tofu -chdir=infrastructure/opentofu/probes/development-project-read validate -no-color

--- a/.github/workflows/opentofu-development-wif-pilot.yml
+++ b/.github/workflows/opentofu-development-wif-pilot.yml
@@ -1,0 +1,45 @@
+name: OpenTofu Development WIF Pilot
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: opentofu-development-wif-pilot
+  cancel-in-progress: false
+
+jobs:
+  read-only-plan:
+    environment: development
+    runs-on: ubuntu-latest
+    env:
+      TF_IN_AUTOMATION: "true"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Authenticate with development WIF plan identity
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/1031333818730/locations/global/workloadIdentityPools/omi-opentofu-9842-dev/providers/github
+          service_account: omi-tofu-plan-dev-9842@based-hardware-dev.iam.gserviceaccount.com
+
+      - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: 1.12.4
+          tofu_wrapper: false
+
+      - name: Run a development-only read-only OpenTofu probe
+        run: |
+          export TF_DATA_DIR="${RUNNER_TEMP}/opentofu-development-wif-pilot"
+          tofu -chdir=infrastructure/opentofu/probes/development-project-read init -backend=false -input=false -no-color
+          tofu -chdir=infrastructure/opentofu/probes/development-project-read validate -no-color
+          tofu -chdir=infrastructure/opentofu/probes/development-project-read plan \
+            -input=false \
+            -lock=false \
+            -refresh=false \
+            -no-color

--- a/infrastructure/opentofu/README.md
+++ b/infrastructure/opentofu/README.md
@@ -27,3 +27,19 @@ It then checks the generated plan is empty. `check_opentofu_foundation.py` allow
 ## State bootstrap and live pilot
 
 The `.backend.hcl.example` files are placeholders, not executable configuration. Follow the staged manual work recorded in [issue #9842](https://github.com/BasedHardware/omi/issues/9842) before initializing a real backend or authenticating a plan. Keep development and production state isolated, and never add secret payloads, secret-version resources, or secret-value data sources to this module.
+
+## Development WIF proof pilot
+
+`pilots/development-wif-plan` is intentionally not a general infrastructure
+module. It defines one development-only bootstrap: a dedicated GitHub WIF pool,
+one plan service account, its WIF impersonation binding, and project-level
+`roles/browser`. Its immutable variables reject any project other than
+`based-hardware-dev`; its provider accepts only `BasedHardware/omi` `main`.
+
+An approved development operator applies that bootstrap only after creating a
+separate versioned state bucket. Then `OpenTofu Development WIF Pilot` can
+exchange its GitHub OIDC token and run the data-only
+`probes/development-project-read` plan. The probe has no resources, remote
+backend, refresh, lock, or apply path. The pilot guard and fixture tests reject
+production scope, broader roles, secret access, release ownership, long-lived
+credentials, and `tofu apply`.

--- a/infrastructure/opentofu/README.md
+++ b/infrastructure/opentofu/README.md
@@ -34,7 +34,8 @@ The `.backend.hcl.example` files are placeholders, not executable configuration.
 module. It defines one development-only bootstrap: a dedicated GitHub WIF pool,
 one plan service account, its WIF impersonation binding, and project-level
 `roles/browser`. Its immutable variables reject any project other than
-`based-hardware-dev`; its provider accepts only `BasedHardware/omi` `main`.
+`based-hardware-dev`; its provider accepts only Omi's immutable GitHub
+repository/owner IDs, dedicated workflow, `development` environment, and `main`.
 
 An approved development operator applies that bootstrap only after creating a
 separate versioned state bucket. Then `OpenTofu Development WIF Pilot` can
@@ -48,4 +49,5 @@ The credentials-free validation workflow supplies exactly one checked-in,
 invalid `offline-validation-only` token literal to satisfy Google-provider
 initialization for the bootstrap's backend-free, no-refresh plan. It cannot
 authenticate to GCP, and the guard rejects any real credential source or a
-different token value.
+different token value. CI saves the plan and accepts exactly the five approved
+create actions, not merely any successful non-empty plan.

--- a/infrastructure/opentofu/README.md
+++ b/infrastructure/opentofu/README.md
@@ -43,3 +43,9 @@ exchange its GitHub OIDC token and run the data-only
 backend, refresh, lock, or apply path. The pilot guard and fixture tests reject
 production scope, broader roles, secret access, release ownership, long-lived
 credentials, and `tofu apply`.
+
+The credentials-free validation workflow supplies exactly one checked-in,
+invalid `offline-validation-only` token literal to satisfy Google-provider
+initialization for the bootstrap's backend-free, no-refresh plan. It cannot
+authenticate to GCP, and the guard rejects any real credential source or a
+different token value.

--- a/infrastructure/opentofu/pilots/development-wif-plan/.terraform.lock.hcl
+++ b/infrastructure/opentofu/pilots/development-wif-plan/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:0qkP2yFo87EamHXoV0cK2w6hADP2grd+ZfzAixUPDSw=",
+    "h1:22CAxZ/tGKrnH+5+Cg3DM18S/OvpJZrVMRzp3A40h7Y=",
+    "h1:IH3uigEekXZECc3XgxC771MS1u32uWq5RHmZtVBsau8=",
+    "h1:Jw+wqWmsOFONn1I4BVShIkywBAu25VXfTvPBiQJRYYA=",
+    "h1:LxtuVWb0Y6r8I3RsQ8dgXozVzeG1rzFDnCav5EkZCoc=",
+    "h1:MAAe4zFFdqS9M5rpmJK/vKgdb6ZMD/s/0Xd97yTDipA=",
+    "h1:O5jnIJXJcM6QWNYDPJAeR/yD01GfvrX4q4X6yLg9Afg=",
+    "h1:ULGxKibTy8Z9F3roMLNFiPgw+MDs7FYuOdiy+Oispi8=",
+    "h1:WO2Jt6hHnY9lvpUdUdhnZ318vq4xPq3R4WYmQ2u7QpU=",
+    "h1:YS1XbzFYWp1xFGo8XyI6TrDrKoz4Ka4CVaeTpPI6xOY=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}

--- a/infrastructure/opentofu/pilots/development-wif-plan/README.md
+++ b/infrastructure/opentofu/pilots/development-wif-plan/README.md
@@ -14,6 +14,11 @@ Account Token Creator role, and no ability to deploy Cloud Run/GKE resources.
 The GitHub workflow performs a read-only `google_project` data-source plan with
 no remote backend, refresh, lock, or apply path.
 
+The separate validation workflow uses a single checked-in,
+`offline-validation-only` token literal solely to initialize the Google provider
+for the bootstrap's backend-free, no-refresh plan. It is invalid for GCP and
+the guard rejects any different token or credential source.
+
 ## Operator bootstrap
 
 This PR does not apply the module. A separately approved development operator must first create a dedicated, versioned GCS state bucket with uniform bucket-level access and retain its name outside source control. Then the operator initializes this module with the reviewed bucket config, runs a saved plan, and applies that saved plan using a write-capable development-only identity.

--- a/infrastructure/opentofu/pilots/development-wif-plan/README.md
+++ b/infrastructure/opentofu/pilots/development-wif-plan/README.md
@@ -3,11 +3,13 @@
 This module creates exactly one development-only GitHub Workload Identity Federation path for issue #9842:
 
 - pool: `omi-opentofu-9842-dev`;
-- provider: GitHub OIDC, restricted to `BasedHardware/omi` on `main`;
+- provider: GitHub OIDC, restricted to immutable repository ID `776121034`,
+  owner ID `162546372`, the dedicated workflow, `development` environment, and
+  `main`;
 - service account: `omi-tofu-plan-dev-9842@based-hardware-dev.iam.gserviceaccount.com`; and
-- grant: project-level `roles/browser` only, which is sufficient for the
-  probe's `resourcemanager.projects.get` call and does not grant access to
-  resources in the project.
+- grant: project-level `roles/browser` only. It does not grant access to
+  project resources, but it does allow the probe's `resourcemanager.projects.get`
+  call and project IAM-policy metadata reads.
 
 It deliberately grants no Secret Manager role, no Storage write role, no Service
 Account Token Creator role, and no ability to deploy Cloud Run/GKE resources.
@@ -17,7 +19,8 @@ no remote backend, refresh, lock, or apply path.
 The separate validation workflow uses a single checked-in,
 `offline-validation-only` token literal solely to initialize the Google provider
 for the bootstrap's backend-free, no-refresh plan. It is invalid for GCP and
-the guard rejects any different token or credential source.
+the guard rejects any different token or credential source. It saves the plan
+and asserts that it has exactly the five approved creates before CI passes.
 
 ## Operator bootstrap
 

--- a/infrastructure/opentofu/pilots/development-wif-plan/README.md
+++ b/infrastructure/opentofu/pilots/development-wif-plan/README.md
@@ -1,0 +1,27 @@
+# Development WIF read-only plan pilot
+
+This module creates exactly one development-only GitHub Workload Identity Federation path for issue #9842:
+
+- pool: `omi-opentofu-9842-dev`;
+- provider: GitHub OIDC, restricted to `BasedHardware/omi` on `main`;
+- service account: `omi-tofu-plan-dev-9842@based-hardware-dev.iam.gserviceaccount.com`; and
+- grant: project-level `roles/browser` only, which is sufficient for the
+  probe's `resourcemanager.projects.get` call and does not grant access to
+  resources in the project.
+
+It deliberately grants no Secret Manager role, no Storage write role, no Service
+Account Token Creator role, and no ability to deploy Cloud Run/GKE resources.
+The GitHub workflow performs a read-only `google_project` data-source plan with
+no remote backend, refresh, lock, or apply path.
+
+## Operator bootstrap
+
+This PR does not apply the module. A separately approved development operator must first create a dedicated, versioned GCS state bucket with uniform bucket-level access and retain its name outside source control. Then the operator initializes this module with the reviewed bucket config, runs a saved plan, and applies that saved plan using a write-capable development-only identity.
+
+After the bootstrap read-back confirms the provider, service account, and one
+`roles/browser` grant, dispatch `OpenTofu Development WIF Pilot` from `main`.
+Its expected proof is successful GitHub OIDC exchange plus a `google_project`
+read of `based-hardware-dev`. Record the workflow URL and metadata-only
+read-back on [issue #9842](https://github.com/BasedHardware/omi/issues/9842).
+
+Do not import existing resources, add a production backend config, or run this module against `based-hardware`.

--- a/infrastructure/opentofu/pilots/development-wif-plan/main.tf
+++ b/infrastructure/opentofu/pilots/development-wif-plan/main.tf
@@ -1,0 +1,61 @@
+terraform {
+  required_version = ">= 1.12.4, < 2.0.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+
+  # The operator supplies a reviewed development-only GCS backend config when
+  # bootstrapping this pilot. CI always removes this block in its temporary copy.
+  backend "gcs" {}
+}
+
+provider "google" {
+  project = var.project_id
+}
+
+resource "google_service_account" "plan" {
+  account_id   = var.plan_service_account_id
+  display_name = "Omi OpenTofu development plan pilot"
+  description  = "Read-only GitHub WIF identity for OpenTofu development pilot #9842."
+}
+
+resource "google_iam_workload_identity_pool" "github" {
+  workload_identity_pool_id = var.workload_identity_pool_id
+  display_name              = "Omi OpenTofu development GitHub pool"
+  description               = "GitHub OIDC pool for Omi OpenTofu development pilot #9842."
+  disabled                  = false
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github"
+  display_name                       = "Omi GitHub Actions development plan provider"
+  description                        = "Restricts the development plan identity to BasedHardware/omi main."
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+  }
+
+  attribute_condition = "assertion.repository == '${var.github_repository}' && assertion.ref == 'refs/heads/main'"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+resource "google_service_account_iam_member" "github_plan_impersonation" {
+  service_account_id = google_service_account.plan.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repository}"
+}
+
+resource "google_project_iam_member" "plan_project_browser" {
+  project = var.project_id
+  role    = "roles/browser"
+  member  = "serviceAccount:${google_service_account.plan.email}"
+}

--- a/infrastructure/opentofu/pilots/development-wif-plan/main.tf
+++ b/infrastructure/opentofu/pilots/development-wif-plan/main.tf
@@ -34,14 +34,17 @@ resource "google_iam_workload_identity_pool_provider" "github" {
   workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
   workload_identity_pool_provider_id = "github"
   display_name                       = "Omi GitHub Actions development plan provider"
-  description                        = "Restricts the development plan identity to BasedHardware/omi main."
+  description                        = "Restricts the development plan identity to Omi's immutable GitHub identity, workflow, environment, and main."
 
   attribute_mapping = {
-    "google.subject"       = "assertion.sub"
-    "attribute.repository" = "assertion.repository"
+    "google.subject"                = "assertion.sub"
+    "attribute.repository_id"       = "assertion.repository_id"
+    "attribute.repository_owner_id" = "assertion.repository_owner_id"
+    "attribute.workflow_ref"        = "assertion.workflow_ref"
+    "attribute.environment"         = "assertion.environment"
   }
 
-  attribute_condition = "assertion.repository == '${var.github_repository}' && assertion.ref == 'refs/heads/main'"
+  attribute_condition = "assertion.repository_id == '${var.github_repository_id}' && assertion.repository_owner_id == '${var.github_repository_owner_id}' && assertion.ref == 'refs/heads/main' && assertion.workflow_ref == '${var.github_workflow_ref}' && assertion.environment == 'development'"
 
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"
@@ -51,7 +54,7 @@ resource "google_iam_workload_identity_pool_provider" "github" {
 resource "google_service_account_iam_member" "github_plan_impersonation" {
   service_account_id = google_service_account.plan.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repository}"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository_id/${var.github_repository_id}"
 }
 
 resource "google_project_iam_member" "plan_project_browser" {

--- a/infrastructure/opentofu/pilots/development-wif-plan/variables.tf
+++ b/infrastructure/opentofu/pilots/development-wif-plan/variables.tf
@@ -20,14 +20,36 @@ variable "project_number" {
   }
 }
 
-variable "github_repository" {
+variable "github_repository_id" {
   type        = string
-  description = "The only GitHub repository allowed to exchange this identity."
-  default     = "BasedHardware/omi"
+  description = "The immutable GitHub repository ID allowed to exchange this identity."
+  default     = "776121034"
 
   validation {
-    condition     = var.github_repository == "BasedHardware/omi"
-    error_message = "The WIF pilot must remain restricted to BasedHardware/omi."
+    condition     = var.github_repository_id == "776121034"
+    error_message = "The WIF pilot must remain restricted to Omi's immutable GitHub repository ID."
+  }
+}
+
+variable "github_repository_owner_id" {
+  type        = string
+  description = "The immutable GitHub organization ID that owns the allowed repository."
+  default     = "162546372"
+
+  validation {
+    condition     = var.github_repository_owner_id == "162546372"
+    error_message = "The WIF pilot must remain restricted to BasedHardware's immutable GitHub organization ID."
+  }
+}
+
+variable "github_workflow_ref" {
+  type        = string
+  description = "The only GitHub Actions workflow that may exchange the pilot identity."
+  default     = "BasedHardware/omi/.github/workflows/opentofu-development-wif-pilot.yml@refs/heads/main"
+
+  validation {
+    condition     = var.github_workflow_ref == "BasedHardware/omi/.github/workflows/opentofu-development-wif-pilot.yml@refs/heads/main"
+    error_message = "The WIF pilot must remain restricted to its dedicated main-branch workflow."
   }
 }
 

--- a/infrastructure/opentofu/pilots/development-wif-plan/variables.tf
+++ b/infrastructure/opentofu/pilots/development-wif-plan/variables.tf
@@ -1,0 +1,54 @@
+variable "project_id" {
+  type        = string
+  description = "The development-only GCP project for the pilot."
+  default     = "based-hardware-dev"
+
+  validation {
+    condition     = var.project_id == "based-hardware-dev"
+    error_message = "The WIF pilot may target only based-hardware-dev."
+  }
+}
+
+variable "project_number" {
+  type        = string
+  description = "The immutable project number for based-hardware-dev."
+  default     = "1031333818730"
+
+  validation {
+    condition     = var.project_number == "1031333818730"
+    error_message = "The WIF pilot may target only the based-hardware-dev project number."
+  }
+}
+
+variable "github_repository" {
+  type        = string
+  description = "The only GitHub repository allowed to exchange this identity."
+  default     = "BasedHardware/omi"
+
+  validation {
+    condition     = var.github_repository == "BasedHardware/omi"
+    error_message = "The WIF pilot must remain restricted to BasedHardware/omi."
+  }
+}
+
+variable "workload_identity_pool_id" {
+  type        = string
+  description = "Dedicated development WIF pool name."
+  default     = "omi-opentofu-9842-dev"
+
+  validation {
+    condition     = var.workload_identity_pool_id == "omi-opentofu-9842-dev"
+    error_message = "The pilot must use its dedicated development WIF pool."
+  }
+}
+
+variable "plan_service_account_id" {
+  type        = string
+  description = "Dedicated development-only read-only plan service account name."
+  default     = "omi-tofu-plan-dev-9842"
+
+  validation {
+    condition     = var.plan_service_account_id == "omi-tofu-plan-dev-9842"
+    error_message = "The pilot must use its dedicated development plan service account."
+  }
+}

--- a/infrastructure/opentofu/probes/development-project-read/.terraform.lock.hcl
+++ b/infrastructure/opentofu/probes/development-project-read/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:0qkP2yFo87EamHXoV0cK2w6hADP2grd+ZfzAixUPDSw=",
+    "h1:22CAxZ/tGKrnH+5+Cg3DM18S/OvpJZrVMRzp3A40h7Y=",
+    "h1:IH3uigEekXZECc3XgxC771MS1u32uWq5RHmZtVBsau8=",
+    "h1:Jw+wqWmsOFONn1I4BVShIkywBAu25VXfTvPBiQJRYYA=",
+    "h1:LxtuVWb0Y6r8I3RsQ8dgXozVzeG1rzFDnCav5EkZCoc=",
+    "h1:MAAe4zFFdqS9M5rpmJK/vKgdb6ZMD/s/0Xd97yTDipA=",
+    "h1:O5jnIJXJcM6QWNYDPJAeR/yD01GfvrX4q4X6yLg9Afg=",
+    "h1:ULGxKibTy8Z9F3roMLNFiPgw+MDs7FYuOdiy+Oispi8=",
+    "h1:WO2Jt6hHnY9lvpUdUdhnZ318vq4xPq3R4WYmQ2u7QpU=",
+    "h1:YS1XbzFYWp1xFGo8XyI6TrDrKoz4Ka4CVaeTpPI6xOY=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}

--- a/infrastructure/opentofu/probes/development-project-read/main.tf
+++ b/infrastructure/opentofu/probes/development-project-read/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_version = ">= 1.12.4, < 2.0.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+variable "project_id" {
+  type        = string
+  description = "The project that the WIF plan pilot may read."
+  default     = "based-hardware-dev"
+
+  validation {
+    condition     = var.project_id == "based-hardware-dev"
+    error_message = "The pilot probe may read only based-hardware-dev."
+  }
+}
+
+provider "google" {
+  project = var.project_id
+}
+
+data "google_project" "development" {
+  project_id = var.project_id
+}
+
+output "project_number" {
+  value       = data.google_project.development.number
+  description = "Confirms the WIF principal can read the expected development project only."
+}


### PR DESCRIPTION
## Scope

Implements the development-only proof slice for #9842. It creates source code only; no GCP resources have been created or updated.

- Defines a five-resource bootstrap: dedicated GitHub WIF pool/provider, a dedicated development plan service account, its `workloadIdentityUser` binding, and project-level `roles/browser`.
- Locks the pilot to `based-hardware-dev` (project number `1031333818730`) and immutable GitHub repository ID `776121034`, owner ID `162546372`, the dedicated workflow, `development` environment, and `main`.
- Adds a manually dispatched workflow that exchanges GitHub OIDC only after bootstrap, then runs a data-only `google_project` plan with no remote backend, refresh, lock, or apply path.
- Adds an offline validation workflow plus static guard/fixtures that reject production scope, broader roles, secret access, release ownership, long-lived key credentials, extra OpenTofu files/providers/modules/provisioners, and `tofu apply`.
- Saves the offline bootstrap plan, renders JSON, and requires exactly the five approved `create` actions—no other resource or action can pass CI.

## Explicit operator gate

This PR does **not** apply the bootstrap. A separately approved development operator must create the isolated versioned GCS state bucket, use a write-capable development-only identity to apply the reviewed saved plan, perform a metadata-only read-back, and then dispatch the workflow from `main`. Production remains out of scope.

## Verification

- `python3 .github/scripts/test_check_opentofu_development_wif_pilot.py` — 10 passing tests.
- `python3 .github/scripts/check_opentofu_development_wif_pilot.py` — passed.
- `actionlint -shellcheck "" .github/workflows/opentofu-development-wif-pilot.yml .github/workflows/opentofu-development-wif-pilot-validate.yml` — passed.
- OpenTofu `1.12.4`: in a fresh environment with no ADC or GCP credentials, source `init -backend=false` and `validate` passed; the backend-free, no-refresh saved bootstrap plan passed JSON validation with exactly 5 creates and 0 changes/destroys.
- Development read-only profile: `probes/development-project-read` plan read `based-hardware-dev` and emitted project number `1031333818730`, with no infrastructure changes.
- `make preflight` and the push hook — passed all 15 selected checks.

Addresses the P2 plan-proof review thread. Refs #9842.