### PR TITLE
fix(deploy): raise backend-listen progressDeadlineSeconds to 1800s

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -1,3 +1,4 @@
+progressDeadlineSeconds: 1800
 # Default values for backend-listen.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -1,3 +1,4 @@
+progressDeadlineSeconds: 1800
 # Default values for backend-listen.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/backend/charts/backend-listen/templates/deployment.yaml
+++ b/backend/charts/backend-listen/templates/deployment.yaml
@@ -8,6 +8,10 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  # A 12-60 HPA replica rollout paced by node autoscaler routinely needs >600s
+  # (the k8s default); the deploy CLI already waits 1800s. Keep these aligned so
+  # a healthy-but-slow rollout finishes instead of failing at the k8s deadline.
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds | default 1800 }}
   selector:
     matchLabels:
       {{- include "backend-listen.selectorLabels" . | nindent 6 }}

--- a/backend/tests/unit/test_verify_dev_backend_deployment.py
+++ b/backend/tests/unit/test_verify_dev_backend_deployment.py
@@ -560,3 +560,18 @@ def test_backend_listen_rollout_wait_can_cover_a_real_rollout():
                 f'{relative} waits {value}s on backend-listen, but a roll at the HPA floor needs '
                 f'>= {required_seconds}s ({waves} waves x {per_pod_startup_seconds}s startup budget)'
             )
+
+    # The k8s deadline is the actual failure point (kubectl returns
+    # ProgressDeadlineExceeded the moment it trips, regardless of the CLI
+    # --timeout). It defaults to 600s and must be raised to cover a real roll,
+    # or a healthy-but-slow rollout fails at the deployment level even though the
+    # CLI would wait (2026-07-17, runs 29591891153 / 29611750428).
+    progress_deadline = values.get('progressDeadlineSeconds')
+    assert progress_deadline is not None, (
+        'backend-listen chart must set progressDeadlineSeconds; the k8s default (600s) '
+        f'is below the {required_seconds}s a real roll needs'
+    )
+    assert progress_deadline >= required_seconds, (
+        f'progressDeadlineSeconds={progress_deadline}s is below the {required_seconds}s a roll at '
+        f'the HPA floor needs ({waves} waves x {per_pod_startup_seconds}s startup budget)'
+    )


### PR DESCRIPTION
## Problem

The `backend-listen` GKE rollout keeps failing with `error: deployment "prod-omi-backend-listen" exceeded its progress deadline` (runs [29591891153](https://github.com/BasedHardware/omi/actions/runs/29591891153), [29611750428](https://github.com/BasedHardware/omi/actions/runs/29611750428)), blocking every prod backend deploy — including the Plus/Unlimited launch.

**Root cause:** the deployment's k8s `progressDeadlineSeconds` defaulted to **600s**, but a 12–60 HPA-replica roll paced by the node autoscaler routinely needs longer (`maxSurge 2 + maxUnavailable 1` = 3 pods in flight, startupProbe alone permits 300s/pod). During a >600s node-capacity stall, k8s marks the rollout Failed. #9915 raised the deploy *CLI* wait to 1800s, but `kubectl rollout status` returns `ProgressDeadlineExceeded` the instant the k8s deadline trips **regardless of `--timeout`** — so the CLI bump alone couldn't fix it. The image is healthy; scheduled pods run with 0 restarts and the rollout converges on its own after the workflow gives up.

## Fix

Set `progressDeadlineSeconds` via the chart (`| default 1800`, explicit `1800` in prod + dev values) so the k8s deadline matches the CLI wait. A genuinely stuck rollout (crashloop) still fails — those pods never become available and both the CLI (1800s) and this deadline (1800s) fire together.

## Guard (shared cause with #9915)

This is the second fix to the same "backend-listen rollout wait must cover a real roll" cause. Rather than another one-off, I extended the guard #9915 added — `test_backend_listen_rollout_wait_can_cover_a_real_rollout` — to also require the chart's `progressDeadlineSeconds` to cover a roll at the HPA floor (derived from the chart's own probe/strategy/autoscaling values). Mutation-checked: removing the value fails the guard.

## Verification

- `helm template` renders `progressDeadlineSeconds: 1800` at the Deployment spec level for prod and dev.
- 18 tests in `test_verify_dev_backend_deployment.py` pass; mutation removing the value fails with `must set progressDeadlineSeconds`.
- Live cluster during the failure: 22/23 pods available on healthy old+new pods, only the rollout incomplete — confirming a slow, not broken, roll.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

