### PR TITLE
fix(subscription): restrict Neo purchase on web, show full new catalog

### DIFF
--- a/backend/tests/unit/test_subscription_restructure.py
+++ b/backend/tests/unit/test_subscription_restructure.py
@@ -184,8 +184,35 @@ def test_filter_plans_shows_neo_on_mobile_for_current_neo_subscriber(load_subscr
     assert 'unlimited' in [d['plan_id'] for d in filtered]
 
 
-def test_filter_plans_keeps_neo_on_web_for_new_user(load_subscription):
-    """Web / unknown platform is unaffected — Neo stays in the catalog."""
+def test_filter_plans_hides_neo_on_web_for_new_user(load_subscription):
+    """Web sells the full new catalog (Plus + Unlimited + Operator + Architect);
+    deprecated Neo is hidden from the web purchase catalog.
+
+    Regression: web (X-App-Platform: web) previously hid nothing, so Neo was
+    offered for purchase alongside the new tiers. Neo purchase is restricted to
+    existing subscribers only.
+    """
+    with load_subscription() as sub_mod:
+        definitions = sub_mod.get_paid_plan_definitions()
+        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform='web', ever_purchased=False)
+    plan_ids = [d['plan_id'] for d in filtered]
+    assert 'unlimited' not in plan_ids  # Neo hidden
+    assert 'plus' in plan_ids
+    assert 'unlimited_v2' in plan_ids
+    assert 'operator' in plan_ids
+    assert 'architect' in plan_ids
+
+
+def test_filter_plans_shows_neo_on_web_for_current_neo_subscriber(load_subscription):
+    """Existing Neo subscribers still see Neo on web so they can manage/cancel."""
+    with load_subscription() as sub_mod:
+        definitions = sub_mod.get_paid_plan_definitions()
+        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.unlimited, platform='web', ever_purchased=True)
+    assert 'unlimited' in [d['plan_id'] for d in filtered]
+
+
+def test_filter_plans_keeps_neo_for_unknown_platform(load_subscription):
+    """A header-less / unknown platform is still unfiltered — Neo stays visible."""
     with load_subscription() as sub_mod:
         definitions = sub_mod.get_paid_plan_definitions()
         filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform=None, ever_purchased=False)
@@ -206,6 +233,26 @@ def test_filter_plans_hides_neo_on_windows_for_new_user(load_subscription):
     assert 'unlimited' not in plan_ids
     assert 'operator' in plan_ids
     assert 'architect' in plan_ids
+
+
+def test_neo_hidden_from_purchase_on_every_client_platform(load_subscription):
+    """Reusable guard: the deprecated Neo plan is never offered for purchase to a
+    new user on ANY real client platform.
+
+    Twice now a platform was omitted from the Neo-hidden set and started offering
+    Neo: first Windows (only 'macos' was hidden), then web (hid nothing). This
+    pins the invariant across every X-App-Platform a client actually sends, so the
+    next platform added can't silently reintroduce the deprecated-plan-for-sale bug.
+    """
+    with load_subscription() as sub_mod:
+        definitions = sub_mod.get_paid_plan_definitions()
+        for platform in ('ios', 'android', 'macos', 'windows', 'web'):
+            filtered = sub_mod.filter_plans_for_user(
+                definitions, PlanType.basic, platform=platform, ever_purchased=False
+            )
+            plan_ids = [d['plan_id'] for d in filtered]
+            assert 'unlimited' not in plan_ids, (platform, plan_ids)
+            assert plan_ids, platform  # never an empty catalog
 
 
 def test_windows_full_catalog_matches_macos_canonical(load_subscription):
@@ -306,6 +353,40 @@ def test_version_gating_windows_always_new(load_subscription):
         assert sub_mod.should_show_new_plans('Windows', '1.0.0') is True
         # Unparseable version fails open on desktop (same as macOS).
         assert sub_mod.should_show_new_plans('windows', 'not.a.version') is True
