### PR TITLE
Preserve message-text spacing in the XML chat history sent to the LLM

### DIFF
--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -200,7 +200,10 @@ class Message(BaseModel):
 {file_section}
 </message>"""
 
-            formatted_messages.append(msg.replace('    ', '').strip())
+            # Only strip the block's surrounding whitespace. The template above is flush-left, so a
+            # .replace('    ', '') here would instead delete 4-space runs from message.text (code,
+            # tables, aligned or pasted text), corrupting the history shown to the LLM.
+            formatted_messages.append(msg.strip())
 
         return '\n'.join(formatted_messages)
 

--- a/backend/tests/unit/test_chat_xml_preserve_spacing.py
+++ b/backend/tests/unit/test_chat_xml_preserve_spacing.py
@@ -1,0 +1,32 @@
+"""Regression test: get_messages_as_xml must not strip spacing out of message text.
+
+models.chat.Message.get_messages_as_xml built each message block from a flush-left f-string
+template and then did msg.replace('    ', '').strip(). The template has no 4-space runs, so the
+replace only deleted 4-space runs from the interpolated message.text (code, tables, aligned or
+pasted text), corrupting the chat history fed to the LLM. It now only strips the block's
+surrounding whitespace.
+"""
+
+from datetime import datetime, timezone
+
+from models.chat import Message
+
+
+def _msg(text):
+    return Message(
+        id='1',
+        text=text,
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        sender='human',
+        type='text',
+    )
+
+
+def test_four_space_run_in_message_text_is_preserved():
+    xml = Message.get_messages_as_xml([_msg('def foo():        return 1')])
+    assert 'def foo():        return 1' in xml
+
+
+def test_message_text_content_present():
+    xml = Message.get_messages_as_xml([_msg('hello world')])
+    assert '<content>hello world</content>' in xml


### PR DESCRIPTION
## What

`models/chat.py` `Message.get_messages_as_xml` builds each message block from a flush-left f-string template and then ran:

```python
formatted_messages.append(msg.replace('    ', '').strip())
```

The template lines are flush-left (no 4-space indentation), so the `replace('    ', '')` never targets the template. It only deletes 4-space runs from the interpolated `message.text` - i.e. from user content like code, tables, and aligned or pasted text - silently corrupting the chat history that is fed to the LLM.

Example: `"def foo():        return 1"` became `"def foo():return 1"`.

## Fix

Drop the `replace` and only strip the block's surrounding whitespace:

```python
formatted_messages.append(msg.strip())
```

## Tests

`tests/unit/test_chat_xml_preserve_spacing.py` (pure staticmethod, no mocks):

- a 4-space run inside `message.text` survives in the produced XML
- the message content is present in the XML

The spacing case fails against the pre-fix source (the run was deleted) and passes after.

## Verification

```
python -m pytest tests/unit/test_chat_xml_preserve_spacing.py -q
  -> 2 passed  (1 fail when the source fix is reverted, test kept)

black --line-length 120 --skip-string-normalization --check models/chat.py tests/unit/test_chat_xml_preserve_spacing.py
  -> clean
python -m pyright -p pyrightconfig.json models/chat.py   -> 0 errors
python scripts/check_module_stub_pollution.py            -> 0 violations
```

## Product invariants affected

None. `scripts/pr-preflight --suggest` lists no locked product invariant for the changed paths.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

