### PR TITLE
fix: repair CI regressions + prod deploy failure from #9964

### DIFF
--- a/backend/scripts/validate-backend-runtime-env.py
+++ b/backend/scripts/validate-backend-runtime-env.py
@@ -771,7 +771,11 @@ def _validate_cloud_run(
             job_config = _as_config_dict(raw_job_config) or {}
             job_state = _as_config_dict(state_jobs.get(job))
             if job_state is None:
-                errors.append(ValidationError(f'cloud_run/{job}', 'missing job state'))
+                # The job is declared in the runtime-env contract but not live in this
+                # environment (deployed by a separate workflow, or intentionally absent like
+                # memory-maintenance-job while MEMORY_MODE=off). Its static config is validated
+                # elsewhere; skip the live comparison rather than failing the whole deploy.
+                print(f'note: cloud_run job {job!r} absent from live state; skipping live env check')
                 continue
             actual_env = _env_entries_by_name(job_state.get('env', []))
             errors.extend(
@@ -1778,9 +1782,27 @@ def _fetch_live_cloud_run_state(env_config: ConfigDict) -> ConfigDict:
             f'--region={region}',
             '--format=json',
         ]
-        result = subprocess.run(command, check=True, capture_output=True, text=True)
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            # A job declared in the runtime-env contract can legitimately be absent from a
+            # given environment: memory-maintenance-job stays undeployed in prod while
+            # MEMORY_MODE=off (it ships via a separate workflow, not this deploy). Do not crash
+            # the whole deploy validation on a not-found job — omit it so the consumer skips its
+            # live check. Any other gcloud failure (auth, transient, bad flag) is a real error.
+            if _is_cloud_run_not_found(result.stderr):
+                print(f'note: cloud_run job {job!r} not found in {project}/{region}; skipping live check')
+                continue
+            raise RuntimeError(
+                f'gcloud run jobs describe {job} failed (exit {result.returncode}): {result.stderr.strip()}'
+            )
         jobs[job] = {'env': _cloud_run_job_env(json.loads(result.stdout))}
     return {'services': services, 'jobs': jobs}
+
+
+def _is_cloud_run_not_found(stderr: str) -> bool:
+    """True when a gcloud describe failed because the resource does not exist (vs a real error)."""
+    text = (stderr or '').lower()
+    return 'cannot find' in text or 'not_found' in text or 'not found' in text
 
 
 def _cloud_run_job_env(raw_job_state: object) -> list[Any]:

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -5,6 +5,7 @@ import importlib.util
 import re
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import yaml
@@ -1711,3 +1712,64 @@ def test_repo_ilb_endpoints_use_http_scheme(env_name):
             _check_service('gke', svc_name, svc_cfg)
 
     assert violations == [], f'ILB endpoints must use http:// (no TLS): {violations}'
+
+
+# --- live Cloud Run job describe: tolerate a declared-but-not-deployed job (#9964 deploy fix) ---
+
+_LIVE_SERVICE_JSON = '{"spec":{"template":{"metadata":{"annotations":{}},"spec":{"containers":[{"env":[]}]}}}}'
+
+
+def _live_env_config():
+    return {
+        'gcp_project': 'based-hardware',
+        'region': 'us-central1',
+        'cloud_run': {
+            'services': {'backend': {}},
+            'jobs': {'memory-maintenance-job': {}, 'notifications-job': {}},
+        },
+    }
+
+
+def _job_name(command):
+    return command[command.index('describe') + 1]
+
+
+def test_is_cloud_run_not_found_matches_gcloud_message():
+    validator = load_validator()
+    assert validator._is_cloud_run_not_found('ERROR: (gcloud.run.jobs.describe) Cannot find job [x].') is True
+    assert validator._is_cloud_run_not_found('ERROR: NOT_FOUND: resource missing') is True
+    assert validator._is_cloud_run_not_found('ERROR: PERMISSION_DENIED') is False
+    assert validator._is_cloud_run_not_found('') is False
+
+
+def test_fetch_live_cloud_run_state_skips_not_found_job(monkeypatch):
+    # memory-maintenance-job is declared in the runtime-env contract but not deployed to prod
+    # (MEMORY_MODE=off). A not-found live describe must not crash the deploy validation.
+    validator = load_validator()
+
+    def fake_run(command, **kwargs):
+        if 'services' in command:
+            return SimpleNamespace(returncode=0, stdout=_LIVE_SERVICE_JSON, stderr='')
+        if _job_name(command) == 'memory-maintenance-job':
+            return SimpleNamespace(returncode=1, stdout='', stderr='ERROR: Cannot find job [memory-maintenance-job].')
+        return SimpleNamespace(returncode=0, stdout='{}', stderr='')
+
+    monkeypatch.setattr(validator.subprocess, 'run', fake_run)
+    state = validator._fetch_live_cloud_run_state(_live_env_config())
+
+    assert 'memory-maintenance-job' not in state['jobs']  # skipped, not crashed
+    assert 'notifications-job' in state['jobs']  # a live job is still fetched + validated
+
+
+def test_fetch_live_cloud_run_state_raises_on_non_not_found_job_error(monkeypatch):
+    # A real gcloud failure (auth/transient/bad flag) must still surface, not be swallowed.
+    validator = load_validator()
+
+    def fake_run(command, **kwargs):
+        if 'services' in command:
+            return SimpleNamespace(returncode=0, stdout=_LIVE_SERVICE_JSON, stderr='')
+        return SimpleNamespace(returncode=1, stdout='', stderr='ERROR: PERMISSION_DENIED')
+
+    monkeypatch.setattr(validator.subprocess, 'run', fake_run)
+    with pytest.raises(RuntimeError):
+        validator._fetch_live_cloud_run_state(_live_env_config())

--- a/backend/tests/unit/test_fair_use_plan_aware.py
+++ b/backend/tests/unit/test_fair_use_plan_aware.py
@@ -50,12 +50,16 @@ class TestFairUseCapsForPlan:
         # Guards the whole point of the feature: Unlimited must tolerate more before scrutiny.
         assert fair_use_mod.FAIR_USE_DAILY_SPEECH_MS_UNLIMITED > fair_use_mod.FAIR_USE_DAILY_SPEECH_MS
 
-    def test_free_tier_is_never_unlimited_even_with_zero_configured_cap(self):
-        # Free's configured monthly cap can be 0 ("no cap configured") in some envs; that
-        # must NOT be mistaken for a paid unlimited plan (regression for the is_paid_plan guard).
-        with patch.object(fair_use_mod, 'get_plan_limits') as gpl:
-            gpl.return_value = type('L', (), {'transcription_seconds': 0})()
-            assert fair_use_mod._is_unlimited_tier(PlanType.basic) is False
+    def test_free_and_plus_are_never_unlimited_tier(self):
+        # The whole point of the tier split: Free/Plus must never get the raised caps.
+        assert fair_use_mod._is_unlimited_tier(PlanType.basic) is False
+        assert fair_use_mod._is_unlimited_tier(PlanType.plus) is False
+        assert fair_use_mod._is_unlimited_tier(None) is False
+
+    def test_is_unlimited_tier_accepts_raw_string_plan(self):
+        # subscription.plan may arrive as a raw string; PlanType is a str enum so membership holds.
+        assert fair_use_mod._is_unlimited_tier('unlimited_v2') is True
+        assert fair_use_mod._is_unlimited_tier('basic') is False
 
 
 class TestCheckSoftCapsPlanAware:

--- a/backend/tests/unit/test_listen_runtime_regressions.py
+++ b/backend/tests/unit/test_listen_runtime_regressions.py
@@ -30,6 +30,7 @@ def _runtime_for_periodic_usage(*, tracking, exhausted):
         fair_use_last_check_ts=0.0,
         fair_use_track_dg_usage=tracking,
         fair_use_dg_budget_exhausted=exhausted,
+        fair_use_plan=None,
     )
 
     async def wait(_seconds):
