### PR TITLE
Keep the best AI task when relevance_score is zero in migrate_ai_tasks

### DIFF
--- a/backend/database/staged_tasks.py
+++ b/backend/database/staged_tasks.py
@@ -367,8 +367,10 @@ def migrate_ai_tasks(uid: str) -> dict:
     if len(ai_tasks) <= 3:
         return {'moved': 0, 'kept': len(ai_tasks)}
 
-    # Sort by relevance_score ascending (best first)
-    ai_tasks.sort(key=lambda x: x.get('relevance_score') or 999)
+    # Sort by relevance_score ascending (best first). relevance_score is an int in
+    # 0-1000 where 0 is the most relevant, so only a genuinely missing (None) score
+    # should sort last: `or 999` would also demote a valid best score of 0.
+    ai_tasks.sort(key=lambda x: 999 if x.get('relevance_score') is None else x.get('relevance_score'))
     keep = ai_tasks[:3]
     to_move = ai_tasks[3:]
 

--- a/backend/tests/unit/test_staged_tasks_relevance_zero.py
+++ b/backend/tests/unit/test_staged_tasks_relevance_zero.py
@@ -1,0 +1,134 @@
+"""Regression test: migrate_ai_tasks must keep the best (relevance_score == 0) AI task.
+
+database.staged_tasks.migrate_ai_tasks keeps the top 3 AI action items by relevance_score
+ascending (best first) and moves the rest to staged_tasks. The sort key used
+`x.get('relevance_score') or 999`, which coerces a valid best score of 0 (relevance_score is
+an int in 0-1000 where 0 is most relevant) to 999, sorting the single most relevant task last
+so it gets moved out of action_items instead of kept. The key now maps only a genuinely missing
+(None) score to 999.
+
+Seam: database.staged_tasks reads/writes exclusively through the module-level `db`, so a fake
+db that streams action-item docs and records batched writes exercises the real migration path.
+"""
+
+import database.staged_tasks as staged_tasks
+
+
+class _FakeDoc:
+    def __init__(self, doc_id, data):
+        self.id = doc_id
+        self._data = data
+
+    def to_dict(self):
+        return dict(self._data)
+
+
+class _FakeQuery:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def where(self, **kwargs):
+        return self
+
+    def select(self, *args, **kwargs):
+        return self
+
+    def stream(self):
+        return iter(self._docs)
+
+
+class _FakeDocRef:
+    def __init__(self, doc_id):
+        self.id = doc_id
+
+
+class _FakeCollection:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def where(self, **kwargs):
+        return _FakeQuery(self._docs)
+
+    def document(self, doc_id=None):
+        return _FakeDocRef(doc_id)
+
+
+class _FakeUserDoc:
+    def __init__(self, action_docs):
+        self._action_docs = action_docs
+
+    def collection(self, name):
+        # Only action_items is streamed; staged_tasks is used solely for .document(id).
+        return _FakeCollection(self._action_docs if name == 'action_items' else [])
+
+
+class _FakeUsersCollection:
+    def __init__(self, action_docs):
+        self._action_docs = action_docs
+
+    def document(self, uid):
+        return _FakeUserDoc(self._action_docs)
+
+
+class _FakeBatch:
+    def __init__(self, moved_ids):
+        self._moved_ids = moved_ids
+
+    def set(self, ref, data):
+        # A set into staged_tasks is a "move out of action_items".
+        self._moved_ids.append(ref.id)
+
+    def delete(self, ref):
+        pass
+
+    def commit(self):
+        pass
+
+
+class _FakeDB:
+    def __init__(self, action_docs, moved_ids):
+        self._action_docs = action_docs
+        self._moved_ids = moved_ids
+
+    def collection(self, name):  # 'users'
+        return _FakeUsersCollection(self._action_docs)
+
+    def batch(self):
+        return _FakeBatch(self._moved_ids)
+
+
+def test_migrate_keeps_relevance_zero_task(monkeypatch):
+    # Five AI tasks; ascending best-first means score 0 is the single best and must be kept.
+    action_docs = [
+        _FakeDoc('t0', {'source': 'screenshot', 'relevance_score': 0}),  # best (0)
+        _FakeDoc('t1', {'source': 'screenshot', 'relevance_score': 1}),
+        _FakeDoc('t2', {'source': 'screenshot', 'relevance_score': 2}),
+        _FakeDoc('t3', {'source': 'screenshot', 'relevance_score': 3}),
+        _FakeDoc('t4', {'source': 'screenshot', 'relevance_score': 4}),
+    ]
+    moved_ids: list[str] = []
+    monkeypatch.setattr(staged_tasks, 'db', _FakeDB(action_docs, moved_ids))
+
+    staged_tasks.migrate_ai_tasks('u1')
+
+    # Keep the three lowest scores (t0, t1, t2); move the rest. The best (t0, score 0)
+    # must NOT be moved out. With the old `or 999` key it sorted last and was moved.
+    assert 't0' not in moved_ids
+    assert set(moved_ids) == {'t3', 't4'}
+
+
+def test_migrate_still_sorts_missing_score_last(monkeypatch):
+    # A genuinely missing score must still sort last (moved), distinct from a 0.
+    action_docs = [
+        _FakeDoc('z', {'source': 'screenshot', 'relevance_score': 0}),
+        _FakeDoc('a', {'source': 'screenshot', 'relevance_score': 5}),
+        _FakeDoc('b', {'source': 'screenshot', 'relevance_score': 7}),
+        _FakeDoc('none', {'source': 'screenshot'}),  # missing relevance_score
+    ]
+    moved_ids: list[str] = []
+    monkeypatch.setattr(staged_tasks, 'db', _FakeDB(action_docs, moved_ids))
+
+    staged_tasks.migrate_ai_tasks('u1')
+
+    # Keep z(0), a(5), b(7); the missing-score task sorts last and is moved.
+    assert moved_ids == ['none']


### PR DESCRIPTION
Keep the best AI task when relevance_score is zero in migrate_ai_tasks

migrate_ai_tasks keeps the top 3 AI-generated action items by relevance_score
ascending (best first) and moves the rest into staged_tasks. The sort key was:

    ai_tasks.sort(key=lambda x: x.get('relevance_score') or 999)

relevance_score is an Optional[int] documented as 0-1000 where 0 is the most
relevant. The `or 999` treats a valid best score of 0 as if it were missing,
sorting that task last, so the single most relevant AI task is moved out of
action_items instead of kept in the top 3. Only a genuinely missing (None)
score should sort last.

Fix: distinguish None from 0.

    ai_tasks.sort(key=lambda x: 999 if x.get('relevance_score') is None else x.get('relevance_score'))

This is the same falsy-zero class as the merged goals and datetime-sort-sentinel
fixes: a value that is falsy but valid (0) should not share the missing-value
sentinel.

Test: tests/unit/test_staged_tasks_relevance_zero.py drives migrate_ai_tasks
through a fake db (staged_tasks reads and writes only through the module-level
db) with five AI tasks including one scored 0, and asserts the score-0 task is
kept, not moved. A second test asserts a genuinely missing score still sorts
last, so the None handling is preserved.

Verification (run in backend/):
- black --line-length 120 --skip-string-normalization --check: clean
- pytest tests/unit/test_staged_tasks_relevance_zero.py: 2 passed
- prove-fail: against the pre-fix source the keep-the-zero test fails (the best
  task is moved to staged_tasks instead of kept)
- pyright database/staged_tasks.py tests/unit/test_staged_tasks_relevance_zero.py: 0 errors
- scripts/check_module_stub_pollution.py: 0 violations


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

