### PR TITLE
fix(deploy): reconcile pusher runtime config before preflight

### DIFF
--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -130,6 +130,62 @@ jobs:
           location: ${{ env.REGION }}
           project_id: ${{ vars.GCP_PROJECT_ID }}
 
+      - name: Resolve production pusher runtime targets
+        if: env.SERVICE == 'pusher' && vars.ENV == 'prod'
+        id: pusher-runtime-targets
+        run: |
+          set -euo pipefail
+          SYNC_SERVICE_URL="$(
+            gcloud run services describe backend-sync \
+              --region="${{ env.REGION }}" \
+              --project="${{ vars.GCP_PROJECT_ID }}" \
+              --format='value(status.url)'
+          )"
+          SYNC_TASKS_INVOKER_SA="$(
+            gcloud run services describe backend-sync \
+              --region="${{ env.REGION }}" \
+              --project="${{ vars.GCP_PROJECT_ID }}" \
+              --format=json \
+              | jq -r '.spec.template.spec.containers[0].env[]? | select(.name == "SYNC_TASKS_INVOKER_SA") | .value'
+          )"
+          test -n "$SYNC_SERVICE_URL"
+          test -n "$SYNC_TASKS_INVOKER_SA"
+          {
+            echo "account_deletion_handler_url=${SYNC_SERVICE_URL}/v1/users/account-deletion-wipes/run"
+            echo "sync_tasks_handler_url=${SYNC_SERVICE_URL}/v2/sync-jobs/run"
+            echo "sync_tasks_invoker_sa=${SYNC_TASKS_INVOKER_SA}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Apply non-secret pusher runtime config
+        if: env.SERVICE == 'pusher'
+        env:
+          ACCOUNT_DELETION_HANDLER_URL: ${{ steps.pusher-runtime-targets.outputs.account_deletion_handler_url }}
+          CONVERSATION_SUMMARIZED_APP_IDS: ${{ vars.CONVERSATION_SUMMARIZED_APP_IDS }}
+          ENVIRONMENT: ${{ vars.ENV }}
+          GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
+          MCP_AUTHORIZATION_SERVER_URL: ${{ vars.MCP_AUTHORIZATION_SERVER_URL }}
+          MCP_OAUTH_CHATGPT_CLIENT_ID: ${{ vars.MCP_OAUTH_CHATGPT_CLIENT_ID }}
+          MCP_OAUTH_CHATGPT_REDIRECT_URIS: ${{ vars.MCP_OAUTH_CHATGPT_REDIRECT_URIS }}
+          MCP_OAUTH_CLAUDE_CLIENT_ID: ${{ vars.MCP_OAUTH_CLAUDE_CLIENT_ID }}
+          MCP_OAUTH_CLAUDE_CLIENT_NAME: ${{ vars.MCP_OAUTH_CLAUDE_CLIENT_NAME }}
+          MCP_OAUTH_CLAUDE_REDIRECT_URIS: ${{ vars.MCP_OAUTH_CLAUDE_REDIRECT_URIS }}
+          MCP_OAUTH_PUBLIC_CLIENT_ID: ${{ vars.MCP_OAUTH_PUBLIC_CLIENT_ID }}
+          MCP_OAUTH_PUBLIC_REDIRECT_URIS: ${{ vars.MCP_OAUTH_PUBLIC_REDIRECT_URIS }}
+          MCP_RESOURCE_URL: ${{ vars.MCP_RESOURCE_URL }}
+          RAPID_API_HOST: ${{ vars.RAPID_API_HOST }}
+          REDIS_DB_HOST: ${{ vars.REDIS_DB_HOST }}
+          STT_PRERECORDED_MODEL: ${{ vars.STT_PRERECORDED_MODEL }}
+          STT_SERVICE_MODELS: ${{ vars.STT_SERVICE_MODELS }}
+          SYNC_TASKS_HANDLER_URL: ${{ steps.pusher-runtime-targets.outputs.sync_tasks_handler_url }}
+          SYNC_TASKS_INVOKER_SA: ${{ steps.pusher-runtime-targets.outputs.sync_tasks_invoker_sa }}
+          TYPESENSE_HOST: ${{ vars.TYPESENSE_HOST }}
+          TWILIO_ACCOUNT_SID: ${{ vars.TWILIO_ACCOUNT_SID }}
+          TWILIO_API_KEY_SID: ${{ vars.TWILIO_API_KEY_SID }}
+          TWILIO_TWIML_APP_SID: ${{ vars.TWILIO_TWIML_APP_SID }}
+          X_OAUTH_CLIENT_ID: ${{ vars.X_OAUTH_CLIENT_ID }}
+          X_OAUTH_REDIRECT_URI: ${{ vars.X_OAUTH_REDIRECT_URI }}
+        run: backend/scripts/deploy-backend-config.sh
+
       - name: Preflight pusher ConfigMap and Secret references
         if: env.SERVICE == 'pusher'
         run: |

--- a/backend/tests/unit/test_verify_pusher_config_references.py
+++ b/backend/tests/unit/test_verify_pusher_config_references.py
@@ -127,6 +127,50 @@ def test_typesense_and_google_binding_classifications_are_explicit():
     assert {"TYPESENSE_API_KEY", "GOOGLE_CLIENT_SECRET"}.issubset(kinds["secret"])
 
 
+def test_standalone_pusher_reconciles_non_secret_config_before_preflight():
+    """Static workflow contract: reconciliation makes rendered references live before Helm."""
+    workflow = (SCRIPT.parents[2] / ".github/workflows/gcp_backend_pusher.yml").read_text(encoding="utf-8")
+    required_config = {
+        "CONVERSATION_SUMMARIZED_APP_IDS",
+        "GOOGLE_CLIENT_ID",
+        "MCP_AUTHORIZATION_SERVER_URL",
+        "MCP_OAUTH_CHATGPT_CLIENT_ID",
+        "MCP_OAUTH_CHATGPT_REDIRECT_URIS",
+        "MCP_OAUTH_PUBLIC_CLIENT_ID",
+        "MCP_OAUTH_PUBLIC_REDIRECT_URIS",
+        "MCP_RESOURCE_URL",
+        "RAPID_API_HOST",
+        "REDIS_DB_HOST",
+        "STT_PRERECORDED_MODEL",
+        "STT_SERVICE_MODELS",
+        "TYPESENSE_HOST",
+        "TWILIO_ACCOUNT_SID",
+        "TWILIO_API_KEY_SID",
+        "TWILIO_TWIML_APP_SID",
+        "X_OAUTH_CLIENT_ID",
+        "X_OAUTH_REDIRECT_URI",
+    }
+    prod_only_config = {
+        "ACCOUNT_DELETION_HANDLER_URL",
+        "MCP_OAUTH_CLAUDE_CLIENT_ID",
+        "MCP_OAUTH_CLAUDE_CLIENT_NAME",
+        "MCP_OAUTH_CLAUDE_REDIRECT_URIS",
+        "SYNC_TASKS_HANDLER_URL",
+        "SYNC_TASKS_INVOKER_SA",
+    }
+
+    resolve_index = workflow.index("- name: Resolve production pusher runtime targets")
+    reconcile_index = workflow.index("- name: Apply non-secret pusher runtime config")
+    preflight_index = workflow.index("- name: Preflight pusher ConfigMap and Secret references")
+    helm_index = workflow.index("helm -n ${{ vars.ENV }}-omi-backend upgrade --install")
+    reconcile = workflow[reconcile_index:preflight_index]
+
+    assert resolve_index < reconcile_index < preflight_index < helm_index
+    assert all(f"          {name}:" in reconcile for name in required_config | prod_only_config)
+    assert "backend/scripts/deploy-backend-config.sh" in reconcile
+    assert "secrets." not in reconcile
+
+
 def test_rendered_dev_pusher_direct_bindings_match_source_contract(preflight: SimpleNamespace):
     deployment = preflight.rendered_pusher_deployment("dev")
     expected, clear_historical_secret = preflight.dev_pusher_binding_contract()


### PR DESCRIPTION
## Summary
- Reconcile the non-secret pusher runtime ConfigMap before metadata-only reference preflight and Helm rollout.
- Resolve the existing production backend-sync task URLs and invoker identity without logging values.
- Add a static workflow contract for `reconcile -> preflight -> Helm`, required public inputs, and absence of `secrets.*` bindings.

## Root cause and guard
A standalone pusher deploy could preflight a ConfigMap that had never been applied by that path. This allowed an old runtime-config contract to survive until rollout. The workflow now fails closed after reconciling the complete non-secret ConfigMap and before preflight/Helm.

## Verification
- `backend/.venv/bin/python -m pytest backend/tests/unit/test_verify_pusher_config_references.py -q` — 19 passed
- `make preflight` — 17 selected checks passed
- Normal `git push` pre-push hook — passed: deployment-secret boundary, dev/prod runtime-env validation, Pyright warnings only, selected backend suites, OpenAPI compatibility/export, formatting, and workflow checks.

No secret values are read, logged, or added to workflow YAML. No deployment was triggered.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

