### PR TITLE
fix(backend): copy services/ into pusher runtime image (#9857)

### DIFF
--- a/.github/failure-classes/FC-runtime-image-import-gap.json
+++ b/.github/failure-classes/FC-runtime-image-import-gap.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "FC-runtime-image-import-gap",
+  "violated_contract": "A service's runtime container image must copy every first-party package its entrypoints import, so the process never fails at import time with ModuleNotFoundError.",
+  "canonical_prevention": "Reconcile each whitelist-copy Dockerfile against the first-party packages its entrypoints statically reach with a hermetic import-contract test.",
+  "evidence_prs": [9140, 9141, 9704],
+  "scope_hints": ["backend/pusher/**", "backend/**/Dockerfile"],
+  "status": "open"
+}

--- a/backend/pusher/Dockerfile
+++ b/backend/pusher/Dockerfile
@@ -68,6 +68,7 @@ COPY backend/config/ ./config/
 COPY backend/database/ ./database/
 COPY backend/models/ ./models/
 COPY backend/routers/ ./routers/
+COPY backend/services/ ./services/
 COPY backend/utils/ ./utils/
 COPY backend/pusher/ ./pusher/
 

--- a/backend/tests/unit/test_pusher_dockerfile_import_contract.py
+++ b/backend/tests/unit/test_pusher_dockerfile_import_contract.py
@@ -1,0 +1,96 @@
+"""Static import contract for the pusher runtime image.
+
+`backend/pusher/Dockerfile` whitelist-copies only the first-party packages the
+pusher reaches. When a pusher-reachable module gains a `from <pkg> import ...`
+against a first-party package that the Dockerfile does not copy, the runtime
+image crashes at import time with `ModuleNotFoundError` (dev pusher
+CrashLoopBackOff — issue #9857; the earlier `jsonschema`/`services` gaps in
+#9140/#9141/#9704 were the same class).
+
+An in-process `import routers.pusher` cannot catch this: the full `backend/`
+tree is present under pytest, so the import always succeeds. The only hermetic
+guard is to reconcile the Dockerfile's copy whitelist against the first-party
+packages that pusher's entrypoints statically reach.
+
+# omi-test-quality: source-inspection -- static contract: the packaging gap only
+# exists in the trimmed Docker image, which cannot be imported in-process.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+DOCKERFILE = BACKEND_DIR / "pusher" / "Dockerfile"
+
+# Modules that are the pusher runtime entrypoints. Traversal follows their
+# first-party imports transitively.
+ENTRYPOINTS = ["pusher.main", "routers.pusher"]
+
+# First-party top-level packages = importable directories under backend/ (those
+# containing Python source). A same-named directory without any `.py` (e.g.
+# `typesense/`, which only holds a schema file) is data, not a package — the
+# matching `import typesense` resolves to the third-party pip client instead.
+FIRST_PARTY = {p.name for p in BACKEND_DIR.iterdir() if p.is_dir() and any(p.rglob("*.py"))}
+
+
+def _copied_packages() -> set[str]:
+    """Top-level packages copied into the runtime image via `COPY backend/<pkg>/`."""
+    text = DOCKERFILE.read_text()
+    return set(re.findall(r"^COPY\s+backend/(\w+)/", text, re.MULTILINE))
+
+
+def _resolve(module: str) -> Path | None:
+    """Resolve a dotted first-party module to a parseable .py file, if any."""
+    rel = module.replace(".", "/")
+    for candidate in (BACKEND_DIR / f"{rel}.py", BACKEND_DIR / rel / "__init__.py"):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _reachable_top_level_packages() -> set[str]:
+    """BFS from the entrypoints, following absolute first-party imports."""
+    referenced: set[str] = set()
+    visited: set[str] = set()
+    queue = list(ENTRYPOINTS)
+
+    while queue:
+        module = queue.pop()
+        if module in visited:
+            continue
+        visited.add(module)
+
+        top = module.split(".")[0]
+        if top in FIRST_PARTY:
+            referenced.add(top)
+
+        path = _resolve(module)
+        if path is None:
+            continue
+
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    queue.append(alias.name)
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                # Relative imports (level > 0) stay within an already-copied
+                # package, so only absolute imports can introduce a new top-level.
+                queue.append(node.module)
+
+    return {pkg for pkg in referenced if pkg in FIRST_PARTY}
+
+
+def test_pusher_dockerfile_copies_every_reachable_first_party_package():
+    copied = _copied_packages()
+    reachable = _reachable_top_level_packages()
+
+    missing = sorted(reachable - copied)
+    assert not missing, (
+        "pusher/Dockerfile does not COPY first-party packages that pusher's "
+        f"entrypoints import: {missing}. The runtime image will crash at import "
+        "time with ModuleNotFoundError. Add `COPY backend/<pkg>/ ./<pkg>/`."
+    )


### PR DESCRIPTION
## Bug
The dev **pusher** Deployment is stuck in `CrashLoopBackOff` / `ProgressDeadlineExceeded`. The container fails at import time:

```
ModuleNotFoundError: No module named 'services'
```

## Root cause
`backend/routers/pusher.py` imports `from services.conversation_finalization import final_attempt_failed` (added by #9704), but `backend/pusher/Dockerfile` whitelist-copies only `config/ database/ models/ routers/ utils/ pusher/` — it never copies `backend/services/`. The trimmed runtime image therefore cannot import the pusher router path.

## Fix
- Add `COPY backend/services/ ./services/` to `backend/pusher/Dockerfile`. `services.conversation_finalization` is a namespace module (no `__init__.py`) whose only first-party imports are `database` and `utils`, both already copied — so this single line is sufficient.
- Add a hermetic regression test (`tests/unit/test_pusher_dockerfile_import_contract.py`) that reconciles the Dockerfile copy whitelist against the first-party packages pusher's entrypoints (`pusher.main`, `routers.pusher`) statically reach. An in-process `import routers.pusher` cannot catch this — the full `backend/` tree is present under pytest — so the guard is a labeled static import contract. It catches this class (#9140/#9141 `jsonschema`, #9704 `services`).

## Verification
- `python3 -m pytest tests/unit/test_pusher_dockerfile_import_contract.py` → **1 passed** with the fix.
- Temporarily removing the new `COPY services/` line → the test **fails**, naming exactly `['services']`, confirming it would have caught this bug.
- `typesense` (a `backend/typesense/` schema dir vs the third-party `typesense` pip client) is correctly excluded — first-party detection requires the dir to contain `.py` sources.
- **UNVERIFIED:** actual Docker image build + dev rollout to `Available=True` not executed in this run (no Docker/liblc3 toolchain available here). Packaging correctness is verified against pusher's real transitive import graph.

Failure-Class: FC-runtime-image-import-gap

🤖 automated by hourly watchdog; opened for review, not merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

