### PR TITLE
fix(app): conversation audio player shows captured audio length, not wall-clock span

### DIFF
--- a/app/lib/widgets/conversation_audio_player_widget.dart
+++ b/app/lib/widgets/conversation_audio_player_widget.dart
@@ -396,7 +396,7 @@ class _ConversationAudioPlayerWidgetState extends State<ConversationAudioPlayerW
                                 thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
                                 overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
                                 // Dense MP3 has no gaps on its timeline — plain track.
-                                trackShape: _GapAwareTrackShape(const []),
+                                trackShape: const _GapAwareTrackShape([]),
                               ),
                               child: Slider(
                                 value: combinedPosition.inMilliseconds.toDouble().clamp(

--- a/app/lib/widgets/conversation_audio_player_widget.dart
+++ b/app/lib/widgets/conversation_audio_player_widget.dart
@@ -121,8 +121,10 @@ class _ConversationAudioPlayerWidgetState extends State<ConversationAudioPlayerW
   void _calculateTotalDuration() {
     final stamp = widget.conversation.conversationAudio;
     if (stamp != null && stamp.spans.isNotEmpty) {
-      // Wall-clock timeline (collapsed gaps are shaded on the slider).
-      _totalDuration = Duration(milliseconds: (stamp.duration * 1000).toInt());
+      // Dense-artifact timeline: total is the actual captured audio length (the
+      // MP3 has inter-part gaps and lead-in silence collapsed out), so the
+      // slider matches what plays.
+      _totalDuration = Duration(milliseconds: (stamp.capturedDuration * 1000).toInt());
       return;
     }
     double totalSeconds = 0;
@@ -141,8 +143,9 @@ class _ConversationAudioPlayerWidgetState extends State<ConversationAudioPlayerW
   /// Get combined position across all tracks
   Duration _getCombinedPosition(int? currentIndex, Duration trackPosition) {
     if (_singleArtifact) {
-      final wall = _timelineMapper!.artifactToWall(trackPosition.inMilliseconds / 1000.0);
-      return Duration(milliseconds: (wall * 1000).toInt());
+      // Dense MP3 plays linearly; position is raw artifact time (matches the
+      // captured-duration total).
+      return trackPosition;
     }
     if (currentIndex == null || currentIndex >= _trackStartOffsets.length) {
       return trackPosition;
@@ -159,7 +162,7 @@ class _ConversationAudioPlayerWidgetState extends State<ConversationAudioPlayerW
     if (conversationAudio != null && conversationAudio.isCached && conversationAudio.spans.isNotEmpty) {
       _timelineMapper = AudioTimelineMapper(conversationAudio.spans);
       _singleArtifact = true;
-      _totalDuration = Duration(milliseconds: (_timelineMapper!.wallDuration * 1000).toInt());
+      _totalDuration = Duration(milliseconds: (_timelineMapper!.capturedDuration * 1000).toInt());
       return AudioSource.uri(Uri.parse(conversationAudio.signedUrl!));
     }
 
@@ -273,9 +276,8 @@ class _ConversationAudioPlayerWidgetState extends State<ConversationAudioPlayerW
   /// Seek to a combined position across all tracks
   Future<void> _seekToCombinedPosition(Duration targetPosition) async {
     if (_singleArtifact) {
-      // Wall timeline -> dense MP3 position; gap seeks snap to the next span.
-      final artifactSeconds = _timelineMapper!.wallToArtifact(targetPosition.inMilliseconds / 1000.0);
-      await _audioPlayer.seek(Duration(milliseconds: (artifactSeconds * 1000).toInt()));
+      // targetPosition is already artifact time (the slider runs on the dense MP3).
+      await _audioPlayer.seek(targetPosition);
       return;
     }
 
@@ -393,16 +395,8 @@ class _ConversationAudioPlayerWidgetState extends State<ConversationAudioPlayerW
                                 trackHeight: 4,
                                 thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
                                 overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
-                                trackShape: _GapAwareTrackShape(
-                                  _singleArtifact && _timelineMapper!.wallDuration > 0
-                                      ? _timelineMapper!.gapRangesWall
-                                          .map((gap) => (
-                                                gap.$1 / _timelineMapper!.wallDuration,
-                                                gap.$2 / _timelineMapper!.wallDuration,
-                                              ))
-                                          .toList()
-                                      : const [],
-                                ),
+                                // Dense MP3 has no gaps on its timeline — plain track.
+                                trackShape: _GapAwareTrackShape(const []),
                               ),
                               child: Slider(
                                 value: combinedPosition.inMilliseconds.toDouble().clamp(

--- a/app/lib/widgets/conversation_bottom_bar.dart
+++ b/app/lib/widgets/conversation_bottom_bar.dart
@@ -108,9 +108,11 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
     if (widget.conversation == null) return;
     final stamp = widget.conversation!.conversationAudio;
     if (stamp != null && stamp.spans.isNotEmpty) {
-      // Wall-clock timeline: the total the user sees spans the whole
-      // conversation, with the collapsed gaps shaded on the scrubber.
-      _totalDuration = Duration(milliseconds: (stamp.duration * 1000).toInt());
+      // Dense-artifact timeline: the total is the actual captured audio length
+      // (the MP3 has inter-part gaps and lead-in silence collapsed out), so the
+      // scrubber matches what the user can hear. Transcript-segment taps still
+      // map their wall timestamp to the MP3 position via the spans manifest.
+      _totalDuration = Duration(milliseconds: (stamp.capturedDuration * 1000).toInt());
       return;
     }
     double totalSeconds = 0;
@@ -124,8 +126,9 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
 
   Duration _getCombinedPosition(int? currentIndex, Duration trackPosition) {
     if (_singleArtifact) {
-      final wall = _timelineMapper!.artifactToWall(trackPosition.inMilliseconds / 1000.0);
-      return Duration(milliseconds: (wall * 1000).toInt());
+      // The dense MP3 plays linearly; position is the raw artifact time so it
+      // advances 1:1 with playback against the captured-duration total.
+      return trackPosition;
     }
     if (currentIndex == null || currentIndex >= _trackStartOffsets.length) {
       return trackPosition;
@@ -201,10 +204,11 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
     }
     if (!mounted || _audioPlayer == null) return;
 
-    // Single-artifact mode seeks on the wall timeline; the spans manifest maps
-    // it to the exact MP3 position (including across collapsed gaps).
-    final filePosition =
-        _singleArtifact ? segmentStartSeconds : _calculateFilePositionForTimestamp(segmentStartSeconds);
+    // A transcript segment's timestamp is on the wall timeline; the spans
+    // manifest maps it to the exact position in the dense MP3 (artifact time).
+    final filePosition = _singleArtifact
+        ? _timelineMapper!.wallToArtifact(segmentStartSeconds)
+        : _calculateFilePositionForTimestamp(segmentStartSeconds);
 
     // Ensure position is not negative
     final targetPosition = Duration(milliseconds: (filePosition * 1000).clamp(0, double.infinity).toInt());
@@ -284,7 +288,7 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
         // offsets — position and seeks go through the spans mapper.
         _timelineMapper = AudioTimelineMapper(conversationAudio.spans);
         _singleArtifact = true;
-        _totalDuration = Duration(milliseconds: (_timelineMapper!.wallDuration * 1000).toInt());
+        _totalDuration = Duration(milliseconds: (_timelineMapper!.capturedDuration * 1000).toInt());
         await _audioPlayer!.setAudioSource(AudioSource.uri(Uri.parse(conversationAudio.signedUrl!)), preload: true);
         _isAudioInitialized = true;
         return;
@@ -772,31 +776,12 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
                         color: Colors.white.withValues(alpha: 0.3),
                         borderRadius: BorderRadius.circular(2),
                       ),
-                      child: Stack(
-                        children: [
-                          FractionallySizedBox(
-                            alignment: Alignment.centerLeft,
-                            widthFactor: progress,
-                            child: Container(
-                              decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(2)),
-                            ),
-                          ),
-                          // Shade the collapsed capture gaps on the wall timeline.
-                          if (_singleArtifact)
-                            ..._timelineMapper!.gapRangesWall.map((gap) {
-                              final wallTotal = _timelineMapper!.wallDuration;
-                              if (wallTotal <= 0) return const SizedBox.shrink();
-                              final left = (gap.$1 / wallTotal).clamp(0.0, 1.0) * progressBarWidth;
-                              final width = ((gap.$2 - gap.$1) / wallTotal).clamp(0.0, 1.0) * progressBarWidth;
-                              return Positioned(
-                                left: left,
-                                top: 0,
-                                bottom: 0,
-                                width: width,
-                                child: Container(color: Colors.black.withValues(alpha: 0.45)),
-                              );
-                            }),
-                        ],
+                      child: FractionallySizedBox(
+                        alignment: Alignment.centerLeft,
+                        widthFactor: progress,
+                        child: Container(
+                          decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(2)),
+                        ),
                       ),
                     ),
                   ),
@@ -819,14 +804,13 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
     if (_audioPlayer == null) return;
 
     if (_singleArtifact) {
-      // targetPosition is on the wall timeline; map to the dense MP3. A seek
-      // into a collapsed gap snaps to the next captured span.
-      final artifactSeconds = _timelineMapper!.wallToArtifact(targetPosition.inMilliseconds / 1000.0);
+      // targetPosition is already artifact time (the scrubber runs on the dense
+      // MP3; segment taps are mapped wall->artifact before they get here).
       PlatformManager.instance.analytics.audioPlaybackSeeked(
         conversationId: widget.conversation?.id ?? '',
         toPositionSeconds: targetPosition.inSeconds,
       );
-      await _audioPlayer!.seek(Duration(milliseconds: (artifactSeconds * 1000).toInt()));
+      await _audioPlayer!.seek(targetPosition);
       return;
     }
 


### PR DESCRIPTION
## Problem

The audio player on the transcript page showed the **wrong duration** — longer than the audio you can actually hear.

## Root cause

When a conversation is served as one dense MP3 (gaps collapsed) + a spans manifest, the backend stamps two numbers:
- `duration` = **wall-clock** = `started_at` → last part's end (includes lead-in silence + collapsed inter-part gaps)
- `captured_duration` = **actual audio** = sum of the recorded parts

Both `ConversationBottomBar` (transcript page) and the standalone `ConversationAudioPlayerWidget` used `duration` (wall) as the scrubber total, so the total ran past the audio.

**Verified on a real conversation (2 parts):** player showed **23:51** (wall = 1431s) for **19:12** of audio (`captured_duration` = 1152s). The extra ~4:39 = a 199s lead-in before the first part + an 80s gap between parts — both collapsed out of the MP3 but still counted in the wall total.

## Fix

Switch both players to a **dense-artifact timeline**:
- total = `captured_duration` (the MP3's real length),
- position = raw artifact time (advances 1:1 with playback),
- scrubber seeks map directly to artifact time,
- **transcript-segment taps still map wall→artifact** via `AudioTimelineMapper.wallToArtifact`, so tapping a segment lands on the exact words,
- removed the gap-shading overlay (a dense timeline has no gaps).

`AudioTimelineMapper` is unchanged — the fix is purely which duration/position the widgets display.

## Testing

- `flutter analyze` clean on both widgets.
- `test/unit/audio_timeline_mapper_test.dart` + `audio_urls_response_test.dart` — 16/16 pass. These already assert `capturedDuration` (audio length) vs `wallDuration` and the `wallToArtifact` mapping the segment-seek relies on.
- Verified against real prod data: total now resolves to `captured_duration` (19:12) instead of wall (23:51).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




Failure-Class: none
