### PR TITLE
fix add gap between chat input bar and keyboard

### DIFF
--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -469,8 +469,8 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                     ? 6
                                     : (textFieldFocusNode.hasFocus &&
                                             (textController.text.length > 40 || textController.text.contains('\n'))
-                                        ? 0
-                                        : 2),
+                                        ? 4
+                                        : 10),
                               ),
                               child: Stack(
                                 clipBehavior: Clip.none,


### PR DESCRIPTION
## What

On mobile chat, the send pill sat flush against the keyboard — bottom padding was 2px with the keyboard open, and 0px once the draft grew past 40 chars or went multiline (screenshot in the report showed no gap at all above the QWERTY suggestions strip).

## Fix

Bump the keyboard-open bottom padding of the send bar in `app/lib/pages/chat/page.dart`: 10px in the normal state, 4px in the expanded long-text state. The floating-chat (`isPivotBottom`) case is unchanged at 6px.

## Verification

- `dart format` clean; `flutter analyze lib/pages/chat/page.dart` shows the same 28 pre-existing infos before and after the change (no new lint).
- Visual-only spacing tweak; no behavior test applies.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

