### PR TITLE
fix(devops): guard WIF pilot partial recovery

### DIFF
--- a/.github/scripts/check_opentofu_development_wif_pilot.py
+++ b/.github/scripts/check_opentofu_development_wif_pilot.py
@@ -10,7 +10,6 @@ import sys
 from pathlib import Path
 from typing import Any, Sequence
 
-
 ROOT = Path(__file__).resolve().parents[2]
 PILOT_DIR = ROOT / "infrastructure" / "opentofu" / "pilots" / "development-wif-plan"
 PROBE_DIR = ROOT / "infrastructure" / "opentofu" / "probes" / "development-project-read"
@@ -31,11 +30,31 @@ EXPECTED_BOOTSTRAP_RESOURCES = frozenset(
         "google_project_iam_member.plan_project_browser",
     }
 )
+EXPECTED_PARTIAL_RECOVERY_RESOURCES = frozenset(
+    {
+        "google_service_account.plan",
+        "google_project_iam_member.plan_project_browser",
+    }
+)
+EXPECTED_PARTIAL_RECOVERY_CREATES = EXPECTED_BOOTSTRAP_RESOURCES - EXPECTED_PARTIAL_RECOVERY_RESOURCES
+EXPECTED_PARTIAL_RECOVERY_ACTIONS = {
+    **{address: ["no-op"] for address in EXPECTED_PARTIAL_RECOVERY_RESOURCES},
+    **{address: ["create"] for address in EXPECTED_PARTIAL_RECOVERY_CREATES},
+}
+EXPECTED_PARTIAL_RECOVERY_VALUES = {
+    "google_service_account.plan": {"account_id": "omi-tofu-plan-dev-9842"},
+    "google_project_iam_member.plan_project_browser": {
+        "project": "based-hardware-dev",
+        "role": "roles/browser",
+        "member": "serviceAccount:omi-tofu-plan-dev-9842@based-hardware-dev.iam.gserviceaccount.com",
+    },
+}
 RESOURCE = re.compile(r'^\s*resource\s+"(?P<type>[^"]+)"\s+"(?P<name>[^"]+)"', re.MULTILINE)
 DATA = re.compile(r'^\s*data\s+"(?P<type>[^"]+)"\s+"(?P<name>[^"]+)"', re.MULTILINE)
 MODULE = re.compile(r'^\s*module\s+"(?P<name>[^"]+)"', re.MULTILINE)
 PROVIDER = re.compile(r'^\s*provider\s+"(?P<name>[^"]+)"', re.MULTILINE)
 PROVISIONER = re.compile(r'^\s*provisioner\s+"(?P<name>[^"]+)"', re.MULTILINE)
+DISPLAY_NAME = re.compile(r'^\s*display_name\s*=\s*"(?P<value>[^"]*)"', re.MULTILINE)
 
 
 def read(path: Path) -> str:
@@ -73,6 +92,18 @@ def resource_body(text: str, address: str) -> str | None:
         re.MULTILINE | re.DOTALL,
     )
     return None if match is None else match.group("body")
+
+
+def check_display_name_limit(text: str, address: str) -> list[str]:
+    body = resource_body(text, address)
+    if body is None:
+        return []
+    match = DISPLAY_NAME.search(body)
+    if match is None:
+        return [f"bootstrap {address} must declare a display_name"]
+    if len(match.group("value")) > 32:
+        return [f"bootstrap {address} display_name must not exceed 32 characters"]
+    return []
 
 
 def check_bootstrap(text: str) -> list[str]:
@@ -150,6 +181,11 @@ def check_bootstrap(text: str) -> list[str]:
         for expected in required:
             if expected not in body:
                 errors.append(f"bootstrap {address} is missing required contract {expected!r}")
+    for address in (
+        "google_iam_workload_identity_pool.github",
+        "google_iam_workload_identity_pool_provider.github",
+    ):
+        errors.extend(check_display_name_limit(text, address))
     return errors
 
 
@@ -211,7 +247,11 @@ def check_plan(plan: dict[str, Any]) -> list[str]:
             continue
         address = change.get("address")
         action = change.get("change", {}).get("actions") if isinstance(change.get("change"), dict) else None
