### PR TITLE
fix(desktop): preserve artifact and voice continuity

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-voiceturndomain.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-voiceturndomain.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift": 2155
+    "desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift": 2191
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift": "The strict VoiceTurnDomain target centralizes reducer ownership and moves the lifecycle state machine intact."
+    "desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift": "A recoverable screen-evidence transition must stay atomic with the reducer-owned lifecycle it modifies; extracting it would weaken that ownership boundary."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -497,9 +497,16 @@ class FloatingControlBarState: NSObject, ObservableObject {
       if let questionId = pair.questionMessageId { ids.insert(questionId) }
       if let answerId = pair.answerMessageId { ids.insert(answerId) }
     }
+    // A terminal-only agent completion can be folded into the producing row by
+    // the shared display projection. Resolve the viewport anchors through that
+    // projection before collecting resources so the notch follows the same row
+    // and artifact cards as the main transcript.
+    let viewportMessages = ids.compactMap {
+      AgentLifecycleDisplayProjection.projectedMessage(id: $0, in: provider.messages)
+    }
     return ChatContinuityInvariants.resourcesBelongingToMessages(
-      messages: provider.messages,
-      messageIds: ids
+      messages: viewportMessages,
+      messageIds: Set(viewportMessages.map(\.id))
     )
   }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -4037,10 +4037,12 @@ class FloatingControlBarManager {
       )
     else { return false }
     observeAgentCompletionContext(pillID: pillID, runId: runId)