+
+
+def test_version_gating_web_always_new(load_subscription):
+    """Web is an always-latest client: always gets the new catalog, version-agnostic."""
+    with load_subscription() as sub_mod:
+        assert 'web' in sub_mod.WEB_PLATFORMS
+        assert sub_mod.should_show_new_plans('web', None) is True
+        assert sub_mod.should_show_new_plans('web', '0.0.1') is True
+        assert sub_mod.should_show_new_plans('web', '99.99.999') is True
+        assert sub_mod.should_show_new_plans('Web', '1.0.0') is True  # case-insensitive
+
+
+def test_web_full_catalog_shows_new_plans_and_hides_neo(load_subscription):
+    """End-to-end catalog resolution for a web client (X-App-Platform: web).
+
+    Web renders the full new catalog under canonical titles — Plus + Unlimited
+    (mobile tiers) AND Operator + Architect (desktop tiers) — never the legacy
+    'Omi Pro' / 'Unlimited Plan' rename, and never deprecated Neo for a new user.
+    """
+    with load_subscription() as sub_mod:
+        new_plans_enabled = sub_mod.should_show_new_plans('web', None)
+        assert new_plans_enabled is True
+        definitions = sub_mod.get_paid_plan_definitions()
+        # No legacy adaptation for web (new_plans_enabled) → raw canonical catalog.
+        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform='web', ever_purchased=False)
+    by_id = {d['plan_id']: d for d in filtered}
+    assert set(by_id) == {'plus', 'unlimited_v2', 'operator', 'architect'}, by_id
+    assert 'unlimited' not in by_id  # Neo hidden
+    assert by_id['operator']['title'] == 'Operator'
+    assert by_id['architect']['title'] == 'Architect'
+    assert by_id['unlimited_v2']['title'] == 'Unlimited'
+    titles = [d['title'] for d in filtered]
+    assert 'Omi Pro' not in titles
+    assert 'Unlimited Plan' not in titles
 
 
 def test_version_gating_mobile_requires_version(load_subscription):

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -464,19 +464,27 @@ LEGACY_PRICE_MAP = {
 # Platform identifiers for the two mobile clients (X-App-Platform header).
 _MOBILE_PLATFORM_TOKENS = {'ios', 'android'}
 
+# The web storefront (X-App-Platform: web). It's an always-latest client that
+# renders the full new catalog (Plus + Unlimited + Operator + Architect) and is
+# the primary Stripe checkout surface; only deprecated Neo is hidden there.
+WEB_PLATFORMS = {'web'}
+
 
 def _platform_hidden_plans(platform: Optional[str]) -> Set[PlanType]:
     """Plans hidden from the purchase catalog per platform.
 
-    Mobile sells Plus + Unlimited; desktop sells Operator + Architect; Neo is
-    deprecated on both. Web is unfiltered. A subscriber on a hidden plan still
-    sees it via `filter_plans_for_user`'s current-plan / ever-purchased escapes.
+    Mobile sells Plus + Unlimited; desktop sells Operator + Architect; web sells
+    all four. Neo is deprecated everywhere and hidden on every platform. A
+    subscriber on a hidden plan still sees it via `filter_plans_for_user`'s
+    current-plan / ever-purchased escapes.
     """
     p = (platform or '').lower()
     if p in _MOBILE_PLATFORM_TOKENS:
         return {PlanType.unlimited, PlanType.operator, PlanType.architect}
     if p in DESKTOP_PLATFORMS:
         return {PlanType.unlimited, PlanType.plus, PlanType.unlimited_v2}
+    if p in WEB_PLATFORMS:
+        return {PlanType.unlimited}
     return set()
 
 
@@ -561,12 +569,16 @@ def should_show_new_plans(platform: Optional[str], app_version: Optional[str]) -
     Mobile (android/ios): any build at or above NEW_PLANS_MIN_MOBILE_VERSION
     qualifies; a missing or unparseable version defaults to the legacy catalog
     (old mobile builds crash on the operator enum).
+    Web: always the new catalog (it's an always-latest client, version-agnostic).
     Unknown platform: legacy catalog.
     """
     if not platform:
         return False
 
     platform_lower = platform.lower()
+
+    if platform_lower in WEB_PLATFORMS:
+        return True
 
     if platform_lower in DESKTOP_PLATFORMS:
         if not app_version:

--- a/web/app/src/components/settings/SettingsPage.tsx
+++ b/web/app/src/components/settings/SettingsPage.tsx
@@ -933,7 +933,10 @@ function UsageSectionContent({
   };
 
   const getPlanDisplayName = (plan: string) => {
-    if (plan === 'unlimited') return 'Unlimited';
+    if (plan === 'unlimited' || plan === 'unlimited_v2') return 'Unlimited';
+    if (plan === 'plus') return 'Plus';
+    if (plan === 'operator') return 'Operator';
+    if (plan === 'architect') return 'Architect';
     if (plan === 'basic') return 'Free';
     return plan || 'Free';
   };

--- a/web/app/src/lib/api.ts
+++ b/web/app/src/lib/api.ts
@@ -1397,10 +1397,14 @@ export async function getUserSubscription(): Promise<UserSubscription | null> {
       '/v1/users/me/subscription',
     );
 
+    // Any paid tier counts as premium for UI gating (Manage vs Choose Plan).
+    // Plus / Unlimited arrive wired as 'unlimited'; Operator / Architect arrive
+    // as their real plan id now that web renders the full new catalog.
+    const paidPlans = ['unlimited', 'plus', 'unlimited_v2', 'operator', 'architect'];
     const result: UserSubscription = {
       plan: response.subscription?.plan || 'basic',
       status: response.subscription?.status || 'active',
-      is_unlimited: response.subscription?.plan === 'unlimited',
+      is_unlimited: paidPlans.includes(response.subscription?.plan ?? ''),
       current_period_end: response.subscription?.current_period_end,
       cancel_at_period_end: response.subscription?.cancel_at_period_end,
       current_price_id: response.subscription?.current_price_id,

--- a/web/app/src/types/user.ts
+++ b/web/app/src/types/user.ts
@@ -63,7 +63,7 @@ export interface UserUsageResponse {
 
 // Subscription details
 export interface Subscription {
-  plan: 'basic' | 'unlimited';
+  plan: 'basic' | 'unlimited' | 'plus' | 'unlimited_v2' | 'operator' | 'architect';
   status: 'active' | 'inactive';
   current_period_end?: number;
   stripe_subscription_id?: string;


### PR DESCRIPTION
## What

Restrict the deprecated **Neo** (`unlimited`) plan from the **web** purchase catalog, and make web render the full new plan lineup.

Web (`X-App-Platform: web`) previously hid nothing from the catalog, so Neo was offered for purchase alongside the new tiers — even though Neo is already hidden on mobile and desktop. This closes that gap and shows the intended catalog on web.

### Backend (`utils/subscription.py`)
- Added `WEB_PLATFORMS = {'web'}`.
- `should_show_new_plans('web')` → always `True` (web is an always-latest, version-agnostic client) → no legacy adaptation, so plans render under canonical titles.
- `_platform_hidden_plans('web')` → `{unlimited}` (Neo only).
- Net result: web shows **Plus + Unlimited + Operator + Architect**; Neo is hidden from purchase but stays visible to existing Neo subscribers via `filter_plans_for_user`'s current-plan / ever-purchased escapes (so they can still manage/cancel).

### Web frontend
Now that web renders the full new catalog, an Operator/Architect subscriber's current plan reaches web as its real id (Plus/Unlimited still wire to `unlimited`). To avoid mis-showing them as Free:
- `types/user.ts` — widened the `Subscription.plan` union.
- `lib/api.ts` — `is_unlimited` = any paid tier (for the Manage-vs-Choose-Plan UI gate).
- `SettingsPage.tsx` — display labels for the new plans.

## Why

Consistency + product intent: Neo is deprecated everywhere; web was the only surface still selling it. Existing Neo subscribers are untouched (migration handled separately).

## Reusable guard

Adds `test_neo_hidden_from_purchase_on_every_client_platform` — asserts Neo is hidden from purchase for a new user on **every** real client platform (ios/android/macos/windows/web). The same cause (a platform omitted from the Neo-hidden set) previously shipped for **Windows** (`test_filter_plans_hides_neo_on_windows_for_new_user`); this pins the invariant so the next platform added can't silently reintroduce the deprecated-plan-for-sale bug.

## Testing

- Backend: added web catalog tests + the all-platforms guard; inverted the stale `keeps_neo_on_web` test (it conflated web with `platform=None`; real web sends `'web'`). All affected tests pass individually, and the pre-existing mobile/desktop/windows catalog tests still pass.
  - Note: the whole-file `pytest` run fails locally on a **pre-existing** Prometheus re-registration artifact under the local 3.12 venv (verified identical failures on clean `main` with the same venv); the 3.11 CI runner handles it.
- Web: `tsc --noEmit` → exit 0.
- Not run end-to-end: the live web→Stripe checkout (needs the running Next.js app + Stripe). The added tests exercise the exact catalog-resolution functions both `/v1/payments/available-plans` and `/v1/users/me/subscription` call.

## Product invariants

None affected (`scripts/pr-preflight --suggest` → `none`).

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

