### PR TITLE
fix(llm-gateway): gate promotion and bound fallback

### DIFF
--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -284,23 +284,33 @@ jobs:
             echo "sync_tasks_invoker_sa=${SYNC_TASKS_INVOKER_SA}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Render backend runtime env
-        id: runtime-env
-        env:
-          ACCOUNT_DELETION_HANDLER_URL: ${{ steps.account-deletion-target.outputs.account_deletion_handler_url }}
-          CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}
-          CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}
-          GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
-          MCP_OAUTH_CLAUDE_CLIENT_ID: ${{ vars.MCP_OAUTH_CLAUDE_CLIENT_ID }}
-          MCP_OAUTH_CLAUDE_CLIENT_NAME: ${{ vars.MCP_OAUTH_CLAUDE_CLIENT_NAME }}
-          MCP_OAUTH_CLAUDE_REDIRECT_URIS: ${{ vars.MCP_OAUTH_CLAUDE_REDIRECT_URIS }}
-          OMI_LLM_GATEWAY_URL: ${{ vars.OMI_LLM_GATEWAY_URL }}
-          STT_PRERECORDED_MODEL: ${{ vars.STT_PRERECORDED_MODEL }}
-          SYNC_LEDGER_FENCE_MODE: ${{ vars.SYNC_LEDGER_FENCE_MODE || 'legacy' }}
-          SYNC_TASKS_HANDLER_URL: ${{ steps.account-deletion-target.outputs.sync_tasks_handler_url }}
-          SYNC_TASKS_INVOKER_SA: ${{ steps.account-deletion-target.outputs.sync_tasks_invoker_sa }}
+      - name: Determine whether this deploy requests gateway-first serving
+        id: gateway-intent
         run: |
-          python3 backend/scripts/render_backend_runtime_env.py --env ${{ vars.ENV }} >> "$GITHUB_OUTPUT"
+          python3 backend/scripts/verify-llm-gateway-serving.py \
+            --environment="${{ vars.ENV }}" \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ env.REGION }}" \
+            --listener-values="backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml" \
+            --intent-only >> "$GITHUB_OUTPUT"
+
+      - name: Get GKE credentials for gateway serving gate
+        if: ${{ steps.gateway-intent.outputs.enabled == 'true' }}
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          cluster_name: ${{ vars.GKE_CLUSTER }}
+          location: ${{ env.REGION }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+
+      - name: Verify LLM gateway control plane before promotion
+        id: gateway-serving
+        if: ${{ steps.gateway-intent.outputs.enabled == 'true' }}
+        run: |
+          python3 backend/scripts/verify-llm-gateway-serving.py \
+            --environment="${{ vars.ENV }}" \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ env.REGION }}" \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Preflight Cloud Run deploy
         run: |
@@ -344,6 +354,40 @@ jobs:
         run: |
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:latest
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
+
+      - name: Probe LLM gateway from the Cloud Run VPC before promotion
+        if: ${{ steps.gateway-intent.outputs.enabled == 'true' }}
+        run: |
+          backend/scripts/probe-llm-gateway-from-cloud-run.sh \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ env.REGION }}" \
+            --image="gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}" \
+            --gateway-url="${{ steps.gateway-serving.outputs.gateway_url }}" \
+            --network="${{ vars.CLOUD_RUN_VPC_NETWORK }}" \
+            --subnet="${{ vars.CLOUD_RUN_VPC_SUBNET }}" \
+            --vpc-egress=private-ranges-only \
+            --name-suffix="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      # The endpoint is rendered only after the deployment gate derived it
+      # from the provisioned ingress address. Direct mode gets the inert
+      # sentinel from the manifest and does not require a gateway dependency.
+      - name: Render backend runtime env
+        id: runtime-env
+        env:
+          ACCOUNT_DELETION_HANDLER_URL: ${{ steps.account-deletion-target.outputs.account_deletion_handler_url }}
+          CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}
+          CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}
+          GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
+          MCP_OAUTH_CLAUDE_CLIENT_ID: ${{ vars.MCP_OAUTH_CLAUDE_CLIENT_ID }}
+          MCP_OAUTH_CLAUDE_CLIENT_NAME: ${{ vars.MCP_OAUTH_CLAUDE_CLIENT_NAME }}
+          MCP_OAUTH_CLAUDE_REDIRECT_URIS: ${{ vars.MCP_OAUTH_CLAUDE_REDIRECT_URIS }}
+          OMI_LLM_GATEWAY_URL: ${{ steps.gateway-serving.outputs.gateway_url || 'http://127.0.0.1:9' }}
+          STT_PRERECORDED_MODEL: ${{ vars.STT_PRERECORDED_MODEL }}
+          SYNC_LEDGER_FENCE_MODE: ${{ vars.SYNC_LEDGER_FENCE_MODE || 'legacy' }}
+          SYNC_TASKS_HANDLER_URL: ${{ steps.account-deletion-target.outputs.sync_tasks_handler_url }}
+          SYNC_TASKS_INVOKER_SA: ${{ steps.account-deletion-target.outputs.sync_tasks_invoker_sa }}
+        run: |
+          python3 backend/scripts/render_backend_runtime_env.py --env ${{ vars.ENV }} >> "$GITHUB_OUTPUT"
 
       # Strips Secret Manager bindings left on services for settings the manifest
       # now declares as public literals; gcloud cannot flip a binding's type in

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -138,17 +138,21 @@ jobs:
       - name: Install Python deps for deploy scripts
         run: python3 -m pip install -q pyyaml
 
-      - name: Render backend runtime env
-        id: runtime-env
-        env:
-          CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}
-          CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}
-          GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
-          OMI_LLM_GATEWAY_URL: ${{ vars.OMI_LLM_GATEWAY_URL }}
-          STT_PRERECORDED_MODEL: ${{ vars.STT_PRERECORDED_MODEL }}
-          SYNC_LEDGER_FENCE_MODE: ${{ vars.SYNC_LEDGER_FENCE_MODE || 'legacy' }}
+      - name: Get GKE credentials for gateway serving gate
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          cluster_name: ${{ vars.GKE_CLUSTER }}
+          location: ${{ env.REGION }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+
+      - name: Verify LLM gateway control plane before promotion
+        id: gateway-serving
         run: |
-          python3 backend/scripts/render_backend_runtime_env.py --env dev >> "$GITHUB_OUTPUT"
+          python3 backend/scripts/verify-llm-gateway-serving.py \
+            --environment=dev \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ env.REGION }}" \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Preflight Cloud Run deploy
         run: |
@@ -188,6 +192,30 @@ jobs:
         run: |
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:latest
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
+
+      - name: Probe LLM gateway from the Cloud Run VPC before promotion
+        run: |
+          backend/scripts/probe-llm-gateway-from-cloud-run.sh \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ env.REGION }}" \
+            --image="gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}" \
+            --gateway-url="${{ steps.gateway-serving.outputs.gateway_url }}" \
+            --network="${{ vars.CLOUD_RUN_VPC_NETWORK }}" \
+            --subnet="${{ vars.CLOUD_RUN_VPC_SUBNET }}" \
+            --vpc-egress=private-ranges-only \
+            --name-suffix="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Render backend runtime env from the gated gateway endpoint
+        id: runtime-env
+        env:
+          CLOUD_RUN_VPC_NETWORK: ${{ vars.CLOUD_RUN_VPC_NETWORK }}
+          CLOUD_RUN_VPC_SUBNET: ${{ vars.CLOUD_RUN_VPC_SUBNET }}
+          GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
+          OMI_LLM_GATEWAY_URL: ${{ steps.gateway-serving.outputs.gateway_url }}
+          STT_PRERECORDED_MODEL: ${{ vars.STT_PRERECORDED_MODEL }}
+          SYNC_LEDGER_FENCE_MODE: ${{ vars.SYNC_LEDGER_FENCE_MODE || 'legacy' }}
+        run: |
+          python3 backend/scripts/render_backend_runtime_env.py --env dev >> "$GITHUB_OUTPUT"
 
       - name: Migrate legacy public Cloud Run bindings
         run: >-
@@ -276,13 +304,6 @@ jobs:
           service: ${{ env.SERVICE }}
           provision_sync_ledger_ttl: 'true'
           provision_budget_alerts: 'false'
-
-      - name: Get GKE credentials
-        uses: google-github-actions/get-gke-credentials@v3
-        with:
-          cluster_name: ${{ vars.GKE_CLUSTER }}
-          location: ${{ env.REGION }}
-          project_id: ${{ vars.GCP_PROJECT_ID }}
 
       - name: Install Helm
         uses: azure/setup-helm@v5

--- a/.github/workflows/gcp_llm_gateway.yml
+++ b/.github/workflows/gcp_llm_gateway.yml
@@ -102,6 +102,27 @@ jobs:
         run: |
           IMAGE_TAG="${GITHUB_SHA::7}" backend/scripts/deploy-llm-gateway.sh
 
+      - name: Verify LLM Gateway serving data plane
+        id: gateway-serving
+        run: |
+          python3 backend/scripts/verify-llm-gateway-serving.py \
+            --environment="${{ vars.ENV }}" \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ env.REGION }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Probe LLM Gateway from the Cloud Run VPC
+        run: |
+          backend/scripts/probe-llm-gateway-from-cloud-run.sh \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ env.REGION }}" \
+            --image="gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}" \
+            --gateway-url="${{ steps.gateway-serving.outputs.gateway_url }}" \
+            --network="${{ vars.CLOUD_RUN_VPC_NETWORK }}" \
+            --subnet="${{ vars.CLOUD_RUN_VPC_SUBNET }}" \
+            --vpc-egress=private-ranges-only \
+            --name-suffix="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
       - name: Smoke LLM Gateway
         run: |
           NAMESPACE="${{ vars.ENV }}-omi-backend"

