### PR TITLE
fix(web): preserve voice recorder media type

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -856,8 +856,8 @@ async def transcribe_voice_message(
         for file in upload_files:
             filename = file.filename
             assert filename is not None
-            if filename.lower().endswith('.wav'):
-                temp_path = f"/tmp/{uid}_{uuid.uuid4()}.wav"
+            if (suffix := Path(filename).suffix.lower()) in ('.wav', '.webm', '.mp4'):
+                temp_path = f"/tmp/{uid}_{uuid.uuid4()}{suffix}"
                 await run_blocking(storage_executor, _save_wav, temp_path, file.file)
                 wav_paths.append(temp_path)
             else:

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -1106,6 +1106,28 @@ class TestVoiceMessageTranscribeEndpoint:
         finally:
             _cleanup_chat_client(saved)
 
+    @pytest.mark.parametrize(
+        ('suffix', 'content_type'),
+        [('webm', 'audio/webm'), ('mp4', 'audio/mp4')],
+    )
+    def test_multipart_browser_container_preserves_extension_for_prerecorded_stt(self, suffix, content_type):
+        """Browser MediaRecorder uploads must not be stored as WAV files."""
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(
+                module, 'transcribe_voice_message_segment', return_value=('Hello world', 'en')
+            ) as transcribe:
+                response = client.post(
+                    '/v2/voice-message/transcribe',
+                    files={'files': (f'audio.{suffix}', b'containerized-audio', content_type)},
+                )
+
+            assert response.status_code == 200
+            assert response.json()['transcript'] == 'Hello world'
+            assert transcribe.call_args.args[0].endswith(f'.{suffix}')
+        finally:
+            _cleanup_chat_client(saved)
+
 
 # ---------------------------------------------------------------------------
 # WebSocket endpoint tests: /v2/voice-message/transcribe-stream

--- a/backend/tests/unit/test_parakeet_prerecorded.py
+++ b/backend/tests/unit/test_parakeet_prerecorded.py
@@ -396,6 +396,65 @@ class TestTranscribeUrl:
         assert len(words) == 1
         assert words[0]['text'] == 'hello'
 
+    @pytest.mark.parametrize(
+        ('content_type', 'container_format'),
+        [('audio/webm', 'webm'), ('video/mp4', 'mp4')],
+    )
+    def test_transcodes_browser_containers_before_posting_to_parakeet(self, content_type, container_format):
+        container_bytes = b'browser-container'
+        wav_bytes = _make_wav()
+        stream_resp = MagicMock()
+        stream_resp.raise_for_status = MagicMock()
+        stream_resp.headers = {'content-length': str(len(container_bytes)), 'content-type': content_type}
+        stream_resp.iter_bytes = MagicMock(return_value=iter([container_bytes]))
+        stream_resp.__enter__ = MagicMock(return_value=stream_resp)
+        stream_resp.__exit__ = MagicMock(return_value=False)
+
+        decoded_audio = MagicMock()
+        decoded_audio.export.side_effect = lambda buffer, format: buffer.write(wav_bytes)
+
+        with patch('httpx.Client') as mock_client_cls, patch.object(
+            pr.AudioSegment, 'from_file', return_value=decoded_audio
+        ) as from_file:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.stream.return_value = stream_resp
+            mock_client.post.return_value = _mock_parakeet_response()
+            mock_client_cls.return_value = mock_client
+
+            pr.parakeet_prerecorded('https://storage.example.com/browser-audio', diarize=False)
+
+        assert from_file.call_args.args[0].getvalue() == container_bytes
+        assert from_file.call_args.kwargs == {'format': container_format}
+        posted_file = mock_client.post.call_args.kwargs['files']['file']
+        assert posted_file[0] == 'audio.wav'
+        assert posted_file[1].getvalue() == wav_bytes
+
+    def test_rejects_undecodable_browser_container_without_retrying(self):
+        container_bytes = b'not-a-real-webm'
+        stream_resp = MagicMock()
+        stream_resp.raise_for_status = MagicMock()
+        stream_resp.headers = {'content-length': str(len(container_bytes)), 'content-type': 'audio/webm'}
+        stream_resp.iter_bytes = MagicMock(return_value=iter([container_bytes]))
+        stream_resp.__enter__ = MagicMock(return_value=stream_resp)
+        stream_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch('httpx.Client') as mock_client_cls, patch.object(
+            pr.AudioSegment, 'from_file', side_effect=RuntimeError('decode failed')
+        ):
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.stream.return_value = stream_resp
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(pr.ParakeetAudioDecodeError):
+                pr.parakeet_prerecorded('https://storage.example.com/browser-audio', diarize=False)
+
+        mock_client.stream.assert_called_once()
+        mock_client.post.assert_not_called()
+
     def test_rejects_oversized_content_length(self):
         stream_resp = MagicMock()
         stream_resp.raise_for_status = MagicMock()

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -11,6 +11,7 @@ import fal_client
 import httpx
 import numpy as np
 from deepgram import DeepgramClient, DeepgramClientOptions
+from pydub import AudioSegment  # pydub is untyped
 
 from config.prerecorded_stt import (
     PrerecordedSTTConfigurationError as _PrerecordedSTTConfigurationError,
@@ -769,6 +770,36 @@ class ModulatePrerecordedProvider(PrerecordedSTTProvider):
 _PARAKEET_TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=30.0, pool=10.0)
 _PARAKEET_URL_DOWNLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0)
 _PARAKEET_MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024  # 100 MB
