### PR TITLE
Report a midnight daily-summary time correctly instead of defaulting to 10 PM

### DIFF
--- a/backend/tests/unit/test_daily_summary_hour_midnight.py
+++ b/backend/tests/unit/test_daily_summary_hour_midnight.py
@@ -1,0 +1,33 @@
+"""Regression test: a midnight (hour 0) daily-summary time must not be reported as 10 PM.
+
+utils.retrieval.tools.notification_settings_tools.manage_daily_summary_tool built the current
+hour with `get_daily_summary_hour_local(uid) or 22`. Hour 0 (midnight) is a valid setting
+(set_daily_summary_hour_local accepts 0 <= h <= 23), but `0 or 22` evaluates to 22, so a user who
+set midnight was told 10:00 PM on both enable and get_settings. The hour is now taken as-is unless
+the getter returns None (unset).
+"""
+
+import utils.retrieval.tools.notification_settings_tools as mod
+
+
+def _call(monkeypatch, action, stored_hour, enabled=True):
+    monkeypatch.setattr(mod.notification_db, 'get_daily_summary_hour_local', lambda uid: stored_hour)
+    monkeypatch.setattr(mod.notification_db, 'get_daily_summary_enabled', lambda uid: enabled)
+    monkeypatch.setattr(mod.notification_db, 'set_daily_summary_enabled', lambda uid, v: None)
+    return mod.manage_daily_summary_tool.func(action=action, config={'configurable': {'user_id': 'u1'}})
+
+
+def test_get_settings_reports_midnight(monkeypatch):
+    result = _call(monkeypatch, 'get_settings', 0)
+    assert 'midnight' in result
+    assert '10:00 PM' not in result
+
+
+def test_enable_reports_midnight(monkeypatch):
+    result = _call(monkeypatch, 'enable', 0)
+    assert 'midnight' in result
+
+
+def test_unset_hour_defaults_to_22(monkeypatch):
+    result = _call(monkeypatch, 'get_settings', None)
+    assert '10:00 PM' in result  # None -> unset -> default 22 -> "10:00 PM"

--- a/backend/utils/retrieval/tools/notification_settings_tools.py
+++ b/backend/utils/retrieval/tools/notification_settings_tools.py
@@ -102,7 +102,8 @@ def manage_daily_summary_tool(
 
     if action == "enable":
         notification_db.set_daily_summary_enabled(uid, True)
-        current_hour = notification_db.get_daily_summary_hour_local(uid) or 22
+        _hour = notification_db.get_daily_summary_hour_local(uid)
+        current_hour = 22 if _hour is None else _hour
         hour_str = _format_hour(current_hour)
         return f"Daily summary notifications enabled. You'll receive them at {hour_str}."
 
@@ -129,7 +130,8 @@ def manage_daily_summary_tool(
 
     elif action == "get_settings":
         enabled = notification_db.get_daily_summary_enabled(uid)
-        current_hour = notification_db.get_daily_summary_hour_local(uid) or 22
+        _hour = notification_db.get_daily_summary_hour_local(uid)
+        current_hour = 22 if _hour is None else _hour
         hour_str = _format_hour(current_hour)
 
         if enabled:


### PR DESCRIPTION
## What

`utils/retrieval/tools/notification_settings_tools.py` `manage_daily_summary_tool` read the user's daily-summary hour with `get_daily_summary_hour_local(uid) or 22`. Hour `0` (midnight) is a valid setting (`set_daily_summary_hour_local` accepts `0 <= h <= 23`), but `0 or 22` evaluates to `22`, so a user who set midnight was told "10:00 PM" on both the `enable` and `get_settings` actions. `_format_hour` already renders `0` as "12:00 AM (midnight)"; only the `or 22` clobbered it.

## Fix

Take the stored hour as-is and fall back to 22 only when the getter returns `None` (unset), at both call sites:

```python
_hour = notification_db.get_daily_summary_hour_local(uid)
current_hour = 22 if _hour is None else _hour
```

## Tests

`tests/unit/test_daily_summary_hour_midnight.py` drives `manage_daily_summary_tool` (monkeypatching the notifications DB): a stored hour of 0 reports midnight for both `get_settings` and `enable`, and an unset hour still defaults to 10 PM. The midnight case fails against the pre-fix source and passes after.

## Verification

```
python -m pytest tests/unit/test_daily_summary_hour_midnight.py -q   -> 3 passed
  (the midnight case fails on origin/main's unfixed source)
black --line-length 120 --skip-string-normalization --check <files>  -> clean
python -m pyright -p pyrightconfig.json utils/retrieval/tools/notification_settings_tools.py  -> 0 errors
python scripts/check_module_stub_pollution.py  -> 0 violations
```

## Product invariants affected

None. `scripts/pr-preflight --suggest` lists no locked product invariant for the changed paths.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

