### PR TITLE
fix(deploy): invoke gateway probe through bash

### DIFF
--- a/.github/failure-classes/FC-workflow-executable-assumption.json
+++ b/.github/failure-classes/FC-workflow-executable-assumption.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "FC-workflow-executable-assumption",
+  "violated_contract": "A deployment workflow must not directly execute a repository script unless its executable mode is a checked-in and verified part of the workflow contract.",
+  "canonical_prevention": "Invoke repository scripts through an explicit interpreter at workflow boundaries, then cover every caller with a deployment-contract test so Git mode assumptions cannot block a rollout before promotion.",
+  "evidence_prs": [9943],
+  "scope_hints": [".github/workflows/**", "backend/scripts/**", "backend/tests/unit/test_*deploy_contract.py"],
+  "status": "open"
+}

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -358,7 +358,7 @@ jobs:
       - name: Probe LLM gateway from the Cloud Run VPC before promotion
         if: ${{ steps.gateway-intent.outputs.enabled == 'true' }}
         run: |
-          backend/scripts/probe-llm-gateway-from-cloud-run.sh \
+          bash backend/scripts/probe-llm-gateway-from-cloud-run.sh \
             --project="${{ vars.GCP_PROJECT_ID }}" \
             --region="${{ env.REGION }}" \
             --image="gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}" \

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -195,7 +195,7 @@ jobs:
 
       - name: Probe LLM gateway from the Cloud Run VPC before promotion
         run: |
-          backend/scripts/probe-llm-gateway-from-cloud-run.sh \
+          bash backend/scripts/probe-llm-gateway-from-cloud-run.sh \
             --project="${{ vars.GCP_PROJECT_ID }}" \
             --region="${{ env.REGION }}" \
             --image="gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}" \

--- a/.github/workflows/gcp_llm_gateway.yml
+++ b/.github/workflows/gcp_llm_gateway.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Probe LLM Gateway from the Cloud Run VPC
         run: |
-          backend/scripts/probe-llm-gateway-from-cloud-run.sh \
+          bash backend/scripts/probe-llm-gateway-from-cloud-run.sh \
             --project="${{ vars.GCP_PROJECT_ID }}" \
             --region="${{ env.REGION }}" \
             --image="gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}" \

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -148,6 +148,12 @@ def test_backend_deploy_requires_serving_and_cloud_run_vpc_gates_before_gateway_
     assert 'OMI_LLM_GATEWAY_URL: ${{ steps.gateway-serving.outputs.gateway_url }}' in auto_dev
 
 
+def test_gateway_vpc_probe_workflows_explicitly_use_bash():
+    for workflow_name in ('gcp_backend_auto_dev.yml', 'gcp_backend.yml', 'gcp_llm_gateway.yml'):
+        workflow = (BACKEND_ROOT.parent / '.github/workflows' / workflow_name).read_text(encoding='utf-8')
+        assert 'bash backend/scripts/probe-llm-gateway-from-cloud-run.sh' in workflow
+
+
 def test_monitoring_scrapes_llm_gateway_with_shared_metrics_secret_contract():
     for environment in ('dev', 'prod'):
         monitoring = _load_yaml(f'charts/monitoring/kube-prometheus-stack/{environment}_omi_monitoring_values.yaml')


### PR DESCRIPTION
## Summary

- Invoke the Cloud Run VPC LLM-gateway probe through `bash` in each deployment workflow.
- Add a deployment-contract regression test for all three probe callers.

## Root cause

The probe script is tracked without the executable bit (`100644`), but the workflows invoked it directly. The dev deployment exited with status 126 before creating a new Cloud Run revision or shifting traffic.

## Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_llm_gateway_deploy_contract.py` (8 passed)
- `backend/scripts/pre-deploy-check.sh` (90 passed; validated dev and prod runtime environments)
- `make preflight` (passed)

## Guard rationale

This is a narrowly scoped workflow-boundary contract, not a shared runtime primitive: the executable-mode assumption exists only where GitHub Actions invokes a checked-in probe script. The regression test covers each existing caller, and the new failure-class record cites the merged change that exposed the issue (#9943).

## Failure class

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