-        if not isinstance(address, str) or not isinstance(action, list) or not all(isinstance(item, str) for item in action):
+        if (
+            not isinstance(address, str)
+            or not isinstance(action, list)
+            or not all(isinstance(item, str) for item in action)
+        ):
             errors.append("bootstrap plan contains a malformed address or action")
             continue
         if address in actual:
@@ -223,6 +263,90 @@ def check_plan(plan: dict[str, Any]) -> list[str]:
     for address, actions in actual.items():
         if actions != ["create"]:
             errors.append(f"bootstrap plan {address} must have only a create action, found {actions}")
+    return errors
+
+
+def plan_root_resources(plan: dict[str, Any], section: str) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    errors: list[str] = []
+    section_value = plan.get(section)
+    if not isinstance(section_value, dict):
+        return {}, [f"bootstrap recovery plan {section} must be an object"]
+    values = section_value.get("values")
+    if not isinstance(values, dict):
+        return {}, [f"bootstrap recovery plan {section}.values must be an object"]
+    root_module = values.get("root_module")
+    if not isinstance(root_module, dict):
+        return {}, [f"bootstrap recovery plan {section}.values.root_module must be an object"]
+    resources = root_module.get("resources")
+    if not isinstance(resources, list):
+        return {}, [f"bootstrap recovery plan {section}.values.root_module.resources must be a list"]
+    if root_module.get("child_modules"):
+        errors.append(f"bootstrap recovery plan {section} must not contain child modules")
+
+    actual: dict[str, dict[str, Any]] = {}
+    for resource in resources:
+        if not isinstance(resource, dict):
+            errors.append(f"bootstrap recovery plan {section} contains a malformed resource")
+            continue
+        address = resource.get("address")
+        if not isinstance(address, str):
+            errors.append(f"bootstrap recovery plan {section} contains a resource without an address")
+            continue
+        if address in actual:
+            errors.append(f"bootstrap recovery plan {section} contains duplicate resource {address}")
+        actual[address] = resource
+    return actual, errors
+
+
+def check_partial_recovery_plan(plan: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    prior_resources, prior_errors = plan_root_resources(plan, "prior_state")
+    errors.extend(prior_errors)
+    if set(prior_resources) != EXPECTED_PARTIAL_RECOVERY_RESOURCES:
+        errors.append(
+            "bootstrap recovery prior state must contain exactly " f"{sorted(EXPECTED_PARTIAL_RECOVERY_RESOURCES)}"
+        )
+    for address, expected_values in EXPECTED_PARTIAL_RECOVERY_VALUES.items():
+        values = prior_resources.get(address, {}).get("values")
+        if not isinstance(values, dict):
+            errors.append(f"bootstrap recovery prior state {address} must contain resource values")
+            continue
+        for key, expected in expected_values.items():
+            if values.get(key) != expected:
+                errors.append(f"bootstrap recovery prior state {address} must retain {key}={expected!r}")
+
+    planned_resources, planned_errors = plan_root_resources(plan, "planned_values")
+    errors.extend(planned_errors)
+    if set(planned_resources) != EXPECTED_BOOTSTRAP_RESOURCES:
+        errors.append(
+            "bootstrap recovery planned values must contain exactly " f"{sorted(EXPECTED_BOOTSTRAP_RESOURCES)}"
+        )
+
+    changes = plan.get("resource_changes")
+    if not isinstance(changes, list):
+        return errors + ["bootstrap recovery plan resource_changes must be a list"]
+    actual_actions: dict[str, list[str]] = {}
+    for change in changes:
+        if not isinstance(change, dict):
+            errors.append("bootstrap recovery plan contains a malformed resource change")
+            continue
+        address = change.get("address")
+        actions = change.get("change", {}).get("actions") if isinstance(change.get("change"), dict) else None
+        if (
+            not isinstance(address, str)
+            or not isinstance(actions, list)
+            or not all(isinstance(item, str) for item in actions)
+        ):
+            errors.append("bootstrap recovery plan contains a malformed address or action")
+            continue
+        if address in actual_actions:
+            errors.append(f"bootstrap recovery plan contains duplicate change {address}")
+        actual_actions[address] = actions
+    if actual_actions != EXPECTED_PARTIAL_RECOVERY_ACTIONS:
+        errors.append(
+            "bootstrap recovery plan actions must be exactly "
+            f"{EXPECTED_PARTIAL_RECOVERY_ACTIONS}, found {actual_actions}"
+        )
     return errors
 
 
@@ -280,13 +404,17 @@ def check_validation_workflow(text: str) -> list[str]:
         "backend-config",
     ):
         if forbidden in text:
