### PR TITLE
Stop negative-cached segments from voting in a unit's detected language

### DIFF
--- a/backend/tests/unit/test_translation_negative_cache_detection.py
+++ b/backend/tests/unit/test_translation_negative_cache_detection.py
@@ -1,0 +1,110 @@
+"""Regression: a negative-cached segment must not vote in the unit's detected language.
+
+TranslationEngine reconstructs a unit's detected_language by taking the most common
+non-empty detection across its segments. A negative-cache hit means "this segment needs no
+translation", which is not a language detection, so before the translation_core split it was
+stored as '' and skipped by the tally (`if det_lang:`). The split started storing the target
+language for segment-level negative hits, so a unit that mixes already-seen target-language
+text with foreign speech now reports the target language. TranslationCoordinator feeds that
+value to ConversationLanguageState.observe_detection, which pushes the conversation into
+monolingual mode and stops translating that speaker's foreign speech.
+
+The whole-unit negative hit keeps using the target language: there the no-op really does
+describe the entire unit. Only the per-segment hit is wrong.
+
+Seam: TranslationEngine takes its cache, provider chain and profile resolver by constructor
+injection, so this drives the real engine with fakes and needs no monkeypatching.
+"""
+
+from config.translation import TranslationProfile
+from utils.translation_core.engine import TranslationEngine
+from utils.translation_core.planner import TranslationMode, TranslationUnit, build_translation_plan
+from utils.translation_core.providers import ProviderBatch, ProviderTranslation, TranslationProvider
+
+_PROFILE = TranslationProfile(
+    providers=(TranslationProvider.google,),
+    nllb_url='',
+    nllb_timeout_seconds=1.0,
+    google_project_id='test-project',
+    cache_ttl_seconds=60,
+    negative_cache_ttl_seconds=60,
+)
+
+_TARGET_TEXT = 'Hello there my friend.'
+_FOREIGN_TEXT = 'Como estas amigo mio?'
+
+
+class _FakeCache:
+    """Only the listed fingerprints are negative-cached; nothing is positively cached."""
+
+    def __init__(self, negative_fingerprints: set[str]) -> None:
+        self._negative = negative_fingerprints
+
+    def get(self, fingerprint: str, target_language: str):
+        return None
+
+    def is_negative(self, fingerprint: str, target_language: str) -> bool:
+        return fingerprint in self._negative
+
+    def put(self, fingerprint: str, target_language: str, value: object, profile: object) -> None:
+        return None
+
+
+class _FakeProviders:
+    """Detects the foreign language for whatever the engine actually sends for translation."""
+
+    def __init__(self, detected_language: str) -> None:
+        self._detected_language = detected_language
+        self.requested: list[list[str]] = []
+
+    def translate(self, contents, target_language, source_language, profile, mode):
+        self.requested.append(list(contents))
+        return ProviderBatch(
+            provider=TranslationProvider.google,
+            translations=tuple(
+                ProviderTranslation(text=f'translated:{content}', detected_language=self._detected_language)
+                for content in contents
+            ),
+        )
+
+
+def _fingerprint_of(unit: TranslationUnit, text: str) -> str:
+    """Ask the planner itself which fingerprint it assigns to that sentence."""
+    plan = build_translation_plan([unit], TranslationMode.sentence)
+    return next(segment.fingerprint for segment in plan.unique_segments if segment.text == text)
+
+
+def test_negative_cached_segment_does_not_vote_for_target_language():
+    unit = TranslationUnit(ordinal=0, unit_id='unit-1', text=f'{_TARGET_TEXT} {_FOREIGN_TEXT}')
+    cache = _FakeCache({_fingerprint_of(unit, _TARGET_TEXT)})
+    providers = _FakeProviders(detected_language='es')
+    engine = TranslationEngine(cache, providers, lambda: _PROFILE)
+
+    outcome = engine.translate([unit], target_language='en', mode=TranslationMode.sentence)[0]
+
+    # Only the foreign sentence was actually detected, so it is the unit's language.
+    assert outcome.detected_language == 'es'
+    # The negative-cached sentence is still returned untranslated alongside the translated one.
+    assert _TARGET_TEXT in outcome.text
+    assert providers.requested == [[_FOREIGN_TEXT]]
+
+
+def test_negative_cached_segments_do_not_outvote_the_only_detection():
+    # Two negative-cached target-language sentences would outvote the single foreign detection
+    # 2-to-1 if they were allowed to vote at all.
+    unit = TranslationUnit(
+        ordinal=0,
+        unit_id='unit-2',
+        text=f'{_TARGET_TEXT} Good to see you again. {_FOREIGN_TEXT}',
+    )
+    cache = _FakeCache(
+        {
+            _fingerprint_of(unit, _TARGET_TEXT),
+            _fingerprint_of(unit, 'Good to see you again.'),
+        }
+    )
+    engine = TranslationEngine(cache, _FakeProviders(detected_language='es'), lambda: _PROFILE)
+
+    outcome = engine.translate([unit], target_language='en', mode=TranslationMode.sentence)[0]
+
+    assert outcome.detected_language == 'es'

