### PR TITLE
fix(deploy): scope the transcription candidate gate to development

### DIFF
--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -370,7 +370,7 @@ jobs:
           no_traffic: true
           flags: >-
             --revision-suffix=${{ steps.image-tag.outputs.revision_suffix }}
-            ${{ format('--tag={0}', env.TRANSCRIPTION_CANDIDATE_TAG) }}
+            ${{ github.event.inputs.environment == 'development' && format('--tag={0}', env.TRANSCRIPTION_CANDIDATE_TAG) || '' }}
             ${{ steps.runtime-env.outputs.cloud_run_flags }}
           env_vars: ${{ steps.runtime-env.outputs.backend_env_vars }}
           secrets: ${{ steps.runtime-env.outputs.backend_secrets }}
@@ -531,10 +531,19 @@ jobs:
         run: |
           python3 backend/scripts/validate-backend-runtime-env.py --env ${{ vars.ENV }} --check-workflows --check-live-cloud-run
 
-      # The manual development deployment runs this same no-traffic probe before
+      # The manual development deployment runs this no-traffic probe before
       # promotion, making it the required auth and route dry run for production.
+      #
+      # Development-only by construction. The probe reaches the candidate over a
+      # Cloud Run tag URL, which is a run.app URL. Production deliberately serves
+      # no run.app URL (`run.googleapis.com/default-url-disabled=true`, ingress
+      # `internal-and-cloud-load-balancing`), so a production tag resolves to no
+      # HTTPS endpoint and this runner sits outside the VPC that could reach one.
+      # Do not enable these steps for production without first giving the probe a
+      # route that does not depend on a public revision URL.
       - name: Resolve transcription candidate URL
         id: transcription-candidate
+        if: ${{ github.event.inputs.environment == 'development' }}
         run: |
           candidate_url="$(python3 backend/scripts/resolve_cloud_run_tagged_url.py \
             --project=${{ vars.GCP_PROJECT_ID }} \
@@ -545,6 +554,7 @@ jobs:
           printf 'url=%s\n' "$candidate_url" >> "$GITHUB_OUTPUT"
 
       - name: Gate backend candidate on known audio
+        if: ${{ github.event.inputs.environment == 'development' }}
         uses: ./.github/actions/transcription-release-candidate-probe
         with:
           candidate_api_url: ${{ steps.transcription-candidate.outputs.url }}
@@ -552,7 +562,7 @@ jobs:
           firebase_auth_project_id: based-hardware
 
       - name: Remove passed transcription candidate tag
-        if: ${{ success() }}
+        if: ${{ success() && github.event.inputs.environment == 'development' }}
         run: |
           gcloud run services update-traffic ${{ env.SERVICE }} \
             --project=${{ vars.GCP_PROJECT_ID }} \
@@ -562,8 +572,9 @@ jobs:
 
       - name: Remove failed transcription candidate tag
         # Tag is created at deploy-backend; clean it up on any later failure,
-        # not only after the candidate URL resolution step succeeds.
-        if: ${{ failure() && steps.deploy-backend.outcome == 'success' }}
+        # not only after the candidate URL resolution step succeeds. Production
+        # never creates the tag, so there is nothing to remove there.
+        if: ${{ failure() && steps.deploy-backend.outcome == 'success' && github.event.inputs.environment == 'development' }}
         run: |
           gcloud run services update-traffic ${{ env.SERVICE }} \
             --project=${{ vars.GCP_PROJECT_ID }} \

--- a/backend/tests/unit/test_sync_two_lane.py
+++ b/backend/tests/unit/test_sync_two_lane.py
@@ -202,10 +202,50 @@ def test_normal_backend_deploys_fail_closed_on_fence_transitions_and_gate_stt_ca
     assert 'OMI_TRANSCRIPTION_SYNTHETIC_' not in manual
     assert 'Remove passed transcription candidate tag' in manual
     assert 'Remove failed transcription candidate tag' in manual
-    assert 'if: ${{ failure() && steps.deploy-backend.outcome == \'success\' }}' in manual
+    assert (
+        'if: ${{ failure() && steps.deploy-backend.outcome == \'success\''
+        ' && github.event.inputs.environment == \'development\' }}' in manual
+    )
     assert manual.index('Gate backend candidate on known audio') < manual.index(
         'Shift Cloud Run traffic to validated revisions'
     )
