### PR TITLE
fix(ci): pre-push single-flight runner registers only host-available signals (#9724)

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -39,6 +39,11 @@ checks:
     triggers: [".github/scripts/desktop-changelog.py", ".github/scripts/test_desktop_changelog.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#9717: changelog JSON I/O must decode/encode as UTF-8 regardless of contributor host locale"
+  - id: preflight-runner-signal-tests
+    command: ["python3", ".github/scripts/test_preflight_runner.py"]
+    triggers: [".github/scripts/preflight_runner.py", ".github/scripts/test_preflight_runner.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#9724: single-flight pre-push runner must register only host-available signals (no SIGHUP on Windows)"
   - id: agents-md-lean
     command: ["python3", ".github/scripts/check_agents_md_lean.py"]
     triggers: ["AGENTS.md", ".github/scripts/check_agents_md_lean.py"]

--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -143,6 +143,15 @@ def join_existing(state_dir: Path, wanted_fingerprint: str) -> int | None:
     return int(result.get("exit_code", 1))
 
 
+def forwardable_signals() -> list[int]:
+    """Signals we forward to the child, limited to those the host exposes.
+
+    Windows Python has no SIGHUP, so registering it unconditionally crashes the
+    single-flight wrapper (AttributeError) before any pre-push check runs.
+    """
+    return [getattr(signal, name) for name in ("SIGINT", "SIGTERM", "SIGHUP") if hasattr(signal, name)]
+
+
 def run_owned(
     state_dir: Path,
     lock_dir: Path,
@@ -175,13 +184,17 @@ def run_owned(
     def forward_signal(signum: int, _frame: object) -> None:
         if child is not None and child.poll() is None:
             try:
-                os.killpg(child.pid, signum)
-            except ProcessLookupError:
+                # POSIX runs the child in its own session (start_new_session)
+                # so we can signal the whole group; Windows lacks killpg.
+                if hasattr(os, "killpg"):
+                    os.killpg(child.pid, signum)
+                else:
+                    child.send_signal(signum)
+            except (ProcessLookupError, OSError, ValueError):
                 pass
 
-    previous_handlers = {
-        signum: signal.signal(signum, forward_signal) for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
-    }
+    # Only register signals the host actually exposes; e.g. Windows has no SIGHUP.
+    previous_handlers = {signum: signal.signal(signum, forward_signal) for signum in forwardable_signals()}
     exit_code = 1
     try:
         print(f"Pre-push single-flight log: {log_path}")

--- a/.github/scripts/test_preflight_runner.py
+++ b/.github/scripts/test_preflight_runner.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Unit tests for preflight_runner.py signal selection (stdlib unittest).
+
+Regression coverage for #9724: the single-flight pre-push wrapper must register
+only signals the host exposes. Native Windows Python has no SIGHUP, so building
+the handler map from a fixed (SIGINT, SIGTERM, SIGHUP) tuple raised
+AttributeError and rejected every `git push` before the checks ran. The CI host
+is POSIX and has SIGHUP, so this exercises selection by faking the host signal
+set rather than relying on the platform.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import signal
+import unittest
+import unittest.mock
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "preflight_runner", Path(__file__).with_name("preflight_runner.py")
+)
+runner = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(runner)
+
+
+class ForwardableSignalsTests(unittest.TestCase):
+    def test_includes_available_signals(self) -> None:
+        selected = runner.forwardable_signals()
+        self.assertIn(signal.SIGINT, selected)
+        self.assertIn(signal.SIGTERM, selected)
+
+    def test_skips_signals_absent_on_host(self) -> None:
+        # Simulate a host (e.g. Windows) that lacks SIGHUP.
+        fake_signal = unittest.mock.Mock(spec=["SIGINT", "SIGTERM"])
+        fake_signal.SIGINT = signal.SIGINT
+        fake_signal.SIGTERM = signal.SIGTERM
+        with unittest.mock.patch.object(runner, "signal", fake_signal):
+            selected = runner.forwardable_signals()
+        self.assertEqual(selected, [signal.SIGINT, signal.SIGTERM])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug (#9724)
On native Windows, every `git push` fails before the pre-push checks run:
```
AttributeError: module 'signal' has no attribute 'SIGHUP'
```

## Root cause
`.github/scripts/preflight_runner.py` `run_owned()` built its signal handler map from a fixed `(signal.SIGINT, signal.SIGTERM, signal.SIGHUP)` tuple. Windows Python does not expose `SIGHUP`, so constructing the map raised `AttributeError` and the wrapper exited 1, causing Git to reject the push. The forwarding callback also used POSIX-only `os.killpg`, a second portability hazard if a signal were ever delivered.

## Fix
- Extract `forwardable_signals()` — selects only signals the host actually exposes (`hasattr(signal, name)`), so `SIGHUP` is simply skipped where absent.
- `forward_signal()` now forwards via `os.killpg` when available (POSIX group semantics preserved) and falls back to `child.send_signal()` on hosts without `killpg`.

## Test
- New `test_preflight_runner.py` fakes a SIGHUP-less host and asserts selection yields `[SIGINT, SIGTERM]`; also asserts the available signals are included on POSIX.
- Registered as `preflight-runner-signal-tests` in `.github/checks-manifest.yaml` (local + ci lanes).

## Verification
```
$ python3 .github/scripts/test_preflight_runner.py   # OK (2 tests)
$ python3 .github/scripts/test_run_checks.py          # OK (20 tests) — manifest entry valid
```
Confirmed the old fixed tuple raises `AttributeError` on a mocked SIGHUP-less host, while `forwardable_signals()` returns `[SIGINT, SIGTERM]`.

No user-visible desktop change → no changelog fragment. Scope: repo dev tooling only (no workflow/secret/auth/signing changes).

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

