### PR TITLE
Guard chat-tools manifest resolution against a null app_home_url

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -433,7 +433,7 @@ def _process_chat_tools_manifest(external_integration: dict, app_dict: dict) -> 
     fetched_tools = manifest_result.get('tools')
     if fetched_tools:
         # Resolve relative endpoints to absolute URLs
-        base_url = external_integration.get('app_home_url', '').rstrip('/')
+        base_url = (external_integration.get('app_home_url') or '').rstrip('/')
         if base_url:
             for tool in fetched_tools:
                 endpoint = tool.get('endpoint', '')
@@ -1120,7 +1120,7 @@ def refresh_app_manifest(app_id: str, uid: str = Depends(auth.get_current_user_u
 
     fetched_tools = manifest_result.get('tools')
     if fetched_tools:
-        base_url = external_integration.get('app_home_url', '').rstrip('/')
+        base_url = (external_integration.get('app_home_url') or '').rstrip('/')
         if base_url:
             for tool in fetched_tools:
                 endpoint = tool.get('endpoint', '')

--- a/backend/tests/unit/test_app_home_url_null_manifest.py
+++ b/backend/tests/unit/test_app_home_url_null_manifest.py
@@ -1,0 +1,59 @@
+"""Regression: chat-tools manifest resolution must not 500 on a present-null app_home_url.
+
+routers.apps._process_chat_tools_manifest resolves relative tool endpoints against
+external_integration['app_home_url']. app_home_url is Optional[str] = None (models/app.py), so a
+create/update request can send it explicitly as null. The code used
+`external_integration.get('app_home_url', '').rstrip('/')`, whose '' default only applies when the
+key is ABSENT; a present null slips the default and `None.rstrip('/')` raises AttributeError, an
+unhandled 500 on POST/PATCH /v1/apps and POST /v1/apps/{app_id}/refresh-manifest. The `if base_url:`
+guard on the next line shows an empty home URL is a valid state (endpoints stay relative), so a null
+must behave like absent, not crash. Fix: `(get('app_home_url') or '')` at both call sites.
+
+Seam: _process_chat_tools_manifest is pure except the manifest fetch, which is a module-level
+function reference monkeypatched here (no sys.modules mutation, no import-time IO).
+"""
+
+import os
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key-not-real")
+os.environ.setdefault("PINECONE_API_KEY", "test-pinecone-key-not-real")
+
+import routers.apps as apps
+
+
+def _fake_manifest(url, **kwargs):
+    # kwargs so both call sites work: fetch_app_chat_tools_from_manifest(url) and (url, force_refresh=True).
+    return {'tools': [{'name': 'do_thing', 'endpoint': '/api/action'}]}
+
+
+def test_null_app_home_url_skips_resolution_without_crash(monkeypatch):
+    monkeypatch.setattr(apps, 'fetch_app_chat_tools_from_manifest', _fake_manifest)
+    ext = {'chat_tools_manifest_url': 'https://valid.example', 'app_home_url': None}
+
+    result = apps._process_chat_tools_manifest(ext, {})  # must not raise
+
+    # A null home URL yields an empty base, so the relative endpoint is left as-is (resolution skipped).
+    assert result['chat_tools'][0]['endpoint'] == '/api/action'
+
+
+def test_absent_app_home_url_still_skips_resolution(monkeypatch):
+    monkeypatch.setattr(apps, 'fetch_app_chat_tools_from_manifest', _fake_manifest)
+    ext = {'chat_tools_manifest_url': 'https://valid.example'}  # key absent
+
+    result = apps._process_chat_tools_manifest(ext, {})
+
+    assert result['chat_tools'][0]['endpoint'] == '/api/action'
+
+
+def test_present_app_home_url_resolves_relative_endpoint(monkeypatch):
+    monkeypatch.setattr(apps, 'fetch_app_chat_tools_from_manifest', _fake_manifest)
+    ext = {'chat_tools_manifest_url': 'https://valid.example', 'app_home_url': 'https://example.com/'}
+
+    result = apps._process_chat_tools_manifest(ext, {})
+
+    # A real home URL still resolves relative endpoints to absolute (trailing slash stripped).
+    assert result['chat_tools'][0]['endpoint'] == 'https://example.com/api/action'


### PR DESCRIPTION
Guard chat-tools manifest resolution against a null app_home_url

routers/apps.py resolves relative chat-tool endpoints against
external_integration['app_home_url'] in two places: the shared
_process_chat_tools_manifest helper (used by POST /v1/apps and PATCH
/v1/apps/{app_id}) and the inline block in refresh_app_manifest (POST
/v1/apps/{app_id}/refresh-manifest). Both used:

    base_url = external_integration.get('app_home_url', '').rstrip('/')

app_home_url is Optional[str] = None (models/app.py), so a request can send it
explicitly as null. The '' default only applies when the key is ABSENT; a
present null slips the default and None.rstrip('/') raises AttributeError. The
call sites are not wrapped in try/except, so this is an unhandled 500 for an app
that exposes chat tools through a manifest URL and sends app_home_url: null with
no auth steps to backfill it.

The `if base_url:` guard on the next line shows an empty home URL is already an
expected, valid state (relative endpoints are left unresolved), so a null should
behave like absent, not crash.

Fix (both sites):

    base_url = (external_integration.get('app_home_url') or '').rstrip('/')

Behavior is identical for every previously-working case (absent, empty, and real
URL); only the null crash becomes the intended skip.

Test: tests/unit/test_app_home_url_null_manifest.py exercises the shared
_process_chat_tools_manifest helper (pure except the manifest fetch, which is
monkeypatched on its module-level function reference):
- null app_home_url: no crash, relative endpoint left as-is
- absent app_home_url: unchanged (relative endpoint left as-is)
- real app_home_url: relative endpoint resolved to absolute

Verification (run in backend/):
- black --line-length 120 --skip-string-normalization --check: clean
- pytest tests/unit/test_app_home_url_null_manifest.py: 3 passed
- prove-fail: against the pre-fix source the null test fails with
  AttributeError: 'NoneType' object has no attribute 'rstrip' at routers/apps.py:436
- pyright routers/apps.py: 0 errors (unchanged from base)
- scripts/check_module_stub_pollution.py: 0 violations


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

