### PR TITLE
Contain translation persist failures so a batch does not drop its remaining segments

### DIFF
--- a/backend/routers/listen/transcripts.py
+++ b/backend/routers/listen/transcripts.py
@@ -113,43 +113,58 @@ class TranscriptProcessor:
             self.translation_coordinator and self.translation_coordinator._flushing  # type: ignore[reportPrivateUsage]
         ):
             return
-        async with self.translation_lock:
-            conversation = (
-                await self.cache.get(conversation_id)
-                if conversation_id == self.host.state.current_conversation_id
-                else await self._load_conversation(conversation_id)
+        # TranslationCoordinator invokes this callback from a bare task and only catches
+        # (RuntimeError, ValueError), so a persist failure escaping here aborts the batch loop and
+        # silently drops the translations for every remaining segment. Keep the failure contained.
+        try:
+            async with self.translation_lock:
+                conversation = (
+                    await self.cache.get(conversation_id)
+                    if conversation_id == self.host.state.current_conversation_id
+                    else await self._load_conversation(conversation_id)
+                )
+                if not conversation:
+                    return
+                for index, segment in enumerate(conversation.get('transcript_segments', [])):
+                    if segment['id'] != segment_id:
+                        continue
+                    translations = segment.get('translations', [])
+                    translation = Translation(lang=self.host.translation_language, text=translated_text).model_dump()
+                    replacement = next(
+                        (
+                            i
+                            for i, value in enumerate(translations)
+                            if value.get('lang') == self.host.translation_language
+                        ),
+                        None,
+                    )
+                    if replacement is None:
+                        translations.append(translation)
+                    else:
+                        translations[replacement] = translation
+                    conversation['transcript_segments'][index]['translations'] = translations
+                    await self.host.persistence.call(
+                        conversations_db.update_conversation_segments,
+                        self.host.request.uid,
+                        conversation_id,
+                        conversation['transcript_segments'],
+                        data_protection_level=(
+                            self.cache.protection_level
+                            if conversation_id == self.host.state.current_conversation_id
+                            else None
+                        ),
+                    )
+                    if conversation_id == self.host.state.current_conversation_id:
+                        self.cache.update_segments(conversation['transcript_segments'])
+                        self.host.send_event(TranslationEvent(segments=[conversation['transcript_segments'][index]]))
+                    return
+        except Exception as error:
+            logger.error(
+                'Translation persist failed segment=%s uid=%s type=%s',
+                segment_id,
+                self.host.request.uid,
+                type(error).__name__,
             )
-            if not conversation:
-                return
-            for index, segment in enumerate(conversation.get('transcript_segments', [])):
-                if segment['id'] != segment_id:
-                    continue
-                translations = segment.get('translations', [])
-                translation = Translation(lang=self.host.translation_language, text=translated_text).model_dump()
-                replacement = next(
-                    (i for i, value in enumerate(translations) if value.get('lang') == self.host.translation_language),
-                    None,
-                )
-                if replacement is None:
-                    translations.append(translation)
-                else:
-                    translations[replacement] = translation
-                conversation['transcript_segments'][index]['translations'] = translations
-                await self.host.persistence.call(
-                    conversations_db.update_conversation_segments,
-                    self.host.request.uid,
-                    conversation_id,
-                    conversation['transcript_segments'],
-                    data_protection_level=(
-                        self.cache.protection_level
-                        if conversation_id == self.host.state.current_conversation_id
-                        else None
-                    ),
-                )
-                if conversation_id == self.host.state.current_conversation_id:
-                    self.cache.update_segments(conversation['transcript_segments'])
-                    self.host.send_event(TranslationEvent(segments=[conversation['transcript_segments'][index]]))
-                return
 
     async def _update_live_conversation(
         self,

--- a/backend/tests/unit/test_translation_persist_guard.py
+++ b/backend/tests/unit/test_translation_persist_guard.py
@@ -1,0 +1,74 @@
+"""Regression: a failed translation persist must not escape and abort the rest of the batch.
+
+TranscriptProcessor._on_translation_ready is the callback TranslationCoordinator invokes for each
+finished translation. Before the listen split the whole body was wrapped in
+`try/except Exception: logger.error(...)` (routers/transcribe.py at e8adfc5623^). The split dropped
+that guard, and the caller (_flush_batch in utils/translation_coordinator.py) catches only
+(RuntimeError, ValueError). So a transient persist error, for example a Firestore/network failure
+from update_conversation_segments, escapes the batch loop and silently drops the translations for
+every remaining segment in that batch. The coordinator runs the callback from a bare task, so
+nothing surfaces except an unretrieved-task warning.
+
+Seam: TranscriptProcessor takes only a host, so this builds a fake host by constructor injection
+and drives the real callback. No patching and no sys.modules mutation. The conversation id differs
+from the session's current conversation so the load goes through persistence rather than the cache.
+"""
+
+from types import SimpleNamespace
+
+from routers.listen.transcripts import TranscriptProcessor
+from utils.transcribe_store import conversations_db
+
+
+class _Persistence:
+    def __init__(self, conversation: dict, fail_update: bool) -> None:
+        self._conversation = conversation
+        self._fail_update = fail_update
+        self.updates: list[tuple] = []
+
+    async def call(self, fn, *args, **kwargs):
+        if fn is conversations_db.get_conversation:
+            return self._conversation
+        if fn is conversations_db.update_conversation_segments:
+            if self._fail_update:
+                raise ConnectionError('firestore unavailable')
+            self.updates.append(args)
+            return None
+        return None
+
+
+def _conversation() -> dict:
+    return {'id': 'conv-1', 'transcript_segments': [{'id': 'seg-1', 'text': 'hello', 'translations': []}]}
+
+
+def _host(conversation: dict, *, fail_update: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        limits=SimpleNamespace(max_segment_buffer_size=100, max_photo_buffer_size=100),
+        # A different current conversation forces the persistence load path.
+        state=SimpleNamespace(active=True, current_conversation_id='other-conversation'),
+        persistence=_Persistence(conversation, fail_update),
+        request=SimpleNamespace(uid='uid-1'),
+        translation_language='es',
+        send_event=lambda event: None,
+    )
+
+
+async def test_persist_failure_does_not_escape_the_callback():
+    host = _host(_conversation(), fail_update=True)
+    processor = TranscriptProcessor(host)
+
+    # Must not raise. _flush_batch only catches (RuntimeError, ValueError), so an escaping error
+    # aborts the batch loop and drops the remaining segments' translations.
+    await processor._on_translation_ready('seg-1', 'hola', 'es', 'conv-1')
+
+
+async def test_successful_persist_still_writes_the_translation():
+    host = _host(_conversation(), fail_update=False)
+    processor = TranscriptProcessor(host)
+
+    await processor._on_translation_ready('seg-1', 'hola', 'es', 'conv-1')
+
+    assert host.persistence.updates, 'the translation should have been persisted'
+    persisted_segments = host.persistence.updates[0][2]
+    assert persisted_segments[0]['translations'][0]['text'] == 'hola'
+    assert persisted_segments[0]['translations'][0]['lang'] == 'es'


### PR DESCRIPTION
Contain translation persist failures so a batch does not drop its remaining segments

TranscriptProcessor._on_translation_ready is the callback TranslationCoordinator invokes for
each finished translation. Before the listen split the whole body was wrapped in a broad
guard (routers/transcribe.py at e8adfc5623^):

    try:
        ...
    except Exception as e:
        logger.error(f"Translation persist error: {e} {uid} {session_id}")

The split (c7ca348b04, "refactor(quality): split oversized product sources") recreated the
callback in routers/listen/transcripts.py without that guard. The caller catches only two
types (utils/translation_coordinator.py):

    except (RuntimeError, ValueError) as error:
        logger.error('TranslationCoordinator batch error: %s', error)

So a transient persist failure, for example a Firestore or network error raised by
update_conversation_segments, escapes _on_translation_ready, propagates out of the batch loop
in _flush_batch, and silently drops the translations for every remaining segment in that
batch. The coordinator invokes the callback from a bare task, so nothing surfaces except an
unretrieved-task warning. For the final batch flushed at session teardown those translations
are lost for good.

Fix: restore the guard around the persist body so the failure is logged and contained. The
diff is mostly the re-indentation that adding the try block requires.

Every other callback path created by the same split kept its broad guard (speakers.py match
and load_and_run, receiver.py _process_photo, runtime.py _refresh_credits and _teardown,
transcripts.py trigger_realtime_integrations), so this one is the outlier.

asyncio.CancelledError derives from BaseException, so the broad except does not interfere with
the shield-based cancellation in _flush_after_batch_window.

Tests (tests/unit/test_translation_persist_guard.py) build a fake host by constructor
injection and drive the real callback. TranscriptProcessor takes only a host, so no patching
is required:
- a persist error raised by update_conversation_segments is contained rather than escaping
- a successful persist still writes the translation with the expected lang and text

Verification (run in backend/):
- pytest tests/unit/test_translation_persist_guard.py: 2 passed
- prove-fail: with transcripts.py reverted to main, the containment test fails with
  "ConnectionError: firestore unavailable" escaping the callback, while the successful-persist
  test still passes, so the change only affects the failure path
- pytest test_fast_unit_duration_guard.py (3 passed), test_transcribe_conversation_cache.py
  (3 passed), test_conversation_lifecycle_contract.py (13 passed)
- black --line-length 120 --skip-string-normalization --check: clean
- pyright routers/listen/transcripts.py: 0 errors
- scripts/check_module_stub_pollution.py: 0 violations

I did not exercise a live translated session. The test drives the real callback through the
same call the coordinator makes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