@@ -75,7 +76,11 @@ async def test_periodic_fair_use_check_preserves_proactive_tracking_and_clears_s
     monkeypatch.setattr(runtime_module, 'FAIR_USE_ENABLED', True)
     monkeypatch.setattr(runtime_module, 'FAIR_USE_RESTRICT_DAILY_DG_MS', 60_000)
     monkeypatch.setattr(runtime_module, 'get_rolling_speech_ms', lambda _uid: {'daily_ms': 1})
-    monkeypatch.setattr(runtime_module, 'check_soft_caps', lambda _uid, *, speech_totals: caps)
+    monkeypatch.setattr(runtime_module, 'check_soft_caps', lambda _uid, *, speech_totals, plan: caps)
+    monkeypatch.setattr(runtime_module, 'is_daily_audio_ceiling_exceeded', lambda _uid, *, speech_totals: False)
+    monkeypatch.setattr(
+        runtime_module.user_db, 'get_user_valid_subscription', lambda _uid: SimpleNamespace(plan='basic')
+    )
     monkeypatch.setattr(runtime_module, 'get_enforcement_stage', lambda _uid: 'observe')
     monkeypatch.setattr(runtime_module, 'trigger_classifier_if_needed', classifier)
     monkeypatch.setattr(runtime_module, 'start_background_task', start_background)

--- a/backend/utils/fair_use.py
+++ b/backend/utils/fair_use.py
@@ -18,7 +18,7 @@ import database.users as users_db
 from database.redis_db import r as redis_client
 from models.fair_use import SoftCapTrigger
 from models.users import PlanType
-from utils.subscription import get_plan_limits, has_transcription_credits, is_paid_plan
+from utils.subscription import has_transcription_credits, is_paid_plan
 from utils.executors import db_executor, postprocess_executor, run_blocking
 from utils.llm.fair_use_classifier import classify_user_purpose
 from utils.notifications import send_notification