--- a/app/lib/backend/http/api/messages.dart
+++ b/app/lib/backend/http/api/messages.dart
@@ -57,6 +57,15 @@ Future<List<ServerMessage>> clearChatServer({String? appId}) async {
 }
 
 ServerMessageChunk? parseMessageChunk(String line, String messageId) {
+  if (line.startsWith('error: ')) {
+    final message = line.substring('error: '.length).trim();
+    return ServerMessageChunk(
+      messageId,
+      message.isEmpty ? ServerMessageChunk.failedMessage().text : message,
+      MessageChunkType.error,
+    );
+  }
+
   if (line.startsWith('think: ')) {
     return ServerMessageChunk(messageId, line.substring(7).replaceAll("__CRLF__", "\n"), MessageChunkType.think);
   }

--- a/app/test/unit/chat_stream_error_test.dart
+++ b/app/test/unit/chat_stream_error_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/http/api/messages.dart';
+import 'package:omi/backend/schema/message.dart';
+
+void main() {
+  test('parses a bounded chat SSE failure frame', () {
+    final chunk = parseMessageChunk('error: The response took too long. Please try again.', 'message-id');
+
+    expect(chunk, isNotNull);
+    expect(chunk!.messageId, 'message-id');
+    expect(chunk.type, MessageChunkType.error);
+    expect(chunk.text, 'The response took too long. Please try again.');
+  });
+}

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -27,6 +27,8 @@ Key env vars: `OPENAI_API_KEY` (LLM calls — not `OPENAI_ADMIN_KEY` which is bi
 
 Chat SSE deadlines: `AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS` (default `25`), `AGENT_STREAM_PROGRESS_HEARTBEAT_SECONDS` (default `20`), `AGENT_STREAM_MAX_DURATION_SECONDS` (default `150`), and `AGENT_STREAM_CANCEL_GRACE_SECONDS` (default `2`) bound silent setup/producer work and keep valid long tool calls observable. Values must be positive.
 
+LLM gateway resilience: `OMI_LLM_GATEWAY_CONNECT_TIMEOUT_SECONDS` (default `3`), `OMI_LLM_GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS` (default `15`), `OMI_LLM_GATEWAY_CIRCUIT_FAILURE_THRESHOLD` (default `2`), and `OMI_LLM_GATEWAY_CIRCUIT_COOLDOWN_SECONDS` (default `30`) bound the optional gateway hop. Gateway-first callers use the shared process-local circuit and may fall back only before stream output. Never restore a production `OMI_LLM_GATEWAY_URL` static IP: the backend deployment derives it after `verify-llm-gateway-serving.py` validates the ready Kubernetes workload, ingress/ILB attachment, and Cloud Run VPC smoke route.
+
 ## Directory Structure
 
 ```
@@ -163,7 +165,7 @@ Helm charts: `backend/charts/{agent-proxy,agent-vm-reaper,backend-listen,backend
 - **agent-vm-reaper** (`backend/charts/agent-vm-reaper/`) — CronJob that deletes stale `omi-agent-*` GCE VMs left by desktop agent sandboxes.
 - **backend-secrets** (`backend/charts/backend-secrets/`) — ExternalSecret and SecretStore resources that sync backend runtime secrets into GKE namespaces.
 
-Backend runtime env contract: keep `backend/deploy/runtime_env.yaml` aligned with GKE Helm values and Cloud Run runtime env; run `backend/scripts/pre-deploy-check.sh` after backend runtime env or deploy workflow changes.
+Backend runtime env contract: keep `backend/deploy/runtime_env.yaml` aligned with GKE Helm values and Cloud Run runtime env; run `backend/scripts/pre-deploy-check.sh` after backend runtime env or deploy workflow changes. The `llm_gateway` manifest section owns the release, ingress, and static-address identity; a reserved address alone is never an endpoint contract. Gateway-mode promotion requires the control-plane gate plus `probe-llm-gateway-from-cloud-run.sh` before Cloud Run revisions are created.
 
 Firestore index boundary: backend deploy workflows run `reconcile_firestore_indexes.py --check-only` against `RUNTIME_GCP_PROJECT_ID` in an isolated approved-source job using dedicated read-only credentials. Manual deploys must keep `firestore.indexes.json` identical to `main` and deploy the exact checked candidate SHA. A failed gate writes and locally revalidates a short-lived, redacted create-only proposal before upload; backend deployment must never mutate the serving schema.
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -25,6 +25,8 @@ By default, the lock refresh preserves already-locked package versions so unrela
 
 Key env vars: `OPENAI_API_KEY` (LLM calls — not `OPENAI_ADMIN_KEY` which is billing-only), `DEEPGRAM_API_KEY` (STT), `GEMINI_API_KEY` and `ANTHROPIC_API_KEY` (local harness chat/realtime via Rust desktop backend), `ENCRYPTION_SECRET` (required for tests), `REDIS_DB_HOST` (cache/rate-limiting, fail-open without it), `ADMIN_KEY` (local dev auth bypass via token `ADMIN_KEY<uid>`), `SERVICE_ACCOUNT_JSON` (Firestore/GCS credentials).
 
+Chat SSE deadlines: `AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS` (default `25`), `AGENT_STREAM_PROGRESS_HEARTBEAT_SECONDS` (default `20`), `AGENT_STREAM_MAX_DURATION_SECONDS` (default `150`), and `AGENT_STREAM_CANCEL_GRACE_SECONDS` (default `2`) bound silent setup/producer work and keep valid long tool calls observable. Values must be positive.
+
 ## Directory Structure
 
 ```

--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -7328,5 +7328,73 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "omi-llm-gateway-client-reachability",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "LLM Gateway",
+    "title": "LLM Gateway - client reachability degraded",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 900, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "(sum(rate(llm_gateway_chat_extraction_requests_total{mode=\"fallback\"}[15m])) / clamp_min(sum(rate(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[15m])), 1e-9) > bool 0.05) or (max(llm_gateway_circuit_open) > bool 0) or ((sum(increase(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[15m])) >= bool 10) and (sum(increase(llm_gateway_chat_extraction_requests_total{mode=\"serving\",outcome=\"success\"}[15m])) == bool 0)) or (histogram_quantile(0.95, sum(rate(llm_gateway_client_first_byte_seconds_bucket[5m])) by (le)) > bool 5)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"conditions": [{"evaluator": {"params": [0], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B", "type": "threshold"}
+      }
+    ],
+    "updated": "2026-07-17T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {"runbook": "backend/docs/runbooks/llm-gateway-fallback.md", "summary": "Client fallback, open circuit, zero gateway successes under traffic, or p95 first-byte latency indicates the gateway is unreachable or stalling", "threshold": "fallback >5%, circuit open, no serving success for 10 requests, or p95 first byte >5s"},
+    "labels": {"severity": "warning", "instatus_component": "ai-chat"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "record": null
+  },
+  {
+    "uid": "omi-llm-gateway-no-ready-endpoints",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "LLM Gateway",
+    "title": "LLM Gateway - no ready production endpoints",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 300, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(kube_endpoint_address_available{namespace=\"prod-omi-backend\",endpoint=\"prod-omi-llm-gateway\"}) < bool 1", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"conditions": [{"evaluator": {"params": [0], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B", "type": "threshold"}
+      }
+    ],
+    "updated": "2026-07-17T00:00:00Z",
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {"runbook": "backend/docs/runbooks/llm-gateway-fallback.md", "summary": "The production LLM Gateway Service has no ready EndpointSlice address or kube-state-metrics is absent", "threshold": "ready endpoint count <1"},
+    "labels": {"severity": "warning", "instatus_component": "ai-chat"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "record": null
   }
 ]

--- a/backend/charts/monitoring/alerts/resilience.json
+++ b/backend/charts/monitoring/alerts/resilience.json
@@ -20,7 +20,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(llm_gateway_requests_total{fallback_used=\"true\"}[30m])) / clamp_min(sum(rate(llm_gateway_requests_total[30m])), 1e-9)",
+          "expr": "sum(rate(llm_gateway_chat_extraction_requests_total{mode=\"fallback\"}[30m])) / clamp_min(sum(rate(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[30m])), 1e-9)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -289,6 +289,74 @@
     "keep_firing_for": "0s",
     "annotations": {"__dashboardUid__": "omi-resilience-fallbacks", "__panelId__": "6", "summary": "An expected real-traffic journey metrics scrape target is absent or unhealthy", "threshold": "either named scrape job absent or any target up < 1"},
     "labels": {"severity": "warning", "instatus_component": "observability"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "record": null
+  },
+  {
+    "uid": "omi-llm-gateway-client-reachability",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "LLM Gateway",
+    "title": "LLM Gateway - client reachability degraded",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 900, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "(sum(rate(llm_gateway_chat_extraction_requests_total{mode=\"fallback\"}[15m])) / clamp_min(sum(rate(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[15m])), 1e-9) > bool 0.05) or (max(llm_gateway_circuit_open) > bool 0) or ((sum(increase(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[15m])) >= bool 10) and (sum(increase(llm_gateway_chat_extraction_requests_total{mode=\"serving\",outcome=\"success\"}[15m])) == bool 0)) or (histogram_quantile(0.95, sum(rate(llm_gateway_client_first_byte_seconds_bucket[5m])) by (le)) > bool 5)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"conditions": [{"evaluator": {"params": [0], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B", "type": "threshold"}
+      }
+    ],
+    "updated": "2026-07-17T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {"runbook": "backend/docs/runbooks/llm-gateway-fallback.md", "summary": "Client fallback, open circuit, zero gateway successes under traffic, or p95 first-byte latency indicates the gateway is unreachable or stalling", "threshold": "fallback >5%, circuit open, no serving success for 10 requests, or p95 first byte >5s"},
+    "labels": {"severity": "warning", "instatus_component": "ai-chat"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "record": null
+  },
+  {
+    "uid": "omi-llm-gateway-no-ready-endpoints",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "LLM Gateway",
+    "title": "LLM Gateway - no ready production endpoints",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 300, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(kube_endpoint_address_available{namespace=\"prod-omi-backend\",endpoint=\"prod-omi-llm-gateway\"}) < bool 1", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {"conditions": [{"evaluator": {"params": [0], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B", "type": "threshold"}
+      }
+    ],
+    "updated": "2026-07-17T00:00:00Z",
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {"runbook": "backend/docs/runbooks/llm-gateway-fallback.md", "summary": "The production LLM Gateway Service has no ready EndpointSlice address or kube-state-metrics is absent", "threshold": "ready endpoint count <1"},
+    "labels": {"severity": "warning", "instatus_component": "ai-chat"},
     "isPaused": false,
     "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
     "record": null

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -4,6 +4,11 @@ environments:
     gcp_project: based-hardware-dev
     runtime_gcp_project: based-hardware
     region: us-central1
+    llm_gateway:
+      namespace: dev-omi-backend
+      release_name: dev-omi-llm-gateway
+      ingress_name: dev-omi-llm-gateway
+      static_address_name: dev-omi-self-hosted-llm-ip-address
     gke:
       backend-listen:
         values_file: backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -302,7 +307,11 @@ environments:
               value: http://parakeet.omiapi.com
               category: service_discovery
             OMI_LLM_GATEWAY_URL:
-              value: http://172.16.63.232
+              env_var: OMI_LLM_GATEWAY_URL
+              # The workflow replaces this with the ingress-derived address
+              # after the gateway serving gate passes. Direct mode never uses
+              # the sentinel, and it is deliberately not a routable contract.
+              default: http://127.0.0.1:9
               category: service_discovery
             OMI_LLM_GATEWAY_FEATURE_MODE:
               value: gateway
@@ -417,7 +426,8 @@ environments:
               value: http://parakeet.omiapi.com
               category: service_discovery
             OMI_LLM_GATEWAY_URL:
-              value: http://172.16.63.232
+              env_var: OMI_LLM_GATEWAY_URL
+              default: http://127.0.0.1:9
               category: service_discovery
             OMI_LLM_GATEWAY_FEATURE_MODE:
               value: gateway
@@ -515,7 +525,8 @@ environments:
               value: http://parakeet.omiapi.com
               category: service_discovery
             OMI_LLM_GATEWAY_URL:
-              value: http://172.16.63.232
+              env_var: OMI_LLM_GATEWAY_URL
+              default: http://127.0.0.1:9
               category: service_discovery
             OMI_LLM_GATEWAY_FEATURE_MODE:
               value: gateway
@@ -674,6 +685,11 @@ environments:
     gcp_project: based-hardware
     runtime_gcp_project: based-hardware
     region: us-central1
+    llm_gateway:
+      namespace: prod-omi-backend
+      release_name: prod-omi-llm-gateway
+      ingress_name: prod-omi-llm-gateway
+      static_address_name: prod-omi-self-hosted-llm-ip-address
     gke:
       backend-listen:
         values_file: backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -922,7 +938,10 @@ environments:
               value: http://parakeet.omi.me
               category: service_discovery
             OMI_LLM_GATEWAY_URL:
-              value: http://172.16.160.108
+              env_var: OMI_LLM_GATEWAY_URL
+              # Never make a reserved ILB IP independently valid runtime
+              # configuration. The deployment gate derives the live address.
+              default: http://127.0.0.1:9
               category: service_discovery
             OMI_LLM_GATEWAY_FEATURE_MODE:
               value: 'off'
@@ -1051,7 +1070,8 @@ environments:
               value: http://parakeet.omi.me
               category: service_discovery
             OMI_LLM_GATEWAY_URL:
-              value: http://172.16.160.108
+              env_var: OMI_LLM_GATEWAY_URL
+              default: http://127.0.0.1:9
               category: service_discovery
             OMI_LLM_GATEWAY_FEATURE_MODE:
               value: 'off'
@@ -1148,7 +1168,8 @@ environments:
               value: http://parakeet.omi.me
               category: service_discovery
             OMI_LLM_GATEWAY_URL:
-              value: http://172.16.160.108
+              env_var: OMI_LLM_GATEWAY_URL
+              default: http://127.0.0.1:9
               category: service_discovery
             OMI_LLM_GATEWAY_FEATURE_MODE:
               value: 'off'

--- a/backend/docs/runbooks/llm-gateway-fallback.md
+++ b/backend/docs/runbooks/llm-gateway-fallback.md
@@ -1,14 +1,19 @@
 # LLM Gateway — fallback rate elevated (ticket)
 
-**What it means:** The LLM gateway is serving a higher-than-normal share of requests via fallback routes (upstream model/provider issues). This is **dependency health**, not a product outage — chat may still succeed via fallbacks.
+**What it means:** The gateway or one of its upstream routes is unhealthy. A short client transport deadline and per-process circuit send new requests directly to the legacy provider after consecutive gateway transport failures, so this is normally a degraded dependency rather than a total chat outage. A circuit-open event still requires prompt investigation: it can mean the gateway is unreachable from Cloud Run even when its pods look healthy.
 
-**PromQL:** `sum(rate(llm_gateway_requests_total{fallback_used="true"}[30m])) / clamp_min(sum(rate(llm_gateway_requests_total[30m])), 1e-9)`
+**PromQL:** `sum(rate(llm_gateway_chat_extraction_requests_total{mode="fallback"}[30m])) / clamp_min(sum(rate(llm_gateway_chat_extraction_requests_total{mode=~"serving|fallback"}[30m])), 1e-9)`
+
+**Client-side signals:** `llm_gateway_chat_extraction_requests_total{mode="fallback"}`, `llm_gateway_circuit_open`, `llm_gateway_client_first_byte_seconds`, and structured `llm_gateway_backend_event` logs with `reason=circuit_open`. The gateway cannot emit a request metric for a TCP black hole it never receives, so inspect client-side fallback/circuit telemetry as the primary signal for reachability failures.
+
+**Alerts:** the deployed LLM Gateway rules page on a client fallback ratio above 5%, any open circuit, zero gateway-serving successes after 10 client attempts, p95 client first-byte latency above 5 seconds, or zero ready production gateway endpoints. The first four are client-visible by design; the fifth is the Kubernetes control-plane corroboration.
 
 **Owner:** llm-gateway / platform team.
 
 **First checks:**
-1. Upstream provider status and 5xx/429 rates on primary routes.
-2. Prometheus `llm_gateway_requests_total{fallback_used="true"}` rate and breakdown by route/model lane.
-3. Whether a single feature or model lane is driving the spike.
+1. Confirm the current Cloud Run revisions are still `OMI_LLM_GATEWAY_FEATURE_MODE=direct` unless a deliberately gated promotion has occurred.
+2. Run the same evidence chain used by promotion: `verify-llm-gateway-serving.py` for deployment/Service/EndpointSlice/Ingress/ILB attachment, followed by the Cloud Run VPC probe. Do not treat a reserved IP as proof of reachability.
+3. Inspect `llm_gateway_circuit_open`, client fallback ratio, `llm_gateway_client_first_byte_seconds` p95, and `llm_gateway_backend_event` reasons. If the circuit is open, keep/direct-route while repairing the data plane.
+4. Then inspect gateway `llm_gateway_requests_total{fallback_used="true"}` by route/model lane and upstream provider status.
 
 **Severity:** Ticket — investigate during business hours unless user-facing chat error rates also rise.

--- a/backend/scripts/probe-llm-gateway-from-cloud-run.sh
+++ b/backend/scripts/probe-llm-gateway-from-cloud-run.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Launch a short-lived Cloud Run Job in the same VPC path as backend serving.
+# The job performs the authenticated /ready and minimal auto-lane request used
+# by the gateway smoke test, then is deleted even when the probe fails.
+set -euo pipefail
+
+PROJECT=""
+REGION=""
+IMAGE=""
+GATEWAY_URL=""
+NETWORK=""
+SUBNET=""
+VPC_EGRESS=""
+TOKEN_SECRET="OMI_LLM_GATEWAY_SERVICE_TOKEN"
+NAME_SUFFIX=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project) PROJECT="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    --image) IMAGE="$2"; shift 2 ;;
+    --gateway-url) GATEWAY_URL="$2"; shift 2 ;;
+    --network) NETWORK="$2"; shift 2 ;;
+    --subnet) SUBNET="$2"; shift 2 ;;
+    --vpc-egress) VPC_EGRESS="$2"; shift 2 ;;
+    --token-secret) TOKEN_SECRET="$2"; shift 2 ;;
+    --name-suffix) NAME_SUFFIX="$2"; shift 2 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+for required in PROJECT REGION IMAGE GATEWAY_URL NETWORK SUBNET VPC_EGRESS NAME_SUFFIX; do
+  if [[ -z "${!required}" ]]; then
+    echo "ERROR: --${required,,} is required" >&2
+    exit 2
+  fi
+done
+if [[ ! "$NAME_SUFFIX" =~ ^[a-z0-9-]+$ ]]; then
+  echo "ERROR: --name-suffix must contain only lowercase letters, digits, and hyphens" >&2
+  exit 2
+fi
+
+JOB_NAME="llm-gateway-vpc-probe-${NAME_SUFFIX}"
+cleanup() {
+  gcloud run jobs delete "$JOB_NAME" --project="$PROJECT" --region="$REGION" --quiet >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+gcloud run jobs deploy "$JOB_NAME" \
+  --project="$PROJECT" \
+  --region="$REGION" \
+  --image="$IMAGE" \
+  --network="$NETWORK" \
+  --subnet="$SUBNET" \
+  --vpc-egress="$VPC_EGRESS" \
+  --set-env-vars="SMOKE_URL=$GATEWAY_URL" \
+  --set-secrets="OMI_LLM_GATEWAY_SERVICE_TOKEN=${TOKEN_SECRET}:latest" \
+  --command=python \
+  --args=scripts/smoke-llm-gateway.py,--url,"$GATEWAY_URL" \
+  --task-timeout=90s \
+  --max-retries=0 \
+  --quiet
+
+gcloud run jobs execute "$JOB_NAME" \
+  --project="$PROJECT" \
+  --region="$REGION" \
+  --wait \
+  --quiet

--- a/backend/scripts/verify-llm-gateway-serving.py
+++ b/backend/scripts/verify-llm-gateway-serving.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Fail closed before a backend deploy can enable the LLM gateway route.
+
+This intentionally checks the serving data plane rather than treating a
+reserved address as evidence of a reachable gateway.  The emitted URL is
+derived from the ILB address only after Kubernetes and Compute agree on its
+attachment, so Cloud Run never receives a hand-maintained static IP.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, cast
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / 'backend/deploy/runtime_env.yaml'
+BACKEND_LISTEN_VALUES_DIR = ROOT / 'backend/charts/backend-listen'
+
+CommandRunner = Callable[[list[str]], str]
+JsonDict = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class GatewayTarget:
+    namespace: str
+    release_name: str
+    ingress_name: str
+    static_address_name: str
+
+
+def _as_dict(value: object) -> JsonDict:
+    if not isinstance(value, dict):
+        raise ValueError('expected a mapping')
+    return cast(JsonDict, value)
+
+
+def load_gateway_target(*, manifest_path: Path, environment: str) -> GatewayTarget:
+    with manifest_path.open('r', encoding='utf-8') as handle:
+        manifest = _as_dict(yaml.safe_load(handle))
+    environments = _as_dict(manifest.get('environments'))
+    environment_config = _as_dict(environments.get(environment))
+    gateway = _as_dict(environment_config.get('llm_gateway'))
+    fields = ('namespace', 'release_name', 'ingress_name', 'static_address_name')
+    missing = [field for field in fields if not isinstance(gateway.get(field), str) or not gateway[field].strip()]
+    if missing:
+        raise ValueError(f'{environment}.llm_gateway missing {", ".join(missing)}')
+    return GatewayTarget(**{field: str(gateway[field]) for field in fields})
+
+
+def gateway_promotion_requested(
+    *, manifest_path: Path, environment: str, listener_values_path: Path | None = None
+) -> bool:
+    """Return whether any backend surface requests gateway-first serving."""
+
+    with manifest_path.open('r', encoding='utf-8') as handle:
+        manifest = _as_dict(yaml.safe_load(handle))
+    environment_config = _as_dict(_as_dict(manifest.get('environments')).get(environment))
+    for env_entries in _gateway_mode_env_maps(environment_config):
+        if _gateway_mode_enabled(env_entries.get('OMI_LLM_GATEWAY_FEATURE_MODE')):
+            return True
+    values_path = listener_values_path or BACKEND_LISTEN_VALUES_DIR / f'{environment}_omi_backend_listen_values.yaml'
+    with values_path.open('r', encoding='utf-8') as handle:
+        listener_values = _as_dict(yaml.safe_load(handle))
+    listener_env = listener_values.get('env')
+    if not isinstance(listener_env, list):
+        raise ValueError(f'{values_path} missing env list')
+    return any(
+        isinstance(entry, Mapping)
+        and entry.get('name') == 'OMI_LLM_GATEWAY_FEATURE_MODE'
+        and _gateway_mode_enabled(entry.get('value'))
+        for entry in listener_env
+    )
+
+
+def _gateway_mode_enabled(mode: object) -> bool:
+    if isinstance(mode, Mapping):
+        mode = mode.get('value', '')
+    return str(mode).strip().lower() in {'1', 'true', 'yes', 'gateway'}
+
+
+def _gateway_mode_env_maps(environment_config: JsonDict) -> list[Mapping[str, object]]:
+    env_maps: list[Mapping[str, object]] = []
+    gke = environment_config.get('gke')
+    if isinstance(gke, Mapping):
+        for component in gke.values():
+            if isinstance(component, Mapping) and isinstance(component.get('env'), Mapping):
+                env_maps.append(cast(Mapping[str, object], component['env']))
+    cloud_run = environment_config.get('cloud_run')
+    if isinstance(cloud_run, Mapping) and isinstance(cloud_run.get('services'), Mapping):
+        for service in cloud_run['services'].values():
+            if isinstance(service, Mapping) and isinstance(service.get('env'), Mapping):
+                env_maps.append(cast(Mapping[str, object], service['env']))
+    return env_maps
+
+
+def verify_gateway_serving(
+    *,
+    target: GatewayTarget,
+    project: str,
+    region: str,
+    run: CommandRunner,
+) -> str:
+    """Verify ready workload, endpoints, ingress, and attached internal ILB."""
+
+    deployment = _json(run, ['kubectl', '-n', target.namespace, 'get', 'deployment', target.release_name, '-o', 'json'])
+    if not _deployment_available(deployment):
+        raise RuntimeError(f'deployment/{target.release_name} is not Available with ready replicas')
+
+    _json(run, ['kubectl', '-n', target.namespace, 'get', 'service', target.release_name, '-o', 'json'])
+    endpoint_slices = _json(
+        run,
+        [
+            'kubectl',
+            '-n',
+            target.namespace,
+            'get',
+            'endpointslice',
+            '-l',
+            f'kubernetes.io/service-name={target.release_name}',
+            '-o',
+            'json',
+        ],
+    )
+    if not _has_ready_endpoint(endpoint_slices):
+        raise RuntimeError(f'service/{target.release_name} has no Ready EndpointSlice endpoint')
+
+    ingress = _json(run, ['kubectl', '-n', target.namespace, 'get', 'ingress', target.ingress_name, '-o', 'json'])
+    annotations = _mapping_at(ingress, 'metadata', 'annotations')
+    declared_address = annotations.get('kubernetes.io/ingress.regional-static-ip-name')
+    if declared_address != target.static_address_name:
+        raise RuntimeError(
+            f'ingress/{target.ingress_name} must declare regional static address {target.static_address_name!r}'
+        )
+
+    address = _json(
+        run,
+        [
+            'gcloud',
+            'compute',
+            'addresses',
+            'describe',
+            target.static_address_name,
+            '--project',
+            project,
+            '--region',
+            region,
+            '--format=json',
+        ],
+    )
+    address_ip = str(address.get('address', '')).strip()
+    if not address_ip:
+        raise RuntimeError(f'address/{target.static_address_name} has no assigned IP')
+    if address_ip not in _ingress_ips(ingress):
+        raise RuntimeError(f'ingress/{target.ingress_name} is not attached to address {address_ip}')
+
+    forwarding_rules = _json(
+        run,
+        [
+            'gcloud',
+            'compute',
+            'forwarding-rules',
+            'list',
+            '--project',
+            project,
+            '--regions',
+            region,
+            '--format=json',
+        ],
+    )
+    if not _has_attached_internal_forwarding_rule(forwarding_rules, address_ip):
+        raise RuntimeError(f'no internal forwarding rule in {region} is attached to {address_ip}')
+    return f'http://{address_ip}'
+
+
+def _run(command: list[str]) -> str:
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    return completed.stdout
+
+
+def _json(run: CommandRunner, command: list[str]) -> JsonDict:
+    try:
+        loaded = json.loads(run(command))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f'command did not return JSON: {" ".join(command[:4])}') from exc
+    if isinstance(loaded, list):
+        return {'items': loaded}
+    return _as_dict(loaded)
+
+
+def _deployment_available(deployment: JsonDict) -> bool:
+    status = _mapping_at(deployment, 'status')
+    if int(status.get('availableReplicas', 0) or 0) < 1 or int(status.get('readyReplicas', 0) or 0) < 1:
+        return False
+    conditions = status.get('conditions')
+    return isinstance(conditions, list) and any(
+        isinstance(condition, Mapping)
+        and condition.get('type') == 'Available'
+        and str(condition.get('status')).lower() == 'true'
+        for condition in conditions
+    )
+
+
+def _has_ready_endpoint(endpoint_slices: JsonDict) -> bool:
+    items = endpoint_slices.get('items')
+    if not isinstance(items, list):
+        return False
+    for endpoint_slice in items:
+        if not isinstance(endpoint_slice, Mapping):
+            continue
+        endpoints = endpoint_slice.get('endpoints')
+        if not isinstance(endpoints, list):
+            continue
+        for endpoint in endpoints:
+            if not isinstance(endpoint, Mapping):
+                continue
+            conditions = endpoint.get('conditions')
+            ready = conditions.get('ready') if isinstance(conditions, Mapping) else None
+            addresses = endpoint.get('addresses')
+            if (
+                ready is True
+                and isinstance(addresses, list)
+                and any(isinstance(address, str) and address for address in addresses)
+            ):
+                return True
+    return False
+
+
+def _ingress_ips(ingress: JsonDict) -> set[str]:
+    load_balancer = _mapping_at(ingress, 'status', 'loadBalancer')
+    entries = load_balancer.get('ingress')
+    if not isinstance(entries, list):
+        return set()
+    return {
+        str(entry['ip']).strip()
+        for entry in entries
+        if isinstance(entry, Mapping) and isinstance(entry.get('ip'), str) and entry['ip'].strip()
+    }
+
+
+def _has_attached_internal_forwarding_rule(forwarding_rules: JsonDict, address_ip: str) -> bool:
+    items = forwarding_rules.get('items')
+    if not isinstance(items, list):
+        return False
+    return any(
+        isinstance(rule, Mapping)
+        and str(rule.get('IPAddress', '')).strip() == address_ip
+        and str(rule.get('loadBalancingScheme', '')).upper().startswith('INTERNAL')
+        for rule in items
+    )
+
+
+def _mapping_at(value: Mapping[str, Any], *keys: str) -> Mapping[str, Any]:
+    current: object = value
+    for key in keys:
+        if not isinstance(current, Mapping):
+            return {}
+        current = current.get(key)
+    return cast(Mapping[str, Any], current) if isinstance(current, Mapping) else {}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--environment', choices=('dev', 'prod'), required=True)
+    parser.add_argument('--project', required=True)
+    parser.add_argument('--region', required=True)
+    parser.add_argument('--manifest', type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument(
+        '--listener-values',
+        type=Path,
+        help='The exact backend-listen Helm values file this deploy will apply.',
+    )
+    parser.add_argument(
+        '--intent-only', action='store_true', help='Print whether this manifest requests gateway-first serving.'
+    )
+    parser.add_argument('--github-output', type=Path, help='Write gateway_url to this GitHub Actions output file.')
+    args = parser.parse_args()
+
+    if args.intent_only:
+        print(
+            'enabled='
+            f'{str(gateway_promotion_requested(manifest_path=args.manifest, environment=args.environment, listener_values_path=args.listener_values)).lower()}'
+        )
+        return 0
+
+    target = load_gateway_target(manifest_path=args.manifest, environment=args.environment)
+    gateway_url = verify_gateway_serving(target=target, project=args.project, region=args.region, run=_run)
+    print(f'LLM gateway serving gate passed: {gateway_url}')
+    if args.github_output:
+        with args.github_output.open('a', encoding='utf-8') as handle:
+            handle.write(f'gateway_url={gateway_url}\n')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -498,6 +498,8 @@
         "backend/scripts/sync_ledger_fence_cutover.py",
         "backend/scripts/verify_dev_backend_deployment.py",
         "backend/scripts/verify_sync_ledger_fence_transition.py",
+        "backend/scripts/verify-llm-gateway-serving.py",
+        "backend/scripts/probe-llm-gateway-from-cloud-run.sh",
         "backend/scripts/render_backend_runtime_env.py",
         "backend/scripts/repair_cloud_run_traffic.py",
         "backend/scripts/firebase_release_probe_token.py",
@@ -513,6 +515,8 @@
         "tests/unit/test_repair_cloud_run_traffic.py",
         "tests/unit/test_deploy_status_report.py",
         "tests/unit/test_backend_runtime_env_validator.py",
+        "tests/unit/test_verify_llm_gateway_serving.py",
+        "tests/unit/test_llm_gateway_deploy_contract.py",
         "tests/unit/test_sync_two_lane.py",
         "tests/unit/test_firebase_release_probe_token.py",
         "tests/unit/test_transcription_capability_probe.py",
@@ -524,7 +528,8 @@
         "traffic shifts only after candidate revisions are Ready=True",
         "spec.traffic mismatches are repaired or block deploy with an explicit command",
         "normal deploys cannot change the serving sync ledger fence mode",
-        "production backend traffic cannot shift until the exact tagged candidate proves the known-audio full route"
+        "production backend traffic cannot shift until the exact tagged candidate proves the known-audio full route",
+        "gateway-first serving cannot be promoted until the ready workload, EndpointSlice, ingress/ILB attachment, and authenticated Cloud Run VPC route all pass"
       ]
     },
     {

--- a/backend/tests/unit/test_chat_async_offload.py
+++ b/backend/tests/unit/test_chat_async_offload.py
@@ -38,6 +38,7 @@ os.environ.setdefault('TYPESENSE_PROTOCOL', 'http')
 # per-test call within the fast-unit duration guard.
 import utils.retrieval.graph as graph  # noqa: E402
 import utils.retrieval.agentic as agentic  # noqa: E402
+import utils.other.chat_file as chat_file  # noqa: E402
 
 
 async def _collect_agentic_chunks(producer):
@@ -79,6 +80,118 @@ async def test_has_file_context_offloads_llm_call_off_loop():
     assert result is True
     assert 'thread' in ran_on, "retrieve_is_file_question was not called"
     assert ran_on['thread'] is not loop_thread, "retrieve_is_file_question must run off the event-loop thread"
+
+
+def _file_chat_tool_for_stream_test():
+    """Create a FileChatTool without its production Firestore constructor for a hermetic stream test."""
+    tool = object.__new__(chat_file.FileChatTool)
+    tool.uid = 'uid1'
+    tool.chat_session_id = 'session1'
+    tool.thread_id = None
+    tool.assistant_id = None
+    return tool
+
+
+async def test_file_assistants_stream_runs_setup_and_sync_callbacks_off_loop():
+    """The real non-vision file stream keeps the loop responsive and bridges worker callbacks."""
+    loop = asyncio.get_running_loop()
+    loop_thread = threading.current_thread()
+    ask_started = asyncio.Event()
+    worker_finished = asyncio.Event()
+    release_worker = threading.Event()
+    worker_threads = {}
+    tool = _file_chat_tool_for_stream_test()
+    callback = agentic.AsyncStreamingCallback()
+
+    def fake_ensure(self):
+        worker_threads['ensure'] = threading.current_thread()
+        self.thread_id = 'thread1'
+        self.assistant_id = 'assistant1'
+
+    def blocking_ask(self, _uid, _question, _file_ids, _thread_id, _assistant_id, stream_callback):
+        worker_threads['ask'] = threading.current_thread()
+        loop.call_soon_threadsafe(ask_started.set)
+        try:
+            assert release_worker.wait(timeout=0.5), 'test did not release the blocking Assistants stream'
+            stream_callback.put_data_nowait('file answer')
+            return 'file answer'
+        finally:
+            stream_callback.end_nowait()
+            loop.call_soon_threadsafe(worker_finished.set)
+
+    with patch.object(chat_file, '_assert_direct_file_chat_allowed', lambda: None), patch.object(
+        chat_file.chat_db, 'get_chat_files_desc', lambda *_args, **_kwargs: []
+    ), patch.object(chat_file.FileChatTool, '_ensure_thread_and_assistant', fake_ensure), patch.object(
+        chat_file.FileChatTool, 'ask_stream', blocking_ask
+    ):
+        task = asyncio.create_task(tool.process_chat_with_file_stream('summarize', ['file1'], callback))
+        await asyncio.wait_for(ask_started.wait(), timeout=0.5)
+
+        health_check_ran = asyncio.Event()
+        loop.call_soon(health_check_ran.set)
+        await asyncio.wait_for(health_check_ran.wait(), timeout=0.1)
+        assert not task.done(), 'the worker-side stream should still be pending while the loop serves other work'
+
+        release_worker.set()
+        assert await task == 'file answer'
+        await asyncio.wait_for(worker_finished.wait(), timeout=0.5)
+
+    assert worker_threads['ensure'] is not loop_thread
+    assert worker_threads['ask'] is not loop_thread
+    assert await callback.queue.get() == 'data: file answer'
+    assert await callback.queue.get() is None
+
+
+async def test_file_stream_deadline_fires_while_sync_assistants_stream_is_off_loop():
+    """A blocked Assistants iterator yields the terminal SSE error instead of freezing its deadline."""
+    loop = asyncio.get_running_loop()
+    ask_started = asyncio.Event()
+    worker_finished = asyncio.Event()
+    release_worker = threading.Event()
+    tool = _file_chat_tool_for_stream_test()
+
+    def fake_ensure(self):
+        self.thread_id = 'thread1'
+        self.assistant_id = 'assistant1'
+
+    def blocking_ask(self, _uid, _question, _file_ids, _thread_id, _assistant_id, stream_callback):
+        loop.call_soon_threadsafe(ask_started.set)
+        try:
+            assert release_worker.wait(timeout=0.5), 'test did not release the blocking Assistants stream'
+            return ''
+        finally:
+            stream_callback.end_nowait()
+            loop.call_soon_threadsafe(worker_finished.set)
+
+    message = SimpleNamespace(files_id=['file1'], text='summarize')
+    session = SimpleNamespace(id='session1', file_ids=['file1'])
+    callback_data = {}
+
+    async def collect_file_stream():
+        return [
+            chunk
+            async for chunk in graph._execute_file_chat_stream('uid1', [message], session, callback_data=callback_data)
+        ]
+
+    with patch.object(graph, 'FileChatTool', lambda *_args: tool), patch.object(
+        chat_file, '_assert_direct_file_chat_allowed', lambda: None
+    ), patch.object(chat_file.chat_db, 'get_chat_files_desc', lambda *_args, **_kwargs: []), patch.object(
+        chat_file.FileChatTool, '_ensure_thread_and_assistant', fake_ensure
+    ), patch.object(
+        chat_file.FileChatTool, 'ask_stream', blocking_ask
+    ), patch.object(
+        graph, 'AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS', 0.01
+    ), patch.object(
+        agentic, 'AGENT_STREAM_CANCEL_GRACE_SECONDS', 0.05
+    ):
+        stream_task = asyncio.create_task(collect_file_stream())
+        await asyncio.wait_for(ask_started.wait(), timeout=0.5)
+        chunks = await asyncio.wait_for(stream_task, timeout=0.5)
+        release_worker.set()
+        await asyncio.wait_for(worker_finished.wait(), timeout=0.5)
+
+    assert chunks == [f'error: {agentic.AGENT_STREAM_TIMEOUT_MESSAGE}']
+    assert callback_data['error'] == 'stream_failure'
 
 
 async def test_agentic_setup_reads_run_off_loop():

--- a/backend/tests/unit/test_chat_async_offload.py
+++ b/backend/tests/unit/test_chat_async_offload.py
@@ -18,8 +18,10 @@ regression that reintroduces an inline call fails. (Not a source grep: the offlo
 observed via the thread each helper actually runs on.)
 """
 
+import asyncio
 import os
 import threading
+from contextlib import ExitStack, nullcontext
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -36,6 +38,25 @@ os.environ.setdefault('TYPESENSE_PROTOCOL', 'http')
 # per-test call within the fast-unit duration guard.
 import utils.retrieval.graph as graph  # noqa: E402
 import utils.retrieval.agentic as agentic  # noqa: E402
+
+
+async def _collect_agentic_chunks(producer):
+    """Drive the real public stream with deterministic setup dependencies."""
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(agentic, 'get_user_timezone', lambda _uid: 'UTC'))
+        stack.enter_context(patch.object(agentic, '_get_agentic_qa_prompt', lambda *_args, **_kwargs: 'SYSTEM'))
+        stack.enter_context(patch.object(agentic, 'load_app_tools', lambda _uid: []))
+        stack.enter_context(patch.object(agentic, 'get_current_datetime_block', lambda _uid, tz=None: ''))
+        stack.enter_context(patch.object(agentic, '_convert_tools', lambda _core, _app: ([], {})))
+        stack.enter_context(patch.object(agentic, '_messages_to_anthropic', lambda _messages: []))
+        stack.enter_context(patch.object(agentic, '_inject_current_datetime', lambda messages, _block: messages))
+        stack.enter_context(patch.object(agentic, '_run_anthropic_agent_stream', producer))
+        return [
+            chunk
+            async for chunk in agentic.execute_agentic_chat_stream(
+                'uid1', [], app=None, callback_data={}, chat_session=None
+            )
+        ]
 
 
 async def test_has_file_context_offloads_llm_call_off_loop():
@@ -109,3 +130,102 @@ async def test_agentic_setup_reads_run_off_loop():
     for name in ('tz', 'prompt', 'app_tools'):
         assert name in threads, f"{name} setup helper was not called"
         assert threads[name] is not loop_thread, f"{name} setup read must run off the event-loop thread"
+
+
+async def test_callback_preserves_langchain_persona_stream_contract():
+    """The shared callback must still bridge LangChain token/end events for persona chat."""
+    callback = agentic.AsyncStreamingCallback()
+
+    await callback.on_llm_new_token('hello')
+    await callback.on_llm_end(None)
+
+    assert await callback.queue.get() == 'data: hello'
+    assert await callback.queue.get() is None
+
+
+async def test_persona_stream_forwards_langchain_callbacks_and_terminates():
+    """Persona chat must yield tokens and its terminal sentinel through the real stream path."""
+
+    class FakeLLM:
+        async def agenerate(self, *, callbacks, **_kwargs):
+            await callbacks[0].on_llm_new_token('hello')
+            await callbacks[0].on_llm_end(None)
+
+    callback_data = {}
+    app = SimpleNamespace(id='persona-1', name='Persona', persona_prompt='SYSTEM')
+    with patch.object(graph, 'get_llm', lambda *_args, **_kwargs: FakeLLM()), patch.object(
+        graph, 'get_chat_tracer_callbacks', lambda **_kwargs: []
+    ), patch.object(graph, 'track_usage', lambda *_args, **_kwargs: nullcontext()):
+        chunks = [
+            chunk
+            async for chunk in graph.execute_persona_chat_stream(
+                'uid1', [], app, callback_data=callback_data, chat_session=None
+            )
+        ]
+
+    assert chunks == ['data: hello', None]
+    assert callback_data['answer'] == 'hello'
+
+
+async def test_persona_callback_drain_cancels_a_silent_producer():
+    """Persona/file queue consumers use the same bounded lifecycle as default chat."""
+    callback = agentic.AsyncStreamingCallback()
+    cancelled = asyncio.Event()
+
+    async def stalled_producer():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    task = asyncio.create_task(stalled_producer())
+    with patch.object(graph, 'AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS', 0.01), patch.object(
+        agentic, 'AGENT_STREAM_CANCEL_GRACE_SECONDS', 0.05
+    ):
+        chunks = [chunk async for chunk in graph._drain_chat_callback(callback, task, route='persona')]
+
+    assert chunks == [f'error: {agentic.AGENT_STREAM_TIMEOUT_MESSAGE}']
+    assert cancelled.is_set()
+
+
+async def test_agentic_stream_cancels_a_silent_producer_before_the_proxy_deadline():
+    """A stalled provider/tool produces a terminal SSE error instead of an unbounded queue wait."""
+    cancelled = asyncio.Event()
+
+    async def stalled_producer(*_args, **_kwargs):
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    with patch.object(agentic, 'AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS', 0.01), patch.object(
+        agentic, 'AGENT_STREAM_CANCEL_GRACE_SECONDS', 0.05
+    ):
+        chunks = await _collect_agentic_chunks(stalled_producer)
+
+    assert chunks == [f'error: {agentic.AGENT_STREAM_TIMEOUT_MESSAGE}']
+    assert cancelled.is_set()
+
+
+async def test_agentic_stream_surfaces_a_producer_crash_without_waiting_for_idle_timeout():
+    """A producer exception before callback.end() immediately terminates the SSE stream."""
+
+    async def crashing_producer(*_args, **_kwargs):
+        raise RuntimeError('simulated provider failure')
+
+    chunks = await _collect_agentic_chunks(crashing_producer)
+
+    assert chunks == [f'error: {agentic.AGENT_STREAM_FAILURE_MESSAGE}']
+
+
+async def test_agentic_stream_treats_a_cancelled_producer_as_a_failure():
+    """Only a client cancellation is silent; a producer cancellation is a terminal SSE error."""
+
+    async def cancelled_producer(*_args, **_kwargs):
+        raise asyncio.CancelledError
+
+    chunks = await _collect_agentic_chunks(cancelled_producer)
+
+    assert chunks == [f'error: {agentic.AGENT_STREAM_FAILURE_MESSAGE}']

--- a/backend/tests/unit/test_gateway_anthropic_client.py
+++ b/backend/tests/unit/test_gateway_anthropic_client.py
@@ -9,6 +9,14 @@ import pytest
 
 from utils.llm import gateway_anthropic
 from utils.llm.gateway_client import CHAT_AGENT_AUTO_LANE_ID, LLM_GATEWAY_FEATURE_MODE_ENV_VAR
+from utils.llm.gateway_resilience import GatewayCircuitBreaker
+
+
+@pytest.fixture(autouse=True)
+def _reset_gateway_circuit_between_tests():
+    gateway_anthropic.gateway_circuit.reset()
+    yield
+    gateway_anthropic.gateway_circuit.reset()
 
 
 class _MessageStream:
@@ -254,6 +262,38 @@ async def test_gateway_anthropic_stream_fallback_records_recovered_after_legacy_
 
 
 @pytest.mark.asyncio
+async def test_gateway_anthropic_stream_transport_failure_before_first_event_uses_legacy_and_opens_circuit(monkeypatch):
+    recorded: list[dict] = []
+    fallbacks: list[dict] = []
+    circuit = GatewayCircuitBreaker(
+        failure_threshold=1,
+        cooldown_seconds=30,
+        monotonic=lambda: 0.0,
+    )
+    monkeypatch.setattr(gateway_anthropic, 'gateway_circuit', circuit)
+    gateway_messages = MagicMock()
+    gateway_messages.stream.return_value = _MessageStream([], error=httpx.ReadTimeout('first byte timed out'))
+    legacy_messages = MagicMock()
+    legacy_messages.stream.return_value = _message_stop_stream()
+    client = _gateway_client(
+        monkeypatch,
+        gateway_messages=gateway_messages,
+        legacy_messages=legacy_messages,
+        recorded=recorded,
+        fallbacks=fallbacks,
+    )
+
+    async with client.messages.stream(model='claude-sonnet-4-6', max_tokens=10) as stream:
+        events = [event async for event in stream]
+
+    assert [event.type for event in events] == ['content_block_delta', 'message_stop']
+    assert not circuit.allow_request()
+    assert fallbacks[0]['outcome'] == 'recovered'
+    assert fallbacks[0]['gateway_reason'] == 'timeout'
+    assert recorded == []
+
+
+@pytest.mark.asyncio
 async def test_gateway_anthropic_stream_fallback_records_exhausted_on_legacy_failure(monkeypatch):
     fallbacks: list[dict] = []
     gateway_messages = MagicMock()
@@ -348,6 +388,32 @@ async def test_gateway_anthropic_nonstream_fallback_waits_for_legacy_success(mon
 
     assert result.id == 'legacy-message'
     assert fallbacks[0]['outcome'] == 'recovered'
+
+
+@pytest.mark.asyncio
+async def test_gateway_anthropic_open_circuit_bypasses_a_second_transport_attempt(monkeypatch):
+    monkeypatch.setattr(
+        gateway_anthropic,
+        'gateway_circuit',
+        GatewayCircuitBreaker(failure_threshold=1, cooldown_seconds=30.0),
+    )
+    gateway_messages = MagicMock()
+    gateway_messages.create = AsyncMock(side_effect=httpx.ConnectError('connection refused'))
+    legacy_messages = MagicMock()
+    legacy_messages.create = AsyncMock(return_value=SimpleNamespace(id='legacy-message'))
+    client = _gateway_client(
+        monkeypatch,
+        gateway_messages=gateway_messages,
+        legacy_messages=legacy_messages,
+        recorded=[],
+        fallbacks=[],
+    )
+
+    assert (await client.messages.create(model='claude-sonnet-4-6', max_tokens=10)).id == 'legacy-message'
+    assert (await client.messages.create(model='claude-sonnet-4-6', max_tokens=10)).id == 'legacy-message'
+
+    assert gateway_messages.create.await_count == 1
+    assert legacy_messages.create.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_gateway_resilience.py
+++ b/backend/tests/unit/test_gateway_resilience.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from utils.llm import gateway_resilience
+from utils.llm.gateway_resilience import GatewayCircuitBreaker, gateway_transport_timeout
+
+
+def test_gateway_transport_timeout_bounds_connect_and_first_byte(monkeypatch) -> None:
+    monkeypatch.setenv('OMI_LLM_GATEWAY_CONNECT_TIMEOUT_SECONDS', '2.5')
+    monkeypatch.setenv('OMI_LLM_GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS', '11')
+
+    timeout = gateway_transport_timeout()
+
+    assert timeout.connect == 2.5
+    assert timeout.pool == 2.5
+    assert timeout.read == 11.0
+    assert timeout.write == 11.0
+
+
+def test_gateway_circuit_bypasses_until_bounded_cooldown_expires() -> None:
+    now = [100.0]
+    circuit = GatewayCircuitBreaker(failure_threshold=2, cooldown_seconds=30.0, monotonic=lambda: now[0])
+
+    assert circuit.allow_request() is True
+    circuit.record_transport_failure()
+    assert circuit.allow_request() is True
+    circuit.record_transport_failure()
+    assert circuit.allow_request() is False
+
+    now[0] += 30.0
+    assert circuit.allow_request() is True
+
+
+def test_gateway_first_byte_observation_has_bounded_feature_and_outcome_labels(monkeypatch) -> None:
+    histogram = MagicMock()
+    child = MagicMock()
+    histogram.labels.return_value = child
+    now = iter((103.25,))
+    monkeypatch.setattr(gateway_resilience, 'LLM_GATEWAY_CLIENT_FIRST_BYTE_SECONDS', histogram)
+    monkeypatch.setattr(gateway_resilience.time, 'monotonic', lambda: next(now))
+
+    gateway_resilience.observe_gateway_first_byte(feature='chat_agent', started_at=100.0, outcome='transport_failure')
+
+    histogram.labels.assert_called_once_with(feature='chat_agent', outcome='transport_failure')
+    child.observe.assert_called_once_with(3.25)

--- a/backend/tests/unit/test_gateway_serving_streaming.py
+++ b/backend/tests/unit/test_gateway_serving_streaming.py
@@ -13,6 +13,14 @@ from pydantic import Field
 
 from utils.llm import gateway_serving
 from utils.llm.gateway_client import feature_auto_lane_id
+from utils.llm.gateway_resilience import GatewayCircuitBreaker
+
+
+@pytest.fixture(autouse=True)
+def _reset_gateway_circuit_between_tests():
+    gateway_serving.gateway_circuit.reset()
+    yield
+    gateway_serving.gateway_circuit.reset()
 
 
 class _StreamChatModel(BaseChatModel):
@@ -123,6 +131,27 @@ def test_gateway_serving_stream_falls_back_before_first_chunk(monkeypatch):
     assert recorded[0]['mode'] == 'fallback'
     assert recorded[0]['outcome'] == 'fallback'
     assert fallbacks[0]['outcome'] == 'recovered'
+
+
+def test_gateway_serving_open_circuit_bypasses_a_second_transport_attempt(monkeypatch):
+    monkeypatch.setattr(
+        gateway_serving,
+        'gateway_circuit',
+        GatewayCircuitBreaker(failure_threshold=1, cooldown_seconds=30.0),
+    )
+    gateway = _StreamChatModel(name='gateway', chunks=[], fail_before_yield=True)
+    legacy = _StreamChatModel(name='legacy', chunks=['fallback'])
+    wrapped = gateway_serving.wrap_gateway_with_legacy_fallback(
+        feature='chat_responses',
+        gateway_model=gateway,
+        legacy_model=legacy,
+    )
+
+    assert [chunk.message.content for chunk in wrapped._stream([])] == ['fallback']
+    assert [chunk.message.content for chunk in wrapped._stream([])] == ['fallback']
+
+    assert len(gateway.calls) == 1
+    assert len(legacy.calls) == 2
 
 
 def test_gateway_serving_stream_empty_gateway_uses_legacy_and_does_not_claim_gateway_success(monkeypatch):

--- a/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
+++ b/backend/tests/unit/test_llm_gateway_chat_extraction_pilot.py
@@ -185,7 +185,11 @@ def test_chat_structured_gateway_request_uses_auto_lane_and_service_auth(monkeyp
     assert captured['json']['messages'] == [{'role': 'user', 'content': 'classified prompt'}]
     assert captured['json']['response_format']['type'] == 'json_schema'
     assert captured['json']['response_format']['json_schema']['schema']['properties']['value']['type'] == 'boolean'
-    assert captured['client_kwargs'] == {'timeout': gateway_client.CHAT_EXTRACTION_TIMEOUT_SECONDS}
+    timeout = captured['client_kwargs']['timeout']
+    assert timeout.connect == 3.0
+    assert timeout.pool == 3.0
+    assert timeout.read == gateway_client.CHAT_EXTRACTION_TIMEOUT_SECONDS
+    assert timeout.write == gateway_client.CHAT_EXTRACTION_TIMEOUT_SECONDS
 
 
 def test_chat_structured_gateway_allows_background_timeout_override(monkeypatch):
@@ -205,7 +209,11 @@ def test_chat_structured_gateway_allows_background_timeout_override(monkeypatch)
     )
 
     assert result == chat.RequiresContext(value=True)
-    assert captured['client_kwargs'] == {'timeout': gateway_client.BACKGROUND_CHAT_EXTRACTION_TIMEOUT_SECONDS}
+    timeout = captured['client_kwargs']['timeout']
+    assert timeout.connect == 3.0
+    assert timeout.pool == 3.0
+    assert timeout.read == 15.0
+    assert timeout.write == 15.0
 
 
 def test_strict_schema_normalizes_action_item_extraction_for_openai():

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -12,7 +12,7 @@ from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.runnables import Runnable
 import pytest
 
-from utils.llm import clients, gateway_shadow
+from utils.llm import clients, gateway_shadow, gateway_serving
 from utils.llm import providers
 from utils.llm.gateway_client import DEFAULT_LLM_GATEWAY_URL, GatewayContextChatOpenAI, get_llm_gateway_base_url
 from utils.llm.gateway_client import (
@@ -27,6 +27,13 @@ from utils.llm.gateway_client import (
 from utils.llm.clients import get_llm_gateway_chat_structured
 from utils.llm.usage_tracker import reset_usage_context, set_usage_context
 import httpx
+
+
+@pytest.fixture(autouse=True)
+def _reset_gateway_circuit_between_tests():
+    gateway_serving.gateway_circuit.reset()
+    yield
+    gateway_serving.gateway_circuit.reset()
 
 
 class FakeChatModel(BaseChatModel):

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -58,19 +58,13 @@ def test_llm_gateway_anthropic_secret_and_authenticated_readiness_probe_contract
         assert 'X-Omi-Service-Caller: backend' in probe_command
 
 
-def test_prod_gateway_wiring_declared_but_serving_off_until_gateway_deployed():
+def test_prod_gateway_wiring_is_off_until_verified_promotion():
     manifest = _load_yaml('deploy/runtime_env.yaml')
     prod = manifest['environments']['prod']
     gke_env = prod['gke']['backend-listen']['env']
     assert (
         gke_env['OMI_LLM_GATEWAY_URL']['value'] == 'http://prod-omi-llm-gateway.prod-omi-backend.svc.cluster.local:8080'
     )
-    # 'off' until the llm-gateway is actually deployed in prod: the 2026-07-17 prod
-    # deploy shipped FEATURE_MODE=gateway pointing at an unattached static IP (Cloud
-    # Run) / nonexistent cluster service (GKE), and every chat LLM call hung through
-    # connect timeouts + retries (2-9 min per /v2/messages POST). Flip back to
-    # 'gateway' only once a reachable prod gateway exists (helm release + ingress
-    # bound to the reserved IP).
     assert gke_env['OMI_LLM_GATEWAY_FEATURE_MODE']['value'] == 'off'
     assert gke_env['OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE']['value'] == 'true'
     assert gke_env['OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION']['value'] == 'true'
@@ -80,7 +74,11 @@ def test_prod_gateway_wiring_declared_but_serving_off_until_gateway_deployed():
 
     for service in ('backend', 'backend-sync', 'backend-integration'):
         service_config = prod['cloud_run']['services'][service]
-        assert service_config['env']['OMI_LLM_GATEWAY_URL']['value'] == 'http://172.16.160.108'
+        assert service_config['env']['OMI_LLM_GATEWAY_URL'] == {
+            'env_var': 'OMI_LLM_GATEWAY_URL',
+            'default': 'http://127.0.0.1:9',
+            'category': 'service_discovery',
+        }
         assert service_config['env']['OMI_LLM_GATEWAY_FEATURE_MODE']['value'] == 'off'
         assert service_config['env']['OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE']['value'] == 'true'
         assert service_config['env']['OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION']['value'] == 'true'
@@ -98,6 +96,12 @@ def test_prod_gateway_wiring_declared_but_serving_off_until_gateway_deployed():
     assert gateway['ingress']['annotations']['kubernetes.io/ingress.regional-static-ip-name'] == (
         'prod-omi-self-hosted-llm-ip-address'
     )
+    assert prod['llm_gateway'] == {
+        'namespace': 'prod-omi-backend',
+        'release_name': 'prod-omi-llm-gateway',
+        'ingress_name': 'prod-omi-llm-gateway',
+        'static_address_name': 'prod-omi-self-hosted-llm-ip-address',
+    }
 
 
 def test_gateway_deploy_workflow_and_helper_allow_explicit_prod_launches():
@@ -110,6 +114,27 @@ def test_gateway_deploy_workflow_and_helper_allow_explicit_prod_launches():
     assert 'LLM_GATEWAY_GSA is required for Vertex Workload Identity' in helper
     assert 'serviceAccount.annotations.iam\\\\.gke\\\\.io/gcp-service-account=${LLM_GATEWAY_GSA}' in helper
     assert 'LLM_GATEWAY_GSA: ${{ vars.LLM_GATEWAY_GSA }}' in workflow
+    assert 'Verify LLM Gateway serving data plane' in workflow
+    assert 'Probe LLM Gateway from the Cloud Run VPC' in workflow
+    assert 'verify-llm-gateway-serving.py' in workflow
+    assert 'probe-llm-gateway-from-cloud-run.sh' in workflow
+
+
+def test_backend_deploy_requires_serving_and_cloud_run_vpc_gates_before_gateway_promotion():
+    workflow = (BACKEND_ROOT.parent / '.github/workflows/gcp_backend.yml').read_text(encoding='utf-8')
+    auto_dev = (BACKEND_ROOT.parent / '.github/workflows/gcp_backend_auto_dev.yml').read_text(encoding='utf-8')
+
+    assert 'Determine whether this deploy requests gateway-first serving' in workflow
+    assert 'Verify LLM gateway control plane before promotion' in workflow
+    assert 'Probe LLM gateway from the Cloud Run VPC before promotion' in workflow
+    assert "steps.gateway-intent.outputs.enabled == 'true'" in workflow
+    assert (
+        '--listener-values="backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml"' in workflow
+    )
+    assert "steps.gateway-serving.outputs.gateway_url || 'http://127.0.0.1:9'" in workflow
+    assert 'Verify LLM gateway control plane before promotion' in auto_dev
+    assert 'Probe LLM gateway from the Cloud Run VPC before promotion' in auto_dev
+    assert 'OMI_LLM_GATEWAY_URL: ${{ steps.gateway-serving.outputs.gateway_url }}' in auto_dev
 
 
 def test_monitoring_scrapes_llm_gateway_with_shared_metrics_secret_contract():

--- a/backend/tests/unit/test_llm_provider_plugin_structure.py
+++ b/backend/tests/unit/test_llm_provider_plugin_structure.py
@@ -142,6 +142,10 @@ def test_openai_compatible_provider_applies_base_url_headers_and_google_prefix(m
     assert call['api_key'] == 'sk-openrouter'
     assert call['base_url'] == 'https://openrouter.ai/api/v1'
     assert call['default_headers'] == {'X-Title': 'Omi Chat'}
+    # Direct providers are the gateway recovery path and retain their existing
+    # provider-sized timeout/retry budget.
+    assert call['request_timeout'] == 120
+    assert call['max_retries'] == 1
     assert call['temperature'] == 0.7
 
 

--- a/backend/tests/unit/test_monitoring_alert_rule_contract.py
+++ b/backend/tests/unit/test_monitoring_alert_rule_contract.py
@@ -42,3 +42,20 @@ def test_split_alert_exports_preserve_error_count_no_data_contract():
     assert ERROR_COUNT_RULES <= split.keys()
     for uid in ERROR_COUNT_RULES:
         assert combined[uid]["noDataState"] == split[uid]["noDataState"] == "OK"
+
+
+def test_llm_gateway_alerts_cover_client_black_holes_and_ready_endpoints():
+    split = _rules(MONITORING / "alerts" / "resilience.json")
+    combined = _rules(MONITORING / "alert-rules.json")
+    expected = {"omi-llm-gateway-client-reachability", "omi-llm-gateway-no-ready-endpoints"}
+
+    assert expected <= split.keys()
+    assert expected <= combined.keys()
+    reachability_expr = split["omi-llm-gateway-client-reachability"]["data"][0]["model"]["expr"]
+    assert "llm_gateway_chat_extraction_requests_total" in reachability_expr
+    assert "llm_gateway_circuit_open" in reachability_expr
+    assert 'outcome="success"' in reachability_expr
+    assert "llm_gateway_client_first_byte_seconds_bucket" in reachability_expr
+    endpoint_rule = split["omi-llm-gateway-no-ready-endpoints"]
+    assert endpoint_rule["noDataState"] == "Alerting"
+    assert "kube_endpoint_address_available" in endpoint_rule["data"][0]["model"]["expr"]

--- a/backend/tests/unit/test_prompt_cache_integration.py
+++ b/backend/tests/unit/test_prompt_cache_integration.py
@@ -143,6 +143,8 @@ if not hasattr(langchain_core_mod, "__path__"):
     langchain_core_mod.__path__ = []
 langchain_runnables_mod = _stub_module("langchain_core.runnables")
 langchain_runnables_mod.RunnableConfig = dict
+langchain_callbacks_mod = _stub_module("langchain_core.callbacks")
+langchain_callbacks_mod.BaseCallbackHandler = type("BaseCallbackHandler", (), {})
 
 # --- LLMs/memory stubs ---
 llms_mod = _stub_module("utils.llms")

--- a/backend/tests/unit/test_verify_llm_gateway_serving.py
+++ b/backend/tests/unit/test_verify_llm_gateway_serving.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / 'scripts' / 'verify-llm-gateway-serving.py'
+SPEC = importlib.util.spec_from_file_location('verify_llm_gateway_serving', SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+
+
+@pytest.fixture
+def gateway_gate(monkeypatch):
+    module = importlib.util.module_from_spec(SPEC)
+    monkeypatch.setitem(sys.modules, SPEC.name, module)
+    SPEC.loader.exec_module(module)
+    return module
+
+
+def _runner(responses: dict[str, object], calls: list[list[str]]):
+    def run(command: list[str]) -> str:
+        calls.append(command)
+        if command[:5] == ['gcloud', 'compute', 'forwarding-rules', 'list', '--project']:
+            key = 'gcloud compute forwarding-rules list'
+        elif command[:4] == ['gcloud', 'compute', 'addresses', 'describe']:
+            key = f'gcloud compute addresses describe {command[4]}'
+        else:
+            key = ' '.join(command[:6])
+        return json.dumps(responses[key])
+
+    return run
+
+
+def _healthy_responses() -> dict[str, object]:
+    return {
+        'kubectl -n prod-omi-backend get deployment prod-omi-llm-gateway': {
+            'status': {
+                'availableReplicas': 1,
+                'readyReplicas': 1,
+                'conditions': [{'type': 'Available', 'status': 'True'}],
+            }
+        },
+        'kubectl -n prod-omi-backend get service prod-omi-llm-gateway': {'metadata': {'name': 'prod-omi-llm-gateway'}},
+        'kubectl -n prod-omi-backend get endpointslice -l': {
+            'items': [{'endpoints': [{'conditions': {'ready': True}, 'addresses': ['10.0.0.8']}]}]
+        },
+        'kubectl -n prod-omi-backend get ingress prod-omi-llm-gateway': {
+            'metadata': {
+                'annotations': {'kubernetes.io/ingress.regional-static-ip-name': 'prod-omi-self-hosted-llm-ip-address'}
+            },
+            'status': {'loadBalancer': {'ingress': [{'ip': '172.16.160.108'}]}},
+        },
+        'gcloud compute addresses describe prod-omi-self-hosted-llm-ip-address': {'address': '172.16.160.108'},
+        'gcloud compute forwarding-rules list': [
+            {'IPAddress': '172.16.160.108', 'loadBalancingScheme': 'INTERNAL_MANAGED'}
+        ],
+    }
+
+
+def test_gateway_promotion_intent_tracks_runtime_and_helm_listener_surfaces(gateway_gate, tmp_path: Path) -> None:
+    manifest = Path(__file__).resolve().parents[2] / 'deploy' / 'runtime_env.yaml'
+
+    assert gateway_gate.gateway_promotion_requested(manifest_path=manifest, environment='prod') is False
+
+    listener_values = tmp_path / 'prod_listener_values.yaml'
+    listener_values.write_text('env:\n  - name: OMI_LLM_GATEWAY_FEATURE_MODE\n    value: gateway\n', encoding='utf-8')
+    assert (
+        gateway_gate.gateway_promotion_requested(
+            manifest_path=manifest,
+            environment='prod',
+            listener_values_path=listener_values,
+        )
+        is True
+    )
+
+
+def test_verify_gateway_serving_derives_url_only_from_ready_attached_ilb(gateway_gate) -> None:
+    calls: list[list[str]] = []
+    target = gateway_gate.GatewayTarget(
+        namespace='prod-omi-backend',
+        release_name='prod-omi-llm-gateway',
+        ingress_name='prod-omi-llm-gateway',
+        static_address_name='prod-omi-self-hosted-llm-ip-address',
+    )
+
+    url = gateway_gate.verify_gateway_serving(
+        target=target,
+        project='based-hardware',
+        region='us-central1',
+        run=_runner(_healthy_responses(), calls),
+    )
+
+    assert url == 'http://172.16.160.108'
+    assert any(command[0:4] == ['kubectl', '-n', 'prod-omi-backend', 'get'] for command in calls)
+    assert any(command[0:3] == ['gcloud', 'compute', 'forwarding-rules'] for command in calls)
+
+
+def test_verify_gateway_serving_rejects_reserved_address_without_forwarding_rule(gateway_gate) -> None:
+    responses = _healthy_responses()
+    responses['gcloud compute forwarding-rules list'] = []
+    target = gateway_gate.GatewayTarget(
+        namespace='prod-omi-backend',
+        release_name='prod-omi-llm-gateway',
+        ingress_name='prod-omi-llm-gateway',
+        static_address_name='prod-omi-self-hosted-llm-ip-address',
+    )
+
+    with pytest.raises(RuntimeError, match='no internal forwarding rule'):
+        gateway_gate.verify_gateway_serving(
+            target=target,
+            project='based-hardware',
+            region='us-central1',
+            run=_runner(responses, []),
+        )

--- a/backend/utils/llm/gateway_anthropic.py
+++ b/backend/utils/llm/gateway_anthropic.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import time
 import uuid
 from collections.abc import Mapping
 from typing import Any, cast
@@ -22,6 +23,7 @@ from utils.llm.gateway_client import (
     should_route_features_through_gateway,
 )
 from utils.llm.gateway_observability import record_gateway_request_result
+from utils.llm.gateway_resilience import gateway_circuit, gateway_transport_timeout, observe_gateway_first_byte
 from utils.llm.gateway_serving import is_gateway_transport_failure, record_gateway_fallback_terminal
 
 _CHAT_AGENT_FEATURE = 'chat_agent'
@@ -75,7 +77,7 @@ def _get_or_create_gateway_anthropic_client(*, byok_api_key: str | None = None) 
     client = anthropic.AsyncAnthropic(
         api_key='gateway-managed',
         base_url=get_llm_gateway_base_url(),
-        timeout=120.0,
+        timeout=gateway_transport_timeout(),
         max_retries=0,
         default_headers=default_headers,
     )
@@ -141,6 +143,9 @@ class _GatewayFirstAnthropicMessages:
         gateway_kwargs['model'] = CHAT_AGENT_AUTO_LANE_ID
         gateway_kwargs['extra_headers'] = _gateway_request_headers(gateway_kwargs.get('extra_headers'))
         request_id = _set_request_id(gateway_kwargs)
+        if not gateway_circuit.allow_request():
+            return await self._legacy_create(kwargs, request_id=request_id, gateway_reason='circuit_open')
+        gateway_started_at = time.monotonic()
         try:
             result = await self._gateway_messages.create(**gateway_kwargs)
         except asyncio.CancelledError:
@@ -166,43 +171,51 @@ class _GatewayFirstAnthropicMessages:
                     credential_source=self._credential_source,
                 )
                 raise
-            gateway_reason = _fallback_reason(exc)
-            try:
-                result = await self._legacy_messages.create(**kwargs)
-            except asyncio.CancelledError:
-                record_gateway_fallback_terminal(
-                    feature=_CHAT_AGENT_FEATURE,
-                    gateway_reason=gateway_reason,
-                    outcome='exhausted',
-                    request_id=request_id,
-                    credential_source=self._credential_source,
-                    request_outcome='cancelled',
-                    request_reason='client_cancelled',
-                )
-                raise
-            except Exception:
-                record_gateway_fallback_terminal(
-                    feature=_CHAT_AGENT_FEATURE,
-                    gateway_reason=gateway_reason,
-                    outcome='exhausted',
-                    request_id=request_id,
-                    credential_source=self._credential_source,
-                )
-                raise
-            record_gateway_fallback_terminal(
-                feature=_CHAT_AGENT_FEATURE,
-                gateway_reason=gateway_reason,
-                outcome='recovered',
-                request_id=request_id,
-                credential_source=self._credential_source,
+            gateway_circuit.record_transport_failure()
+            observe_gateway_first_byte(
+                feature=_CHAT_AGENT_FEATURE, started_at=gateway_started_at, outcome='transport_failure'
             )
-            return result
+            return await self._legacy_create(kwargs, request_id=request_id, gateway_reason=_fallback_reason(exc))
+        gateway_circuit.record_transport_success()
+        observe_gateway_first_byte(feature=_CHAT_AGENT_FEATURE, started_at=gateway_started_at, outcome='success')
         record_gateway_request_result(
             feature=_CHAT_AGENT_FEATURE,
             outcome='success',
             reason='ok',
             route=feature_auto_lane_id(_CHAT_AGENT_FEATURE),
             mode='serving',
+            request_id=request_id,
+            credential_source=self._credential_source,
+        )
+        return result
+
+    async def _legacy_create(self, kwargs: dict[str, Any], *, request_id: str, gateway_reason: str) -> Any:
+        try:
+            result = await self._legacy_messages.create(**kwargs)
+        except asyncio.CancelledError:
+            record_gateway_fallback_terminal(
+                feature=_CHAT_AGENT_FEATURE,
+                gateway_reason=gateway_reason,
+                outcome='exhausted',
+                request_id=request_id,
+                credential_source=self._credential_source,
+                request_outcome='cancelled',
+                request_reason='client_cancelled',
+            )
+            raise
+        except Exception:
+            record_gateway_fallback_terminal(
+                feature=_CHAT_AGENT_FEATURE,
+                gateway_reason=gateway_reason,
+                outcome='exhausted',
+                request_id=request_id,
+                credential_source=self._credential_source,
+            )
+            raise
+        record_gateway_fallback_terminal(
+            feature=_CHAT_AGENT_FEATURE,
+            gateway_reason=gateway_reason,
+            outcome='recovered',
             request_id=request_id,
             credential_source=self._credential_source,
         )
@@ -232,8 +245,13 @@ class _GatewayAnthropicStreamWithFallback:
         self._gateway_fallback_reason: str | None = None
         self._saw_output = False
         self._terminal_recorded = False
+        self._gateway_started_at: float | None = None
 
     async def __aenter__(self):
+        if not gateway_circuit.allow_request():
+            self._gateway_fallback_reason = 'circuit_open'
+            return await self._start_legacy_fallback()
+        self._gateway_started_at = time.monotonic()
         try:
             self._active = await self._gateway_messages.stream(**self._gateway_kwargs).__aenter__()
         except asyncio.CancelledError:
@@ -261,34 +279,78 @@ class _GatewayAnthropicStreamWithFallback:
                 )
                 self._terminal_recorded = True
                 raise
+            gateway_circuit.record_transport_failure()
+            self._observe_gateway_first_byte('transport_failure')
             self._gateway_fallback_reason = _fallback_reason(exc)
+            return await self._start_legacy_fallback()
+        self._using_gateway = True
+        return self
+
+    async def _switch_to_legacy_fallback_before_output(
+        self, *, gateway_reason: str, error: BaseException | None
+    ) -> None:
+        """Close an unproductive gateway stream before replaying it directly.
+
+        The caller has not received an event yet, so replaying is safe.  Once
+        an event has escaped this wrapper, retrying through the legacy provider
+        could duplicate output and is intentionally prohibited.
+        """
+
+        active = self._active
+        self._active = None
+        self._iterator = None
+        self._using_gateway = False
+        self._gateway_fallback_reason = gateway_reason
+        if active is not None:
             try:
-                self._active = await self._legacy_messages.stream(**self._legacy_kwargs).__aenter__()
+                if error is None:
+                    await active.__aexit__(None, None, None)
+                else:
+                    await active.__aexit__(type(error), error, error.__traceback__)
             except asyncio.CancelledError:
-                record_gateway_fallback_terminal(
-                    feature=_CHAT_AGENT_FEATURE,
-                    gateway_reason=self._gateway_fallback_reason,
-                    outcome='exhausted',
-                    request_id=self._request_id,
-                    credential_source=self._credential_source,
-                    request_outcome='cancelled',
-                    request_reason='client_cancelled',
-                )
-                self._terminal_recorded = True
                 raise
             except Exception:
-                record_gateway_fallback_terminal(
-                    feature=_CHAT_AGENT_FEATURE,
-                    gateway_reason=self._gateway_fallback_reason,
-                    outcome='exhausted',
-                    request_id=self._request_id,
-                    credential_source=self._credential_source,
-                )
-                self._terminal_recorded = True
-                raise
-            self._using_legacy_fallback = True
-            return self
-        self._using_gateway = True
+                # The transport failure is already known; cleanup must not
+                # prevent the safe no-output legacy fallback.
+                pass
+        await self._start_legacy_fallback()
+
+    def _observe_gateway_first_byte(self, outcome: str) -> None:
+        if self._gateway_started_at is None:
+            return
+        observe_gateway_first_byte(
+            feature=_CHAT_AGENT_FEATURE,
+            started_at=self._gateway_started_at,
+            outcome=outcome,
+        )
+        self._gateway_started_at = None
+
+    async def _start_legacy_fallback(self):
+        try:
+            self._active = await self._legacy_messages.stream(**self._legacy_kwargs).__aenter__()
+        except asyncio.CancelledError:
+            record_gateway_fallback_terminal(
+                feature=_CHAT_AGENT_FEATURE,
+                gateway_reason=self._gateway_fallback_reason or 'unexpected_error',
+                outcome='exhausted',
+                request_id=self._request_id,
+                credential_source=self._credential_source,
+                request_outcome='cancelled',
+                request_reason='client_cancelled',
+            )
+            self._terminal_recorded = True
+            raise
+        except Exception:
+            record_gateway_fallback_terminal(
+                feature=_CHAT_AGENT_FEATURE,
+                gateway_reason=self._gateway_fallback_reason or 'unexpected_error',
+                outcome='exhausted',
+                request_id=self._request_id,
+                credential_source=self._credential_source,
+            )
+            self._terminal_recorded = True
+            raise
+        self._using_legacy_fallback = True
         return self
 
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
@@ -353,15 +415,28 @@ class _GatewayAnthropicStreamWithFallback:
                 self._record_terminal(outcome='cancelled', reason='client_cancelled')
             raise
         except StopAsyncIteration:
+            if self._using_gateway and not self._saw_output:
+                await self._switch_to_legacy_fallback_before_output(
+                    gateway_reason='empty_stream_before_output', error=None
+                )
+                return await self.__anext__()
             if self._should_record_terminal():
                 self._record_terminal(outcome='error', reason='stream_eof_before_message_stop')
             raise
         except Exception as exc:
+            if self._using_gateway and not self._saw_output and is_gateway_transport_failure(exc):
+                gateway_circuit.record_transport_failure()
+                self._observe_gateway_first_byte('transport_failure')
+                await self._switch_to_legacy_fallback_before_output(gateway_reason=_fallback_reason(exc), error=exc)
+                return await self.__anext__()
             if self._should_record_terminal():
                 phase = 'midstream' if self._saw_output else 'before_output'
                 self._record_terminal(outcome='error', reason=f'stream_{phase}_{_gateway_error_reason(exc)}')
             raise
 
+        if self._using_gateway and not self._saw_output:
+            gateway_circuit.record_transport_success()
+            self._observe_gateway_first_byte('success')
         self._saw_output = True
         event_type = getattr(event, 'type', None)
         if event_type == 'message_stop' and self._should_record_terminal():

--- a/backend/utils/llm/gateway_byok.py
+++ b/backend/utils/llm/gateway_byok.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 from pydantic import SecretStr
 
 from utils.llm.gateway_client import GatewayContextChatOpenAI, get_llm_gateway_base_url, get_llm_gateway_service_token
+from utils.llm.gateway_resilience import gateway_transport_timeout
 from utils.llm.usage_tracker import get_usage_callback
 
 _BYOK_GATEWAY_HEADER_PREFIX = 'X-Omi-Byok-'
@@ -50,6 +51,8 @@ def get_or_create_omi_gateway_llm_for_byok(
 
     options = options or {}
     base_url = f'{get_llm_gateway_base_url()}/v1'
+    request_timeout = options.get('request_timeout', gateway_transport_timeout())
+    max_retries = options.get('max_retries', 0)
     service_token = get_llm_gateway_service_token()
     default_headers: dict[str, str] = {
         'X-Omi-Service-Caller': 'backend',
@@ -68,8 +71,8 @@ def get_or_create_omi_gateway_llm_for_byok(
         service_token_cache_key,
         provider,
         key_fingerprint,
-        options.get('request_timeout', 120),
-        options.get('max_retries', 1),
+        repr(request_timeout),
+        max_retries,
         feature,
     )
     cached = _byok_gateway_llm_cache.get(cache_key)
@@ -80,8 +83,8 @@ def get_or_create_omi_gateway_llm_for_byok(
         'base_url': base_url,
         'callbacks': [_usage_callback],
         'default_headers': default_headers,
-        'request_timeout': options.get('request_timeout', 120),
-        'max_retries': options.get('max_retries', 1),
+        'request_timeout': request_timeout,
+        'max_retries': max_retries,
     }
     if streaming:
         kwargs['streaming'] = True

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any, TypeVar, cast
@@ -13,6 +14,7 @@ from langchain_openai import ChatOpenAI
 from pydantic import BaseModel, PrivateAttr, ValidationError
 
 from utils.llm.gateway_observability import record_direct_exception_surface, record_gateway_request_result
+from utils.llm.gateway_resilience import gateway_circuit, gateway_transport_timeout, observe_gateway_first_byte
 from utils.llm.usage_tracker import get_current_context
 
 LLM_GATEWAY_SERVICE_TOKEN_ENV_VAR = 'OMI_LLM_GATEWAY_SERVICE_TOKEN'
@@ -152,8 +154,12 @@ def invoke_chat_structured_gateway(
     call does not stall the event loop. Do **not** call this from ``async def``
     code without first offloading via ``run_blocking(llm_executor, ...)``.
     """
+    if not gateway_circuit.allow_request():
+        record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='circuit_open')
+        return None
+    gateway_started_at = time.monotonic()
     try:
-        with httpx.Client(timeout=timeout_seconds) as client:
+        with httpx.Client(timeout=_gateway_timeout(timeout_seconds)) as client:
             response = client.post(
                 f'{get_llm_gateway_base_url()}/v1/chat/completions',
                 headers=_gateway_headers(feature=feature),
@@ -174,19 +180,27 @@ def invoke_chat_structured_gateway(
             record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='invalid_json_shape')
             return None
         result = _validate_output_model(output_model, cast(Mapping[str, object], decoded))
+        gateway_circuit.record_transport_success()
+        observe_gateway_first_byte(feature=feature, started_at=gateway_started_at, outcome='success')
         record_chat_extraction_gateway_result(feature=feature, outcome='success', reason='ok')
         return result
     except httpx.HTTPStatusError as exc:
         reason = f'http_{exc.response.status_code}'
         if is_gateway_transport_status_code(exc.response.status_code):
+            gateway_circuit.record_transport_failure()
+            observe_gateway_first_byte(feature=feature, started_at=gateway_started_at, outcome='transport_failure')
             record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason=reason)
             return None
         record_chat_extraction_gateway_result(feature=feature, outcome='error', reason=reason)
         raise
     except httpx.TimeoutException:
+        gateway_circuit.record_transport_failure()
+        observe_gateway_first_byte(feature=feature, started_at=gateway_started_at, outcome='transport_failure')
         record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='timeout')
         return None
     except httpx.RequestError:
+        gateway_circuit.record_transport_failure()
+        observe_gateway_first_byte(feature=feature, started_at=gateway_started_at, outcome='transport_failure')
         record_chat_extraction_gateway_result(feature=feature, outcome='fallback', reason='request_error')
         return None
     except (ValidationError, JsonSchemaValidationError):
@@ -347,6 +361,19 @@ def _validate_output_model(
 ) -> StructuredOutput:
     validate_json_schema(instance=decoded, schema=_strict_model_json_schema(output_model))
     return output_model.model_validate(decoded)
+
+
+def _gateway_timeout(timeout_seconds: float) -> httpx.Timeout:
+    """Keep feature-specific total budgets while bounding the gateway connect/read hop."""
+
+    shared = gateway_transport_timeout()
+    bounded = min(timeout_seconds, shared.read or timeout_seconds)
+    return httpx.Timeout(
+        connect=shared.connect,
+        read=bounded,
+        write=bounded,
+        pool=shared.pool,
+    )
 
 
 def generate_image_via_gateway(

--- a/backend/utils/llm/gateway_resilience.py
+++ b/backend/utils/llm/gateway_resilience.py
@@ -1,0 +1,143 @@
+"""Bound gateway transport failures before they become user-visible stalls.
+
+The gateway is an optional serving hop: a transport failure may use the legacy
+provider, but it must never make every subsequent feature call wait for the
+upstream client timeout.  This module owns the process-local circuit state and
+the transport deadline used by every gateway-first client.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections.abc import Callable
+
+import httpx
+
+from utils.metrics import LLM_GATEWAY_CIRCUIT_OPEN, LLM_GATEWAY_CLIENT_FIRST_BYTE_SECONDS
+
+GATEWAY_CONNECT_TIMEOUT_SECONDS_ENV = 'OMI_LLM_GATEWAY_CONNECT_TIMEOUT_SECONDS'
+GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS_ENV = 'OMI_LLM_GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS'
+GATEWAY_CIRCUIT_FAILURE_THRESHOLD_ENV = 'OMI_LLM_GATEWAY_CIRCUIT_FAILURE_THRESHOLD'
+GATEWAY_CIRCUIT_COOLDOWN_SECONDS_ENV = 'OMI_LLM_GATEWAY_CIRCUIT_COOLDOWN_SECONDS'
+
+DEFAULT_GATEWAY_CONNECT_TIMEOUT_SECONDS = 3.0
+DEFAULT_GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS = 15.0
+DEFAULT_GATEWAY_CIRCUIT_FAILURE_THRESHOLD = 2
+DEFAULT_GATEWAY_CIRCUIT_COOLDOWN_SECONDS = 30.0
+
+
+def gateway_transport_timeout() -> httpx.Timeout:
+    """Return the shared bounded gateway transport timeout.
+
+    ``read`` is the SDK's first-response-byte deadline and also remains the
+    maximum silent interval while a streamed response is active.  A successful
+    stream is never replayed through the legacy provider after output begins.
+    """
+
+    connect = _positive_float(GATEWAY_CONNECT_TIMEOUT_SECONDS_ENV, DEFAULT_GATEWAY_CONNECT_TIMEOUT_SECONDS)
+    first_byte = _positive_float(GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS_ENV, DEFAULT_GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS)
+    return httpx.Timeout(connect=connect, read=first_byte, write=first_byte, pool=connect)
+
+
+def gateway_connect_timeout_seconds() -> float:
+    return _positive_float(GATEWAY_CONNECT_TIMEOUT_SECONDS_ENV, DEFAULT_GATEWAY_CONNECT_TIMEOUT_SECONDS)
+
+
+def gateway_first_byte_timeout_seconds() -> float:
+    return _positive_float(GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS_ENV, DEFAULT_GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS)
+
+
+def observe_gateway_first_byte(*, feature: str, started_at: float, outcome: str) -> None:
+    """Observe the bounded gateway hop without adding a serving dependency on metrics."""
+
+    try:
+        LLM_GATEWAY_CLIENT_FIRST_BYTE_SECONDS.labels(feature=feature, outcome=outcome).observe(
+            max(0.0, time.monotonic() - started_at)
+        )
+    except Exception:
+        return
+
+
+class GatewayCircuitBreaker:
+    """A small lock-protected circuit breaker for one backend process."""
+
+    def __init__(
+        self,
+        *,
+        failure_threshold: int | None = None,
+        cooldown_seconds: float | None = None,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._failure_threshold = failure_threshold or _positive_int(
+            GATEWAY_CIRCUIT_FAILURE_THRESHOLD_ENV, DEFAULT_GATEWAY_CIRCUIT_FAILURE_THRESHOLD
+        )
+        self._cooldown_seconds = cooldown_seconds or _positive_float(
+            GATEWAY_CIRCUIT_COOLDOWN_SECONDS_ENV, DEFAULT_GATEWAY_CIRCUIT_COOLDOWN_SECONDS
+        )
+        self._monotonic = monotonic
+        self._lock = threading.Lock()
+        self._consecutive_failures = 0
+        self._open_until = 0.0
+
+    def allow_request(self) -> bool:
+        with self._lock:
+            if self._monotonic() >= self._open_until:
+                if self._open_until:
+                    self._open_until = 0.0
+                    self._consecutive_failures = 0
+                    _set_circuit_metric(False)
+                return True
+            return False
+
+    def record_transport_success(self) -> None:
+        with self._lock:
+            self._consecutive_failures = 0
+            self._open_until = 0.0
+            _set_circuit_metric(False)
+
+    def record_transport_failure(self) -> None:
+        with self._lock:
+            self._consecutive_failures += 1
+            if self._consecutive_failures < self._failure_threshold:
+                return
+            self._open_until = self._monotonic() + self._cooldown_seconds
+            _set_circuit_metric(True)
+
+    def reset(self) -> None:
+        """Clear state for hermetic process-local tests."""
+
+        with self._lock:
+            self._consecutive_failures = 0
+            self._open_until = 0.0
+            _set_circuit_metric(False)
+
+
+def _positive_float(env_var: str, default: float) -> float:
+    raw = os.getenv(env_var, '').strip()
+    try:
+        value = float(raw) if raw else default
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _positive_int(env_var: str, default: int) -> int:
+    raw = os.getenv(env_var, '').strip()
+    try:
+        value = int(raw) if raw else default
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _set_circuit_metric(open_: bool) -> None:
+    try:
+        LLM_GATEWAY_CIRCUIT_OPEN.set(1 if open_ else 0)
+    except Exception:
+        # Resilience code must not make metrics availability part of serving.
+        return
+
+
+gateway_circuit = GatewayCircuitBreaker()

--- a/backend/utils/llm/gateway_serving.py
+++ b/backend/utils/llm/gateway_serving.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 import uuid
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, AsyncIterator, Iterator, TypeVar
@@ -56,6 +57,7 @@ except ImportError:  # pragma: no cover - stubbed test environments
 
 from utils.llm.gateway_client import GATEWAY_TRANSPORT_STATUS_CODES, feature_auto_lane_id
 from utils.llm.gateway_observability import record_gateway_request_result
+from utils.llm.gateway_resilience import gateway_circuit, observe_gateway_first_byte
 from utils.observability.fallback import record_fallback
 
 logger = logging.getLogger(__name__)
@@ -454,6 +456,15 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
         **kwargs: Any,
     ) -> ChatResult:
         gateway_kwargs, request_id = _gateway_call_kwargs(kwargs)
+        if not gateway_circuit.allow_request():
+            return _run_legacy_fallback(
+                feature=self.feature,
+                gateway_reason='circuit_open',
+                call=lambda: self.legacy_model._generate(messages, stop=stop, run_manager=run_manager, **kwargs),
+                request_id=request_id,
+                credential_source=self.credential_source,
+            )
+        gateway_started_at = time.monotonic()
         try:
             result = self.gateway_model._generate(messages, stop=stop, run_manager=run_manager, **gateway_kwargs)
         except Exception as exc:
@@ -467,6 +478,8 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
                     credential_source=self.credential_source,
                 )
                 raise
+            gateway_circuit.record_transport_failure()
+            observe_gateway_first_byte(feature=self.feature, started_at=gateway_started_at, outcome='transport_failure')
             return _run_legacy_fallback(
                 feature=self.feature,
                 gateway_reason=_fallback_reason(exc),
@@ -475,6 +488,8 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
                 credential_source=self.credential_source,
             )
 
+        gateway_circuit.record_transport_success()
+        observe_gateway_first_byte(feature=self.feature, started_at=gateway_started_at, outcome='success')
         _record_gateway_terminal(
             feature=self.feature,
             outcome='success',
@@ -493,6 +508,15 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
         **kwargs: Any,
     ) -> ChatResult:
         gateway_kwargs, request_id = _gateway_call_kwargs(kwargs)
+        if not gateway_circuit.allow_request():
+            return await _run_legacy_fallback_async(
+                feature=self.feature,
+                gateway_reason='circuit_open',
+                call=lambda: self.legacy_model._agenerate(messages, stop=stop, run_manager=run_manager, **kwargs),
+                request_id=request_id,
+                credential_source=self.credential_source,
+            )
+        gateway_started_at = time.monotonic()
         try:
             result = await self.gateway_model._agenerate(messages, stop=stop, run_manager=run_manager, **gateway_kwargs)
         except asyncio.CancelledError:
@@ -516,6 +540,8 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
                     credential_source=self.credential_source,
                 )
                 raise
+            gateway_circuit.record_transport_failure()
+            observe_gateway_first_byte(feature=self.feature, started_at=gateway_started_at, outcome='transport_failure')
             return await _run_legacy_fallback_async(
                 feature=self.feature,
                 gateway_reason=_fallback_reason(exc),
@@ -524,6 +550,8 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
                 credential_source=self.credential_source,
             )
 
+        gateway_circuit.record_transport_success()
+        observe_gateway_first_byte(feature=self.feature, started_at=gateway_started_at, outcome='success')
         _record_gateway_terminal(
             feature=self.feature,
             outcome='success',
@@ -544,9 +572,22 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
         yielded = False
         stream = None
         gateway_kwargs, request_id = _gateway_call_kwargs(kwargs)
+        if not gateway_circuit.allow_request():
+            yield from _iter_legacy_fallback(
+                feature=self.feature,
+                gateway_reason='circuit_open',
+                stream=self.legacy_model._stream(messages, stop=stop, run_manager=run_manager, **kwargs),
+                request_id=request_id,
+                credential_source=self.credential_source,
+            )
+            return
+        gateway_started_at = time.monotonic()
         try:
             stream = self.gateway_model._stream(messages, stop=stop, run_manager=run_manager, **gateway_kwargs)
             for chunk in stream:
+                if not yielded:
+                    gateway_circuit.record_transport_success()
+                    observe_gateway_first_byte(feature=self.feature, started_at=gateway_started_at, outcome='success')
                 yielded = True
                 yield chunk
         except GeneratorExit:
@@ -580,6 +621,8 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
                     credential_source=self.credential_source,
                 )
                 raise
+            gateway_circuit.record_transport_failure()
+            observe_gateway_first_byte(feature=self.feature, started_at=gateway_started_at, outcome='transport_failure')
             gateway_reason = _fallback_reason(exc)
         else:
             if yielded:
@@ -614,9 +657,27 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
         yielded = False
         stream = None
         gateway_kwargs, request_id = _gateway_call_kwargs(kwargs)
+        if not gateway_circuit.allow_request():
+            legacy_stream = _aiter_legacy_fallback(
+                feature=self.feature,
+                gateway_reason='circuit_open',
+                stream=self.legacy_model._astream(messages, stop=stop, run_manager=run_manager, **kwargs),
+                request_id=request_id,
+                credential_source=self.credential_source,
+            )
+            try:
+                async for chunk in legacy_stream:
+                    yield chunk
+            finally:
+                await _close_async_iterator(legacy_stream)
+            return
+        gateway_started_at = time.monotonic()
         try:
             stream = self.gateway_model._astream(messages, stop=stop, run_manager=run_manager, **gateway_kwargs)
             async for chunk in stream:
+                if not yielded:
+                    gateway_circuit.record_transport_success()
+                    observe_gateway_first_byte(feature=self.feature, started_at=gateway_started_at, outcome='success')
                 yielded = True
                 yield chunk
         except (GeneratorExit, asyncio.CancelledError):
@@ -650,6 +711,8 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
                     credential_source=self.credential_source,
                 )
                 raise
+            gateway_circuit.record_transport_failure()
+            observe_gateway_first_byte(feature=self.feature, started_at=gateway_started_at, outcome='transport_failure')
             gateway_reason = _fallback_reason(exc)
         else:
             if yielded:
@@ -699,6 +762,15 @@ class GatewayWithLegacyFallbackRunnable(Runnable):
 
     def invoke(self, input: Any, config: Any = None, **kwargs: Any) -> Any:
         gateway_kwargs, request_id = _gateway_call_kwargs(kwargs)
+        if not gateway_circuit.allow_request():
+            return _run_legacy_fallback(
+                feature=self._feature,
+                gateway_reason='circuit_open',
+                call=lambda: self._legacy.invoke(input, config=config, **kwargs),
+                request_id=request_id,
+                credential_source=self._credential_source,
+            )
+        gateway_started_at = time.monotonic()
         try:
             result = self._gateway.invoke(input, config=config, **gateway_kwargs)
         except Exception as exc:
@@ -712,6 +784,10 @@ class GatewayWithLegacyFallbackRunnable(Runnable):
                     credential_source=self._credential_source,
                 )
                 raise
+            gateway_circuit.record_transport_failure()
+            observe_gateway_first_byte(
+                feature=self._feature, started_at=gateway_started_at, outcome='transport_failure'
+            )
             return _run_legacy_fallback(
                 feature=self._feature,
                 gateway_reason=_fallback_reason(exc),
@@ -720,6 +796,8 @@ class GatewayWithLegacyFallbackRunnable(Runnable):
                 credential_source=self._credential_source,
             )
 
+        gateway_circuit.record_transport_success()
+        observe_gateway_first_byte(feature=self._feature, started_at=gateway_started_at, outcome='success')
         _record_gateway_terminal(
             feature=self._feature,
             outcome='success',
@@ -732,6 +810,15 @@ class GatewayWithLegacyFallbackRunnable(Runnable):
 
     async def ainvoke(self, input: Any, config: Any = None, **kwargs: Any) -> Any:
         gateway_kwargs, request_id = _gateway_call_kwargs(kwargs)
+        if not gateway_circuit.allow_request():
+            return await _run_legacy_fallback_async(
+                feature=self._feature,
+                gateway_reason='circuit_open',
+                call=lambda: self._legacy.ainvoke(input, config=config, **kwargs),
+                request_id=request_id,
+                credential_source=self._credential_source,
+            )
+        gateway_started_at = time.monotonic()
         try:
             result = await self._gateway.ainvoke(input, config=config, **gateway_kwargs)
         except asyncio.CancelledError:
@@ -755,6 +842,10 @@ class GatewayWithLegacyFallbackRunnable(Runnable):
                     credential_source=self._credential_source,
                 )
                 raise
+            gateway_circuit.record_transport_failure()
+            observe_gateway_first_byte(
+                feature=self._feature, started_at=gateway_started_at, outcome='transport_failure'
+            )
             return await _run_legacy_fallback_async(
                 feature=self._feature,
                 gateway_reason=_fallback_reason(exc),
@@ -763,6 +854,8 @@ class GatewayWithLegacyFallbackRunnable(Runnable):
                 credential_source=self._credential_source,
             )
 
+        gateway_circuit.record_transport_success()
+        observe_gateway_first_byte(feature=self._feature, started_at=gateway_started_at, outcome='success')
         _record_gateway_terminal(
             feature=self._feature,
             outcome='success',

--- a/backend/utils/llm/providers.py
+++ b/backend/utils/llm/providers.py
@@ -18,6 +18,7 @@ from langchain_openai import ChatOpenAI
 from pydantic import SecretStr
 
 from utils.llm.gateway_client import GatewayContextChatOpenAI, get_llm_gateway_base_url, get_llm_gateway_service_token
+from utils.llm.gateway_resilience import gateway_transport_timeout
 from utils.llm.usage_tracker import get_usage_callback
 
 logger = logging.getLogger(__name__)
@@ -94,6 +95,8 @@ def get_or_create_openai_compatible_llm(
     if key not in _llm_cache:
         kwargs: Dict[str, Any] = {
             'callbacks': [_usage_callback],
+            # The direct provider is the recovery path. Keep its established
+            # deadline/retry budget; only the optional gateway hop is short.
             'request_timeout': options.get('request_timeout', 120),
             'max_retries': options.get('max_retries', 1),
         }
@@ -127,6 +130,8 @@ def get_or_create_omi_gateway_llm(
 
     options = options or {}
     base_url = f'{get_llm_gateway_base_url()}/v1'
+    request_timeout = options.get('request_timeout', gateway_transport_timeout())
+    max_retries = options.get('max_retries', 0)
     service_token = get_llm_gateway_service_token()
     default_headers = {'X-Omi-Service-Caller': 'backend'}
     if service_token:
@@ -140,8 +145,8 @@ def get_or_create_omi_gateway_llm(
         {
             'base_url': base_url,
             'service_token': service_token_cache_key,
-            'request_timeout': options.get('request_timeout', 120),
-            'max_retries': options.get('max_retries', 1),
+            'request_timeout': repr(request_timeout),
+            'max_retries': max_retries,
             'feature': feature,
         },
     )
@@ -151,8 +156,8 @@ def get_or_create_omi_gateway_llm(
             'base_url': base_url,
             'callbacks': [_usage_callback],
             'default_headers': default_headers,
-            'request_timeout': options.get('request_timeout', 120),
-            'max_retries': options.get('max_retries', 1),
+            'request_timeout': request_timeout,
+            'max_retries': max_retries,
         }
         if streaming:
             kwargs['streaming'] = True

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -100,6 +100,18 @@ LLM_GATEWAY_CHAT_EXTRACTION_COMPARISONS = Counter(
     ['feature', 'field', 'outcome'],
 )
 
+LLM_GATEWAY_CIRCUIT_OPEN = Gauge(
+    'llm_gateway_circuit_open',
+    'Whether this backend process is bypassing the LLM gateway after transport failures',
+)
+
+LLM_GATEWAY_CLIENT_FIRST_BYTE_SECONDS = Histogram(
+    'llm_gateway_client_first_byte_seconds',
+    'Client time until the gateway returns a non-streaming response, first stream event, or transport failure',
+    ['feature', 'outcome'],
+    buckets=(0.1, 0.25, 0.5, 1, 2, 3, 5, 10, 15, 30),
+)
+
 OMI_FALLBACK_TOTAL = Counter(
     'omi_fallback_total',
     'Fallback / resilience transitions by component, path, reason, and outcome',

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -16,7 +16,7 @@ from pydantic import ValidationError
 
 import database.chat as chat_db
 from models.chat import ChatSession, FileChat
-from utils.executors import db_executor, run_blocking
+from utils.executors import db_executor, llm_executor, run_blocking
 from utils.llm.gateway_client import raise_if_gateway_feature_mode_blocks_direct_model_surface
 import logging
 
@@ -198,16 +198,21 @@ class FileChatTool:
             answer = await self._ask_vision_stream(question, files, callback)
             return answer
 
-        # _ensure_thread_and_assistant can fail before ask_stream runs.
-        # ask_stream has its own try/finally on callback, so only guard
-        # the setup phase here.
+        # The Assistants setup and stream iterator both use the synchronous
+        # OpenAI client. Keep the complete non-vision sequence off the event
+        # loop so graph.py can enforce its first-event and total-stream bounds.
+        return await run_blocking(llm_executor, self._ensure_and_ask_stream, question, file_ids, callback)
+
+    def _ensure_and_ask_stream(self, question: str, file_ids: List[str], callback: _StreamingCallbackProtocol) -> str:
+        """Run the synchronous Assistants setup and stream in the LLM executor."""
         try:
             self._ensure_thread_and_assistant()
         except Exception:
+            # ask_stream owns its callback finalizer; setup fails before that
+            # function is entered, so terminate the callback here instead.
             callback.end_nowait()
             raise
-        answer = self.ask_stream(self.uid, question, file_ids, self.thread_id, self.assistant_id, callback)
-        return answer
+        return self.ask_stream(self.uid, question, file_ids, self.thread_id, self.assistant_id, callback)
 
     async def _ask_vision_stream(
         self,
@@ -264,8 +269,8 @@ class FileChatTool:
             try:
                 thread = openai.beta.threads.retrieve(self.thread_id, timeout=timeout)  # type: ignore[reportDeprecated]  # Assistants API still in use
                 logger.info(f"Retrieved existing thread: {thread.id}")
-            except Exception as e:
-                logger.error(f"Failed to retrieve thread {self.thread_id}, creating new one. Error: {e}")
+            except Exception as error:
+                logger.error('file chat thread retrieval failed error_type=%s', type(error).__name__)
                 self.thread_id = None
 
         if not self.thread_id:
@@ -274,8 +279,8 @@ class FileChatTool:
                 self.thread_id = thread.id
                 created_new = True
                 logger.info(f"Created new thread: {self.thread_id}")
-            except Exception as e:
-                raise Exception(f"Failed to create OpenAI thread: {e}")
+            except Exception as error:
+                raise RuntimeError('failed to create OpenAI thread') from error
 
         # Handle assistant
         if self.assistant_id:
@@ -283,8 +288,8 @@ class FileChatTool:
             try:
                 assistant = openai.beta.assistants.retrieve(self.assistant_id, timeout=timeout)  # type: ignore[reportDeprecated]  # Assistants API still in use
                 logger.info(f"Retrieved existing assistant: {assistant.id}")
-            except Exception as e:
-                logger.error(f"Failed to retrieve assistant {self.assistant_id}, creating new one. Error: {e}")
+            except Exception as error:
+                logger.error('file chat assistant retrieval failed error_type=%s', type(error).__name__)
                 self.assistant_id = None
 
         if not self.assistant_id:
@@ -299,8 +304,8 @@ class FileChatTool:
                 self.assistant_id = assistant.id
                 created_new = True
                 logger.info(f"Created new assistant: {self.assistant_id}")
-            except Exception as e:
-                raise Exception(f"Failed to create OpenAI assistant: {e}")
+            except Exception as error:
+                raise RuntimeError('failed to create OpenAI assistant') from error
 
         # Save to database if we created new ones
         if created_new:
@@ -308,8 +313,8 @@ class FileChatTool:
                 chat_db.update_chat_session_openai_ids(
                     self.uid, self.chat_session_id, self.thread_id, self.assistant_id
                 )
-            except Exception as e:
-                logger.error(f"Failed to save thread/assistant IDs to database: {e}")
+            except Exception as error:
+                logger.error('file chat identifier save failed error_type=%s', type(error).__name__)
                 # Continue anyway - IDs will be recreated next time
 
     def _fill_question(self, uid: str, question: str, file_ids: List[str], thread_id: str) -> None:
@@ -421,17 +426,17 @@ class FileChatTool:
             for openai_file_id in _openai_file_ids(files):
                 try:
                     openai.files.delete(openai_file_id, timeout=30.0)
-                except Exception as e:
-                    logger.error(f"Failed to delete file {openai_file_id}: {e}")
+                except Exception as error:
+                    logger.error('file chat file deletion failed error_type=%s', type(error).__name__)
             chat_db.delete_multi_files(self.uid, files)
 
         if self.thread_id:
             try:
                 openai.beta.threads.delete(self.thread_id, timeout=30.0)  # type: ignore[reportDeprecated]  # Assistants API still in use
-            except Exception as e:
-                logger.error(f"Failed to delete thread {self.thread_id}: {e}")
+            except Exception as error:
+                logger.error('file chat thread deletion failed error_type=%s', type(error).__name__)
         if self.assistant_id:
             try:
                 openai.beta.assistants.delete(self.assistant_id, timeout=30.0)  # type: ignore[reportDeprecated]  # Assistants API still in use
-            except Exception as e:
-                logger.error(f"Failed to delete assistant {self.assistant_id}: {e}")
+            except Exception as error:
+                logger.error('file chat assistant deletion failed error_type=%s', type(error).__name__)

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -9,10 +9,11 @@ tool use API with streaming for real-time responses.
 import uuid
 import asyncio
 import contextvars
-import traceback
+import os
 from typing import List, Optional, AsyncGenerator, Any, Tuple
 
 from langchain_core.runnables import RunnableConfig
+from langchain_core.callbacks import BaseCallbackHandler
 
 # Context variable to store config for tools
 agent_config_context: contextvars.ContextVar[dict] = contextvars.ContextVar('agent_config', default=None)
@@ -71,6 +72,30 @@ except ImportError:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _positive_timeout_from_env(name: str, default: float) -> float:
+    """Read a positive stream deadline at import time so invalid deploy config fails fast."""
+    raw_value = os.environ.get(name, str(default))
+    try:
+        timeout = float(raw_value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f'{name} must be a number') from error
+    if timeout <= 0:
+        raise ValueError(f'{name} must be greater than zero')
+    return timeout
+
+
+# The first event must arrive before the client/proxy deadline. Afterwards a
+# heartbeat keeps a known-long tool call observable while the total deadline
+# still prevents an agent task from running without bound.
+AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS = _positive_timeout_from_env('AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS', 25.0)
+AGENT_STREAM_PROGRESS_HEARTBEAT_SECONDS = _positive_timeout_from_env('AGENT_STREAM_PROGRESS_HEARTBEAT_SECONDS', 20.0)
+AGENT_STREAM_MAX_DURATION_SECONDS = _positive_timeout_from_env('AGENT_STREAM_MAX_DURATION_SECONDS', 150.0)
+AGENT_STREAM_CANCEL_GRACE_SECONDS = _positive_timeout_from_env('AGENT_STREAM_CANCEL_GRACE_SECONDS', 2.0)
+AGENT_STREAM_PROGRESS_HEARTBEAT = 'Still working…'
+AGENT_STREAM_TIMEOUT_MESSAGE = 'The response took too long. Please try again.'
+AGENT_STREAM_FAILURE_MESSAGE = 'Unable to complete the response. Please try again.'
 
 # PROMPT CACHE OPTIMIZATION: This list MUST stay fixed and in this exact order.
 # Anthropic caches the tools array as part of the request prefix.  If the tool
@@ -161,7 +186,7 @@ def get_tool_display_name(tool_name: str, tool_obj: Optional[Any] = None) -> str
     return tool_name.replace('_', ' ').title()
 
 
-class AsyncStreamingCallback:
+class AsyncStreamingCallback(BaseCallbackHandler):
     """Callback for streaming LLM responses with data and thought prefixes."""
 
     def __init__(self):
@@ -190,6 +215,18 @@ class AsyncStreamingCallback:
 
     def end_nowait(self):
         self.queue.put_nowait(None)
+
+    async def on_llm_new_token(self, token: str, **_kwargs) -> None:
+        """Bridge LangChain streaming callbacks for persona chat."""
+        await self.put_data(token)
+
+    async def on_llm_end(self, _response, **_kwargs) -> None:
+        """Always terminate the persona callback queue on normal completion."""
+        await self.end()
+
+    async def on_llm_error(self, _error: Exception, **_kwargs) -> None:
+        """Terminate the persona callback queue without exposing provider details."""
+        await self.end()
 
 
 # ---------------------------------------------------------------------------
@@ -545,6 +582,67 @@ async def _run_anthropic_agent_stream(
 # ---------------------------------------------------------------------------
 
 
+async def next_stream_chunk(callback: AsyncStreamingCallback, task: asyncio.Task, timeout_seconds: float) -> str | None:
+    """Return the next callback chunk while supervising the producer task.
+
+    The callback queue is not a completion primitive: an uncaught producer
+    error can leave it empty forever. Race the queue receive against the
+    producer so unexpected completion is surfaced immediately, and bound an
+    otherwise silent dependency stall below the client/proxy deadline.
+    """
+    queue_get_task = asyncio.create_task(callback.queue.get())
+    try:
+        completed, _pending = await asyncio.wait(
+            {queue_get_task, task},
+            timeout=timeout_seconds,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if queue_get_task in completed:
+            return queue_get_task.result()
+
+        if task in completed:
+            try:
+                task.result()
+            except asyncio.CancelledError as error:
+                raise RuntimeError('agent producer was cancelled') from error
+            raise RuntimeError('agent producer exited without an end-of-stream callback')
+
+        raise asyncio.TimeoutError
+    finally:
+        if not queue_get_task.done():
+            queue_get_task.cancel()
+            try:
+                await queue_get_task
+            except asyncio.CancelledError:
+                pass
+
+
+async def cancel_stream_task(task: asyncio.Task) -> None:
+    """Request cancellation without letting a non-cooperative dependency hold the SSE open."""
+    if task.done():
+        return
+
+    task.cancel()
+    completed, _pending = await asyncio.wait({task}, timeout=AGENT_STREAM_CANCEL_GRACE_SECONDS)
+    if task not in completed:
+        # A dependency that suppresses cancellation must not keep a client
+        # request alive. Retain a done callback solely to consume any eventual
+        # exception rather than leaking an unhandled-task warning.
+        task.cancel()
+        task.add_done_callback(_consume_agent_task_exception)
+        logger.error('Agent stream producer ignored cancellation within %.1fs', AGENT_STREAM_CANCEL_GRACE_SECONDS)
+
+
+def _consume_agent_task_exception(task: asyncio.Task) -> None:
+    """Consume a detached task result without logging raw provider data."""
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        pass
+    except Exception as error:
+        logger.error('Detached agent stream producer failed error_type=%s', type(error).__name__)
+
+
 @_traceable(name="chat.anthropic.stream", run_type="chain")
 async def execute_agentic_chat_stream(
     uid: str,
@@ -558,37 +656,52 @@ async def execute_agentic_chat_stream(
 
     Yields formatted chunks with "data: " or "think: " prefixes.
     """
-    # Resolve the user's timezone once and reuse it for both the system prompt and the
-    # injected datetime block, avoiding a duplicate notification_db lookup per request.
-    # These setup helpers do blocking Firestore reads (and a LangSmith prompt fetch inside
-    # _get_agentic_qa_prompt); offload them so they don't block the event loop while this
-    # async generator is driven on the loop by StreamingResponse. (get_current_datetime_block
-    # below stays inline — with tz passed it's pure formatting, no I/O.)
-    tz = await run_blocking(db_executor, get_user_timezone, uid)
-
-    # Build system prompt
-    system_prompt = await run_blocking(db_executor, _get_agentic_qa_prompt, uid, app, messages, context=context, tz=tz)
-
-    # Get prompt metadata for tracing/versioning
-    prompt_name, prompt_commit, prompt_source = None, None, None
+    first_event_deadline = asyncio.get_running_loop().time() + AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS
     try:
-        from utils.observability.langsmith_prompts import get_prompt_metadata
+        # Resolve the user's timezone once and reuse it for both the system prompt and the
+        # injected datetime block, avoiding a duplicate notification_db lookup per request.
+        # These helpers perform Firestore and LangSmith I/O before the producer task exists,
+        # so they share the first-event deadline instead of leaving the SSE body silent.
+        async with asyncio.timeout(AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS):
+            tz = await run_blocking(db_executor, get_user_timezone, uid)
+            system_prompt = await run_blocking(
+                db_executor, _get_agentic_qa_prompt, uid, app, messages, context=context, tz=tz
+            )
 
-        prompt_name, prompt_commit, prompt_source = get_prompt_metadata()
-    except Exception as e:
-        logger.error(f"Could not get prompt metadata: {e}")
+            # Get prompt metadata for tracing/versioning
+            prompt_name, prompt_commit, prompt_source = None, None, None
+            try:
+                from utils.observability.langsmith_prompts import get_prompt_metadata
 
-    # Core tools (fixed order) — always visible to Claude
-    core_tools = list(CORE_TOOLS)
+                prompt_name, prompt_commit, prompt_source = get_prompt_metadata()
+            except Exception as error:
+                logger.error('Could not get prompt metadata error_type=%s', type(error).__name__)
 
-    # Dynamic app tools — deferred, discovered on-demand via tool search
-    app_tools = []
-    try:
-        app_tools = await run_blocking(db_executor, load_app_tools, uid)
-        if app_tools:
-            logger.info(f"Loaded {len(app_tools)} app tools (deferred via tool search)")
-    except Exception as e:
-        logger.error(f"Error loading app tools: {e}")
+            # Core tools (fixed order) — always visible to Claude
+            core_tools = list(CORE_TOOLS)
+
+            # Dynamic app tools — deferred, discovered on-demand via tool search
+            app_tools = []
+            try:
+                app_tools = await run_blocking(db_executor, load_app_tools, uid)
+                if app_tools:
+                    logger.info(f"Loaded {len(app_tools)} app tools (deferred via tool search)")
+            except Exception as error:
+                logger.error('Error loading app tools error_type=%s', type(error).__name__)
+    except asyncio.TimeoutError:
+        logger.warning('Agent stream timed out before the producer started uid=%s', uid)
+        if callback_data is not None:
+            callback_data['error'] = 'setup_timeout'
+        yield f'error: {AGENT_STREAM_TIMEOUT_MESSAGE}'
+        return
+    except asyncio.CancelledError:
+        raise
+    except Exception as error:
+        logger.error('Agent stream setup failed uid=%s error_type=%s', uid, type(error).__name__)
+        if callback_data is not None:
+            callback_data['error'] = type(error).__name__
+        yield f'error: {AGENT_STREAM_FAILURE_MESSAGE}'
+        return
 
     # Append app tool awareness to system prompt so Claude knows to search for them
     if app_tools:
@@ -672,12 +785,36 @@ You have fetch_url_tool available. When the user shares any URL (starting with h
 
     # Stream from callback queue
     try:
+        started_at = asyncio.get_running_loop().time()
+        received_first_event = False
         while True:
-            chunk = await callback.queue.get()
+            remaining_seconds = AGENT_STREAM_MAX_DURATION_SECONDS - (asyncio.get_running_loop().time() - started_at)
+            if remaining_seconds <= 0:
+                raise asyncio.TimeoutError
+
+            wait_timeout = min(
+                (
+                    max(0, first_event_deadline - asyncio.get_running_loop().time())
+                    if not received_first_event
+                    else AGENT_STREAM_PROGRESS_HEARTBEAT_SECONDS
+                ),
+                remaining_seconds,
+            )
+            try:
+                chunk = await next_stream_chunk(callback, task, wait_timeout)
+            except asyncio.TimeoutError:
+                # A successful first status/token means the agent can be in a
+                # deliberately long tool call (some app tools allow 120s).
+                # Keep the proxy/client stream alive until the hard task cap.
+                if received_first_event and remaining_seconds > wait_timeout:
+                    yield f'think: {AGENT_STREAM_PROGRESS_HEARTBEAT}'
+                    continue
+                raise
             if chunk is None:
                 break
 
-            if chunk.startswith("think: "):
+            received_first_event = True
+            if chunk.startswith("think: ") and chunk != f'think: {AGENT_STREAM_PROGRESS_HEARTBEAT}':
                 tool_usage_count += 1
 
             yield chunk
@@ -694,13 +831,25 @@ You have fetch_url_tool available. When the user shares any URL (starting with h
                 callback_data['chart_data'] = chart_data_from_config
             logger.info(f"Collected {len(callback_data['memories_found'])} conversations for citation")
 
-    except asyncio.CancelledError:
-        task.cancel()
-        raise
-    except Exception as e:
-        logger.error(f"Error in execute_agentic_chat_stream: {e}")
-        traceback.print_exc()
+    except asyncio.TimeoutError:
+        logger.warning('Agent stream reached its bounded deadline uid=%s', uid)
+        await cancel_stream_task(task)
         if callback_data is not None:
-            callback_data['error'] = str(e)
+            callback_data['error'] = 'idle_timeout'
+        yield f'error: {AGENT_STREAM_TIMEOUT_MESSAGE}'
+        return
+    except asyncio.CancelledError:
+        await cancel_stream_task(task)
+        raise
+    except Exception as error:
+        logger.error('Agent stream failed uid=%s error_type=%s', uid, type(error).__name__)
+        await cancel_stream_task(task)
+        if callback_data is not None:
+            callback_data['error'] = type(error).__name__
+        yield f'error: {AGENT_STREAM_FAILURE_MESSAGE}'
+        return
+    finally:
+        if not task.done():
+            task.cancel()
 
     yield None  # Signal completion

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -191,6 +191,21 @@ class AsyncStreamingCallback(BaseCallbackHandler):
 
     def __init__(self):
         self.queue = asyncio.Queue()
+        # Sync providers can invoke the nowait methods from an executor worker.
+        # asyncio.Queue is bound to this request loop, so its mutation must always
+        # be marshalled back to that loop instead of happening from the worker.
+        self._loop = asyncio.get_running_loop()
+
+    def _put_nowait_threadsafe(self, value: str | None) -> None:
+        """Queue a synchronous callback value on the loop that owns the response."""
+        if self._loop.is_closed():
+            return
+        try:
+            self._loop.call_soon_threadsafe(self.queue.put_nowait, value)
+        except RuntimeError:
+            # The request loop can close after a bounded stream is cancelled while
+            # a non-cooperative sync provider is still unwinding in its worker.
+            return
 
     async def put_data(self, text):
         await self.queue.put(f"data: {text}")
@@ -203,18 +218,18 @@ class AsyncStreamingCallback(BaseCallbackHandler):
 
     def put_thought_nowait(self, text, app_id: Optional[str] = None):
         if app_id:
-            self.queue.put_nowait(f"think: {text}|app_id:{app_id}")
+            self._put_nowait_threadsafe(f"think: {text}|app_id:{app_id}")
         else:
-            self.queue.put_nowait(f"think: {text}")
+            self._put_nowait_threadsafe(f"think: {text}")
 
     def put_data_nowait(self, text):
-        self.queue.put_nowait(f"data: {text}")
+        self._put_nowait_threadsafe(f"data: {text}")
 
     async def end(self):
         await self.queue.put(None)
 
     def end_nowait(self):
-        self.queue.put_nowait(None)
+        self._put_nowait_threadsafe(None)
 
     async def on_llm_new_token(self, token: str, **_kwargs) -> None:
         """Bridge LangChain streaming callbacks for persona chat."""

--- a/backend/utils/retrieval/graph.py
+++ b/backend/utils/retrieval/graph.py
@@ -24,11 +24,72 @@ from utils.llm.clients import get_llm
 from utils.llm.usage_tracker import Features, track_usage
 from utils.executors import run_blocking, llm_executor
 from utils.other.chat_file import FileChatTool
-from utils.retrieval.agentic import AsyncStreamingCallback, execute_agentic_chat_stream
+from utils.retrieval.agentic import (
+    AGENT_STREAM_FAILURE_MESSAGE,
+    AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS,
+    AGENT_STREAM_MAX_DURATION_SECONDS,
+    AGENT_STREAM_PROGRESS_HEARTBEAT,
+    AGENT_STREAM_PROGRESS_HEARTBEAT_SECONDS,
+    AGENT_STREAM_TIMEOUT_MESSAGE,
+    AsyncStreamingCallback,
+    cancel_stream_task,
+    execute_agentic_chat_stream,
+    next_stream_chunk,
+)
 from utils.observability.langsmith import get_chat_tracer_callbacks
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+async def _drain_chat_callback(
+    callback: AsyncStreamingCallback, task: asyncio.Task, *, route: str
+) -> AsyncGenerator[str | None, None]:
+    """Drain a callback queue without allowing its producer to strand an SSE response."""
+    started_at = asyncio.get_running_loop().time()
+    received_first_event = False
+    try:
+        while True:
+            remaining_seconds = AGENT_STREAM_MAX_DURATION_SECONDS - (asyncio.get_running_loop().time() - started_at)
+            if remaining_seconds <= 0:
+                raise asyncio.TimeoutError
+
+            wait_timeout = min(
+                (
+                    AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS
+                    if not received_first_event
+                    else AGENT_STREAM_PROGRESS_HEARTBEAT_SECONDS
+                ),
+                remaining_seconds,
+            )
+            try:
+                chunk = await next_stream_chunk(callback, task, wait_timeout)
+            except asyncio.TimeoutError:
+                if received_first_event and remaining_seconds > wait_timeout:
+                    yield f'think: {AGENT_STREAM_PROGRESS_HEARTBEAT}'
+                    continue
+                raise
+
+            if chunk is None:
+                await task
+                return
+
+            received_first_event = True
+            yield chunk
+    except asyncio.TimeoutError:
+        logger.warning('%s chat stream reached its bounded deadline', route)
+        await cancel_stream_task(task)
+        yield f'error: {AGENT_STREAM_TIMEOUT_MESSAGE}'
+    except asyncio.CancelledError:
+        await cancel_stream_task(task)
+        raise
+    except Exception as error:
+        logger.error('%s chat stream failed error_type=%s', route, type(error).__name__)
+        await cancel_stream_task(task)
+        yield f'error: {AGENT_STREAM_FAILURE_MESSAGE}'
+    finally:
+        if not task.done():
+            task.cancel()
 
 
 # ---------------------------------------------------------------------------
@@ -85,13 +146,14 @@ async def _execute_file_chat_stream(
 
         task = asyncio.create_task(_produce())
 
-        # Drain the queue concurrently while the producer runs
-        while True:
-            chunk = await callback.queue.get()
+        async for chunk in _drain_chat_callback(callback, task, route='file'):
+            if chunk and chunk.startswith('error: '):
+                if callback_data is not None:
+                    callback_data['error'] = 'stream_failure'
+                yield chunk
+                return
             if chunk:
                 yield chunk
-            else:
-                break
 
         answer = await task
 
@@ -174,17 +236,16 @@ async def execute_persona_chat_stream(
                 )
             )
 
-        while True:
-            try:
-                chunk = await callback.queue.get()
-                if chunk:
-                    token = chunk.replace("data: ", "")
-                    full_response.append(token)
-                    yield chunk
-                else:
-                    break
-            except asyncio.CancelledError:
-                break
+        async for chunk in _drain_chat_callback(callback, task, route='persona'):
+            if chunk and chunk.startswith('error: '):
+                if callback_data is not None:
+                    callback_data['error'] = 'stream_failure'
+                yield chunk
+                return
+            if chunk:
+                if chunk.startswith("data: "):
+                    full_response.append(chunk.removeprefix("data: "))
+                yield chunk
 
         await task
 

--- a/backend/utils/retrieval/graph.py
+++ b/backend/utils/retrieval/graph.py
@@ -22,7 +22,7 @@ from models.chat import ChatSession, Message, PageContext
 from utils.llm.chat import retrieve_is_file_question
 from utils.llm.clients import get_llm
 from utils.llm.usage_tracker import Features, track_usage
-from utils.executors import run_blocking, llm_executor
+from utils.executors import db_executor, llm_executor, run_blocking
 from utils.other.chat_file import FileChatTool
 from utils.retrieval.agentic import (
     AGENT_STREAM_FAILURE_MESSAGE,
@@ -123,12 +123,6 @@ async def _execute_file_chat_stream(
     last_message = messages[-1] if messages else None
     question = last_message.text if last_message else ""
 
-    try:
-        fc_tool = FileChatTool(uid, chat_session.id)
-    except Exception as e:
-        logger.error(f"Failed to create FileChatTool: {e}")
-        raise
-
     # Determine which files to use
     if last_message and last_message.files_id and len(last_message.files_id) > 0:
         file_ids = last_message.files_id
@@ -140,8 +134,11 @@ async def _execute_file_chat_stream(
     callback = AsyncStreamingCallback()
 
     try:
-        # Run the producer as a concurrent task so chunks stream in real-time
+        # The constructor reads Firestore synchronously, so it belongs inside
+        # the supervised producer as well. That starts the first-event deadline
+        # before any blocking file-chat setup can hold the event loop.
         async def _produce() -> str:
+            fc_tool = await run_blocking(db_executor, FileChatTool, uid, chat_session.id)
             return await fc_tool.process_chat_with_file_stream(question, file_ids, callback=cast(Any, callback))
 
         task = asyncio.create_task(_produce())
@@ -163,11 +160,11 @@ async def _execute_file_chat_stream(
             callback_data['ask_for_nps'] = True
 
         yield None
-    except Exception as e:
-        logger.error(f"Error in file chat: {e}")
+    except Exception as error:
+        logger.error('file chat stream failed error_type=%s', type(error).__name__)
         if callback_data is not None:
-            callback_data['error'] = str(e)
-        yield None
+            callback_data['error'] = 'stream_failure'
+        yield f'error: {AGENT_STREAM_FAILURE_MESSAGE}'
 
 
 # ---------------------------------------------------------------------------
@@ -257,11 +254,11 @@ async def execute_persona_chat_stream(
         yield None
         return
 
-    except Exception as e:
-        logger.error(f"Error in execute_persona_chat_stream: {e}")
+    except Exception as error:
+        logger.error('persona chat stream failed error_type=%s', type(error).__name__)
         if callback_data is not None:
-            callback_data['error'] = str(e)
-        yield None
+            callback_data['error'] = 'stream_failure'
+        yield f'error: {AGENT_STREAM_FAILURE_MESSAGE}'
         return
 
 


### PR DESCRIPTION
## Summary

- Bound chat streaming and gateway-first transport failures so a dead optional hop falls back without repeated 120-second waits.
- Keep production gateway serving **off** by default; derive any future promoted Cloud Run gateway endpoint from the ready ingress/ILB instead of a configured IP.
- Gate every gateway-first backend deploy on ready workload/service/endpoints, the attached internal forwarding rule, and an authenticated real-route probe from the serving Cloud Run VPC path.
- Add per-process gateway circuit breaking, client first-byte telemetry, and deployed alerts for fallback/circuit/zero-success/latency/endpoint failures.
- Offload file-chat setup and synchronous assistant streaming work from the event loop, so the SSE first-event deadline and terminal error frame can run even when setup stalls.

## Verification

- Focused gateway/SSE/file-chat suite after rebase: **49 passed**.
- Earlier focused project-file selection: 128 tests passed.
- Async-blocker scan: 0 selected findings.
- YAML/JSON parse validation, Python compilation, shell syntax validation, and `git diff --check`.
- Live GKE/ILB/Cloud Run VPC probe intentionally runs as the deploy gate; it was not run from a local workstation.

## Failure class

Failure-Class: FC-per-hop-timeout
