### PR TITLE
fix(release): align beta smoke qualification checks

### DIFF
--- a/.github/scripts/check-desktop-auto-beta-candidate.py
+++ b/.github/scripts/check-desktop-auto-beta-candidate.py
@@ -11,18 +11,17 @@ from pathlib import Path
 
 from desktop_release_metadata import fail, parse_metadata
 
-
 TAG_RE = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)\+(?P<build>\d+)-macos$")
 EXPECTED_BUNDLE_ID = "com.omi.computer-macos"
 EXPECTED_TEAM_ID = "9536L8KLMP"
 REQUIRED_SMOKE_CHECKS = {
     "Launch + identity metadata is aligned",
     "Auth persistence prerequisites: signing identity and Keychain-compatible entitlements are sane",
-    "Backend routing config has no local/dev leakage",
+    "Backend routing config matches the declared external backend",
     "Sparkle/update metadata and authoritative ZIP artifacts are present",
     "Native helper/runtime bundle integrity passed",
     "Local storage/database package surface is present",
-    "Signed desktop artifact Keychain write/read/delete canary passed",
+    "Signed artifact Keychain write/read/delete canary passed",
     "Signed desktop artifact smoke completed",
 }
 

--- a/.github/scripts/test_check_desktop_auto_beta_candidate.py
+++ b/.github/scripts/test_check_desktop_auto_beta_candidate.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import re
 import tempfile
 from pathlib import Path
 
 SCRIPT = Path(__file__).with_name("check-desktop-auto-beta-candidate.py")
+SIGNED_SMOKE = Path(__file__).parents[2] / "desktop/macos/scripts/smoke-signed-desktop-artifact.sh"
 SPEC = importlib.util.spec_from_file_location("check_desktop_auto_beta_candidate", SCRIPT)
 assert SPEC and SPEC.loader
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -75,6 +77,11 @@ def expect_failure(args: argparse.Namespace, fragment: str) -> None:
 
 
 def main() -> int:
+    # omi-test-quality: source-inspection -- static contract: qualification labels must match signed-smoke output.
+    smoke_labels = set(re.findall(r'^\s*pass "([^"]+)"\s*$', SIGNED_SMOKE.read_text(encoding="utf-8"), re.MULTILINE))
+    missing_labels = sorted(REQUIRED_SMOKE_CHECKS - smoke_labels)
+    assert not missing_labels, f"qualification requires labels not emitted by signed smoke: {missing_labels}"
+
     with tempfile.TemporaryDirectory() as temp_dir:
         args = fixtures(Path(temp_dir))
         result = validate(args)


### PR DESCRIPTION
## Summary
- Align required signed-smoke labels with the labels emitted by the signed-artifact smoke script.
- Add a focused contract check so future label drift fails before a candidate is cut.

## Verification
- `python3 .github/scripts/test_check_desktop_auto_beta_candidate.py`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

