### PR TITLE
Default a null tool method to POST in app manifest validation

### DIFF
--- a/backend/tests/unit/test_app_tool_method_null.py
+++ b/backend/tests/unit/test_app_tool_method_null.py
@@ -1,0 +1,35 @@
+"""Regression test: a manifest tool with method=null must not crash validation.
+
+utils.apps._validate_tool_definition normalizes an app-manifest tool. It guarded name /
+description / endpoint against non-string values but built
+`'method': typed_tool.get('method', 'POST').upper()`. dict.get's default applies only to
+ABSENT keys, so a present-but-null method (`"method": null`) made get return None and
+None.upper() raised AttributeError, aborting manifest tool validation. method now falls back
+to 'POST' for a null or empty value.
+"""
+
+from utils.apps import _validate_tool_definition
+
+
+def _tool(**overrides):
+    t = {'name': 't', 'description': 'd', 'endpoint': 'https://e'}
+    t.update(overrides)
+    return t
+
+
+def test_null_method_defaults_to_post():
+    result = _validate_tool_definition(_tool(method=None))
+    assert result is not None
+    assert result['method'] == 'POST'
+
+
+def test_absent_method_defaults_to_post():
+    result = _validate_tool_definition(_tool())
+    assert result is not None
+    assert result['method'] == 'POST'
+
+
+def test_string_method_is_uppercased():
+    result = _validate_tool_definition(_tool(method='get'))
+    assert result is not None
+    assert result['method'] == 'GET'

--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -1609,7 +1609,7 @@ def _validate_tool_definition(tool: Dict[str, Any]) -> Dict[str, Any] | None:
         'name': name.strip(),
         'description': description.strip(),
         'endpoint': endpoint.strip(),
-        'method': typed_tool.get('method', 'POST').upper(),
+        'method': (typed_tool.get('method') or 'POST').upper(),
         'auth_required': typed_tool.get('auth_required', True),
     }
 


### PR DESCRIPTION
## What

`utils/apps.py` `_validate_tool_definition` normalizes a single tool from an app manifest. It guards `name`, `description`, and `endpoint` against non-string values, then builds:

```python
'method': typed_tool.get('method', 'POST').upper(),
```

`dict.get`'s default only applies when the key is ABSENT. A present-but-null method (`"method": null` in the manifest JSON) makes `get` return `None`, and `None.upper()` raises `AttributeError`, aborting manifest tool validation (a failed app import) instead of falling back to the default.

## Fix

Coerce a null or empty method to the `POST` default before uppercasing:

```python
'method': (typed_tool.get('method') or 'POST').upper(),
```

## Tests

`tests/unit/test_app_tool_method_null.py` (pure function, no mocks):

- a null method defaults to `POST`
- an absent method defaults to `POST`
- a string method is uppercased (`get` -> `GET`)

The null case raises `AttributeError` against the pre-fix source and passes after.

## Verification

```
python -m pytest tests/unit/test_app_tool_method_null.py -q
  -> 3 passed  (1 fail with AttributeError when the source fix is reverted, test kept)

black --line-length 120 --skip-string-normalization --check utils/apps.py tests/unit/test_app_tool_method_null.py
  -> clean
python -m pyright -p pyrightconfig.json utils/apps.py   -> 0 errors
python scripts/check_module_stub_pollution.py           -> 0 violations
```

## Product invariants affected

None. `scripts/pr-preflight --suggest` lists no locked product invariant for the changed paths.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

