### PR TITLE
feat: add auto-save for SD card every 2s in sync mode

### DIFF
--- a/omi/firmware/omi/src/lib/core/sd_card.h
+++ b/omi/firmware/omi/src/lib/core/sd_card.h
@@ -43,6 +43,7 @@ uint32_t write_to_file(uint8_t *data, uint32_t length);
 int sd_ring_get_info(sd_ring_info_t *info);
 int sd_ring_read(uint64_t start_seq, uint8_t *buf, uint32_t max_bytes, uint32_t *bytes_read, uint32_t *packets_read);
 int sd_ring_advance(uint64_t new_read_seq);
+int sd_ring_advance_async(uint64_t new_read_seq);
 int sd_ring_clear(void);
 
 uint32_t get_file_size(void);

--- a/omi/firmware/omi/src/lib/core/storage.c
+++ b/omi/firmware/omi/src/lib/core/storage.c
@@ -49,6 +49,10 @@ LOG_MODULE_REGISTER(storage, CONFIG_LOG_DEFAULT_LEVEL);
 
 #define SYNC_SPEED_LOG_INTERVAL_MS (2 * 1000)
 
+/* How often, during a bulk read, to persist the ring read pointer up to the
+ * packets the phone has confirmed receiving (incremental auto-save). */
+#define STORAGE_ADVANCE_CHECKPOINT_MS 2000
+
 static void storage_config_changed_handler(const struct bt_gatt_attr *attr, uint16_t value);
 static ssize_t storage_write_handler(struct bt_conn *conn,
                                      const struct bt_gatt_attr *attr,
@@ -122,6 +126,15 @@ static uint64_t transfer_start_seq;
 static uint64_t current_read_seq;
 static uint32_t remaining_packets;
 static uint8_t transfer_end_status;
+
+/* Incremental auto-save: bytes of audio the phone has confirmed receiving are
+ * accumulated in the TX-completion callback, then the ring read pointer is
+ * advanced (and persisted to SD) up to that point. Only delivered data is ever
+ * freed, so a mid-sync disconnect resumes from the last checkpoint instead of
+ * re-syncing from the start. */
+static atomic_t sync_confirmed_bytes = ATOMIC_INIT(0);
+static uint64_t sync_checkpoint_seq;
+static int64_t sync_checkpoint_deadline_ms;
 
 static atomic_t storage_status_used_bytes = ATOMIC_INIT(0);
 static atomic_t storage_status_unread_packets = ATOMIC_INIT(0);
@@ -229,11 +242,13 @@ static int storage_notify(struct bt_conn *conn, const void *data, uint16_t len)
     return bt_gatt_notify(conn, &storage_service.attrs[STORAGE_WRITE_NOTIFY_ATTR_IDX], data, len);
 }
 
-/* Completion callback: a bulk DATA notification was sent, free its throttle slot. */
+/* Completion callback: a bulk DATA notification was sent, free its throttle slot.
+ * user_data carries this notification's audio-byte count (set in
+ * storage_notify_data); accumulate what the phone has confirmed receiving. */
 static void storage_data_tx_done(struct bt_conn *conn, void *user_data)
 {
     ARG_UNUSED(conn);
-    ARG_UNUSED(user_data);
+    atomic_add(&sync_confirmed_bytes, (atomic_val_t) (uintptr_t) user_data);
     transport_bulk_tx_release();
 }
 
@@ -254,12 +269,13 @@ static int storage_notify_data(struct bt_conn *conn, const void *data, uint16_t 
         return -ENOMEM;
     }
 
+    /* len includes the 1-byte NOTIFY_DATA marker; the audio payload is len-1. */
     struct bt_gatt_notify_params params = {
         .attr = &storage_service.attrs[STORAGE_WRITE_NOTIFY_ATTR_IDX],
         .data = data,
         .len = len,
         .func = storage_data_tx_done,
-        .user_data = NULL,
+        .user_data = (void *) (uintptr_t) (len > 0U ? (uint16_t) (len - 1U) : 0U),
     };
 
     int err = bt_gatt_notify_cb(conn, &params);
