### PR TITLE
fix(desktop): stabilize PTT agent routing

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline.json
@@ -27,7 +27,7 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2769,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4900,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2408,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 5153,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 5128,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1572,
     "desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnStateMachine.swift": 1790,
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1915,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -2976,28 +2976,9 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     return player
   }
 
-  /// Replaces the provider's post-tool narration with the kernel's durable
-  /// admission fact. A spawn receipt is not a child completion receipt, so this
-  /// is the only spoken acknowledgement for a PTT spawn turn.
-  private func playCanonicalSpawnAcknowledgement(_ text: String) {
-    let acknowledgement = text.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !acknowledgement.isEmpty else { return }
-
-    // A provider can begin a speculative response before its tool call returns.
-    // Once the kernel accepts the spawn, that narration can no longer make
-    // lifecycle claims. Stop it before taking the deterministic acknowledgement
-    // lease so no stale audio competes with the canonical fact.
-    takeOverVoiceOutputForAuthoritativeLocalResult()
-    guard let lease = acquireVoiceOutput(.deterministicAgentAck, reason: "canonical_spawn_receipt")
-    else { return }
-    responseGlowGate.markPlaybackActive(lease: lease)
-    FloatingBarVoicePlaybackService.shared.speakOneShot(acknowledgement, lease: lease)
-  }
-
-  /// Local results such as accepted agent receipts and verified/fail-closed
-  /// screen evidence supersede any speculative provider narration for this
-  /// turn. Keep the physical preemption and reducer lease release together so
-  /// every authoritative answer can acquire its own deterministic lease.
+  /// A verified, fail-closed screen result supersedes provider narration for
+  /// this turn. Keep physical preemption and reducer lease release together so
+  /// that local error can acquire its own deterministic lease.
   func takeOverVoiceOutputForAuthoritativeLocalResult() {
     if let activeLease = VoiceTurnCoordinator.shared.outputSnapshot.activeLease {
       FloatingBarVoicePlaybackService.shared.interruptCurrentResponse(leaseID: activeLease.id)
@@ -4007,14 +3988,14 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
               "external_tool_name": name,
               "external_tool_error": "",
             ]
-            VoiceTurnCoordinator.shared.send(
-              .authoritativeLocalResultAcceptedScoped(
-                turnID: turnID,
-                identity: identity,
-                callID: VoiceToolCallID(callId),
-                kind: .spawnReceipt))
-            self.assistantText = receipt.assistantText
-            self.playCanonicalSpawnAcknowledgement(receipt.assistantText)
+            // The receipt is canonical for journal persistence, while the same
+            // realtime turn remains the sole audible response. Clearing any
+            // pre-tool speculation keeps it out of the visible reply without
+            // interrupting native provider audio or changing voices.
+            self.assistantText = ""
+            log(
+              "RealtimeHub[\(self.providerTag)]: accepted spawn receipt; preserving native provider continuation"
+            )
             if let pill = receipt.pillProjection {
               AgentPillsManager.shared.upsertSpawnedPill(
                 id: pill.pillID,
@@ -4303,7 +4284,6 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     guard acceptsTurnEvent(identity, source: source), let identity else { return }
     guard RealtimeProviderOutputPresentationPolicy.decide(
       screenGroundingState: screenGroundingState,
-      hasCanonicalSpawnReceipt: acceptedSpawnJournalReceiptByContinuityKey[turnIdempotencyKey] != nil,
       reducerOutputSuppressed: VoiceTurnCoordinator.shared.outputSnapshot.providerOutputSuppressed
     ) == .present else { return }
     guard let lease = acquireVoiceOutput(.nativeRealtime, reason: "provider_audio") else { return }
@@ -4375,7 +4355,6 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     guard acceptsTurnEvent(identity, source: source), let identity else { return }
     guard RealtimeProviderOutputPresentationPolicy.decide(
       screenGroundingState: screenGroundingState,
-      hasCanonicalSpawnReceipt: acceptedSpawnJournalReceiptByContinuityKey[turnIdempotencyKey] != nil,
       reducerOutputSuppressed: VoiceTurnCoordinator.shared.outputSnapshot.providerOutputSuppressed
     ) == .present else { return }
     if !text.isEmpty {
@@ -4566,12 +4545,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         reason: .providerNoResponse)
     }
     let pendingToolCount = VoiceTurnCoordinator.shared.activeTurn?.pendingToolCallIDs.count ?? 0
-    let hasCanonicalSpawnReceipt =
-      acceptedSpawnJournalReceiptByContinuityKey[turnIdempotencyKey] != nil
     let postToolContinuationRequired =
       VoiceTurnCoordinator.shared.activeTurn?.postToolContinuationRequired == true
-        && RealtimeAcceptedSpawnPresentationPolicy.requiresProviderContinuation(
-          hasCanonicalSpawnReceipt: hasCanonicalSpawnReceipt)
     switch RealtimeProviderTurnDoneDisposition.decide(
       pendingToolCount: pendingToolCount,
       postToolContinuationRequired: postToolContinuationRequired)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
@@ -57,20 +57,6 @@ struct RealtimeLocalProfileTurnPlan: Equatable {
 }
 #endif
 
-/// A canonical spawn receipt proves that the child exists, but it does not
-/// authorize the realtime provider to narrate the child's eventual outcome.
-/// Provider continuations remain necessary for transport completion, but are
-/// not presented to the user for that turn.
-enum RealtimeAcceptedSpawnPresentationPolicy {
-  static func suppressesProviderContinuation(hasCanonicalSpawnReceipt: Bool) -> Bool {
-    hasCanonicalSpawnReceipt
-  }
-
-  static func requiresProviderContinuation(hasCanonicalSpawnReceipt: Bool) -> Bool {
-    !hasCanonicalSpawnReceipt
-  }
-}
-
 /// Audio and text are two transports for the same response. Keeping every
 /// presentation gate here prevents one transport from exposing output the other
 /// correctly withheld.
@@ -78,22 +64,15 @@ enum RealtimeProviderOutputPresentationPolicy {
   enum Disposition: Equatable {
     case present
     case suppressScreenGrounding
-    case suppressCanonicalLocalResult
     case suppressReducerOwnedOutput
   }
 
   static func decide(
     screenGroundingState: RealtimeScreenGroundingState,
-    hasCanonicalSpawnReceipt: Bool,
     reducerOutputSuppressed: Bool
   ) -> Disposition {
     if screenGroundingState.suppressesProviderOutput {
       return .suppressScreenGrounding
-    }
-    if RealtimeAcceptedSpawnPresentationPolicy.suppressesProviderContinuation(
-      hasCanonicalSpawnReceipt: hasCanonicalSpawnReceipt)
-    {
-      return .suppressCanonicalLocalResult
     }
     return reducerOutputSuppressed ? .suppressReducerOwnedOutput : .present
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -153,7 +153,7 @@ enum RealtimeHubTools {
     let providerProperty: [String: Any]? = availableDirectedProviders.isEmpty ? nil : [
       "type": "string",
       "enum": availableDirectedProviders,
-      "description": "Optional available local provider to run this background agent through.",
+      "description": "Optional local provider override only when the current user explicitly names it; omit for a regular Omi agent.",
     ]
     return GeneratedRealtimeTools.baseOpenAITools(providerProperty: providerProperty)
   }

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedRealtimeTools.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedRealtimeTools.swift
@@ -259,7 +259,7 @@ enum GeneratedRealtimeTools {
             "openclaw",
             "hermes"
           ],
-          "description": "Optional local provider override."
+          "description": "Optional local provider override only when the current user explicitly names it; omit for a regular Omi agent."
         },
         "parent_run_id": {
           "type": "string",

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
@@ -287,7 +287,7 @@ enum GeneratedToolCapabilities {
       "Creates a canonical kernel session/run; visible runs project into floating-bar pills.",
       "Calling spawn_agent is the only way to start a visible floating-bar background agent; saying you will start one does not start it.",
       "Use visible=false for parent-linked background work that should not appear as a pill.",
-      "If the user asks to use OpenClaw or Hermes, pass provider='openclaw' or provider='hermes'.",
+      "Pass provider='openclaw' or provider='hermes' only when the current user explicitly names that provider; otherwise omit provider so Omi starts its regular managed agent.",
       "Inspect progress with list_agent_sessions or get_agent_run."
     ]
     ),

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
@@ -41,7 +41,7 @@ enum GeneratedSwiftToolExecutor: String {
 
 enum GeneratedToolExecutors {
   static let manifestVersion = 1
-  static let manifestDigest = "sha256:1d6723e73f0976062771591ed1e1cb19ab9a2bc60e5e9db296613e4f02aa8fbf"
+  static let manifestDigest = "sha256:eddc8fda648c0e53797d0892c9409780ffb32eeb4d839a6510d027f310917544"
 
   static let aliasToCanonical: [String: GeneratedSwiftTool] = [
     "search_screen_history": .semanticSearch,

--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -132,6 +132,7 @@ final class HubSystemInstructionTests: XCTestCase {
         let provider = properties?["provider"] as? [String: Any]
 
         XCTAssertEqual(provider?["enum"] as? [String], ["openclaw"])
+        XCTAssertTrue((provider?["description"] as? String ?? "").contains("current user explicitly names it"))
     }
 
     func testRealtimeSpawnAgentOmitsProviderWhenNoLocalProvidersAreAvailable() {

--- a/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift
@@ -47,26 +47,17 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
     XCTAssertFalse(recall.assistantText.contains("GAUNTLET-OLD"))
   }
 
-  func testCanonicalSpawnReceiptSuppressesProviderContinuationPresentation() {
-    XCTAssertTrue(
-      RealtimeAcceptedSpawnPresentationPolicy.suppressesProviderContinuation(
-        hasCanonicalSpawnReceipt: true))
-    XCTAssertFalse(
-      RealtimeAcceptedSpawnPresentationPolicy.suppressesProviderContinuation(
-        hasCanonicalSpawnReceipt: false))
-    XCTAssertFalse(
-      RealtimeAcceptedSpawnPresentationPolicy.requiresProviderContinuation(
-        hasCanonicalSpawnReceipt: true))
-    XCTAssertTrue(
-      RealtimeAcceptedSpawnPresentationPolicy.requiresProviderContinuation(
-        hasCanonicalSpawnReceipt: false))
+  func testCanonicalSpawnReceiptKeepsProviderContinuationInNativeVoiceLane() {
     XCTAssertEqual(
-      RealtimeProviderTurnDoneDisposition.decide(
-        pendingToolCount: 0,
-        postToolContinuationRequired:
-          RealtimeAcceptedSpawnPresentationPolicy.requiresProviderContinuation(
-            hasCanonicalSpawnReceipt: true)),
-      .finalizeLogicalTurn)
+      RealtimeProviderOutputPresentationPolicy.decide(
+        screenGroundingState: .inactive,
+        reducerOutputSuppressed: false),
+      .present)
+    XCTAssertEqual(
+        RealtimeProviderTurnDoneDisposition.decide(
+          pendingToolCount: 0,
+          postToolContinuationRequired: true),
+      .requestPostToolContinuation)
   }
 
   func testCanonicalSpawnReceiptNeverRedrivesAfterExpectedSessionRefresh() {
@@ -327,6 +318,8 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
   }
 
   func testRealtimeHubUsesCanonicalVoicePlaybackServiceForLocalSpeechFallbacks() throws {
+    // omi-test-quality: source-inspection -- static contract: the realtime controller must not
+    // reintroduce a local TTS takeover for an accepted background-agent receipt.
     let source = try realtimeHubControllerSource()
 
     XCTAssertFalse(source.contains("AVSpeechSynthesizer"))
@@ -340,13 +333,13 @@ final class RealtimeHubSpawnAgentTests: XCTestCase {
     XCTAssertTrue(
       source.contains(
         "acquireVoiceOutput(.selectedVoiceFallback, reason: \"text_no_native_audio\")"))
-    // omi-test-quality: source-inspection -- static wiring contract for the
-    // behavioral policy tested above and the shared deterministic-ack lease.
-    XCTAssertTrue(source.contains("playCanonicalSpawnAcknowledgement(receipt.assistantText)"))
-    XCTAssertTrue(source.contains("acquireVoiceOutput(.deterministicAgentAck"))
-    XCTAssertTrue(source.contains(".authoritativeLocalResultAcceptedScoped("))
+    // The spawn receipt persists the canonical lifecycle fact, but only the
+    // native provider continuation may answer the same PTT turn aloud.
+    XCTAssertTrue(source.contains("preserving native provider continuation"))
+    XCTAssertFalse(source.contains("playCanonicalSpawnAcknowledgement"))
+    XCTAssertFalse(source.contains("kind: .spawnReceipt"))
     XCTAssertTrue(source.contains("RealtimeHeadlessPTTSessionSwapPolicy.shouldRedrive("))
-    XCTAssertTrue(source.contains("requiresProviderContinuation("))
+    XCTAssertTrue(source.contains("postToolContinuationRequired"))
   }
 
   func testRealtimeHubAudibleOutputIsLeaseGated() throws {

--- a/desktop/macos/Desktop/Tests/RealtimeScreenEvidenceTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeScreenEvidenceTests.swift
@@ -75,26 +75,23 @@ final class RealtimeScreenEvidenceTests: XCTestCase {
     XCTAssertEqual(
       RealtimeProviderOutputPresentationPolicy.decide(
         screenGroundingState: .awaitingReport(receipt()),
-        hasCanonicalSpawnReceipt: false,
         reducerOutputSuppressed: false),
       .suppressScreenGrounding)
     XCTAssertEqual(
       RealtimeProviderOutputPresentationPolicy.decide(
         screenGroundingState: .accepted(receipt()),
-        hasCanonicalSpawnReceipt: false,
         reducerOutputSuppressed: false),
       .present,
       "the verified continuation must reach both native audio and text presentation")
     XCTAssertEqual(
       RealtimeProviderOutputPresentationPolicy.decide(
         screenGroundingState: .inactive,
-        hasCanonicalSpawnReceipt: true,
         reducerOutputSuppressed: false),
-      .suppressCanonicalLocalResult)
+      .present,
+      "a durable spawn receipt does not preempt native realtime audio")
     XCTAssertEqual(
       RealtimeProviderOutputPresentationPolicy.decide(
         screenGroundingState: .inactive,
-        hasCanonicalSpawnReceipt: false,
         reducerOutputSuppressed: true),
       .suppressReducerOwnedOutput)
   }

--- a/desktop/macos/Desktop/Tests/VoiceTurnReducerTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnReducerTests.swift
@@ -693,12 +693,12 @@ final class VoiceTurnReducerTests: XCTestCase {
     XCTAssertEqual(acceptJournal(continuation).model.turn?.phase, .terminal(.success))
   }
 
-  func testCanonicalSpawnReceiptCompletesWithoutProviderContinuation() throws {
+  func testCanonicalSpawnReceiptKeepsProviderContinuationForNativeVoiceOutput() throws {
     let (startingModel, turnID, sessionID, responseID) = awaitingHubResponse()
     let reservation = reserveIdentity(startingModel, turnID: turnID)
     let toolIdentity = reservation.identity
     let callID = VoiceToolCallID("spawn-agent")
-    var model = reduce(
+    let model = reduce(
       reservation.model,
       .toolStartedScoped(turnID: turnID, identity: toolIdentity, callID: callID)
     ).model
@@ -707,26 +707,43 @@ final class VoiceTurnReducerTests: XCTestCase {
     XCTAssertTrue(model.turn?.deadlines.contains(.pendingTools) == true)
     XCTAssertFalse(model.turn?.deadlines.contains(.providerResponse) == true)
 
-    model = reduce(
-      model,
-      .authoritativeLocalResultAcceptedScoped(
-        turnID: turnID,
-        identity: toolIdentity,
-        callID: callID,
-        kind: .spawnReceipt)
-    ).model
-
-    XCTAssertTrue(model.turn?.providerFinished == true)
-    XCTAssertFalse(model.turn?.postToolContinuationRequired == true)
-    guard case .writing = model.turn?.journalFinalization else {
-      return XCTFail("the canonical receipt must open the journal fence")
-    }
-
     let finished = reduce(
       model,
       .toolFinishedScoped(turnID: turnID, identity: toolIdentity, callID: callID)
     ).model
-    let accepted = acceptJournal(finished)
+    XCTAssertFalse(finished.turn?.providerFinished == true)
+    XCTAssertTrue(finished.turn?.postToolContinuationRequired == true)
+    XCTAssertEqual(finished.turn?.journalFinalization, .pending)
+
+    let providerIdentity = try XCTUnwrap(finished.turn?.providerEffectIdentity)
+    let toolOnlyCycleFinished = reduce(
+      finished,
+      .providerTurnFinishedScoped(
+        turnID: turnID,
+        identity: providerIdentity,
+        sessionID: sessionID,
+        responseID: responseID)
+    ).model
+    XCTAssertEqual(toolOnlyCycleFinished.turn?.phase, .awaitingResponse)
+    XCTAssertTrue(toolOnlyCycleFinished.turn?.postToolContinuationRequired == true)
+
+    let continuation = reduce(
+      toolOnlyCycleFinished,
+      .providerResponseStartedScoped(
+        turnID: turnID,
+        identity: providerIdentity,
+        sessionID: sessionID,
+        responseID: responseID)
+    ).model
+    let completed = reduce(
+      continuation,
+      .providerTurnFinishedScoped(
+        turnID: turnID,
+        identity: providerIdentity,
+        sessionID: sessionID,
+        responseID: responseID)
+    ).model
+    let accepted = acceptJournal(completed)
     XCTAssertEqual(accepted.model.turn?.phase, .terminal(.success))
     XCTAssertEqual(accepted.model.lastTerminal?.reason, .success)
     XCTAssertEqual(accepted.model.lastTerminal?.route, .hub(sessionID: sessionID))

--- a/desktop/macos/agent/scripts/generate-tool-surfaces.mjs
+++ b/desktop/macos/agent/scripts/generate-tool-surfaces.mjs
@@ -317,7 +317,8 @@ function openAIToolDefinition({ exposedName, tool }, { includeSpawnProvider = fa
       properties.provider = {
         type: "string",
         enum: directedProviders,
-        description: "Optional available local provider to run this background agent through.",
+        description:
+          "Optional local provider only when the current user explicitly names it; omit for a regular Omi agent.",
       };
     }
     return {

--- a/desktop/macos/agent/src/runtime/control-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/control-tool-manifest.ts
@@ -716,7 +716,7 @@ Pass parentRunId to link the new run to a parent.`,
     promptGuidelines: [
       "Calling spawn_agent is the only way to start a visible floating-bar background agent; saying you will start one does not start it.",
       "Use visible=false for parent-linked background work that should not appear as a pill.",
-      "If the user asks to use OpenClaw or Hermes, pass provider='openclaw' or provider='hermes'.",
+      "Pass provider='openclaw' or provider='hermes' only when the current user explicitly names that provider; otherwise omit provider so Omi starts its regular managed agent.",
       "Inspect progress with list_agent_sessions or get_agent_run.",
     ],
     capabilityDoc: controlDoc(
@@ -736,7 +736,7 @@ Pass parentRunId to link the new run to a parent.`,
     properties: {
       objective: { type: "string", description: "Self-contained background-agent objective." },
       requestedAgentCount: { type: "number", description: "Number of sibling agents requested in this single canonical route decision (default 1, maximum 8)." },
-      provider: { type: "string", enum: ["openclaw", "hermes"], description: "Optional local provider override." },
+      provider: { type: "string", enum: ["openclaw", "hermes"], description: "Optional local provider override only when the current user explicitly names it; omit for a regular Omi agent." },
       parentRunId: { type: "string", description: "Optional parent run to link via delegation." },
       visible: { type: "boolean", description: "Whether to project into floating-bar pill UI. Default true." },
       title: { type: "string", description: "Optional visible session title." },

--- a/desktop/macos/agent/src/runtime/control-tools.ts
+++ b/desktop/macos/agent/src/runtime/control-tools.ts
@@ -1261,7 +1261,7 @@ export async function handleAgentControlToolCall(
             effect: "spawn_agent",
             syntaxFacts: {
               parentRunId,
-              explicitProvider: adapterId,
+              explicitProvider: parsed.provider ?? null,
               requestedAgentCount: parsed.requestedAgentCount,
             },
           },

--- a/desktop/macos/agent/src/runtime/external-surface-tool-policy.ts
+++ b/desktop/macos/agent/src/runtime/external-surface-tool-policy.ts
@@ -72,6 +72,12 @@ const PERMISSION_CAPABILITY_SUBJECTS = new Set([
   "full disk access permission",
 ]);
 
+const DIRECTED_PROVIDER_TARGETS = [
+  { provider: "openclaw" as const, pattern: "(?:open\\s*claw|open\\s*cloud)" },
+  { provider: "hermes" as const, pattern: "hermes" },
+] as const;
+const DIRECTED_PROVIDER_ACTION = "(?:ask|tell|ping|message|use|run|try|start|spawn|delegate(?:\\s+to)?|have|let|send|make)";
+
 /**
  * External surfaces propose tools; this policy owns the semantic safety rewrite
  * before any capability or invocation ledger row is minted.
@@ -143,7 +149,8 @@ export function routeExternalSurfaceTool(
     return { action: "execute", toolName: input.toolName, toolInput: input.toolInput, recoveredFromDelegation: false };
   }
 
-  const objective = textField(input.toolInput, "objective") || textField(input.toolInput, "brief");
+  const toolInput = constrainSpawnProviderToCurrentUserIntent(input.toolInput, input.originatingPrompt);
+  const objective = textField(toolInput, "objective") || textField(toolInput, "brief");
   const permission = permissionRequest(objective);
   if (!permission) {
     if (mentionsPermissionCapability(objective)) {
@@ -153,10 +160,10 @@ export function routeExternalSurfaceTool(
         message: "Permission work must use a direct native permission tool with an explicit check or request action",
       };
     }
-    return { action: "execute", toolName: input.toolName, toolInput: input.toolInput, recoveredFromDelegation: false };
+    return { action: "execute", toolName: input.toolName, toolInput, recoveredFromDelegation: false };
   }
   if (
-    hasExplicitExternalPermissionTarget(objective, input.originatingPrompt, input.toolInput)
+    hasExplicitExternalPermissionTarget(objective, input.originatingPrompt, toolInput)
     || hasExplicitExternalPermissionTarget("", input.precedingAssistantText ?? "", {})
   ) {
     return {
@@ -181,6 +188,39 @@ export function routeExternalSurfaceTool(
     toolInput: { type: permission.type },
     recoveredFromDelegation: true,
   };
+}
+
+/**
+ * A realtime model may propose a local provider, but choosing a user's local
+ * Hermes/OpenClaw credential boundary is not model authority. Only the current
+ * user utterance may select it. Everything else stays on the regular Omi
+ * managed-agent path, including a model-invented or stale provider field.
+ */
+function constrainSpawnProviderToCurrentUserIntent(
+  toolInput: Record<string, unknown>,
+  originatingPrompt: string,
+): Record<string, unknown> {
+  const selectedProvider = directedProviderSelectedByUser(originatingPrompt);
+  if (selectedProvider) return { ...toolInput, provider: selectedProvider };
+
+  const suppliedProvider = textField(toolInput, "provider");
+  if (suppliedProvider !== "openclaw" && suppliedProvider !== "hermes") return toolInput;
+
+  const { provider: _, ...defaultOmiInput } = toolInput;
+  return defaultOmiInput;
+}
+
+function directedProviderSelectedByUser(prompt: string): "openclaw" | "hermes" | null {
+  const normalized = prompt.toLowerCase();
+  const selected = DIRECTED_PROVIDER_TARGETS.flatMap(({ provider, pattern }) => {
+    const target = `(?:the\\s+)?${pattern}(?:\\s+agent)?`;
+    const positive = new RegExp(
+      `(?:\\b${DIRECTED_PROVIDER_ACTION}\\s+${target}\\b|\\b(?:with|via|using|in)\\s+${target}\\b|^\\s*${pattern}\\s*(?::|,|—|-))`,
+    );
+    const negated = new RegExp(`\\b(?:don't|do not|never)\\s+${DIRECTED_PROVIDER_ACTION}\\s+${target}\\b`);
+    return positive.test(normalized) && !negated.test(normalized) ? [provider] : [];
+  });
+  return selected.length === 1 ? selected[0]! : null;
 }
 
 function normalizedPermissionType(value: string): string | null {

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -1379,7 +1379,7 @@ const controlVoicePatches: Partial<Record<AgentControlManifestTool["name"], OmiT
     schemaOverride: schema(
       {
         objective: { type: "string", description: "Self-contained background-agent objective." },
-        provider: { type: "string", enum: ["openclaw", "hermes"], description: "Optional local provider override." },
+        provider: { type: "string", enum: ["openclaw", "hermes"], description: "Optional local provider override only when the current user explicitly names it; omit for a regular Omi agent." },
         parent_run_id: { type: "string", description: "Optional parent run to link via delegation." },
         visible: { type: "boolean", description: "Whether to project into floating-bar pill UI. Default true." },
         title: { type: "string", description: "Optional visible session title." },

--- a/desktop/macos/agent/tests/external-surface-authority.test.ts
+++ b/desktop/macos/agent/tests/external-surface-authority.test.ts
@@ -424,6 +424,41 @@ describe("external realtime surface authority", () => {
     })).toMatchObject({ action: "execute", toolName: "set_desktop_attention_override" });
   });
 
+  it("defaults external spawns to Omi unless the current user selects one provider", () => {
+    expect(routeExternalSurfaceTool({
+      toolName: "spawn_agent",
+      toolInput: { objective: "Sleep for five seconds", provider: "hermes" },
+      originatingPrompt: "Have an agent sleep for five seconds.",
+    })).toEqual({
+      action: "execute",
+      toolName: "spawn_agent",
+      toolInput: { objective: "Sleep for five seconds" },
+      recoveredFromDelegation: false,
+    });
+
+    expect(routeExternalSurfaceTool({
+      toolName: "spawn_agent",
+      toolInput: { objective: "Check X trends", provider: "hermes" },
+      originatingPrompt: "Ask OpenCloud what is trending on X.",
+    })).toEqual({
+      action: "execute",
+      toolName: "spawn_agent",
+      toolInput: { objective: "Check X trends", provider: "openclaw" },
+      recoveredFromDelegation: false,
+    });
+
+    expect(routeExternalSurfaceTool({
+      toolName: "spawn_agent",
+      toolInput: { objective: "Review the release notes" },
+      originatingPrompt: "Run this in Hermes.",
+    })).toEqual({
+      action: "execute",
+      toolName: "spawn_agent",
+      toolInput: { objective: "Review the release notes", provider: "hermes" },
+      recoveredFromDelegation: false,
+    });
+  });
+
   it("applies semantic safety policy from the persisted external run prompt", () => {
     const permissionFixture = createFixture();
     const permissionRun = permissionFixture.kernel.beginExternalSurfaceRun({
@@ -1219,7 +1254,10 @@ describe("external realtime surface authority", () => {
       surfaceRef: { surfaceKind: "realtime_voice", externalRefKind: "chat", externalRefId: "default" },
       defaultAdapterId: "pi-mono",
     }, () => 1);
-    const run = kernel.beginExternalSurfaceRun(beginInput(session.agentSessionId));
+    const run = kernel.beginExternalSurfaceRun({
+      ...beginInput(session.agentSessionId),
+      prompt: "Ask OpenClaw to check the release notes in the background",
+    });
     const routed = kernel.routeExternalSurfaceToolInvocation({
       ownerId: "owner",
       sessionId: session.agentSessionId,

--- a/desktop/macos/agent/tests/fixtures/tool-manifest.json
+++ b/desktop/macos/agent/tests/fixtures/tool-manifest.json
@@ -2626,7 +2626,7 @@
     "promptGuidelines": [
       "Calling spawn_agent is the only way to start a visible floating-bar background agent; saying you will start one does not start it.",
       "Use visible=false for parent-linked background work that should not appear as a pill.",
-      "If the user asks to use OpenClaw or Hermes, pass provider='openclaw' or provider='hermes'.",
+      "Pass provider='openclaw' or provider='hermes' only when the current user explicitly names that provider; otherwise omit provider so Omi starts its regular managed agent.",
       "Inspect progress with list_agent_sessions or get_agent_run."
     ],
     "latency": "async background",
@@ -2643,7 +2643,7 @@
         },
         "provider": {
           "type": "string",
-          "description": "Optional local provider override.",
+          "description": "Optional local provider override only when the current user explicitly names it; omit for a regular Omi agent.",
           "enum": [
             "openclaw",
             "hermes"
@@ -2713,7 +2713,7 @@
         },
         "provider": {
           "type": "string",
-          "description": "Optional local provider override.",
+          "description": "Optional local provider override only when the current user explicitly names it; omit for a regular Omi agent.",
           "enum": [
             "openclaw",
             "hermes"
@@ -2805,7 +2805,7 @@
               "openclaw",
               "hermes"
             ],
-            "description": "Optional local provider override."
+            "description": "Optional local provider override only when the current user explicitly names it; omit for a regular Omi agent."
           },
           "parent_run_id": {
             "type": "string",

--- a/desktop/macos/changelog/unreleased/20260716-ptt-agent-spawn-native-voice.json
+++ b/desktop/macos/changelog/unreleased/20260716-ptt-agent-spawn-native-voice.json
@@ -1,0 +1,3 @@
+{
+  "change": "Kept push-to-talk on one voice when starting a background agent"
+}

--- a/desktop/macos/changelog/unreleased/20260716-ptt-default-omi-agent.json
+++ b/desktop/macos/changelog/unreleased/20260716-ptt-default-omi-agent.json
@@ -1,0 +1,3 @@
+{
+  "change": "Kept background agents on Omi unless you choose another provider"
+}

--- a/desktop/macos/scripts/check-hub-controller-ratchet.py
+++ b/desktop/macos/scripts/check-hub-controller-ratchet.py
@@ -62,7 +62,6 @@ EXTRACTED_TYPE_NAMES: frozenset[str] = frozenset(
         "RealtimeHubErrorOwnership",
         "RealtimeHubBargeInAction",
         "RealtimeLocalProfileTurnPlan",
-        "RealtimeAcceptedSpawnPresentationPolicy",
         "RealtimeProviderOutputPresentationPolicy",
         "RealtimeProviderTurnDoneDisposition",
         "RealtimePostToolContinuationControllerAction",

--- a/desktop/macos/scripts/check_desktop_test_quality.py
+++ b/desktop/macos/scripts/check_desktop_test_quality.py
@@ -45,7 +45,7 @@ TEST_ROOT = "desktop/macos/Desktop/Tests"
 # Pinned debt ceilings. These may only decrease. Escaped sites are not counted.
 # Run with --print after improving tests, then lower both relevant values.
 SOURCE_INSPECTION_FILE_BASELINE = 57
-SOURCE_INSPECTION_SITE_BASELINE = 162
+SOURCE_INSPECTION_SITE_BASELINE = 161
 WALL_CLOCK_WAIT_BASELINE = 19
 
 MIN_REASON_LENGTH = 12

--- a/docs/doc/developer/agent-control-plane-invariants.mdx
+++ b/docs/doc/developer/agent-control-plane-invariants.mdx
@@ -292,6 +292,13 @@ boundary, even when the control bridge itself uses managed-cloud routing. An
 adapter ID alone may not use that exception, and neither may cross a parent
 run's boundary or override an existing session's adapter.
 
+For model-driven external surfaces, that selector is valid only when the
+current user explicitly names the exact provider. The external-surface policy
+normalizes a matching provider, strips an invented/stale/mismatched provider,
+and therefore defaults generic delegation to the managed Omi adapter before the
+kernel mints a child session. A signed desktop UI selection remains explicit
+user control and follows the same provider-boundary rules.
+
 Guard surface:
 
 - `execution-policy.ts` is the shared resolver used by control tools and the
@@ -300,6 +307,8 @@ Guard surface:
   `control-tools.test.ts` exhaust production declarations, managed routing,
   directed and signed top-level local-provider starts, and signed local-session
   resumption.
+- `external-surface-authority.test.ts` verifies generic PTT delegation cannot
+  select a local provider while an explicitly named provider is preserved.
 
 ### Execution role owns agent-management authority
 

--- a/docs/product/invariants/agent-control-plane.md
+++ b/docs/product/invariants/agent-control-plane.md
@@ -84,12 +84,15 @@ must name the invariant they affect and update the matching guard test.
 - A realtime spawn acknowledgement is an admission receipt, not a child
   completion claim. The kernel derives that acknowledgement deterministically;
   only the canonical child run's terminal lifecycle may report completion,
-  failure, cancellation, or timeout. PTT presents that deterministic
-  acknowledgement, suppresses provider continuations for the spawned turn, and
-  advances its logical completion path from the validated receipt rather than
-  waiting on a provider continuation. Session-refresh recovery must recognize
-  that validated receipt as committed work and never replay it into a duplicate
-  child run.
+  failure, cancellation, or timeout. The receipt is persistence-only: it
+  records the canonical journal fact but does not claim a deterministic local
+  TTS lease or stop the native realtime stream. The active provider's post-tool
+  continuation is the sole audible response for the spawned turn; any pre-tool
+  speculation is cleared so it stays out of the visible reply without
+  interrupting the native voice lane, and the turn advances from that provider
+  continuation rather than from the receipt itself. Session-refresh recovery
+  must recognize that validated receipt as committed work and never replay it
+  into a duplicate child run.
 - Workstream consolidation moves task-scoped history through the canonical
   journal migration transaction, preserving typed payloads, revisions, outbox
   state, sequencing, and restart visibility; it never inserts or deletes turn

--- a/docs/product/invariants/chat-continuity.md
+++ b/docs/product/invariants/chat-continuity.md
@@ -76,6 +76,11 @@ rollback window; this is migration input, not a second store.
   session/run/attempt lifecycle plus a matching semantic digest for the provider.
   A parent journal receipt without that child is failure; legacy raw
   session/run/attempt payload aliases are never provider-visible.
+- A local Hermes or OpenClaw override is selected only when the current user
+  explicitly names that exact provider. A provider value proposed by a model,
+  stale context, or a generic delegation request is not authority and is
+  stripped before child-session admission, leaving the child on regular Omi
+  managed routing.
 - Each terminal canonical child run converges into exactly one visible pill
   status and one `agentCompletion` block on its producing journal turn. A
   continuation reuses its child session but has a new run identity, so its own


### PR DESCRIPTION
## Summary

- Keep background-agent spawn acknowledgements inside the active OpenAI Realtime PTT voice lane.
- Treat an external model's local-provider enum as a proposal, not user authority: generic PTT delegation now defaults to Omi's managed agent.
- Preserve an exact current-turn Hermes or OpenClaw request, correct a mismatched model proposal, and accept the spoken `OpenCloud` alias for OpenClaw.

## Root cause and durable guard

An accepted spawn receipt previously claimed a deterministic local-TTS lease, stopped the native realtime stream, and treated the provider continuation as suppressed. The receipt now remains persistence-only; the existing post-tool continuation fence keeps the native provider responsible for the audible reply.

Separately, the realtime schema exposes optional local providers and the model emitted `provider: "hermes"` for a generic request ("Have an agent sleep for five seconds"). That enum was treated as a provider choice, which admitted a local Hermes runtime even though the user never selected it. The shared external-surface policy now owns that boundary before child-session admission: only a directed provider selection in the current user utterance may reach the control plane. Tests cover generic delegation, model/provider mismatch correction, explicit Hermes, and unavailable explicit OpenClaw.

## Invariants

- INV-AGENT-*
- INV-CHAT-1
- INV-VOICE-1

## Failure class

Failure-Class: FC-split-mutation-authority

## Verification

- `cd desktop/macos/agent && npx vitest run tests/external-surface-authority.test.ts tests/omi-tool-manifest.test.ts` — 32 passed
- `cd desktop/macos && xcrun swift test --package-path Desktop --filter HubSystemInstructionTests` — 17 passed
- `cd desktop/macos && ./scripts/agent-logic-harness.sh --cross-surface-smoke` — Swift 76, Node 247, Rust 13 passed
- `OMI_PR_BODY_FILE=/tmp/omi-ptt-spawn-native-voice-pr.md make preflight` — passed
