### PR TITLE
fix(desktop): changelog script decodes/encodes JSON as UTF-8 regardless of host locale (#9717)

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -34,6 +34,11 @@ checks:
     triggers: [".github/schemas/desktop-release-evidence-v1.schema.json", ".github/scripts/desktop_release_doctor.py", ".github/scripts/desktop_release_doctor_report.py", ".github/scripts/test_desktop_release_doctor.py", ".github/workflows/desktop_release_doctor.yml"]
     lanes: ["local", "ci"]
     reason: "advisory desktop release evidence and drift report"
+  - id: desktop-changelog-io-tests
+    command: ["python3", ".github/scripts/test_desktop_changelog.py"]
+    triggers: [".github/scripts/desktop-changelog.py", ".github/scripts/test_desktop_changelog.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#9717: changelog JSON I/O must decode/encode as UTF-8 regardless of contributor host locale"
   - id: agents-md-lean
     command: ["python3", ".github/scripts/check_agents_md_lean.py"]
     triggers: ["AGENTS.md", ".github/scripts/check_agents_md_lean.py"]

--- a/.github/scripts/desktop-changelog.py
+++ b/.github/scripts/desktop-changelog.py
@@ -24,14 +24,14 @@ class ChangelogError(Exception):
 
 def read_json(path: Path) -> object:
     try:
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise ChangelogError(f"{path} is not valid JSON: {exc}") from exc
 
 
 def write_json(path: Path, data: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
 
 def normalize_changes(raw: object, path: Path) -> list[str]:

--- a/.github/scripts/test_desktop_changelog.py
+++ b/.github/scripts/test_desktop_changelog.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Unit tests for desktop-changelog.py I/O encoding (stdlib unittest).
+
+Regression coverage for #9717: read_json/write_json must always use UTF-8 so a
+contributor on a non-UTF-8 host locale (e.g. GBK on native Windows Python) does
+not crash with a UnicodeDecodeError. The CI host is UTF-8, so a plain round-trip
+would not catch a missing encoding; these tests assert the encoding is forwarded
+on every platform.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "desktop_changelog", Path(__file__).with_name("desktop-changelog.py")
+)
+changelog = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(changelog)
+
+
+class EncodingTests(unittest.TestCase):
+    def test_read_json_forces_utf8(self) -> None:
+        captured: dict[str, object] = {}
+        real_read_text = Path.read_text
+
+        def spy(self: Path, *args: object, **kwargs: object) -> str:
+            captured["encoding"] = kwargs.get("encoding")
+            return real_read_text(self, *args, **kwargs)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "changelog.json"
+            path.write_text('{"note": "“curly”"}', encoding="utf-8")
+            with unittest.mock.patch.object(Path, "read_text", spy):
+                self.assertEqual(changelog.read_json(path), {"note": "“curly”"})
+        self.assertEqual(captured["encoding"], "utf-8")
+
+    def test_write_json_forces_utf8(self) -> None:
+        captured: dict[str, object] = {}
+        real_write_text = Path.write_text
+
+        def spy(self: Path, *args: object, **kwargs: object) -> int:
+            captured["encoding"] = kwargs.get("encoding")
+            return real_write_text(self, *args, **kwargs)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "out" / "changelog.json"
+            with unittest.mock.patch.object(Path, "write_text", spy):
+                changelog.write_json(path, {"note": "“curly”"})
+        self.assertEqual(captured["encoding"], "utf-8")
+
+    def test_round_trip_preserves_non_ascii(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "changelog.json"
+            payload = {"note": "“curly” — café"}
+            changelog.write_json(path, payload)
+            self.assertEqual(changelog.read_json(path), payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug (#9717)

On native Windows Python with `PYTHONUTF8` unset and a non-UTF-8 default locale (e.g. GBK), `desktop-changelog.py validate` crashes with `UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 ...` before it can report a validation result. The traceback ends in `read_json()` at `path.read_text()`.

## Root cause

`read_json`/`write_json` called `Path.read_text()` / `Path.write_text()` without an explicit `encoding`, so native Windows Python used the process ANSI code page instead of UTF-8. The checked-in changelog JSON and CI are UTF-8, so any non-ASCII byte (curly quotes, em dashes) blows up on a legacy locale.

## Fix

Pass `encoding="utf-8"` on both the read and write calls — the smallest correct change, matching the encoding of the checked-in files and CI.

## Regression test

`.github/scripts/test_desktop_changelog.py` (wired into `.github/checks-manifest.yaml` as `desktop-changelog-io-tests`, local+ci lanes). Because CI runs on a UTF-8 host a plain round-trip would not catch the bug, so the tests assert the UTF-8 encoding is forwarded on every platform, plus a non-ASCII round-trip. Verified: reverting the fix fails the two encoding tests; with the fix all three pass.

Failure-Class: none

🤖 automated by hourly watchdog; opened for review, not merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

