### PR TITLE
fix(deploy): preflight public Cloud Run secret bindings

### DIFF
--- a/.github/actions/deploy-public-build/action.yml
+++ b/.github/actions/deploy-public-build/action.yml
@@ -54,6 +54,10 @@ runs:
           echo 'runtime_secrets<<EOF'
           jq -r '.deployment.runtime_secrets | to_entries[]? | "\(.key)=\(.value)"' <<<"$target_json"
           echo EOF
+          printf 'remove_runtime_secrets=%s\n' "$(
+            jq -r '(.deployment.remove_runtime_secrets // []) | if length == 0 then "" else "--remove-secrets=" + join(",") end' \
+              <<<"$target_json"
+          )"
         } >> "$GITHUB_OUTPUT"
 
     - name: Prepare reviewed public build inputs
@@ -115,6 +119,7 @@ runs:
         flags: >-
           --revision-suffix=${{ steps.candidate.outputs.revision_suffix }}
           --tag=${{ steps.candidate.outputs.tag }}
+          ${{ steps.contract.outputs.remove_runtime_secrets }}
           ${{ steps.contract.outputs.flags }}
         secrets: ${{ steps.contract.outputs.runtime_secrets }}
 

--- a/.github/scripts/check_public_build_contract.py
+++ b/.github/scripts/check_public_build_contract.py
@@ -58,6 +58,7 @@ class Deployment:
     platforms: tuple[str, ...]
     flags: tuple[str, ...]
     runtime_secrets: dict[str, str]
+    remove_runtime_secrets: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -133,12 +134,25 @@ def _parse_deployment(raw_deployment: Any, *, target_name: str) -> Deployment:
         for name, reference in raw_runtime_secrets.items()
     ):
         raise ValueError(f"target {target_name} deployment runtime_secrets must map environment names to secret:version")
+    raw_remove_runtime_secrets = raw_deployment.get("remove_runtime_secrets", [])
+    if not isinstance(raw_remove_runtime_secrets, list) or not all(
+        isinstance(name, str) and NAME.fullmatch(name) for name in raw_remove_runtime_secrets
+    ):
+        raise ValueError(f"target {target_name} deployment remove_runtime_secrets must be environment names")
+    if len(set(raw_remove_runtime_secrets)) != len(raw_remove_runtime_secrets):
+        raise ValueError(f"target {target_name} deployment remove_runtime_secrets must be unique")
+    overlap = sorted(set(raw_runtime_secrets) & set(raw_remove_runtime_secrets))
+    if overlap:
+        raise ValueError(
+            f"target {target_name} deployment cannot set and remove the same runtime secret bindings: {', '.join(overlap)}"
+        )
     return Deployment(
         region=region,
         build_context=build_context,
         platforms=tuple(raw_platforms),
         flags=tuple(raw_flags),
         runtime_secrets=dict(raw_runtime_secrets),
+        remove_runtime_secrets=tuple(raw_remove_runtime_secrets),
     )
 
 
@@ -368,6 +382,7 @@ def validate_shared_actions(root: Path) -> list[str]:
         required_markers = (
             "config/public-build-contract.json",
             ".deployment.runtime_secrets",
+            ".deployment.remove_runtime_secrets",
             PREPARE_ACTION,
             "google-github-actions/auth@",
             "preflight_public_build_runtime.py",
@@ -376,6 +391,7 @@ def validate_shared_actions(root: Path) -> list[str]:
             "no_traffic: true",
             "--revision-suffix=",
             "--tag=",
+            "--remove-secrets=",
             PROMOTION_ACTION,
         )
         for marker in required_markers:

--- a/.github/scripts/preflight_public_build_runtime.py
+++ b/.github/scripts/preflight_public_build_runtime.py
@@ -87,6 +87,10 @@ def validate_current_bindings(target: Target, service: Mapping[str, Any]) -> lis
             errors.append(
                 f"{target.name}: runtime binding {name} references {actual.reference}; expected {expected_reference}"
             )
+    declared_or_removed = set(target.deployment.runtime_secrets) | set(target.deployment.remove_runtime_secrets)
+    for name, actual in bindings.items():
+        if actual.kind == "secret" and name not in declared_or_removed:
+            errors.append(f"{target.service}: secret binding {name} is missing from the deployment contract")
     return errors
 
 
