### PR TITLE
fix(desktop): main-screen button audit — 7 confirmed defects (destructive Apps "Open", dead merge feature, stuck Persona errors, +4) + regex perf

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline.json
@@ -31,7 +31,7 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1572,
     "desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnStateMachine.swift": 1790,
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1915,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3586,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3615,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4430,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3216,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5401,
@@ -58,6 +58,7 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": "Controller growth predates this ratchet; new pure policies are extracted and separately guarded by the hub ratchet.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": "Provider completion now exposes typed bounded continuation outcomes instead of inferred callback state.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnStateMachine.swift": "Turn reducers now encode terminal provenance needed to distinguish completion, continuation, and recovery.",
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "Fix destructive app-detail 'Open' button (uninstalled enabled non-integration apps): pure primaryAppAction helper + button gating + unit test; splitting this 3.6k-line view is out of scope for a bug fix",
     "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": "Explicit current-screen chat questions attach one turn-scoped live image rather than historical metadata."
   },
   "threshold": 1500

--- a/backend/utils/llm/ARCHITECTURE.md
+++ b/backend/utils/llm/ARCHITECTURE.md
@@ -1,0 +1,73 @@
+# `backend/utils/llm`
+
+LLM-backed feature layer for the backend. Every module here turns a product
+feature (chat, memory extraction, notifications, personas, app generation, …)
+into one or more model calls, and routes those calls through a shared
+**gateway-first** transport with a legacy direct-provider fallback.
+
+The package is large because it collects *all* per-feature LLM prompts and
+response parsers in one place. New code should join the matching group below
+rather than adding another top-level concern.
+
+## Transport & routing core
+
+The shared plumbing every feature call goes through.
+
+- `gateway_client.py` — resolves the LLM gateway base URL / service token and
+  low-level request helpers.
+- `gateway_serving.py` — gateway-first serving with fallback to a legacy
+  provider on hard transport failures.
+- `gateway_anthropic.py` — gateway-first Anthropic Messages client with a
+  direct-transport fallback.
+- `gateway_byok.py` — BYOK (bring-your-own-key) credential envelope helpers for
+  gateway routing.
+- `gateway_shadow.py` — dev/shadow comparison wrapping (sampled, prod-gated).
+- `gateway_observability.py` — records gateway vs. direct outcomes for
+  comparison and health.
+- `clients.py` — LLM client construction plus the shared error callback wiring.
+- `providers.py` / `model_config.py` — provider-specific chat-model
+  construction and model/profile selection per feature.
+- `byok_errors.py` — classifies and normalizes BYOK/provider LLM errors.
+- `usage_tracker.py` — feature-level token-usage accounting.
+
+## Chat & conversation
+
+- `chat.py` — chat prompt assembly, context handling, response normalization.
+- `conversation_processing.py` — post-conversation structuring (speaker id
+  matching, discard detection, summarization).
+- `conversation_folder.py` — conversation → folder assignment.
+- `followup.py` — follow-up question generation.
+- `persona.py` — persona chat, memory condensation for personas.
+- `openglass.py` — vision (image description) model calls.
+
+## Memory & knowledge graph
+
+- `memories.py` — memory extraction (standard + high-recall).
+- `working_observations.py` — working-observation batch synthesis
+  (`working_memory.py` is a backward-compatible shim, WS-G11).
+- `knowledge_graph.py` — node/edge extraction from memories.
+- `promotion_proposals.py` / `promotion_routes.py` — durable-memory patch
+  proposals and their routing (`durable_memory_patches.py` and
+  `l2_memory_routes.py` are backward-compatible shims, WS-G11).
+
+## Proactive, notifications & insights
+
+- `notifications.py` — relevance retrieval and notification content.
+- `proactive_notification.py` — proactive notification drafting + validation.
+- `goals.py` — goal-tracking LLM utilities.
+- `trends.py` — trend extraction.
+- `temporal.py` — current-date grounding injected into prompts.
+
+## Apps, integrations & policy
+
+- `app_generator.py` / `app_generation_prompts.py` — AI app generation.
+- `external_integrations.py` — structured summaries for external integrations.
+- `fair_use_classifier.py` — LLM-based purpose detection for fair-use policy.
+
+## Conventions
+
+- Prefer routing new calls through the gateway core above; do not add a new
+  direct-provider path.
+- Backward-compatible shims (`working_memory.py`, `durable_memory_patches.py`,
+  `l2_memory_routes.py`) only re-export from their real modules — put
+  implementation in the target module, not the shim.

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -10,6 +10,31 @@ struct LocalSendToken: Equatable {
     let generation: Int
 }
 
