### PR TITLE
fix(payment): show Plus/Unlimited transcription terms on the plan card

### DIFF
--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -144,3 +144,17 @@ def test_wire_plan_remaps_mobile_tiers_only_for_clients_without_the_enum(monkeyp
     # Non-mobile plans are never remapped.
     assert wire(PlanType.unlimited, 'ios', '1.0.600') == PlanType.unlimited
     assert wire(PlanType.operator, 'ios', '1.0.600') == PlanType.operator
+
+
+def test_plus_and_unlimited_v2_features_state_transcription_limits(subscription_module):
+    """Mobile cards render get_plan_features; Plus/Unlimited must state their
+    transcription terms, not fall through to the Free-tier feature list."""
+    m = subscription_module
+    plus_mobile = m.get_plan_features(PlanType.plus, simplified=True)
+    unlim_mobile = m.get_plan_features(PlanType.unlimited_v2, simplified=True)
+
+    assert any("minutes of transcription" in f for f in plus_mobile), plus_mobile
+    assert any(f"{m.PLUS_TIER_MINUTES_LIMIT_PER_MONTH:,}" in f for f in plus_mobile), plus_mobile
+    assert any("Unlimited transcription" in f for f in unlim_mobile), unlim_mobile
+    # Must not leak the Free-tier "Unlimited listening time" fallback.
+    assert not any("listening" in f for f in plus_mobile), plus_mobile

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -963,6 +963,30 @@ def get_plan_features(plan: PlanType, simplified: bool = False) -> List[str]:
             "Desktop capture with Free-tier allowance",
         ]
 
+    if plan == PlanType.plus:
+        if simplified:
+            return [
+                f"{PLUS_TIER_MINUTES_LIMIT_PER_MONTH:,} minutes of transcription per month",
+                f"{PLUS_CHAT_QUESTIONS_PER_MONTH} chat questions per month",
+            ]
+        return [
+            f"{PLUS_TIER_MINUTES_LIMIT_PER_MONTH:,} minutes of transcription per month",
+            f"{PLUS_CHAT_QUESTIONS_PER_MONTH} chat questions per month",
+            "Unlimited memories and insights",
+        ]
+
+    if plan == PlanType.unlimited_v2:
+        if simplified:
+            return [
+                "Unlimited transcription",
+                f"{UNLIMITED_V2_CHAT_QUESTIONS_PER_MONTH} chat questions per month",
+            ]
+        return [
+            "Unlimited transcription",
+            f"{UNLIMITED_V2_CHAT_QUESTIONS_PER_MONTH} chat questions per month",
+            "Unlimited memories and insights",
+        ]
+
     # Basic plan
     return [
         (


### PR DESCRIPTION
## Problem

The **Plus** plan card on mobile didn't show its "1,500 minutes" transcription limit — it showed the **Free-tier** feature list ("600 minutes of listening per month", "Unlimited memories"), reading as *unlimited*. Reported after #9935 merged.

## Cause

The mobile card renders `get_plan_features(plan_type)` (the `subtitle`/`description` I set in the catalog aren't fields on the mobile `SubscriptionPlan` model). `get_plan_features` had **no `plus` / `unlimited_v2` branch**, so both fell through to the Basic/Free feature list.

## Fix

Add the branches:
- **Plus** → `1,500 minutes of transcription per month`, `200 chat questions per month`
- **Unlimited** → `Unlimited transcription`, `1000 chat questions per month`

(both mobile-simplified and full/web variants). Amounts read from the same env-overridable constants as the limits.

## Verification

- New regression test asserts the Plus/Unlimited feature lists state their transcription terms and no longer leak the Free-tier "listening" copy.
- `pytest tests/unit/test_subscription_plans.py` (9) + `test_subscription_restructure.py` (28) → **37 passed**.

Needs the same on-device check after deploy: the Plus card should read "1,500 minutes of transcription per month".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

