### PR TITLE
fix(home): restore map on daily recap cards

### DIFF
--- a/app/lib/pages/home/home_content.dart
+++ b/app/lib/pages/home/home_content.dart
@@ -308,7 +308,7 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
   }
 
   Widget _buildDailyRecapsPreview(BuildContext context) {
-    const cardHeight = 130.0;
+    const cardHeight = 170.0;
     if (_loadingSummaries) {
       return Padding(
         padding: const EdgeInsets.only(top: 12),
@@ -354,7 +354,10 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
   }
 
   static const double _cardWidth = 260.0;
-  static const double _mapHeight = 60.0;
+  // At 60px with retinaMode: true the tile layer rendered blank on the home
+  // recap card (reported on prod). 100px is enough for flutter_map to fetch
+  // and paint tiles reliably while keeping the card compact.
+  static const double _mapHeight = 100.0;
 
   Widget _buildSummaryCard(BuildContext context, DailySummary summary, double cardHeight) {
     final hasMap = summary.locations.isNotEmpty;


### PR DESCRIPTION
## Summary
- Fixes user report: map on daily recap cards on the home page renders as blank empty space
- Root cause: \`_mapHeight = 60.0\` was too small for \`flutter_map 7.0.2\` to reliably fetch/paint retina tiles at zoom 13. The tile layer silently skipped the tile fetch, leaving only the dark card background where the map should be. The detail page uses the same \`TileLayer\` config and works because its map is much taller.
- Bumps \`_mapHeight\` 60 → 100 and \`cardHeight\` 130 → 170 to keep proportions right. No API/URL/dependency changes.

## Test plan
- [ ] Home page daily recap cards: tiles + purple location markers actually paint (not empty dark space) for cards where \`summary.locations.isNotEmpty\`
- [ ] Cards without locations still hide the map area cleanly (\`hasMap = false\` path, text uses full card height)
- [ ] Date chip still overlays the bottom-right of the card correctly at the new dimensions
- [ ] Detail page map unchanged and still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

