### PR TITLE
fix(backend): refresh geolocation cache TTL so a stationary user's location doesn't expire (#9782)

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline.json
@@ -7,7 +7,7 @@
     "backend/routers/mcp_sse.py": 1857,
     "backend/routers/sync.py": 1981,
     "backend/routers/transcribe.py": 3110,
-    "backend/routers/users.py": 2040,
+    "backend/routers/users.py": 2044,
     "backend/scripts/validate-backend-runtime-env.py": 1694,
     "backend/utils/apps.py": 1641,
     "backend/utils/memory/legacy_backfill.py": 1816,
@@ -50,6 +50,7 @@
     "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 2892
   },
   "raise_justifications": {
+    "backend/routers/users.py": "Geolocation dedup path now refreshes the cache TTL (#9782) so a stationary user's location doesn't expire.",
     "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "PTT lifecycle ownership now passes explicit terminal and bounded completed-agent context through the runtime boundary.",
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": "PTT continuity work adds durable bridge seams and exact-turn automation evidence rather than parallel callbacks.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": "Agent completion presentation now follows the canonical terminal lifecycle used by PTT and chat.",

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -344,9 +344,19 @@ def get_cached_signed_url(blob_path: str) -> str:
     return signed_url.decode()
 
 
+GEOLOCATION_CACHE_TTL = 60 * 30  # 30 minutes
+
+
 def cache_user_geolocation(uid: str, geolocation: Dict[str, Any]) -> None:
     r.set(f'users:{uid}:geolocation', _serialize_cache_value(geolocation))
-    r.expire(f'users:{uid}:geolocation', 60 * 30)  # FIXME: too much?
+    r.expire(f'users:{uid}:geolocation', GEOLOCATION_CACHE_TTL)
+
+
+def refresh_user_geolocation_ttl(uid: str) -> None:
+    # A stationary user keeps re-sending the same coordinates, which set_user_geolocation
+    # dedups without rewriting the value. Refresh the TTL on that path so the cached location
+    # doesn't expire out from under conversations/daily-recap while the user hasn't moved.
+    r.expire(f'users:{uid}:geolocation', GEOLOCATION_CACHE_TTL)
 
 
 def get_cached_user_geolocation(uid: str) -> Optional[Dict[str, Any]]:
@@ -830,7 +840,8 @@ def remove_conversation_summary_app_id(app_id: str) -> bool:
 # Lua script: atomic increment + TTL in a single round-trip.
 # Returns [current_count, ttl_remaining].  Sets TTL on first hit
 # and self-heals any key that lost its TTL (prevents permanent buckets).
-_RATE_LIMIT_LUA = r.register_script("""
+_RATE_LIMIT_LUA = r.register_script(
+    """
 local key = KEYS[1]
 local window = tonumber(ARGV[1])
 local current = redis.call('INCR', key)
@@ -843,7 +854,8 @@ if ttl < 0 then
     ttl = window
 end
 return {current, ttl}
-""")
+"""
+)
 
 
 def check_rate_limit(key: str, policy: str, max_requests: int, window: int) -> tuple[bool, int, int]:
@@ -872,7 +884,8 @@ def check_rate_limit(key: str, policy: str, max_requests: int, window: int) -> t
 # Burst uses a sorted set keyed by timestamp-ms for sliding-window accuracy,
 # trimmed on every call (O(log n)). Daily char counter auto-expires at midnight
 # UTC (caller passes seconds_until_midnight_utc as the TTL).
-_TTS_RATE_LIMIT_LUA = r.register_script("""
+_TTS_RATE_LIMIT_LUA = r.register_script(
+    """
 local burst_key = KEYS[1]
 local daily_key = KEYS[2]
 local now_ms = tonumber(ARGV[1])
@@ -900,7 +913,8 @@ if new_daily == char_count then
     redis.call('EXPIRE', daily_key, daily_ttl)
 end
 return {0, 0}
-""")
+"""
+)
 
 
 def _seconds_until_midnight_utc() -> int:

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -31,6 +31,7 @@ from database.conversations import get_in_progress_conversation, get_conversatio
 from database.redis_db import (
     cache_user_geolocation,
     get_cached_user_geolocation,
+    refresh_user_geolocation_ttl,
     set_user_webhook_db,
     get_user_webhook_db,
     disable_user_webhook_db,
@@ -429,6 +430,9 @@ def set_user_geolocation(geolocation: Geolocation, uid: str = Depends(auth.get_c
 
             # Only update if location has changed up to 4 decimal places
             if last_lat == new_lat and last_lon == new_lon:
+                # Refresh the TTL so a stationary user's location doesn't expire; otherwise
+                # conversations/daily-recap created while the user hasn't moved lose their location.
+                refresh_user_geolocation_ttl(uid)
                 return {'status': 'ok', 'message': 'Location not changed significantly.'}
 
             cache_user_geolocation(uid, geolocation.model_dump())

--- a/backend/tests/unit/test_user_geolocation_ttl_refresh.py
+++ b/backend/tests/unit/test_user_geolocation_ttl_refresh.py
@@ -1,0 +1,141 @@
+"""Regression: a stationary user's cached geolocation must not expire.
+
+set_user_geolocation dedups repeated submissions of the same coordinates (rounded to 4 decimals)
+by returning early. Before the fix it returned without touching the cache, so the 30-minute TTL set
+at the last real move was never refreshed. A phone's foreground task re-sends the same location every
+~5 minutes while stationary, all of which were deduped, so after 30 minutes the key expired and every
+conversation / daily-recap created afterward got no location (issue #9782). The unchanged path now
+refreshes the TTL. routers/users.py has a heavy import graph, so we import it under a stub finder and
+call the handler directly.
+"""
+
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+_STUB = (
+    'database',
+    'utils',
+    'firebase_admin',
+    'google',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'ulid',
+    'langchain',
+    'langchain_core',
+    'stripe',
+    'openai',
+    'anthropic',
+    'redis',
+    'sentry_sdk',
+    'requests',
+)
+
+
+def _is_stubbed_name(name):
+    return any(name == p or name.startswith(p + '.') for p in _STUB)
+
+
+def _snapshot_stubbed_modules():
+    return {name: module for name, module in sys.modules.items() if _is_stubbed_name(name)}
+
+
+def _clear_stubbed_modules():
+    for name in list(sys.modules):
+        if _is_stubbed_name(name):
+            sys.modules.pop(name, None)
+
+
+def _restore_stubbed_modules(snapshot):
+    for name in list(sys.modules):
+        if _is_stubbed_name(name) and name not in snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(snapshot)
+
+
+def _install_python_multipart_stub():
+    if 'python_multipart' in sys.modules:
+        return False
+    if importlib.util.find_spec('python_multipart') is not None:
+        return False
+    mod = types.ModuleType('python_multipart')
+    mod.__version__ = '0.0.20'
+    sys.modules['python_multipart'] = mod
+    return True
+
+
+class _AutoMock(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        m = MagicMock()
+        setattr(self, name, m)
+        return m
+
+
+class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path=None, target=None):
+        if _is_stubbed_name(name):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        return _AutoMock(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _Finder()
+_snap = _snapshot_stubbed_modules()
+_clear_stubbed_modules()
+_rm_mp = _install_python_multipart_stub()
+sys.meta_path.insert(0, _finder)
+try:
+    from routers import users as users_mod
+finally:
+    sys.meta_path.remove(_finder)
+    _restore_stubbed_modules(_snap)
+    if _rm_mp:
+        sys.modules.pop('python_multipart', None)
+
+from models.geolocation import Geolocation  # noqa: E402
+
+
+def test_unchanged_location_refreshes_ttl_without_rewriting():
+    cached = Geolocation(latitude=37.7749, longitude=-122.4194).model_dump()
+    same = Geolocation(latitude=37.77491, longitude=-122.41939)  # within 4-decimal dedup window
+    with patch.object(users_mod, 'get_cached_user_geolocation', return_value=cached), patch.object(
+        users_mod, 'refresh_user_geolocation_ttl'
+    ) as refresh, patch.object(users_mod, 'cache_user_geolocation') as cache:
+        result = users_mod.set_user_geolocation(same, uid='u1')
+
+    assert result['message'] == 'Location not changed significantly.'
+    refresh.assert_called_once_with('u1')  # TTL kept alive so the location doesn't expire
+    cache.assert_not_called()  # value unchanged, no rewrite
+
+
+def test_changed_location_rewrites_cache():
+    cached = Geolocation(latitude=37.7749, longitude=-122.4194).model_dump()
+    moved = Geolocation(latitude=40.7128, longitude=-74.0060)
+    with patch.object(users_mod, 'get_cached_user_geolocation', return_value=cached), patch.object(
+        users_mod, 'refresh_user_geolocation_ttl'
+    ) as refresh, patch.object(users_mod, 'cache_user_geolocation') as cache:
+        result = users_mod.set_user_geolocation(moved, uid='u1')
+
+    assert result == {'status': 'ok'}
+    cache.assert_called_once()  # new coordinates written (which also resets the TTL)
+    refresh.assert_not_called()


### PR DESCRIPTION
## What
Refresh the Redis TTL on the geolocation cache when a user re-submits the **same** coordinates, so a stationary user's cached location no longer silently expires.

## Why
`set_user_geolocation` dedups repeated submissions of the same coordinates (rounded to 4 decimal places / ~11m) by returning early:

```python
if last_lat == new_lat and last_lon == new_lon:
    return {'status': 'ok', 'message': 'Location not changed significantly.'}
```

That early return never touched the cache, and `cache_user_geolocation` sets a 30-minute TTL (`users:{uid}:geolocation`). The mobile foreground task re-sends the current location every ~5 minutes. While the user is stationary, **every** send is deduped, so the TTL from the last real move is never refreshed and the key expires after 30 minutes. Once it's gone, `get_cached_user_geolocation` returns `None`, and every conversation / daily-recap created afterward (`routers/conversations.py`, `utils/conversations/finalizer.py`) gets **no location** — exactly the missing-location symptom reported.

## Evidence (from issue #9782)
> Conversation location is not working properly in either Conversation view or Daily Recap on Android, even though location permission is enabled and GPS is active.
> User says this has been happening for about a week.
> Environment: Omi AI 1.0.544, Samsung SM-S938B, Android 16.

The client foreground task, its `location` foreground-service type, and the callback registration are all intact; the location drops out on the server side when the cache TTL lapses for a stationary user.

## Fix
On the unchanged path, refresh the TTL (`refresh_user_geolocation_ttl`) without rewriting the value, so the cached location survives while the user hasn't moved. Changed coordinates still rewrite the cache (which also resets the TTL) as before.

## Verified
- New behavioral regression test drives `set_user_geolocation` through mocked cache seams:
  - unchanged resubmit → TTL refreshed, value not rewritten
  - moved → cache rewritten, no standalone refresh
- Confirmed the test **fails without the fix** (`Expected 'refresh_user_geolocation_ttl' to be called once. Called 0 times.`) and passes with it.
- `python -m pytest tests/unit/test_user_geolocation_ttl_refresh.py tests/unit/test_redis_db_cache_serialization.py tests/unit/test_users_webhook_url_validation.py` → 13 passed.

Note: this removes one concrete, high-confidence cause of missing conversation/recap location. If the reporter still sees gaps after this ships, the remaining suspects are client-side location fetch failures on that specific device.

Failure-Class: none

Auto-generated from issue feedback by the mini issues-improver. Review before merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