-            errors.append(f"pilot validation workflow contains forbidden credential or mutation reference {forbidden!r}")
+            errors.append(
+                f"pilot validation workflow contains forbidden credential or mutation reference {forbidden!r}"
+            )
     return errors
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--plan-json", type=Path)
+    plan_group = parser.add_mutually_exclusive_group()
+    plan_group.add_argument("--plan-json", type=Path)
+    plan_group.add_argument("--partial-recovery-plan-json", type=Path)
     args = parser.parse_args(argv)
 
     bootstrap = module_source(PILOT_DIR)
@@ -300,16 +428,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         + check_workflow(read(WORKFLOW))
         + check_validation_workflow(read(VALIDATION_WORKFLOW))
     )
-    if args.plan_json is not None:
+    plan_path = args.plan_json or args.partial_recovery_plan_json
+    if plan_path is not None:
         try:
-            plan = json.loads(read(args.plan_json))
+            plan = json.loads(read(plan_path))
         except (OSError, json.JSONDecodeError) as exc:
-            errors.append(f"could not read bootstrap plan JSON {args.plan_json}: {exc}")
+            errors.append(f"could not read bootstrap plan JSON {plan_path}: {exc}")
         else:
             if not isinstance(plan, dict):
-                errors.append(f"bootstrap plan JSON {args.plan_json} must be an object")
+                errors.append(f"bootstrap plan JSON {plan_path} must be an object")
             else:
-                errors.extend(check_plan(plan))
+                errors.extend(
+                    check_partial_recovery_plan(plan)
+                    if args.partial_recovery_plan_json is not None
+                    else check_plan(plan)
+                )
 
     if errors:
         print("Development WIF pilot check failed:", file=sys.stderr)

--- a/.github/scripts/test_check_opentofu_development_wif_pilot.py
+++ b/.github/scripts/test_check_opentofu_development_wif_pilot.py
@@ -7,8 +7,8 @@ import importlib.util
 import sys
 import tempfile
 import unittest
+from copy import deepcopy
 from pathlib import Path
-
 
 ROOT = Path(__file__).resolve().parents[2]
 CHECKER_PATH = ROOT / ".github" / "scripts" / "check_opentofu_development_wif_pilot.py"
@@ -21,6 +21,39 @@ SPEC.loader.exec_module(CHECKER)
 
 
 class DevelopmentWifPilotFixture(unittest.TestCase):
+    def partial_recovery_plan(self) -> dict[str, object]:
+        def resource(address: str, values: dict[str, str] | None = None) -> dict[str, object]:
+            return {"address": address, "values": values or {}}
+
+        prior_resources = [
+            resource(
+                "google_service_account.plan",
+                {"account_id": "omi-tofu-plan-dev-9842"},
+            ),
+            resource(
+                "google_project_iam_member.plan_project_browser",
+                {
+                    "project": "based-hardware-dev",
+                    "role": "roles/browser",
+                    "member": "serviceAccount:omi-tofu-plan-dev-9842@based-hardware-dev.iam.gserviceaccount.com",
+                },
+            ),
+        ]
+        return {
+            "prior_state": {"values": {"root_module": {"resources": prior_resources}}},
+            "planned_values": {
+                "values": {
+                    "root_module": {
+                        "resources": [resource(address) for address in sorted(CHECKER.EXPECTED_BOOTSTRAP_RESOURCES)]
+                    }
+                }
+            },
+            "resource_changes": [
+                {"address": address, "change": {"actions": actions}}
+                for address, actions in sorted(CHECKER.EXPECTED_PARTIAL_RECOVERY_ACTIONS.items())
+            ],
+        }
+
     def test_checked_in_pilot_contract_passes(self) -> None:
         self.assertEqual(CHECKER.main(), 0)
 