@@ -360,6 +376,61 @@ static void reset_transfer_state(void)
     current_read_seq = 0;
     remaining_packets = 0;
     transfer_end_status = 0;
+    atomic_set(&sync_confirmed_bytes, 0);
+    sync_checkpoint_seq = 0;
+    sync_checkpoint_deadline_ms = 0;
+}
+
+/* Ring seq the phone has confirmed receiving (whole packets only). */
+static uint64_t sync_confirmed_seq(void)
+{
+    uint32_t bytes = (uint32_t) atomic_get(&sync_confirmed_bytes);
+    return transfer_start_seq + (uint64_t) (bytes / RAW_AUDIO_PACKET_BYTES);
+}
+
+/* Adjust the cached status for `delta` packets freed, without an SD read, so
+ * the app sees free space grow live during a sync. Recording (write_seq) still
+ * corrects it via the periodic SD refresh; this only makes the freeing visible
+ * between refreshes. */
+static void sync_status_account_freed(uint64_t delta)
+{
+    uint64_t freed = delta * (uint64_t) RAW_AUDIO_PACKET_BYTES;
+    atomic_val_t used = atomic_get(&storage_status_used_bytes);
+    atomic_val_t unread = atomic_get(&storage_status_unread_packets);
+    atomic_val_t free_b = atomic_get(&storage_status_free_bytes);
+
+    atomic_set(&storage_status_used_bytes, used > (atomic_val_t) freed ? used - (atomic_val_t) freed : 0);
+    atomic_set(&storage_status_unread_packets, unread > (atomic_val_t) delta ? unread - (atomic_val_t) delta : 0);
+    atomic_set(&storage_status_free_bytes, free_b + (atomic_val_t) freed);
+}
+
+/* Persist the ring read pointer up to the confirmed-synced seq. Throttled to
+ * STORAGE_ADVANCE_CHECKPOINT_MS unless forced. Only moves forward over data the
+ * phone already has, so it is always safe to call mid-transfer.
+ *
+ * force=false (mid-transfer): non-blocking advance so the BLE send stream never
+ * stalls. force=true (DONE / disconnect): blocking, to guarantee the read
+ * pointer is persisted before the transfer tears down. */
+static void sync_checkpoint_advance(bool force)
+{
+    uint64_t confirmed = sync_confirmed_seq();
+    if (confirmed <= sync_checkpoint_seq) {
+        return;
+    }
+
+    int64_t now = k_uptime_get();
+    if (!force && now < sync_checkpoint_deadline_ms) {
+        return;
+    }
+    sync_checkpoint_deadline_ms = now + STORAGE_ADVANCE_CHECKPOINT_MS;
+
+    uint64_t delta = confirmed - sync_checkpoint_seq;
+    int ret = force ? sd_ring_advance(confirmed) : sd_ring_advance_async(confirmed);
+    if (ret == 0) {
+        sync_checkpoint_seq = confirmed;
+        sync_status_account_freed(delta);
+        LOG_INF("Ring auto-advanced to synced seq %llu", (unsigned long long) confirmed);
+    }
 }
 
 void storage_stop_transfer(void)
@@ -410,6 +481,9 @@ static int start_pending_read(struct bt_conn *conn)
     current_read_seq = pending_start_seq;
     remaining_packets = requested_packets;
     transfer_end_status = 0;
+    atomic_set(&sync_confirmed_bytes, 0);
+    sync_checkpoint_seq = pending_start_seq;
+    sync_checkpoint_deadline_ms = k_uptime_get() + STORAGE_ADVANCE_CHECKPOINT_MS;
     sync_speed_reset(SYNC_SPEED_MODE_NONE);
 
     return 0;
@@ -520,6 +594,9 @@ static void write_to_gatt(struct bt_conn *conn)
 
         current_read_seq += packets_read;
         remaining_packets -= packets_read;
+
+        /* Free device storage as the phone confirms receipt (throttled). */
+        sync_checkpoint_advance(false);
     }
 
     done_pending = true;
