### PR TITLE
Catch AttributeError in search_files_tool config parsing

### DIFF
--- a/backend/tests/unit/test_file_tools_config_guard.py
+++ b/backend/tests/unit/test_file_tools_config_guard.py
@@ -1,0 +1,20 @@
+"""Regression test: search_files_tool must not crash on a config missing 'configurable'.
+
+utils.retrieval.tools.file_tools.search_files_tool reads the agent config with
+`configurable = cfg.get('configurable'); uid = configurable.get('user_id')`. When the
+'configurable' key is absent (but cfg is a dict), get returns None and None.get raises
+AttributeError, which the `except (KeyError, TypeError)` did NOT catch, so it escaped uncaught and
+broke the chat turn instead of returning the intended error string. The six sibling retrieval
+tools all catch AttributeError here; file_tools was the lone omission. AttributeError is now caught.
+"""
+
+import utils.retrieval.tools.file_tools as mod
+
+
+def test_missing_configurable_returns_error_not_crash():
+    # cfg is a dict but has no 'configurable' key -> cfg.get('configurable') is None ->
+    # None.get('user_id') is an AttributeError that must be caught and surfaced as an error string.
+    result = mod.search_files_tool.func(question="x", config={"foo": "bar"})
+
+    assert isinstance(result, str)
+    assert result.startswith("Error: Configuration error")

--- a/backend/utils/retrieval/tools/file_tools.py
+++ b/backend/utils/retrieval/tools/file_tools.py
@@ -69,7 +69,7 @@ def search_files_tool(question: str, file_ids: Optional[List[str]] = None, confi
         configurable: Any = cfg.get('configurable')
         uid = configurable.get('user_id')
         chat_session_id = configurable.get('chat_session_id')
-    except (KeyError, TypeError) as e:
+    except (KeyError, TypeError, AttributeError) as e:
         logger.error(f"❌ search_files_tool - error accessing config: {e}")
         import traceback
 


### PR DESCRIPTION
## What

`utils/retrieval/tools/file_tools.py` `search_files_tool` reads the agent config:

```python
configurable = cfg.get('configurable')
uid = configurable.get('user_id')
```

When the `configurable` key is absent (but `cfg` is a dict), `get` returns `None` and `None.get('user_id')` raises `AttributeError`. The handler was `except (KeyError, TypeError)`, which does not catch it, so the error escaped uncaught and broke the chat turn instead of returning the intended `"Error: Configuration error - ..."` string. The six sibling retrieval tools (`action_item_tools`, `conversation_tools`, `memory_tools`) all catch `AttributeError` at this exact seam; `file_tools` was the lone omission.

## Fix

Add `AttributeError` to the except tuple:

```python
except (KeyError, TypeError, AttributeError) as e:
```

## Tests

`tests/unit/test_file_tools_config_guard.py` calls `search_files_tool` with a config dict that has no `configurable` key and asserts it returns the error string rather than raising. It raises `AttributeError` against the pre-fix source and passes after.

## Verification

```
python -m pytest tests/unit/test_file_tools_config_guard.py -q   -> 1 passed
  (fails with AttributeError on origin/main's unfixed source)
black --line-length 120 --skip-string-normalization --check <files>  -> clean
python -m pyright -p pyrightconfig.json utils/retrieval/tools/file_tools.py  -> 0 errors
python scripts/check_module_stub_pollution.py  -> 0 violations
```

## Product invariants affected

None. `scripts/pr-preflight --suggest` lists no locked product invariant for the changed paths.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

