### PR TITLE
fix(backend): surface active tasks first so the Tasks page isn't buried under completed items

### DIFF
--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -145,6 +145,11 @@ def _prepare_action_item_for_write(action_item_data: Dict[str, Any], *, partial:
 
 def _prepare_action_item_for_read(action_item_data: Dict[str, Any]) -> Dict[str, Any]:
     """Prepare action item data for reading from database"""
+    # `completed` may be missing OR explicitly null (legacy/partial writes). setdefault
+    # won't overwrite an existing null, so drop it first and let status derive a concrete
+    # bool — strict client parsers reject a null `completed` and drop the whole page.
+    if action_item_data.get('completed') is None:
+        action_item_data.pop('completed', None)
     action_item_data.setdefault('status', 'completed' if action_item_data.get('completed') else 'active')
     action_item_data.setdefault('completed', action_item_data['status'] == 'completed')
     action_item_data.setdefault('owner', 'unknown')
@@ -457,12 +462,17 @@ def get_action_items(
         action_item = _prepare_action_item_for_read(data)
         action_items.append(action_item)
 
-    # Sort results by due_at first (items without due_at come last), then by created_at.
+    # Sort: incomplete items first, then by due_at (items without due_at come last), then
+    # by created_at. Active-first is load-bearing for the default (completed=None) fetch:
+    # clients page this list (e.g. limit=100) and filter client-side, so without it a user
+    # with 100+ completed items that have due dates would have every active item pushed off
+    # page 1 — the task list then looks empty / all-done (see the reported regression).
     # The final order differs from the Firestore order_by (due_at/created_at DESC), so pagination
     # must be applied AFTER this sort. Slicing the Firestore-ordered set with offset/limit and then
     # re-sorting only that slice returns the wrong items for any page (even page 0 with a limit).
     action_items.sort(
         key=lambda x: (
+            bool(x.get('completed')),
             x.get('due_at') is None,
             x.get('due_at') or datetime.max.replace(tzinfo=timezone.utc),
             -(x.get('created_at', datetime.min.replace(tzinfo=timezone.utc)).timestamp()),

--- a/backend/tests/unit/test_action_items_pagination_order.py
+++ b/backend/tests/unit/test_action_items_pagination_order.py
@@ -23,9 +23,13 @@ BASE = datetime(2026, 1, 1, tzinfo=timezone.utc)
 
 
 class _Doc:
-    def __init__(self, doc_id, created_at, due_at):
+    def __init__(self, doc_id, created_at, due_at, completed=None):
         self.id = doc_id
         self._data = {'created_at': created_at, 'due_at': due_at}
+        # Only stamp `completed` when the test cares about it, so the existing
+        # all-active fixtures keep exercising the missing-field default path.
+        if completed is not None:
+            self._data['completed'] = completed
 
     def to_dict(self):
         return dict(self._data)
@@ -105,3 +109,49 @@ def test_non_positive_limit_does_not_truncate(fake_db):
     # negative slice). Such a limit means "no page cap", so the full sorted order is returned.
     assert _ids(fake_db, limit=0) == ['C', 'D', 'B', 'A', 'E']
     assert _ids(fake_db, limit=-5) == ['C', 'D', 'B', 'A', 'E']
+
+
+# Docs mixing completed + active. A completed task with an EARLIER due date must still sort
+# after every active task. Regression: for a user with 100+ old completed (due-dated) tasks,
+# active tasks were pushed past the client's first page (limit=100) on the default
+# completed=None fetch, so the task list rendered empty / all-done.
+MIXED = [
+    _Doc('done_soon', BASE, BASE + timedelta(days=1), completed=True),
+    _Doc('active_late', BASE, BASE + timedelta(days=9), completed=False),
+    _Doc('active_none', BASE, None, completed=False),
+    _Doc('done_late', BASE, BASE + timedelta(days=5), completed=True),
+]
+
+
+def _mixed_ids(fake_db, **kwargs):
+    query = _Query(list(MIXED))
+    fake_db.collection.return_value.document.return_value.collection.return_value = query
+    return [item['id'] for item in action_items.get_action_items('uid1', **kwargs)]
+
+
+def test_incomplete_items_sort_before_completed(fake_db):
+    # Active first (by due, no-due last), then completed (by due) — never a completed item ahead
+    # of an active one, even when the completed item is due sooner.
+    assert _mixed_ids(fake_db) == ['active_late', 'active_none', 'done_soon', 'done_late']
+
+
+def test_first_page_surfaces_active_items(fake_db):
+    # The core regression guard: a small first page must contain the active items, not be crowded
+    # out by sooner-due completed tasks.
+    page = _mixed_ids(fake_db, limit=2, offset=0)
+    assert page == ['active_late', 'active_none']
+
+
+@pytest.mark.parametrize(
+    "raw,expected_completed,expected_status",
+    [
+        ({'completed': None}, False, 'active'),  # explicit null (legacy/partial write)
+        ({}, False, 'active'),  # missing entirely
+        ({'completed': True}, True, 'completed'),
+        ({'completed': False}, False, 'active'),
+    ],
+)
+def test_completed_normalized_to_bool(raw, expected_completed, expected_status):
+    out = action_items._prepare_action_item_for_read(dict(raw))
+    assert out['completed'] is expected_completed
+    assert out['status'] == expected_status


### PR DESCRIPTION
## Problem

Heavy users' Tasks page showed **all tasks as done**, and unchecking the "done" filter showed **"No Tasks Yet"** — even though they had many active tasks. Reported on prod for a user with 226 active + ~340 completed items.

## Root cause

The Tasks page loads items with one call (`GET /v1/action-items`, `completed=null`, **limit 100**) and filters client-side. `get_action_items` re-sorts in Python by **due date ascending (items with a due date first)** and — since **#8595** (Jun 30) — paginates *after* that sort. For a user with 100+ old completed tasks that have (past) due dates, those fill the first 100-item page, pushing every active task (usually no due date → sorted last) past the client's first page. The app then:
- sees a page that is entirely `completed=true` → `shouldAutoRevealCompleted` auto-flips to the completed view ("all done", introduced by `d918a48`),
- has zero active items in that page → "No Tasks Yet" when the done filter is off.

Verified against the affected account: the default fetch returned **100 completed** items on page 1; the newest-created (active) items sat past position 100.

## Fix

`backend/database/action_items.py`:
1. **Active-first ordering** — add `bool(x.get('completed'))` as the leading sort key in `get_action_items`, so incomplete items always sort ahead of completed ones (due-date order preserved within each group). Page 1 now surfaces active tasks for every client (app/desktop/web).
2. **Null coercion** — `_prepare_action_item_for_read` normalizes a null/missing `completed` to `False`. The old `setdefault` left an explicit `null` in place, which the strict generated client parser rejects (dropping the whole page). ~7 such items existed on the affected account.

## Verification

- **Against the affected account (prod data):** default fetch (`completed=null, limit=100`) went from **100 completed → 100 active** on page 1; no `completed:null` leaks through.
- **Tests:** extended `tests/unit/test_action_items_pagination_order.py` — active-first ordering, first-page-surfaces-active, and completed null/missing/true/false coercion. 10/10 pass; 42 pass across related action-item suites; black clean.

No API/route/model change — internal ordering + normalization only.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