@@ -688,14 +765,16 @@ static void storage_write(void)
 
         if (transfer_active) {
             if (conn == NULL) {
+                /* Link dropped mid-sync: persist progress up to the last packet
+                 * the phone confirmed, so reconnect resumes from there. */
+                sync_checkpoint_advance(true);
                 storage_stop_transfer();
             } else if (done_pending) {
                 int err = send_done(conn, transfer_end_status, current_read_seq);
                 if (err == -ENOMEM) {
                     k_yield();
-                } else if (err == -EAGAIN) {
-                    reset_transfer_state();
                 } else {
+                    sync_checkpoint_advance(true);
                     reset_transfer_state();
                 }
             } else {

--- a/omi/firmware/omi/src/sd_card.c
+++ b/omi/firmware/omi/src/sd_card.c
@@ -1003,13 +1003,17 @@ void sd_worker_thread(void)
             }
             break;
 
-        case REQ_ADVANCE_READ:
+        case REQ_ADVANCE_READ: {
+            /* Perform the advance regardless; a NULL resp is a fire-and-forget
+             * (async) request from the sync checkpoint that must not block. */
+            int adv_res = advance_read_seq_internal(req.u.advance.new_read_seq, false);
             if (req.u.advance.resp) {
-                req.u.advance.resp->res = advance_read_seq_internal(req.u.advance.new_read_seq, false);
+                req.u.advance.resp->res = adv_res;
                 k_sem_give(&req.u.advance.resp->sem);
                 release_resp_busy(req.u.advance.resp->busy_flag);
             }
             break;
+        }
 
         case REQ_CLEAR_RING:
             if (req.u.status.resp) {
@@ -1383,6 +1387,19 @@ int sd_ring_advance(uint64_t new_read_seq)
     }
 
     return resp.res;
+}
+
+int sd_ring_advance_async(uint64_t new_read_seq)
+{
+    /* Fire-and-forget: queue the advance on the priority queue and return
+     * immediately (no worker round-trip). Used by the sync checkpoint so the
+     * BLE send stream is never stalled. Persist happens in the worker; if it
+     * fails the next checkpoint / the final blocking advance re-persists. */
+    sd_req_t req = {0};
+    req.type = REQ_ADVANCE_READ;
+    req.u.advance.new_read_seq = new_read_seq;
+    req.u.advance.resp = NULL;
+    return k_msgq_put(&sd_prio_msgq, &req, K_NO_WAIT);
 }
 
 int sd_ring_clear(void)


### PR DESCRIPTION
## Problem

Today the device only advances the SD ring **read pointer after the entire sync
finishes** (after `NOTIFY_DONE` — the app advances only on completion, by design,
for data safety). Two consequences:

- **Nothing is freed until the very end.** The on-device ring can hold hundreds of
  MB, and a full sync takes hours. Free space on the device stays flat the whole
  time and only jumps at the end.
- **A mid-sync disconnect loses all progress.** BLE drops are common (weak signal,
  app backgrounded, etc.). Since `read_seq` wasn't advanced, on reconnect the app
  re-reads from the original pointer and **the whole sync restarts from the
  beginning** — potentially re-sending hundreds of MB.

## Change

Advance + persist the ring `read_seq` **incrementally, as data is confirmed
delivered to the phone** (counted in the BLE TX-completion callback), checkpointed
every ~2 s and once more on `DONE` / disconnect.

- Only data the phone has actually received (TX-confirmed at the link layer) is
  ever freed → **safe, no over-advance / data loss**.
- On reconnect the app reads from the now-advanced `read_seq`, so a dropped sync
  **resumes near where it stopped instead of restarting from scratch**.
- Free space grows **live** during the sync.

Compatible with the current app: it still reads from `read_seq` and still sends
`CMD_RING_ADVANCE` after `DONE` (now a no-op since we've already advanced).

## Implementation

- `storage.c` — accumulate TX-confirmed bytes; `sync_checkpoint_advance()` advances
  `read_seq` to the confirmed seq (throttled 2 s, forced on DONE/disconnect) and
  updates the cached used/free/unread counters without touching the SD.
- `sd_card.c` / `sd_card.h` — `sd_ring_advance_async()`: fire-and-forget ring advance
  on the SD worker.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

