### PR TITLE
fix(developer-api): clarify memory access readiness

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -2,7 +2,7 @@
   "files": {
     "backend/routers/apps.py": 2335,
     "backend/routers/chat.py": 1580,
-    "backend/routers/developer.py": 2186,
+    "backend/routers/developer.py": 2184,
     "backend/routers/mcp_sse.py": 1857,
     "backend/routers/sync.py": 1981,
     "backend/routers/users.py": 2046

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -94,6 +94,25 @@ class DeveloperSuccessResponse(BaseModel):
     success: bool
 
 
+DEVELOPER_MEMORY_ACCESS_NOT_READY = 'developer_memory_access_not_ready'
+
+
+def _developer_memory_access_not_ready_detail(reason: Optional[str]) -> dict:
+    return {
+        'enabled': False,
+        'code': DEVELOPER_MEMORY_ACCESS_NOT_READY,
+        'message': (
+            'Developer Memory API access is not enabled for this account. '
+            'Your API key can be valid and correctly scoped; this endpoint also requires server-side memory '
+            'readiness. Try again after access is enabled, or contact Omi support if it remains unavailable.'
+        ),
+        'reason': reason,
+        'consumer': 'developer_api',
+        'archive_default_visible': False,
+        'archive_capability': False,
+    }
+
+
 def _developer_request_ip(request: Request) -> Optional[str]:
     client = getattr(request, 'client', None)
     if not client:
@@ -375,14 +394,7 @@ def get_memories(
         return [CleanerMemory.model_validate(memory) for memory in memory_result.memories]
     if memory_result.read_decision in {MemoryReadDecision.DENY_MEMORY, MemoryReadDecision.SHADOW_ONLY}:
         raise HTTPException(
-            status_code=403,
-            detail={
-                'enabled': False,
-                'reason': memory_result.fallback_reason,
-                'consumer': 'developer_api',
-                'archive_default_visible': False,
-                'archive_capability': False,
-            },
+            status_code=403, detail=_developer_memory_access_not_ready_detail(memory_result.fallback_reason)
         )
     if memory_result.should_use_legacy_fallback:
         pass
@@ -487,25 +499,11 @@ def search_memories_vector(
     )
     if memory_result.read_decision in {MemoryReadDecision.DENY_MEMORY, MemoryReadDecision.SHADOW_ONLY}:
         raise HTTPException(
-            status_code=403,
-            detail={
-                'enabled': False,
-                'reason': memory_result.fallback_reason,
-                'consumer': 'developer_api',
-                'archive_default_visible': False,
-                'archive_capability': False,
-            },
+            status_code=403, detail=_developer_memory_access_not_ready_detail(memory_result.fallback_reason)
         )
     if memory_result.should_use_legacy_fallback:
         raise HTTPException(
-            status_code=403,
-            detail={
-                'enabled': False,
-                'reason': memory_result.fallback_reason,
-                'consumer': 'developer_api',
-                'archive_default_visible': False,
-                'archive_capability': False,
-            },
+            status_code=403, detail=_developer_memory_access_not_ready_detail(memory_result.fallback_reason)
         )
     return {
         'items': memory_result.memories,

--- a/backend/tests/unit/test_dev_api_canonical_grant_ordering.py
+++ b/backend/tests/unit/test_dev_api_canonical_grant_ordering.py
@@ -241,7 +241,12 @@ def _restore_developer_module():
 
 def _auth_context():
     return ProductAuthorizationContext(
-        uid='uid1', consumer='developer_api', surface='developer_api', app_id='test-app', key_id='test-key'
+        uid='uid1',
+        consumer='developer_api',
+        surface='developer_api',
+        app_id='test-app',
+        key_id='test-key',
+        scopes=('memories.read',),
     )
 
 
@@ -368,6 +373,59 @@ def test_get_memories_allowed_grant_canonical_lists():
     assert resp.status_code == 200
     assert len(resp.json()) == 1
     assert resp.json()[0]['id'] == 'canon-1'
+
+
+def test_get_memories_missing_rollout_state_has_actionable_contract():
+    """A valid memory-read key must not look invalid when account rollout is absent."""
+    client = _build()
+
+    developer_module.search_memory_default_developer_memories = MagicMock(
+        return_value=type(
+            'DeniedMemoryResult',
+            (),
+            {
+                'read_decision': developer_module.MemoryReadDecision.DENY_MEMORY,
+                'memories': [],
+                'fallback_reason': 'missing_rollout_state',
+                'should_use_legacy_fallback': False,
+            },
+        )()
+    )
+
+    resp = client.get('/v1/dev/user/memories')
+
+    assert resp.status_code == 403
+    detail = resp.json()['detail']
+    assert detail['code'] == 'developer_memory_access_not_ready'
+    assert detail['reason'] == 'missing_rollout_state'
+    assert 'key can be valid and correctly scoped' in detail['message']
+    assert developer_module.authorize_memory_external_default_memory_read.called
+
+
+def test_search_memories_vector_missing_rollout_state_has_actionable_contract():
+    """Vector search uses the same account-readiness error after a valid key grant."""
+    client = _build()
+
+    developer_module.search_memory_default_developer_memories_vector = MagicMock(
+        return_value=type(
+            'DeniedVectorMemoryResult',
+            (),
+            {
+                'read_decision': developer_module.MemoryReadDecision.DENY_MEMORY,
+                'memories': [],
+                'fallback_reason': 'missing_rollout_state',
+                'should_use_legacy_fallback': False,
+            },
+        )()
+    )
+
+    resp = client.get('/v1/dev/user/memories/vector/search', params={'query': 'memory'})
+
+    assert resp.status_code == 403
+    detail = resp.json()['detail']
+    assert detail['code'] == 'developer_memory_access_not_ready'
+    assert detail['reason'] == 'missing_rollout_state'
+    assert 'key can be valid and correctly scoped' in detail['message']
 
 
 # =============================================================================

--- a/docs/doc/developer/api/keys.mdx
+++ b/docs/doc/developer/api/keys.mdx
@@ -18,6 +18,12 @@ description: "Manage your Developer API keys"
   </Card>
 </CardGroup>
 
+<Note>
+Developer API keys are self-service: while signed in to Omi, open **Developer → API Keys** to create,
+list, and revoke your keys. The lifecycle endpoints below use that signed-in Omi/Firebase session; an
+`omi_dev_...` key cannot create, list, or revoke keys itself.
+</Note>
+
 ---
 
 ## List API Keys
@@ -27,13 +33,13 @@ description: "Manage your Developer API keys"
 </Card>
 
 <Note>
-This endpoint requires authentication with an existing API key or user session. The secret key values are not returned (only the prefix is shown).
+This endpoint requires your signed-in Omi/Firebase session. The secret key values are not returned (only the prefix is shown).
 </Note>
 
 <Tabs>
   <Tab title="cURL">
     ```bash
-    curl -H "Authorization: Bearer $API_KEY" \
+    curl -H "Authorization: Bearer $FIREBASE_ID_TOKEN" \
       "https://api.omi.me/v1/dev/keys"
     ```
   </Tab>
@@ -43,7 +49,7 @@ This endpoint requires authentication with an existing API key or user session. 
 
     response = requests.get(
         "https://api.omi.me/v1/dev/keys",
-        headers={"Authorization": f"Bearer {API_KEY}"}
+        headers={"Authorization": f"Bearer {firebase_id_token}"}
     )
     keys = response.json()
     ```
@@ -52,7 +58,7 @@ This endpoint requires authentication with an existing API key or user session. 
     ```javascript
     const response = await fetch(
       "https://api.omi.me/v1/dev/keys",
-      { headers: { Authorization: `Bearer ${API_KEY}` } }
+      { headers: { Authorization: `Bearer ${firebaseIdToken}` } }
     );
     const keys = await response.json();
     ```
@@ -68,14 +74,16 @@ This endpoint requires authentication with an existing API key or user session. 
         "name": "My Analytics Dashboard",
         "key_prefix": "omi_dev_abc123",
         "created_at": "2025-01-15T10:30:00Z",
-        "last_used_at": "2025-01-20T14:22:00Z"
+        "last_used_at": "2025-01-20T14:22:00Z",
+        "scopes": ["conversations:read", "memories:read"]
       },
       {
         "id": "key_456def",
         "name": "Automation Script",
         "key_prefix": "omi_dev_def456",
         "created_at": "2025-01-18T09:00:00Z",
-        "last_used_at": null
+        "last_used_at": null,
+        "scopes": ["memories:read"]
       }
     ]
     ```
@@ -88,6 +96,7 @@ This endpoint requires authentication with an existing API key or user session. 
     | `key_prefix` | string | First part of the key (for identification) |
     | `created_at` | datetime | When the key was created |
     | `last_used_at` | datetime | When the key was last used (null if never used) |
+    | `scopes` | array | Permissions assigned to the key |
   </Accordion>
 </AccordionGroup>
 
@@ -99,11 +108,17 @@ This endpoint requires authentication with an existing API key or user session. 
   Create a new developer API key
 </Card>
 
+<Note>
+Create keys from the signed-in Omi web app. The REST endpoint is the same self-service flow and requires a
+Firebase ID token, not an existing `omi_dev_...` key. The new secret is returned only once.
+</Note>
+
 <AccordionGroup>
   <Accordion title="Request Body" icon="code" defaultOpen={true}>
     | Parameter | Type | Required | Description |
     |-----------|------|----------|-------------|
     | `name` | string | **Yes** | Descriptive name for the key |
+    | `scopes` | array of strings | No | Permissions for the key. If omitted, the key receives the read-only scopes. |
   </Accordion>
 </AccordionGroup>
 
@@ -111,9 +126,9 @@ This endpoint requires authentication with an existing API key or user session. 
   <Tab title="cURL">
     ```bash
     curl -X POST "https://api.omi.me/v1/dev/keys" \
-      -H "Authorization: Bearer $API_KEY" \
+      -H "Authorization: Bearer $FIREBASE_ID_TOKEN" \
       -H "Content-Type: application/json" \
-      -d '{"name": "My New Integration"}'
+      -d '{"name": "My New Integration", "scopes": ["memories:read"]}'
     ```
   </Tab>
   <Tab title="Python">
@@ -123,10 +138,10 @@ This endpoint requires authentication with an existing API key or user session. 
     response = requests.post(
         "https://api.omi.me/v1/dev/keys",
         headers={
-            "Authorization": f"Bearer {API_KEY}",
+            "Authorization": f"Bearer {firebase_id_token}",
             "Content-Type": "application/json"
         },
-        json={"name": "My New Integration"}
+        json={"name": "My New Integration", "scopes": ["memories:read"]}
     )
     new_key = response.json()
     print(f"Store this key securely: {new_key['key']}")
@@ -139,10 +154,10 @@ This endpoint requires authentication with an existing API key or user session. 
       {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${API_KEY}`,
+          Authorization: `Bearer ${firebaseIdToken}`,
           "Content-Type": "application/json"
         },
-        body: JSON.stringify({ name: "My New Integration" })
+        body: JSON.stringify({ name: "My New Integration", scopes: ["memories:read"] })
       }
     );
     const newKey = await response.json();
@@ -159,7 +174,8 @@ This endpoint requires authentication with an existing API key or user session. 
     "key_prefix": "omi_dev_ghi789",
     "key": "omi_dev_ghi789_full_secret_key_here",
     "created_at": "2025-01-20T15:00:00Z",
-    "last_used_at": null
+    "last_used_at": null,
+    "scopes": ["memories:read"]
   }
   ```
 </Accordion>
@@ -167,6 +183,16 @@ This endpoint requires authentication with an existing API key or user session. 
 <Warning>
 The full API key (`key` field) is only returned once during creation. Store it securely immediately - you won't be able to see it again!
 </Warning>
+
+### Scopes
+
+Choose the least-privileged scopes needed by your integration:
+
+- Read: `conversations:read`, `memories:read`, `action_items:read`, `goals:read`
+- Write: `conversations:write`, `memories:write`, `action_items:write`, `goals:write`
+
+Memory scopes authorize the key, but they do not bypass the account-level Developer Memory API readiness
+gate. See [Memories](/doc/developer/api/memories) for that availability contract.
 
 ---
 
@@ -188,7 +214,7 @@ The full API key (`key` field) is only returned once during creation. Store it s
   <Tab title="cURL">
     ```bash
     curl -X DELETE "https://api.omi.me/v1/dev/keys/key_789ghi" \
-      -H "Authorization: Bearer $API_KEY"
+      -H "Authorization: Bearer $FIREBASE_ID_TOKEN"
     ```
   </Tab>
   <Tab title="Python">
@@ -197,7 +223,7 @@ The full API key (`key` field) is only returned once during creation. Store it s
 
     response = requests.delete(
         f"https://api.omi.me/v1/dev/keys/key_789ghi",
-        headers={"Authorization": f"Bearer {API_KEY}"}
+        headers={"Authorization": f"Bearer {firebase_id_token}"}
     )
     if response.status_code == 204:
         print("Key revoked successfully")
@@ -209,7 +235,7 @@ The full API key (`key` field) is only returned once during creation. Store it s
       "https://api.omi.me/v1/dev/keys/key_789ghi",
       {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${API_KEY}` }
+        headers: { Authorization: `Bearer ${firebaseIdToken}` }
       }
     );
     if (response.status === 204) {

--- a/docs/doc/developer/api/memories.mdx
+++ b/docs/doc/developer/api/memories.mdx
@@ -24,6 +24,31 @@ description: "Create and retrieve memories via the Developer API"
   </Card>
 </CardGroup>
 
+## Access and availability
+
+Memory endpoints require a Developer API key with the corresponding scope: `memories:read` for reads and
+`memories:write` for writes. Creating a key is self-service in **Developer → API Keys**, and creation
+records the matching key grant when the key includes a memory scope.
+
+Default memory reads also have a separate, server-owned account readiness gate. A valid, correctly scoped
+key can therefore receive `403` while that account is not yet provisioned for Developer Memory API access.
+Do not recreate the key in that case; retry after the account is enabled or contact Omi support if it remains
+unavailable.
+
+```json
+{
+  "detail": {
+    "enabled": false,
+    "code": "developer_memory_access_not_ready",
+    "message": "Developer Memory API access is not enabled for this account.",
+    "reason": "missing_rollout_state"
+  }
+}
+```
+
+`code` is the stable programmatic signal. `reason` provides a diagnostic for the current server-side gate and
+must not be treated as a key or scope error.
+
 ---
 
 ## Get Memories

--- a/docs/doc/developer/api/overview.mdx
+++ b/docs/doc/developer/api/overview.mdx
@@ -32,7 +32,8 @@ The Omi Developer API provides programmatic access to your personal Omi data, al
 
 <Steps>
   <Step title="Get Your API Key" icon="key">
-    Open the Omi app and navigate to **Settings → Developer → Create Key**
+    While signed in, open the Omi web app and navigate to **Developer → API Keys**. Create a key and choose
+    only the scopes your integration needs.
 
     <Tip>Copy the key immediately - you won't be able to see it again!</Tip>
   </Step>
@@ -72,6 +73,12 @@ The Omi Developer API provides programmatic access to your personal Omi data, al
     Check out the endpoint pages for detailed documentation on each resource.
   </Step>
 </Steps>
+
+<Note>
+Key creation is self-service. Memory endpoints additionally require server-side account readiness, so a valid
+key with `memories:read` can return `403` with code `developer_memory_access_not_ready`. That response does
+not mean the key is invalid or missing its scope; see [Memories](/doc/developer/api/memories).
+</Note>
 
 ---
 
@@ -171,7 +178,7 @@ X-RateLimit-Reset: 1642694400
     | `204 No Content` | Request succeeded with no response body |
     | `400 Bad Request` | Invalid request parameters |
     | `401 Unauthorized` | Invalid or missing API key |
-    | `403 Forbidden` | API key doesn't have required permissions |
+    | `403 Forbidden` | Required scope, key grant, or server-side memory availability is missing |
     | `404 Not Found` | Resource not found |
     | `422 Unprocessable Entity` | Validation error |
     | `429 Too Many Requests` | Rate limit exceeded |
@@ -180,7 +187,10 @@ X-RateLimit-Reset: 1642694400
   <Accordion title="Error Response Format" icon="code">
     ```json
     {
-      "detail": "Invalid API key"
+      "detail": {
+        "code": "developer_memory_access_not_ready",
+        "message": "Developer Memory API access is not enabled for this account."
+      }
     }
     ```
   </Accordion>

--- a/docs/doc/developer/cli/quickstart.mdx
+++ b/docs/doc/developer/cli/quickstart.mdx
@@ -51,6 +51,12 @@ Choose 1 or 2 [1]: _
     Choose the scopes you want — `memories:read`, `memories:write`,
     `conversations:read`, etc. The CLI validates the `omi_dev_` prefix
     client-side so you fail fast on a typo.
+
+    Memory scopes are necessary but not sufficient for the Memory API: Omi also
+    applies a server-side account readiness gate. A `403` with code
+    `developer_memory_access_not_ready` means the key can still be valid and
+    correctly scoped. Do not rotate it; retry after the account is enabled or
+    contact Omi support if the state persists.
   </Tab>
   <Tab title="Headless / CI">
     ```bash

--- a/docs/doc/developer/cli/troubleshooting.mdx
+++ b/docs/doc/developer/cli/troubleshooting.mdx
@@ -41,6 +41,19 @@ only has `memories:read`.
 Generate a new key in the Omi web app under **Developer → API Keys** with the
 scope you need, then `omi auth login` to swap it in.
 
+## "Developer Memory API access is not ready" (exit 2)
+
+```text
+✗ Developer Memory API access is not enabled for this account
+```
+
+If a memory command returns `403` with code `developer_memory_access_not_ready`, the key has passed
+authentication and can already have the required memory scope. Omi also checks a server-side account
+readiness gate before exposing the canonical memory layer.
+
+Do not rotate or recreate the key to resolve this response. Retry after the account is enabled, or contact Omi
+support if it persists.
+
 ## "Rate limited" (exit 4)
 
 ```text


### PR DESCRIPTION
## Summary

- Return a stable, actionable error when a valid Developer Memory API key is blocked by account-level readiness.
- Preserve the existing fail-closed authorization gate and diagnostic reason.
- Document self-service key provisioning, scopes, and the separate memory readiness requirement.

## Verification

- `cd backend && test_list_file=$(mktemp) && printf '%s\n' tests/unit/test_dev_api_canonical_grant_ordering.py tests/unit/test_dev_api_memories_pagination.py tests/unit/test_default_read_rollout_decision.py tests/unit/test_product_authorization.py > "$test_list_file" && PYTHON=/Users/david/.codex/worktrees/1ed8/omi/backend/.venv/bin/python BACKEND_UNIT_TEST_FILE_LIST="$test_list_file" BACKEND_PYTEST_FILE_ISOLATION=0 bash test.sh`
- `make preflight` (with this PR body)

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

