### PR TITLE
fix(backend): share strict Firestore transaction fixture

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -222,6 +222,8 @@ npm run test:listen-lifecycle:emulator  # Real Firestore transaction contention 
 
 **Test isolation / import purity** — never mutate `sys.modules` at module scope in tests; production modules must not construct clients or do IO at import time. Sanctioned seams: `monkeypatch.setattr` on a lazy-held singleton, FastAPI `app.dependency_overrides`. Enforced by `python scripts/check_module_stub_pollution.py` and `python scripts/scan_import_time_side_effects.py`. Full prescription: `backend/docs/test_isolation.md`.
 
+**Firestore transaction fakes** — a fake at this service boundary must enforce its ordering and constraint semantics. Use `tests.unit.fixtures.strict_firestore_transaction.StrictFirestore` for transaction tests that need document-reference reads plus `set`/`update`: it rejects reads after the first write, the production rule that #9739's lenient fake missed. If an incident requires queries, deletes, retry, or contention behavior, first cover it with the Firestore emulator; extend the fixture only for a proven hermetic guard.
+
 Pre-mock heavy deps before importing the module under test. Use `patch.object(target_module, "func")` not string-based `patch("module.func")` — the string form silently patches the wrong reference if the function was already imported. When modules construct objects at import time, use lazy getters to avoid triggering heavy init in tests.
 
 ### Memory continuity gauntlet gates

