### PR TITLE
fix(deploy): migrate legacy prod Cloud Run public bindings

### DIFF
--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -345,6 +345,20 @@ jobs:
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:latest
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
 
+      # Strips Secret Manager bindings left on services for settings the manifest
+      # now declares as public literals; gcloud cannot flip a binding's type in
+      # place. No-ops once a service carries no legacy binding.
+      - name: Migrate legacy public Cloud Run bindings
+        run: >-
+          python3 backend/scripts/preflight-cloud-run-deploy.py
+          --env ${{ vars.ENV }}
+          --project="${{ vars.GCP_PROJECT_ID }}"
+          --region="${{ env.REGION }}"
+          --migrate-legacy-public-binding backend
+          --migrate-legacy-public-binding backend-sync
+          --migrate-legacy-public-binding backend-sync-backfill
+          --migrate-legacy-public-binding backend-integration
+
       - name: Deploy ${{ env.SERVICE }} to Cloud Run
         id: deploy-backend
         uses: google-github-actions/deploy-cloudrun@v3

--- a/backend/scripts/preflight-cloud-run-deploy.py
+++ b/backend/scripts/preflight-cloud-run-deploy.py
@@ -148,7 +148,9 @@ def migrate_legacy_public_bindings(
     manifest_path: Path = DEFAULT_MANIFEST,
     runner: Any = subprocess.run,
 ) -> list[str]:
-    _require_development_scope(env=env, project=project, check_name='Legacy public-binding migration')
+    _require_manifest_scope(
+        env=env, project=project, manifest_path=manifest_path, check_name='Legacy public-binding migration'
+    )
     service_configs = _cloud_run_service_configs(env=env, manifest_path=manifest_path)
 
     migrated: list[str] = []
