### PR TITLE
Keep goal-advice chat context when a stored message has null text

### DIFF
--- a/backend/tests/unit/test_goal_context_null_message_text.py
+++ b/backend/tests/unit/test_goal_context_null_message_text.py
@@ -1,0 +1,40 @@
+"""Regression test: a null message text must not drop the whole chat block from goal context.
+
+utils.llm.goals._get_goal_context builds goal-advice context from recent chat messages with
+text = msg.get('text', '')[:200]. get's default only applies to an ABSENT key, so a stored
+message with text=None makes None[:200] raise; the broad except then leaves chat_context empty,
+dropping the entire recent-chat block from the goal-advice prompt. The memory block below already
+guards with if m.get('content'). Null text now coerces to '' and is skipped, keeping the rest.
+"""
+
+import utils.llm.goals as goals
+
+
+def _isolate(monkeypatch, messages):
+    monkeypatch.setattr(goals, 'vector_search', lambda *a, **k: [])
+    monkeypatch.setattr(goals.conversations_db, 'get_conversations', lambda *a, **k: [])
+    monkeypatch.setattr(goals.memories_db, 'get_memories', lambda *a, **k: [])
+    monkeypatch.setattr(goals.chat_db, 'get_messages', lambda *a, **k: messages)
+
+
+def test_null_text_message_does_not_drop_chat_block(monkeypatch):
+    _isolate(
+        monkeypatch,
+        [
+            {'sender': 'human', 'text': None},
+            {'sender': 'human', 'text': 'I want to run a marathon'},
+        ],
+    )
+
+    result = goals._get_goal_context('u1', 'fitness')
+
+    assert 'I want to run a marathon' in result['chat_context']
+
+
+def test_all_valid_messages_present(monkeypatch):
+    _isolate(monkeypatch, [{'sender': 'human', 'text': 'hello'}, {'sender': 'ai', 'text': 'hi there'}])
+
+    result = goals._get_goal_context('u1', 'fitness')
+
+    assert 'User: hello' in result['chat_context']
+    assert 'Omi: hi there' in result['chat_context']

--- a/backend/utils/llm/goals.py
+++ b/backend/utils/llm/goals.py
@@ -78,7 +78,10 @@ def _get_goal_context(uid: str, goal_title: str) -> Dict[str, str]:
             chat_lines: List[str] = []
             for msg in reversed(recent_messages):  # Chronological order
                 sender = "User" if msg.get('sender') == 'human' else "Omi"
-                text = msg.get('text', '')[:200]
+                # get('text', '') only defaults an ABSENT key; a stored message with text=None would
+                # make None[:200] raise, and the broad except below then drops the entire chat block
+                # from the goal-advice prompt. The memory block below already guards with if m.get(...).
+                text = (msg.get('text') or '')[:200]
                 if text:
                     chat_lines.append(f"{sender}: {text}")
             chat_context = '\n'.join(chat_lines[-10:])  # Last 10 messages


### PR DESCRIPTION
## What

`utils/llm/goals.py` `_get_goal_context` builds the recent-chat block of the goal-advice prompt:

```python
text = msg.get('text', '')[:200]
```

`get`'s default only applies when the key is ABSENT. A stored message with `text=None` makes `None[:200]` raise, and the broad `except` around the block then swallows it and leaves `chat_context` empty - dropping the entire recent-chat block from the goal-advice prompt for that user. The memory block just below already guards with `if m.get('content')`, so null field values are expected here.

## Fix

Coerce a null `text` to `''` so it is skipped (the following `if text:` already filters empties), keeping the other messages:

```python
text = (msg.get('text') or '')[:200]
```

## Tests

`tests/unit/test_goal_context_null_message_text.py` drives `_get_goal_context` with the four retrieval blocks mocked (`vector_search`, `conversations_db.get_conversations`, `memories_db.get_memories`, `chat_db.get_messages`):

- a null-text message alongside a valid one keeps the valid message in `chat_context`
- all-valid messages are rendered (`User:` / `Omi:`)

The null case fails against the pre-fix source (empty `chat_context` from the swallowed crash) and passes after.

## Verification

```
python -m pytest tests/unit/test_goal_context_null_message_text.py -q
  -> 2 passed  (1 fail when the source fix is reverted, test kept)

black --line-length 120 --skip-string-normalization --check utils/llm/goals.py tests/unit/test_goal_context_null_message_text.py
  -> clean
python -m pyright -p pyrightconfig.json utils/llm/goals.py   -> 0 errors
python scripts/check_module_stub_pollution.py                -> 0 violations
```

## Product invariants affected

None. `scripts/pr-preflight --suggest` lists no locked product invariant for the changed paths.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

