### PR TITLE
Default Task.executed_at to None instead of an evaluated-once timestamp

### DIFF
--- a/backend/models/task.py
+++ b/backend/models/task.py
@@ -24,7 +24,10 @@ class Task(BaseModel):
     action: TaskAction
     status: TaskStatus
     created_at: datetime
-    executed_at: Optional[datetime] = datetime.now()
+    # Default to None (not yet executed). A bare datetime.now() default is evaluated once at class
+    # definition, so every Task built without an explicit executed_at would share the process-start
+    # timestamp and look already-executed. updated_at below already uses the correct None default.
+    executed_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     request_id: Optional[str] = None
     memory_id: Optional[str] = None

--- a/backend/tests/unit/test_task_executed_at_default.py
+++ b/backend/tests/unit/test_task_executed_at_default.py
@@ -1,0 +1,32 @@
+"""Regression test: Task.executed_at must default to None, not an evaluated-once timestamp.
+
+models.task.Task declared `executed_at: Optional[datetime] = datetime.now()`. A bare
+datetime.now() default is evaluated once, when the class is defined, so every Task built
+without an explicit executed_at shared the same process-start timestamp and looked
+already-executed at a stale time (silent wrong persisted data). It now defaults to None, like
+the sibling updated_at field.
+"""
+
+from datetime import datetime, timezone
+
+from models.task import Task, TaskAction, TaskStatus
+
+
+def _make(**overrides):
+    data = dict(
+        id='t1',
+        action=TaskAction.HUME_MERSURE_USER_EXPRESSION,
+        status=TaskStatus.PROCESSING,
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    data.update(overrides)
+    return Task(**data)
+
+
+def test_executed_at_defaults_to_none():
+    assert _make().executed_at is None
+
+
+def test_explicit_executed_at_is_preserved():
+    dt = datetime(2024, 5, 6, 7, 8, 9, tzinfo=timezone.utc)
+    assert _make(executed_at=dt).executed_at == dt


### PR DESCRIPTION
## What

`models/task.py` declared:

```python
executed_at: Optional[datetime] = datetime.now()
```

A bare `datetime.now()` default is evaluated once, when the class is defined, not per instance. So every `Task` built without an explicit `executed_at` shared the same process-start timestamp and looked already-executed at a stale time, instead of being unset. The sibling `updated_at` field on the next line already defaults to `None`.

## Fix

Default `executed_at` to `None` (not yet executed), matching `updated_at`. Per-instance timestamps are set explicitly by the code that executes the task.

## Tests

`tests/unit/test_task_executed_at_default.py`:

- a `Task` built without `executed_at` has `executed_at is None`
- an explicit `executed_at` is preserved

The default-None case fails against the pre-fix source (it was a datetime) and passes after.

## Verification

```
python -m pytest tests/unit/test_task_executed_at_default.py -q
  -> 2 passed  (1 fail when the source fix is reverted, test kept)

black --line-length 120 --skip-string-normalization --check models/task.py tests/unit/test_task_executed_at_default.py
  -> clean
python -m pyright -p pyrightconfig.json models/task.py   -> 0 errors, 0 warnings
python scripts/check_module_stub_pollution.py            -> 0 violations
```

## Product invariants affected

None. `scripts/pr-preflight --suggest` lists no locked product invariant for the changed paths.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

