### PR TITLE
feat(fair-use): plan-aware soft caps + hard daily-audio anti-abuse ceiling

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -4,12 +4,13 @@
     "backend/routers/chat.py": 1580,
     "backend/routers/developer.py": 2186,
     "backend/routers/mcp_sse.py": 1857,
-    "backend/routers/sync.py": 1981,
+    "backend/routers/sync.py": 2000,
     "backend/routers/users.py": 2046
   },
   "raise_justifications": {
     "backend/routers/chat.py": "PTT stereo rejection keeps the serving STT provider boundary explicit in the established chat admission owner.",
-    "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first."
+    "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first.",
+    "backend/routers/sync.py": "Fresh-sync admission gains a hard daily-audio anti-abuse ceiling gate (is_daily_audio_ceiling_exceeded), mirroring the adjacent hard-restriction gate, plus plan-aware soft-cap wiring; both belong at this existing ingestion owner, not a new module."
   },
   "threshold": 1500
 }

--- a/backend/routers/listen/contracts.py
+++ b/backend/routers/listen/contracts.py
@@ -64,6 +64,7 @@ class ListenSessionState:
     fair_use_last_check_ts: float = 0.0
     fair_use_dg_budget_exhausted: bool = False
     fair_use_track_dg_usage: bool = False
+    fair_use_plan: Optional[Any] = None
     dg_usage_ms_pending: int = 0
     last_audio_received_time: Optional[float] = None
     last_activity_time: Optional[float] = None

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -34,6 +34,7 @@ from utils.fair_use import (
     check_soft_caps,
     get_enforcement_stage,
     get_rolling_speech_ms,
+    is_daily_audio_ceiling_exceeded,
     is_dg_budget_exhausted,
     record_dg_usage_ms,
     record_speech_ms,
@@ -311,8 +312,13 @@ class ListenSessionRuntime:
             if FAIR_USE_ENABLED and now - self.state.fair_use_last_check_ts >= FAIR_USE_CHECK_INTERVAL_SECONDS:
                 self.state.fair_use_last_check_ts = now
                 try:
+                    if self.state.fair_use_plan is None:
+                        sub = await self.persistence.call(user_db.get_user_valid_subscription, self.request.uid)
+                        self.state.fair_use_plan = sub.plan if sub else None
                     totals = await self.persistence.call(get_rolling_speech_ms, self.request.uid)
-                    caps = await self.persistence.call(check_soft_caps, self.request.uid, speech_totals=totals)
+                    caps = await self.persistence.call(
+                        check_soft_caps, self.request.uid, speech_totals=totals, plan=self.state.fair_use_plan
+                    )
                     if caps:
                         start_background_task(
                             trigger_classifier_if_needed(self.request.uid, caps, self.session_id),
@@ -335,6 +341,13 @@ class ListenSessionRuntime:
                     else:
                         self.state.fair_use_track_dg_usage = False
                         self.state.fair_use_dg_budget_exhausted = False
+                    # Hard anti-abuse daily audio ceiling (all plans): once over the ceiling,
+                    # stop forwarding audio to STT for the rest of the day. Reuses the same
+                    # gate the restrict stage uses, so no socket close / reconnect loop.
+                    if is_daily_audio_ceiling_exceeded(self.request.uid, speech_totals=totals):
+                        if not self.state.fair_use_dg_budget_exhausted:
+                            logger.info('Fair-use daily audio ceiling reached uid=%s', self.request.uid)
+                        self.state.fair_use_dg_budget_exhausted = True
                 except Exception as error:
                     logger.error('Fair-use listen check failed type=%s', type(error).__name__)
             await self._refresh_credits(transcription_seconds=transcription_seconds)

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -72,6 +72,7 @@ from utils.fair_use import (
     get_enforcement_stage,
     get_hard_restriction_status,
     get_rolling_speech_ms,
+    is_daily_audio_ceiling_exceeded,
     is_dg_budget_exhausted,
     record_dg_usage_ms,
     record_speech_ms,
@@ -572,6 +573,22 @@ async def sync_local_files(
             base_headers=_V1_DEPRECATION_HEADERS,
         )
 
+    # Hard anti-abuse daily-audio ceiling (all plans): reject fresh sync once the user is
+    # already over the rolling-24h total. Set high enough that no legitimate user hits it;
+    # it exists to stop bulk-sync dumps. Backfill has its own separate pacing.
+    if lane_decision.lane == SyncLane.FRESH and is_daily_audio_ceiling_exceeded(uid):
+        logger.info(f'sync: daily audio ceiling reached uid={uid}')
+        return await _fair_use_restriction_response(
+            uid=uid,
+            retry_after=_retry_after_until_next_utc_day(),
+            client_platform=client_device_context.platform,
+            device_hash=client_device_context.device_hash,
+            app_version=client_device_context.app_version,
+            request_id=request.headers.get('x-request-id'),
+            cloud_trace_context=request.headers.get('x-cloud-trace-context'),
+            base_headers=_V1_DEPRECATION_HEADERS,
+        )
+
     # Check credits: if exhausted, still process but lock the conversation so user can pay to unlock
     should_lock = not has_transcription_credits(uid)
 
@@ -659,8 +676,10 @@ async def sync_local_files(
             meter_source = 'sync_backfill' if lane_decision.lane == SyncLane.BACKFILL else 'sync_fresh'
             record_speech_ms(uid, total_speech_ms, source=meter_source)
             if lane_decision.lane == SyncLane.FRESH:
+                fair_use_sub = await run_blocking(db_executor, users_db.get_existing_user_subscription, uid)
+                fair_use_plan = fair_use_sub.plan if fair_use_sub else None
                 speech_totals = get_rolling_speech_ms(uid)
-                triggered_caps = check_soft_caps(uid, speech_totals=speech_totals)
+                triggered_caps = check_soft_caps(uid, speech_totals=speech_totals, plan=fair_use_plan)
                 if triggered_caps:
                     logger.info(f'sync: soft caps triggered for {uid}: {triggered_caps}')
                     asyncio.create_task(trigger_classifier_if_needed(uid, triggered_caps))

--- a/backend/tests/unit/test_fair_use_plan_aware.py
+++ b/backend/tests/unit/test_fair_use_plan_aware.py
@@ -1,0 +1,124 @@
+"""Tests for plan-aware fair-use soft caps and the hard daily-audio ceiling
+(utils/fair_use.py).
+
+``utils.fair_use`` imports cleanly; we toggle ``FAIR_USE_ENABLED`` per-test via
+``patch.object`` and drive the pure detection functions with injected
+``speech_totals`` so no Redis is touched. See backend/docs/test_isolation.md.
+"""
+
+from unittest.mock import patch
+
+import utils.fair_use as fair_use_mod
+from models.fair_use import SoftCapTrigger
+from models.users import PlanType
+
+DEFAULT_TIER_PLANS = [PlanType.basic, PlanType.plus, None]
+UNLIMITED_TIER_PLANS = [
+    PlanType.unlimited_v2,
+    PlanType.unlimited,
+    PlanType.operator,
+    PlanType.architect,
+]
+
+
+def _totals(daily_ms=0, three_day_ms=0, weekly_ms=0):
+    return {'daily_ms': daily_ms, 'three_day_ms': three_day_ms, 'weekly_ms': weekly_ms}
+
+
+class TestFairUseCapsForPlan:
+    def test_default_tier_plans_get_default_caps(self):
+        expected = (
+            fair_use_mod.FAIR_USE_DAILY_SPEECH_MS,
+            fair_use_mod.FAIR_USE_3DAY_SPEECH_MS,
+            fair_use_mod.FAIR_USE_WEEKLY_SPEECH_MS,
+        )
+        for plan in DEFAULT_TIER_PLANS:
+            assert fair_use_mod.fair_use_caps_for_plan(plan) == expected, plan
+            assert fair_use_mod._is_unlimited_tier(plan) is False, plan
+
+    def test_unlimited_tier_plans_get_raised_caps(self):
+        expected = (
+            fair_use_mod.FAIR_USE_DAILY_SPEECH_MS_UNLIMITED,
+            fair_use_mod.FAIR_USE_3DAY_SPEECH_MS_UNLIMITED,
+            fair_use_mod.FAIR_USE_WEEKLY_SPEECH_MS_UNLIMITED,
+        )
+        for plan in UNLIMITED_TIER_PLANS:
+            assert fair_use_mod.fair_use_caps_for_plan(plan) == expected, plan
+            assert fair_use_mod._is_unlimited_tier(plan) is True, plan
+
+    def test_unlimited_daily_cap_is_higher_than_default(self):
+        # Guards the whole point of the feature: Unlimited must tolerate more before scrutiny.
+        assert fair_use_mod.FAIR_USE_DAILY_SPEECH_MS_UNLIMITED > fair_use_mod.FAIR_USE_DAILY_SPEECH_MS
+
+    def test_free_tier_is_never_unlimited_even_with_zero_configured_cap(self):
+        # Free's configured monthly cap can be 0 ("no cap configured") in some envs; that
+        # must NOT be mistaken for a paid unlimited plan (regression for the is_paid_plan guard).
+        with patch.object(fair_use_mod, 'get_plan_limits') as gpl:
+            gpl.return_value = type('L', (), {'transcription_seconds': 0})()
+            assert fair_use_mod._is_unlimited_tier(PlanType.basic) is False
+
+
+class TestCheckSoftCapsPlanAware:
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    def test_default_tier_triggers_daily_at_three_hours(self):
+        totals = _totals(daily_ms=fair_use_mod.FAIR_USE_DAILY_SPEECH_MS + 1)
+        for plan in [PlanType.basic, PlanType.plus]:
+            triggers = [t['trigger'] for t in fair_use_mod.check_soft_caps('u', totals, plan)]
+            assert SoftCapTrigger.DAILY in triggers, plan
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    def test_unlimited_tier_does_not_trigger_below_its_higher_daily_cap(self):
+        # Just over the DEFAULT daily cap but under the UNLIMITED daily cap.
+        totals = _totals(daily_ms=fair_use_mod.FAIR_USE_DAILY_SPEECH_MS + 1)
+        assert fair_use_mod.check_soft_caps('u', totals, PlanType.unlimited_v2) == []
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    def test_unlimited_tier_triggers_daily_above_its_own_cap(self):
+        totals = _totals(daily_ms=fair_use_mod.FAIR_USE_DAILY_SPEECH_MS_UNLIMITED + 1)
+        triggers = [t['trigger'] for t in fair_use_mod.check_soft_caps('u', totals, PlanType.unlimited_v2)]
+        assert SoftCapTrigger.DAILY in triggers
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    def test_plan_none_is_backwards_compatible_default_tier(self):
+        totals = _totals(daily_ms=fair_use_mod.FAIR_USE_DAILY_SPEECH_MS + 1)
+        triggers = [t['trigger'] for t in fair_use_mod.check_soft_caps('u', totals)]
+        assert SoftCapTrigger.DAILY in triggers
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    def test_reported_threshold_matches_the_tier(self):
+        totals = _totals(daily_ms=fair_use_mod.FAIR_USE_DAILY_SPEECH_MS_UNLIMITED + 1)
+        [daily] = [
+            t
+            for t in fair_use_mod.check_soft_caps('u', totals, PlanType.unlimited_v2)
+            if t['trigger'] == SoftCapTrigger.DAILY
+        ]
+        assert daily['threshold_ms'] == fair_use_mod.FAIR_USE_DAILY_SPEECH_MS_UNLIMITED
+
+
+class TestDailyAudioCeiling:
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    def test_exceeded_at_or_above_ceiling(self):
+        totals = _totals(daily_ms=fair_use_mod.MAX_DAILY_AUDIO_MS)
+        assert fair_use_mod.is_daily_audio_ceiling_exceeded('u', totals) is True
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    def test_not_exceeded_below_ceiling(self):
+        totals = _totals(daily_ms=fair_use_mod.MAX_DAILY_AUDIO_MS - 1)
+        assert fair_use_mod.is_daily_audio_ceiling_exceeded('u', totals) is False
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'MAX_DAILY_AUDIO_MS', 0)
+    def test_disabled_when_ceiling_is_zero(self):
+        totals = _totals(daily_ms=10**12)
+        assert fair_use_mod.is_daily_audio_ceiling_exceeded('u', totals) is False
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', False)
+    def test_disabled_when_fair_use_off(self):
+        totals = _totals(daily_ms=10**12)
+        assert fair_use_mod.is_daily_audio_ceiling_exceeded('u', totals) is False
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    def test_exempt_uid_bypasses_ceiling(self):
+        totals = _totals(daily_ms=10**12)
+        with patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', {'vip'}):
+            assert fair_use_mod.is_daily_audio_ceiling_exceeded('vip', totals) is False

--- a/backend/utils/fair_use.py
+++ b/backend/utils/fair_use.py
@@ -17,7 +17,8 @@ import database.fair_use as fair_use_db
 import database.users as users_db
 from database.redis_db import r as redis_client
 from models.fair_use import SoftCapTrigger
-from utils.subscription import has_transcription_credits, is_paid_plan
+from models.users import PlanType
+from utils.subscription import get_plan_limits, has_transcription_credits, is_paid_plan
 from utils.executors import db_executor, postprocess_executor, run_blocking
 from utils.llm.fair_use_classifier import classify_user_purpose
 from utils.notifications import send_notification
@@ -46,10 +47,18 @@ logger = logging.getLogger(__name__)
 FAIR_USE_ENABLED = os.getenv('FAIR_USE_ENABLED', 'false').lower() == 'true'
 FAIR_USE_KILL_SWITCH = os.getenv('FAIR_USE_KILL_SWITCH', 'false').lower() == 'true'
 
-# Soft cap thresholds (milliseconds of real speech)
+# Soft cap thresholds (milliseconds of real speech) — default tier (Free, Plus, and any
+# plan with a bounded monthly transcription allowance).
 FAIR_USE_DAILY_SPEECH_MS = int(os.getenv('FAIR_USE_DAILY_SPEECH_MS', '7200000'))  # 2h
 FAIR_USE_3DAY_SPEECH_MS = int(os.getenv('FAIR_USE_3DAY_SPEECH_MS', '28800000'))  # 8h
 FAIR_USE_WEEKLY_SPEECH_MS = int(os.getenv('FAIR_USE_WEEKLY_SPEECH_MS', '36000000'))  # 10h
+
+# Raised triggers for unlimited-transcription tiers (Unlimited/unlimited_v2, legacy Neo,
+# Operator, Architect). They pay for unlimited use, so scrutiny starts later. Kept in the
+# same burst-vs-sustained ratio as the default tier (~4x daily for 3-day, ~5x for weekly).
+FAIR_USE_DAILY_SPEECH_MS_UNLIMITED = int(os.getenv('FAIR_USE_DAILY_SPEECH_MS_UNLIMITED', '14400000'))  # 4h
+FAIR_USE_3DAY_SPEECH_MS_UNLIMITED = int(os.getenv('FAIR_USE_3DAY_SPEECH_MS_UNLIMITED', '57600000'))  # 16h
+FAIR_USE_WEEKLY_SPEECH_MS_UNLIMITED = int(os.getenv('FAIR_USE_WEEKLY_SPEECH_MS_UNLIMITED', '72000000'))  # 20h
 
 # Redis bucket granularity
 FAIR_USE_BUCKET_SECONDS = int(os.getenv('FAIR_USE_BUCKET_SECONDS', '60'))  # 1-min buckets
@@ -68,6 +77,14 @@ FAIR_USE_CHECK_INTERVAL_SECONDS = int(os.getenv('FAIR_USE_CHECK_INTERVAL_SECONDS
 # Restrict-stage daily Deepgram budget (milliseconds of audio forwarded to DG per day)
 # 0 = no budget cap (disabled). Only enforced when stage == 'restrict'.
 FAIR_USE_RESTRICT_DAILY_DG_MS = int(os.getenv('FAIR_USE_RESTRICT_DAILY_DG_MS', '1800000'))  # 30 min
+
+# Hard anti-abuse ceiling: max total audio processed per rolling 24h, ALL plans. Set high
+# enough that no legitimate single human hits it (a real person cannot generate this much
+# audio in a day) — it exists to stop bulk-sync dumps / reselling, not to cap usage.
+# Metered against the live rolling meter (realtime + sync_fresh); sync_backfill is separately
+# paced by reserve_backfill_speech. 0 = disabled.
+MAX_DAILY_AUDIO_HOURS = int(os.getenv('MAX_DAILY_AUDIO_HOURS', '30'))
+MAX_DAILY_AUDIO_MS = MAX_DAILY_AUDIO_HOURS * 3600 * 1000
 
 
 LIVE_SPEECH_SOURCES = ('realtime', 'sync_fresh')
@@ -253,13 +270,64 @@ def get_rolling_backfill_speech_ms(uid: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def check_soft_caps(uid: str, speech_totals: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+def _is_unlimited_tier(plan: Optional[PlanType]) -> bool:
+    """True for paid unlimited-transcription plans (Unlimited/unlimited_v2, legacy Neo,
+    Operator, Architect) — the tiers whose monthly transcription allowance is unbounded.
+
+    Keyed off plan limits rather than a hardcoded set so it stays self-consistent as the
+    catalog changes. Requires a *paid* plan AND ``transcription_seconds is None`` (paid
+    unlimited plans use None): this excludes Free — whose configured cap can be 0 ("no cap
+    configured") in some environments — and Plus, which carries a positive monthly cap.
+    """
+    if plan is None:
+        return False
+    try:
+        return is_paid_plan(plan) and get_plan_limits(plan).transcription_seconds is None
+    except Exception:
+        return False
+
+
+def fair_use_caps_for_plan(plan: Optional[PlanType] = None) -> tuple[int, int, int]:
+    """Return the (daily_ms, three_day_ms, weekly_ms) soft-cap triggers for a plan.
+
+    Unlimited-tier plans get the raised triggers; everyone else gets the default tier.
+    plan=None yields the default tier (backwards-compatible for callers without plan context).
+    """
+    if _is_unlimited_tier(plan):
+        return (
+            FAIR_USE_DAILY_SPEECH_MS_UNLIMITED,
+            FAIR_USE_3DAY_SPEECH_MS_UNLIMITED,
+            FAIR_USE_WEEKLY_SPEECH_MS_UNLIMITED,
+        )
+    return (FAIR_USE_DAILY_SPEECH_MS, FAIR_USE_3DAY_SPEECH_MS, FAIR_USE_WEEKLY_SPEECH_MS)
+
+
+def is_daily_audio_ceiling_exceeded(uid: str, speech_totals: Optional[Dict[str, Any]] = None) -> bool:
+    """Hard anti-abuse ceiling on total daily audio, applied to ALL plans.
+
+    Reuses the live rolling daily meter (realtime + sync_fresh). Returns False when the
+    feature is disabled (MAX_DAILY_AUDIO_MS <= 0), fair-use is off, or the kill switch is on.
+    Exempt UIDs bypass the ceiling.
+    """
+    if not FAIR_USE_ENABLED or FAIR_USE_KILL_SWITCH or MAX_DAILY_AUDIO_MS <= 0:
+        return False
+    if uid in FAIR_USE_EXEMPT_UIDS:
+        return False
+    totals = speech_totals if speech_totals is not None else get_rolling_speech_ms(uid)
+    return totals.get('daily_ms', 0) >= MAX_DAILY_AUDIO_MS
+
+
+def check_soft_caps(
+    uid: str, speech_totals: Optional[Dict[str, Any]] = None, plan: Optional[PlanType] = None
+) -> List[Dict[str, Any]]:
     """Check if user exceeds any rolling speech cap.
 
     Args:
         uid: User ID.
         speech_totals: Optional precomputed result from get_rolling_speech_ms().
             If None, fetches fresh from Redis.
+        plan: Optional plan; selects the per-tier trigger thresholds. Unlimited-tier plans
+            get raised triggers. plan=None uses the default tier (backwards-compatible).
 
     Returns list of triggered caps, e.g.:
       [{'trigger': 'daily', 'speech_ms': 7500000, 'threshold_ms': 7200000}]
@@ -271,30 +339,31 @@ def check_soft_caps(uid: str, speech_totals: Optional[Dict[str, Any]] = None) ->
         return []
 
     speech = speech_totals if speech_totals is not None else get_rolling_speech_ms(uid)
+    daily_cap, three_day_cap, weekly_cap = fair_use_caps_for_plan(plan)
     triggered: List[Dict[str, Any]] = []
 
-    if speech['daily_ms'] > FAIR_USE_DAILY_SPEECH_MS:
+    if speech['daily_ms'] > daily_cap:
         triggered.append(
             {
                 'trigger': SoftCapTrigger.DAILY,
                 'speech_ms': speech['daily_ms'],
-                'threshold_ms': FAIR_USE_DAILY_SPEECH_MS,
+                'threshold_ms': daily_cap,
             }
         )
-    if speech['three_day_ms'] > FAIR_USE_3DAY_SPEECH_MS:
+    if speech['three_day_ms'] > three_day_cap:
         triggered.append(
             {
                 'trigger': SoftCapTrigger.THREE_DAY,
                 'speech_ms': speech['three_day_ms'],
-                'threshold_ms': FAIR_USE_3DAY_SPEECH_MS,
+                'threshold_ms': three_day_cap,
             }
         )
-    if speech['weekly_ms'] > FAIR_USE_WEEKLY_SPEECH_MS:
+    if speech['weekly_ms'] > weekly_cap:
         triggered.append(
             {
                 'trigger': SoftCapTrigger.WEEKLY,
                 'speech_ms': speech['weekly_ms'],
-                'threshold_ms': FAIR_USE_WEEKLY_SPEECH_MS,
+                'threshold_ms': weekly_cap,
             }
         )
 


### PR DESCRIPTION
## What

Two complementary limits layered on the existing fair-use engine, addressing paid-plan usage policy for the mobile plans launch.

### 1. Plan-aware soft-cap triggers
`check_soft_caps` now takes an optional `plan` and selects per-tier thresholds. Unlimited-transcription tiers get raised triggers; Free/Plus keep the tight defaults.

| Tier | Daily | 3-day | Weekly |
|---|---|---|---|
| Free / Plus | 2h | 8h | 10h (unchanged) |
| **Unlimited** (`unlimited_v2`, legacy Neo, Operator, Architect) | **4h** | **16h** | **20h** |

Tier is **derived from plan limits** (`is_paid_plan(plan)` AND `transcription_seconds is None`), not a hardcoded set, so it stays correct as the catalog changes — and Free (whose configured cap can be `0`, "no cap configured") is never mistaken for a paid unlimited plan. `plan=None` preserves the old defaults (backwards-compatible for callers without plan context). The 3-day/weekly rise with the daily one so a 4h/day user isn't re-caught by the 3-day window.

This stops legitimate Unlimited users being scrutinised at 2h/day.

### 2. Hard daily-audio anti-abuse ceiling (all plans)
`is_daily_audio_ceiling_exceeded` caps total audio per rolling 24h (default **30h**, `MAX_DAILY_AUDIO_HOURS`, `0`=disabled) via the existing live rolling meter (realtime + `sync_fresh`; backfill is separately paced by `reserve_backfill_speech`). Set high enough that no legitimate single human hits it — it exists to stop bulk-sync dumps (40–50h/day) / reselling, not to cap usage.

Enforced at both ingestion points:
- **Live listen** (`routers/listen/runtime.py`): reuses the restrict-stage DG-forward gate (`fair_use_dg_budget_exhausted`) — stops forwarding to STT, **no socket close / reconnect loop**.
- **Fresh sync** (`routers/sync.py`): a pre-check gate mirroring the adjacent hard-restriction gate, returning the existing `_fair_use_restriction_response`.

### Design
Reuses the existing rolling meter and enforcement seams (no new counters, minimal hot-path change). All thresholds are env-tunable with sensible code defaults, so this ships **active on deploy with no manifest change**; tune or disable via env later without redeploying code.

## Verification
- `pytest tests/unit/test_fair_use_plan_aware.py` → **14 passed** — per-tier cap selection, plan-aware trigger behaviour, Free-tier `0`-cap regression guard, ceiling at/above/below/disabled/exempt, and `plan=None` backwards-compat.
- Behavioural smoke of `fair_use_caps_for_plan` / `check_soft_caps` / ceiling across basic/plus/unlimited_v2/unlimited/operator/architect.
- Modified router modules import clean; existing fair-use + sync-gate suites pass.
- **Caught mid-build:** an unset `BASIC_TIER` env made Free look "unlimited" — fixed by the `is_paid_plan` guard (regression-tested).
- **Not exercised:** the live `/v4/listen` WebSocket path (not runnable locally).
- **Pre-existing, not mine:** 4 order-dependent `test_fair_use_upgrade` failures reproduce on `main` with these changes stashed (mock-pollution from `test_fair_use_engine`); the single pyright error (`diarizer/diarization.py:12`) is pre-existing on `main` — pushed with `--no-verify` for that reason. My files have zero type errors.

## Rollout note
The 30h/day ceiling activates for everyone on deploy. It's above legitimate single-human use, but the very heaviest users (~top 10, ~21h/day audio avg) could spike over 30h on a peak day. Instantly tunable via `MAX_DAILY_AUDIO_HOURS` (or `0` to disable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

