### PR TITLE
perf: reduce Firestore read amplification

### DIFF
--- a/app/lib/backend/http/api/action_items.dart
+++ b/app/lib/backend/http/api/action_items.dart
@@ -14,6 +14,26 @@ Future<ActionItemsResponse> getActionItems({
   DateTime? startDate,
   DateTime? endDate,
 }) async {
+  return await tryGetActionItems(
+        limit: limit,
+        offset: offset,
+        completed: completed,
+        conversationId: conversationId,
+        startDate: startDate,
+        endDate: endDate,
+      ) ??
+      const ActionItemsResponse(actionItems: [], hasMore: false);
+}
+
+/// Returns null when the action-items request fails instead of conflating a failure with an empty list.
+Future<ActionItemsResponse?> tryGetActionItems({
+  int limit = 50,
+  int offset = 0,
+  bool? completed,
+  String? conversationId,
+  DateTime? startDate,
+  DateTime? endDate,
+}) async {
   String url = '${Env.apiBaseUrl}v1/action-items?limit=$limit&offset=$offset';
 
   if (completed != null) {
@@ -31,14 +51,14 @@ Future<ActionItemsResponse> getActionItems({
 
   var response = await makeApiCall(url: url, headers: {}, method: 'GET', body: '');
 
-  if (response == null) return const ActionItemsResponse(actionItems: [], hasMore: false);
+  if (response == null) return null;
 
   if (response.statusCode == 200) {
     var body = utf8.decode(response.bodyBytes);
     return wire.GeneratedActionItemsResponse.fromJson(jsonDecode(body) as Map<String, dynamic>);
   } else {
     Logger.debug('getActionItems error ${response.statusCode}');
-    return const ActionItemsResponse(actionItems: [], hasMore: false);
+    return null;
   }
 }
 

--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -80,7 +80,7 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
       PlatformManager.instance.analytics.actionItemsPageOpened();
       final provider = Provider.of<ActionItemsProvider>(context, listen: false);
       if (provider.actionItems.isEmpty) {
-        provider.fetchActionItems(showShimmer: true);
+        provider.ensureLoaded(showShimmer: true);
       }
       final taskIntegrationProvider = Provider.of<TaskIntegrationProvider>(context, listen: false);
       if (!taskIntegrationProvider.hasLoaded && !taskIntegrationProvider.isLoading) {

--- a/app/lib/providers/action_items_provider.dart
+++ b/app/lib/providers/action_items_provider.dart
@@ -14,7 +14,25 @@ import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 
+typedef ActionItemsFetcher = Future<ActionItemsResponse?> Function({
+  int limit,
+  int offset,
+  bool? completed,
+  String? conversationId,
+  DateTime? startDate,
+  DateTime? endDate,
+});
+
 class ActionItemsProvider extends ChangeNotifier {
+  ActionItemsProvider({ActionItemsFetcher? getActionItems})
+      : _getActionItems = getActionItems ?? api.tryGetActionItems {
+    unawaited(_preload());
+  }
+
+  final ActionItemsFetcher _getActionItems;
+  Future<void>? _initialLoad;
+  bool _initialLoadCompleted = false;
+
   List<ActionItemWithMetadata> _actionItems = [];
 
   bool _isLoading = false;
@@ -127,13 +145,25 @@ class ActionItemsProvider extends ChangeNotifier {
     }).toList();
   }
 
-  ActionItemsProvider() {
-    _preload();
+  Future<void> _preload() async {
+    await ensureLoaded(showShimmer: true);
+    await _migrateCategoryOrderFromPrefs();
   }
 
-  void _preload() async {
-    await fetchActionItems();
-    _migrateCategoryOrderFromPrefs();
+  /// Shares the eager Home preload with the Tasks page's first visible load.
+  Future<void> ensureLoaded({bool showShimmer = false}) {
+    if (_initialLoadCompleted) return Future.value();
+
+    final existingLoad = _initialLoad;
+    if (existingLoad != null) return existingLoad;
+
+    final load = fetchActionItems(showShimmer: showShimmer).then((loaded) {
+      _initialLoadCompleted = loaded;
+    });
+    _initialLoad = load.whenComplete(() {
+      _initialLoad = null;
+    });
+    return _initialLoad!;
   }
 
   /// One-time migration: convert SharedPreferences taskCategoryOrder to sort_order on items
@@ -169,7 +199,8 @@ class ActionItemsProvider extends ChangeNotifier {
   static bool shouldAutoRevealCompleted(List<ActionItemWithMetadata> items) =>
       items.isNotEmpty && items.every((item) => item.completed);
 
-  Future<void> fetchActionItems({bool showShimmer = false}) async {
+  Future<bool> fetchActionItems({bool showShimmer = false}) async {
+    var loaded = false;
     if (showShimmer) {
       setLoading(true);
     } else {
@@ -177,7 +208,7 @@ class ActionItemsProvider extends ChangeNotifier {
     }
 
     try {
-      final response = await api.getActionItems(
+      final response = await _getActionItems(
         limit: 100,
         offset: 0,
         completed: _includeCompleted ? null : false,
@@ -185,11 +216,14 @@ class ActionItemsProvider extends ChangeNotifier {
         endDate: _endDate,
       );
 
-      _actionItems = response.actionItems;
-      _hasMore = response.hasMore;
+      if (response != null) {
+        _actionItems = response.actionItems;
+        _hasMore = response.hasMore;
+        loaded = true;
 
-      if (!_showCompletedView && shouldAutoRevealCompleted(_actionItems)) {
-        _showCompletedView = true;
+        if (!_showCompletedView && shouldAutoRevealCompleted(_actionItems)) {
+          _showCompletedView = true;
+        }
       }
     } catch (e) {
       Logger.debug('Error fetching action items: $e');
@@ -202,6 +236,7 @@ class ActionItemsProvider extends ChangeNotifier {
     }
 
     notifyListeners();
+    return loaded;
   }
 
   Future<void> loadMoreActionItems() async {
@@ -210,7 +245,7 @@ class ActionItemsProvider extends ChangeNotifier {
     setFetching(true);
 
     try {
-      final response = await api.getActionItems(
+      final response = await _getActionItems(
         limit: 50,
         offset: _actionItems.length,
         completed: _includeCompleted ? null : false,
@@ -218,8 +253,10 @@ class ActionItemsProvider extends ChangeNotifier {
         endDate: _endDate,
       );
 
-      _actionItems.addAll(response.actionItems);
-      _hasMore = response.hasMore;
+      if (response != null) {
+        _actionItems.addAll(response.actionItems);
+        _hasMore = response.hasMore;
+      }
     } catch (e) {
       Logger.debug('Error loading more action items: $e');
     } finally {

--- a/app/test/unit/action_items_initial_load_test.dart
+++ b/app/test/unit/action_items_initial_load_test.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/action_item.dart';
+import 'package:omi/providers/action_items_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  test('shares the Home preload with the Tasks page initial load', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+
+    final firstResponse = Completer<ActionItemsResponse>();
+    var requests = 0;
+    final provider = ActionItemsProvider(
+      getActionItems: ({limit = 50, offset = 0, completed, conversationId, startDate, endDate}) {
+        requests++;
+        return firstResponse.future;
+      },
+    );
+
+    final tasksPageLoad = provider.ensureLoaded(showShimmer: true);
+
+    expect(requests, 1);
+    firstResponse.complete(const ActionItemsResponse(actionItems: [], hasMore: false));
+    await tasksPageLoad;
+    await provider.ensureLoaded(showShimmer: true);
+    expect(requests, 1);
+
+    provider.dispose();
+  });
+
+  test('retries the initial load after the preload fails', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+
+    final firstResponse = Completer<ActionItemsResponse?>();
+    var requests = 0;
+    final provider = ActionItemsProvider(
+      getActionItems: ({limit = 50, offset = 0, completed, conversationId, startDate, endDate}) {
+        requests++;
+        return requests == 1
+            ? firstResponse.future
+            : Future.value(const ActionItemsResponse(actionItems: [], hasMore: false));
+      },
+    );
+
+    final initialLoad = provider.ensureLoaded(showShimmer: true);
+    firstResponse.complete(null);
+    await initialLoad;
+    await provider.ensureLoaded(showShimmer: true);
+
+    expect(requests, 2);
+    provider.dispose();
+  });
+}

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -8,6 +8,7 @@ from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
 from database.firestore_transaction_retry import run_with_transaction_contention_retry
+from database.firestore_read_metrics import FirestoreReadFamily, FirestoreReadMode, record_firestore_read
 from ._client import db
 
 logger = logging.getLogger(__name__)
@@ -454,13 +455,21 @@ def get_action_items(
     docs = query.stream()
 
     action_items: List[Dict[str, Any]] = []
+    document_count = 0
     for doc in docs:
+        document_count += 1
         data: Dict[str, Any] = _typed_doc(doc)
         if data.get('deleted'):
             continue
         data['id'] = doc.id
         action_item = _prepare_action_item_for_read(data)
         action_items.append(action_item)
+
+    record_firestore_read(
+        FirestoreReadFamily.ACTION_ITEMS_LIST,
+        FirestoreReadMode.UNBOUNDED,
+        document_count,
+    )
 
     # Sort: incomplete items first, then by due_at (items without due_at come last), then
     # by created_at. Active-first is load-bearing for the default (completed=None) fetch:

--- a/backend/database/firestore_read_metrics.py
+++ b/backend/database/firestore_read_metrics.py
@@ -1,0 +1,42 @@
+"""Low-cardinality telemetry for Firestore reads that can amplify with user data.
+
+The enum-backed labels deliberately rule out user identifiers, query text, and
+routes. Add a family only for a reviewed, bounded set of read paths.
+"""
+
+from enum import StrEnum
+
+from prometheus_client import Counter, Histogram
+
+
+class FirestoreReadFamily(StrEnum):
+    ACTION_ITEMS_LIST = 'action_items_list'
+    LISTEN_MONTHLY_USAGE = 'listen_monthly_usage'
+
+
+class FirestoreReadMode(StrEnum):
+    UNBOUNDED = 'unbounded'
+
+
+FIRESTORE_READ_OPERATIONS = Counter(
+    'omi_firestore_read_operations_total',
+    'Firestore reads by reviewed query family and boundedness',
+    ['family', 'mode'],
+)
+
+FIRESTORE_DOCUMENTS_PER_OPERATION = Histogram(
+    'omi_firestore_documents_per_operation',
+    'Firestore documents iterated for a reviewed read operation',
+    ['family'],
+    buckets=(0, 1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500),
+)
+
+
+def record_firestore_read(
+    family: FirestoreReadFamily,
+    mode: FirestoreReadMode,
+    documents: int,
+) -> None:
+    """Record one completed Firestore read without accepting dynamic labels."""
+    FIRESTORE_READ_OPERATIONS.labels(family=family.value, mode=mode.value).inc()
+    FIRESTORE_DOCUMENTS_PER_OPERATION.labels(family=family.value).observe(documents)

--- a/backend/database/user_usage.py
+++ b/backend/database/user_usage.py
@@ -1,10 +1,11 @@
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, Iterable, List, Optional, Tuple, cast
 
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
 from ._client import db
+from .firestore_read_metrics import FirestoreReadFamily, FirestoreReadMode, record_firestore_read
 from models.user_usage import UsageStats
 
 
@@ -214,7 +215,15 @@ def get_today_usage_stats(uid: str, date: datetime) -> Dict[str, Any]:
 
 
 def _aggregate_stats(query: Any) -> Dict[str, Any]:
-    docs = query.stream()
+    return _aggregate_stats_from_docs(query.stream())
+
+
+def _aggregate_stats_from_docs(docs: Iterable[Any]) -> Dict[str, Any]:
+    stats, _ = _aggregate_stats_with_count(docs)
+    return stats
+
+
+def _aggregate_stats_with_count(docs: Iterable[Any]) -> Tuple[Dict[str, Any], int]:
     stats: Dict[str, Any] = {
         'transcription_seconds': 0,
         'words_transcribed': 0,
@@ -222,14 +231,16 @@ def _aggregate_stats(query: Any) -> Dict[str, Any]:
         'memories_created': 0,
         'speech_seconds': 0,
     }
+    document_count = 0
     for doc in docs:
+        document_count += 1
         data: Dict[str, Any] = _typed_doc(doc)
         stats['transcription_seconds'] += data.get('transcription_seconds', 0)
         stats['words_transcribed'] += data.get('words_transcribed', 0)
         stats['insights_gained'] += data.get('insights_gained', 0)
         stats['memories_created'] += data.get('memories_created', 0)
         stats['speech_seconds'] += data.get('speech_seconds', 0)
-    return stats
+    return stats, document_count
 
 
 def get_monthly_usage_stats(uid: str, date: datetime) -> Dict[str, Any]:
@@ -255,7 +266,13 @@ def get_monthly_usage_stats_since(uid: str, date: datetime, start_date: datetime
         .where(filter=FieldFilter('month', '==', date.month))
         .where(filter=FieldFilter('id', '>=', start_doc_id))
     )
-    return _aggregate_stats(query)
+    stats, document_count = _aggregate_stats_with_count(query.stream())
+    record_firestore_read(
+        FirestoreReadFamily.LISTEN_MONTHLY_USAGE,
+        FirestoreReadMode.UNBOUNDED,
+        document_count,
+    )
+    return stats
 
 
 def get_yearly_usage_stats(uid: str, date: datetime) -> Dict[str, Any]:

--- a/backend/tests/unit/test_action_items_pagination_order.py
+++ b/backend/tests/unit/test_action_items_pagination_order.py
@@ -142,6 +142,17 @@ def test_first_page_surfaces_active_items(fake_db):
     assert page == ['active_late', 'active_none']
 
 
+def test_list_observes_every_scanned_document(fake_db, monkeypatch):
+    observed = []
+    monkeypatch.setattr(action_items, 'record_firestore_read', lambda *args: observed.append(args))
+
+    _ids(fake_db, limit=2)
+
+    assert [(family.value, mode.value, documents) for family, mode, documents in observed] == [
+        ('action_items_list', 'unbounded', 5)
+    ]
+
+
 @pytest.mark.parametrize(
     "raw,expected_completed,expected_status",
     [

--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -12,6 +12,8 @@ backend/docs/test_isolation.md and testing/import_isolation.py.
 import os
 from pathlib import Path
 from types import ModuleType
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -64,3 +66,38 @@ def test_architect_is_treated_as_paid_unlimited_plan(subscription_module):
 def test_basic_plan_features_include_unlimited_memories(subscription_module):
     features = subscription_module.get_plan_features(PlanType.basic)
     assert "Unlimited memories" in features
+
+
+def test_unlimited_transcription_plan_skips_monthly_usage_scan(monkeypatch, subscription_module):
+    monkeypatch.setattr(subscription_module, 'is_trial_paywalled', lambda uid, source: False)
+    monkeypatch.setattr(subscription_module.users_db, 'is_byok_active', lambda uid: False, raising=False)
+    monkeypatch.setattr(subscription_module, 'get_byok_key', lambda provider: None)
+    monkeypatch.setattr(
+        subscription_module.users_db,
+        'get_user_valid_subscription',
+        lambda uid: SimpleNamespace(plan=PlanType.architect),
+        raising=False,
+    )
+    monthly_usage = MagicMock(return_value={'transcription_seconds': 999999})
+    monkeypatch.setattr(subscription_module, 'get_monthly_usage_for_subscription', monthly_usage)
+
+    assert subscription_module.has_transcription_credits('uid') is True
+    monthly_usage.assert_not_called()
+
+
+def test_bounded_transcription_plan_reads_monthly_usage_and_enforces_cap(monkeypatch, subscription_module):
+    monkeypatch.setattr(subscription_module, 'is_trial_paywalled', lambda uid, source: False)
+    monkeypatch.setattr(subscription_module.users_db, 'is_byok_active', lambda uid: False, raising=False)
+    monkeypatch.setattr(subscription_module, 'get_byok_key', lambda provider: None)
+    monkeypatch.setattr(
+        subscription_module.users_db,
+        'get_user_valid_subscription',
+        lambda uid: SimpleNamespace(plan=PlanType.basic),
+        raising=False,
+    )
+    monkeypatch.setattr(subscription_module, 'get_plan_limits', lambda plan: SimpleNamespace(transcription_seconds=60))
+    monthly_usage = MagicMock(return_value={'transcription_seconds': 60})
+    monkeypatch.setattr(subscription_module, 'get_monthly_usage_for_subscription', monthly_usage)
+
+    assert subscription_module.has_transcription_credits('uid') is False
+    monthly_usage.assert_called_once_with('uid')

--- a/backend/tests/unit/test_user_usage.py
+++ b/backend/tests/unit/test_user_usage.py
@@ -20,6 +20,7 @@ os.environ.setdefault(
 )
 
 from database import user_usage  # noqa: E402
+from database.firestore_read_metrics import FirestoreReadFamily, FirestoreReadMode  # noqa: E402
 
 
 @pytest.fixture
@@ -105,3 +106,26 @@ def test_realtime_ptt_included_via_grand_total(mock_db):
 def test_only_proactive_counts_zero(mock_db):
     _setup_docs(mock_db, {"2026-06-23": {"conv_apps.gpt-5.call_count": 100, "memories.gpt-4.call_count": 50}})
     assert user_usage.get_monthly_chat_usage("uid", now=NOW)["questions"] == 0
+
+
+def test_monthly_usage_since_observes_every_scanned_hourly_document(mock_db, monkeypatch):
+    docs = [
+        _Snap({'transcription_seconds': 15}),
+        _Snap({'transcription_seconds': 25}),
+    ]
+    query = MagicMock()
+    query.where.return_value = query
+    query.stream.return_value = iter(docs)
+    mock_db.collection.return_value.document.return_value.collection.return_value = query
+
+    observed = []
+    monkeypatch.setattr(user_usage, 'record_firestore_read', lambda *args: observed.append(args))
+
+    usage = user_usage.get_monthly_usage_stats_since(
+        'uid',
+        datetime(2026, 6, 23, tzinfo=timezone.utc),
+        datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+
+    assert usage['transcription_seconds'] == 40
+    assert observed == [(FirestoreReadFamily.LISTEN_MONTHLY_USAGE, FirestoreReadMode.UNBOUNDED, 2)]

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -1092,13 +1092,15 @@ def has_transcription_credits(uid: str, source: Optional[str] = None) -> bool:
     if not subscription:
         return False
 
-    usage = get_monthly_usage_for_subscription(uid)
     limits = get_plan_limits(subscription.plan)
 
-    # Check transcription seconds (0 means unlimited)
-    if limits.transcription_seconds and limits.transcription_seconds > 0:
-        if usage.get('transcription_seconds', 0) >= limits.transcription_seconds:
-            return False
+    # Paid and other unlimited-transcription plans do not need a monthly usage scan.
+    if not limits.transcription_seconds or limits.transcription_seconds <= 0:
+        return True
+
+    usage = get_monthly_usage_for_subscription(uid)
+    if usage.get('transcription_seconds', 0) >= limits.transcription_seconds:
+        return False
 
     return True
 


### PR DESCRIPTION
## Summary

- coalesce the eager Home task preload with the Tasks page's initial request, while preserving an empty successful result and retrying a failed initial request
- skip the monthly hourly-usage Firestore scan for unlimited-transcription plans while retaining the bounded-plan quota check
- export low-cardinality Prometheus telemetry for the two known unbounded read paths: operation count and scanned documents

## Verification

- `cd backend && PYTHON=.venv/bin/python bash test-preflight.sh`
- `cd backend && bash test.sh`
- focused backend regressions: `20 passed`
- `flutter test` full suite: `858 passed` before rebase (run through the local Flutter Tools source fallback because the bundled Dart VM did not start)
- `cd app && bash scripts/analyze_ratchet.sh`
- `make preflight`
- independent Sol source review: approved

## Local-path note

The offline backend harness could not start because this machine does not have `redis-server`. The rebased Flutter-suite rerun could not start because the local engine compiler snapshot is incompatible with the available Dart SDK; the original full suite and hermetic regression tests cover the changed load behavior. The Flutter UI could not be dogfooded because no debug Flutter VM Service was running for `agent-flutter`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