@@ -270,21 +270,22 @@ def get_rolling_backfill_speech_ms(uid: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _is_unlimited_tier(plan: Optional[PlanType]) -> bool:
-    """True for paid unlimited-transcription plans (Unlimited/unlimited_v2, legacy Neo,
-    Operator, Architect) — the tiers whose monthly transcription allowance is unbounded.
+# Paid unlimited-transcription tiers get the raised fair-use triggers. Hardcoded (like
+# _platform_hidden_plans in utils.subscription) rather than derived from get_plan_limits so
+# utils.fair_use does not depend on utils.subscription.get_plan_limits at import time (that
+# import broke module-stubbing tests), and so a mis-set BASIC_TIER cap can never flip Free
+# into this set. Plus and Free carry a bounded monthly cap and stay on the default tier.
+_UNLIMITED_TRANSCRIPTION_PLANS = frozenset(
+    {PlanType.unlimited, PlanType.unlimited_v2, PlanType.operator, PlanType.architect}
+)
 
-    Keyed off plan limits rather than a hardcoded set so it stays self-consistent as the
-    catalog changes. Requires a *paid* plan AND ``transcription_seconds is None`` (paid
-    unlimited plans use None): this excludes Free — whose configured cap can be 0 ("no cap
-    configured") in some environments — and Plus, which carries a positive monthly cap.
-    """
-    if plan is None:
-        return False
-    try:
-        return is_paid_plan(plan) and get_plan_limits(plan).transcription_seconds is None
-    except Exception:
-        return False
+
+def _is_unlimited_tier(plan: Optional[PlanType]) -> bool:
+    """True for paid unlimited-transcription tiers (Unlimited/unlimited_v2, legacy Neo,
+    Operator, Architect) — the plans whose monthly transcription allowance is unbounded.
+    Free and Plus (bounded monthly cap) stay on the default tier. Robust to ``None`` and to
+    plans passed as raw strings (PlanType is a str enum)."""
+    return plan in _UNLIMITED_TRANSCRIPTION_PLANS
 
 
 def fair_use_caps_for_plan(plan: Optional[PlanType] = None) -> tuple[int, int, int]:


### PR DESCRIPTION
Follow-up to #9964, fixing the two failures its merge surfaced: the red `main` CI **and** the failed prod deploy (run 29641667073).

## 1. CI regressions (commit 1)

#9964 landed with two test breakages:

**`utils/fair_use.py` — dropped the fragile `get_plan_limits` import.** #9964 added a top-level `from utils.subscription import get_plan_limits`, which broke every test that stubs `utils.subscription` with an incomplete fake to dodge the module's circular import (`test_dg_usage_batch` + the `load_module_fresh` cohort) — `ImportError` at collection. Replaced the `get_plan_limits`-derived tier check with a hardcoded `PlanType` frozenset (`_UNLIMITED_TRANSCRIPTION_PLANS`), matching `_platform_hidden_plans`. Same tier membership → no behaviour change; robust to raw-string plans; can't be flipped by a mis-set `BASIC_TIER`.

**`test_listen_runtime_regressions.py` — stale test.** Built the session `state` as a `SimpleNamespace` missing the new `fair_use_plan` field (`AttributeError`), stubbed `check_soft_caps` without the new `plan` kwarg, and didn't mock the in-loop subscription fetch / ceiling call. Updated the fixture + monkeypatches. The deployed runtime was correct — the real `ListenSessionState` already carries the field; only the test double was stale.

## 2. Deploy failure (commit 2)

The prod deploy died at the post-deploy `validate-backend-runtime-env.py --check-live-cloud-run` step:
```
gcloud run jobs describe memory-maintenance-job … → exit 1  (unhandled CalledProcessError)
```
`memory-maintenance-job` is declared in the prod runtime-env contract but **intentionally not deployed to prod** — `MEMORY_MODE=off` pending Gate 3, shipped via a separate workflow. Confirmed live: prod has only `notifications-job`; describing `memory-maintenance-job` returns NOT_FOUND. `_fetch_live_cloud_run_state` used `check=True`, so a not-found job crashed the whole deploy.

Fix: a not-found job describe is **skipped** (with a note); any other gcloud failure still raises. Services stay strict (this pipeline deploys them). Rendered-state validation is unchanged, so config drift on live jobs is still caught.

## Verification
- `pytest test_backend_runtime_env_validator + test_fair_use_plan_aware + test_listen_runtime_regressions + test_dg_usage_batch` → **94 passed**.
- New validator tests: `_is_cloud_run_not_found` matching; fetch skips a not-found job while keeping a present one; fetch still raises on a non-not-found gcloud error.
- `test_desktop_transcribe` batch-order failure reproduces on `main` with this diff stashed (pre-existing pollution, unrelated).

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
