### PR TITLE
fix(deploy): keep prod LLM-gateway serving off until the gateway exists

### DIFF
--- a/.github/failure-classes/FC-unprovisioned-rollout-target.json
+++ b/.github/failure-classes/FC-unprovisioned-rollout-target.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-unprovisioned-rollout-target",
+  "violated_contract": "A rollout flag that routes production traffic to a service endpoint must not be enabled for an environment until that endpoint is provisioned and reachable there.",
+  "canonical_prevention": "Before enabling a routing flag for an environment, verify the referenced endpoint exists in that environment (deployed release, attached forwarding rule or resolvable service) with a deploy-lane check; keep the flag off with wiring declared until that proof exists.",
+  "evidence_prs": [
+    9651
+  ],
+  "scope_hints": [
+    "backend/deploy/**",
+    "backend/charts/**",
+    ".github/workflows/**"
+  ],
+  "status": "open"
+}

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -122,7 +122,7 @@ env:
   - name: OMI_ENV_STAGE
     value: "prod"
   - name: OMI_LLM_GATEWAY_FEATURE_MODE
-    value: "gateway"
+    value: "off"
   - name: OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE
     value: "true"
   - name: OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -823,7 +823,7 @@ environments:
               name: prod-omi-backend-secrets
               key: SERVICE_ACCOUNT_JSON
           OMI_LLM_GATEWAY_FEATURE_MODE:
-            value: gateway
+            value: 'off'
             category: rollout
           OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE:
             value: 'true'
@@ -925,7 +925,7 @@ environments:
               value: http://172.16.160.108
               category: service_discovery
             OMI_LLM_GATEWAY_FEATURE_MODE:
-              value: gateway
+              value: 'off'
               category: rollout
             OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE:
               value: 'true'
@@ -1054,7 +1054,7 @@ environments:
               value: http://172.16.160.108
               category: service_discovery
             OMI_LLM_GATEWAY_FEATURE_MODE:
-              value: gateway
+              value: 'off'
               category: rollout
             OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE:
               value: 'true'
@@ -1151,7 +1151,7 @@ environments:
               value: http://172.16.160.108
               category: service_discovery
             OMI_LLM_GATEWAY_FEATURE_MODE:
-              value: gateway
+              value: 'off'
               category: rollout
             OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE:
               value: 'true'

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -58,14 +58,20 @@ def test_llm_gateway_anthropic_secret_and_authenticated_readiness_probe_contract
         assert 'X-Omi-Service-Caller: backend' in probe_command
 
 
-def test_prod_gateway_is_reachable_by_both_gke_and_cloud_run_callers():
+def test_prod_gateway_wiring_declared_but_serving_off_until_gateway_deployed():
     manifest = _load_yaml('deploy/runtime_env.yaml')
     prod = manifest['environments']['prod']
     gke_env = prod['gke']['backend-listen']['env']
     assert (
         gke_env['OMI_LLM_GATEWAY_URL']['value'] == 'http://prod-omi-llm-gateway.prod-omi-backend.svc.cluster.local:8080'
     )
-    assert gke_env['OMI_LLM_GATEWAY_FEATURE_MODE']['value'] == 'gateway'
+    # 'off' until the llm-gateway is actually deployed in prod: the 2026-07-17 prod
+    # deploy shipped FEATURE_MODE=gateway pointing at an unattached static IP (Cloud
+    # Run) / nonexistent cluster service (GKE), and every chat LLM call hung through
+    # connect timeouts + retries (2-9 min per /v2/messages POST). Flip back to
+    # 'gateway' only once a reachable prod gateway exists (helm release + ingress
+    # bound to the reserved IP).
+    assert gke_env['OMI_LLM_GATEWAY_FEATURE_MODE']['value'] == 'off'
     assert gke_env['OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE']['value'] == 'true'
     assert gke_env['OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION']['value'] == 'true'
     assert gke_env['USE_VERTEX_AI']['value'] == 'true'
@@ -75,7 +81,7 @@ def test_prod_gateway_is_reachable_by_both_gke_and_cloud_run_callers():
     for service in ('backend', 'backend-sync', 'backend-integration'):
         service_config = prod['cloud_run']['services'][service]
         assert service_config['env']['OMI_LLM_GATEWAY_URL']['value'] == 'http://172.16.160.108'
