### PR TITLE
fix(ci): sync new issues to an existing project column

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           project_field: Status
           # Optional unless that project_field was set up. Then this field is required.
           # The value to modify in the project field
-          project_value: Backlog
+          project_value: Someday
           # Optional, labels to work with. Read below to see how to configure it.
           # If this value is set, the action will be applied only to issues with such label(s).
           labels: |


### PR DESCRIPTION
## Summary

New-issue project sync has been failing: `github-issue-sync` assigns `Status: Backlog`, but the project board no longer has a "Backlog" column. Available values are ["Someday","Next Week","TODO (This week)","In progress","In review","Done"], so every sync run errors with "Project value 'Backlog' does not exist".

This maps the sync default to **Someday**, the semantic equivalent of a backlog (unscheduled pool). If the team prefers new issues landing elsewhere (e.g. "TODO (This week)"), it is a one-word change on line 36.

## Verification

Failing run error lists the valid columns; "Someday" is taken verbatim from that list. Config-only change; no way to exercise the issue-opened trigger before merge.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

