### PR TITLE
Finalize pending conversations when a listen session ends inside the retry window

### DIFF
--- a/backend/routers/listen/conversations.py
+++ b/backend/routers/listen/conversations.py
@@ -279,8 +279,11 @@ class LiveConversationController:
         return None
 
     async def process_pending(self, timed_out_id: Optional[str]) -> None:
-        if await self.host.wait(7):
-            return
+        # Interruptible delay, not a polling loop. An early wake means the session is shutting
+        # down, which is precisely when the timed-out conversation and anything still stuck in
+        # `processing` must be finalized, so the wake shortens the wait instead of skipping the
+        # work. Returning here dropped both (pre-split this was an unconditional sleep).
+        await self.host.wait(7)
         if timed_out_id:
             await self.process_conversation(timed_out_id)
         processing = await self.host.persistence.call(

--- a/backend/tests/unit/test_listen_process_pending_shutdown.py
+++ b/backend/tests/unit/test_listen_process_pending_shutdown.py
@@ -1,0 +1,88 @@
+"""Regression: a listen session ending inside the 7s window must still finalize pending work.
+
+LiveConversationController.process_pending defers finalization by 7 seconds, then finalizes the
+timed-out conversation and re-dispatches anything still stuck in `processing`. The listen split
+turned the original unconditional `await asyncio.sleep(7.0)` into `if await self.host.wait(7):
+return`. host.wait is wait_for_event(shutdown_event, seconds), which returns True when woken
+early by shutdown, and runtime sets shutdown_event immediately before draining background tasks
+without cancelling them. So any session ending inside that window returned early and skipped both
+the timed-out conversation's finalization and the processing re-dispatch.
+
+The `if ...: return` form is the polling-loop idiom (lifecycle_loop correctly uses
+`if await self.host.wait(5): break`). process_pending is a one-shot deferred action, so an early
+wake must shorten the wait, not cancel the work.
+
+Seam: the controller takes only a host, so this subclasses it to record the two finalization
+calls and drives the real process_pending. No patching and no sys.modules mutation.
+"""
+
+from types import SimpleNamespace
+
+from routers.listen.conversations import LiveConversationController
+
+
+class _Host:
+    """Minimal listen host. wait() returns True to mean 'woken early by shutdown'."""
+
+    def __init__(self, *, woken_by_shutdown: bool, processing: list[dict[str, str]]) -> None:
+        self.request = SimpleNamespace(uid='uid-1')
+        self._woken_by_shutdown = woken_by_shutdown
+        self._processing = processing
+        self.waited: list[float] = []
+        self.persistence = SimpleNamespace(call=self._call)
+
+    async def wait(self, seconds: float) -> bool:
+        self.waited.append(seconds)
+        return self._woken_by_shutdown
+
+    async def _call(self, _fn, *_args):
+        return self._processing
+
+
+class _RecordingController(LiveConversationController):
+    """Records the finalization calls instead of touching Firestore."""
+
+    def __init__(self, host: _Host) -> None:
+        super().__init__(host)
+        self.processed: list[str] = []
+        self.scheduled: list[str] = []
+
+    async def process_conversation(self, conversation_id: str) -> bool:
+        self.processed.append(conversation_id)
+        return True
+
+    async def schedule_finalization(self, conversation_id: str) -> bool:
+        self.scheduled.append(conversation_id)
+        return True
+
+
+async def test_session_ending_inside_the_window_still_finalizes():
+    host = _Host(woken_by_shutdown=True, processing=[{'id': 'conv-processing'}])
+    controller = _RecordingController(host)
+
+    await controller.process_pending('conv-timed-out')
+
+    # An early shutdown wake must not drop the pending finalization work.
+    assert controller.processed == ['conv-timed-out']
+    assert controller.scheduled == ['conv-processing']
+    assert host.waited == [7]
+
+
+async def test_normal_session_finalizes_after_the_full_delay():
+    host = _Host(woken_by_shutdown=False, processing=[{'id': 'conv-processing'}])
+    controller = _RecordingController(host)
+
+    await controller.process_pending('conv-timed-out')
+
+    assert controller.processed == ['conv-timed-out']
+    assert controller.scheduled == ['conv-processing']
+
+
+async def test_no_timed_out_conversation_still_redispatches_processing():
+    host = _Host(woken_by_shutdown=True, processing=[{'id': 'conv-a'}, {'id': 'conv-b'}])
+    controller = _RecordingController(host)
+
+    await controller.process_pending(None)
+
+    assert controller.processed == []
+    assert controller.scheduled == ['conv-a', 'conv-b']


### PR DESCRIPTION
Finalize pending conversations when a listen session ends inside the retry window

LiveConversationController.process_pending defers finalization by 7 seconds, then finalizes
the timed-out conversation and re-dispatches anything still stuck in `processing`. It
currently returns early when that wait is interrupted:

    async def process_pending(self, timed_out_id: Optional[str]) -> None:
        if await self.host.wait(7):
            return

host.wait is wait_for_event(self.state.shutdown_event, seconds) (routers/listen/runtime.py),
which returns True when woken early by shutdown rather than when the sleep elapses
(utils/async_tasks.py). runtime.py then sets shutdown_event and drains background tasks
without cancelling them:

    self.state.shutdown_event.set()
    await self.task_supervisor.drain_monitored(timeout=self.limits.bg_drain_timeout, cancel=False)

So a listen session that ends within that 7 second window wakes process_pending immediately
with True and it returns, skipping both the timed-out conversation's finalization and the
re-dispatch of conversations stuck in `processing`. The drain deliberately lets background
work finish, so this work should run rather than be dropped.

Before the listen split this was an unconditional sleep (routers/transcribe.py at c7ca348b04^):

    async def process_pending_conversations(timed_out_id: Optional[str]):
        await asyncio.sleep(7.0)
        if timed_out_id:
            await _process_conversation(timed_out_id)
        await cleanup_processing_conversations()

The `if await wait(...): return` shape is the polling-loop idiom, and it is correct in
lifecycle_loop, which uses `if await self.host.wait(5): break` to leave a loop.
process_pending is a one-shot deferred action, so an early wake should shorten the wait rather
than cancel the work.

Fix: keep the wait interruptible, drop the early return.

    await self.host.wait(7)

Tests (tests/unit/test_listen_process_pending_shutdown.py) subclass LiveConversationController
to record the two finalization calls and drive the real process_pending. The controller takes
only a host, so no patching is required:
- a session woken by shutdown still finalizes the timed-out conversation and re-dispatches processing
- a normal full-delay session behaves exactly as before
- with no timed-out conversation, processing is still re-dispatched

Verification (run in backend/):
- pytest tests/unit/test_listen_process_pending_shutdown.py: 3 passed
- prove-fail: with the source reverted to main, the two shutdown-path tests fail
  (assert [] == ['conv-timed-out'] and assert [] == ['conv-a', 'conv-b']) while the
  normal-delay test still passes, so the change only affects the interrupted path
- pytest test_conversation_lifecycle_contract.py (13 passed), test_conversation_finalization_jobs.py
  (22 passed), test_listen_session_bootstrap.py (4 passed)
- black --line-length 120 --skip-string-normalization --check: clean
- pyright routers/listen/conversations.py: 0 errors
- scripts/check_module_stub_pollution.py: 0 violations

Note: test_listen_persistence.py and test_listen_runtime_regressions.py do not import in my
local environment (deepgram SDK version mismatch, ImportError on DeepgramClientOptions). They
fail identically with this change reverted, so that is a local environment gap rather than a
regression from this PR; CI runs them with the pinned SDK.

I did not exercise a live WebSocket session. The test drives the real process_pending through
the same call the runtime makes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

