### PR TITLE
fix(firmware): don't let SD card mount failure block BLE on DevKit v2

### DIFF
--- a/omi/firmware/devkit/src/main.c
+++ b/omi/firmware/devkit/src/main.c
@@ -227,17 +227,19 @@ int main(void)
 
     err = mount_sd_card();
     if (err) {
-        LOG_ERR("Failed to mount SD card (err %d)", err);
-        return err;
-    }
-    k_msleep(500);
+        // Offline storage is optional; a failed SD mount (bad/missing/incompatible card
+        // or wiring fault) must not abort boot and block BLE/transport entirely.
+        LOG_ERR("Failed to mount SD card (err %d), continuing without offline storage", err);
+    } else {
+        k_msleep(500);
 
-    LOG_PRINTK("\n");
-    LOG_INF("Initializing storage...\n");
+        LOG_PRINTK("\n");
+        LOG_INF("Initializing storage...\n");
 
-    err = storage_init();
-    if (err) {
-        LOG_ERR("Failed to initialize storage (err %d)", err);
+        err = storage_init();
+        if (err) {
+            LOG_ERR("Failed to initialize storage (err %d)", err);
+        }
     }
 #endif
 


### PR DESCRIPTION
## What

On DevKit v2, make a failed SD card mount **non-fatal** so it no longer blocks Bluetooth/transport startup. If `mount_sd_card()` fails, the device now logs the error and continues booting into `transport_start()` (BLE) and the mic/codec path, skipping only the offline-storage init that depends on the card.

## Why

`main()` returned immediately when `mount_sd_card()` failed, so any SD problem aborted the entire boot **before** BLE ever started — the device advertised nothing and gave no LED/serial indication. Notably `storage_init()` failure two lines below was already treated as non-fatal, so the SD mount was the sole hard-abort on an otherwise-optional offline-storage feature.

Evidence from #9771 (reporter reflashed the stock `Omi_DK2_v2.0.10.uf2` and ran extensive isolation):

> SD card failures (of any origin — bad card, bad format, bad wiring, or a real firmware bug) should not be able to take down Bluetooth entirely with zero user feedback. That's the fix that closes the whole failure class.

The reporter proved the failure is independent of card format/class: an exFAT 64GB SDXC card, a FAT32-reformatted SDXC card, and a FAT32 32GB SDHC card all produced zero firmware writes and no BLE advertisement — i.e. `disk_access_init()` / `fs_mount()` never succeeded on the unit, and that failure cascaded into killing BLE. Decoupling BLE from SD init is the fix that closes the class regardless of the underlying SD root cause.

## Change

`omi/firmware/devkit/src/main.c` — SD mount failure now logs and continues instead of `return err;`; storage init runs only when the mount succeeded.

## Verified

- Static review: control flow now falls through to `transport_start()` on SD failure; `storage_init()` (which spawns the `storage_write` thread against the mounted card) runs only inside the mount-success branch, so an unmounted card no longer feeds that thread. Brace balance and the `#ifdef CONFIG_OMI_ENABLE_OFFLINE_STORAGE` block are intact.
- **UNVERIFIED on hardware:** I do not have a DevKit v2 to flash, and the devkit firmware is not built by any existing CI lane (only CV1 `omi/firmware/omi` is). A full NCS 2.9.0 Docker + `west update` build of the devkit target was out of scope for this focused fix and could not exercise the real BLE-advertisement path without the physical board anyway. No firmware boot-path test harness exists in `omi/firmware/devkit`, so no regression test was added.

Failure-Class: none

Auto-generated from issue feedback by the mini issues-improver. Review before merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

