### PR TITLE
fix(deploy): align dev LLM gateway static address

### DIFF
--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -8,7 +8,7 @@ environments:
       namespace: dev-omi-backend
       release_name: dev-omi-llm-gateway
       ingress_name: dev-omi-llm-gateway
-      static_address_name: dev-omi-self-hosted-llm-ip-address
+      static_address_name: dev-llm-gateway-ilb-ip-address
     gke:
       backend-listen:
         values_file: backend/charts/backend-listen/dev_omi_backend_listen_values.yaml

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -104,6 +104,17 @@ def test_prod_gateway_wiring_is_off_until_verified_promotion():
     }
 
 
+def test_gateway_runtime_static_address_matches_helm_ingress_declaration():
+    manifest = _load_yaml('deploy/runtime_env.yaml')
+
+    for environment in ('dev', 'prod'):
+        gateway = _load_yaml(f'charts/llm-gateway/{environment}_omi_llm_gateway_values.yaml')
+        assert (
+            manifest['environments'][environment]['llm_gateway']['static_address_name']
+            == gateway['ingress']['annotations']['kubernetes.io/ingress.regional-static-ip-name']
+        )
+
+
 def test_gateway_deploy_workflow_and_helper_allow_explicit_prod_launches():
     helper = (BACKEND_ROOT / 'scripts/deploy-llm-gateway.sh').read_text(encoding='utf-8')
     workflow = (BACKEND_ROOT.parent / '.github/workflows/gcp_llm_gateway.yml').read_text(encoding='utf-8')


### PR DESCRIPTION
## Summary

- Align the development LLM-gateway serving contract with the currently attached, healthy ingress address.
- Add a regression test requiring each environment's runtime address declaration to match its Helm ingress annotation.

## Root cause

The new development gateway gate expected `dev-omi-self-hosted-llm-ip-address`, but the deployed ingress has always declared `dev-llm-gateway-ilb-ip-address`. The former address is reserved but unattached, so the gate correctly stopped the Cloud Run rollout before build or traffic changes.

## Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_llm_gateway_deploy_contract.py` (7 passed)
- `backend/scripts/pre-deploy-check.sh` (90 passed)
- `make preflight` (passed)
- The selected backend suite passed through the complete pre-push gate using the runner's documented CI-equivalent 1.0s timing ceiling. The host's stricter 0.12s local ceiling flagged unrelated existing timing tests, while all assertions passed.

## Failure class

Failure-Class: FC-unprovisioned-rollout-target


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

