### PR TITLE
fix(desktop): keep qualification health probe unauthenticated

### DIFF
--- a/desktop/macos/changelog/unreleased/20260718-qualification-health-probe.json
+++ b/desktop/macos/changelog/unreleased/20260718-qualification-health-probe.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved macOS beta qualification reliability."
+}

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -115,12 +115,19 @@ def automation_port_from_base_url(base_url: str) -> int:
     return int(base_url.rsplit(":", 1)[1])
 
 
-def request_json(base_url: str, method: str, route: str, body: dict[str, typing.Any] | None = None) -> dict[str, typing.Any]:
+def request_json(
+    base_url: str,
+    method: str,
+    route: str,
+    body: dict[str, typing.Any] | None = None,
+    authenticate: bool = True,
+) -> dict[str, typing.Any]:
     data = None
     headers = {"Accept": "application/json"}
-    token = automation_token(automation_port_from_base_url(base_url))
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
+    if authenticate:
+        token = automation_token(automation_port_from_base_url(base_url))
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
     if body is not None:
         data = json.dumps(body).encode("utf-8")
         headers["Content-Type"] = "application/json"
@@ -155,7 +162,7 @@ def log_path_from_health(health: dict[str, typing.Any], explicit_log: str | None
 
 
 def resolve_log_path(base_url: str, explicit_log: str | None = None) -> Path:
-    health = request_json(base_url, "GET", "/health")
+    health = request_json(base_url, "GET", "/health", authenticate=False)
     if not health.get("ok"):
         raise RuntimeError(f"unable to resolve bundle log path: {health.get('error', health)}")
     return log_path_from_health(health, explicit_log)

--- a/desktop/macos/tests/test-omi-harness.sh
+++ b/desktop/macos/tests/test-omi-harness.sh
@@ -40,6 +40,8 @@ export PYTHONPATH="$TMPDIR${PYTHONPATH:+:$PYTHONPATH}"
 python3 - "$HARNESS" <<'PY'
 import importlib.machinery
 import importlib.util
+import json
+import os
 import sys
 
 path = sys.argv[1]
@@ -78,6 +80,71 @@ except RuntimeError:
     pass
 else:
     raise AssertionError("relative health log path must fail loudly")
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+requests = []
+
+
+def fake_urlopen(request, timeout):
+    route = request.full_url.rsplit(":59999", 1)[1]
+    requests.append(
+        {
+            "route": route,
+            "method": request.get_method(),
+            "authorization": request.get_header("Authorization"),
+        }
+    )
+    if route == "/health":
+        return FakeResponse({"ok": True, "logFilePath": "/private/tmp/omi/harness-test.log"})
+    if route == "/state":
+        return FakeResponse({"ok": True, "result": {"selectedTab": "home"}})
+    if route == "/action":
+        return FakeResponse({"ok": True, "result": {"accepted": True}})
+    raise AssertionError(f"unexpected route: {route}")
+
+
+os.environ["OMI_AUTOMATION_TOKEN"] = "test-automation-token"
+module.urllib.request.urlopen = fake_urlopen
+assert module.resolve_log_path("http://127.0.0.1:59999").as_posix().endswith("harness-test.log")
+assert module.state_snapshot(
+    module.HarnessContext(
+        base_url="http://127.0.0.1:59999",
+        flow_path=module.Path("flow.yaml"),
+        run_dir=module.Path("runs"),
+        steps_dir=module.Path("runs/steps"),
+        lane="bridge",
+        log_path=module.Path("/private/tmp/omi/harness-test.log"),
+        log_start=0,
+        bundle_id=None,
+        process_match=None,
+    )
+) == {"selectedTab": "home"}
+assert module.request_json(
+    "http://127.0.0.1:59999", "POST", "/action", {"name": "refresh_all_data"}
+)["result"]["accepted"]
+
+assert [(request["method"], request["route"]) for request in requests] == [
+    ("GET", "/health"),
+    ("GET", "/state"),
+    ("POST", "/action"),
+]
+assert requests[0]["authorization"] is None
+assert requests[1]["authorization"] == "Bearer test-automation-token"
+assert requests[2]["authorization"] == "Bearer test-automation-token"
 PY
 
 write_flow() {


### PR DESCRIPTION
## What changed and why

`omi-harness` was attaching the automation bearer token to its log-path `GET /health` probe. The bridge reserves top-level `logFilePath` for the unauthenticated diagnostic response, so Tier-2 qualification stopped before flow execution. The probe now opts out of authentication while normal `/state` and `/action` requests retain their existing authenticated default.

## Product invariants affected

none

## How it was verified

- Red: the focused harness test failed before the change because the health probe carried `Authorization`.
- Green: `bash desktop/macos/tests/test-omi-harness.sh` passed after the change.
- The test exercises production `resolve_log_path`, `state_snapshot`, and `request_json` through a controllable HTTP transport seam.
- `desktop-core-harness.sh --self-check` was previously green in Codex's environment; this local worktree's standalone Python lacks PyYAML before it reaches that self-check.

## Tests

The regression test asserts the log-path health request has no Authorization header, while `/state` and `/action` retain the bearer token.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

