### PR TITLE
fix cached conversations crash on missing plugin_id

### DIFF
--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -366,6 +366,17 @@ class ServerConversation {
     if (structured != null) {
       normalized['structured'] = structured.toGenerated().toJson();
     }
+    // Legacy caches (< toJson wire-format fix) wrote plugins_results entries as
+    // {'appId', 'content'}; the wire parser requires the plugin_id key.
+    final rawPluginResults = normalized['plugins_results'];
+    if (rawPluginResults is List) {
+      normalized['plugins_results'] = rawPluginResults.map((entry) {
+        if (entry is Map<String, dynamic> && !entry.containsKey('plugin_id')) {
+          return {...entry, 'plugin_id': entry['appId'] ?? entry['app_id']};
+        }
+        return entry;
+      }).toList();
+    }
     final generated = wire.GeneratedConversation.fromJson(normalized);
     return ServerConversation.fromGenerated(
       generated,
@@ -388,7 +399,9 @@ class ServerConversation {
       startedAt: generated.startedAt,
       finishedAt: generated.finishedAt,
       transcriptSegments: generated.transcriptSegments.map(_transcriptSegmentFromGenerated).toList(),
-      appResults: generated.appsResults.map(AppResponse.fromGenerated).toList(),
+      appResults: generated.appsResults.isNotEmpty
+          ? generated.appsResults.map(AppResponse.fromGenerated).toList()
+          : generated.pluginsResults.map((result) => AppResponse(result.content, appId: result.pluginId)).toList(),
       suggestedSummarizationApps: generated.suggestedSummarizationApps,
       geolocation:
           geolocation ?? (generated.geolocation == null ? null : Geolocation.fromGenerated(generated.geolocation!)),
@@ -423,7 +436,10 @@ class ServerConversation {
       'started_at': startedAt?.toUtc().toIso8601String(),
       'finished_at': finishedAt?.toUtc().toIso8601String(),
       'transcript_segments': transcriptSegments.map((segment) => segment.toJson()).toList(),
-      'plugins_results': appResults.map((result) => result.toJson()).toList(),
+      'apps_results': appResults.map((result) => result.toGenerated().toJson()).toList(),
+      'plugins_results': appResults.map((result) {
+        return wire.GeneratedPluginResult(pluginId: result.appId, content: result.content).toJson();
+      }).toList(),
       'suggested_summarization_apps': suggestedSummarizationApps,
       'geolocation': geolocation?.toJson(),
       'photos': photos.map((photo) => photo.toJson()).toList(),

--- a/app/test/unit/conversation_cache_roundtrip_test.dart
+++ b/app/test/unit/conversation_cache_roundtrip_test.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+
+ServerConversation _conversation({List<AppResponse> appResults = const []}) {
+  return ServerConversation(
+    id: 'test-id',
+    createdAt: DateTime.utc(2026, 7, 1, 12, 0, 0),
+    structured: Structured('Test', 'Test'),
+    appResults: appResults,
+  );
+}
+
+void main() {
+  group('ServerConversation cache round trip', () {
+    test('toJson output with app results parses back without throwing and preserves them', () {
+      final conv = _conversation(appResults: [AppResponse('summary text', appId: 'app-1')]);
+      final restored = ServerConversation.fromJson(jsonDecode(jsonEncode(conv.toJson())));
+      expect(restored.appResults, hasLength(1));
+      expect(restored.appResults.first.appId, 'app-1');
+      expect(restored.appResults.first.content, 'summary text');
+    });
+
+    test('legacy cache entry with appId-keyed plugins_results does not crash and recovers app results', () {
+      // Written by ServerConversation.toJson before the wire-format fix:
+      // plugins_results entries had 'appId' instead of the required 'plugin_id' key.
+      final legacyJson = {
+        'id': 'legacy-id',
+        'created_at': '2026-07-01T12:00:00.000Z',
+        'structured': {'title': 'Legacy', 'overview': ''},
+        'started_at': null,
+        'finished_at': null,
+        'plugins_results': [
+          {'appId': 'app-1', 'content': 'legacy summary'},
+        ],
+      };
+      final restored = ServerConversation.fromJson(legacyJson);
+      expect(restored.appResults, hasLength(1));
+      expect(restored.appResults.first.appId, 'app-1');
+      expect(restored.appResults.first.content, 'legacy summary');
+    });
+
+    test('plugin result with null plugin_id round trips', () {
+      final conv = _conversation(appResults: [AppResponse('no app id', appId: null)]);
+      final restored = ServerConversation.fromJson(jsonDecode(jsonEncode(conv.toJson())));
+      expect(restored.appResults, hasLength(1));
+      expect(restored.appResults.first.appId, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Crash

Crashlytics [cc235c2f374b36f10489f755620ab120](https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/cc235c2f374b36f10489f755620ab120): `FlutterError - FormatException: Missing required field: plugin_id`, thrown from `GeneratedPluginResult.fromJson` while `SharedPreferencesUtil.cachedConversations` parses the conversation cache during `ConversationProvider.getInitialConversations` — a fatal crash on app startup.

## Root cause

`ServerConversation.toJson()` (the cache write path) serialized `plugins_results` entries via `AppResponse.toJson()`, which emits `{'appId', 'content'}`. The wire parser `GeneratedPluginResult.fromJson` requires the `plugin_id` key to be present (per the OpenAPI spec, `PluginResult.plugin_id` is required-but-nullable). So any user with at least one app result in a cached conversation crashed on the next launch. Separately, the cache never wrote `apps_results`, which is the key `ServerConversation.fromGenerated` actually reads app results from — so cached app results were silently dropped even when parsing succeeded.

## Fix

- `ServerConversation.toJson()` now writes wire-format `plugins_results` (`{'plugin_id', 'content'}`) and also `apps_results`, so the cache round-trips cleanly through the generated wire parser.
- `ServerConversation.fromJson()` normalizes legacy cache entries that lack the `plugin_id` key (recovering the id from `appId`/`app_id`), so caches already corrupted in the wild parse instead of crashing after the update.
- `ServerConversation.fromGenerated()` falls back to `plugins_results` when `apps_results` is empty, recovering app results from legacy caches.

## Verification

- New regression test `app/test/unit/conversation_cache_roundtrip_test.dart` (3 tests): toJson→fromJson round trip preserves app results; a legacy cache entry with `appId`-keyed `plugins_results` (the exact Crashlytics shape) parses and recovers the app result — this test throws the reported `FormatException` before the fix; null `plugin_id` round trips.
- `bash app/test.sh`: all 865 tests pass.
- `dart analyze` on the changed files: no errors or warnings (only pre-existing info-level lints).

## Product invariants affected

none

Failure-Class: FC-malformed-doc-read

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