-        assert service_config['env']['OMI_LLM_GATEWAY_FEATURE_MODE']['value'] == 'gateway'
+        assert service_config['env']['OMI_LLM_GATEWAY_FEATURE_MODE']['value'] == 'off'
         assert service_config['env']['OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE']['value'] == 'true'
         assert service_config['env']['OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION']['value'] == 'true'
         assert service_config['env']['USE_VERTEX_AI']['value'] == 'true'


### PR DESCRIPTION
## Summary

Prod chat (mobile TestFlight + App Store) went down after today's prod backend deploy — every `POST /v2/messages` hung 122–560s (vs the normal 3–10s) until mobile clients gave up.

**Root cause:** `d83e37d21a` ("feat(llm-gateway): enable production serving", merged Jul 13) turned on `OMI_LLM_GATEWAY_FEATURE_MODE=gateway` for all prod backend services, but the llm-gateway itself was never deployed to prod:

- Cloud Run services point at `http://172.16.160.108` — the static IP `prod-omi-self-hosted-llm-ip-address` is **RESERVED with no forwarding rule** (TCP blackhole; audit logs show no forwarding rule ever attached).
- GKE `backend-listen` points at `prod-omi-llm-gateway.prod-omi-backend.svc.cluster.local` — **no such helm release/service exists** in the prod cluster.

Because prod deploys had been failing since Jul 14 (fixed by #9911), the flag sat unshipped until today's deploy (`backend:7290a41`, ~11:43 UTC) released it. Every `omi:auto:*` LLM call (chat_agent, chat_extraction, fair_use, onboarding) then hung through connect timeouts + openai-client retries before falling back to the direct path.

**This PR** flips the five prod `OMI_LLM_GATEWAY_FEATURE_MODE` entries to `'off'` (Cloud Run backend / backend-sync / backend-sync-backfill via anchor / backend-integration, plus GKE backend-listen), matching the live mitigation already applied to prod, and updates the deploy contract test to encode "wiring declared, serving off until the gateway is actually deployed". URL/token wiring stays so re-enablement is a one-line flip once a reachable prod gateway exists.

## Live mitigation already applied (prod is healthy now)

- Removed `OMI_LLM_GATEWAY_FEATURE_MODE` from Cloud Run `backend` (revision `backend-01158-lmd`, 100% traffic), `backend-sync`, `backend-sync-backfill`, `backend-integration`; same for GKE `prod-omi-backend-listen` via `kubectl set env`.
- This PR makes the repo manifest match prod so the next deploy doesn't re-break chat.

## Verification

- Before: real-user `POST /v2/messages` latencies 122s/248s/364s/505s on `backend-7290a41`; gateway telemetry `outcome=error reason=unexpected_error` (fair_use, onboarding) and `outcome=fallback reason=timeout` (chat_agent, chat_extraction).
- After: real-user POSTs 3.5s/3.6s/8.8s 200 on `backend-01158-lmd`; authenticated end-to-end send as a real user (`viUv7Gt…`) via `https://api.omi.me/v2/messages` returned the AI reply over SSE in **3.9s**.
- `pytest tests/unit/test_llm_gateway_deploy_contract.py tests/unit/test_backend_runtime_env_validator.py` → 61 passed.
- `validate-backend-runtime-env.py --env dev --check-workflows` and `--env prod --check-workflows` → both pass.
- `helm lint charts/backend-listen -f prod_omi_backend_listen_values.yaml` → 0 failed.
- Note: `scripts/pre-deploy-check.sh` not run locally (uv cannot fetch cpython 3.11.15 on this machine right now); CI runs the same contract.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: new

Adds `.github/failure-classes/FC-unprovisioned-rollout-target.json`: a rollout flag routing production traffic to a service endpoint must not be enabled for an environment until that endpoint is provisioned and reachable there (evidence: #9651).

## Follow-up

- Deploy the llm-gateway to prod (helm release + ingress bound to `prod-omi-self-hosted-llm-ip-address`, service token, Vertex WI perms) before flipping FEATURE_MODE back to `gateway`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
