### PR TITLE
feat(backend): default free-plan users to self-hosted Parakeet STT

### DIFF
--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -212,9 +212,17 @@ class ListenSessionRuntime:
             request.onboarding_mode,
             base.transcription_prefs.get('single_language_mode', False),
         )
+        # Free plans default to self-hosted Parakeet unless the user picked an engine
+        # (custom STT or an explicit Parakeet request). Read the plan only when Parakeet
+        # could actually apply; language support + fallback live in get_stt_service_for_language.
+        prefer_parakeet = False
+        if not self.use_custom_stt and requested_service != 'parakeet' and os.getenv('HOSTED_PARAKEET_API_URL'):
+            subscription = await run_blocking(db_executor, user_db.get_user_valid_subscription, request.uid)
+            prefer_parakeet = subscription is None or subscription.plan == PlanType.basic
         self.stt_service, self.stt_language, self.stt_model = get_stt_service_for_language(
             self.language,
             multi_lang_enabled=not single_language_mode,
+            prefer_parakeet=prefer_parakeet,
         )
         if not self.stt_service or not self.stt_language:
             await request.websocket.close(code=1008, reason=f'The language is not supported, {self.language}')

--- a/backend/tests/unit/test_parakeet_free_default.py
+++ b/backend/tests/unit/test_parakeet_free_default.py
@@ -1,0 +1,37 @@
+"""get_stt_service_for_language(prefer_parakeet=...) — the free-plan Parakeet default.
+
+prefer_parakeet routes to the self-hosted Parakeet engine for supported languages and
+falls back to the normal provider selection otherwise (or when Parakeet isn't configured).
+"""
+
+import pytest
+
+from utils.stt.streaming import STTService, get_stt_service_for_language
+
+
+@pytest.fixture
+def parakeet_available(monkeypatch):
+    monkeypatch.setenv('HOSTED_PARAKEET_API_URL', 'http://parakeet.internal/v3/stream')
+
+
+def test_prefers_parakeet_for_supported_language(parakeet_available):
+    svc, _lang, model = get_stt_service_for_language('en', prefer_parakeet=True)
+    assert svc == STTService.parakeet
+    assert model == 'parakeet'
+
+
+def test_falls_back_for_unsupported_language(parakeet_available):
+    # Japanese isn't in parakeet_languages -> normal provider selection.
+    svc, _lang, _model = get_stt_service_for_language('ja', prefer_parakeet=True)
+    assert svc != STTService.parakeet
+
+
+def test_no_prefer_keeps_default(parakeet_available):
+    svc, _lang, _model = get_stt_service_for_language('en', prefer_parakeet=False)
+    assert svc != STTService.parakeet
+
+
+def test_prefer_ignored_when_service_unconfigured(monkeypatch):
+    monkeypatch.delenv('HOSTED_PARAKEET_API_URL', raising=False)
+    svc, _lang, _model = get_stt_service_for_language('en', prefer_parakeet=True)
+    assert svc != STTService.parakeet

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -270,8 +270,12 @@ def _stt_selection_from_mode(_language: str, base_lang: str) -> str:
     return 'none'
 
 
-def get_stt_service_for_language(language: str, multi_lang_enabled: bool = True) -> Tuple[STTService, str, str]:
+def get_stt_service_for_language(
+    language: str, multi_lang_enabled: bool = True, prefer_parakeet: bool = False
+) -> Tuple[STTService, str, str]:
     base_lang = _normalize_language(language)
+    if prefer_parakeet and os.getenv('HOSTED_PARAKEET_API_URL') and base_lang in parakeet_languages:
+        return STTService.parakeet, base_lang or 'en', 'parakeet'
     for m in stt_service_models:
         m = m.strip()
         if m.startswith('dg-'):


### PR DESCRIPTION
## What

Free-plan users' live transcription defaults to the self-hosted Parakeet streaming STT (paid plans unchanged). Live streaming only — offline/synced device recordings are not affected.

## Behavior

Route to Parakeet when all hold: plan is free (`PlanType.basic`/no subscription), the user hasn't picked an engine (**not** custom STT and **not** an explicit Parakeet request), Parakeet is configured (`HOSTED_PARAKEET_API_URL`), and it can serve the language (`parakeet_languages`). Unsupported languages fall back to the normal provider selection.

`routers/listen/runtime.py` computes `prefer_parakeet` — reading the plan only when Parakeet could actually apply — and passes it to `get_stt_service_for_language`, which handles language support + fallback.

## Capacity

Parakeet currently runs on a single GPU pod (recent peak ~4 concurrent streams). Free users are the bulk of live transcription, so scale the Parakeet GPU fleet before this ramps and watch `parakeet_active_streams` + latency.

## Testing

- `tests/unit/test_parakeet_free_default.py`: supported-language routing, unsupported-language fallback, no-prefer default, unconfigured-service. All pass.
- `scan_async_blockers.py`: 0 findings (plan read is `run_blocking`-wrapped).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

