### PR TITLE
fix(desktop): keep retired tasks consistent across surfaces

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline.json
@@ -29,7 +29,7 @@
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3643,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4448,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3243,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5490,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5510,
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1570,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1578,
     "desktop/macos/Desktop/Sources/OmiApp.swift": 1634,
@@ -39,10 +39,10 @@
     "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": 1608,
     "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6215,
     "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2840,
-    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1610,
+    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1607,
     "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3501,
     "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": 1907,
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 2949,
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 2961,
     "desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift": 2155
   },
   "raise_justifications": {
@@ -61,7 +61,7 @@
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "Rebase reconciliation applies the pinned swift-format to the main-branch app-detail safety fixes; runtime behavior is unchanged.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior.",
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": "Tasks now bind first-load, loading, error, and retry state to the selected To Do or Done view so completed cache rows cannot suppress an active-view fetch.",
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": "Strict concurrency imports annotate legacy AppKit image usage without changing runtime behavior.",
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
     "desktop/macos/Desktop/Sources/OmiApp.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior.",
@@ -71,10 +71,10 @@
     "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior.",
     "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": "Adds carryingLocalOnlyFields projection guard so journal replay preserves local-only row state (metadata/rating/notificationScreenshot); INV-CHAT-1 write-path fix.",
     "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": "Strict concurrency cleanup keeps non-Sendable JSON payloads behind checked boundaries without changing runtime behavior.",
-    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior.",
+    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": "Canonical task lifecycle projection prevents cancelled or superseded backend documents from being resurrected by a Dashboard visibility refresh.",
     "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
     "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": "Strict concurrency cleanup unwraps actor-safe screenshot image boxes at UI boundary without changing rendering behavior.",
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior.",
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "To Do and Done now retain independent load and error state so an aggregate cache cannot mask the selected view's fetch result.",
     "desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift": "The strict VoiceTurnDomain target centralizes reducer ownership and moves the lifecycle state machine intact."
   },
   "threshold": 1500

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -580,6 +580,18 @@ class TasksViewModel: ObservableObject {
   }
   var error: String? { store.error }
   var tasks: [TaskActionItem] { store.tasks }
