### PR TITLE
fix(ci): make pre-push single-flight runner portable on Windows

### DIFF
--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -18,6 +18,15 @@ POLL_SECONDS = 0.2
 STATUS_INTERVAL_SECONDS = 5.0
 
 
+def forwardable_signals() -> tuple[int, ...]:
+    """Interrupt signals the host exposes, so the handler map never assumes POSIX.
+
+    Windows Python omits ``SIGHUP``; building the map unconditionally raised
+    ``AttributeError`` before any pre-push check could run.
+    """
+    return tuple(getattr(signal, name) for name in ("SIGINT", "SIGTERM", "SIGHUP") if hasattr(signal, name))
+
+
 def atomic_json(path: Path, value: dict) -> None:
     temporary = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
     temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -175,13 +184,14 @@ def run_owned(
     def forward_signal(signum: int, _frame: object) -> None:
         if child is not None and child.poll() is None:
             try:
-                os.killpg(child.pid, signum)
-            except ProcessLookupError:
+                if hasattr(os, "killpg"):
+                    os.killpg(child.pid, signum)
+                else:
+                    child.send_signal(signum)
+            except (ProcessLookupError, OSError):
                 pass
 
-    previous_handlers = {
-        signum: signal.signal(signum, forward_signal) for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
-    }
+    previous_handlers = {signum: signal.signal(signum, forward_signal) for signum in forwardable_signals()}
     exit_code = 1
     try:
         print(f"Pre-push single-flight log: {log_path}")

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -16,8 +16,12 @@ import urllib.error
 from pathlib import Path
 from unittest.mock import patch
 
+import signal
+from types import SimpleNamespace
+
 from pr_metadata import TransientPRMetadataError, load_from_api, load_from_event_file
 from pr_preflight import changed_files, format_failure_class_suggest, resolve_pr_metadata, select_checks
+import preflight_runner
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 RUNNER = SCRIPT_DIR / "preflight_runner.py"
@@ -395,6 +399,22 @@ class SelectionTests(unittest.TestCase):
             text = path.read_text(encoding="utf-8")
             for reference in deprecated_references:
                 self.assertNotIn(reference, text, f"{path}: update {reference} to a non-Node-20 action")
+
+
+class SignalPortabilityTests(unittest.TestCase):
+    def test_forwardable_signals_are_all_present_on_this_host(self) -> None:
+        selected = preflight_runner.forwardable_signals()
+        self.assertIn(signal.SIGINT, selected)
+        self.assertIn(signal.SIGTERM, selected)
+        for signum in selected:
+            self.assertIsInstance(signum, int)
+
+    def test_forwardable_signals_skips_sighup_when_host_omits_it(self) -> None:
+        # Windows Python has no SIGHUP; selection must drop it instead of crashing.
+        windows_signal = SimpleNamespace(SIGINT=signal.SIGINT, SIGTERM=signal.SIGTERM)
+        with patch.object(preflight_runner, "signal", windows_signal):
+            selected = preflight_runner.forwardable_signals()
+        self.assertEqual(selected, (signal.SIGINT, signal.SIGTERM))
 
 
 class SingleFlightTests(unittest.TestCase):


### PR DESCRIPTION
## What

`run_owned()` in `.github/scripts/preflight_runner.py` built its signal handler map from `(signal.SIGINT, signal.SIGTERM, signal.SIGHUP)` unconditionally, and forwarded signals with POSIX-only `os.killpg`. Now it selects only the signals the host exposes (new `forwardable_signals()` helper) and falls back to `child.send_signal()` when `os.killpg` is unavailable.

## Why

From #9724:

> On Windows, every `git push` fails before the underlying pre-push checks start.
> `run_owned()` builds its handler map from `(signal.SIGINT, signal.SIGTERM, signal.SIGHUP)` unconditionally. Windows Python does not expose `SIGHUP`, so the wrapper exits with code 1 and Git rejects the push.
> Observed: `AttributeError: module 'signal' has no attribute 'SIGHUP'` from `run_owned()`.

Windows Python omits `SIGHUP` (and `os.killpg`), so the wrapper crashed at import-of-handlers time and blocked all pushes routed through `scripts/pre-push-singleflight`. Running `scripts/pre-push` directly succeeded — only the single-flight wrapper failed.

## Change

- `forwardable_signals()` returns only `SIGINT`/`SIGTERM`/`SIGHUP` that the running `signal` module actually defines.
- `forward_signal()` uses `os.killpg` on POSIX (unchanged behavior) and `child.send_signal()` where `killpg` is absent, catching `OSError` in addition to `ProcessLookupError`.

## Verified

- Added `SignalPortabilityTests` in `.github/scripts/test_pr_preflight.py`: a regression test that patches the runner's `signal` module to omit `SIGHUP` (the Windows shape) and asserts selection drops it rather than raising — no real signal is sent, per the issue's request.
- `python3 -m unittest test_pr_preflight.SignalPortabilityTests -v` → 2 tests pass.
- `python3 -m black --line-length 120 --skip-string-normalization --check` → clean on both files.
- Note: two unrelated `MetadataTests` (`test_api_loader_*`) error under local Python 3.9 (a tempfile/`HTTPError` teardown quirk in `FakeResponse`); they fail identically on the untouched base, independent of this change.

Auto-generated from issue feedback by the mini issues-improver. Review before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

