### PR TITLE
Coerce null LLM fields to defaults in generate_app_from_prompt

### DIFF
--- a/backend/tests/unit/test_app_generator_null_fields.py
+++ b/backend/tests/unit/test_app_generator_null_fields.py
@@ -1,0 +1,54 @@
+"""Regression test: null LLM fields must not 500 app generation.
+
+utils.llm.app_generator.generate_app_from_prompt constructs GeneratedAppData from the LLM's
+parsed JSON, OUTSIDE the JSON-parse try/except. It used app_data.get(k, default), whose default
+only applies to an ABSENT key. A present-but-null field slipped through and then crashed:
+None[:50] (name), "chat" in None (capabilities), or GeneratedAppData validation for the required
+str fields description/category. Null fields now coerce to their defaults.
+"""
+
+import asyncio
+
+import utils.llm.app_generator as ag
+
+
+class _FakeResp:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeLLM:
+    def __init__(self, content):
+        self._content = content
+
+    async def ainvoke(self, messages):
+        return _FakeResp(self._content)
+
+
+def _patch_llm(monkeypatch, content):
+    monkeypatch.setattr(ag, 'get_llm', lambda *a, **k: _FakeLLM(content))
+
+
+def test_null_llm_fields_fall_back_to_defaults(monkeypatch):
+    _patch_llm(monkeypatch, '{"name": null, "description": null, "category": null, "capabilities": null}')
+
+    result = asyncio.run(ag.generate_app_from_prompt("make me an app"))
+
+    assert result.name == "My App"
+    assert result.description == "An AI-powered app"
+    assert result.category == "other"
+    assert result.capabilities == ["chat"]
+
+
+def test_valid_llm_fields_are_used(monkeypatch):
+    content = (
+        '{"name": "My Bot", "description": "d", "category": "productivity", '
+        '"capabilities": ["chat"], "chat_prompt": "be helpful"}'
+    )
+    _patch_llm(monkeypatch, content)
+
+    result = asyncio.run(ag.generate_app_from_prompt("x"))
+
+    assert result.name == "My Bot"
+    assert result.capabilities == ["chat"]
+    assert result.chat_prompt == "be helpful"

--- a/backend/utils/llm/app_generator.py
+++ b/backend/utils/llm/app_generator.py
@@ -137,14 +137,18 @@ async def generate_app_from_prompt(user_prompt: str) -> GeneratedAppData:
         else:
             raise ValueError("Failed to parse LLM response as JSON")
 
-    # Validate and construct the response
+    # Coerce present-but-null LLM fields to their defaults. app_data.get(k, default) only applies the
+    # default when k is ABSENT, so a null value ({"name": null}, {"capabilities": null}) slips through
+    # and then crashes here (None[:50], "chat" in None) or fails GeneratedAppData validation - all
+    # outside the JSON try/except above, so an uncaught 500 on app generation.
+    caps = app_data.get("capabilities") or ["chat"]
     return GeneratedAppData(
-        name=app_data.get("name", "My App")[:50],
-        description=app_data.get("description", "An AI-powered app"),
-        category=app_data.get("category", "other"),
-        capabilities=app_data.get("capabilities", ["chat"]),
-        chat_prompt=app_data.get("chat_prompt") if "chat" in app_data.get("capabilities", []) else None,
-        memory_prompt=app_data.get("memory_prompt") if "memories" in app_data.get("capabilities", []) else None,
+        name=(app_data.get("name") or "My App")[:50],
+        description=app_data.get("description") or "An AI-powered app",
+        category=app_data.get("category") or "other",
+        capabilities=caps,
+        chat_prompt=app_data.get("chat_prompt") if "chat" in caps else None,
+        memory_prompt=app_data.get("memory_prompt") if "memories" in caps else None,
     )
 
 


### PR DESCRIPTION
## What

`utils/llm/app_generator.py` `generate_app_from_prompt` builds `GeneratedAppData` from the LLM's parsed JSON, outside the JSON-parse try/except. It read each field with `app_data.get(k, default)`, whose default only applies when the key is ABSENT. A present-but-null field slipped through and then crashed:

- `name=app_data.get("name", "My App")[:50]` -> `None[:50]` `TypeError` on `{"name": null}`
- `"chat" in app_data.get("capabilities", [])` -> `"chat" in None` `TypeError` on `{"capabilities": null}`
- `description` / `category` are required `str` on `GeneratedAppData`, so a null there is a pydantic `ValidationError`

All of these are outside the try/except, so any is an uncaught 500 on app generation from a single null field in the LLM output.

## Fix

Coerce `name`, `description`, `category`, and `capabilities` to their defaults with `(get(k) or default)`, and reuse the coerced capabilities list for the chat/memories membership checks:

```python
caps = app_data.get("capabilities") or ["chat"]
return GeneratedAppData(
    name=(app_data.get("name") or "My App")[:50],
    description=app_data.get("description") or "An AI-powered app",
    category=app_data.get("category") or "other",
    capabilities=caps,
    chat_prompt=app_data.get("chat_prompt") if "chat" in caps else None,
    memory_prompt=app_data.get("memory_prompt") if "memories" in caps else None,
)
```

## Tests

`tests/unit/test_app_generator_null_fields.py` drives `generate_app_from_prompt` with a fake LLM (via `monkeypatch.setattr` on `get_llm`):

- all-null fields return the defaults with no raise
- valid fields are used as-is

The null case raises `TypeError` against the pre-fix source and passes after.

## Verification

```
python -m pytest tests/unit/test_app_generator_null_fields.py -q
  -> 2 passed  (1 fail with TypeError when the source fix is reverted, test kept)

black --line-length 120 --skip-string-normalization --check utils/llm/app_generator.py tests/unit/test_app_generator_null_fields.py
  -> clean
python -m pyright -p pyrightconfig.json utils/llm/app_generator.py   -> 0 errors, 0 warnings
python scripts/check_module_stub_pollution.py                        -> 0 violations
```

## Product invariants affected

None. `scripts/pr-preflight --suggest` lists no locked product invariant for the changed paths.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