+_PARAKEET_CONTAINER_MIME_FORMATS = {
+    'audio/webm': 'webm',
+    'video/webm': 'webm',
+    'audio/mp4': 'mp4',
+    'video/mp4': 'mp4',
+}
+
+
+class ParakeetAudioDecodeError(ValueError):
+    """A downloaded browser container cannot be made safe for Parakeet."""
+
+
+def _normalize_parakeet_download(audio_bytes: bytes, content_type: str | None) -> bytes:
+    """Convert browser containers to WAV before Parakeet's WAV-only batch path."""
+
+    media_type = (content_type or '').split(';', 1)[0].strip().lower()
+    container_format = _PARAKEET_CONTAINER_MIME_FORMATS.get(media_type)
+    if container_format is None:
+        return audio_bytes
+
+    try:
+        decoded_audio = AudioSegment.from_file(BytesIO(audio_bytes), format=container_format)
+        wav_buffer = BytesIO()
+        decoded_audio.export(wav_buffer, format='wav')
+        wav_bytes = wav_buffer.getvalue()
+        del decoded_audio
+        del wav_buffer
+        return wav_bytes
+    except Exception as error:
+        raise ParakeetAudioDecodeError('Browser audio container could not be decoded') from error
 
 
 @timeit
@@ -900,9 +931,12 @@ def parakeet_prerecorded(
                     chunks.append(chunk)
                 audio_bytes = b''.join(chunks)
                 del chunks
+                audio_bytes = _normalize_parakeet_download(audio_bytes, resp.headers.get('content-type'))
         return parakeet_prerecorded_from_bytes(
             audio_bytes, diarize=diarize, attempts=attempts, return_language=return_language, language=language
         )
+    except ParakeetAudioDecodeError:
+        raise
     except Exception as e:
         logger.error(
             'Parakeet prerecorded (url) error exception_type=%s attempt=%s',

--- a/web/app/src/components/chat/VoiceRecorder.tsx
+++ b/web/app/src/components/chat/VoiceRecorder.tsx
@@ -7,6 +7,8 @@ import { transcribeVoiceMessage } from '@/lib/api';
 
 type RecordingState = 'idle' | 'recording' | 'transcribing';
 
+const recordingMimeTypes = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4'];
+
 interface InlineVoiceRecorderProps {
   onTranscript: (text: string) => void;
   disabled?: boolean;
@@ -17,7 +19,10 @@ interface InlineVoiceRecorderProps {
  * Click to start recording, click again to stop and transcribe.
  * The mic button stays visible after transcription for continuous use.
  */
-export function InlineVoiceRecorder({ onTranscript, disabled }: InlineVoiceRecorderProps) {
+export function InlineVoiceRecorder({
+  onTranscript,
+  disabled,
+}: InlineVoiceRecorderProps) {
   const [state, setState] = useState<RecordingState>('idle');
   const [error, setError] = useState<string | null>(null);
   const [duration, setDuration] = useState(0);
@@ -28,9 +33,11 @@ export function InlineVoiceRecorder({ onTranscript, disabled }: InlineVoiceRecor
   const durationIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   // Check if browser supports recording
-  const isSupported = typeof navigator !== 'undefined' &&
+  const isSupported =
+    typeof navigator !== 'undefined' &&
     navigator.mediaDevices &&
-    typeof navigator.mediaDevices.getUserMedia === 'function';
+    typeof navigator.mediaDevices.getUserMedia === 'function' &&
+    typeof MediaRecorder !== 'undefined';
 
   // Cleanup on unmount
   useEffect(() => {
@@ -42,7 +49,7 @@ export function InlineVoiceRecorder({ onTranscript, disabled }: InlineVoiceRecor
         mediaRecorderRef.current.stop();
       }
       if (streamRef.current) {
-        streamRef.current.getTracks().forEach(track => track.stop());
+        streamRef.current.getTracks().forEach((track) => track.stop());
       }
     };
   }, []);
@@ -55,9 +62,12 @@ export function InlineVoiceRecorder({ onTranscript, disabled }: InlineVoiceRecor
       streamRef.current = stream;
 
       // Start recording
-      const mediaRecorder = new MediaRecorder(stream, {
-        mimeType: MediaRecorder.isTypeSupported('audio/webm') ? 'audio/webm' : 'audio/mp4',
-      });
+      const mimeType = recordingMimeTypes.find((candidate) =>
+        MediaRecorder.isTypeSupported(candidate),
+      );
+      const mediaRecorder = mimeType
+        ? new MediaRecorder(stream, { mimeType })
+        : new MediaRecorder(stream);
       mediaRecorderRef.current = mediaRecorder;
       audioChunksRef.current = [];
 
@@ -69,11 +79,13 @@ export function InlineVoiceRecorder({ onTranscript, disabled }: InlineVoiceRecor
 
       mediaRecorder.onstop = async () => {
         // Stop all tracks
-        stream.getTracks().forEach(track => track.stop());
+        stream.getTracks().forEach((track) => track.stop());
         streamRef.current = null;
 
         // Process audio
-        const audioBlob = new Blob(audioChunksRef.current, { type: 'audio/webm' });
+        const audioBlob = new Blob(audioChunksRef.current, {
+          type: mediaRecorder.mimeType || mimeType || 'audio/webm',
+        });
         await processAudio(audioBlob);
       };
 
@@ -83,7 +95,7 @@ export function InlineVoiceRecorder({ onTranscript, disabled }: InlineVoiceRecor
 
       // Start duration counter
       durationIntervalRef.current = setInterval(() => {
-        setDuration(d => d + 1);
+        setDuration((d) => d + 1);
       }, 1000);
     } catch (err) {
       console.error('Failed to start recording:', err);
@@ -152,9 +164,7 @@ export function InlineVoiceRecorder({ onTranscript, disabled }: InlineVoiceRecor
   return (
     <div className="flex items-center gap-2">
       {/* Error message */}
-      {error && (
-        <span className="text-xs text-error whitespace-nowrap">{error}</span>
-      )}
+      {error && <span className="text-xs text-error whitespace-nowrap">{error}</span>}
 
       {/* Duration display when recording */}
       {state === 'recording' && (
@@ -185,15 +195,18 @@ export function InlineVoiceRecorder({ onTranscript, disabled }: InlineVoiceRecor
         className={cn(
           'p-2 rounded-lg flex-shrink-0',
           'transition-all duration-200',
-          state === 'idle' && 'text-text-tertiary hover:text-purple-primary hover:bg-bg-tertiary',
+          state === 'idle' &&
+            'text-text-tertiary hover:text-purple-primary hover:bg-bg-tertiary',
           state === 'recording' && 'text-white bg-error hover:bg-error/80 animate-pulse',
           state === 'transcribing' && 'text-text-quaternary cursor-not-allowed',
-          'disabled:opacity-50 disabled:cursor-not-allowed'
+          'disabled:opacity-50 disabled:cursor-not-allowed',
         )}
         title={
-          state === 'idle' ? 'Click to start recording' :
-          state === 'recording' ? 'Click to stop and transcribe' :
-          'Transcribing...'
+          state === 'idle'
+            ? 'Click to start recording'
+            : state === 'recording'
+              ? 'Click to stop and transcribe'
+              : 'Transcribing...'
         }
       >
         {state === 'transcribing' ? (

--- a/web/app/src/lib/api.ts
+++ b/web/app/src/lib/api.ts
@@ -742,6 +742,15 @@ export async function uploadChatFiles(
 /**
  * Transcribe voice message to text
  */
+function getAudioFileExtension(mimeType: string): string {
+  const normalizedMimeType = mimeType.split(';', 1)[0].toLowerCase();
+  if (normalizedMimeType === 'audio/webm' || normalizedMimeType === 'video/webm')
+    return 'webm';
+  if (normalizedMimeType === 'audio/mp4' || normalizedMimeType === 'video/mp4')
+    return 'mp4';
+  return 'wav';
+}
+
 export async function transcribeVoiceMessage(audioBlob: Blob): Promise<string> {
   let token: string | null = null;
 
@@ -759,14 +768,20 @@ export async function transcribeVoiceMessage(audioBlob: Blob): Promise<string> {
   const url = `${API_BASE_URL}/v2/voice-message/transcribe`;
 
   const formData = new FormData();
-  // API expects field name 'files' (matching mobile app)
-  formData.append('files', audioBlob, 'audio.wav');
+  // The backend uses the filename extension when it uploads audio for STT.
+  formData.append('files', audioBlob, `audio.${getAudioFileExtension(audioBlob.type)}`);
+  const deviceIdHash = await getWebDeviceIdHash();
+  const headers: HeadersInit = {
+    Authorization: `Bearer ${token}`,
+    'X-App-Platform': 'web',
+  };
+  if (deviceIdHash) {
+    headers['X-Device-Id-Hash'] = deviceIdHash;
+  }
 
   const response = await fetch(url, {
     method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
+    headers,
     body: formData,
   });
 


### PR DESCRIPTION
## Summary

- Preserve the browser `MediaRecorder` container type (WebM or MP4) through the web upload and backend temporary object.
- Allow those two container extensions at the existing prerecorded voice-message endpoint.
- Normalize WebM/MP4 downloads to WAV inside the Parakeet provider before its WAV-only batch and speaker-processing pipeline.
- Include regression coverage for Chromium WebM and Safari MP4 uploads, plus corrupt-container rejection.

## Root cause and durable guard

The web recorder emitted WebM or MP4 bytes but relabeled them as `audio.wav`. Cloud Storage then inferred WAV MIME metadata before Deepgram fetched the temporary URL. The client now keeps the actual MIME type and filename extension, while the backend accepts the corresponding container extensions. Deepgram can consume those containers directly; Parakeet cannot, so its provider boundary converts only supported browser-container MIME types to a real WAV before posting to Parakeet or extracting speaker segments. Invalid containers become an explicit non-retryable input error rather than being mislabeled as WAV.

## Verification

- `bash backend/test.sh` (661 selected unit-test files passed)
- `backend/.venv/bin/python -m pytest -q -m 'not integration and not slow' backend/tests/unit/test_desktop_transcribe.py` (63 passed, 5 deselected)
- `backend/.venv/bin/python -m pytest -q -m 'not integration and not slow' backend/tests/unit/test_parakeet_prerecorded.py` (44 passed)
- `cd web/app && npx tsc --noEmit` (no errors)
- `cd web/app && NEXT_PUBLIC_FIREBASE_*=build-placeholder npm run build` (production build succeeded)
- `make preflight` and `scripts/pr-preflight --lane local --pr-body-file /tmp/omi-web-voice-pr-body.md` (passed)

## Product invariants affected

none

## Failure class

Failure-Class: none

No existing registered class covers browser audio-container identity. The root-cause and durable boundary guard are documented above, with Chromium WebM and Safari MP4 regression coverage.