@@ -40,13 +73,32 @@ class DevelopmentWifPilotFixture(unittest.TestCase):
 
     def test_bootstrap_variables_reject_production_project(self) -> None:
         source = CHECKER.read(CHECKER.BOOTSTRAP_VARIABLES)
-        errors = CHECKER.check_bootstrap_variables(source.replace('default     = "based-hardware-dev"', 'default     = "based-hardware"'))
+        errors = CHECKER.check_bootstrap_variables(
+            source.replace('default     = "based-hardware-dev"', 'default     = "based-hardware"')
+        )
         self.assertIn("based-hardware-dev", "\n".join(errors))
 
     def test_bootstrap_rejects_non_immutable_github_identity(self) -> None:
         source = CHECKER.read(CHECKER.BOOTSTRAP)
         errors = CHECKER.check_bootstrap(source.replace("assertion.repository_id", "assertion.repository", 1))
         self.assertIn("repository_id", "\n".join(errors))
+
+    def test_bootstrap_rejects_overlong_wif_display_names(self) -> None:
+        source = CHECKER.read(CHECKER.BOOTSTRAP)
+        errors = CHECKER.check_bootstrap(
+            source.replace(
+                'display_name              = "Omi OpenTofu dev GitHub pool"',
+                'display_name              = "' + "x" * 33 + '"',
+            )
+        )
+        self.assertIn("google_iam_workload_identity_pool.github display_name", "\n".join(errors))
+        errors = CHECKER.check_bootstrap(
+            source.replace(
+                'display_name                       = "Omi GitHub dev plan OIDC"',
+                'display_name                       = "' + "x" * 33 + '"',
+            )
+        )
+        self.assertIn("google_iam_workload_identity_pool_provider.github display_name", "\n".join(errors))
 
     def test_bootstrap_rejects_extra_open_tofu_files(self) -> None:
         with tempfile.TemporaryDirectory(prefix="omi-opentofu-pilot-") as temp_dir:
@@ -72,9 +124,27 @@ class DevelopmentWifPilotFixture(unittest.TestCase):
         errors = CHECKER.check_plan(plan)
         self.assertIn("must be exactly", "\n".join(errors))
 
+    def test_partial_recovery_plan_requires_exact_known_state_and_actions(self) -> None:
+        plan = self.partial_recovery_plan()
+        self.assertEqual(CHECKER.check_partial_recovery_plan(plan), [])
+
+        unexpected_state = deepcopy(plan)
+        unexpected_state["prior_state"]["values"]["root_module"]["resources"].append(
+            {"address": "google_iam_workload_identity_pool.github", "values": {}}
+        )
+        errors = CHECKER.check_partial_recovery_plan(unexpected_state)
+        self.assertIn("prior state must contain exactly", "\n".join(errors))
+
+        destructive_change = deepcopy(plan)
+        destructive_change["resource_changes"][0]["change"]["actions"] = ["delete", "create"]
+        errors = CHECKER.check_partial_recovery_plan(destructive_change)
+        self.assertIn("actions must be exactly", "\n".join(errors))
+
     def test_probe_rejects_resources_and_remote_state(self) -> None:
         source = CHECKER.read(CHECKER.PROBE)
-        errors = CHECKER.check_probe(source + '\nresource "google_cloud_run_v2_service" "forbidden" {}\nbackend "gcs" {}\n')
+        errors = CHECKER.check_probe(
+            source + '\nresource "google_cloud_run_v2_service" "forbidden" {}\nbackend "gcs" {}\n'
+        )
         self.assertIn("must not declare resources", "\n".join(errors))
         self.assertIn("must not use a remote backend", "\n".join(errors))
 
@@ -88,7 +158,9 @@ class DevelopmentWifPilotFixture(unittest.TestCase):
         source = CHECKER.read(CHECKER.VALIDATION_WORKFLOW)
         errors = CHECKER.check_validation_workflow(source.replace("offline-validation-only", "not-a-sentinel"))
         self.assertIn("offline-validation-only", "\n".join(errors))