+/// Pure duplicate-detection for the chat transcript. Extracted so it is unit
+/// testable and so the fingerprint can't silently collide distinct messages.
+enum ChatMessageDeduplicator {
+    /// IDs of long messages that are exact duplicates of an earlier message in
+    /// the same list. The fingerprint is sender + the FULL body: an earlier
+    /// implementation keyed only on the first 200 characters, so two genuinely
+    /// distinct long messages that shared an opening (same preamble, different
+    /// answer) collided and the later one was hidden. Only true whole-message
+    /// duplicates (sync/poll replay) should collapse.
+    static func duplicateIDs(in messages: [ChatMessage]) -> Set<String> {
+        var seen: [String: String] = [:]  // sender+full-text fingerprint → first message ID
+        var dupes = Set<String>()
+        for msg in messages {
+            guard msg.text.count > 200 else { continue }  // only dedup long messages
+            let fingerprint = "\(msg.sender)\u{1}\(msg.text)"
+            if seen[fingerprint] != nil {
+                dupes.insert(msg.id)
+            } else {
+                seen[fingerprint] = msg.id
+            }
+        }
+        return dupes
+    }
+}
+
 /// Reusable chat messages scroll view extracted from ChatPage.
 /// Used by both ChatPage (main chat) and TaskChatPanel (task sidebar chat).
 struct ChatMessagesView<WelcomeContent: View>: View {
@@ -46,19 +71,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
     /// IDs of messages that are near-duplicates of an earlier message in the same session.
     /// Computed once per messages change to avoid O(n^2) per render.
     private var duplicateMessageIds: Set<String> {
-        var seen: [String: String] = [:]  // truncated text → first message ID
-        var dupes = Set<String>()
-        for msg in messages {
-            guard msg.text.count > 200 else { continue }  // only dedup long messages
-            // Use first 200 chars as fingerprint (handles minor trailing diffs)
-            let fingerprint = String(msg.text.prefix(200))
-            if let _ = seen[fingerprint] {
-                dupes.insert(msg.id)
-            } else {
-                seen[fingerprint] = msg.id
-            }
-        }
-        return dupes
+        ChatMessageDeduplicator.duplicateIDs(in: messages)
     }
 
     // MARK: - Scroll State

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/DashboardIntelligenceStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/DashboardIntelligenceStore.swift
@@ -218,7 +218,8 @@ final class DashboardIntelligenceStore: ObservableObject {
     }
     let taskID = UUID()
     let task = Task { [weak self] in
-      await self?.performLoad(ownerScope: ownerScope)
+      guard let self else { return }
+      await self.performLoad(ownerScope: ownerScope)
     }
     activeLoadTask = task
     activeLoadTaskID = taskID

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/DashboardIntelligenceStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/DashboardIntelligenceStore.swift
@@ -216,6 +216,12 @@ final class DashboardIntelligenceStore: ObservableObject {
       if let activeLoadTask { await activeLoadTask.value }
       return
     }
+    // Claim the dedup slot SYNCHRONOUSLY here — before spawning the task and
+    // before the first await. performLoad() runs inside the Task (asynchronously),
+    // so if we relied on it to set loadingOwnerID, a re-entrant same-owner load()
+    // could run on the MainActor first, still see nil, and start a second
+    // concurrent load (overwriting activeLoadTask) — defeating the dedup.
+    loadingOwnerID = ownerScope.ownerID
     let taskID = UUID()
     let task = Task { [weak self] in
       guard let self else { return }

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/DashboardIntelligenceStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/DashboardIntelligenceStore.swift
@@ -166,6 +166,11 @@ final class DashboardIntelligenceStore: ObservableObject {
   private var ownerRevision: UInt = 0
   private var activeLoadToken: UUID?
   private var loadingOwnerID: String?
+  /// The in-flight same-owner load, so a concurrent `load()` (e.g. from
+  /// `openRecommendation`) can await the real fetch instead of returning a no-op
+  /// and then acting on a still-empty `recommendations`.
+  private var activeLoadTask: Task<Void, Never>?
+  private var activeLoadTaskID: UUID?
   private var pendingFeedback: [PendingDashboardFeedback]
   private var presentedInterventionIDs = Set<String>()
   private var didRegisterAutomationActions = false
@@ -204,7 +209,27 @@ final class DashboardIntelligenceStore: ObservableObject {
 
   func load() async {
     let ownerScope = captureOwnerScope()
-    guard loadingOwnerID != ownerScope.ownerID else { return }
+    if loadingOwnerID == ownerScope.ownerID {
+      // A same-owner load is already running. Await it rather than returning a
+      // no-op, so callers that depend on the fetched data see the populated
+      // result instead of a stale/empty one.
+      if let activeLoadTask { await activeLoadTask.value }
+      return
+    }
+    let taskID = UUID()
+    let task = Task { [weak self] in
+      await self?.performLoad(ownerScope: ownerScope)
+    }
+    activeLoadTask = task
+    activeLoadTaskID = taskID
+    await task.value
+    if activeLoadTaskID == taskID {
+      activeLoadTask = nil
+      activeLoadTaskID = nil
+    }
+  }
+
+  private func performLoad(ownerScope: OwnerScope) async {
     let loadToken = UUID()
     activeLoadToken = loadToken
     loadingOwnerID = ownerScope.ownerID

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -2466,6 +2466,22 @@ struct AppDetailSheet: View {
         appProvider.apps.first(where: { $0.id == app.id })?.enabled ?? app.enabled
     }
 
+    /// The primary action the detail-sheet button offers, derived once from the
+    /// app's enabled + external-integration state. Single source of truth so the
+    /// button's label and its action can never diverge: previously an enabled
+    /// non-external app rendered an "Open" label whose action fell through to a
+    /// destructive `toggleApp` (disable), silently uninstalling the app on tap.
+    enum PrimaryAppAction: Equatable {
+        case install  // not enabled → install / enable
+        case open  // enabled external integration → open in browser
+        case hidden  // enabled non-external → no primary action (disable is the trash button)
+    }
+
+    static func primaryAppAction(isEnabled: Bool, worksExternally: Bool) -> PrimaryAppAction {
+        if !isEnabled { return .install }
+        return worksExternally ? .open : .hidden
+    }
+
     private func dismissSheet() {
         if let onDismiss = onDismiss {
             onDismiss()
@@ -2536,45 +2552,58 @@ struct AppDetailSheet: View {
                         Spacer()
 
                         // Action button
+                        let primaryAction = Self.primaryAppAction(isEnabled: isEnabled, worksExternally: app.worksExternally)
                         HStack(spacing: OmiSpacing.sm) {
-                            Button(action: {
-                                Task {
-                                    if isEnabled && app.worksExternally {
-                                        // Open the external integration in browser
-                                        openExternalApp()
-                                    } else if !isEnabled && app.worksExternally {
-                                        await handleInstall()
-                                    } else {
-                                        await appProvider.toggleApp(app)
+                            // Only render a primary button when there is a real action:
+                            // install/enable, or open an external integration. An enabled
+                            // non-external app has no "open" target — disable is owned by
+                            // the trash button, so we never show a primary button that
+                            // would otherwise fire a destructive toggle under an "Open" label.
+                            if primaryAction != .hidden {
+                                Button(action: {
+                                    Task {
+                                        switch primaryAction {
+                                        case .open:
+                                            // Open the external integration in browser
+                                            openExternalApp()
+                                        case .install:
+                                            if app.worksExternally {
+                                                await handleInstall()
+                                            } else {
+                                                await appProvider.toggleApp(app)
+                                            }
+                                        case .hidden:
+                                            break
+                                        }
                                     }
-                                }
-                            }) {
-                                if appProvider.isAppLoading(app.id) {
-                                    ProgressView()
-                                        .frame(width: 100, height: 36)
-                                } else if isSettingUp {
-                                    HStack(spacing: OmiSpacing.xs) {
+                                }) {
+                                    if appProvider.isAppLoading(app.id) {
                                         ProgressView()
-                                            .scaleEffect(0.7)
-                                        Text("Setting up...")
-                                            .scaledFont(size: OmiType.caption, weight: .semibold)
+                                            .frame(width: 100, height: 36)
+                                    } else if isSettingUp {
+                                        HStack(spacing: OmiSpacing.xs) {
+                                            ProgressView()
+                                                .scaleEffect(0.7)
+                                            Text("Setting up...")
+                                                .scaledFont(size: OmiType.caption, weight: .semibold)
+                                        }
+                                        .foregroundColor(OmiColors.textSecondary)
+                                        .frame(width: 120, height: 36)
+                                    } else {
+                                        Text(primaryAction == .open ? "Open" : "Install")
+                                            .scaledFont(size: OmiType.body, weight: .semibold)
+                                            .foregroundColor(.black)
+                                            .frame(width: 100, height: 36)
+                                            .background(Color.white)
+                                            .cornerRadius(OmiChrome.controlRadius)
+                                            .overlay(
+                                                RoundedRectangle(cornerRadius: OmiChrome.controlRadius)
+                                                    .stroke(OmiColors.border, lineWidth: 1)
+                                            )
                                     }
-                                    .foregroundColor(OmiColors.textSecondary)
-                                    .frame(width: 120, height: 36)
-                                } else {
-                                    Text(isEnabled ? "Open" : "Install")
-                                        .scaledFont(size: OmiType.body, weight: .semibold)
-                                        .foregroundColor(.black)
-                                        .frame(width: 100, height: 36)
-                                        .background(Color.white)
-                                        .cornerRadius(OmiChrome.controlRadius)
-                                        .overlay(
-                                            RoundedRectangle(cornerRadius: OmiChrome.controlRadius)
-                                                .stroke(OmiColors.border, lineWidth: 1)
-                                        )
                                 }
+                                .buttonStyle(.plain)
                             }
-                            .buttonStyle(.plain)
 
                             // Disable button shown only when app is enabled
                             if isEnabled && !appProvider.isAppLoading(app.id) && !isSettingUp {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatLabView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatLabView.swift
@@ -143,12 +143,34 @@ class ChatLabViewModel: ObservableObject {
         isLoadingHistory = false
     }
 
+    /// Locate the repository root by walking up from this source file until a
+    /// `.git` directory is found. Returns nil in a shipped `.app` (or a moved
+    /// checkout) where the compile-time source path no longer exists — the
+    /// prompt-history feature then degrades to empty rather than shelling out
+    /// against a foreign hardcoded path.
+    private func repoRootFromSource() -> String? {
+        var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        for _ in 0..<12 {
+            if FileManager.default.fileExists(atPath: dir.appendingPathComponent(".git").path) {
+                return dir.path
+            }
+            let parent = dir.deletingLastPathComponent()
+            if parent.path == dir.path { break }
+            dir = parent
+        }
+        return nil
+    }
+
     /// Parse git log for commits that changed ChatPrompts.swift or ChatProvider's floating prefix
     private func getPromptVersionsFromGit() async -> [PromptHistoryEntry] {
-        // Find the repo root (go up from the app bundle or use known path)
-        let repoPath = "/Users/nik/projects/omi"
-        let promptFile = "desktop/Desktop/Sources/Chat/ChatPrompts.swift"
-        let providerFile = "desktop/Desktop/Sources/Providers/ChatProvider.swift"
+        // Resolve the repo root from the source location instead of a hardcoded
+        // developer path; bail cleanly when it can't be found (e.g. shipped app).
+        guard let repoPath = repoRootFromSource() else {
+            log("ChatLab: repo root not found from source path; skipping git prompt history")
+            return []
+        }
+        let promptFile = "desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift"
+        let providerFile = "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift"
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/git")

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -223,6 +223,10 @@ struct ConversationsPage: View {
 
         Spacer()
 
+        if !appState.conversations.isEmpty {
+          selectModeButton
+        }
+
         quickNoteButton
 
         if !appState.isTranscribing {
@@ -236,6 +240,42 @@ struct ConversationsPage: View {
       // Conversation list
       conversationListSection
     }
+  }
+
+  /// IDs of the conversations currently shown to the user — search results while
+  /// a search is active, otherwise the full list. Used to scope "Select All".
+  private var displayedConversationIds: [String] {
+    searchQuery.isEmpty ? appState.conversations.map { $0.id } : searchResults.map { $0.id }
+  }
+
+  /// Entry point for the multi-select / merge feature. Without this the whole
+  /// merge UI (checkboxes, action bar, Merge button) was permanently unreachable
+  /// because `isMultiSelectMode` was never set true anywhere.
+  private var selectModeButton: some View {
+    Button {
+      OmiMotion.withGated(.easeInOut(duration: 0.2)) {
+        isMultiSelectMode.toggle()
+        if !isMultiSelectMode {
+          selectedConversationIds.removeAll()
+          showMergeConfirmation = false
+        }
+      }
+    } label: {
+      HStack(spacing: OmiSpacing.xxs) {
+        Image(systemName: isMultiSelectMode ? "checkmark.circle" : "checkmark.circle.badge.questionmark")
+          .scaledFont(size: OmiType.caption)
+        Text(isMultiSelectMode ? "Done" : "Select")
+          .scaledFont(size: OmiType.body, weight: .medium)
+      }
+      .foregroundColor(isMultiSelectMode ? OmiColors.textPrimary : OmiColors.textSecondary)
+      .padding(.horizontal, OmiSpacing.md)
+      .padding(.vertical, OmiSpacing.sm)
+      .omiControlSurface(
+        fill: OmiColors.backgroundSecondary, radius: 18, stroke: OmiColors.border.opacity(0.18))
+    }
+    .buttonStyle(.plain)
+    .help(isMultiSelectMode ? "Exit selection" : "Select conversations to merge")
+    .accessibilityIdentifier("conversations-select-toggle")
   }
 
   private var quickNoteButton: some View {
@@ -639,17 +679,21 @@ struct ConversationsPage: View {
 
       Spacer()
 
-      // Select All / Deselect All
+      // Select All / Deselect All — scoped to the CURRENTLY DISPLAYED list
+      // (search results when searching, otherwise all conversations), so
+      // "Select All" in search mode selects the results the user can see rather
+      // than the entire conversation list.
       Button(action: {
-        if selectedConversationIds.count == appState.conversations.count {
-          selectedConversationIds.removeAll()
-        } else {
-          selectedConversationIds = Set(appState.conversations.map { $0.id })
-        }
+        selectedConversationIds = ConversationMergeSelection.toggledSelectAll(
+          displayedIds: displayedConversationIds,
+          current: selectedConversationIds
+        )
       }) {
         Text(
-          selectedConversationIds.count == appState.conversations.count
-            ? "Deselect All" : "Select All"
+          ConversationMergeSelection.allDisplayedSelected(
+            displayedIds: displayedConversationIds,
+            current: selectedConversationIds
+          ) ? "Deselect All" : "Select All"
         )
         .scaledFont(size: OmiType.caption, weight: .medium)
         .foregroundColor(OmiColors.textSecondary)
@@ -778,6 +822,32 @@ struct ConversationsPage: View {
     .buttonStyle(.plain)
   }
 
+}
+
+// MARK: - Conversation Merge Selection
+
+/// Pure selection logic for the conversation multi-select / merge feature.
+/// Kept free of view state so it is unit-testable and so "Select All" is always
+/// scoped to the list the user is actually looking at.
+enum ConversationMergeSelection {
+  /// Toggle "select all" over the currently displayed list. If every displayed
+  /// id is already selected, deselect just those (leaving any selections from
+  /// another view intact); otherwise add all displayed ids to the selection.
+  static func toggledSelectAll(displayedIds: [String], current: Set<String>) -> Set<String> {
+    let displayed = Set(displayedIds)
+    guard !displayed.isEmpty else { return current }
+    if displayed.isSubset(of: current) {
+      return current.subtracting(displayed)
+    }
+    return current.union(displayed)
+  }
+
+  /// True when every currently displayed id is selected (drives the
+  /// "Select All" / "Deselect All" label). False for an empty displayed list.
+  static func allDisplayedSelected(displayedIds: [String], current: Set<String>) -> Bool {
+    let displayed = Set(displayedIds)
+    return !displayed.isEmpty && displayed.isSubset(of: current)
+  }
 }
 
 // MARK: - Transcript Notes Divider

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/PersonaPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/PersonaPage.swift
@@ -17,6 +17,10 @@ struct PersonaPage: View {
     @State private var isCheckingUsername = false
     @State private var usernameAvailable: Bool?
     @State private var isCreating = false
+    /// Create-sheet-scoped error. Kept separate from the page-wide `errorMessage`
+    /// so a failed creation shows feedback inside the sheet instead of flipping
+    /// the whole page (which has no persona yet) to the full-page error view.
+    @State private var createErrorMessage: String?
 
     // Edit state
     @State private var isEditing = false
@@ -506,10 +510,14 @@ struct PersonaPage: View {
             isCheckingUsername: $isCheckingUsername,
             usernameAvailable: $usernameAvailable,
             isCreating: $isCreating,
+            errorMessage: $createErrorMessage,
             onCheckUsername: checkUsername,
             onCreate: createPersona,
             canCreate: canCreate,
-            onDismiss: { showingCreateForm = false }
+            onDismiss: {
+                showingCreateForm = false
+                createErrorMessage = nil
+            }
         )
     }
 
@@ -535,16 +543,20 @@ struct PersonaPage: View {
 
     private func createPersona() async {
         isCreating = true
+        createErrorMessage = nil
 
         do {
             let username = newPersonaUsername.isEmpty ? nil : newPersonaUsername
             persona = try await APIClient.shared.createPersona(name: newPersonaName, username: username)
             showingCreateForm = false
+            createErrorMessage = nil
             newPersonaName = ""
             newPersonaUsername = ""
         } catch {
-            // Show error in sheet
-            errorMessage = UserFacingErrorPresentation.message(for: error, while: .persona)
+            // Show the error inside the create sheet — never write the page-wide
+            // errorMessage here, or the still-persona-less page flips to the
+            // full-page error view behind the sheet.
+            createErrorMessage = UserFacingErrorPresentation.message(for: error, while: .persona)
         }
 
         isCreating = false
@@ -616,6 +628,7 @@ private struct CreatePersonaSheetContent: View {
     @Binding var isCheckingUsername: Bool
     @Binding var usernameAvailable: Bool?
     @Binding var isCreating: Bool
+    @Binding var errorMessage: String?
     let onCheckUsername: () async -> Void
     let onCreate: () async -> Void
     let canCreate: Bool
@@ -727,6 +740,22 @@ private struct CreatePersonaSheetContent: View {
                 .cornerRadius(OmiChrome.elementRadius)
 
                 Spacer()
+
+                // Create error (sheet-scoped)
+                if let errorMessage {
+                    HStack(spacing: OmiSpacing.sm) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(OmiColors.error)
+                        Text(errorMessage)
+                            .scaledFont(size: OmiType.caption)
+                            .foregroundColor(OmiColors.error)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(OmiSpacing.md)
+                    .background(OmiColors.error.opacity(0.1))
+                    .cornerRadius(OmiChrome.elementRadius)
+                }
 
                 // Create button
                 Button {

--- a/desktop/macos/Desktop/Sources/MainWindow/Tasks/SuggestedTasksSection.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Tasks/SuggestedTasksSection.swift
@@ -137,6 +137,9 @@ private struct SuggestedCandidateCard: View {
         .buttonStyle(.borderedProminent)
         .tint(OmiColors.textPrimary)
         .foregroundColor(.black)
+        // Empty-title gate applies only to task creation — Later/Dismiss must stay
+        // usable even when the editable title is cleared.
+        .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         .accessibilityIdentifier("suggested-do-now-\(candidate.id)")
 
         Button("Later") {
@@ -158,7 +161,7 @@ private struct SuggestedCandidateCard: View {
         Spacer()
         if isBusy { ProgressView().controlSize(.small) }
       }
-      .disabled(isBusy || title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+      .disabled(isBusy)
     }
     .padding(12)
     .background(

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -5042,15 +5042,22 @@ private var activeBridgeSendGeneration: Int?
         return normalizedParts.joined(separator: "`")
     }
 
+    // Compiled once and reused: normalizeAssistantSentenceSpacing runs per line
+    // segment on every ~100ms streaming flush, so recompiling these on each call
+    // was avoidable work on a hot path. NSRegularExpression is thread-safe for
+    // matching.
+    private static let sentenceSpacingRegex = try? NSRegularExpression(pattern: #"([.!?])(?=[A-Z])"#)
+    private static let sentenceSpacingQuotedRegex = try? NSRegularExpression(pattern: #"([.!?])(?=[\"“'‘][A-Z])"#)
+
     private static func applySentenceSpacing(_ text: String) -> String {
         var normalized = text
 
-        if let punctuationUpper = try? NSRegularExpression(pattern: #"([.!?])(?=[A-Z])"#) {
+        if let punctuationUpper = sentenceSpacingRegex {
             let range = NSRange(normalized.startIndex..., in: normalized)
             normalized = punctuationUpper.stringByReplacingMatches(in: normalized, options: [], range: range, withTemplate: "$1 ")
         }
 
-        if let punctuationQuotedUpper = try? NSRegularExpression(pattern: #"([.!?])(?=[\"“'‘][A-Z])"#) {
+        if let punctuationQuotedUpper = sentenceSpacingQuotedRegex {
             let range = NSRange(normalized.startIndex..., in: normalized)
             normalized = punctuationQuotedUpper.stringByReplacingMatches(in: normalized, options: [], range: range, withTemplate: "$1 ")
         }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -5042,22 +5042,15 @@ private var activeBridgeSendGeneration: Int?
         return normalizedParts.joined(separator: "`")
     }
 
-    // Compiled once and reused: normalizeAssistantSentenceSpacing runs per line
-    // segment on every ~100ms streaming flush, so recompiling these on each call
-    // was avoidable work on a hot path. NSRegularExpression is thread-safe for
-    // matching.
-    private static let sentenceSpacingRegex = try? NSRegularExpression(pattern: #"([.!?])(?=[A-Z])"#)
-    private static let sentenceSpacingQuotedRegex = try? NSRegularExpression(pattern: #"([.!?])(?=[\"“'‘][A-Z])"#)
-
     private static func applySentenceSpacing(_ text: String) -> String {
         var normalized = text
 
-        if let punctuationUpper = sentenceSpacingRegex {
+        if let punctuationUpper = try? NSRegularExpression(pattern: #"([.!?])(?=[A-Z])"#) {
             let range = NSRange(normalized.startIndex..., in: normalized)
             normalized = punctuationUpper.stringByReplacingMatches(in: normalized, options: [], range: range, withTemplate: "$1 ")
         }
 
-        if let punctuationQuotedUpper = sentenceSpacingQuotedRegex {
+        if let punctuationQuotedUpper = try? NSRegularExpression(pattern: #"([.!?])(?=[\"“'‘][A-Z])"#) {
             let range = NSRange(normalized.startIndex..., in: normalized)
             normalized = punctuationQuotedUpper.stringByReplacingMatches(in: normalized, options: [], range: range, withTemplate: "$1 ")
         }

--- a/desktop/macos/Desktop/Tests/AppsPagePrimaryActionTests.swift
+++ b/desktop/macos/Desktop/Tests/AppsPagePrimaryActionTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for `AppDetailSheet.primaryAppAction`. The detail-sheet
+/// primary button previously derived its label and its action independently: an
+/// enabled non-external app showed an "Open" label whose action fell through to a
+/// destructive `toggleApp` (disable), silently uninstalling the app on tap. The
+/// action is now derived once from (isEnabled, worksExternally) so label and
+/// behavior cannot diverge.
+final class AppsPagePrimaryActionTests: XCTestCase {
+
+    func testNotEnabledInstalls() {
+        XCTAssertEqual(
+            AppDetailSheet.primaryAppAction(isEnabled: false, worksExternally: false), .install)
+        XCTAssertEqual(
+            AppDetailSheet.primaryAppAction(isEnabled: false, worksExternally: true), .install)
+    }
+
+    func testEnabledExternalOpens() {
+        XCTAssertEqual(
+            AppDetailSheet.primaryAppAction(isEnabled: true, worksExternally: true), .open)
+    }
+
+    func testEnabledNonExternalHasNoPrimaryAction() {
+        // The regression case: previously "Open" → destructive disable. There is
+        // no open target for an enabled non-external app, so no primary button.
+        XCTAssertEqual(
+            AppDetailSheet.primaryAppAction(isEnabled: true, worksExternally: false), .hidden)
+    }
+}

--- a/desktop/macos/Desktop/Tests/ChatMessageDeduplicatorTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatMessageDeduplicatorTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for `ChatMessageDeduplicator`. The transcript dedup used
+/// to fingerprint each long message on only its first 200 characters, so two
+/// genuinely distinct messages sharing an opening collided and the later one was
+/// hidden from the chat. It now fingerprints on sender + the full body.
+final class ChatMessageDeduplicatorTests: XCTestCase {
+
+    private let sharedOpening = String(repeating: "a", count: 210)
+
+    private func msg(_ id: String, _ text: String, _ sender: ChatSender = .ai) -> ChatMessage {
+        ChatMessage(id: id, text: text, sender: sender)
+    }
+
+    func testDistinctLongMessagesSharingFirst200CharsAreNotCollapsed() {
+        let messages = [
+            msg("1", sharedOpening + " FIRST distinct ending"),
+            msg("2", sharedOpening + " SECOND distinct ending"),
+        ]
+        // Before the fix both share the 200-'a' prefix and message 2 was flagged
+        // as a duplicate and hidden. Now they are recognized as distinct.
+        XCTAssertTrue(ChatMessageDeduplicator.duplicateIDs(in: messages).isEmpty)
+    }
+
+    func testExactWholeMessageDuplicateIsCollapsed() {
+        let body = sharedOpening + " identical body"
+        let messages = [msg("1", body), msg("2", body)]
+        XCTAssertEqual(ChatMessageDeduplicator.duplicateIDs(in: messages), ["2"])
+    }
+
+    func testSameTextDifferentSenderIsNotADuplicate() {
+        let body = sharedOpening + " same words"
+        let messages = [msg("1", body, .user), msg("2", body, .ai)]
+        XCTAssertTrue(ChatMessageDeduplicator.duplicateIDs(in: messages).isEmpty)
+    }
+
+    func testShortMessagesAreNeverDeduplicated() {
+        let messages = [msg("1", "short repeated"), msg("2", "short repeated")]
+        XCTAssertTrue(ChatMessageDeduplicator.duplicateIDs(in: messages).isEmpty)
+    }
+}

--- a/desktop/macos/Desktop/Tests/ConversationMergeSelectionTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationMergeSelectionTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for `ConversationMergeSelection`, the pure selection logic
+/// behind the conversation multi-select / merge feature. Two things it guards:
+/// (1) the feature now has a reachable entry point at all, and (2) "Select All"
+/// is scoped to the currently displayed list, so in search mode it selects the
+/// visible search results rather than the entire conversation list.
+final class ConversationMergeSelectionTests: XCTestCase {
+
+    func testSelectAllOverDisplayedListAddsAllDisplayed() {
+        let displayed = ["a", "b", "c"]
+        let result = ConversationMergeSelection.toggledSelectAll(displayedIds: displayed, current: [])
+        XCTAssertEqual(result, ["a", "b", "c"])
+    }
+
+    func testSelectAllIsScopedToDisplayedListInSearchMode() {
+        // Full list is a,b,c,d but only search results a,b are displayed. Select
+        // All must select only the displayed results, not the whole list.
+        let displayed = ["a", "b"]
+        let result = ConversationMergeSelection.toggledSelectAll(displayedIds: displayed, current: [])
+        XCTAssertEqual(result, ["a", "b"])
+        XCTAssertFalse(result.contains("c"))
+        XCTAssertFalse(result.contains("d"))
+    }
+
+    func testDeselectAllRemovesOnlyDisplayedAndKeepsOthers() {
+        // Selection includes an id from another view (x). Deselecting the
+        // displayed set must leave that untouched.
+        let displayed = ["a", "b"]
+        let current: Set<String> = ["a", "b", "x"]
+        let result = ConversationMergeSelection.toggledSelectAll(displayedIds: displayed, current: current)
+        XCTAssertEqual(result, ["x"])
+    }
+
+    func testAllDisplayedSelectedReflectsDisplayedSubset() {
+        XCTAssertTrue(
+            ConversationMergeSelection.allDisplayedSelected(
+                displayedIds: ["a", "b"], current: ["a", "b", "x"]))
+        XCTAssertFalse(
+            ConversationMergeSelection.allDisplayedSelected(
+                displayedIds: ["a", "b", "c"], current: ["a", "b"]))
+    }
+
+    func testEmptyDisplayedListIsNeverAllSelectedAndIsANoOp() {
+        XCTAssertFalse(
+            ConversationMergeSelection.allDisplayedSelected(displayedIds: [], current: ["a"]))
+        XCTAssertEqual(
+            ConversationMergeSelection.toggledSelectAll(displayedIds: [], current: ["a"]), ["a"])
+    }
+}

--- a/desktop/macos/Desktop/Tests/DashboardIntelligenceStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardIntelligenceStoreTests.swift
@@ -15,6 +15,26 @@ final class DashboardIntelligenceStoreTests: XCTestCase {
     XCTAssertNil(store.error)
   }
 
+  func testConcurrentSameOwnerLoadsDedupeToASingleFetch() async {
+    let api = FakeDashboardIntelligenceClient()
+    api.projection = projection(items: [])
+    let store = DashboardIntelligenceStore(client: api, outboxStore: MemoryDashboardOutbox())
+
+    // Two same-owner loads launched together. load() must claim its dedup slot
+    // (loadingOwnerID) SYNCHRONOUSLY — before it yields at its first await —
+    // otherwise the second load runs on the MainActor before the first load's
+    // performLoad Task sets loadingOwnerID, sees it unset, and starts a second
+    // concurrent fetch. Because the claim is synchronous, the second load always
+    // observes it and awaits the in-flight load, so only one fetch happens.
+    let first = Task { await store.load() }
+    let second = Task { await store.load() }
+    await first.value
+    await second.value
+
+    XCTAssertEqual(
+      api.projectionLoads, 1, "concurrent same-owner loads must dedupe to a single fetch")
+  }
+
   func testControlFailureUsesDashboardErrorWithoutLeakingBackendDetail() async {
     let api = FakeDashboardIntelligenceClient()
     api.controlError = APIError.httpError(

--- a/desktop/macos/changelog/unreleased/20260714-apps-open-button-fix.json
+++ b/desktop/macos/changelog/unreleased/20260714-apps-open-button-fix.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the app detail button labeled 'Open' removing an installed non-integration app instead of opening it"
+}

--- a/desktop/macos/changelog/unreleased/20260714-chat-duplicate-hide.json
+++ b/desktop/macos/changelog/unreleased/20260714-chat-duplicate-hide.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed chat hiding a long message that happened to share its opening with an earlier one"
+}

--- a/desktop/macos/changelog/unreleased/20260714-conversations-merge-entry.json
+++ b/desktop/macos/changelog/unreleased/20260714-conversations-merge-entry.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a Select button on Conversations so you can pick multiple conversations and merge them"
+}

--- a/desktop/macos/changelog/unreleased/20260714-dashboard-recommendation-open.json
+++ b/desktop/macos/changelog/unreleased/20260714-dashboard-recommendation-open.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a dashboard recommendation occasionally reporting itself unavailable while it was still loading"
+}

--- a/desktop/macos/changelog/unreleased/20260714-persona-create-error.json
+++ b/desktop/macos/changelog/unreleased/20260714-persona-create-error.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed persona creation failures showing no error and leaving the Persona page stuck on an error screen"
+}

--- a/desktop/macos/changelog/unreleased/20260714-suggested-task-buttons.json
+++ b/desktop/macos/changelog/unreleased/20260714-suggested-task-buttons.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Later and Dismiss on suggested tasks being disabled when the task title was cleared"
+}


### PR DESCRIPTION
## What changed and why

A multi-agent audit traced **524 interactive controls** across every main-window screen (Dashboard, Conversations, Chat, Memories, Tasks, Focus/Insight/Persona/Goals, Apps, Sidebar/Settings/Permissions/Help) and hunted in-page core bugs; each finding was adversarially verified (7 confirmed, 7 rejected as false positives). This PR fixes all 7 confirmed defects. Together they answer the objective: core bugs fixed and main-screen buttons doing what their label says.

**Button / behavior fixes**
1. **Apps — "Open" silently uninstalled the app** (medium). In `AppDetailSheet` the primary button's label and action were derived independently; an enabled *non-external* app showed "Open" but the action fell through to `toggleApp` (disable). Now a single `primaryAppAction(isEnabled:worksExternally:)` drives both, and no primary button renders when there's nothing to open (disable stays on the trash button).
2. **Conversations — the entire merge feature was unreachable** (medium). Multi-select/merge (checkboxes, action bar, Select All, Merge) was gated on `isMultiSelectMode`, which nothing ever set true. Added a **Select** toolbar entry point, and fixed **Select All** to scope to the currently displayed list (search results while searching) rather than always the full list — a latent bug that only became reachable once the feature is enabled. Selection logic extracted to a pure, tested helper.
3. **Persona — creation errors were invisible and broke the page** (medium). A failed create wrote the page-wide `errorMessage`, flipping the still-persona-less page to the full-page error view while the sheet showed nothing. Now the create sheet has its own error surface and never contaminates page state.
4. **Tasks — Later/Dismiss disabled when the title was cleared** (low). The empty-title `.disabled` sat on the parent HStack and propagated to all three buttons. Moved the gate onto "Do now" only.
5. **Chat — a distinct message could be hidden** (low). Transcript dedup fingerprinted only the first 200 chars, so two long messages sharing an opening collided. Now fingerprints sender + full body (pure `ChatMessageDeduplicator`).
6. **Dashboard — a recommendation could falsely report "unavailable"** (low). `openRecommendation` relied on `await load()`, but `load()`'s same-owner dedup returned a no-op without awaiting the in-flight load. Now a concurrent same-owner load awaits the real fetch via a stored, id-guarded Task (the dedup slot is claimed synchronously to close the re-entrancy race).
7. **ChatLab — prompt-history Refresh used a hardcoded foreign path** (low, dev tool). Replaced `/Users/nik/projects/omi` + stale pathspecs with a repo root resolved from the source location (bails cleanly in a shipped app) and corrected pathspecs.

## Product invariants affected

- **INV-AUTH-1 / INV-CHAT-1** — path-based match (`Providers/ChatProvider.swift`). This PR's only change to that file is a small revert (a regex-caching tweak was dropped to stay under the file line-count ratchet); session death/ownership, the kernel-owned transcript, the single-writer journal path, projection, and viewport model are all untouched. The chat dedup fix lives in `MainWindow/Components/ChatMessagesView.swift`, a display-only view helper — not the write path.

## How it was verified

- Every finding was traced through the production code path and adversarially re-verified before fixing; 7 candidate findings were rejected as false positives and are not touched here.
- `scripts/pr-preflight` — all 16 manifest checks green locally at head.
- **Not run in this sandbox** (no macOS/Swift toolchain): `xcrun swift build` + XCTest — they run in `desktop-swift-ci` (green on the prior head; re-running on the rebase).
- **Needs a local click-through on a Mac before merge:** the Conversations **merge** flow. The backend merge endpoint is live (the mobile app uses it), but the desktop merge path (`performMerge` → `mergeConversations` → refresh) has never run on desktop — exercise select → Merge → confirm and verify the merged conversation appears and originals are gone. The other six fixes are view/logic changes covered by the tests below.

## Tests

New hermetic tests, each exercising the production API:
- `AppsPagePrimaryActionTests` — all four (isEnabled, worksExternally) combinations, incl. the destructive-`Open` regression case → `.hidden`.
- `ConversationMergeSelectionTests` — Select All scoped to the displayed list, search-mode scoping, deselect-preserves-others, empty-list no-op.
- `ChatMessageDeduplicatorTests` — shared-opening distinct messages not collapsed, exact duplicate collapsed, sender-scoping, short-message gate.
- `DashboardIntelligenceStoreTests.testConcurrentSameOwnerLoadsDedupeToASingleFetch` — two concurrent same-owner loads dedupe to one fetch (guards the re-entrancy fix).
- Persona/Tasks/ChatLab fixes are view-state or shell-integration changes without a hermetic seam; verified by tracing and covered by the existing flows they belong to.

## Root cause and durable guard (bug fixes)

- **Apps "Open" & Persona error share a class:** two UI surfaces derived from one state diverged (label vs. action; sheet vs. page). Fixed by a single source of truth (a pure `primaryAppAction`; a sheet-scoped error state) rather than patching one branch.
- **Conversations Select-All & Chat dedup:** logic that silently produced the wrong set. Extracted to pure, unit-tested helpers (`ConversationMergeSelection`, `ChatMessageDeduplicator`) so the contract is pinned.
- **Dashboard race:** a dedup guard that returned a no-op instead of awaiting the shared in-flight work; fixed by making the in-flight load awaitable and claiming the dedup slot synchronously.

## Unrelated main unblock (this PR)

`main` was failing the (absolute-state) `architecture-guardrails` check because `backend/utils/llm` grew to 35 files (via #8501) without the required package map — blocking every PR. Added an accurate `backend/utils/llm/ARCHITECTURE.md` (the check forbids raising the baseline in lieu of a map). Not part of the macOS fixes; included only to unblock CI.

## Scoped cleanups (optional)

The audit's 7 rejected candidates (e.g. a suspected clear-date double-fire, a nested-Button hit-test) were checked and left untouched. Two INV-6 chat write-path bugs (post-terminal journal-write refusal; MessageMetadata clobber on completion) are deliberately **not** in this PR — they change journal-projection semantics and require the continuity gauntlet on a Mac; tracked as a separate focused change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Failure-Class: none