+  var activeTasks: [TaskActionItem] {
+    showCompleted ? store.completedTasks : store.incompleteTasks
+  }
+  var isActiveViewLoading: Bool {
+    showCompleted ? store.isLoadingCompleted : store.isLoadingIncomplete
+  }
+  var activeViewError: String? {
+    showCompleted ? store.completedError : store.incompleteError
+  }
+  var hasLoadedActiveView: Bool {
+    showCompleted ? store.hasLoadedCompletedTasks : store.hasLoadedIncompleteTasks
+  }
 
   init(
     ownerIDProvider: @escaping @MainActor () -> String? = {
@@ -1727,17 +1739,25 @@ class TasksViewModel: ObservableObject {
   func loadTasksForFirstUse() async {
     guard
       TasksPageFirstUseLoadPolicy.shouldLoadTasks(
-        hasRenderedTasks: !store.tasks.isEmpty,
-        isLoading: store.isLoading
+        isActiveViewLoaded: hasLoadedActiveView,
+        isActiveViewLoading: isActiveViewLoading
       )
     else { return }
 
     log("TasksPage: First-use loading task list")
-    await store.loadTasksIfNeeded()
+    if showCompleted {
+      await store.loadCompletedTasks()
+    } else {
+      await store.loadTasksIfNeeded()
+    }
   }
 
   func loadTasks() async {
-    await store.loadTasks()
+    if showCompleted {
+      await store.loadCompletedTasks()
+    } else {
+      await store.loadTasks()
+    }
   }
 
   func revealTaskForNavigation(_ task: TaskActionItem) {
@@ -2705,9 +2725,9 @@ struct TasksPage: View {
       }
 
       // Content
-      if viewModel.isLoading && viewModel.tasks.isEmpty {
+      if viewModel.isActiveViewLoading && viewModel.activeTasks.isEmpty {
         loadingView
-      } else if let error = viewModel.error, viewModel.tasks.isEmpty {
+      } else if let error = viewModel.activeViewError, viewModel.activeTasks.isEmpty {
         errorView(error)
       } else if viewModel.displayTasks.isEmpty && !viewModel.isInlineCreating
         && suggestedStore.candidates.isEmpty && !suggestedStore.isLoading

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemModels.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemModels.swift
@@ -320,7 +320,7 @@ extension ActionItemRecord {
       backendSynced: true,
       description: item.description,
       completed: item.completed,
-      deleted: item.deleted ?? false,
+      deleted: item.isRetired,
       source: item.source,
       conversationId: item.conversationId,
       priority: item.priority,
@@ -373,7 +373,7 @@ extension ActionItemRecord {
     self.backendSynced = true
     self.description = item.description
     self.completed = item.completed
-    self.deleted = item.deleted ?? false
+    self.deleted = item.isRetired
     self.deletedBy = item.deletedBy
     self.source = item.source
     self.conversationId = item.conversationId
@@ -753,7 +753,7 @@ struct StagedTaskRecord: Codable, FetchableRecord, PersistableRecord, Identifiab
       backendSynced: true,
       description: item.description,
       completed: item.completed,
-      deleted: item.deleted ?? false,
+      deleted: item.isRetired,
       source: item.source,
       conversationId: item.conversationId,
       priority: item.priority,

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -603,8 +603,7 @@ actor ActionItemStorage {
   @discardableResult
   func reconcileDashboardVisibilityFields(
     _ items: [TaskActionItem],
-    authorization: LocalMutationAuthorization,
-    deriveDeletedFromCancelledStatus: Bool = false
+    authorization: LocalMutationAuthorization
   ) async throws -> Int {
     try authorization.require()
     guard !items.isEmpty else { return 0 }
@@ -623,13 +622,11 @@ actor ActionItemStorage {
           else { continue }
 
           // The list/detail wire model carries no `deleted` field; the
-          // backend projects soft-deletion as status cancelled/superseded.
-          // Callers doing authoritative per-document reconciliation opt in
-          // to that derivation.
-          let statusImpliesDeleted =
-            deriveDeletedFromCancelledStatus
-            && (item.taskStatus == "cancelled" || item.taskStatus == "superseded")
-          let incomingDeleted = item.deleted ?? statusImpliesDeleted
+          // backend projects soft retirement as status cancelled/superseded.
+          // `TaskActionItem.isRetired` is the one lifecycle projection for
+          // every caller, so a dashboard detail refresh cannot resurrect a
+          // task that the canonical list has already retired.
+          let incomingDeleted = item.isRetired
           var changed = false
 
           if record.completed != item.completed {

--- a/desktop/macos/Desktop/Sources/Startup/StartupWarmupPolicy.swift
+++ b/desktop/macos/Desktop/Sources/Startup/StartupWarmupPolicy.swift
@@ -84,8 +84,8 @@ struct DelayedFileIndexingBackfillState {
 }
 
 enum TasksPageFirstUseLoadPolicy {
-  static func shouldLoadTasks(hasRenderedTasks: Bool, isLoading: Bool) -> Bool {
-    !hasRenderedTasks && !isLoading
+  static func shouldLoadTasks(isActiveViewLoaded: Bool, isActiveViewLoading: Bool) -> Bool {
+    !isActiveViewLoaded && !isActiveViewLoading
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshPolicy.swift
+++ b/desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshPolicy.swift
@@ -57,7 +57,7 @@ struct DashboardTaskReconciliationPlan {
   let itemsToSync: [TaskActionItem]
   let backendIdsToHardDelete: Set<String>
   let dashboardVisibleServerIds: Set<String>
-  let completedServerIds: Set<String>
+  let terminalServerIds: Set<String>
   let movedOutServerIds: Set<String>
 
   var shouldMarkIncompleteTasksLoaded: Bool {
@@ -86,12 +86,12 @@ enum DashboardTaskReconciliationPlanner {
     }
 
     var dashboardVisibleServerIds = Set<String>()
-    var completedServerIds = Set<String>()
+    var terminalServerIds = Set<String>()
     var movedOutServerIds = Set<String>()
 
     for item in exactServerItemsById.values {
-      if item.completed || item.deleted == true {
-        completedServerIds.insert(item.id)
+      if item.completed || item.isRetired {
+        terminalServerIds.insert(item.id)
       } else if isDashboardVisible(item, now: now, calendar: calendar) {
         dashboardVisibleServerIds.insert(item.id)
       } else {
@@ -107,7 +107,7 @@ enum DashboardTaskReconciliationPlanner {
       itemsToSync: Array(itemsById.values),
       backendIdsToHardDelete: missingServerIds.intersection(localDashboardIds),
       dashboardVisibleServerIds: dashboardVisibleServerIds,
-      completedServerIds: completedServerIds,
+      terminalServerIds: terminalServerIds,
       movedOutServerIds: movedOutServerIds
     )
   }
@@ -117,7 +117,7 @@ enum DashboardTaskReconciliationPlanner {
     now: Date = Date(),
     calendar: Calendar = .current
   ) -> Bool {
-    guard !item.completed, item.deleted != true else { return false }
+    guard !item.completed, !item.isRetired else { return false }
 
     let startOfToday = calendar.startOfDay(for: now)
     guard

--- a/desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshPolicy.swift
+++ b/desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshPolicy.swift
@@ -81,7 +81,7 @@ enum DashboardTaskReconciliationPlanner {
     var itemsById = dashboardWindowServerItems.reduce(into: [String: TaskActionItem]()) { result, item in
       result[item.id] = item
     }
-    exactServerItemsById.values.forEach { item in
+    for item in exactServerItemsById.values {
       itemsById[item.id] = item
     }
 

--- a/desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshService.swift
+++ b/desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshService.swift
@@ -139,7 +139,7 @@ enum DashboardTaskRefreshService {
       }
       guard isCurrent(authorizationSnapshot) else { return }
       log(
-        "DashboardTaskRefreshService: Dashboard freshness reconciled sync=\(plan.itemsToSync.count), hardDeleted=\(plan.backendIdsToHardDelete.count), visible=\(plan.dashboardVisibleServerIds.count), completed=\(plan.completedServerIds.count), movedOut=\(plan.movedOutServerIds.count) without loading Tasks page list"
+        "DashboardTaskRefreshService: Dashboard freshness reconciled sync=\(plan.itemsToSync.count), hardDeleted=\(plan.backendIdsToHardDelete.count), visible=\(plan.dashboardVisibleServerIds.count), terminal=\(plan.terminalServerIds.count), movedOut=\(plan.movedOutServerIds.count) without loading Tasks page list"
       )
     } catch {
       if isCurrent(authorizationSnapshot) {

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -129,6 +129,8 @@ class TasksStore: ObservableObject {
   @Published var hasMoreCompletedTasks = true
   @Published var hasMoreDeletedTasks = true
   @Published var error: String?
+  @Published private(set) var incompleteError: String?
+  @Published private(set) var completedError: String?
 
   /// Counter bumped at the top of `refreshTasksIfNeeded()`, before any of the
   /// early-exit guards. Lets `TasksStoreObserverTests` prove that posting
@@ -150,6 +152,9 @@ class TasksStore: ObservableObject {
     isLoadingIncomplete || isLoadingCompleted || isLoadingDeleted
   }
 
+  var hasLoadedIncompleteTasks: Bool { hasLoadedIncomplete }
+  var hasLoadedCompletedTasks: Bool { hasLoadedCompleted }
+
   func resetSessionState() {
     ownerOperationGeneration &+= 1
     startupMaintenanceTasks.forEach { $0.cancel() }
@@ -170,6 +175,8 @@ class TasksStore: ObservableObject {
     hasMoreCompletedTasks = true
     hasMoreDeletedTasks = true
     error = nil
+    incompleteError = nil
+    completedError = nil
     incompleteOffset = 0
     completedOffset = 0
     deletedOffset = 0
@@ -1156,8 +1163,7 @@ class TasksStore: ObservableObject {
         } else {
           flippedTotal += try await ActionItemStorage.shared.reconcileDashboardVisibilityFields(
             fetched,
-            authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot),
-            deriveDeletedFromCancelledStatus: true
+            authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
           )
         }
       }
@@ -1262,6 +1268,7 @@ class TasksStore: ObservableObject {
 
     isLoadingIncomplete = true
     error = nil
+    incompleteError = nil
     incompleteOffset = 0
 
     // Step 1: Load from local cache first for instant display
@@ -1340,6 +1347,7 @@ class TasksStore: ObservableObject {
       if isCurrent(lease) {
         if incompleteTasks.isEmpty {
           self.error = error.localizedDescription
+          incompleteError = error.localizedDescription
         }
         logError("TasksStore: Failed to load incomplete tasks from API", error: error)
       }
@@ -1457,6 +1465,7 @@ class TasksStore: ObservableObject {
 
     isLoadingCompleted = true
     error = nil
+    completedError = nil
     completedOffset = 0
 
     // Step 1: Load from local cache first
@@ -1523,6 +1532,7 @@ class TasksStore: ObservableObject {
       guard isCurrent(lease) else { return }
       if completedTasks.isEmpty {
         self.error = error.localizedDescription
+        completedError = error.localizedDescription
       }
       logError("TasksStore: Failed to load completed tasks from API", error: error)
     }

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -157,7 +157,9 @@ class TasksStore: ObservableObject {
 
   func resetSessionState() {
     ownerOperationGeneration &+= 1
-    startupMaintenanceTasks.forEach { $0.cancel() }
+    for task in startupMaintenanceTasks {
+      task.cancel()
+    }
     startupMaintenanceTasks.removeAll()
     activeMigrationLease = nil
     activeRetryLease = nil

--- a/desktop/macos/Desktop/Sources/TaskActionItem.swift
+++ b/desktop/macos/Desktop/Sources/TaskActionItem.swift
@@ -79,6 +79,13 @@ struct TaskActionItem: Codable, Identifiable, Equatable {
     return true
   }
 
+  /// Server list/detail responses project soft retirement through canonical
+  /// lifecycle status and may omit the legacy `deleted` field. Keep that
+  /// projection here so every local cache and surface applies the same rule.
+  var isRetired: Bool {
+    deleted == true || taskStatus == "cancelled" || taskStatus == "superseded"
+  }
+
   /// Custom Equatable: compares only display-relevant fields.
   /// Skips `metadata` (JSON key ordering is non-deterministic after SQLite round-trip),
   /// `updatedAt` (set to Date() when nil on sync), and fields lost through SQLite.

--- a/desktop/macos/Desktop/Tests/ActionItemStorageVisibilityReconciliationTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemStorageVisibilityReconciliationTests.swift
@@ -98,11 +98,62 @@ final class ActionItemStorageVisibilityReconciliationTests: XCTestCase {
     XCTAssertEqual(refreshed.description, "local description must survive")
   }
 
+  func testCancelledDetailStatusRemainsRetiredWhenTheWireOmitsDeleted() async throws {
+    let createdAt = Date(timeIntervalSince1970: 1_749_900_000)
+    let activeUpdatedAt = Date(timeIntervalSince1970: 1_749_950_000)
+    let retiredUpdatedAt = Date(timeIntervalSince1970: 1_750_000_000)
+
+    try await ActionItemStorage.shared.syncTaskActionItems(
+      [
+        task(
+          id: "soft-retired-task",
+          description: "remove me from To Do",
+          completed: false,
+          deleted: false,
+          createdAt: createdAt,
+          updatedAt: activeUpdatedAt,
+          dueAt: nil
+        )
+      ],
+      authorization: .unrestricted
+    )
+
+    // Detail/list reads omit the legacy deleted field and represent this
+    // transition through canonical lifecycle status instead.
+    try await ActionItemStorage.shared.syncTaskActionItems(
+      [
+        task(
+          id: "soft-retired-task",
+          description: "remove me from To Do",
+          completed: false,
+          deleted: nil,
+          taskStatus: "cancelled",
+          createdAt: createdAt,
+          updatedAt: retiredUpdatedAt,
+          dueAt: nil
+        )
+      ],
+      authorization: .unrestricted
+    )
+
+    let localTask = try await ActionItemStorage.shared.getLocalActionItem(byBackendId: "soft-retired-task")
+    let cached = try XCTUnwrap(localTask)
+    XCTAssertEqual(cached.deleted, true)
+
+    let todoItems = try await ActionItemStorage.shared.getLocalActionItems(
+      limit: 10,
+      offset: 0,
+      completed: false
+    )
+    XCTAssertTrue(todoItems.isEmpty, "cancelled status must remove the task from To Do")
+  }
+
   private func task(
     id: String,
     description: String,
     completed: Bool,
-    deleted: Bool,
+    deleted: Bool?,
+    taskStatus: String? = nil,
     createdAt: Date,
     updatedAt: Date,
     dueAt: Date?
@@ -114,7 +165,8 @@ final class ActionItemStorageVisibilityReconciliationTests: XCTestCase {
       createdAt: createdAt,
       updatedAt: updatedAt,
       dueAt: dueAt,
-      deleted: deleted
+      deleted: deleted,
+      taskStatus: taskStatus
     )
   }
 }

--- a/desktop/macos/Desktop/Tests/DashboardTaskRefreshPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardTaskRefreshPolicyTests.swift
@@ -101,24 +101,53 @@ final class DashboardTaskRefreshPolicyTests: XCTestCase {
       ])
     XCTAssertEqual(plan.backendIdsToHardDelete, ["deleted-remotely"])
     XCTAssertEqual(plan.dashboardVisibleServerIds, [stillVisible.id, newDashboardTask.id])
-    XCTAssertTrue(plan.completedServerIds.contains(completed.id))
+    XCTAssertTrue(plan.terminalServerIds.contains(completed.id))
     XCTAssertTrue(plan.movedOutServerIds.contains(movedOut.id))
     XCTAssertFalse(plan.shouldMarkIncompleteTasksLoaded)
     XCTAssertFalse(plan.shouldAssignTasksPageList)
+  }
+
+  func testDashboardDoesNotReintroduceTerminalDetailTask() {
+    let calendar = Calendar(identifier: .gregorian)
+    let now = Date(timeIntervalSince1970: 1_750_000_000)
+    let today = calendar.startOfDay(for: now).addingTimeInterval(10 * 60 * 60)
+
+    for taskStatus in ["cancelled", "superseded"] {
+      let terminalTask = task(
+        id: "\(taskStatus)-remotely",
+        createdAt: now,
+        dueAt: today,
+        taskStatus: taskStatus
+      )
+
+      let plan = DashboardTaskReconciliationPlanner.plan(
+        localDashboardIds: [terminalTask.id],
+        dashboardWindowServerItems: [],
+        exactServerItemsById: [terminalTask.id: terminalTask],
+        missingServerIds: [],
+        now: now,
+        calendar: calendar
+      )
+
+      XCTAssertTrue(plan.terminalServerIds.contains(terminalTask.id))
+      XCTAssertFalse(plan.dashboardVisibleServerIds.contains(terminalTask.id))
+    }
   }
 
   private func task(
     id: String,
     completed: Bool = false,
     createdAt: Date,
-    dueAt: Date?
+    dueAt: Date?,
+    taskStatus: String? = nil
   ) -> TaskActionItem {
     TaskActionItem(
       id: id,
       description: id,
       completed: completed,
       createdAt: createdAt,
-      dueAt: dueAt
+      dueAt: dueAt,
+      taskStatus: taskStatus
     )
   }
 }

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -218,15 +218,15 @@ final class StartupWarmupPolicyTests: XCTestCase {
     XCTAssertTrue(state.reserveDatabaseWarmup(dbAvailable: true))
   }
 
-  func testTasksPageFirstUseLoadsWhenStoreHasNoRenderedTasks() {
+  func testTasksPageFirstUseLoadsWhenActiveViewHasNotHydrated() {
     XCTAssertTrue(
-      TasksPageFirstUseLoadPolicy.shouldLoadTasks(hasRenderedTasks: false, isLoading: false)
+      TasksPageFirstUseLoadPolicy.shouldLoadTasks(isActiveViewLoaded: false, isActiveViewLoading: false)
     )
     XCTAssertFalse(
-      TasksPageFirstUseLoadPolicy.shouldLoadTasks(hasRenderedTasks: true, isLoading: false)
+      TasksPageFirstUseLoadPolicy.shouldLoadTasks(isActiveViewLoaded: true, isActiveViewLoading: false)
     )
     XCTAssertFalse(
-      TasksPageFirstUseLoadPolicy.shouldLoadTasks(hasRenderedTasks: false, isLoading: true)
+      TasksPageFirstUseLoadPolicy.shouldLoadTasks(isActiveViewLoaded: false, isActiveViewLoading: true)
     )
   }
 

--- a/desktop/macos/Desktop/Tests/TasksStoreEmptyCloudReconcileTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksStoreEmptyCloudReconcileTests.swift
@@ -331,7 +331,7 @@ final class TasksStoreEmptyCloudReconcileTests: XCTestCase {
       "locally-created unsynced rows must survive a confirmed-empty wipe")
   }
 
-  func testVisibilityReconcileDerivesDeletionFromCancelledStatusOnlyWhenOptedIn() async throws {
+  func testVisibilityReconcileDerivesDeletionFromCancelledStatusForEveryCaller() async throws {
     let fixture = try await RewindStorageTestIsolation.setUp(
       userIdPrefix: "cancelled-status-reconcile-test")
     addTeardownBlock {
@@ -357,16 +357,10 @@ final class TasksStoreEmptyCloudReconcileTests: XCTestCase {
       createdAt: Date(timeIntervalSince1970: 0),
       taskStatus: "cancelled")
 
-    let withoutOptIn = try await ActionItemStorage.shared.reconcileDashboardVisibilityFields(
+    let reconciled = try await ActionItemStorage.shared.reconcileDashboardVisibilityFields(
       [cancelledWireItem],
       authorization: .unrestricted)
-    XCTAssertEqual(withoutOptIn, 0, "default callers keep the existing no-derivation semantics")
-
-    let withOptIn = try await ActionItemStorage.shared.reconcileDashboardVisibilityFields(
-      [cancelledWireItem],
-      authorization: .unrestricted,
-      deriveDeletedFromCancelledStatus: true)
-    XCTAssertEqual(withOptIn, 1)
+    XCTAssertEqual(reconciled, 1)
 
     let visible = try await ActionItemStorage.shared.getLocalActionItems(
       limit: 10,

--- a/desktop/macos/Desktop/Tests/TasksStoreEmptyCloudReconcileTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksStoreEmptyCloudReconcileTests.swift
@@ -443,19 +443,20 @@ final class TasksStoreEmptyCloudReconcileTests: XCTestCase {
         await MainActor.run {
           NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
         }
+      },
+      { defaults in
+        if let authOwnerID {
+          defaults.set(authOwnerID, forKey: .authUserId)
+        } else {
+          defaults.removeObject(forKey: .authUserId)
+        }
+        if let automationOverrideID {
+          defaults.set(automationOverrideID, forKey: .automationOwnerOverride)
+        } else {
+          defaults.removeObject(forKey: .automationOwnerOverride)
+        }
       }
-    ) { defaults in
-      if let authOwnerID {
-        defaults.set(authOwnerID, forKey: .authUserId)
-      } else {
-        defaults.removeObject(forKey: .authUserId)
-      }
-      if let automationOverrideID {
-        defaults.set(automationOverrideID, forKey: .automationOwnerOverride)
-      } else {
-        defaults.removeObject(forKey: .automationOwnerOverride)
-      }
-    }
+    )
   }
 
   private func normalizedOwner(_ value: String?) -> String? {

--- a/desktop/macos/Desktop/Tests/TasksViewModelCompletedToggleTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksViewModelCompletedToggleTests.swift
@@ -58,6 +58,19 @@ final class TasksViewModelCompletedToggleTests: XCTestCase {
     XCTAssertEqual(vm.displayTasks.map(\.id), ["done-1"])
   }
 
+  func testTodoPresentationDoesNotUseDoneRowsAsItsLoadingState() {
+    let store = TasksStore.shared
+    store.resetSessionState()
+    store.completedTasks = [task(id: "done-1", completed: true)]
+    store.isLoadingIncomplete = true
+
+    let vm = TasksViewModel()
+
+    XCTAssertTrue(vm.activeTasks.isEmpty)
+    XCTAssertTrue(vm.isActiveViewLoading)
+    XCTAssertFalse(vm.hasLoadedActiveView)
+  }
+
   private func task(id: String, completed: Bool) -> TaskActionItem {
     TaskActionItem(
       id: id,

--- a/desktop/macos/changelog/unreleased/20260717-task-projection-consistency.json
+++ b/desktop/macos/changelog/unreleased/20260717-task-projection-consistency.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Mac task views disagreeing after a task was cancelled or superseded."
+}

--- a/desktop/macos/changelog/unreleased/20260717-task-projection-consistency.json
+++ b/desktop/macos/changelog/unreleased/20260717-task-projection-consistency.json
@@ -1,3 +1,3 @@
 {
-  "change": "Fixed Mac task views disagreeing after a task was cancelled or superseded."
+  "change": "Fixed Mac task views disagreeing after a task was cancelled or superseded"
 }

--- a/desktop/macos/e2e/flows/dashboard.yaml
+++ b/desktop/macos/e2e/flows/dashboard.yaml
@@ -7,6 +7,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
   - desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshService.swift
+  - desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshPolicy.swift
   - desktop/macos/Desktop/Sources/MainWindow/Dashboard/DashboardIntelligenceStore.swift
   - desktop/macos/Desktop/Sources/MainWindow/Dashboard/WhatMattersNowSection.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ConversationListView.swift

--- a/desktop/macos/e2e/flows/tasks.yaml
+++ b/desktop/macos/e2e/flows/tasks.yaml
@@ -5,6 +5,7 @@ description: Tasks page navigation and tasks snapshot via automation bridge
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+  - desktop/macos/Desktop/Sources/Startup/StartupWarmupPolicy.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/TaskChatPanel.swift
   - desktop/macos/Desktop/Sources/Stores/TasksStore.swift
   - desktop/macos/Desktop/Sources/Services/RecurringTaskScheduler.swift


### PR DESCRIPTION
## Summary

- Project cancelled and superseded task statuses through one shared lifecycle rule, so the local cache, Dashboard refresh, and To Do reconciliation all retire the same task.
- Make Tasks-page first-load, loading, error, and retry behavior follow the selected To Do or Done view instead of aggregate task rows.
- Add regression coverage for soft retirement, Dashboard visibility, selected-view state, and both terminal statuses.

## Failure class

Failure-Class: FC-split-mutation-authority

The violated contract was that separate callers projected task retirement differently. The fix converges this lifecycle transition in `TaskActionItem.isRetired`, the shared domain model, rather than adding another surface-specific observer. It covers the reported cross-surface disagreement and follows the class's prior evidence in #9365 and #9597.

## Product invariants

None. `scripts/pr-preflight --suggest` found no product-invariant citations required by these changed paths.

## Verification

- `xcrun swift test -c debug --package-path Desktop --filter 'ActionItemStorageVisibilityReconciliationTests|TasksStoreEmptyCloudReconcileTests|DashboardTaskRefreshPolicyTests|StartupWarmupPolicyTests|TasksViewModelCompletedToggleTests'` (59 tests passed)
- `./scripts/agent-logic-harness.sh --cross-surface-smoke` (Swift, agent, and Rust contract smoke passed)
- `./scripts/swift-format-wrapper.sh lint ...` and `python3 scripts/check_desktop_test_quality.py`
- Built and launched the named ad-hoc `omi-task-projection` bundle; its automation bridge navigated to Tasks. The dev bundle was signed out, so live account data could not be exercised.
- Independent Sol review approved the implementation with no blocking findings.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

