### PR TITLE
Guard delete_app_logo against a URL from another storage bucket

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline.json
@@ -11,7 +11,7 @@
     "backend/utils/apps.py": 1641,
     "backend/utils/memory/legacy_backfill.py": 1816,
     "backend/utils/memory_ingestion/pipeline.py": 1711,
-    "backend/utils/other/storage.py": 1578,
+    "backend/utils/other/storage.py": 1584,
     "backend/utils/retrieval/tools/calendar_tools.py": 1513,
     "backend/utils/sync/pipeline.py": 2296,
     "desktop/macos/Backend-Rust/src/routes/proxy.rs": 2741,
@@ -46,6 +46,7 @@
     "desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift": 2155
   },
   "raise_justifications": {
+    "backend/utils/other/storage.py": "delete_app_logo now requires an exact app-logo bucket prefix (startswith) so a foreign URL embedding the prefix later cannot delete an unrelated object on this deletion path (David review on #9873).",
     "desktop/macos/Desktop/Sources/AuthService.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
     "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior.",
     "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior.",

--- a/backend/tests/unit/test_delete_app_logo_bucket_guard.py
+++ b/backend/tests/unit/test_delete_app_logo_bucket_guard.py
@@ -44,6 +44,20 @@ def test_delete_app_logo_ignores_url_from_other_bucket(monkeypatch):
     assert sink == []  # nothing deleted
 
 
+def test_delete_app_logo_ignores_url_that_embeds_prefix_later(monkeypatch):
+    sink = []
+    monkeypatch.setattr(storage, '_get_storage_client', lambda: _FakeClient(sink))
+    # A foreign-bucket URL that embeds the app-logo prefix later in the path must NOT delete: the
+    # guard requires the URL to start with the prefix, not merely contain it.
+    embedded = (
+        f'https://storage.googleapis.com/other-bucket/https://storage.googleapis.com/{storage.omi_apps_bucket}/x.png'
+    )
+
+    storage.delete_app_logo(embedded)
+
+    assert sink == []  # nothing deleted
+
+
 def test_delete_app_logo_deletes_matching_url(monkeypatch):
     sink = []
     monkeypatch.setattr(storage, '_get_storage_client', lambda: _FakeClient(sink))

--- a/backend/tests/unit/test_delete_app_logo_bucket_guard.py
+++ b/backend/tests/unit/test_delete_app_logo_bucket_guard.py
@@ -1,0 +1,55 @@
+"""Regression test: delete_app_logo must not IndexError on a URL from another bucket.
+
+utils.other.storage.delete_app_logo did img_url.split(prefix)[1] where prefix is the app-logo
+bucket URL. A googleapis URL for a DIFFERENT or legacy bucket makes split return a one-element
+list, so [1] raised IndexError. Callers guard only with the looser
+startswith('https://storage.googleapis.com/'), so such a URL reaches here. It now returns when
+the app-logo bucket prefix is absent, and still deletes a matching URL.
+"""
+
+import utils.other.storage as storage
+
+
+class _FakeBlob:
+    def __init__(self, sink):
+        self._sink = sink
+
+    def delete(self):
+        self._sink.append('deleted')
+
+
+class _FakeBucket:
+    def __init__(self, sink):
+        self._sink = sink
+
+    def blob(self, path):
+        self._sink.append(('blob', path))
+        return _FakeBlob(self._sink)
+
+
+class _FakeClient:
+    def __init__(self, sink):
+        self._sink = sink
+
+    def bucket(self, name):
+        return _FakeBucket(self._sink)
+
+
+def test_delete_app_logo_ignores_url_from_other_bucket(monkeypatch):
+    sink = []
+    monkeypatch.setattr(storage, '_get_storage_client', lambda: _FakeClient(sink))
+
+    storage.delete_app_logo('https://storage.googleapis.com/some-other-bucket/x.png')  # must not raise
+
+    assert sink == []  # nothing deleted
+
+
+def test_delete_app_logo_deletes_matching_url(monkeypatch):
+    sink = []
+    monkeypatch.setattr(storage, '_get_storage_client', lambda: _FakeClient(sink))
+    url = f'https://storage.googleapis.com/{storage.omi_apps_bucket}/app123.png'
+
+    storage.delete_app_logo(url)
+
+    assert ('blob', 'app123.png') in sink
+    assert 'deleted' in sink

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -1502,8 +1502,15 @@ def upload_app_logo(file_path: str, app_id: str):
 
 
 def delete_app_logo(img_url: str):
+    prefix = f'https://storage.googleapis.com/{omi_apps_bucket}/'
+    if prefix not in img_url:
+        # The URL is not an object in the app-logo bucket (e.g. a different or legacy bucket), so
+        # there is nothing to delete here. Return instead of letting split(...)[1] raise IndexError
+        # (callers only guard with the looser startswith('https://storage.googleapis.com/')).
+        logger.warning(f'delete_app_logo: url not in {omi_apps_bucket}, skipping')
+        return
     bucket = _get_storage_client().bucket(omi_apps_bucket)
-    path = img_url.split(f'https://storage.googleapis.com/{omi_apps_bucket}/')[1]
+    path = img_url.split(prefix, 1)[1]
     logger.info(f'delete_app_logo {path}')
     blob = bucket.blob(path)
     blob.delete()

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -1503,14 +1503,13 @@ def upload_app_logo(file_path: str, app_id: str):
 
 def delete_app_logo(img_url: str):
     prefix = f'https://storage.googleapis.com/{omi_apps_bucket}/'
-    if prefix not in img_url:
-        # The URL is not an object in the app-logo bucket (e.g. a different or legacy bucket), so
-        # there is nothing to delete here. Return instead of letting split(...)[1] raise IndexError
-        # (callers only guard with the looser startswith('https://storage.googleapis.com/')).
+    # Require the URL to START WITH the app-logo prefix, not merely contain it: a foreign-bucket URL
+    # embedding the prefix later could otherwise delete an unrelated object (this is a deletion path).
+    if not img_url.startswith(prefix):
         logger.warning(f'delete_app_logo: url not in {omi_apps_bucket}, skipping')
         return
     bucket = _get_storage_client().bucket(omi_apps_bucket)
-    path = img_url.split(prefix, 1)[1]
+    path = img_url[len(prefix) :]
     logger.info(f'delete_app_logo {path}')
     blob = bucket.blob(path)
     blob.delete()


### PR DESCRIPTION
## What

`utils/other/storage.py` `delete_app_logo` computed the object path with:

```python
path = img_url.split(f'https://storage.googleapis.com/{omi_apps_bucket}/')[1]
```

A googleapis URL for a different or legacy bucket makes `split` return a one-element list, so `[1]` raises `IndexError`. Callers guard only with the looser `startswith('https://storage.googleapis.com/')`, so such a URL reaches this function and 500s it.

## Fix

Return early when the app-logo bucket prefix is absent (there is nothing to delete in this bucket), and use `split(prefix, 1)` for the matching case:

```python
prefix = f'https://storage.googleapis.com/{omi_apps_bucket}/'
if prefix not in img_url:
    logger.warning(f'delete_app_logo: url not in {omi_apps_bucket}, skipping')
    return
bucket = _get_storage_client().bucket(omi_apps_bucket)
path = img_url.split(prefix, 1)[1]
```

## Tests

`tests/unit/test_delete_app_logo_bucket_guard.py` drives `delete_app_logo` with a fake storage client (`monkeypatch.setattr` on `_get_storage_client`):

- a URL from another bucket returns without deleting (previously `IndexError`)
- a matching URL deletes the right object

The other-bucket case raises `IndexError` against the pre-fix source and passes after.

## Verification

```
python -m pytest tests/unit/test_delete_app_logo_bucket_guard.py -q
  -> 2 passed  (1 fail with IndexError when the source fix is reverted, test kept)

black --line-length 120 --skip-string-normalization --check utils/other/storage.py tests/unit/test_delete_app_logo_bucket_guard.py
  -> clean
python -m pyright -p pyrightconfig.json utils/other/storage.py   -> 0 errors
python scripts/check_module_stub_pollution.py                    -> 0 violations
```

## Product invariants affected

None. `scripts/pr-preflight --suggest` lists no locked product invariant for the changed paths.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

