### PR TITLE
Fix stale get_stt_service_for_language mock missing prefer_parakeet in listen runtime test

### DIFF
--- a/backend/tests/unit/test_listen_runtime_regressions.py
+++ b/backend/tests/unit/test_listen_runtime_regressions.py
@@ -121,7 +121,7 @@ async def test_bootstrap_forces_single_language_before_selecting_stt_for_onboard
     )
     selected_multi_language_options = []
 
-    def select_stt(language, *, multi_lang_enabled):
+    def select_stt(language, *, multi_lang_enabled, prefer_parakeet=False):
         selected_multi_language_options.append((language, multi_lang_enabled))
         return 'test-stt', 'es', 'test-model'
 


### PR DESCRIPTION
Fix stale get_stt_service_for_language mock missing prefer_parakeet in listen runtime test

tests/unit/test_listen_runtime_regressions.py monkeypatches get_stt_service_for_language with a local mock:

    def select_stt(language, *, multi_lang_enabled):

Production utils/stt/streaming.py gained a prefer_parakeet parameter:

    def get_stt_service_for_language(language, multi_lang_enabled=True, prefer_parakeet=False)

so _bootstrap now calls the function with prefer_parakeet=..., and the stale mock raises:

    TypeError: select_stt() got an unexpected keyword argument 'prefer_parakeet'

which fails test_bootstrap_forces_single_language_before_selecting_stt_for_onboarding on main. It also surfaces on the Backend unit suite for unrelated backend PRs whose changed-file selection pulls in this test.

Fix: add prefer_parakeet=False to the mock signature so it accepts the keyword the production caller now passes. The assertion is unchanged: the mock still records and the test still checks (language, multi_lang_enabled) == [('es', False)]. prefer_parakeet is accepted and ignored, matching the production default.

The other get_stt_service_for_language mocks in the suite (test_desktop_transcribe.py, test_chat_quota_counting_router.py) use MagicMock / return_value, which already accept any keyword, so this is the only stale signature.

Verification (run in backend/):
- black --line-length 120 --skip-string-normalization --check tests/unit/test_listen_runtime_regressions.py: clean
- python scripts/check_module_stub_pollution.py: 0 violations
- pyright: no new type errors from this change. The file has pre-existing pyright findings in its runtime-attribute mocks (identical count on the base branch); this one-line signature change adds none.
- I could not execute this test locally: the module imports the full listen/STT runtime stack, which needs CI-only native dependencies not present in my environment (the module errors on import/collection here). The fix is verified against the production signature and the exact CI TypeError, and CI runs the test.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

