### PR TITLE
fix(deploy): post-deploy live check validates services only, not jobs

### DIFF
--- a/backend/scripts/validate-backend-runtime-env.py
+++ b/backend/scripts/validate-backend-runtime-env.py
@@ -771,11 +771,7 @@ def _validate_cloud_run(
             job_config = _as_config_dict(raw_job_config) or {}
             job_state = _as_config_dict(state_jobs.get(job))
             if job_state is None:
-                # The job is declared in the runtime-env contract but not live in this
-                # environment (deployed by a separate workflow, or intentionally absent like
-                # memory-maintenance-job while MEMORY_MODE=off). Its static config is validated
-                # elsewhere; skip the live comparison rather than failing the whole deploy.
-                print(f'note: cloud_run job {job!r} absent from live state; skipping live env check')
+                errors.append(ValidationError(f'cloud_run/{job}', 'missing job state'))
                 continue
             actual_env = _env_entries_by_name(job_state.get('env', []))
             errors.extend(
@@ -1739,8 +1735,13 @@ def _cloud_run_secret_ref(entry: EnvEntry) -> StringMap | None:
 
 
 def _fetch_live_cloud_run_state(env_config: ConfigDict) -> ConfigDict:
+    # This deploy pipeline (gcp_backend.yml) deploys Cloud Run *services* only — the declared
+    # Cloud Run jobs (memory-maintenance-job, notifications-job) ship via their own workflows,
+    # so their live state is owned elsewhere. Fetch and live-validate services only; validating
+    # a job this pipeline does not deploy produced false failures (a not-found job crashed the
+    # whole deploy, and notifications-job's separately-managed env legitimately differs). The
+    # job contract is still validated statically against the rendered state.
     services: ConfigDict = {}
-    jobs: ConfigDict = {}
     project = env_config['gcp_project']
     region = env_config['region']
     cloud_run = _as_config_dict(env_config.get('cloud_run')) or {}
@@ -1770,57 +1771,7 @@ def _fetch_live_cloud_run_state(env_config: ConfigDict) -> ConfigDict:
             'env': first_container.get('env', []),
             'flags': _cloud_run_network_flags_from_annotations(annotations),
         }
-    job_configs = _as_config_dict(cloud_run.get('jobs')) or {}
-    for job in job_configs:
-        command = [
-            'gcloud',
-            'run',
-            'jobs',
-            'describe',
-            job,
-            f'--project={project}',
-            f'--region={region}',
-            '--format=json',
-        ]
-        result = subprocess.run(command, capture_output=True, text=True)
-        if result.returncode != 0:
-            # A job declared in the runtime-env contract can legitimately be absent from a
-            # given environment: memory-maintenance-job stays undeployed in prod while
-            # MEMORY_MODE=off (it ships via a separate workflow, not this deploy). Do not crash
-            # the whole deploy validation on a not-found job — omit it so the consumer skips its
-            # live check. Any other gcloud failure (auth, transient, bad flag) is a real error.
-            if _is_cloud_run_not_found(result.stderr):
-                print(f'note: cloud_run job {job!r} not found in {project}/{region}; skipping live check')
-                continue
-            raise RuntimeError(
-                f'gcloud run jobs describe {job} failed (exit {result.returncode}): {result.stderr.strip()}'
-            )
-        jobs[job] = {'env': _cloud_run_job_env(json.loads(result.stdout))}
-    return {'services': services, 'jobs': jobs}
-
-
-def _is_cloud_run_not_found(stderr: str) -> bool:
-    """True when a gcloud describe failed because the resource does not exist (vs a real error)."""
-    text = (stderr or '').lower()
-    return 'cannot find' in text or 'not_found' in text or 'not found' in text
-
-
-def _cloud_run_job_env(raw_job_state: object) -> list[Any]:
-    job_state = _as_config_dict(raw_job_state) or {}
-    env_paths = (
-        ('template', 'template', 'containers'),
-        ('template', 'containers'),
-        ('spec', 'template', 'spec', 'template', 'spec', 'containers'),
-    )
-    for path in env_paths:
-        cursor: object = job_state
-        for part in path:
-            cursor = (_as_config_dict(cursor) or {}).get(part)
-        containers = _as_config_list(cursor)
-        if containers:
-            first_container = _as_config_dict(containers[0]) or {}
-            return _as_config_list(first_container.get('env')) or []
-    return []
+    return {'services': services}
 
 
 def _cloud_run_network_flags_from_annotations(annotations: object) -> StringMap:

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -1714,7 +1714,7 @@ def test_repo_ilb_endpoints_use_http_scheme(env_name):
     assert violations == [], f'ILB endpoints must use http:// (no TLS): {violations}'
 
 
-# --- live Cloud Run job describe: tolerate a declared-but-not-deployed job (#9964 deploy fix) ---
+# --- live Cloud Run check validates services only (this pipeline deploys no Cloud Run jobs) ---
 
 _LIVE_SERVICE_JSON = '{"spec":{"template":{"metadata":{"annotations":{}},"spec":{"containers":[{"env":[]}]}}}}'
 
@@ -1730,46 +1730,22 @@ def _live_env_config():
     }
 
 
