### PR TITLE
feat(desktop): show versions in named app titles

### DIFF
--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -96,21 +96,21 @@ struct OMIApp: App {
   @StateObject private var authState = AuthState.shared
   @Environment(\.openWindow) private var openWindow
 
-  /// Launch mode determined at startup from command-line arguments
   static let launchMode = LaunchMode.fromCommandLine()
 
-  /// Window title with version number (different for rewind mode)
   private var windowTitle: String {
-    // Keep a distinct title in non-production builds so custom test apps are easy to identify.
-    if AppBuild.isNonProduction {
-      let baseName = AppBuild.displayName
-      return Self.launchMode == .rewind ? "\(baseName) Rewind" : baseName
-    }
+    Self.windowTitle(
+      displayName: AppBuild.displayName,
+      version: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "",
+      launchMode: Self.launchMode,
+      isNonProduction: AppBuild.isNonProduction)
+  }
 
-    let version =
-      Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
-    let baseName = Self.launchMode == .rewind ? "omi Rewind" : UpdateChannel.appDisplayName
-    return version.isEmpty ? baseName : "\(baseName) v\(version)"
+  static func windowTitle(displayName: String, version: String, launchMode: LaunchMode, isNonProduction: Bool) -> String
+  {
+    let baseName = isNonProduction ? displayName : launchMode == .rewind ? "omi Rewind" : UpdateChannel.appDisplayName
+    let title = isNonProduction && launchMode == .rewind ? "\(baseName) Rewind" : baseName
+    return version.isEmpty ? title : "\(title) v\(version)"
   }
 
   /// Window size based on launch mode

--- a/desktop/macos/Desktop/Tests/OmiAppWindowTitleTests.swift
+++ b/desktop/macos/Desktop/Tests/OmiAppWindowTitleTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class OmiAppWindowTitleTests: XCTestCase {
+  func testNamedBuildIncludesVersion() {
+    XCTAssertEqual(
+      OMIApp.windowTitle(
+        displayName: "Omi Beta",
+        version: "0.12.73",
+        launchMode: .full,
+        isNonProduction: true),
+      "Omi Beta v0.12.73")
+  }
+
+  func testNamedRewindBuildIncludesVersion() {
+    XCTAssertEqual(
+      OMIApp.windowTitle(
+        displayName: "Omi Dev",
+        version: "0.12.73",
+        launchMode: .rewind,
+        isNonProduction: true),
+      "Omi Dev Rewind v0.12.73")
+  }
+
+  func testEmptyVersionFallsBackToName() {
+    XCTAssertEqual(
+      OMIApp.windowTitle(
+        displayName: "Omi Beta",
+        version: "",
+        launchMode: .full,
+        isNonProduction: true),
+      "Omi Beta")
+  }
+
+  func testProductionTitleRemainsUnchanged() {
+    XCTAssertEqual(
+      OMIApp.windowTitle(
+        displayName: "ignored",
+        version: "0.12.70",
+        launchMode: .full,
+        isNonProduction: false),
+      "omi v0.12.70")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260717-named-build-window-version.json
+++ b/desktop/macos/changelog/unreleased/20260717-named-build-window-version.json
@@ -1,0 +1,3 @@
+{
+  "change": "Omi Beta and other named desktop builds now show their installed version in the window title"
+}


### PR DESCRIPTION
## Summary
- Show the installed version in window titles for named desktop bundles such as Omi Beta and Omi Dev.
- Preserve production and empty-version title behavior.

## Product invariants affected
- INV-AUTH-1: Not behaviorally affected. This change only formats the macOS window title after existing bundle/version values are read; it does not change authentication, session, or storage behavior.

## Verification
- `swift test --filter OmiAppWindowTitleTests` — 4 passed
- `make preflight`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