+
+
+def test_transcription_candidate_gate_is_development_only():
+    """The candidate probe must never gate a production deploy.
+
+    The probe reaches the candidate over a Cloud Run tag URL, which is a run.app
+    URL. Production disables run.app URLs and restricts ingress to internal and
+    load-balancer traffic, so a production tag resolves to no HTTPS endpoint and
+    every production deploy fails at the probe (2026-07-17, run 29574215693).
+    """
+    import yaml
+
+    root = Path(__file__).resolve().parents[3]
+    workflow = yaml.safe_load((root / '.github/workflows/gcp_backend.yml').read_text())
+    steps = workflow['jobs']['deploy']['steps']
+    by_name = {step.get('name'): step for step in steps}
+
+    gate_steps = (
+        'Resolve transcription candidate URL',
+        'Gate backend candidate on known audio',
+        'Remove passed transcription candidate tag',
+        'Remove failed transcription candidate tag',
+    )
+    for name in gate_steps:
+        assert name in by_name, f'{name} step is missing'
+        condition = by_name[name].get('if') or ''
+        assert (
+            "github.event.inputs.environment == 'development'" in condition
+        ), f'{name} must be development-only; a production run cannot resolve a tag URL'
+
+    # The tag itself is only requested for development; production never creates one.
+    deploy_flags = by_name['Deploy ${{ env.SERVICE }} to Cloud Run']['with']['flags']
+    assert "github.event.inputs.environment == 'development' && format('--tag={0}'" in deploy_flags
+
+    # Promotion must not depend on the skipped gate.
+    for name in ('Verify validated revisions are still current', 'Shift Cloud Run traffic to validated revisions'):
+        assert by_name[name].get('if') is None, f'{name} must still run when the gate is skipped'
 
 
 def test_static_processed_segment_marker_follows_partial_result_checkpoint():


### PR DESCRIPTION
## Problem

With the Cloud Run binding fix (#9911) merged, the prod deploy got all the way through image build, all four Cloud Run services, GKE Helm, and the post-deploy runtime-env validation — then failed at `Resolve transcription candidate URL` (run [29574215693](https://github.com/BasedHardware/omi/actions/runs/29574215693)):

```
ERROR: Cloud Run tag 'stt-gate-29574215693-1' has no valid HTTPS URL
```

The known-audio probe reaches the candidate revision over a Cloud Run **tag URL**, which is a `run.app` URL. Production deliberately has no `run.app` URL:

| | dev | prod |
|---|---|---|
| `run.googleapis.com/default-url-disabled` | unset | **`true`** |
| ingress | `all` | `internal-and-cloud-load-balancing` |
| `status.url` | `https://backend-…-uc.a.run.app` | **none** |

So a prod tag resolves to no HTTPS endpoint. This is not a transient failure — it is structural, and it would fail **every** prod deploy. Two independent blockers, in fact: even if the default URL were re-enabled, ingress is internal-only while the deploy runs on `ubuntu-latest-m`, a GitHub-hosted runner outside the VPC.

The gate works in dev only because dev is wide open.

## Why it went unnoticed

The gate landed in d4252a6738 on **2026-07-13** — one day *after* the last successful prod deploy (`d40d43be`, 2026-07-12) and one day *before* the binding break (efca8b8c7a, 2026-07-14). It has never executed against prod. The binding bug masked it; fixing that bug surfaced it.

## Change

Scope the `--tag` flag and the four gate steps to `development`. This restores the 2026-07-12 prod behavior and matches the step's own documented intent, already in the workflow:

> The manual development deployment runs this same no-traffic probe before promotion, making it the required auth and route dry run for production.

The gate keeps running on dev, where it works. The comment now records *why* prod is excluded, so this isn't silently re-enabled.

Promotion steps (`Verify validated revisions are still current`, `Shift Cloud Run traffic to validated revisions`) keep no `if:` — a **skipped** step does not fail `success()`, so traffic promotion proceeds normally.

## Verification

- **Parsed the rendered workflow**: all four gate steps carry the development condition; the `--tag` flag is development-gated; both promotion steps still carry no `if:`.
- **Mutation-checked the new guard** — re-enabled the gate for prod and confirmed the test fails with `Gate backend candidate on known audio must be development-only; a production run cannot resolve a tag URL`, then restored. The guard catches the real regression rather than asserting a tautology.
- Confirmed prod's posture directly via `gcloud run services describe` (`default-url-disabled=true`, `status.url` empty, ingress internal-and-LB) and dev's (`ingress: all`, URL present).
- Confirmed no org policy sets `run.disableDefaultURI` — the annotation is set on the service, deliberately.
- `pytest tests/unit/{test_sync_two_lane,test_sync_ledger_fence_cutover,test_smoke_what_matters_now,test_resolve_cloud_run_tagged_url,test_verify_dev_backend_deployment,test_preflight_cloud_run_deploy}.py` → **86 passed**.

Prod is currently unchanged and safe: 100% traffic pinned to the 2026-07-12 revision, the #9911 candidate revision Ready at 0%, and the failed tag cleaned up.

## Regression coverage

`test_transcription_candidate_gate_is_development_only` pins all four gate steps and the tag flag as development-only, and asserts promotion does not depend on the gate. Mutation-verified above.

## Follow-up

This removes the pre-promotion STT gate from prod, which is worth naming explicitly: the pending `main` includes a change defaulting free-plan live transcription to Parakeet, and that is exactly the class of regression this gate was built to catch. Recommend a dev deploy to exercise the gate against that change before promoting prod. Giving the probe a prod-viable route (VPC-connected runner, or a probe path that does not depend on a public revision URL) is separate work.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

