### PR TITLE
feat move This Device memory filter into the filter sheet

### DIFF
--- a/app/lib/pages/memories/page.dart
+++ b/app/lib/pages/memories/page.dart
@@ -211,8 +211,6 @@ class MemoriesPageState extends State<MemoriesPage> with AutomaticKeepAliveClien
                                     SizedBox(width: 44, height: 44, child: _buildShimmerButton()),
                                     const SizedBox(width: 8),
                                     SizedBox(width: 44, height: 44, child: _buildShimmerButton()),
-                                    const SizedBox(width: 8),
-                                    SizedBox(width: 44, height: 44, child: _buildShimmerButton()),
                                   ],
                                 ),
                               ),
@@ -291,14 +289,6 @@ class MemoriesPageState extends State<MemoriesPage> with AutomaticKeepAliveClien
                                           ),
                                         );
                                       },
-                                    ),
-                                    const SizedBox(width: 8),
-                                    FilterChip(
-                                      label: Text(context.l10n.memoryThisDevice, style: const TextStyle(fontSize: 12)),
-                                      selected: provider.filterThisDeviceOnly,
-                                      onSelected: provider.setFilterThisDeviceOnly,
-                                      visualDensity: VisualDensity.compact,
-                                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                                     ),
                                     const SizedBox(width: 8),
                                     SizedBox(

--- a/app/lib/pages/memories/widgets/memory_management_sheet.dart
+++ b/app/lib/pages/memories/widgets/memory_management_sheet.dart
@@ -65,16 +65,26 @@ class MemoryManagementSheet extends StatelessWidget {
           padding: const EdgeInsets.fromLTRB(20, 16, 16, 8),
           child: Text(context.l10n.filterMemories, style: AppStyles.title),
         ),
-        _buildFilterOption(context, context.l10n.filterAll, null),
-        _buildFilterOption(context, context.l10n.filterSystem, MemoryCategory.system),
-        _buildFilterOption(context, context.l10n.filterInteresting, MemoryCategory.interesting),
-        _buildFilterOption(context, context.l10n.filterManual, MemoryCategory.manual),
+        _buildCategoryFilterOption(context, context.l10n.filterAll, null),
+        _buildCategoryFilterOption(context, context.l10n.filterSystem, MemoryCategory.system),
+        _buildCategoryFilterOption(context, context.l10n.filterInteresting, MemoryCategory.interesting),
+        _buildCategoryFilterOption(context, context.l10n.filterManual, MemoryCategory.manual),
+        const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+          child: Divider(height: 1, color: Colors.white10),
+        ),
+        _buildFilterOption(
+          context,
+          context.l10n.memoryThisDevice,
+          isSelected: provider.filterThisDeviceOnly,
+          onTap: () => provider.setFilterThisDeviceOnly(!provider.filterThisDeviceOnly),
+        ),
         const SizedBox(height: 16),
       ],
     );
   }
 
-  Widget _buildFilterOption(BuildContext context, String label, MemoryCategory? category) {
+  Widget _buildCategoryFilterOption(BuildContext context, String label, MemoryCategory? category) {
     // If category is null, it represents "All"
     // For "All", it is selected if the set is empty.
     final bool isSelected;
@@ -84,7 +94,10 @@ class MemoryManagementSheet extends StatelessWidget {
       isSelected = provider.selectedCategories.contains(category);
     }
 
-    return InkWell(
+    return _buildFilterOption(
+      context,
+      label,
+      isSelected: isSelected,
       onTap: () {
         if (category == null) {
           provider.clearCategoryFilter();
@@ -93,6 +106,17 @@ class MemoryManagementSheet extends StatelessWidget {
         }
         // Do NOT pop here to allow multiple selections
       },
+    );
+  }
+
+  Widget _buildFilterOption(
+    BuildContext context,
+    String label, {
+    required bool isSelected,
+    required VoidCallback onTap,
+  }) {
+    return InkWell(
+      onTap: onTap,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
         child: Row(


### PR DESCRIPTION
## What

Moves the **This Device** memory filter chip out of the memories search row and into the filter bottom sheet (opened by the last icon on the search row). It now sits below the category options (All / System / Interesting / Manual), separated by a divider, and toggles without closing the sheet — matching the category options' behavior.

- [page.dart](app/lib/pages/memories/page.dart): removed the standalone `FilterChip` from the search row (and its shimmer placeholder).
- [memory_management_sheet.dart](app/lib/pages/memories/widgets/memory_management_sheet.dart): added the This Device row to the sheet; extracted a shared `_buildFilterOption` row builder reused by the category options.

<img width="603" alt="This Device filter inside the filter sheet" src="https://github.com/user-attachments/assets/eabc6fad-5296-4840-870a-27d85d310fb2" />

## Product invariants affected

- INV-MEM-1 — UI-only relocation of the This Device filter control; filtering semantics and memory-tier behavior are unchanged.

## Verification

- `dart format --line-length 120` on both files (no changes).
- `flutter analyze` on both files — only pre-existing info-level lints, no warnings or errors.
- `scripts/pr-preflight` local lane passes with this body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