@@ -252,6 +254,25 @@ def check_runtime_bindings(
 def _require_development_scope(*, env: str, project: str, check_name: str) -> None:
     if env != 'dev' or project != DEVELOPMENT_PROJECT:
         raise ValueError(f'{check_name} is development-only')
+
+
+def _require_manifest_scope(*, env: str, project: str, manifest_path: Path, check_name: str) -> None:
+    """Bind an operation to the project the manifest declares for `env`.
+
+    Migration is value-preserving but rewrites live service bindings, so the
+    caller must not be able to aim one environment's contract at another's
+    project.
+    """
+    manifest = render_backend_runtime_env._load_yaml(manifest_path)
+    environments = render_backend_runtime_env._as_config_dict(manifest.get('environments'))
+    if environments is None:
+        raise ValueError(f'Missing environments in {manifest_path}')
+    environment_config = render_backend_runtime_env._as_config_dict(environments.get(env))
+    if environment_config is None:
+        raise ValueError(f'{check_name} has no {env} environment in {manifest_path}')
+    expected_project = environment_config.get('gcp_project')
+    if project != expected_project:
+        raise ValueError(f'{check_name} for {env} expects project {expected_project!r}, got {project!r}')
 
 
 def _cloud_run_service_configs(*, env: str, manifest_path: Path) -> dict[str, Any]:

--- a/backend/tests/unit/test_preflight_cloud_run_deploy.py
+++ b/backend/tests/unit/test_preflight_cloud_run_deploy.py
@@ -71,6 +71,7 @@ def test_runtime_binding_check_accepts_manifest_literal_and_secret_bindings_read
         '''\
 environments:
   dev:
+    gcp_project: based-hardware-dev
     cloud_run:
       services:
         backend:
@@ -141,6 +142,7 @@ def test_runtime_binding_check_reports_manifest_declared_secret_missing_from_liv
         '''\
 environments:
   dev:
+    gcp_project: based-hardware-dev
     cloud_run:
       services:
         backend:
@@ -174,6 +176,7 @@ def test_runtime_binding_check_rejects_multi_container_live_service_shape(tmp_pa
         '''\
 environments:
   dev:
+    gcp_project: based-hardware-dev
     cloud_run:
       services:
         backend:
@@ -214,6 +217,7 @@ def test_runtime_binding_check_propagates_gcloud_describe_failure(tmp_path: Path
         '''\
 environments:
   dev:
+    gcp_project: based-hardware-dev
     cloud_run:
       services:
         backend:
@@ -246,6 +250,7 @@ def test_remove_secret_then_pre_candidate_check_accepts_absent_public_binding(tm
         '''\
 environments:
   dev:
+    gcp_project: based-hardware-dev
     cloud_run:
       services:
         backend:
@@ -326,6 +331,7 @@ def test_runtime_binding_check_ignores_undeclared_live_bindings(tmp_path: Path) 
         '''\
 environments:
   dev:
+    gcp_project: based-hardware-dev
     cloud_run:
       services:
         backend:
@@ -394,6 +400,7 @@ def test_runtime_binding_check_reports_declared_type_mismatches_only(tmp_path: P
         '''\
 environments:
   dev:
+    gcp_project: based-hardware-dev
     cloud_run:
       services:
         backend:

--- a/backend/tests/unit/test_verify_dev_backend_deployment.py
+++ b/backend/tests/unit/test_verify_dev_backend_deployment.py
@@ -272,20 +272,78 @@ def test_legacy_binding_migration_rejects_multi_container_services_without_mutat
     ]
 
 
-def test_legacy_binding_migration_rejects_non_dev_projects_without_gcloud_calls() -> None:
+def test_legacy_binding_migration_rejects_mismatched_projects_without_gcloud_calls() -> None:
     preflight = _load_preflight()
     calls: list[list[str]] = []
 
-    with pytest.raises(ValueError, match='development-only'):
+    with pytest.raises(ValueError, match="prod expects project 'based-hardware'"):
         preflight.migrate_legacy_public_bindings(
             services=('backend',),
             env='prod',
-            project='based-hardware',
+            project='based-hardware-dev',
             region='us-central1',
             runner=lambda command, **_kwargs: calls.append(command),
         )
 
     assert calls == []
+
+
+def test_legacy_binding_migration_strips_prod_legacy_bindings() -> None:
+    preflight = _load_preflight()
+    legacy_service = {
+        'spec': {
+            'template': {
+                'spec': {
+                    'containers': [
+                        {
+                            'env': [
+                                {
+                                    'name': 'GOOGLE_CLIENT_ID',
+                                    'valueFrom': {'secretKeyRef': {'name': 'GOOGLE_CLIENT_ID', 'key': 'latest'}},
+                                },
+                                {
+                                    'name': 'GOOGLE_CLIENT_SECRET',
+                                    'valueFrom': {'secretKeyRef': {'name': 'GOOGLE_CLIENT_SECRET', 'key': 'latest'}},
+                                },
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    commands: list[list[str]] = []
+
+    def runner(command: list[str], **_kwargs):
+        commands.append(command)
+        return SimpleNamespace(stdout=json.dumps(legacy_service))
+
+    migrated = preflight.migrate_legacy_public_bindings(
+        services=('backend',),
+        env='prod',
+        project='based-hardware',
+        region='us-central1',
+        runner=runner,
+    )
+
+    assert migrated == ['backend']
+    update = commands[-1]
+    assert update[:5] == ['gcloud', 'run', 'services', 'update', 'backend']
+    assert '--project=based-hardware' in update
+    assert '--no-traffic' in update
+    # Only the manifest-declared public setting is stripped; the real secret stays bound.
+    assert '--remove-secrets=GOOGLE_CLIENT_ID' in update
+
+
+def test_prod_deploy_invokes_legacy_binding_migration_before_deploy() -> None:
+    workflow = BACKEND_DIR.parent / '.github/workflows/gcp_backend.yml'
+    text = workflow.read_text(encoding='utf-8')
+
+    assert 'backend/scripts/preflight-cloud-run-deploy.py' in text
+    assert text.count('--migrate-legacy-public-binding') == 4
+    for service in ('backend', 'backend-sync', 'backend-sync-backfill', 'backend-integration'):
+        assert f'--migrate-legacy-public-binding {service}' in text
+    assert text.index('migrate-legacy-public-binding') < text.index('Deploy ${{ env.SERVICE }} to Cloud Run')
 
 
 def test_dev_deploy_invokes_legacy_binding_migration_only_for_dev_services() -> None:


### PR DESCRIPTION
## Problem

Every prod backend deploy has failed since 2026-07-14:

```
ERROR: (gcloud.run.deploy) Cannot update environment variable [GOOGLE_CLIENT_ID]
to string literal because it has already been set with a different type.
```

efca8b8c7a ("fix(deploy): classify deployment setting boundaries") reclassified `GOOGLE_CLIENT_ID`, `STT_PRERECORDED_MODEL` and the `MCP_OAUTH_CLAUDE_*` settings from Secret Manager references to public literals sourced from environment variables. Those values are genuinely public (an OAuth client ID, a model routing list, the string `Claude`, a public callback URL), so the reclassification is correct.

The gap is the rollout: the "Migrate legacy public Cloud Run bindings" step was wired into `gcp_backend_auto_dev.yml` only, and `migrate_legacy_public_bindings` was hard-gated to dev via `_require_development_scope`. Prod's four Cloud Run services kept the old Secret Manager bindings, and gcloud cannot flip a binding's type in place — so the deploy dies before it can set the literal.

Live drift confirmed on every prod service:

| Service | Declared literal, still bound as secret |
|---|---|
| `backend` | GOOGLE_CLIENT_ID, STT_PRERECORDED_MODEL, MCP_OAUTH_CLAUDE_CLIENT_ID, MCP_OAUTH_CLAUDE_CLIENT_NAME, MCP_OAUTH_CLAUDE_REDIRECT_URIS |
| `backend-sync`, `backend-sync-backfill`, `backend-integration` | GOOGLE_CLIENT_ID, STT_PRERECORDED_MODEL |

## Change

- Scope the migration to the project the manifest declares for the target environment (`_require_manifest_scope`) instead of hardcoding dev. The operation still cannot be aimed at another environment's project. `check_runtime_bindings` stays dev-only.
- Run the migration in `gcp_backend.yml` before the Cloud Run deploy step, mirroring the dev workflow's ordering.

The migration only strips a binding whose secret name equals the manifest-declared public setting name, so real secrets stay bound, and it no-ops once a service is clean — it is not permanent pipeline overhead.

## Verification

- **Live drift** confirmed on all four prod services via `gcloud run services describe`.
- **Value-preserving**: each prod environment variable hashes identical (sha256) to the Secret Manager value it replaces, so the flip cannot change runtime behavior.
- **Dry run against live prod** — `migrate_legacy_public_bindings` with a runner that captures mutations instead of executing them. Planned commands match the independently computed drift set, and `GOOGLE_CLIENT_SECRET` is absent from every removal list:
  ```
  backend:               --remove-secrets=GOOGLE_CLIENT_ID,MCP_OAUTH_CLAUDE_CLIENT_ID,
                           MCP_OAUTH_CLAUDE_CLIENT_NAME,MCP_OAUTH_CLAUDE_REDIRECT_URIS,
                           STT_PRERECORDED_MODEL --no-traffic
  backend-sync:          --remove-secrets=GOOGLE_CLIENT_ID,STT_PRERECORDED_MODEL --no-traffic
  backend-sync-backfill: --remove-secrets=GOOGLE_CLIENT_ID,STT_PRERECORDED_MODEL --no-traffic
  backend-integration:   --remove-secrets=GOOGLE_CLIENT_ID,STT_PRERECORDED_MODEL --no-traffic
  ```
- `validate-backend-runtime-env.py --check-workflows --check-rendered-cloud-run` passes for dev and prod.
- `check_deployment_secret_boundary.py --base origin/main` passes.
- `pytest tests/unit/{test_preflight_cloud_run_deploy,test_verify_dev_backend_deployment,test_backend_runtime_env_validator,test_repair_cloud_run_traffic,test_deploy_status_report,test_mcp_oauth_deploy_contract}.py` → **104 passed**.

Prod traffic is pinned to a named revision and the migration revision is created with `--no-traffic`, so no serving revision changes.

## Regression coverage

- `test_legacy_binding_migration_strips_prod_legacy_bindings` — the migration runs for prod and strips only the manifest-declared public setting, leaving `GOOGLE_CLIENT_SECRET` bound.
- `test_prod_deploy_invokes_legacy_binding_migration_before_deploy` — the prod workflow invokes the migration for all four services ahead of the deploy step. This is the wiring whose absence caused the outage.
- `test_legacy_binding_migration_rejects_mismatched_projects_without_gcloud_calls` — replaces the old dev-only assertion; a mismatched env/project pair still fails with no gcloud calls.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

