### PR TITLE
fix(deploy): size the backend-listen rollout wait for a real rollout

### DIFF
--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -488,7 +488,13 @@ jobs:
             --set gcpProjectId=${{ vars.GCP_PROJECT_ID }} \
             --set runtimeGcpProjectId=${{ vars.RUNTIME_GCP_PROJECT_ID }} \
             --set-string image.tag=${{ steps.image-tag.outputs.short_sha }}
-          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=300s; then
+          # Bounds a healthy-but-slow rollout, not a stuck one: backend-listen runs
+          # 12-60 HPA replicas rolled 3 at a time (maxSurge=2, maxUnavailable=1) and
+          # its startupProbe alone permits 300s per pod, so a full roll routinely
+          # exceeds 300s and node scale-up adds more. A genuinely stalled rollout
+          # still fails fast on the deployment's 600s progressDeadlineSeconds, which
+          # kubectl reports as ProgressDeadlineExceeded regardless of this value.
+          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=1800s; then
             python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service backend-listen || true
             exit 1
           fi

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -329,7 +329,9 @@ jobs:
             --set gcpProjectId=${{ vars.GCP_PROJECT_ID }} \
             --set runtimeGcpProjectId=${{ vars.RUNTIME_GCP_PROJECT_ID }} \
             --set-string image.tag=${{ steps.image-tag.outputs.short_sha }}
-          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=300s; then
+          # See gcp_backend.yml: 300s cannot cover a full backend-listen roll; a
+          # stalled rollout still fails on progressDeadlineSeconds.
+          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=1800s; then
             python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service backend-listen || true
             exit 1
           fi

--- a/.github/workflows/gcp_backend_listen_helm.yml
+++ b/.github/workflows/gcp_backend_listen_helm.yml
@@ -151,7 +151,9 @@ jobs:
 
       - name: Verify rollout
         run: |
-          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=300s; then
+          # See gcp_backend.yml: 300s cannot cover a full backend-listen roll; a
+          # stalled rollout still fails on progressDeadlineSeconds.
+          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=1800s; then
             python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service backend-listen || true
             exit 1
           fi

--- a/backend/tests/unit/test_verify_dev_backend_deployment.py
+++ b/backend/tests/unit/test_verify_dev_backend_deployment.py
@@ -515,3 +515,48 @@ def test_evaluate_fails_closed_when_available_replicas_are_not_the_updated_templ
 
     assert 'gke/deployment: desired replicas are not all available' not in errors
     assert 'gke/deployment: desired replicas are not all updated' in errors
