### PR TITLE
fix(ci): make Telegram deployment notifications optional

### DIFF
--- a/.github/actions/deployment-notifier/action.yaml
+++ b/.github/actions/deployment-notifier/action.yaml
@@ -1,13 +1,13 @@
 name: Notify Telegram
-description: Sends deployment status details to a Telegram.
+description: Sends deployment status details to Telegram when notification credentials are configured.
 
 inputs:
   telegram_bot_token:
     description: Telegram bot token used to send the notification.
-    required: true
+    required: false
   telegram_chat_id:
     description: Telegram chat ID that receives the notification.
-    required: true
+    required: false
   environment:
     description: Deployment environment to show in the Telegram message.
     required: true
@@ -22,7 +22,16 @@ inputs:
 runs:
   using: composite
   steps:
+    - id: configuration
+      name: Check Telegram notification configuration
+      shell: bash
+      env:
+        TELEGRAM_BOT_TOKEN: ${{ inputs.telegram_bot_token }}
+        TELEGRAM_CHAT_ID: ${{ inputs.telegram_chat_id }}
+      run: bash "$GITHUB_ACTION_PATH/check-configuration.sh"
+
     - name: Set deploy status
+      if: steps.configuration.outputs.enabled == 'true'
       shell: bash
       run: |
         if [ "${{ inputs.status }}" == "success" ]; then
@@ -34,6 +43,7 @@ runs:
         fi
 
     - name: Notify Telegram
+      if: steps.configuration.outputs.enabled == 'true'
       shell: bash
       env:
         TELEGRAM_BOT_TOKEN: ${{ inputs.telegram_bot_token }}

--- a/.github/actions/deployment-notifier/check-configuration.sh
+++ b/.github/actions/deployment-notifier/check-configuration.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -n "${TELEGRAM_BOT_TOKEN:-}" && -n "${TELEGRAM_CHAT_ID:-}" ]]; then
+  echo "enabled=true" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+echo "enabled=false" >> "$GITHUB_OUTPUT"
+{
+  echo "### Telegram deployment notification"
+  echo ""
+  echo "Skipped: Telegram bot token or chat ID is not configured."
+} >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/deployment-notifier/test-check-configuration.sh
+++ b/.github/actions/deployment-notifier/test-check-configuration.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-configuration.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+run_case() {
+  local name="$1"
+  local bot_token="$2"
+  local chat_id="$3"
+  local expected_enabled="$4"
+  local expected_summary="$5"
+  local output="$TMP_DIR/$name-output"
+  local summary="$TMP_DIR/$name-summary"
+
+  GITHUB_OUTPUT="$output" \
+    GITHUB_STEP_SUMMARY="$summary" \
+    TELEGRAM_BOT_TOKEN="$bot_token" \
+    TELEGRAM_CHAT_ID="$chat_id" \
+    bash "$SCRIPT"
+
+  grep -Fxq "enabled=$expected_enabled" "$output"
+  if [[ -n "$expected_summary" ]]; then
+    grep -Fxq "$expected_summary" "$summary"
+  elif [[ -s "$summary" ]]; then
+    echo "expected no summary for configured Telegram notification" >&2
+    return 1
+  fi
+}
+
+run_case "missing-both" "" "" "false" "Skipped: Telegram bot token or chat ID is not configured."
+run_case "missing-chat" "bot-token" "" "false" "Skipped: Telegram bot token or chat ID is not configured."
+run_case "configured" "bot-token" "chat-id" "true" ""

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -102,6 +102,11 @@ checks:
     triggers: [".github/scripts/check_deployment_secret_boundary.py", ".github/scripts/test_check_deployment_secret_boundary.py"]
     lanes: ["local", "ci"]
     reason: "deployment secret-boundary fake-name fixtures must remain executable"
+  - id: telegram-deployment-notifier
+    command: ["bash", ".github/actions/deployment-notifier/test-check-configuration.sh"]
+    triggers: [".github/actions/deployment-notifier/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "optional Telegram deployment notifications must not fail deploy workflows when credentials are absent"
   - id: opentofu-foundation-boundary
     command: ["python3", ".github/scripts/check_opentofu_foundation.py"]
     triggers: ["infrastructure/opentofu/**", ".github/scripts/check_opentofu_foundation.py", ".github/workflows/opentofu-foundation-validate.yml"]


### PR DESCRIPTION
## Summary

- make the shared Telegram deployment notifier a non-blocking, configuration-driven integration
- record a clear deployment-summary skip when either Telegram credential is absent
- add an executable regression check and register it in the deterministic CI manifest

## Validation

- `bash .github/actions/deployment-notifier/test-check-configuration.sh`
- `bash -n .github/actions/deployment-notifier/check-configuration.sh .github/actions/deployment-notifier/test-check-configuration.sh`
- `actionlint -color .github/workflows/gcp_backend.yml`
- `python3 .github/scripts/test_run_checks.py`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

