### PR TITLE
Coerce null fields in the fair-use classifier result

### DIFF
--- a/backend/tests/unit/test_fair_use_classifier_null_fields.py
+++ b/backend/tests/unit/test_fair_use_classifier_null_fields.py
@@ -1,0 +1,50 @@
+"""Regression test: a null field in the classifier response must not disable abuse detection.
+
+utils.llm.fair_use_classifier.classify_user_purpose parses the LLM's JSON, then validated fields
+with result.get(k, default). get's default only applies to an ABSENT key, so a present-but-null
+field (misuse_score / confidence / evidence: null) slipped through and raised (float(None),
+None[:10]). The broad except then swallowed it and returned default_result (misuse_score 0.0 =
+"not abuse"), silently disabling abuse detection for that run. Null fields now coerce to defaults.
+"""
+
+import asyncio
+
+import utils.llm.fair_use_classifier as fuc
+
+
+class _FakeResp:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeLLM:
+    def __init__(self, content):
+        self._content = content
+
+    async def ainvoke(self, messages):
+        return _FakeResp(self._content)
+
+
+def _run(monkeypatch, content):
+    monkeypatch.setattr(fuc, '_prepare_conversation_summaries', lambda uid: [{'duration_minutes': 5}])
+    monkeypatch.setattr(fuc, '_classifier_llm', _FakeLLM(content))
+    return asyncio.run(fuc.classify_user_purpose('u1'))
+
+
+def test_null_evidence_does_not_swallow_the_score(monkeypatch):
+    result = _run(
+        monkeypatch,
+        '{"misuse_score": 0.9, "confidence": 0.8, "evidence": null, "usage_type": "commercial"}',
+    )
+    assert result['misuse_score'] == 0.9  # not swallowed to the 0.0 default
+    assert result['evidence'] == []
+    assert result['usage_type'] == 'commercial'
+
+
+def test_null_score_coerces_and_keeps_parsed_result(monkeypatch):
+    result = _run(
+        monkeypatch,
+        '{"misuse_score": null, "confidence": null, "evidence": ["a"], "usage_type": "none"}',
+    )
+    assert result['misuse_score'] == 0.0  # coerced from null, not crashed to default
+    assert result['evidence'] == ["a"]  # proves the parsed result was kept (default evidence is [])

--- a/backend/utils/llm/fair_use_classifier.py
+++ b/backend/utils/llm/fair_use_classifier.py
@@ -245,10 +245,14 @@ Respond with ONLY the JSON output, no other text."""
         result = json.loads(content.strip())
 
         # Validate and clamp
-        result['misuse_score'] = max(0.0, min(1.0, float(result.get('misuse_score', 0.0))))
-        result['confidence'] = max(0.0, min(1.0, float(result.get('confidence', 0.0))))
-        result['usage_type'] = result.get('usage_type', 'none')
-        result['evidence'] = result.get('evidence', [])[:10]  # Cap evidence entries
+        # get(k, default) only defaults an ABSENT key, so a present-but-null field (the LLM emitting
+        # misuse_score / confidence / evidence: null) would slip through and raise (float(None),
+        # None[:10]); the broad except below then swallows it and returns default_result
+        # (misuse_score 0.0 = "not abuse"), silently disabling abuse detection for that run.
+        result['misuse_score'] = max(0.0, min(1.0, float(result.get('misuse_score') or 0.0)))
+        result['confidence'] = max(0.0, min(1.0, float(result.get('confidence') or 0.0)))
+        result['usage_type'] = result.get('usage_type') or 'none'
+        result['evidence'] = (result.get('evidence') or [])[:10]  # Cap evidence entries
         result['model'] = CLASSIFIER_ROUTE
         result['prompt_version'] = 'v2'
 


### PR DESCRIPTION
## What

`utils/llm/fair_use_classifier.py` `classify_user_purpose` parses the classifier LLM's JSON, then validates each field with `result.get(k, default)`. `get`'s default only applies when the key is ABSENT. A present-but-null field (the LLM emitting `misuse_score`, `confidence`, or `evidence` as `null`) slipped through and raised:

- `float(result.get('misuse_score', 0.0))` -> `float(None)` on `{"misuse_score": null}`
- `result.get('evidence', [])[:10]` -> `None[:10]` on `{"evidence": null}`

The broad `except Exception` below then swallowed the error and returned `default_result` (`misuse_score` 0.0 = "not abuse"), silently disabling abuse detection for that run - a security-relevant fail-open.

## Fix

Coerce `misuse_score`, `confidence`, `usage_type`, and `evidence` to their defaults with `(get(k) or default)` so a null field no longer crashes into the swallowed default:

```python
result['misuse_score'] = max(0.0, min(1.0, float(result.get('misuse_score') or 0.0)))
result['confidence'] = max(0.0, min(1.0, float(result.get('confidence') or 0.0)))
result['usage_type'] = result.get('usage_type') or 'none'
result['evidence'] = (result.get('evidence') or [])[:10]
```

## Tests

`tests/unit/test_fair_use_classifier_null_fields.py` drives `classify_user_purpose` with a fake LLM (via the module's `_classifier_llm` injection hook and a patched `_prepare_conversation_summaries`):

- a null `evidence` field keeps the parsed `misuse_score` (0.9) rather than swallowing to the 0.0 default
- null scores coerce to 0.0 and the parsed `evidence` is kept

Both cases fail against the pre-fix source (swallowed to `default_result`) and pass after.

## Verification

```
python -m pytest tests/unit/test_fair_use_classifier_null_fields.py -q
  -> 2 passed  (2 fail when the source fix is reverted, test kept)

black --line-length 120 --skip-string-normalization --check utils/llm/fair_use_classifier.py tests/unit/test_fair_use_classifier_null_fields.py
  -> clean
python -m pyright -p pyrightconfig.json utils/llm/fair_use_classifier.py   -> 0 errors, 0 warnings
python scripts/check_module_stub_pollution.py                              -> 0 violations
```

## Product invariants affected

None. `scripts/pr-preflight --suggest` lists no locked product invariant for the changed paths.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