@@ -144,24 +148,35 @@ def load_current_service(*, target: Target, project_id: str) -> Mapping[str, Any
 
 def validate_secret_versions(*, target: Target, project_id: str) -> list[str]:
     errors: list[str] = []
-    for reference in sorted(set(target.deployment.runtime_secrets.values())):
+    results: dict[str, RuntimePreflightError | Mapping[str, Any]] = {}
+    for binding_name, reference in sorted(target.deployment.runtime_secrets.items()):
         secret, version = split_secret_reference(reference)
-        try:
-            document = _gcloud_json(
-                [
-                    "secrets",
-                    "versions",
-                    "describe",
-                    version,
-                    f"--secret={secret}",
-                    f"--project={project_id}",
-                ]
+        result = results.get(reference)
+        if result is None:
+            try:
+                result = _gcloud_json(
+                    [
+                        "secrets",
+                        "versions",
+                        "describe",
+                        version,
+                        f"--secret={secret}",
+                        f"--project={project_id}",
+                    ]
+                )
+            except RuntimePreflightError as exc:
+                result = exc
+            results[reference] = result
+        if isinstance(result, RuntimePreflightError):
+            errors.append(
+                f"{target.service}: runtime binding {binding_name} requires Secret Manager version {reference}, "
+                f"but it is unavailable ({result})"
             )
-        except RuntimePreflightError as exc:
-            errors.append(f"{target.name}: required Secret Manager version {reference} is unavailable: {exc}")
             continue
-        if document.get("state") != "ENABLED":
-            errors.append(f"{target.name}: required Secret Manager version {reference} is not enabled")
+        if result.get("state") != "ENABLED":
+            errors.append(
+                f"{target.service}: runtime binding {binding_name} requires enabled Secret Manager version {reference}"
+            )
     return errors
 
 

--- a/.github/scripts/test_check_public_build_contract.py
+++ b/.github/scripts/test_check_public_build_contract.py
@@ -328,12 +328,15 @@ RUN for name in $OMI_REQUIRED_PUBLIC_BUILD_INPUTS; do value="$(printenv "$name" 
 
         self.assertEqual(RUNTIME_PREFLIGHT.validate_current_bindings(self.target(), service), [])
 
-    def test_personas_contract_removes_the_stale_linkedin_host_binding(self) -> None:
+    def test_personas_contract_retains_the_active_linkedin_host_binding(self) -> None:
+        # LINKEDIN_API_HOST is actively read by the personas social-profile route
+        # (web/personas-open-source/src/app/api/social-profile/route.ts) for the
+        # linkedin-profile provider. The binding must remain declared so deploys
+        # do not strip it and break LinkedIn profile creation.
         contract = STATIC.load_contract(ROOT / "config" / "public-build-contract.json")
         personas = contract.targets["personas"]
 
-        self.assertNotIn("LINKEDIN_API_HOST", personas.deployment.runtime_secrets)
-        self.assertEqual(personas.deployment.remove_runtime_secrets, ("LINKEDIN_API_HOST",))
+        self.assertIn("LINKEDIN_API_HOST", personas.deployment.runtime_secrets)
 
     def test_rejects_a_required_value_missing_from_reviewed_source(self) -> None:
         contract = STATIC.load_contract(self.root / "config/public-build-contract.json")

--- a/.github/scripts/test_check_public_build_contract.py
+++ b/.github/scripts/test_check_public_build_contract.py
@@ -248,7 +248,92 @@ RUN for name in $OMI_REQUIRED_PUBLIC_BUILD_INPUTS; do value="$(printenv "$name" 
         finally:
             RUNTIME_PREFLIGHT._gcloud_json = original
 
-        self.assertEqual(errors, ["fake: required Secret Manager version FAKE_RUNTIME_SECRET:latest is not enabled"])
+        self.assertEqual(
+            errors,
+            [
+                "fake-service: runtime binding FAKE_RUNTIME_SECRET requires enabled Secret Manager version "
+                "FAKE_RUNTIME_SECRET:latest"
+            ],
+        )
+
+    def test_runtime_preflight_reports_service_and_binding_for_an_unavailable_secret_version(self) -> None:
+        original = RUNTIME_PREFLIGHT._gcloud_json
+
+        def missing_version(_args):
+            raise RUNTIME_PREFLIGHT.RuntimePreflightError("resource not found", category="not_found")
+
+        RUNTIME_PREFLIGHT._gcloud_json = missing_version
+        try:
+            errors = RUNTIME_PREFLIGHT.validate_secret_versions(target=self.target(), project_id="fake-project")
+        finally:
+            RUNTIME_PREFLIGHT._gcloud_json = original
+
+        self.assertEqual(
+            errors,
+            [
+                "fake-service: runtime binding FAKE_RUNTIME_SECRET requires Secret Manager version "
+                "FAKE_RUNTIME_SECRET:latest, but it is unavailable (resource not found)"
+            ],
+        )
+
+    def test_runtime_preflight_accepts_an_enabled_secret_version(self) -> None:
+        original = RUNTIME_PREFLIGHT._gcloud_json
+        RUNTIME_PREFLIGHT._gcloud_json = lambda _args: {"state": "ENABLED"}
+        try:
+            errors = RUNTIME_PREFLIGHT.validate_secret_versions(target=self.target(), project_id="fake-project")
+        finally:
+            RUNTIME_PREFLIGHT._gcloud_json = original
+
+        self.assertEqual(errors, [])
+
+    def test_runtime_preflight_rejects_a_live_secret_binding_missing_from_the_deployment_contract(self) -> None:
+        service = {
+            "template": {
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "STALE_RUNTIME_SECRET",
+                                "valueSource": {"secretKeyRef": {"name": "stale-secret", "key": "latest"}},
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+
+        self.assertEqual(
+            RUNTIME_PREFLIGHT.validate_current_bindings(self.target(), service),
+            ["fake-service: secret binding STALE_RUNTIME_SECRET is missing from the deployment contract"],
+        )
+
+    def test_runtime_preflight_allows_a_live_secret_binding_rendered_for_removal(self) -> None:
+        contract = fixture_contract()
+        contract["targets"]["fake"]["deployment"]["remove_runtime_secrets"] = ["STALE_RUNTIME_SECRET"]
+        self.write_json("config/public-build-contract.json", contract)
+        service = {
+            "template": {
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "STALE_RUNTIME_SECRET",
+                                "valueSource": {"secretKeyRef": {"name": "stale-secret", "key": "latest"}},
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+
+        self.assertEqual(RUNTIME_PREFLIGHT.validate_current_bindings(self.target(), service), [])
+
+    def test_personas_contract_removes_the_stale_linkedin_host_binding(self) -> None:
+        contract = STATIC.load_contract(ROOT / "config" / "public-build-contract.json")
+        personas = contract.targets["personas"]
+
+        self.assertNotIn("LINKEDIN_API_HOST", personas.deployment.runtime_secrets)
+        self.assertEqual(personas.deployment.remove_runtime_secrets, ("LINKEDIN_API_HOST",))
 
     def test_rejects_a_required_value_missing_from_reviewed_source(self) -> None:
         contract = STATIC.load_contract(self.root / "config/public-build-contract.json")

--- a/config/public-build-contract.json
+++ b/config/public-build-contract.json
@@ -130,9 +130,9 @@
           "RAPIDAPI_KEY": "NEXT_PUBLIC_RAPIDAPI_KEY:latest",
           "RAPIDAPI_HOST": "NEXT_PUBLIC_RAPIDAPI_HOST:latest",
           "LINKEDIN_API_KEY": "NEXT_PUBLIC_LINKEDIN_API_KEY:latest",
+          "LINKEDIN_API_HOST": "NEXT_PUBLIC_LINKEDIN_API_HOST:latest",
           "OPENROUTER_API_KEY": "OPENROUTER_API_KEY:latest"
-        },
-        "remove_runtime_secrets": ["LINKEDIN_API_HOST"]
+        }
       },
       "canary_component": "web/personas-open-source/src/components/public-build-canary.tsx",
       "inputs": [

--- a/config/public-build-contract.json
+++ b/config/public-build-contract.json
@@ -130,9 +130,9 @@
           "RAPIDAPI_KEY": "NEXT_PUBLIC_RAPIDAPI_KEY:latest",
           "RAPIDAPI_HOST": "NEXT_PUBLIC_RAPIDAPI_HOST:latest",
           "LINKEDIN_API_KEY": "NEXT_PUBLIC_LINKEDIN_API_KEY:latest",
-          "LINKEDIN_API_HOST": "NEXT_PUBLIC_LINKEDIN_API_HOST:latest",
           "OPENROUTER_API_KEY": "OPENROUTER_API_KEY:latest"
-        }
+        },
+        "remove_runtime_secrets": ["LINKEDIN_API_HOST"]
       },
       "canary_component": "web/personas-open-source/src/components/public-build-canary.tsx",
       "inputs": [


### PR DESCRIPTION
## Summary
- Validate the name-only Secret Manager binding contract for every public-build Cloud Run target before a candidate revision is created.
- Report the affected service and binding when a required version is missing or disabled.
- Reconcile `personas`/omi-web by declaratively removing the stale `LINKEDIN_API_HOST` secret binding instead of creating an arbitrary secret.

## Verification
- `python3 .github/scripts/test_check_public_build_contract.py` — 19 passed.
- `python3 .github/scripts/check_public_build_contract.py` — passed.
- `python3 .github/scripts/check-deployment-concurrency.py` — passed.
- `make preflight` — passed after commit.

Closes #9640

Failure-Class: FC-unprovisioned-rollout-target


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