-    if !resources.isEmpty,
-      let projected = provider.messages.first(where: { $0.id == updated.turnId })
-    {
-      deliverAgentArtifactCompletionToFloatingSurface(projected)
+    if !resources.isEmpty {
+      // `updated` is the canonical journal revision. Project it synchronously
+      // before updating the floating viewport so a Combine refresh cannot make
+      // the main transcript and notch disagree about this artifact card.
+      provider.projectJournalTurn(updated)
+      deliverAgentArtifactCompletionToFloatingSurface(updated.chatMessage())
     }
     return true
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -4038,15 +4038,13 @@ class FloatingControlBarManager {
     else { return false }
     observeAgentCompletionContext(pillID: pillID, runId: runId)
     if !resources.isEmpty {
-      // `updated` is the canonical journal revision. Project it synchronously
-      // before updating the floating viewport so a Combine refresh cannot make
-      // the main transcript and notch disagree about this artifact card.
+      // Project the canonical journal revision synchronously so main and notch agree before the floating
+      // viewport update.
       provider.projectJournalTurn(updated)
       deliverAgentArtifactCompletionToFloatingSurface(updated.chatMessage())
     }
     return true
   }
-
   static func performOwnerBoundPillTerminalAdmission<Value: Sendable>(
     ownerID: String,
     currentOwnerID: @escaping @MainActor () -> String? = {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+ScreenEvidence.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+ScreenEvidence.swift
@@ -186,6 +186,35 @@ extension RealtimeHubController {
   ) {
     if case .rejected = screenGroundingState { return }
     guard let token = screenGroundingState.protocolToken else { return }
+    // The screenshot tool already returns a structured `permission_required`
+    // result for this case. Let the provider turn that into its normal spoken
+    // answer; taking over with the one-shot fallback produces the robotic
+    // system voice and contradicts that recoverable tool contract.
+    if reason == "capture_unavailable",
+      RealtimeScreenGroundingPolicy.failureDisposition(for: evidence) == .providerContinuation
+    {
+      let completion = completeRecoverableScreenEvidenceFailure(token)
+      guard completion == .completed else {
+        log("RealtimeHub: ptt_screen_evidence recoverable_completion=\(completion.rawValue) action=fail_closed")
+        screenGroundingState = .rejected(evidence, token)
+        completeScreenEvidenceFailure(
+          token,
+          failure: RealtimeScreenGroundingPolicy.failureText(for: evidence))
+        return
+      }
+      screenGroundingState = .inactive
+      if let evidence {
+        logScreenEvidence(stage: "permission_unavailable_provider_continuation", evidence: evidence)
+      }
+      DesktopDiagnosticsManager.shared.recordFallback(
+        area: "realtime_hub",
+        from: "screen_evidence",
+        to: "provider_continuation",
+        reason: "screen_recording_permission_required",
+        outcome: .degraded,
+        extra: ["screen_evidence_reason": reason, "user_visible": true])
+      return
+    }
     screenGroundingState = .rejected(evidence, token)
     if let evidence {
       logScreenEvidence(stage: "report_rejected_\(reason)", evidence: evidence)
@@ -298,6 +327,33 @@ extension RealtimeHubController {
         turnID: token.turnID,
         identity: token.screenshotIdentity,
         callID: token.screenshotCallID))
+    return recordScreenEvidenceProtocolCompletion(.completed)
+  }
+
+  /// A permission denial is a recoverable tool error: the provider receives
+  /// its structured payload and responds through the normal native voice path.
+  /// Unlike a deterministic failure, this must not persist or speak a local
+  /// answer, and it must not end the provider turn.
+  @discardableResult
+  func completeRecoverableScreenEvidenceFailure(
+    _ token: VoiceScreenEvidenceProtocolToken
+  ) -> RealtimeScreenEvidenceProtocolCompletion {
+    guard VoiceTurnCoordinator.shared.activeTurnID == token.turnID else {
+      return recordScreenEvidenceProtocolCompletion(.turnNotActive)
+    }
+    guard VoiceTurnCoordinator.shared.activeTurn?.screenEvidenceProtocol == token else {
+      return recordScreenEvidenceProtocolCompletion(.protocolNotActive)
+    }
+    VoiceTurnCoordinator.shared.publish(
+      .screenEvidenceUnavailableScoped(
+        turnID: token.turnID,
+        screenshotIdentity: token.screenshotIdentity,
+        screenshotCallID: token.screenshotCallID))
+    guard VoiceTurnCoordinator.shared.activeTurnID == token.turnID,
+      VoiceTurnCoordinator.shared.activeTurn?.screenEvidenceProtocol == nil
+    else {
+      return recordScreenEvidenceProtocolCompletion(.reducerDidNotResolve)
+    }
     return recordScreenEvidenceProtocolCompletion(.completed)
   }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeScreenEvidence.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeScreenEvidence.swift
@@ -340,7 +340,24 @@ enum RealtimeScreenEvidenceToolExecutionPolicy {
 
 /// Pure policy for locally enforcing current-screen provenance. The model may propose a
 /// screen observation, but it cannot make one user-visible until this policy validates it.
+enum RealtimeScreenEvidenceFailureDisposition: Equatable {
+  /// The provider received a recoverable tool error and should answer in its
+  /// normal native voice lane (for example, by offering Screen Recording).
+  case providerContinuation
+  /// No provider continuation can safely explain the failure, so the local
+  /// deterministic result remains the terminal answer.
+  case authoritativeLocalResult
+}
+
 enum RealtimeScreenGroundingPolicy {
+  static func failureDisposition(
+    for evidence: RealtimeScreenEvidenceDescriptor?
+  ) -> RealtimeScreenEvidenceFailureDisposition {
+    evidence?.captureFailure == .screenRecordingPermissionRequired
+      ? .providerContinuation
+      : .authoritativeLocalResult
+  }
+
   static func failureText(for evidence: RealtimeScreenEvidenceDescriptor?) -> String {
     guard evidence?.captureFailure == .screenRecordingPermissionRequired else {
       return "I couldn't verify the current screen."

--- a/desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift
+++ b/desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift
@@ -525,6 +525,13 @@ enum VoiceTurnEvent: Equatable, Sendable {
     screenshotCallID: VoiceToolCallID,
     reportIdentity: VoiceEffectIdentity,
     reportCallID: VoiceToolCallID)
+  /// A screenshot tool returned a recoverable unavailable result (such as
+  /// missing Screen Recording permission). Clear only the local provenance
+  /// protocol so the provider can continue in its normal voice lane.
+  case screenEvidenceUnavailableScoped(
+    turnID: VoiceTurnID,
+    screenshotIdentity: VoiceEffectIdentity,
+    screenshotCallID: VoiceToolCallID)
   case screenEvidenceProtocolStartedScoped(
     turnID: VoiceTurnID,
     token: VoiceScreenEvidenceProtocolToken,
@@ -586,6 +593,7 @@ enum VoiceTurnEvent: Equatable, Sendable {
       .toolStartedScoped(let turnID, _, _),
       .authoritativeLocalResultAcceptedScoped(let turnID, _, _, _),
       .screenEvidenceReportVerifiedScoped(let turnID, _, _, _, _),
+      .screenEvidenceUnavailableScoped(let turnID, _, _),
       .screenEvidenceProtocolStartedScoped(let turnID, _, _),
       .toolFinishedScoped(let turnID, _, _),
       .playbackStartedScoped(let turnID, _), .transcriptChanged(let turnID, _),
@@ -641,6 +649,7 @@ enum VoiceTurnEvent: Equatable, Sendable {
     case .toolStartedScoped: return "tool_started_scoped"
     case .authoritativeLocalResultAcceptedScoped: return "authoritative_local_result_accepted_scoped"
     case .screenEvidenceReportVerifiedScoped: return "screen_evidence_report_verified_scoped"
+    case .screenEvidenceUnavailableScoped: return "screen_evidence_unavailable_scoped"
     case .screenEvidenceProtocolStartedScoped: return "screen_evidence_protocol_started_scoped"
     case .toolFinishedScoped: return "tool_finished_scoped"
     case .playbackStartedScoped: return "playback_started_scoped"
@@ -884,6 +893,18 @@ package struct VoiceTurnFact: Sendable {
         screenshotCallID: screenshotCallID,
         reportIdentity: reportIdentity,
         reportCallID: reportCallID))
+  }
+
+  package static func screenEvidenceUnavailableScoped(
+    turnID: VoiceTurnID,
+    screenshotIdentity: VoiceEffectIdentity,
+    screenshotCallID: VoiceToolCallID
+  ) -> Self {
+    Self(
+      .screenEvidenceUnavailableScoped(
+        turnID: turnID,
+        screenshotIdentity: screenshotIdentity,
+        screenshotCallID: screenshotCallID))
   }
 
   package static func screenEvidenceProtocolStartedScoped(
@@ -1629,6 +1650,21 @@ struct VoiceTurnReducer {
       // Verification proves the attached JPEG was current for this tool pair;
       // it is not the answer. Keep the normal post-tool continuation fence so
       // native realtime audio answers the user's original question.
+      model.turn?.screenEvidenceProtocol = nil
+      cancel(.screenEvidenceProtocol, in: &model, effects: &effects)
+
+    case .screenEvidenceUnavailableScoped(_, let screenshotIdentity, let screenshotCallID):
+      guard let token = turn.screenEvidenceProtocol,
+        token.screenshotCallID == screenshotCallID,
+        token.screenshotIdentity == screenshotIdentity,
+        acceptsProviderOutput(turn.phase)
+      else {
+        stale(&model, event: event, effects: &effects)
+        return VoiceTurnReduction(model: model, effects: effects)
+      }
+      // A recoverable screenshot-tool error is not a user-visible local
+      // answer. The provider receives the error payload and keeps its normal
+      // post-tool continuation and native voice lane.
       model.turn?.screenEvidenceProtocol = nil
       cancel(.screenEvidenceProtocol, in: &model, effects: &effects)
 

--- a/desktop/macos/Desktop/Tests/FloatingControlBarStateTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingControlBarStateTests.swift
@@ -689,4 +689,66 @@ final class FloatingControlBarStateTests: XCTestCase {
     state.clearCurrentAnswerAnchors()
     XCTAssertTrue(state.viewportDisplayResources(from: provider).isEmpty)
   }
+
+  /// INV-6: a terminal-only completion can be hidden after its artifact is
+  /// projected onto the producing row. The same artifact must stay visible in
+  /// the main transcript and the floating/notch viewport when either identity
+  /// is anchored.
+  func testViewportResourcesResolveTerminalCompletionAnchorToProducingRow() {
+    let state = FloatingControlBarState()
+    let provider = ChatProvider()
+    let pillID = UUID()
+    let artifact = ChatResource.localGeneratedFile(
+      id: "artifact:terminal-anchor",
+      title: "result.html",
+      subtitle: "text/html",
+      mimeType: "text/html",
+      uri: "file:///tmp/result.html"
+    )
+    let producing = ChatMessage(
+      id: "agent-producing-turn",
+      text: "",
+      sender: .ai,
+      contentBlocks: [
+        .agentSpawn(
+          id: "spawn-block",
+          pillId: pillID,
+          sessionId: "session-1",
+          runId: "run-1",
+          title: "HTML agent",
+          objective: "Create an HTML result"
+        )
+      ],
+      resources: [artifact]
+    )
+    let terminal = ChatMessage(
+      id: "agent-terminal-turn",
+      text: "",
+      sender: .ai,
+      contentBlocks: [
+        .agentCompletion(
+          id: "completion-block",
+          pillId: pillID,
+          sessionId: "session-1",
+          runId: "run-1",
+          title: "HTML agent",
+          promptSnippet: "Create an HTML result",
+          output: "Done.",
+          status: "completed"
+        )
+      ]
+    )
+    provider.messages = [producing, terminal]
+
+    let mainMessage = AgentLifecycleDisplayProjection.projectedMessage(
+      id: terminal.id,
+      in: provider.messages
+    )
+    XCTAssertEqual(mainMessage?.id, producing.id)
+    XCTAssertEqual(mainMessage?.displayResources.map(\.id), [artifact.id])
+
+    state.bindAnswerMessage(terminal)
+    XCTAssertEqual(state.currentAIMessage(from: provider)?.id, producing.id)
+    XCTAssertEqual(state.viewportDisplayResources(from: provider).map(\.id), [artifact.id])
+  }
 }

--- a/desktop/macos/Desktop/Tests/RealtimeScreenEvidenceTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeScreenEvidenceTests.swift
@@ -43,6 +43,26 @@ final class RealtimeScreenEvidenceTests: XCTestCase {
     )
   }
 
+  func testScreenRecordingDenialContinuesThroughTheNormalVoiceProvider() {
+    let denied = evidence(
+      bytes: 0,
+      target: .unavailable,
+      captureFailure: .screenRecordingPermissionRequired)
+    let unavailable = evidence(
+      bytes: 0,
+      target: .unavailable,
+      captureFailure: .captureUnavailable)
+
+    XCTAssertEqual(
+      RealtimeScreenGroundingPolicy.failureDisposition(for: denied),
+      .providerContinuation
+    )
+    XCTAssertEqual(
+      RealtimeScreenGroundingPolicy.failureDisposition(for: unavailable),
+      .authoritativeLocalResult
+    )
+  }
+
   private func request(
     descriptor: RealtimeScreenEvidenceDescriptor? = nil,
     callID: String = "screenshot-1",

--- a/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/VoiceTurnReducerTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/VoiceTurnReducerTests.swift
@@ -886,6 +886,74 @@ final class VoiceTurnReducerTests: XCTestCase {
     XCTAssertEqual(acceptJournal(model).model.turn?.phase, .terminal(.success))
   }
 
+  func testScreenRecordingPermissionFailureKeepsNativeVoiceContinuation() throws {
+    let (startingModel, turnID, sessionID, responseID) = awaitingHubResponse()
+    let reservation = reserveIdentity(startingModel, turnID: turnID)
+    let screenshotIdentity = reservation.identity
+    let screenshotCallID = VoiceToolCallID("screenshot")
+    var model = reduce(
+      reservation.model,
+      .toolStartedScoped(
+        turnID: turnID,
+        identity: screenshotIdentity,
+        callID: screenshotCallID)
+    ).model
+    let token = VoiceScreenEvidenceProtocolToken(
+      turnID: turnID,
+      screenshotCallID: screenshotCallID,
+      screenshotIdentity: screenshotIdentity)
+    model =
+      reduce(
+        model,
+        .screenEvidenceProtocolStartedScoped(
+          turnID: turnID,
+          token: token,
+          expiresAfter: 5)
+      ).model
+
+    model =
+      reduce(
+        model,
+        .screenEvidenceUnavailableScoped(
+          turnID: turnID,
+          screenshotIdentity: screenshotIdentity,
+          screenshotCallID: screenshotCallID)
+      ).model
+    XCTAssertNil(model.turn?.screenEvidenceProtocol)
+    XCTAssertFalse(model.turn?.providerFinished == true)
+    XCTAssertTrue(model.turn?.postToolContinuationRequired == true)
+
+    let providerIdentity = try XCTUnwrap(model.turn?.providerEffectIdentity)
+    model =
+      reduce(
+        model,
+        .providerTurnFinishedScoped(
+          turnID: turnID,
+          identity: providerIdentity,
+          sessionID: sessionID,
+          responseID: responseID)
+      ).model
+    model =
+      reduce(
+        model,
+        .toolFinishedScoped(turnID: turnID, identity: screenshotIdentity, callID: screenshotCallID)
+      ).model
+    XCTAssertEqual(model.turn?.phase, .awaitingResponse)
+
+    model =
+      reduce(
+        model,
+        .providerResponseStartedScoped(
+          turnID: turnID,
+          identity: providerIdentity,
+          sessionID: sessionID,
+          responseID: responseID)
+      ).model
+    let nativeLease = VoiceOutputLease(id: VoiceLeaseID(), turnID: turnID, lane: .nativeRealtime)
+    model = reduce(model, .playbackStarted(turnID: turnID, lease: nativeLease)).model
+    XCTAssertEqual(model.turn?.activeLease?.lane, .nativeRealtime)
+  }
+
   func testFailedScreenEvidenceRejectsLateProviderToolWithoutReopeningTheTurn() {
     let (startingModel, turnID, _, _) = awaitingHubResponse()
     let screenshotReservation = reserveIdentity(startingModel, turnID: turnID)

--- a/desktop/macos/agent/src/runtime/artifact-storage.ts
+++ b/desktop/macos/agent/src/runtime/artifact-storage.ts
@@ -168,8 +168,9 @@ export class OmiArtifactStorage {
    * adapter path. Recover that narrow, user-visible case without treating every
    * pathname mentioned in model text as an artifact.
    *
-   * Absolute paths are eligible only under a temporary directory, covering
-   * providers that do not honor Omi's managed working directory convention.
+   * Absolute paths are eligible under a temporary directory or Omi's managed
+   * artifact root. The latter covers nested agents that report a file from
+   * their assigned Omi workspace rather than emitting the structured event.
    * Desktop uses its own stricter delivery grammar ("I built file.html on your
    * Desktop" or "file.html was built on the Desktop"), which resolves only a
    * simple filename beneath the signed-in user's Desktop.
@@ -184,14 +185,23 @@ export class OmiArtifactStorage {
     const discovered: AdapterArtifactReference[] = [];
     const seenPaths = new Set<string>();
 
-    for (const line of finalText.slice(0, MAX_REPORTED_TERMINAL_TEXT_CHARS).split(/\r?\n/)) {
+    const lines = finalText.slice(0, MAX_REPORTED_TERMINAL_TEXT_CHARS).split(/\r?\n/);
+    for (const [lineIndex, line] of lines.entries()) {
       const desktopCandidates = reportedDesktopFileCandidates(line, this.reportedDesktopRoots);
-      if (!EXPLICIT_ARTIFACT_DELIVERY_LANGUAGE.test(line) && desktopCandidates.length === 0) continue;
+      // ACP providers commonly put an explicit "file created" receipt and
+      // its absolute path on separate lines (often inside a Markdown code
+      // block). Keep the acceptance signal local to that receipt rather than
+      // treating an arbitrary managed-workspace pathname as an artifact.
+      const explicitDelivery = hasExplicitArtifactDeliveryContext(lines, lineIndex);
+      if (!explicitDelivery && desktopCandidates.length === 0) continue;
 
       const candidates = [
         ...reportedLocalFileCandidates(line).map((candidate) => ({
           candidate,
-          allowedRoots: this.temporaryArtifactRoots,
+          allowedRoots: [
+            ...this.temporaryArtifactRoots,
+            this.rootDir,
+          ],
         })),
         ...desktopCandidates.map((candidate) => ({
           candidate,
@@ -286,11 +296,34 @@ const MAX_REPORTED_TERMINAL_TEXT_CHARS = 64 * 1024;
 const MAX_REPORTED_TERMINAL_ARTIFACTS = 8;
 const EXPLICIT_ARTIFACT_DELIVERY_LANGUAGE = /(?:\b(?:file|artifact|deliverable|output|result|report|page|document|site)\b[^\n]{0,120}\b(?:lives?|saved|written|created|generated|produced|ready|available|located)\b|\b(?:saved|written|created|generated|produced)\b[^\n]{0,120}\b(?:file|artifact|deliverable|output|result|report|page|document|site)\b|\b(?:file|artifact|deliverable|output|result|report|page|document|site)\b\s*:)/i;
 const REPORTED_LOCAL_FILE_CANDIDATE = /file:\/\/[^\s`<>"']+|\/(?:[^\s`<>"']+)/g;
+const REPORTED_CODE_PATH_CANDIDATE = /`([^`\n]+)`/g;
 const REPORTED_DESKTOP_FILE_CANDIDATE = /\b(?:built|created|generated|saved|wrote)\b[^\n]{0,120}?\b([A-Za-z0-9][A-Za-z0-9._-]{0,127})(?:[`*_]+)?\s+on\s+(?:your|the)\s+desktop\b/gi;
 const REPORTED_DESKTOP_PASSIVE_FILE_CANDIDATE = /\b([A-Za-z0-9][A-Za-z0-9._-]{0,127})(?:[`*_]+)?\s+(?:was\s+)?(?:built|created|generated|saved|written)\s+on\s+(?:your|the)\s+desktop\b/gi;
 
 function reportedLocalFileCandidates(line: string): string[] {
-  return line.match(REPORTED_LOCAL_FILE_CANDIDATE) ?? [];
+  const inline: string[] = [...(line.match(REPORTED_LOCAL_FILE_CANDIDATE) ?? [])];
+  for (const match of line.matchAll(REPORTED_CODE_PATH_CANDIDATE)) {
+    const candidate = match[1]?.trim();
+    if (candidate?.startsWith("/") || candidate?.startsWith("file://")) {
+      inline.push(candidate);
+    }
+  }
+  // A result path is often alone in a fenced Markdown line. Preserve spaces
+  // in managed directory names such as "Application Support", whether the
+  // provider reports it in a table cell, a fenced block, or plain line.
+  const standalone = line.trim();
+  if (standalone.startsWith("/") || standalone.startsWith("file://")) {
+    inline.push(standalone);
+  }
+  return [...new Set(inline)];
+}
+
+function hasExplicitArtifactDeliveryContext(lines: readonly string[], lineIndex: number): boolean {
+  // Keep this bounded to one compact terminal receipt. Markdown dividers and
+  // fenced paths add several otherwise-empty lines between the confirmation
+  // and the path, so a three-line window misses normal provider formatting.
+  const first = Math.max(0, lineIndex - 8);
+  return EXPLICIT_ARTIFACT_DELIVERY_LANGUAGE.test(lines.slice(first, lineIndex + 1).join("\n"));
 }
 
 function reportedDesktopFileCandidates(line: string, desktopRoots: readonly string[]): string[] {
@@ -304,7 +337,7 @@ function reportedDesktopFileCandidates(line: string, desktopRoots: readonly stri
 }
 
 function localPathFromReportedCandidate(candidate: string): string | null {
-  const trimmed = candidate.replace(/[),.;:!?\]}]+$/g, "");
+  const trimmed = candidate.trim().replace(/^`+|`+$/g, "").replace(/[),.;:!?\]}]+$/g, "");
   try {
     const path = trimmed.startsWith("file://") ? fileURLToPath(trimmed) : trimmed;
     return isAbsolute(path) ? resolve(path) : null;

--- a/desktop/macos/agent/tests/run-attempt-lifecycle.test.ts
+++ b/desktop/macos/agent/tests/run-attempt-lifecycle.test.ts
@@ -339,7 +339,7 @@ describe("AgentRuntimeKernel run and attempt lifecycle", () => {
     store.close();
   });
 
-  it("projects verified temporary deliverables reported by OpenClaw and Hermes terminal prose", async () => {
+  it("projects verified temporary and managed-root deliverables reported by OpenClaw and Hermes terminal prose", async () => {
     for (const provider of ["openclaw", "hermes"] as const) {
       const artifactRoot = mkdtempTracked(`omi-${provider}-artifacts-`);
       const externalDirectory = mkdtempTracked(`omi-${provider}-reported-`);
@@ -348,6 +348,7 @@ describe("AgentRuntimeKernel run and attempt lifecycle", () => {
       const reportedPath = join(externalDirectory, "dog_facts.html");
       const desktopPath = join(desktopDirectory, "cool_cat_facts.html");
       const nonTemporaryPath = join(nonTemporaryDirectory, "not_a_deliverable.html");
+      const managedRootPath = join(artifactRoot, "nested_agent_artifact.html");
       const deniedPath = join(externalDirectory, ".claude");
       const symlinkPath = join(externalDirectory, "symlinked_dog_facts.html");
       const { store, adapter, kernel } = createKernelHarness(
@@ -361,6 +362,7 @@ describe("AgentRuntimeKernel run and attempt lifecycle", () => {
       writeFileSync(reportedPath, "<h1>Dog facts</h1>");
       writeFileSync(desktopPath, "<h1>Cat facts</h1>");
       writeFileSync(nonTemporaryPath, "<h1>Not a delivery</h1>");
+      writeFileSync(managedRootPath, "<h1>Nested agent artifact</h1>");
       writeFileSync(deniedPath, "{}");
       symlinkSync(reportedPath, symlinkPath);
       adapter.nextText = `I inspected the file at ${reportedPath} while preparing the answer.`;
@@ -412,6 +414,16 @@ describe("AgentRuntimeKernel run and attempt lifecycle", () => {
       });
       expect(kernel.inspectArtifacts({ runId: nonTemporary.run.runId })).toEqual([]);
 
+      adapter.nextText = `I inspected ${managedRootPath} while preparing the answer.`;
+      const incidentalManagedPath = await kernel.executeRun({
+        ...baseRunInput,
+        adapterId: provider,
+        defaultAdapterId: provider,
+        requestId: `${provider}-incidental-managed-artifact`,
+        cwd: artifactRoot,
+      });
+      expect(kernel.inspectArtifacts({ runId: incidentalManagedPath.run.runId })).toEqual([]);
+
       adapter.nextText = `The file lives at ${desktopPath}.`;
       const genericDesktopPath = await kernel.executeRun({
         ...baseRunInput,
@@ -449,6 +461,39 @@ describe("AgentRuntimeKernel run and attempt lifecycle", () => {
         discoveredFromTerminalReport: true,
         omiManaged: true,
         originalUri: `file://${reportedPath}`,
+      });
+
+      adapter.nextText = [
+        "File created successfully.",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        `| **Absolute path** | \`${managedRootPath}\` |`,
+      ].join("\n");
+      const managedRoot = await kernel.executeRun({
+        ...baseRunInput,
+        adapterId: provider,
+        defaultAdapterId: provider,
+        requestId: `${provider}-managed-root-artifact`,
+        cwd: artifactRoot,
+      });
+      const managedRootArtifacts = kernel.inspectArtifacts({ runId: managedRoot.run.runId });
+      expect(managedRootArtifacts).toEqual([
+        expect.objectContaining({
+          sessionId: managedRoot.session.sessionId,
+          runId: managedRoot.run.runId,
+          attemptId: managedRoot.attempt.attemptId,
+          displayName: "nested_agent_artifact.html",
+          kind: "html",
+          role: "result",
+          mimeType: "text/html",
+          uri: `file://${managedRootPath}`,
+        }),
+      ]);
+      expect(JSON.parse(managedRootArtifacts[0]!.metadataJson)).toMatchObject({
+        discoveredFromTerminalReport: true,
+        omiManaged: true,
+        managedPath: managedRootPath,
       });
 
       adapter.nextText = "Done! 🐱 I built and opened **`cool_cat_facts.html`** on your Desktop.";

--- a/desktop/macos/changelog/unreleased/20260717-artifact-and-ptt-continuity.json
+++ b/desktop/macos/changelog/unreleased/20260717-artifact-and-ptt-continuity.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed generated artifact cards across main and notch chat, and kept Screen Recording prompts on the normal voice path"
+}

--- a/docs/product/invariants/desktop-voice-turns.md
+++ b/docs/product/invariants/desktop-voice-turns.md
@@ -92,6 +92,12 @@ verify that every required fact is published.
   clears the screen protocol while preserving the provider-continuation fence,
   so native realtime audio answers the user's original question from the image.
   Only deterministic screen-verification failure is a local terminal result.
+  A missing Screen Recording permission is instead a recoverable screenshot-tool
+  result: it never supplies visual evidence, but it clears the screen protocol
+  and preserves the provider continuation so the selected native voice can
+  explain the permission request naturally. All other missing, stale,
+  contradictory, or cross-turn evidence failures remain deterministic local
+  results.
   Model-supplied
   evidence IDs and app labels have no authority; native code supplies app identity
   and rejects stale, missing, contradictory, or cross-turn reports without using


### PR DESCRIPTION
## What changed and why

Fixes two desktop continuity regressions: terminal agent artifacts now remain attached to their producing chat row in both main and floating/notch chat, and explicitly delivered files under Omi-managed artifact roots are recognized safely. Missing Screen Recording permission is now treated as a recoverable screenshot-tool result, so the provider continues with its native voice response instead of the robotic local fallback.

## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1
- INV-VOICE-1

## How it was verified

- Exercised the named development bundle `/Applications/omi-main-9b1a6642.app`: a generated HTML artifact appeared on both the main transcript and notch/floating surface.
- Exercised a missing-Screen-Recording PTT turn in that bundle: the permission-required tool response preserved provider continuation and avoided deterministic local speech.
- `./scripts/agent-logic-harness.sh --cross-surface-smoke` — passed (Swift 73, Node 246, Rust 13).
- `npm --prefix agent test` — passed (48 files, 574 tests).
- `./scripts/swift-test-suites.sh` — passed (309 suites, 4 workers).
- `scripts/pr-preflight --pr-body-file …` and `OMI_PR_BODY_FILE=… make preflight` — passed (19 deterministic checks).

## Tests

- `FloatingControlBarStateTests.testViewportResourcesResolveTerminalCompletionAnchorToProducingRow`
- `run-attempt-lifecycle.test.ts` verifies managed-root terminal deliveries are projected only with an explicit delivery receipt and rejects incidental paths.
- `RealtimeScreenEvidenceTests.testScreenRecordingDenialContinuesThroughTheNormalVoiceProvider`
- `VoiceTurnReducerTests.testScreenRecordingPermissionFailureKeepsNativeVoiceContinuation`

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