--- a/backend/utils/translation_core/engine.py
+++ b/backend/utils/translation_core/engine.py
@@ -92,9 +92,14 @@ class TranslationEngine:
             if cached is not None:
                 segment_values[segment.fingerprint] = cached
             elif self.cache.is_negative(segment.fingerprint, target_language):
+                # A negative-cache hit marks "this segment needs no translation", which is not a
+                # language detection. It must not vote in the unit's dominant language, or a unit
+                # mixing cached target-language text with foreign speech reports the target
+                # language. The whole-unit negative hit above is different: there the no-op does
+                # describe the entire unit.
                 segment_values[segment.fingerprint] = CachedTranslation(
                     text=segment.text,
-                    detected_language=_base_language(target_language),
+                    detected_language='',
                 )
             else:
                 missing.append((segment.fingerprint, segment.text))


### PR DESCRIPTION
Stop negative-cached segments from voting in a unit's detected language

A live transcript unit that mixes already-seen target-language text with foreign speech
reports the target language as its detected language. That pushes the conversation into
monolingual mode and makes the backend stop translating that speaker's foreign speech.

TranslationEngine reconstructs a unit's detected_language as the most common non-empty
detection across its segments (_reconstruct in utils/translation_core/engine.py). A
negative-cache hit means "this segment needs no translation", which is not a language
detection. Before the translation_core split, a negative hit stored an empty detected
language and the tally skipped it:

    sent_translation[sent_hash] = (info['text'], '')      # utils/translation.py:1019, pre-split
    ...
    if det_lang:
        detected_langs.append(det_lang)

After the split, the per-segment negative branch stores the target language, so those hits
now vote:

    elif self.cache.is_negative(segment.fingerprint, target_language):
        segment_values[segment.fingerprint] = CachedTranslation(
            text=segment.text,
            detected_language=_base_language(target_language),
        )

For a unit with one cached English sentence and one Spanish sentence the tally is 1 to 1 and
Counter.most_common breaks the tie by insertion order, so the unit reports English. With two
cached English sentences it reports English 2 to 1.

That value is not cosmetic downstream. utils/translation_coordinator.py does:

    if outcome.detected_language:
        self.language_state.observe_detection(outcome.detected_language, 1.0)

ConversationLanguageState.observe_detection takes the target branch for the target language
(consecutive_target += 1, monolingual once the threshold is reached) and the foreign branch
otherwise (consecutive_target = 0, monolingual False). So a unit that was just translated out
of Spanish counts as evidence that the speaker is now speaking English. The same value is
also returned to the client and cached in Redis.

This regressed in a9473a5642 ("refactor(backend): converge translation reliability"), which
split utils/translation.py into utils/translation_core/.

Fix: store an empty detected language for a segment-level negative hit, restoring the
pre-split value so it abstains from the tally.

The whole-unit negative hit earlier in the same function keeps using the target language and
is deliberately unchanged: there the no-op does describe the entire unit. That asymmetry is
the bug.

Tests (tests/unit/test_translation_negative_cache_detection.py) drive the real
TranslationEngine with a fake cache and provider chain. The engine takes both by constructor
injection, so no patching is required:
- one negative-cached target sentence plus one foreign sentence reports the foreign language
- two negative-cached target sentences plus one foreign sentence still report the foreign language

Verification (run in backend/):
- pytest tests/unit/test_translation_negative_cache_detection.py: 2 passed
- prove-fail: with engine.py reverted to main, both fail with "assert 'en' == 'es'"
- pytest test_translation_cost_optimization.py (33 passed), test_translation_dedup_edge_cases.py
  (23 passed), test_translation_optimization.py (38 passed), test_translation_nllb.py (29 passed),
  so no existing test pinned the old value
- black --line-length 120 --skip-string-normalization --check: clean
- pyright utils/translation_core/engine.py: 0 errors
- scripts/check_module_stub_pollution.py: 0 violations

I did not exercise a live translation session. The test drives the real engine through the
same call the coordinator makes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