-def _job_name(command):
-    return command[command.index('describe') + 1]
-
-
-def test_is_cloud_run_not_found_matches_gcloud_message():
+def test_fetch_live_cloud_run_state_validates_services_only(monkeypatch):
+    # gcp_backend.yml deploys Cloud Run services, not jobs (memory-maintenance-job and
+    # notifications-job ship via separate workflows). The live check must describe services
+    # only and never `gcloud run jobs describe` — that produced false deploy failures (a
+    # not-found job crashed it; a separately-managed job's env legitimately differs).
     validator = load_validator()
-    assert validator._is_cloud_run_not_found('ERROR: (gcloud.run.jobs.describe) Cannot find job [x].') is True
-    assert validator._is_cloud_run_not_found('ERROR: NOT_FOUND: resource missing') is True
-    assert validator._is_cloud_run_not_found('ERROR: PERMISSION_DENIED') is False
-    assert validator._is_cloud_run_not_found('') is False
-
-
-def test_fetch_live_cloud_run_state_skips_not_found_job(monkeypatch):
-    # memory-maintenance-job is declared in the runtime-env contract but not deployed to prod
-    # (MEMORY_MODE=off). A not-found live describe must not crash the deploy validation.
-    validator = load_validator()
+    described = []
 
     def fake_run(command, **kwargs):
-        if 'services' in command:
-            return SimpleNamespace(returncode=0, stdout=_LIVE_SERVICE_JSON, stderr='')
-        if _job_name(command) == 'memory-maintenance-job':
-            return SimpleNamespace(returncode=1, stdout='', stderr='ERROR: Cannot find job [memory-maintenance-job].')
-        return SimpleNamespace(returncode=0, stdout='{}', stderr='')
+        described.append(command)
+        assert 'jobs' not in command, f'must not describe Cloud Run jobs: {command}'
+        return SimpleNamespace(returncode=0, stdout=_LIVE_SERVICE_JSON, stderr='')
 
     monkeypatch.setattr(validator.subprocess, 'run', fake_run)
     state = validator._fetch_live_cloud_run_state(_live_env_config())
 
-    assert 'memory-maintenance-job' not in state['jobs']  # skipped, not crashed
-    assert 'notifications-job' in state['jobs']  # a live job is still fetched + validated
-
-
-def test_fetch_live_cloud_run_state_raises_on_non_not_found_job_error(monkeypatch):
-    # A real gcloud failure (auth/transient/bad flag) must still surface, not be swallowed.
-    validator = load_validator()
-
-    def fake_run(command, **kwargs):
-        if 'services' in command:
-            return SimpleNamespace(returncode=0, stdout=_LIVE_SERVICE_JSON, stderr='')
-        return SimpleNamespace(returncode=1, stdout='', stderr='ERROR: PERMISSION_DENIED')
-
-    monkeypatch.setattr(validator.subprocess, 'run', fake_run)
-    with pytest.raises(RuntimeError):
-        validator._fetch_live_cloud_run_state(_live_env_config())
+    assert 'jobs' not in state  # no live job state → consumer skips job env checks
+    assert 'backend' in state['services']  # services are still fetched + validated
+    assert any('services' in cmd for cmd in described)


### PR DESCRIPTION
Fixes the **post-deploy validation** half of the prod deploy failures. (The other half — `STT_PRERECORDED_MODEL` — is a separate config decision, see below.)

## Root cause
The prod backend deploy kept failing at `validate-backend-runtime-env.py --check-live-cloud-run`. The live-state fetch validated Cloud Run **jobs** against the shared runtime-env contract — but `gcp_backend.yml` deploys only Cloud Run **services**. The two declared jobs ship via their own workflows:
- **`memory-maintenance-job`** — not deployed to prod at all (`MEMORY_MODE=off`, Gate 3 pending). `gcloud run jobs describe` → NOT_FOUND → originally crashed the whole deploy (fixed in #9965); once that reached the env comparison it exposed:
- **`notifications-job`** — deployed by its own cron workflow with different env, so its live env legitimately differs from the backend contract (`missing OMI_ENV_STAGE` / `SERVICE_ACCOUNT_JSON`, `PINECONE_API_KEY` drift).

Validating a resource this pipeline doesn't deploy is out of scope and blocks the deploy on drift it can't fix.

## Fix
`_fetch_live_cloud_run_state` fetches and validates **services only** and omits jobs entirely — so the consumer skips live job env checks. Services stay strict (this pipeline deploys them). The job contract is still validated statically against the rendered state, so drift on jobs is still caught where it's actionable. Supersedes #9965's partial not-found tolerance (removes the now-unused helpers).

## Verification
`pytest test_backend_runtime_env_validator.py` → **62 passed**, incl. a new test asserting the live fetch describes services only and never `gcloud run jobs describe`.

## ⚠️ Remaining blocker (NOT in this PR — needs your decision)
The deploy will still fail on `STT_PRERECORDED_MODEL` drift on the 4 services. That's a **half-finished Deepgram-retirement rollout** (`755d81cada`/`c1ea10e103`): it set `STT_PRERECORDED_MODEL` to a **literal `parakeet,modulate-velma-2`**, but the deploy encodes literal env vars with `gcloud --update-env-vars ^,^…` (comma = delimiter), so the value splits into `STT_PRERECORDED_MODEL=parakeet` + a bogus `modulate-velma-2` env. The GCP secret `STT_PRERECORDED_MODEL` still holds the old `parakeet,dg-nova-3`. Fixing it is a prod-config/policy call (see PR discussion).

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

