### PR TITLE
fix(search): relax vector query fallback when only structured filters are set

### DIFF
--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -217,7 +217,12 @@ def query_vectors_by_metadata(
         vector=vector, filter=filter_data, namespace="ns1", include_values=False, include_metadata=True, top_k=1000
     )
     if not xc['matches']:
-        if len(and_clauses) == 3:
+        # Relax-retry when the structured people/topics/entities $or clause produced no hits, dropping
+        # it and re-querying uid-only. The $or clause, when present, is always and_clauses[1] (the date
+        # range is appended after it). The previous len == 3 guard only relaxed when a date filter was
+        # ALSO present, so the common no-date query (uid + $or, len == 2) fell through to return [] and
+        # never broadened. Never pop a date-only clause.
+        if len(and_clauses) > 1 and '$or' in and_clauses[1]:
             and_clauses.pop(1)
             logger.warning(f'query_vectors_by_metadata retrying without structured filters: {json.dumps(filter_data)}')
             xc = index.query(

--- a/backend/tests/unit/test_vector_search_relax_fallback.py
+++ b/backend/tests/unit/test_vector_search_relax_fallback.py
@@ -1,0 +1,64 @@
+"""Regression test: the vector-search relax-retry must fire without a date filter.
+
+database.vector_db.query_vectors_by_metadata queries Pinecone with a uid clause plus an
+optional structured $or clause (people/topics/entities) plus an optional date-range clause.
+When the structured query returns no matches it drops the $or clause and re-queries uid-only.
+The guard was `len(and_clauses) == 3`, which only relaxed when a date filter was ALSO present;
+the common query with people/topics/entities but no date range has len == 2 and fell through to
+`return []`, silently yielding no results. The guard now relaxes whenever the structured $or
+clause is present (and never pops a date-only clause).
+"""
+
+from datetime import datetime, timezone
+
+import database.vector_db as vdb
+
+
+class _FakeIndex:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    def query(self, **kwargs):
+        self.calls += 1
+        if self._responses:
+            return self._responses.pop(0)
+        return {'matches': []}
+
+
+def test_relax_retry_fires_without_date_filter(monkeypatch):
+    fake = _FakeIndex(
+        [
+            {'matches': []},  # structured query (uid + $or) -> no hits
+            {'matches': [{'id': 'u1-conv1', 'metadata': {'memory_id': 'conv1'}}]},  # uid-only retry -> hit
+        ]
+    )
+    monkeypatch.setattr(vdb, 'index', fake)
+
+    result = vdb.query_vectors_by_metadata('u1', [0.0] * 8, [], ['alice'], [], [], [], limit=5)
+
+    assert fake.calls == 2  # the relax-retry fired
+    assert result == ['conv1']
+
+
+def test_no_retry_when_structured_query_hits(monkeypatch):
+    fake = _FakeIndex([{'matches': [{'id': 'u1-conv2', 'metadata': {'memory_id': 'conv2'}}]}])
+    monkeypatch.setattr(vdb, 'index', fake)
+
+    result = vdb.query_vectors_by_metadata('u1', [0.0] * 8, [], ['alice'], [], [], [], limit=5)
+
+    assert fake.calls == 1  # no retry needed
+    assert result == ['conv2']
+
+
+def test_no_retry_for_date_only_query(monkeypatch):
+    # uid + date range only (no structured $or): a no-match must NOT pop the date clause; returns [].
+    fake = _FakeIndex([{'matches': []}])
+    monkeypatch.setattr(vdb, 'index', fake)
+    d0 = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    d1 = datetime(2024, 1, 2, tzinfo=timezone.utc)
+
+    result = vdb.query_vectors_by_metadata('u1', [0.0] * 8, [d0, d1], [], [], [], [], limit=5)
+
+    assert fake.calls == 1  # no relax-retry (nothing structured to drop)
+    assert result == []


### PR DESCRIPTION
## What

`database/vector_db.py` `query_vectors_by_metadata` builds a Pinecone `$and` filter from up to three clauses:

- clause 0: `uid` (always)
- clause 1: a structured `$or` over people / topics / entities (only when any are given)
- clause 2: a `created_at` date range (only when a valid two-element `dates_filter` is given)

When the structured query returns no matches, it is meant to relax: drop the structured `$or` clause and re-query uid-only. The guard was:

```python
if not xc['matches']:
    if len(and_clauses) == 3:
        and_clauses.pop(1)
        ... retry ...
    else:
        return []
```

`len(and_clauses) == 3` is only true when a date filter is ALSO present. The very common query that has people/topics/entities but no date range has `len(and_clauses) == 2`, so it fell through to `return []` and never broadened. Users got empty semantic-search results (degraded RAG / agent retrieval) where a fallback was intended.

## Fix

Relax whenever the structured `$or` clause is present, which - because it is always appended before the date range - is always `and_clauses[1]`:

```python
if len(and_clauses) > 1 and '$or' in and_clauses[1]:
    and_clauses.pop(1)
```

This fires the retry for the no-date case too, and never pops a date-only clause (a `uid + date` query with no structured filter still returns `[]` on a miss, unchanged).

## Tests

`tests/unit/test_vector_search_relax_fallback.py` uses a fake Pinecone index that counts `query` calls:

- people-only query (no date), first query empty -> the retry fires (2 calls) and returns the uid-only hit
- structured query that hits -> no retry (1 call)
- date-only query that misses -> no retry, returns `[]` (the date clause is not dropped)

The no-date case fails against the pre-fix source (1 call, `[]`) and passes after.

## Verification

```
python -m pytest tests/unit/test_vector_search_relax_fallback.py -q
  -> 3 passed  (the no-date case fails when the source fix is reverted, test kept)

black --line-length 120 --skip-string-normalization --check <files>   -> clean
python -m pyright -p pyrightconfig.json database/vector_db.py          -> 0 errors
python scripts/check_module_stub_pollution.py                          -> 0 violations
```

## Product invariants affected

None. `scripts/pr-preflight --suggest` lists no locked product invariant for the changed paths.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