--- a/backend/tests/unit/fixtures/strict_firestore_transaction.py
+++ b/backend/tests/unit/fixtures/strict_firestore_transaction.py
@@ -1,0 +1,148 @@
+"""Narrow Firestore transaction fixture for ordering-sensitive unit tests.
+
+This fixture models document-reference ``get(transaction=...)`` plus transaction
+``set`` and ``update``. It enforces Firestore's rule that every transactional
+read must occur before the first transactional write.
+
+It deliberately does not model queries, deletes, commit/rollback visibility,
+or retry and contention semantics. Extend it only when an incident proves that
+one of those boundaries needs a hermetic guard.
+
+As fixture-integrity policy, a transaction accepts references created by its
+own ``StrictFirestore`` instance only. This prevents accidental mixing of
+unrelated in-memory stores; it is not a claim about Firestore client identity.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from threading import RLock
+from typing import Any
+
+
+class ReadAfterWriteError(RuntimeError):
+    """Raised when a transaction performs a read after staging a write."""
+
+
+class ForeignTransactionError(ValueError):
+    """Raised when fixture policy forbids mixing transaction and reference stores."""
+
+
+class UnsupportedFirestoreOperationError(NotImplementedError):
+    """Raised for a Firestore operation this narrow fixture does not model."""
+
+
+_SUPPORTED_OPERATIONS = 'transaction-bound document get, transaction set, and transaction update'
+
+
+class StrictFirestoreSnapshot:
+    def __init__(self, data: dict[str, Any] | None):
+        self._data = deepcopy(data)
+        self.exists = data is not None
+
+    def to_dict(self) -> dict[str, Any] | None:
+        return deepcopy(self._data)
+
+
+class StrictFirestoreDocument:
+    def __init__(self, database: StrictFirestore, path: tuple[str, ...]):
+        self._database = database
+        self.path = path
+
+    def collection(self, name: str) -> StrictFirestoreCollection:
+        return StrictFirestoreCollection(self._database, (*self.path, name))
+
+    def get(self, transaction: StrictFirestoreTransaction | None = None) -> StrictFirestoreSnapshot:
+        if transaction is not None:
+            transaction._assert_reference_belongs(self)
+            transaction._assert_read_allowed()
+        return StrictFirestoreSnapshot(self._database.rows.get(self.path))
+
+    def delete(self, *args: Any, **kwargs: Any) -> None:
+        raise UnsupportedFirestoreOperationError(f'StrictFirestore supports only {_SUPPORTED_OPERATIONS}')
+
+
+class StrictFirestoreCollection:
+    def __init__(self, database: StrictFirestore, path: tuple[str, ...]):
+        self._database = database
+        self._path = path
+
+    def document(self, name: str) -> StrictFirestoreDocument:
+        return StrictFirestoreDocument(self._database, (*self._path, name))
+
+    def where(self, *args: Any, **kwargs: Any) -> None:
+        raise UnsupportedFirestoreOperationError(f'StrictFirestore supports only {_SUPPORTED_OPERATIONS}')
+
+    def stream(self, *args: Any, **kwargs: Any) -> None:
+        raise UnsupportedFirestoreOperationError(f'StrictFirestore supports only {_SUPPORTED_OPERATIONS}')
+
+
+class StrictFirestoreTransaction:
+    def __init__(self, database: StrictFirestore, *, allow_reads_after_writes: bool = False):
+        self._database = database
+        self._allow_reads_after_writes = allow_reads_after_writes
+        self.lock = database.lock
+        self.sets: list[tuple[tuple[str, ...], dict[str, Any]]] = []
+        self.updates: list[tuple[tuple[str, ...], dict[str, Any]]] = []
+        self.has_written = False
+
+    def _assert_read_allowed(self) -> None:
+        if self.has_written and not self._allow_reads_after_writes:
+            raise ReadAfterWriteError('Firestore transactions must complete all reads before the first write')
+
+    def _assert_reference_belongs(self, ref: StrictFirestoreDocument) -> None:
+        if ref._database is not self._database:
+            raise ForeignTransactionError('Firestore transaction and document reference must belong to the same store')
+
+    def set(self, ref: StrictFirestoreDocument, data: dict[str, Any]) -> None:
+        self._assert_reference_belongs(ref)
+        self.has_written = True
+        payload = deepcopy(data)
+        self.sets.append((ref.path, payload))
+        self._database.rows[ref.path] = payload
+
+    def update(self, ref: StrictFirestoreDocument, patch: dict[str, Any]) -> None:
+        self._assert_reference_belongs(ref)
+        self.has_written = True
+        if ref.path not in self._database.rows:
+            raise RuntimeError('missing row')
+        payload = deepcopy(patch)
+        self.updates.append((ref.path, payload))
+        self._database.rows[ref.path].update(payload)
+
+    def delete(self, *args: Any, **kwargs: Any) -> None:
+        raise UnsupportedFirestoreOperationError(f'StrictFirestore supports only {_SUPPORTED_OPERATIONS}')
+
+    def create(self, *args: Any, **kwargs: Any) -> None:
+        raise UnsupportedFirestoreOperationError(f'StrictFirestore supports only {_SUPPORTED_OPERATIONS}')
+
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        raise UnsupportedFirestoreOperationError(f'StrictFirestore supports only {_SUPPORTED_OPERATIONS}')
+
+    def get_all(self, *args: Any, **kwargs: Any) -> None:
+        raise UnsupportedFirestoreOperationError(f'StrictFirestore supports only {_SUPPORTED_OPERATIONS}')
+
+
+class StrictFirestore:
+    """In-memory Firestore double with strict read-before-write transactions.
+
+    ``allow_reads_after_writes`` is an explicit, greppable opt-out for tests
+    that intentionally do not exercise Firestore transaction semantics. It
+    defaults to ``False`` and must not be used by production-boundary tests.
+    """
+
+    def __init__(
+        self,
+        rows: dict[tuple[str, ...], dict[str, Any]] | None = None,
+        *,
+        allow_reads_after_writes: bool = False,
+    ):
+        self.rows = deepcopy(rows or {})
+        self.lock = RLock()
+        self._allow_reads_after_writes = allow_reads_after_writes
+
+    def collection(self, name: str) -> StrictFirestoreCollection:
+        return StrictFirestoreCollection(self, (name,))
+
+    def transaction(self) -> StrictFirestoreTransaction:
+        return StrictFirestoreTransaction(self, allow_reads_after_writes=self._allow_reads_after_writes)

--- a/backend/tests/unit/test_candidate_lifecycle.py
+++ b/backend/tests/unit/test_candidate_lifecycle.py
@@ -1,7 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
-from threading import RLock
 import json
 from pathlib import Path
 
@@ -10,76 +9,13 @@ from pydantic import ValidationError
 
 import database.candidates as candidates_db
 from models.candidate import CandidateCreate, CandidateStatus
+from tests.unit.fixtures.strict_firestore_transaction import StrictFirestore
 from utils.task_intelligence import candidate_service
-
-
-class FakeSnapshot:
-    def __init__(self, data=None):
-        self._data = deepcopy(data)
-        self.exists = data is not None
-
-    def to_dict(self):
-        return deepcopy(self._data)
-
-
-class FakeRef:
-    def __init__(self, database, path):
-        self.database = database
-        self.path = path
-
-    def collection(self, name):
-        return FakeCollection(self.database, (*self.path, name))
-
-    def get(self, transaction=None):
-        if transaction is not None and transaction.write_started:
-            raise AssertionError('Firestore transactions must complete all reads before the first write')
-        return FakeSnapshot(self.database.rows.get(self.path))
-
-    def update(self, patch):
-        self.database.rows[self.path].update(deepcopy(patch))
-
-
-class FakeCollection:
-    def __init__(self, database, path):
-        self.database = database
-        self.path = path
-
-    def document(self, name):
-        return FakeRef(self.database, (*self.path, name))
-
-
-class FakeTransaction:
-    def __init__(self, database):
-        self.database = database
-        self.lock = database.lock
-        self.write_started = False
-
-    def set(self, ref, data):
-        self.write_started = True
-        self.database.rows[ref.path] = deepcopy(data)
-
-    def update(self, ref, patch):
-        self.write_started = True
-        if ref.path not in self.database.rows:
-            raise RuntimeError('missing row')
-        self.database.rows[ref.path].update(deepcopy(patch))
-
-
-class FakeDB:
-    def __init__(self):
-        self.rows = {}
-        self.lock = RLock()
-
-    def collection(self, name):
-        return FakeCollection(self, (name,))
-
-    def transaction(self):
-        return FakeTransaction(self)
 
 
 @pytest.fixture
 def fake_db(monkeypatch):
-    database = FakeDB()
+    database = StrictFirestore()
     database.rows[('users', 'user-1', 'task_intelligence_control', 'state')] = {
         'workflow_mode': 'read',
         'account_generation': 3,

--- a/backend/tests/unit/test_memory_ledger.py
+++ b/backend/tests/unit/test_memory_ledger.py
@@ -21,6 +21,7 @@ import pytest
 from database import firestore_transaction_retry
 from testing.import_isolation import load_module_fresh, stub_modules
 from tests.unit.fake_firestore import FakeFirestore
+from tests.unit.fixtures.strict_firestore_transaction import StrictFirestore
 from utils.memory.v3.account_generation_source import read_memory_v3_trusted_account_generation
 
 _BACKEND = Path(__file__).resolve().parents[2]
@@ -126,54 +127,11 @@ class _LedgerTransaction:
 
 
 def _ledger_state_write(transaction):
-    return next(payload for path, payload in transaction.sets if path.endswith("/memory_state/head"))
-
-
-class ReadAfterWriteError(Exception):
-    """Mirror of Firestore's read-after-write guard for strict ordering tests."""
-
-
-class _StrictLedgerTransaction:
-    """Transaction fake that enforces Firestore's read-before-write ordering."""
-
-    def __init__(self):
-        self.sets = []
-        self.has_written = False
-
-    def set(self, ref, payload):
-        self.has_written = True
-        self.sets.append((ref.path, payload))
-
-
-class _StrictLedgerDocument:
-    def __init__(self, db, path):
-        self._db = db
-        self.path = path
-
-    def collection(self, name):
-        return _StrictLedgerCollection(self._db, f"{self.path}/{name}")
-
-    def get(self, transaction=None):
-        if transaction is not None and transaction.has_written:
-            raise ReadAfterWriteError("Attempted read after write in a transaction.")
-        return _LedgerSnapshot(self._db.docs.get(self.path))
-
-
-class _StrictLedgerCollection:
-    def __init__(self, db, path):
-        self._db = db
-        self.path = path
-
-    def document(self, document_id):
-        return _StrictLedgerDocument(self._db, f"{self.path}/{document_id}")
-
-
-class _StrictLedgerDb:
-    def __init__(self, docs):
-        self.docs = dict(docs)
-
-    def collection(self, name):
-        return _StrictLedgerCollection(self, name)
+    return next(
+        payload
+        for path, payload in transaction.sets
+        if (path.endswith("/memory_state/head") if isinstance(path, str) else path[-2:] == ("memory_state", "head"))
+    )
 
 
 def test_fold_commits_replays_head_and_valid_time():