+
+
+def test_backend_listen_rollout_wait_can_cover_a_real_rollout():
+    """The rollout wait must outlast a healthy roll, not just one pod's startup.
+
+    backend-listen rolls `maxSurge + maxUnavailable` pods at a time and its
+    startupProbe alone permits `failureThreshold * periodSeconds` per pod, so a
+    wait sized for a single pod fails a healthy deploy (2026-07-17, run
+    29576112586: 28 replicas, `timed out waiting for the condition`, rollout
+    converged on its own minutes later). A stalled rollout is caught by the
+    deployment's progressDeadlineSeconds, not by this bound.
+    """
+    import re
+
+    import yaml
+
+    root = BACKEND_DIR.parent
+    values = yaml.safe_load(
+        (root / 'backend/charts/backend-listen/prod_omi_backend_listen_values.yaml').read_text(encoding='utf-8')
+    )
+    startup = values['startupProbe']
+    per_pod_startup_seconds = startup['failureThreshold'] * startup['periodSeconds']
+    min_replicas = values['autoscaling']['minReplicas']
+    rolling = values['strategy']['rollingUpdate']
+    pods_in_flight = rolling['maxSurge'] + rolling['maxUnavailable']
+
+    # Even at the HPA floor the roll needs this many sequential waves.
+    waves = -(-min_replicas // pods_in_flight)
+    required_seconds = waves * per_pod_startup_seconds
+
+    workflows = (
+        '.github/workflows/gcp_backend.yml',
+        '.github/workflows/gcp_backend_listen_helm.yml',
+        '.github/workflows/gcp_backend_auto_dev.yml',
+    )
+    pattern = re.compile(r'rollout status deploy/\$\{\{ vars\.ENV \}\}-omi-backend-listen --timeout=(\d+)s')
+    for relative in workflows:
+        text = (root / relative).read_text(encoding='utf-8')
+        found = pattern.findall(text)
+        assert found, f'{relative} must wait on the backend-listen rollout'
+        for value in found:
+            assert int(value) >= required_seconds, (
+                f'{relative} waits {value}s on backend-listen, but a roll at the HPA floor needs '
+                f'>= {required_seconds}s ({waves} waves x {per_pod_startup_seconds}s startup budget)'
+            )


### PR DESCRIPTION
## Problem

Run [29576112586](https://github.com/BasedHardware/omi/actions/runs/29576112586) failed at `Deploy backend-listen to GKE using Helm`:

```
Waiting for deployment "prod-omi-backend-listen" rollout to finish: 4 out of 28 new replicas have been updated...
error: timed out waiting for the condition
```

**The rollout was healthy.** Kubernetes converged the exact same rollout to 24/24 updated and Ready on its own, minutes after the workflow had declared failure. The step waited 300s, which cannot cover a real roll of this deployment:

| Derived from `prod_omi_backend_listen_values.yaml` | |
|---|---|
| startupProbe budget per pod | `failureThreshold 30 × periodSeconds 10` = **300s** |
| pods in flight | `maxSurge 2 + maxUnavailable 1` = **3** |
| HPA replicas | **12–60** |
| waves at the HPA **floor** | `ceil(12/3)` = **4** |
| **minimum viable wait** | 4 × 300s = **1200s** |

The 300s wait could not outlast even *one* slow pod, let alone a full roll. It passed historically only when HPA had the deployment scaled small with spare node capacity — so it was a load-dependent flake, guaranteed to fail at high replica counts.

## Evidence the image is fine

Inspected the live cluster while it was "failing":

- New ReplicaSet pods: `Running`, **0 restarts** — no crashloop, no liveness kills.
- Old ReplicaSet pods: healthy, **0 restarts**.
- The one `Pending` pod was waiting on cluster autoscaler capacity (`FailedScheduling: 0/28 nodes are available: 14 Insufficient cpu, 14 Insufficient memory`), then scheduled ~68s later.
- Watched it converge unaided: `28/17/25 → 27/24/24 → 24/24/24 ✅`.

The thousands of `Unhealthy: Readiness probe failed` events are normal startup probe failures aggregated across many pod starts during a long roll — each pod fails readiness a few times during its ~60–90s startup — not a regression.

## Change

Raise the wait to **1800s** at all three call sites that roll this deployment (`gcp_backend.yml`, `gcp_backend_listen_helm.yml`, `gcp_backend_auto_dev.yml`).

This bounds a **healthy-but-slow** rollout only. A genuinely stalled rollout still fails fast on the deployment's **600s `progressDeadlineSeconds`**, which `kubectl rollout status` surfaces as `ProgressDeadlineExceeded` regardless of this value — so the longer wait cannot mask a broken deploy.

## Verification

- Live-cluster inspection during the failure (above): healthy pods, 0 restarts, autoscaler-paced.
- Watched the rollout converge to 24/24 unaided after the workflow failed.
- **Mutation-checked the new guard** — restoring `300s` makes the test fail with `waits 300s on backend-listen, but a roll at the HPA floor needs >= 1200s (4 waves x 300s startup budget)`, then restored.
- `pytest tests/unit/{test_verify_dev_backend_deployment,test_sync_two_lane,test_preflight_cloud_run_deploy,test_smoke_what_matters_now}.py` → **70 passed**.
- `make preflight` → 20/20 checks pass.

## Regression coverage

`test_backend_listen_rollout_wait_can_cover_a_real_rollout` derives the required minimum from the chart's **own** probe, strategy, and autoscaling values, so it tracks the deployment rather than pinning a hardcoded number. If someone lowers the wait, raises `minReplicas`, or loosens the startup probe such that the wait can no longer cover a roll, the test fails.

## Known follow-up: the deploy is not atomic

Worth naming separately, because it is a real risk this run exposed rather than caused. The Helm step **applies** the rollout and *then* waits. When the wait fails, the workflow aborts — but Kubernetes finishes the rollout anyway. Cloud Run traffic never shifts. Production is currently split:

| Component | Serving |
|---|---|
| GKE `backend-listen` (audio/WebSocket ingestion) | `a7dc482` (today's `main`) |
| Cloud Run `backend`, `-sync`, `-sync-backfill`, `-integration` | `d40d43b` (2026-07-12) |

That split has existed since the first partially-successful deploy today, so ingestion is running ~330 commits ahead of the REST/sync tier. This PR makes the wait stop failing spuriously, which prevents the most common way of *entering* that state, but it does not make the deploy atomic. Tracking that separately.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

