### PR TITLE
Coerce created_at to str when sorting X posts by kind

### DIFF
--- a/backend/database/x_posts.py
+++ b/backend/database/x_posts.py
@@ -130,7 +130,7 @@ def get_x_posts(uid: str, limit: int = 100, kind: Optional[str] = None) -> List[
             raw: object = d.to_dict()
             if isinstance(raw, dict):
                 docs.append(cast(Dict[str, Any], raw))
-        docs.sort(key=lambda x: x.get('created_at') or '', reverse=True)
+        docs.sort(key=lambda x: str(x.get('created_at') or ''), reverse=True)
         return docs[:limit]
     query = coll.order_by('created_at', direction=firestore.Query.DESCENDING).limit(limit)
     out: List[Dict[str, Any]] = []

--- a/backend/tests/unit/test_x_posts_sort_mixed_created_at.py
+++ b/backend/tests/unit/test_x_posts_sort_mixed_created_at.py
@@ -1,0 +1,50 @@
+"""Regression test: get_x_posts(kind=...) must not crash on mixed datetime/str created_at.
+
+database.x_posts.get_x_posts sorts the kind-filtered branch with
+`docs.sort(key=lambda x: x.get('created_at') or '', reverse=True)`. Tweets are stored with a
+datetime created_at while other rows store '' or omit it, so a mixed result set raises
+`TypeError: '<' not supported between instances of 'datetime.datetime' and 'str'` (a 500). Line 96
+of the same file already guards the identical pattern with str(); line 133 was the asymmetry.
+The key now coerces to str, matching line 96.
+"""
+
+import datetime
+
+import database.x_posts as x_posts
+
+
+class _FakeDoc:
+    def __init__(self, data):
+        self._data = data
+
+    def to_dict(self):
+        return self._data
+
+
+class _FakeQuery:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def where(self, **kwargs):
+        return self
+
+    def limit(self, n):
+        return self
+
+    def stream(self):
+        return iter(self._docs)
+
+
+def test_kind_branch_sorts_mixed_datetime_and_missing(monkeypatch):
+    dt = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
+    docs = [
+        _FakeDoc({'id': 'a', 'kind': 'tweet', 'created_at': dt}),
+        _FakeDoc({'id': 'b', 'kind': 'tweet'}),  # missing created_at
+    ]
+    monkeypatch.setattr(x_posts, '_posts_ref', lambda uid: _FakeQuery(docs))
+
+    result = x_posts.get_x_posts('u1', kind='tweet')  # must not raise
+
+    ids = [r['id'] for r in result]
+    assert set(ids) == {'a', 'b'}
+    assert result[0]['id'] == 'a'  # the datetime post sorts newest-first, ahead of the empty one


### PR DESCRIPTION
## What

`database/x_posts.py` `get_x_posts` sorts the kind-filtered branch with:

```python
docs.sort(key=lambda x: x.get('created_at') or '', reverse=True)
```

Tweets are stored with a `datetime` `created_at` (`utils/x_connector.py` passes tweepy's `created_at`), while other rows store `''` or omit it. A mixed result set therefore raises `TypeError: '<' not supported between instances of 'datetime.datetime' and 'str'` - a 500 on the X-posts read. Line 96 of the same file already guards the identical sort pattern with `str(...)`; line 133 was the asymmetry.

## Fix

Coerce the sort key to `str`, matching line 96:

```python
docs.sort(key=lambda x: str(x.get('created_at') or ''), reverse=True)
```

## Tests

`tests/unit/test_x_posts_sort_mixed_created_at.py` drives `get_x_posts(kind='tweet')` (via a fake `_posts_ref`) with one datetime `created_at` and one missing, asserting it sorts without raising. It raises `TypeError` against the pre-fix source and passes after.

This is the same class as the merged goals fix (`tests/unit/test_goals_sort_missing_created_at.py` + the `datetime_sort_sentinel_ratchet` fixture).

## Verification

```
python -m pytest tests/unit/test_x_posts_sort_mixed_created_at.py -q  -> 1 passed
  (raises TypeError on origin/main's unfixed source)
black --line-length 120 --skip-string-normalization --check <files>  -> clean
python -m pyright -p pyrightconfig.json database/x_posts.py  -> 0 errors
python scripts/check_module_stub_pollution.py  -> 0 violations
```

## Product invariants affected

None. `scripts/pr-preflight --suggest` lists no locked product invariant for the changed paths.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