@@ -409,11 +367,11 @@ def _clobbered_state_docs(uid):
     reading memory_state/apply_control — the read that regressed to happen after
     the commit/projection writes (issue #9780)."""
     return {
-        f"users/{uid}/memory_state/head": {
+        ('users', uid, 'memory_state', 'head'): {
             "current_head_commit_id": "legacy-head",
             "projection_version": 1,
         },
-        f"users/{uid}/memory_state/apply_control": {
+        ('users', uid, 'memory_state', 'apply_control'): {
             "uid": uid,
             "account_generation": 7,
             "head_commit_id": "canonical-head",
@@ -430,8 +388,8 @@ def test_ledger_append_reads_apply_control_before_any_write():
     the lenient fake did not enforce.
     """
     uid = "u1"
-    database = _StrictLedgerDb(_clobbered_state_docs(uid))
-    transaction = _StrictLedgerTransaction()
+    database = StrictFirestore(_clobbered_state_docs(uid))
+    transaction = database.transaction()
 
     result = memory_ledger._append_commit_transaction(
         transaction,
@@ -454,8 +412,8 @@ def test_ledger_append_reads_apply_control_before_any_write():
 def test_ledger_builder_append_reads_apply_control_before_any_write():
     """Regression for #9780 on the builder append path."""
     uid = "u1"
-    database = _StrictLedgerDb(_clobbered_state_docs(uid))
-    transaction = _StrictLedgerTransaction()
+    database = StrictFirestore(_clobbered_state_docs(uid))
+    transaction = database.transaction()
 
     result = memory_ledger._append_commit_with_builder_transaction(
         transaction,

--- a/backend/tests/unit/test_strict_firestore_transaction.py
+++ b/backend/tests/unit/test_strict_firestore_transaction.py
@@ -1,0 +1,108 @@
+"""Contract tests for the narrow strict Firestore transaction fixture."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.fixtures.strict_firestore_transaction import (
+    ForeignTransactionError,
+    ReadAfterWriteError,
+    StrictFirestore,
+    UnsupportedFirestoreOperationError,
+)
+
+
+def _record(database: StrictFirestore):
+    return database.collection('users').document('user-1').collection('records').document('record')
+
+
+@pytest.mark.parametrize('write_method', ['set', 'update'])
+def test_transaction_rejects_reads_after_any_write(write_method):
+    database = StrictFirestore(
+        {
+            ('users', 'user-1', 'records', 'source'): {'value': 'source'},
+            ('users', 'user-1', 'records', 'target'): {'value': 'target'},
+        }
+    )
+    source = database.collection('users').document('user-1').collection('records').document('source')
+    target = database.collection('users').document('user-1').collection('records').document('target')
+    transaction = database.transaction()
+
+    source.get(transaction=transaction)
+    if write_method == 'set':
+        transaction.set(target, {'value': 'updated'})
+    else:
+        transaction.update(target, {'value': 'updated'})
+
+    with pytest.raises(ReadAfterWriteError, match='complete all reads'):
+        source.get(transaction=transaction)
+
+
+def test_transaction_ordering_state_is_local_to_each_transaction():
+    database = StrictFirestore(
+        {
+            ('users', 'user-1', 'records', 'source'): {'value': 'source'},
+            ('users', 'user-1', 'records', 'target'): {'value': 'target'},
+        }
+    )
+    source = database.collection('users').document('user-1').collection('records').document('source')
+    target = database.collection('users').document('user-1').collection('records').document('target')
+
+    first = database.transaction()
+    first.set(target, {'value': 'updated'})
+
+    assert source.get(transaction=database.transaction()).to_dict() == {'value': 'source'}
+
+
+def test_named_opt_out_allows_reads_after_writes():
+    database = StrictFirestore(
+        {('users', 'user-1', 'records', 'record'): {'value': 'before'}},
+        allow_reads_after_writes=True,
+    )
+    record = database.collection('users').document('user-1').collection('records').document('record')
+    transaction = database.transaction()
+
+    transaction.set(record, {'value': 'after'})
+
+    assert record.get(transaction=transaction).to_dict() == {'value': 'after'}
+
+
+@pytest.mark.parametrize('write_method', ['set', 'update'])
+def test_transaction_rejects_writes_to_a_different_store(write_method):
+    database = StrictFirestore({('users', 'user-1', 'records', 'record'): {'value': 'before'}})
+    foreign_database = StrictFirestore({('users', 'user-1', 'records', 'record'): {'value': 'before'}})
+    transaction = database.transaction()
+    record = _record(foreign_database)
+
+    with pytest.raises(ForeignTransactionError, match='same store'):
+        getattr(transaction, write_method)(record, {'value': 'after'})
+
+
+def test_transaction_rejects_reads_from_a_different_store():
+    database = StrictFirestore()
+    foreign_database = StrictFirestore({('users', 'user-1', 'records', 'record'): {'value': 'before'}})
+
+    with pytest.raises(ForeignTransactionError, match='same store'):
+        _record(foreign_database).get(transaction=database.transaction())
+
+
+@pytest.mark.parametrize(
+    'operation',
+    [
+        pytest.param(lambda database, record: database.transaction().create(record, {'value': 'after'}), id='create'),
+        pytest.param(lambda database, record: database.transaction().delete(record), id='transaction-delete'),
+        pytest.param(lambda database, record: database.transaction().get(record), id='transaction-get'),
+        pytest.param(lambda database, record: database.transaction().get_all([record]), id='transaction-get-all'),
+        pytest.param(lambda _database, record: record.delete(), id='document-delete'),
+        pytest.param(
+            lambda database, _record: database.collection('users').where('id', '==', 'user-1'), id='collection-query'
+        ),
+        pytest.param(lambda database, _record: database.collection('users').stream(), id='collection-stream'),
+    ],
+)
+def test_unsupported_operations_fail_loudly(operation):
+    database = StrictFirestore({('users', 'user-1', 'records', 'record'): {'value': 'before'}})
+    record = _record(database)
+
+    with pytest.raises(UnsupportedFirestoreOperationError, match='supports only'):
+        operation(database, record)

--- a/docs/product/failure-classes.md
+++ b/docs/product/failure-classes.md
@@ -1,5 +1,6 @@
 # Failure-class registry
 
-| Class | Violated contract | Canonical fix primitive | Status |
-| --- | --- | --- | --- |
-| FC-1 | A malformed or legacy Firestore document must not bypass the reader's explicit fail-open or fail-closed policy. | `backend/database/read_boundary.py` | Open — the 14-day closure observation starts when #9827 merges. |
+| Class | Violated contract | Canonical fix primitive | Status | Closed by | Not covered |
+| --- | --- | --- | --- | --- | --- |
+| FC-1 | A malformed or legacy Firestore document must not bypass the reader's explicit fail-open or fail-closed policy. | `backend/database/read_boundary.py` | Open — the 14-day closure observation starts when #9827 merges. | — | — |
+| FC-6 | A Firestore transaction fake must reject reads after the first write; a lenient fake can certify production code Firestore rejects. | `backend/tests/unit/fixtures/strict_firestore_transaction.py` | Closed | Shared strict fixture and strict-by-default convention. | Boundaries without incident evidence; fake styles that cannot be classified mechanically; queries, deletes, retry, and contention semantics. |


### PR DESCRIPTION
## Summary
Closes #9840.

- Consolidate the ledger and candidate-lifecycle Firestore transaction fakes into a shared strict fixture.
- Enforce Firestore's read-before-write rule for transaction-bound document reads after both `set` and `update`.
- Reject transaction/document references from different `StrictFirestore` instances as fixture-integrity policy, preventing accidental mixing of unrelated in-memory stores.
- Make unsupported fake APIs fail with one explicit contract error, so a unit test cannot accidentally treat queries, deletes, bulk reads, or streams as faithfully modelled.
- Record FC-6 and document when to use the fixture versus the Firestore emulator.

## Root cause and durable guard

The prior ledger fake permitted a transaction-bound document read after a staged write, although Firestore rejects that ordering. The shared fixture defaults to rejecting it, so both source suites now exercise the same production constraint.

The fixture intentionally does **not** model query results, deletes, commit/rollback visibility, atomicity, retries, or contention. It rejects those operations explicitly; incidents in those areas require emulator coverage before a targeted fixture extension. Same-instance enforcement is a fake-integrity policy, not a claim about Firestore client identity.

## Verification

- `cd backend && .venv/bin/pytest -q tests/unit/test_strict_firestore_transaction.py tests/unit/test_memory_ledger.py tests/unit/test_candidate_lifecycle.py` — 89 passed
- `cd backend && .venv/bin/pyright -p pyrightconfig.json --pythonpath .venv/bin/python` — 0 errors (2,236 existing repository warnings)
- `make preflight` — 16 checks passed
- Pre-push checks passed.
- Final independent Sol review approved the implementation and policy wording.

## Full-suite note

`cd backend && ./test.sh` previously encountered an unrelated fast-test timing threshold in `test_activate_task_intelligence_dogfood_user.py::test_missing_control_plans_explicit_read_at_default_generation` (0.13s vs 0.12s). Its isolated rerun passed; this PR does not alter that test or timing configuration.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
