### PR TITLE
fix(memory): make maintenance image imports credential-free

### DIFF
--- a/backend/runtime_images.json
+++ b/backend/runtime_images.json
@@ -91,6 +91,9 @@
             "workdir": "/app",
             "entrypoints": ["memory_maintenance_job"],
             "image_import_smoke": true,
+            "smoke_environment": {
+                "ENCRYPTION_SECRET": "0123456789abcdef0123456789abcdef"
+            },
             "dependency_probe_smoke": true,
             "pull_request_smoke": true,
             "dependency_probe_exclusions": {

--- a/backend/scripts/scan_import_time_side_effects.py
+++ b/backend/scripts/scan_import_time_side_effects.py
@@ -62,6 +62,8 @@ DEFAULT_ALLOWLIST = BACKEND_DIR / "tests" / ".import_time_side_effects_legacy"
 SIDE_EFFECT_CTORS: list[tuple[str, str]] = [
     ("openai", "OpenAI"),
     ("openai", "AsyncOpenAI"),
+    ("langchain_openai", "ChatOpenAI"),
+    ("langchain_openai", "OpenAIEmbeddings"),
     ("anthropic", "Anthropic"),
     ("anthropic", "AsyncAnthropic"),
     ("deepgram", "DeepgramClient"),

--- a/backend/tests/.import_time_side_effects_legacy
+++ b/backend/tests/.import_time_side_effects_legacy
@@ -8,7 +8,7 @@
 #
 # Terminal state: this file is deleted (PLAN.md §4, condition #2).
 #
-# Total: 30 entries.
+# Total: 29 entries.
 #
 # The 4 entries marked "surfaced by P2" below were discovered by the alias-
 # resolution hardening of scan_import_time_side_effects.py: the old checker
@@ -41,7 +41,6 @@ backend/scripts/users/retrieval.py
 backend/scripts/vad_multilang_dg_test.py
 backend/scripts/vad_offline_replay.py
 backend/utils/conversations/search.py
-backend/utils/llm/clients.py
 backend/utils/other/storage.py
 
 # surfaced by P2 (from-import alias blind spot)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,16 +17,12 @@ os.environ.setdefault(
     'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
 )
 
-# Some canonical memory modules transitively import utils.llm.clients which
-# instantiates OpenAI clients at module import time; that requires an API key
-# even when the client is never called. Provide a fake key so collection does
-# not crash.
+# Some unit tests exercise canonical-memory LLM call paths. Provide a fake key
+# so client construction remains hermetic when those tests invoke it.
 os.environ.setdefault('OPENAI_API_KEY', 'fake-key-for-hermetic-tests')
 
-# Canonical memory modules transitively import utils.llm.clients which calls
-# tiktoken.encoding_for_model() at module import time; that downloads an
-# encoding file from the network and breaks hermetic CI. Stub it out before
-# any test module imports the chain.
+# Some unit tests exercise token counting. Stub tiktoken before any test
+# triggers an encoding lookup, avoiding a download in hermetic CI.
 if 'tiktoken' not in sys.modules:
     _tiktoken_stub = ModuleType('tiktoken')
     _tiktoken_stub.encoding_for_model = lambda model: type('Encoding', (), {'encode': lambda self, text: list(text)})()

--- a/backend/tests/unit/test_memory_maintenance_job_import.py
+++ b/backend/tests/unit/test_memory_maintenance_job_import.py
@@ -1,0 +1,91 @@
+"""Regression coverage for the credential-free memory-maintenance image smoke."""
+
+import ast
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+MODAL_DIR = BACKEND_DIR / "modal"
+IMPORT_PURITY_SCANNER = BACKEND_DIR / "scripts" / "scan_import_time_side_effects.py"
+PROVIDER_ENV_VARS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY")
+SMOKE_ENCRYPTION_SECRET = "0123456789abcdef0123456789abcdef"
+
+
+def _load_import_purity_scanner():
+    spec = importlib.util.spec_from_file_location("import_purity_scanner_for_test", IMPORT_PURITY_SCANNER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_import_purity_scanner_rejects_langchain_provider_constructors():
+    scanner = _load_import_purity_scanner()
+    source = "\n".join(
+        (
+            "from langchain_openai import ChatOpenAI, OpenAIEmbeddings",
+            "chat = ChatOpenAI()",
+            "embeddings = OpenAIEmbeddings()",
+        )
+    )
+
+    offenders = scanner._module_level_offenders(ast.parse(source), source.splitlines())
+
+    assert (2, "import-time constructor: ChatOpenAI") in offenders
+    assert (3, "import-time constructor: OpenAIEmbeddings") in offenders
+
+
+def test_memory_maintenance_job_imports_without_provider_credentials_or_network():
+    environment = dict(os.environ)
+    for variable in PROVIDER_ENV_VARS:
+        environment.pop(variable, None)
+    environment["ENCRYPTION_SECRET"] = SMOKE_ENCRYPTION_SECRET
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+
+    code = f'''\
+import socket
+import sys
+import types
+
+class ForbiddenProviderClient:
+    def __init__(self, *_args, **_kwargs):
+        raise AssertionError("provider clients must not be constructed while importing the job")
+
+class BlockedNetworkSocket(socket.socket):
+    def connect(self, *_args, **_kwargs):
+        raise AssertionError("network access is forbidden while importing the job")
+
+socket.socket = BlockedNetworkSocket
+anthropic = types.ModuleType("anthropic")
+anthropic.AsyncAnthropic = ForbiddenProviderClient
+langchain_openai = types.ModuleType("langchain_openai")
+langchain_openai.ChatOpenAI = ForbiddenProviderClient
+langchain_openai.OpenAIEmbeddings = ForbiddenProviderClient
+tiktoken = types.ModuleType("tiktoken")
+tiktoken.encoding_for_model = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+    AssertionError("tokenizer must not initialize while importing the job")
+)
+sys.modules.update({{
+    "anthropic": anthropic,
+    "langchain_openai": langchain_openai,
+    "tiktoken": tiktoken,
+}})
+sys.path.insert(0, {str(BACKEND_DIR)!r})
+sys.path.insert(0, {str(MODAL_DIR)!r})
+import memory_maintenance_job
+'''
+
+    result = subprocess.run(
+        [sys.executable, "-I", "-B", "-c", code],
+        cwd=BACKEND_DIR,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/backend/tests/unit/test_runtime_image_contracts.py
+++ b/backend/tests/unit/test_runtime_image_contracts.py
@@ -43,6 +43,12 @@ def test_registered_runtime_image_workflows_smoke_their_declared_dockerfile(cont
     assert contracts_module.workflow_contract_errors(contracts_module.load_contracts()) == []
 
 
+def test_memory_maintenance_import_smoke_supplies_only_its_nonsecret_import_config(contracts_module):
+    memory_maintenance_job = _contract(contracts_module, 'memory-maintenance-job')
+
+    assert dict(memory_maintenance_job.smoke_environment) == {'ENCRYPTION_SECRET': '0123456789abcdef0123456789abcdef'}
+
+
 def test_pusher_contract_rejects_omitted_shared_package(contracts_module, tmp_path):
     pusher = _contract(contracts_module, 'pusher')
     dockerfile = _dockerfile_without(

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -3304,13 +3304,15 @@ class TestTimeoutConfiguration:
 
     def test_llm_mini_has_timeout(self):
         source = self._read_clients_source()
-        llm_mini_line = [l for l in source.split('\n') if 'llm_mini' in l and 'ChatOpenAI' in l][0]
-        assert 'request_timeout=120' in llm_mini_line
-        assert 'max_retries=1' in llm_mini_line
+        start = source.index('def _create_legacy_llm_mini')
+        end = source.find('\n\ndef ', start + 1)
+        factory_body = source[start:end]
+        assert 'request_timeout=120' in factory_body
+        assert 'max_retries=1' in factory_body
 
     def test_anthropic_default_has_timeout(self):
         source = self._read_clients_source()
-        default_line = [l for l in source.split('\n') if '_default_anthropic_client' in l and 'AsyncAnthropic' in l][0]
+        default_line = [l for l in source.split('\n') if '= anthropic.AsyncAnthropic' in l][0]
         assert 'timeout=120' in default_line
         assert 'max_retries=1' in default_line
 

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -1,7 +1,8 @@
 import hashlib
 import logging
 import os
-from typing import Any, Dict, List, Optional
+from functools import lru_cache
+from typing import Any, Callable, Dict, List, Optional
 
 import anthropic
 import httpx
@@ -195,8 +196,15 @@ class _AnthropicClientProxy:
 
     __slots__ = ('_default',)
 
-    def __init__(self, default: anthropic.AsyncAnthropic):
+    def __init__(self, default: Optional[anthropic.AsyncAnthropic] = None):
         object.__setattr__(self, '_default', default)
+
+    def _default_client(self) -> anthropic.AsyncAnthropic:
+        default = self._default
+        if default is None:
+            default = anthropic.AsyncAnthropic(timeout=120.0, max_retries=1)
+            object.__setattr__(self, '_default', default)
+        return default
 
     def _resolve(self) -> anthropic.AsyncAnthropic:
         byok = get_byok_key('anthropic')
@@ -210,7 +218,7 @@ class _AnthropicClientProxy:
                 )
             return legacy
         return get_gateway_first_anthropic_client(
-            legacy_client=self._default,
+            legacy_client=self._default_client(),
             agent_model=ANTHROPIC_AGENT_MODEL,
         )
 
@@ -224,10 +232,17 @@ class _OpenAIEmbeddingsProxy:
     __slots__ = ('_model', '_default', '_ctor_kwargs')
     _METHODS_TO_WRAP = {'embed_documents', 'aembed_documents', 'embed_query', 'aembed_query'}
 
-    def __init__(self, model: str, default: OpenAIEmbeddings, ctor_kwargs: Dict[str, Any]):
+    def __init__(self, model: str, default: Optional[OpenAIEmbeddings], ctor_kwargs: Dict[str, Any]):
         object.__setattr__(self, '_model', model)
         object.__setattr__(self, '_default', default)
         object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
+
+    def _default_client(self) -> OpenAIEmbeddings:
+        default = self._default
+        if default is None:
+            default = OpenAIEmbeddings(model=self._model, **self._ctor_kwargs)
+            object.__setattr__(self, '_default', default)
+        return default
 
     def _resolve(self) -> OpenAIEmbeddings:
         byok = get_byok_key('openai')
@@ -238,7 +253,7 @@ class _OpenAIEmbeddingsProxy:
                 inst = OpenAIEmbeddings(model=self._model, api_key=byok, **self._ctor_kwargs)
                 _openai_cache[cache_key] = inst
             return inst
-        return self._default
+        return self._default_client()
 
     @staticmethod
     def _is_key_failure(e: Exception) -> bool:
@@ -276,7 +291,7 @@ class _OpenAIEmbeddingsProxy:
                 handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation='embed_query')
                 if self._is_key_failure(e):
                     logger.warning("BYOK OpenAI embeddings failed (%s); falling back to Omi key", type(e).__name__)
-                    return self._default.embed_query(text)
+                    return self._default_client().embed_query(text)
             raise
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
@@ -288,7 +303,7 @@ class _OpenAIEmbeddingsProxy:
                 handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation='embed_documents')
                 if self._is_key_failure(e):
                     logger.warning("BYOK OpenAI embeddings failed (%s); falling back to Omi key", type(e).__name__)
-                    return self._default.embed_documents(texts)
+                    return self._default_client().embed_documents(texts)
             raise
 
     def __getattr__(self, name: str):
@@ -308,7 +323,7 @@ class _OpenAIEmbeddingsProxy:
                             logger.warning(
                                 "BYOK OpenAI embeddings failed (%s); falling back to Omi key", type(e).__name__
                             )
-                            return await getattr(self._default, name)(*args, **kwargs)
+                            return await getattr(self._default_client(), name)(*args, **kwargs)
                     raise
 
             return _wrapped_async
@@ -321,7 +336,7 @@ class _OpenAIEmbeddingsProxy:
                     handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation=name)
                     if self._is_key_failure(e):
                         logger.warning("BYOK OpenAI embeddings failed (%s); falling back to Omi key", type(e).__name__)
-                        return getattr(self._default, name)(*args, **kwargs)
+                        return getattr(self._default_client(), name)(*args, **kwargs)
                 raise
 
         return _wrapped
@@ -389,9 +404,10 @@ def _create_byok_client(
     return None
 
 
-# Anthropic client for chat agent (module-level, BYOK-aware)
-_default_anthropic_client = anthropic.AsyncAnthropic(timeout=120.0, max_retries=1)
-anthropic_client = _AnthropicClientProxy(_default_anthropic_client)
+# Anthropic client for chat agent (module-level, BYOK-aware).
+# The proxy constructs the provider client at its first use so importing a
+# deployable entrypoint never needs provider credentials.
+anthropic_client = _AnthropicClientProxy()
 
 
 def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
@@ -597,27 +613,62 @@ ANTHROPIC_AGENT_COMPLEX_MODEL = get_model('chat_agent')
 
 # ---------------------------------------------------------------------------
 # Legacy module-level alias (kept for test compatibility).
-# Production code should use get_llm(feature) exclusively.
+# Production code should use get_llm(feature) exclusively. The proxy preserves
+# the legacy object shape without constructing a provider client at import time.
 # ---------------------------------------------------------------------------
-llm_mini = ChatOpenAI(model='gpt-4.1-mini', callbacks=[_usage_callback], request_timeout=120, max_retries=1)
+
+
+class _LazyClientProxy:
+    """Resolve a compatibility client only when a caller first uses it."""
+
+    __slots__ = ('_factory', '_instance')
+
+    def __init__(self, factory: Callable[[], Any]):
+        object.__setattr__(self, '_factory', factory)
+        object.__setattr__(self, '_instance', None)
+
+    def _resolve(self) -> Any:
+        instance = self._instance
+        if instance is None:
+            instance = self._factory()
+            object.__setattr__(self, '_instance', instance)
+        return instance
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._resolve(), name)
+
+    def __or__(self, other: Any) -> Any:
+        return self._resolve() | other
+
+    def __ror__(self, other: Any) -> Any:
+        return other | self._resolve()
+
+
+def _create_legacy_llm_mini() -> ChatOpenAI:
+    return ChatOpenAI(model='gpt-4.1-mini', callbacks=[_usage_callback], request_timeout=120, max_retries=1)
+
+
+llm_mini = _LazyClientProxy(_create_legacy_llm_mini)
 
 # ---------------------------------------------------------------------------
 # Embeddings, parser, utilities
 # ---------------------------------------------------------------------------
-_embeddings_default = OpenAIEmbeddings(model="text-embedding-3-large")
 embeddings = _OpenAIEmbeddingsProxy(
     model="text-embedding-3-large",
-    default=_embeddings_default,
+    default=None,
     ctor_kwargs={},
 )
 parser = PydanticOutputParser(pydantic_object=StructuredExtraction)
 
-encoding = tiktoken.encoding_for_model('gpt-4')
+
+@lru_cache(maxsize=1)
+def _get_encoding():
+    return tiktoken.encoding_for_model('gpt-4')
 
 
 def num_tokens_from_string(string: str) -> int:
     """Returns the number of tokens in a text string."""
-    num_tokens = len(encoding.encode(string))
+    num_tokens = len(_get_encoding().encode(string))
     return num_tokens
 
 


### PR DESCRIPTION
## Summary

- Defer legacy LLM clients, embeddings, Anthropic, and tokenizer construction until first use so the maintenance-job image imports without provider credentials or network access.
- Declare the deterministic, non-secret encryption configuration required by the entrypoint import smoke and make the import-purity scanner reject the relevant LangChain constructors.
- Add a subprocess regression test that imports the production job with provider constructors and outbound sockets prohibited.

## Failure class

Failure-Class: FC-runtime-image-boundary

## Verification

- `python3 -m pytest -q backend/tests/unit/test_memory_maintenance_job_import.py backend/tests/unit/test_runtime_image_contracts.py` (14 passed)
- `python3 -m pytest -q backend/tests/unit/test_sync_v2.py::TestTimeoutConfiguration` (10 passed)
- `python3 -m pytest -q backend/tests/unit/test_byok_llm_logging.py` (10 passed)
- `python3 -m pytest -q backend/tests/unit/test_omi_qos_tiers.py` (95 passed)
- `python3 backend/scripts/scan_import_time_side_effects.py --check-allowlist-monotonic origin/main`
- `python3 backend/scripts/runtime_image_contracts.py check`
- `DOCKER_DEFAULT_PLATFORM=linux/amd64 make runtime-image-smoke SERVICE=memory-maintenance-job IMAGE=omi-memory-maintenance-import-safety:local`
- `OMI_PR_BODY_FILE=/private/tmp/omi-memory-maintenance-import-safety-pr-body.md make preflight`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