-        errors = CHECKER.check_validation_workflow(source + "\nGOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}\n")
+        errors = CHECKER.check_validation_workflow(
+            source + "\nGOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}\n"
+        )
         self.assertIn("GOOGLE_APPLICATION_CREDENTIALS", "\n".join(errors))
 
 

--- a/infrastructure/opentofu/pilots/development-wif-plan/README.md
+++ b/infrastructure/opentofu/pilots/development-wif-plan/README.md
@@ -32,4 +32,22 @@ Its expected proof is successful GitHub OIDC exchange plus a `google_project`
 read of `based-hardware-dev`. Record the workflow URL and metadata-only
 read-back on [issue #9842](https://github.com/BasedHardware/omi/issues/9842).
 
+## Known partial-apply recovery
+
+If the #9842 bootstrap stops after creating only `google_service_account.plan`
+and `google_project_iam_member.plan_project_browser`, preserve that remote
+state. Do not import, delete, or reapply it with an unreviewed plan. After the
+display-name fix is merged, a separately approved development operator may
+create a fresh saved plan and check it with:
+
+```sh
+python3 .github/scripts/check_opentofu_development_wif_pilot.py \
+  --partial-recovery-plan-json <saved-plan.json>
+```
+
+The recovery check accepts only that exact two-resource prior state, those two
+resources as no-ops, and creates for the WIF pool, provider, and impersonation
+binding. It rejects every update, replacement, deletion, unexpected state
+entry, or IAM change. Apply only the saved plan that passes this check.
+
 Do not import existing resources, add a production backend config, or run this module against `based-hardware`.

--- a/infrastructure/opentofu/pilots/development-wif-plan/main.tf
+++ b/infrastructure/opentofu/pilots/development-wif-plan/main.tf
@@ -25,7 +25,7 @@ resource "google_service_account" "plan" {
 
 resource "google_iam_workload_identity_pool" "github" {
   workload_identity_pool_id = var.workload_identity_pool_id
-  display_name              = "Omi OpenTofu development GitHub pool"
+  display_name              = "Omi OpenTofu dev GitHub pool"
   description               = "GitHub OIDC pool for Omi OpenTofu development pilot #9842."
   disabled                  = false
 }
@@ -33,7 +33,7 @@ resource "google_iam_workload_identity_pool" "github" {
 resource "google_iam_workload_identity_pool_provider" "github" {
   workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
   workload_identity_pool_provider_id = "github"
-  display_name                       = "Omi GitHub Actions development plan provider"
+  display_name                       = "Omi GitHub dev plan OIDC"
   description                        = "Restricts the development plan identity to Omi's immutable GitHub identity, workflow, environment, and main."
 
   attribute_mapping = {


### PR DESCRIPTION
## Summary

- Shorten both Workload Identity Federation display names to satisfy the IAM API's 32-character limit.
- Add a regression guard for both display names.
- Add a state-aware recovery gate for the known development-only partial apply.

Related: #9842

## Root cause and durable guard

The development bootstrap created its service account and `roles/browser` binding, then IAM rejected the WIF pool display name as too long. The provider display name was also too long and would have failed next.

The guard now rejects either overlong WIF display name. Its recovery mode accepts only the recorded two-resource prior state, preserves those resources as no-ops, and permits only creation of the pool, provider, and WIF impersonation binding. It rejects updates, replacements, deletions, unexpected state, and IAM changes.

## Verification

- `python3 .github/scripts/test_check_opentofu_development_wif_pilot.py` — 12 tests passed.
- Backend-free OpenTofu init, validate, saved plan, JSON rendering, and exact five-create assertion — passed with the invalid offline sentinel token; no GCP authentication or mutation path.
- `tofu -chdir=infrastructure/opentofu/pilots/development-wif-plan fmt -check` — passed.
- `make preflight` — passed all 13 selected checks after rebasing onto the current `main`.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

No existing registered failure class covers a provider display-name contract missing from an IaC guard.
