### PR TITLE
feat(app): understand the plus and unlimited_v2 plan tiers

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2902,7 +2902,7 @@
     "upgradePlan": "ترقية الخطة",
     "billingMonthly": "شهري",
     "billingYearly": "سنوي",
-    "savePercent": "وفّر ~17%",
+    "savePercent": "وفّر ~{percent}%",
     "popular": "شائع",
     "currentPlan": "الحالي",
     "neoSubtitle": "{count} سؤال شهرياً",

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "Абнавіць план",
     "billingMonthly": "Штомесяц",
     "billingYearly": "Штогод",
-    "savePercent": "Зэканомце ~17%",
+    "savePercent": "Зэканомце ~{percent}%",
     "popular": "Папулярны",
     "currentPlan": "Бягучы",
     "neoSubtitle": "{count} пытанняў у месяц",

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2904,7 +2904,7 @@
     "upgradePlan": "Надграждане на плана",
     "billingMonthly": "Месечно",
     "billingYearly": "Годишно",
-    "savePercent": "Спестете ~17%",
+    "savePercent": "Спестете ~{percent}%",
     "popular": "Популярен",
     "currentPlan": "Текущ",
     "neoSubtitle": "{count} въпроса на месец",

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "প্ল্যান আপগ্রেড করুন",
     "billingMonthly": "মাসিক",
     "billingYearly": "বার্ষিক",
-    "savePercent": "~17% সাশ্রয়",
+    "savePercent": "~{percent}% সাশ্রয়",
     "popular": "জনপ্রিয়",
     "currentPlan": "বর্তমান",
     "neoSubtitle": "মাসে {count}টি প্রশ্ন",

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "Nadogradi plan",
     "billingMonthly": "Mjesečno",
     "billingYearly": "Godišnje",
-    "savePercent": "Uštedite ~17%",
+    "savePercent": "Uštedite ~{percent}%",
     "popular": "Popularno",
     "currentPlan": "Trenutni",
     "neoSubtitle": "{count} pitanja mjesečno",

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2904,7 +2904,7 @@
     "upgradePlan": "Actualitzar pla",
     "billingMonthly": "Mensual",
     "billingYearly": "Anual",
-    "savePercent": "Estalvia ~17%",
+    "savePercent": "Estalvia ~{percent}%",
     "popular": "Popular",
     "currentPlan": "Actual",
     "neoSubtitle": "{count} preguntes al mes",

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2904,7 +2904,7 @@
     "upgradePlan": "Upgradovat plán",
     "billingMonthly": "Měsíční",
     "billingYearly": "Roční",
-    "savePercent": "Ušetřete ~17%",
+    "savePercent": "Ušetřete ~{percent}%",
     "popular": "Oblíbené",
     "currentPlan": "Aktuální",
     "neoSubtitle": "{count} dotazů měsíčně",

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -2944,7 +2944,7 @@
     "upgradePlan": "Opgrader plan",
     "billingMonthly": "Månedlig",
     "billingYearly": "Årlig",
-    "savePercent": "Spar ~17%",
+    "savePercent": "Spar ~{percent}%",
     "popular": "Populært",
     "currentPlan": "Nuværende",
     "neoSubtitle": "{count} spørgsmål om måneden",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2903,7 +2903,7 @@
     "upgradePlan": "Plan upgraden",
     "billingMonthly": "Monatlich",
     "billingYearly": "Jährlich",
-    "savePercent": "~17% sparen",
+    "savePercent": "~{percent}% sparen",
     "popular": "Beliebt",
     "currentPlan": "Aktuell",
     "neoSubtitle": "{count} Fragen pro Monat",

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -2935,7 +2935,7 @@
     "upgradePlan": "Αναβάθμιση πλάνου",
     "billingMonthly": "Μηνιαίο",
     "billingYearly": "Ετήσιο",
-    "savePercent": "Εξοικονομήστε ~17%",
+    "savePercent": "Εξοικονομήστε ~{percent}%",
     "popular": "Δημοφιλές",
     "currentPlan": "Τρέχον",
     "neoSubtitle": "{count} ερωτήσεις ανά μήνα",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10668,7 +10668,7 @@
     "upgradePlan": "Upgrade Plan",
     "billingMonthly": "Monthly",
     "billingYearly": "Yearly",
-    "savePercent": "Save ~17%",
+    "savePercent": "Save ~{percent}%",
     "popular": "Popular",
     "currentPlan": "Current",
     "neoSubtitle": "{count} questions per month",
@@ -11326,5 +11326,12 @@
     "dataEncryptedBanner": "Your data is secured by default with strong encryption, and you stay in control of how it's stored and used.",
     "@dataEncryptedBanner": {
         "description": "Data privacy page banner summarizing encryption and user control"
+    },
+    "@savePercent": {
+        "placeholders": {
+            "percent": {
+                "type": "int"
+            }
+        }
     }
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -2936,7 +2936,7 @@
     "upgradePlan": "Actualizar plan",
     "billingMonthly": "Mensual",
     "billingYearly": "Anual",
-    "savePercent": "Ahorra ~17%",
+    "savePercent": "Ahorra ~{percent}%",
     "popular": "Popular",
     "currentPlan": "Actual",
     "neoSubtitle": "{count} preguntas al mes",

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -2935,7 +2935,7 @@
     "upgradePlan": "Uuenda plaani",
     "billingMonthly": "Kuine",
     "billingYearly": "Aastane",
-    "savePercent": "Säästa ~17%",
+    "savePercent": "Säästa ~{percent}%",
     "popular": "Populaarne",
     "currentPlan": "Praegune",
     "neoSubtitle": "{count} küsimust kuus",

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "ارتقای طرح",
     "billingMonthly": "ماهانه",
     "billingYearly": "سالانه",
-    "savePercent": "~17% صرفه‌جویی",
+    "savePercent": "~{percent}% صرفه‌جویی",
     "popular": "محبوب",
     "currentPlan": "فعلی",
     "neoSubtitle": "{count} پرسش در ماه",

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -2935,7 +2935,7 @@
     "upgradePlan": "Päivitä suunnitelma",
     "billingMonthly": "Kuukausittain",
     "billingYearly": "Vuosittain",
-    "savePercent": "Säästä ~17%",
+    "savePercent": "Säästä ~{percent}%",
     "popular": "Suosittu",
     "currentPlan": "Nykyinen",
     "neoSubtitle": "{count} kysymystä kuukaudessa",

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -2970,7 +2970,7 @@
     "upgradePlan": "Améliorer le forfait",
     "billingMonthly": "Mensuel",
     "billingYearly": "Annuel",
-    "savePercent": "Économisez ~17%",
+    "savePercent": "Économisez ~{percent}%",
     "popular": "Populaire",
     "currentPlan": "Actuel",
     "neoSubtitle": "{count} questions par mois",

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "שדרג תוכנית",
     "billingMonthly": "חודשי",
     "billingYearly": "שנתי",
-    "savePercent": "חסוך ~17%",
+    "savePercent": "חסוך ~{percent}%",
     "popular": "פופולרי",
     "currentPlan": "נוכחי",
     "neoSubtitle": "{count} שאלות בחודש",

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -2936,7 +2936,7 @@
     "upgradePlan": "प्लान अपग्रेड करें",
     "billingMonthly": "मासिक",
     "billingYearly": "वार्षिक",
-    "savePercent": "~17% बचाएं",
+    "savePercent": "~{percent}% बचाएं",
     "popular": "लोकप्रिय",
     "currentPlan": "वर्तमान",
     "neoSubtitle": "प्रति माह {count} प्रश्न",

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "Nadogradi plan",
     "billingMonthly": "Mjesečno",
     "billingYearly": "Godišnje",
-    "savePercent": "Uštedite ~17%",
+    "savePercent": "Uštedite ~{percent}%",
     "popular": "Popularno",
     "currentPlan": "Trenutni",
     "neoSubtitle": "{count} pitanja mjesečno",

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3031,7 +3031,7 @@
     "upgradePlan": "Csomag frissítése",
     "billingMonthly": "Havi",
     "billingYearly": "Éves",
-    "savePercent": "~17% megtakarítás",
+    "savePercent": "~{percent}% megtakarítás",
     "popular": "Népszerű",
     "currentPlan": "Jelenlegi",
     "neoSubtitle": "{count} kérdés havonta",

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -2977,7 +2977,7 @@
     "upgradePlan": "Upgrade paket",
     "billingMonthly": "Bulanan",
     "billingYearly": "Tahunan",
-    "savePercent": "Hemat ~17%",
+    "savePercent": "Hemat ~{percent}%",
     "popular": "Populer",
     "currentPlan": "Saat ini",
     "neoSubtitle": "{count} pertanyaan per bulan",

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -2935,7 +2935,7 @@
     "upgradePlan": "Aggiorna piano",
     "billingMonthly": "Mensile",
     "billingYearly": "Annuale",
-    "savePercent": "Risparmia ~17%",
+    "savePercent": "Risparmia ~{percent}%",
     "popular": "Popolare",
     "currentPlan": "Attuale",
     "neoSubtitle": "{count} domande al mese",

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -2936,7 +2936,7 @@
     "upgradePlan": "プランをアップグレード",
     "billingMonthly": "月額",
     "billingYearly": "年額",
-    "savePercent": "約17%お得",
+    "savePercent": "約{percent}%お得",
     "popular": "人気",
     "currentPlan": "現在",
     "neoSubtitle": "月{count}件の質問",

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "ಯೋಜನೆ ಅಪ್‌ಗ್ರೇಡ್",
     "billingMonthly": "ಮಾಸಿಕ",
     "billingYearly": "ವಾರ್ಷಿಕ",
-    "savePercent": "~17% ಉಳಿಸಿ",
+    "savePercent": "~{percent}% ಉಳಿಸಿ",
     "popular": "ಜನಪ್ರಿಯ",
     "currentPlan": "ಪ್ರಸ್ತುತ",
     "neoSubtitle": "ತಿಂಗಳಿಗೆ {count} ಪ್ರಶ್ನೆಗಳು",

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2935,7 +2935,7 @@
     "upgradePlan": "플랜 업그레이드",
     "billingMonthly": "월간",
     "billingYearly": "연간",
-    "savePercent": "~17% 절약",
+    "savePercent": "~{percent}% 절약",
     "popular": "인기",
     "currentPlan": "현재",
     "neoSubtitle": "월 {count}개 질문",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16794,8 +16794,8 @@ abstract class AppLocalizations {
   /// No description provided for @savePercent.
   ///
   /// In en, this message translates to:
-  /// **'Save ~17%'**
-  String get savePercent;
+  /// **'Save ~{percent}%'**
+  String savePercent(int percent);
 
   /// No description provided for @popular.
   ///

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8929,7 +8929,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get billingYearly => 'سنوي';
 
   @override
-  String get savePercent => 'وفّر ~17%';
+  String savePercent(int percent) {
+    return 'وفّر ~$percent%';
+  }
 
   @override
   String get popular => 'شائع';

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9013,7 +9013,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get billingYearly => 'Штогод';
 
   @override
-  String get savePercent => 'Зэканомце ~17%';
+  String savePercent(int percent) {
+    return 'Зэканомце ~$percent%';
+  }
 
   @override
   String get popular => 'Папулярны';

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9022,7 +9022,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get billingYearly => 'Годишно';
 
   @override
-  String get savePercent => 'Спестете ~17%';
+  String savePercent(int percent) {
+    return 'Спестете ~$percent%';
+  }
 
   @override
   String get popular => 'Популярен';

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -8997,7 +8997,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get billingYearly => 'বার্ষিক';
 
   @override
-  String get savePercent => '~17% সাশ্রয়';
+  String savePercent(int percent) {
+    return '~$percent% সাশ্রয়';
+  }
 
   @override
   String get popular => 'জনপ্রিয়';

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9012,7 +9012,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get billingYearly => 'Godišnje';
 
   @override
-  String get savePercent => 'Uštedite ~17%';
+  String savePercent(int percent) {
+    return 'Uštedite ~$percent%';
+  }
 
   @override
   String get popular => 'Popularno';

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9041,7 +9041,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get billingYearly => 'Anual';
 
   @override
-  String get savePercent => 'Estalvia ~17%';
+  String savePercent(int percent) {
+    return 'Estalvia ~$percent%';
+  }
 
   @override
   String get popular => 'Popular';

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -8984,7 +8984,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get billingYearly => 'Roční';
 
   @override
-  String get savePercent => 'Ušetřete ~17%';
+  String savePercent(int percent) {
+    return 'Ušetřete ~$percent%';
+  }
 
   @override
   String get popular => 'Oblíbené';

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8974,7 +8974,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get billingYearly => 'Årlig';
 
   @override
-  String get savePercent => 'Spar ~17%';
+  String savePercent(int percent) {
+    return 'Spar ~$percent%';
+  }
 
   @override
   String get popular => 'Populært';

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9063,7 +9063,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get billingYearly => 'Jährlich';
 
   @override
-  String get savePercent => '~17% sparen';
+  String savePercent(int percent) {
+    return '~$percent% sparen';
+  }
 
   @override
   String get popular => 'Beliebt';

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9052,7 +9052,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get billingYearly => 'Ετήσιο';
 
   @override
-  String get savePercent => 'Εξοικονομήστε ~17%';
+  String savePercent(int percent) {
+    return 'Εξοικονομήστε ~$percent%';
+  }
 
   @override
   String get popular => 'Δημοφιλές';

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -8985,7 +8985,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get billingYearly => 'Yearly';
 
   @override
-  String get savePercent => 'Save ~17%';
+  String savePercent(int percent) {
+    return 'Save ~$percent%';
+  }
 
   @override
   String get popular => 'Popular';

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9009,7 +9009,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get billingYearly => 'Anual';
 
   @override
-  String get savePercent => 'Ahorra ~17%';
+  String savePercent(int percent) {
+    return 'Ahorra ~$percent%';
+  }
 
   @override
   String get popular => 'Popular';

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -8986,7 +8986,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get billingYearly => 'Aastane';
 
   @override
-  String get savePercent => 'Säästa ~17%';
+  String savePercent(int percent) {
+    return 'Säästa ~$percent%';
+  }
 
   @override
   String get popular => 'Populaarne';

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -8990,7 +8990,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get billingYearly => 'سالانه';
 
   @override
-  String get savePercent => '~17% صرفه‌جویی';
+  String savePercent(int percent) {
+    return '~$percent% صرفه‌جویی';
+  }
 
   @override
   String get popular => 'محبوب';

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -8988,7 +8988,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get billingYearly => 'Vuosittain';
 
   @override
-  String get savePercent => 'Säästä ~17%';
+  String savePercent(int percent) {
+    return 'Säästä ~$percent%';
+  }
 
   @override
   String get popular => 'Suosittu';

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9070,7 +9070,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get billingYearly => 'Annuel';
 
   @override
-  String get savePercent => 'Économisez ~17%';
+  String savePercent(int percent) {
+    return 'Économisez ~$percent%';
+  }
 
   @override
   String get popular => 'Populaire';

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -8918,7 +8918,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get billingYearly => 'שנתי';
 
   @override
-  String get savePercent => 'חסוך ~17%';
+  String savePercent(int percent) {
+    return 'חסוך ~$percent%';
+  }
 
   @override
   String get popular => 'פופולרי';

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8966,7 +8966,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get billingYearly => 'वार्षिक';
 
   @override
-  String get savePercent => '~17% बचाएं';
+  String savePercent(int percent) {
+    return '~$percent% बचाएं';
+  }
 
   @override
   String get popular => 'लोकप्रिय';

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9018,7 +9018,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get billingYearly => 'Godišnje';
 
   @override
-  String get savePercent => 'Uštedite ~17%';
+  String savePercent(int percent) {
+    return 'Uštedite ~$percent%';
+  }
 
   @override
   String get popular => 'Popularno';

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9026,7 +9026,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get billingYearly => 'Éves';
 
   @override
-  String get savePercent => '~17% megtakarítás';
+  String savePercent(int percent) {
+    return '~$percent% megtakarítás';
+  }
 
   @override
   String get popular => 'Népszerű';

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -8998,7 +8998,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get billingYearly => 'Tahunan';
 
   @override
-  String get savePercent => 'Hemat ~17%';
+  String savePercent(int percent) {
+    return 'Hemat ~$percent%';
+  }
 
   @override
   String get popular => 'Populer';

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9042,7 +9042,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get billingYearly => 'Annuale';
 
   @override
-  String get savePercent => 'Risparmia ~17%';
+  String savePercent(int percent) {
+    return 'Risparmia ~$percent%';
+  }
 
   @override
   String get popular => 'Popolare';

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8845,7 +8845,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get billingYearly => '年額';
 
   @override
-  String get savePercent => '約17%お得';
+  String savePercent(int percent) {
+    return '約$percent%お得';
+  }
 
   @override
   String get popular => '人気';

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9019,7 +9019,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get billingYearly => 'ವಾರ್ಷಿಕ';
 
   @override
-  String get savePercent => '~17% ಉಳಿಸಿ';
+  String savePercent(int percent) {
+    return '~$percent% ಉಳಿಸಿ';
+  }
 
   @override
   String get popular => 'ಜನಪ್ರಿಯ';

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8846,7 +8846,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get billingYearly => '연간';
 
   @override
-  String get savePercent => '~17% 절약';
+  String savePercent(int percent) {
+    return '~$percent% 절약';
+  }
 
   @override
   String get popular => '인기';

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -8998,7 +8998,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get billingYearly => 'Metinis';
 
   @override
-  String get savePercent => 'Sutaupykite ~17%';
+  String savePercent(int percent) {
+    return 'Sutaupykite ~$percent%';
+  }
 
   @override
   String get popular => 'Populiarus';

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9007,7 +9007,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get billingYearly => 'Gadā';
 
   @override
-  String get savePercent => 'Ietaupiet ~17%';
+  String savePercent(int percent) {
+    return 'Ietaupiet ~$percent%';
+  }
 
   @override
   String get popular => 'Populārs';

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9037,7 +9037,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get billingYearly => 'Годишно';
 
   @override
-  String get savePercent => 'Заштедете ~17%';
+  String savePercent(int percent) {
+    return 'Заштедете ~$percent%';
+  }
 
   @override
   String get popular => 'Популарно';

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -8999,7 +8999,9 @@ class AppLocalizationsMr extends AppLocalizations {
   String get billingYearly => 'वार्षिक';
 
   @override
-  String get savePercent => '~17% बचत करा';
+  String savePercent(int percent) {
+    return '~$percent% बचत करा';
+  }
 
   @override
   String get popular => 'लोकप्रिय';

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9012,7 +9012,9 @@ class AppLocalizationsMs extends AppLocalizations {
   String get billingYearly => 'Tahunan';
 
   @override
-  String get savePercent => 'Jimat ~17%';
+  String savePercent(int percent) {
+    return 'Jimat ~$percent%';
+  }
 
   @override
   String get popular => 'Popular';

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9014,7 +9014,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get billingYearly => 'Jaarlijks';
 
   @override
-  String get savePercent => 'Bespaar ~17%';
+  String savePercent(int percent) {
+    return 'Bespaar ~$percent%';
+  }
 
   @override
   String get popular => 'Populair';

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -8985,7 +8985,9 @@ class AppLocalizationsNo extends AppLocalizations {
   String get billingYearly => 'Årlig';
 
   @override
-  String get savePercent => 'Spar ~17%';
+  String savePercent(int percent) {
+    return 'Spar ~$percent%';
+  }
 
   @override
   String get popular => 'Populært';

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9008,7 +9008,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get billingYearly => 'Rocznie';
 
   @override
-  String get savePercent => 'Oszczędź ~17%';
+  String savePercent(int percent) {
+    return 'Oszczędź ~$percent%';
+  }
 
   @override
   String get popular => 'Popularne';

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -8992,7 +8992,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get billingYearly => 'Anual';
 
   @override
-  String get savePercent => 'Economize ~17%';
+  String savePercent(int percent) {
+    return 'Economize ~$percent%';
+  }
 
   @override
   String get popular => 'Popular';

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9030,7 +9030,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get billingYearly => 'Anual';
 
   @override
-  String get savePercent => 'Economisiți ~17%';
+  String savePercent(int percent) {
+    return 'Economisiți ~$percent%';
+  }
 
   @override
   String get popular => 'Popular';

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9017,7 +9017,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get billingYearly => 'Ежегодно';
 
   @override
-  String get savePercent => 'Экономия ~17%';
+  String savePercent(int percent) {
+    return 'Экономия ~$percent%';
+  }
 
   @override
   String get popular => 'Популярный';

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8977,7 +8977,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get billingYearly => 'Ročne';
 
   @override
-  String get savePercent => 'Ušetrite ~17%';
+  String savePercent(int percent) {
+    return 'Ušetrite ~$percent%';
+  }
 
   @override
   String get popular => 'Obľúbené';

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9012,7 +9012,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get billingYearly => 'Letno';
 
   @override
-  String get savePercent => 'Prihranite ~17%';
+  String savePercent(int percent) {
+    return 'Prihranite ~$percent%';
+  }
 
   @override
   String get popular => 'Priljubljeno';

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9000,7 +9000,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get billingYearly => 'Годишње';
 
   @override
-  String get savePercent => 'Уштедите ~17%';
+  String savePercent(int percent) {
+    return 'Уштедите ~$percent%';
+  }
 
   @override
   String get popular => 'Популарно';

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -8993,7 +8993,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get billingYearly => 'Årsvis';
 
   @override
-  String get savePercent => 'Spara ~17%';
+  String savePercent(int percent) {
+    return 'Spara ~$percent%';
+  }
 
   @override
   String get popular => 'Populärt';

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9054,7 +9054,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get billingYearly => 'ஆண்டு';
 
   @override
-  String get savePercent => '~17% சேமிக்கவும்';
+  String savePercent(int percent) {
+    return '~$percent% சேமிக்கவும்';
+  }
 
   @override
   String get popular => 'பிரபலம்';

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9038,7 +9038,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get billingYearly => 'సంవత్సరానికి';
 
   @override
-  String get savePercent => '~17% ఆదా చేయండి';
+  String savePercent(int percent) {
+    return '~$percent% ఆదా చేయండి';
+  }
 
   @override
   String get popular => 'ప్రజాదరణ';

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8944,7 +8944,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get billingYearly => 'รายปี';
 
   @override
-  String get savePercent => 'ประหยัด ~17%';
+  String savePercent(int percent) {
+    return 'ประหยัด ~$percent%';
+  }
 
   @override
   String get popular => 'ยอดนิยม';

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9072,7 +9072,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get billingYearly => 'Taunan';
 
   @override
-  String get savePercent => 'Makatipid ~17%';
+  String savePercent(int percent) {
+    return 'Makatipid ~$percent%';
+  }
 
   @override
   String get popular => 'Sikat';

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9001,7 +9001,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get billingYearly => 'Yıllık';
 
   @override
-  String get savePercent => '~%17 tasarruf';
+  String savePercent(int percent) {
+    return '~%$percent tasarruf';
+  }
 
   @override
   String get popular => 'Popüler';

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9002,7 +9002,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get billingYearly => 'Щорічно';
 
   @override
-  String get savePercent => 'Заощаджуйте ~17%';
+  String savePercent(int percent) {
+    return 'Заощаджуйте ~$percent%';
+  }
 
   @override
   String get popular => 'Популярний';

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9003,7 +9003,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get billingYearly => 'سالانہ';
 
   @override
-  String get savePercent => '~17% بچائیں';
+  String savePercent(int percent) {
+    return '~$percent% بچائیں';
+  }
 
   @override
   String get popular => 'مقبول';

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -8989,7 +8989,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get billingYearly => 'Hàng năm';
 
   @override
-  String get savePercent => 'Tiết kiệm ~17%';
+  String savePercent(int percent) {
+    return 'Tiết kiệm ~$percent%';
+  }
 
   @override
   String get popular => 'Phổ biến';

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8831,7 +8831,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get billingYearly => '年付';
 
   @override
-  String get savePercent => '节省约17%';
+  String savePercent(int percent) {
+    return '节省约$percent%';
+  }
 
   @override
   String get popular => '热门';

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -2935,7 +2935,7 @@
     "upgradePlan": "Atnaujinti planą",
     "billingMonthly": "Mėnesinis",
     "billingYearly": "Metinis",
-    "savePercent": "Sutaupykite ~17%",
+    "savePercent": "Sutaupykite ~{percent}%",
     "popular": "Populiarus",
     "currentPlan": "Dabartinis",
     "neoSubtitle": "{count} klausimų per mėnesį",

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -2935,7 +2935,7 @@
     "upgradePlan": "Jaunināt plānu",
     "billingMonthly": "Mēnesī",
     "billingYearly": "Gadā",
-    "savePercent": "Ietaupiet ~17%",
+    "savePercent": "Ietaupiet ~{percent}%",
     "popular": "Populārs",
     "currentPlan": "Pašreizējais",
     "neoSubtitle": "{count} jautājumi mēnesī",

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "Надгради план",
     "billingMonthly": "Месечно",
     "billingYearly": "Годишно",
-    "savePercent": "Заштедете ~17%",
+    "savePercent": "Заштедете ~{percent}%",
     "popular": "Популарно",
     "currentPlan": "Тековен",
     "neoSubtitle": "{count} прашања месечно",

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "प्लॅन अपग्रेड करा",
     "billingMonthly": "मासिक",
     "billingYearly": "वार्षिक",
-    "savePercent": "~17% बचत करा",
+    "savePercent": "~{percent}% बचत करा",
     "popular": "लोकप्रिय",
     "currentPlan": "सध्याचा",
     "neoSubtitle": "दरमहा {count} प्रश्न",

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -2935,7 +2935,7 @@
     "upgradePlan": "Naik taraf pelan",
     "billingMonthly": "Bulanan",
     "billingYearly": "Tahunan",
-    "savePercent": "Jimat ~17%",
+    "savePercent": "Jimat ~{percent}%",
     "popular": "Popular",
     "currentPlan": "Semasa",
     "neoSubtitle": "{count} soalan sebulan",

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -2935,7 +2935,7 @@
     "upgradePlan": "Plan upgraden",
     "billingMonthly": "Maandelijks",
     "billingYearly": "Jaarlijks",
-    "savePercent": "Bespaar ~17%",
+    "savePercent": "Bespaar ~{percent}%",
     "popular": "Populair",
     "currentPlan": "Huidig",
     "neoSubtitle": "{count} vragen per maand",

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -2935,7 +2935,7 @@
     "upgradePlan": "Oppgrader plan",
     "billingMonthly": "Månedlig",
     "billingYearly": "Årlig",
-    "savePercent": "Spar ~17%",
+    "savePercent": "Spar ~{percent}%",
     "popular": "Populært",
     "currentPlan": "Nåværende",
     "neoSubtitle": "{count} spørsmål per måned",

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -2970,7 +2970,7 @@
     "upgradePlan": "Ulepsz plan",
     "billingMonthly": "Miesięcznie",
     "billingYearly": "Rocznie",
-    "savePercent": "Oszczędź ~17%",
+    "savePercent": "Oszczędź ~{percent}%",
     "popular": "Popularne",
     "currentPlan": "Bieżący",
     "neoSubtitle": "{count} pytań miesięcznie",

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -2971,7 +2971,7 @@
     "upgradePlan": "Fazer upgrade",
     "billingMonthly": "Mensal",
     "billingYearly": "Anual",
-    "savePercent": "Economize ~17%",
+    "savePercent": "Economize ~{percent}%",
     "popular": "Popular",
     "currentPlan": "Atual",
     "neoSubtitle": "{count} perguntas por mês",

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -2935,7 +2935,7 @@
     "upgradePlan": "Actualizare plan",
     "billingMonthly": "Lunar",
     "billingYearly": "Anual",
-    "savePercent": "Economisiți ~17%",
+    "savePercent": "Economisiți ~{percent}%",
     "popular": "Popular",
     "currentPlan": "Curent",
     "neoSubtitle": "{count} întrebări pe lună",

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -2970,7 +2970,7 @@
     "upgradePlan": "Обновить план",
     "billingMonthly": "Ежемесячно",
     "billingYearly": "Ежегодно",
-    "savePercent": "Экономия ~17%",
+    "savePercent": "Экономия ~{percent}%",
     "popular": "Популярный",
     "currentPlan": "Текущий",
     "neoSubtitle": "{count} вопросов в месяц",

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -2940,7 +2940,7 @@
     "upgradePlan": "Aktualizovať plán",
     "billingMonthly": "Mesačne",
     "billingYearly": "Ročne",
-    "savePercent": "Ušetrite ~17%",
+    "savePercent": "Ušetrite ~{percent}%",
     "popular": "Obľúbené",
     "currentPlan": "Aktuálny",
     "neoSubtitle": "{count} otázok mesačne",

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "Nadgradi načrt",
     "billingMonthly": "Mesečno",
     "billingYearly": "Letno",
-    "savePercent": "Prihranite ~17%",
+    "savePercent": "Prihranite ~{percent}%",
     "popular": "Priljubljeno",
     "currentPlan": "Trenutni",
     "neoSubtitle": "{count} vprašanj na mesec",

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "Надогради план",
     "billingMonthly": "Месечно",
     "billingYearly": "Годишње",
-    "savePercent": "Уштедите ~17%",
+    "savePercent": "Уштедите ~{percent}%",
     "popular": "Популарно",
     "currentPlan": "Тренутни",
     "neoSubtitle": "{count} питања месечно",

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -2935,7 +2935,7 @@
     "upgradePlan": "Uppgradera plan",
     "billingMonthly": "Månadsvis",
     "billingYearly": "Årsvis",
-    "savePercent": "Spara ~17%",
+    "savePercent": "Spara ~{percent}%",
     "popular": "Populärt",
     "currentPlan": "Nuvarande",
     "neoSubtitle": "{count} frågor per månad",

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "திட்டத்தை மேம்படுத்து",
     "billingMonthly": "மாதாந்திர",
     "billingYearly": "ஆண்டு",
-    "savePercent": "~17% சேமிக்கவும்",
+    "savePercent": "~{percent}% சேமிக்கவும்",
     "popular": "பிரபலம்",
     "currentPlan": "தற்போதைய",
     "neoSubtitle": "மாதத்திற்கு {count} கேள்விகள்",

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "ప్లాన్ అప్‌గ్రేడ్",
     "billingMonthly": "నెలవారీ",
     "billingYearly": "సంవత్సరానికి",
-    "savePercent": "~17% ఆదా చేయండి",
+    "savePercent": "~{percent}% ఆదా చేయండి",
     "popular": "ప్రజాదరణ",
     "currentPlan": "ప్రస్తుత",
     "neoSubtitle": "నెలకు {count} ప్రశ్నలు",

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -2935,7 +2935,7 @@
     "upgradePlan": "อัปเกรดแผน",
     "billingMonthly": "รายเดือน",
     "billingYearly": "รายปี",
-    "savePercent": "ประหยัด ~17%",
+    "savePercent": "ประหยัด ~{percent}%",
     "popular": "ยอดนิยม",
     "currentPlan": "ปัจจุบัน",
     "neoSubtitle": "{count} คำถามต่อเดือน",

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "I-upgrade ang plan",
     "billingMonthly": "Buwanan",
     "billingYearly": "Taunan",
-    "savePercent": "Makatipid ~17%",
+    "savePercent": "Makatipid ~{percent}%",
     "popular": "Sikat",
     "currentPlan": "Kasalukuyan",
     "neoSubtitle": "{count} tanong bawat buwan",

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -2970,7 +2970,7 @@
     "upgradePlan": "Planı yükselt",
     "billingMonthly": "Aylık",
     "billingYearly": "Yıllık",
-    "savePercent": "~%17 tasarruf",
+    "savePercent": "~%{percent} tasarruf",
     "popular": "Popüler",
     "currentPlan": "Mevcut",
     "neoSubtitle": "Ayda {count} soru",

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -2935,7 +2935,7 @@
     "upgradePlan": "Оновити план",
     "billingMonthly": "Щомісячно",
     "billingYearly": "Щорічно",
-    "savePercent": "Заощаджуйте ~17%",
+    "savePercent": "Заощаджуйте ~{percent}%",
     "popular": "Популярний",
     "currentPlan": "Поточний",
     "neoSubtitle": "{count} запитань на місяць",

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10521,7 +10521,7 @@
     "upgradePlan": "پلان اپ گریڈ کریں",
     "billingMonthly": "ماہانہ",
     "billingYearly": "سالانہ",
-    "savePercent": "~17% بچائیں",
+    "savePercent": "~{percent}% بچائیں",
     "popular": "مقبول",
     "currentPlan": "موجودہ",
     "neoSubtitle": "ماہانہ {count} سوالات",

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -2940,7 +2940,7 @@
     "upgradePlan": "Nâng cấp gói",
     "billingMonthly": "Hàng tháng",
     "billingYearly": "Hàng năm",
-    "savePercent": "Tiết kiệm ~17%",
+    "savePercent": "Tiết kiệm ~{percent}%",
     "popular": "Phổ biến",
     "currentPlan": "Hiện tại",
     "neoSubtitle": "{count} câu hỏi mỗi tháng",

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -2957,7 +2957,7 @@
     "upgradePlan": "升级计划",
     "billingMonthly": "月付",
     "billingYearly": "年付",
-    "savePercent": "节省约17%",
+    "savePercent": "节省约{percent}%",
     "popular": "热门",
     "currentPlan": "当前",
     "neoSubtitle": "每月 {count} 个问题",

--- a/app/lib/models/subscription.dart
+++ b/app/lib/models/subscription.dart
@@ -1,11 +1,40 @@
 import 'package:omi/backend/schema/gen/subscription_usage_wire.g.dart' as wire;
 
-enum PlanType { basic, unlimited, architect, operator }
+enum PlanType { basic, unlimited, architect, operator, plus, unlimitedV2 }
 
 enum SubscriptionStatus { active, inactive }
 
+const Map<PlanType, String> _planTypeWireNames = {
+  PlanType.basic: 'basic',
+  PlanType.unlimited: 'unlimited',
+  PlanType.architect: 'architect',
+  PlanType.operator: 'operator',
+  PlanType.plus: 'plus',
+  PlanType.unlimitedV2: 'unlimited_v2',
+};
+
+extension PlanTypeX on PlanType {
+  String get wireName => _planTypeWireNames[this]!;
+
+  bool get isPaid => this != PlanType.basic;
+
+  /// Plans with no monthly transcription cap. Plus is paid but metered
+  /// (1500 min/month), so it is deliberately excluded.
+  bool get hasUnlimitedTranscription =>
+      this == PlanType.unlimited ||
+      this == PlanType.operator ||
+      this == PlanType.architect ||
+      this == PlanType.unlimitedV2;
+
+  /// Mirrors backend DESKTOP_ENTITLED_PLAN_TYPES.
+  bool get grantsDesktop => this == PlanType.operator || this == PlanType.architect;
+}
+
 PlanType _planTypeFromWire(String? value) {
-  return PlanType.values.asNameMap()[value] ?? PlanType.basic;
+  for (final entry in _planTypeWireNames.entries) {
+    if (entry.value == value) return entry.key;
+  }
+  return PlanType.basic;
 }
 
 SubscriptionStatus _subscriptionStatusFromWire(String? value) {
@@ -100,7 +129,7 @@ class Subscription {
 
   wire.GeneratedSubscription toGenerated() {
     return wire.GeneratedSubscription(
-      plan: plan.name,
+      plan: plan.wireName,
       status: status.name,
       currentPeriodEnd: currentPeriodEnd,
       stripeSubscriptionId: stripeSubscriptionId,

--- a/app/lib/pages/settings/settings_drawer.dart
+++ b/app/lib/pages/settings/settings_drawer.dart
@@ -511,7 +511,7 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
                 Consumer<UsageProvider>(
                   builder: (context, usageProvider, child) {
                     final sp = usageProvider.subscription?.subscription.plan;
-                    final isUnlimited = sp == PlanType.unlimited || sp == PlanType.operator || sp == PlanType.architect;
+                    final isUnlimited = sp?.isPaid ?? false;
                     return _buildSettingsItem(
                       title: context.l10n.planAndUsage,
                       icon: FaIcon(FontAwesomeIcons.chartLine, color: Color(0xFF8E8E93), size: 20),

--- a/app/lib/pages/settings/usage_page.dart
+++ b/app/lib/pages/settings/usage_page.dart
@@ -425,7 +425,9 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
     }
 
     final plan = provider.subscription!.subscription.plan;
-    final isUnlimited = plan == PlanType.unlimited || plan == PlanType.operator || plan == PlanType.architect;
+    final isPaid = plan.isPaid;
+    // Plan names are product names; only the free/unlimited labels are localized.
+    final planLabel = plan == PlanType.plus ? 'Plus' : (isPaid ? context.l10n.unlimitedPlan : context.l10n.basicPlan);
 
     return Container(
       margin: const EdgeInsets.fromLTRB(16, 24, 16, 0),
@@ -442,10 +444,10 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                isUnlimited ? context.l10n.unlimitedPlan : context.l10n.basicPlan,
+                planLabel,
                 style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
               ),
-              if (isUnlimited)
+              if (isPaid)
                 GestureDetector(
                   onTap: _isUpgrading ? null : _showPlansSheet,
                   child: Row(
@@ -458,7 +460,7 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
                 ),
             ],
           ),
-          if (!isUnlimited) ...[
+          if (!isPaid) ...[
             const SizedBox(height: 4),
             Text(context.l10n.basicPlanDescription, style: TextStyle(fontSize: 13, color: Colors.grey.shade500)),
             const SizedBox(height: 16),

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -17,6 +17,7 @@ import 'package:omi/pages/settings/transcription_settings_page.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/usage_provider.dart';
 import 'package:omi/providers/user_provider.dart';
+import 'package:omi/utils/plan_pricing.dart';
 import 'package:omi/services/freemium_transcription_service.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/l10n_extensions.dart';
@@ -1658,7 +1659,7 @@ class _PlansSheetState extends State<PlansSheet> {
             child: _buildDynamicPlanOption(
               isSelected: isSelected,
               planData: planDataWithName,
-              saveTag: isYearly ? '2 Months Free' : null,
+              saveTag: isYearly ? annualSaveTag(tierPlans) : null,
               isPopular: eyebrow == 'Most popular',
               featureSummary: planSubtitle,
               features: planFeatures,
@@ -1681,7 +1682,7 @@ class _PlansSheetState extends State<PlansSheet> {
         _buildDynamicPlanOption(
           isSelected: selectedPlan == 'yearly',
           planData: plans.firstWhere((plan) => plan['interval'] == 'year', orElse: () => plans.first),
-          saveTag: '2 Months Free',
+          saveTag: annualSaveTag(plans),
           isPopular: true,
           onTap: () {
             HapticFeedback.lightImpact();

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -377,14 +377,10 @@ class _PlansSheetState extends State<PlansSheet> {
     final currentSub = provider.subscription?.subscription;
     // Only show "no charge until renewal" dialog for same-tier monthly→annual switch.
     // Cross-tier changes are immediate+prorated on the backend, not deferred.
-    final currentTierName = currentSub?.plan.name; // 'unlimited', 'operator', 'architect'
+    final currentTierName = currentSub?.plan.wireName; // backend plan_id, e.g. 'plus', 'unlimited_v2'
     final isSameTier = currentTierName == tierId;
-    final isUpgradingFromMonthlyToAnnual = isSameTier &&
-        (currentSub?.plan == PlanType.unlimited ||
-            currentSub?.plan == PlanType.operator ||
-            currentSub?.plan == PlanType.architect) &&
-        currentSub?.status == SubscriptionStatus.active &&
-        isYearly;
+    final isUpgradingFromMonthlyToAnnual =
+        isSameTier && (currentSub?.plan.isPaid ?? false) && currentSub?.status == SubscriptionStatus.active && isYearly;
 
     if (isUpgradingFromMonthlyToAnnual && currentSub?.cancelAtPeriodEnd != true) {
       // Show confirmation popup for monthly to annual upgrade
@@ -492,9 +488,7 @@ class _PlansSheetState extends State<PlansSheet> {
 
     final currentSub = provider.subscription!.subscription;
 
-    if (currentSub.plan == PlanType.unlimited ||
-        currentSub.plan == PlanType.operator ||
-        currentSub.plan == PlanType.architect) {
+    if (currentSub.plan.isPaid) {
       final confirmed = await showDialog<bool>(
         context: context,
         builder: (ctx) => ConfirmationDialog(
@@ -518,11 +512,7 @@ class _PlansSheetState extends State<PlansSheet> {
       Map<String, dynamic>? result;
 
       // If user already has a paid plan and it's not canceled
-      if ((currentSub.plan == PlanType.unlimited ||
-              currentSub.plan == PlanType.operator ||
-              currentSub.plan == PlanType.architect) &&
-          currentSub.status == SubscriptionStatus.active &&
-          !currentSub.cancelAtPeriodEnd) {
+      if (currentSub.plan.isPaid && currentSub.status == SubscriptionStatus.active && !currentSub.cancelAtPeriodEnd) {
         result = await provider.upgradeUserSubscription(
           priceId: priceId,
           promotionCode: promoCode.isNotEmpty ? promoCode : null,
@@ -612,8 +602,7 @@ class _PlansSheetState extends State<PlansSheet> {
         }
 
         final sub = provider.subscription?.subscription;
-        final isPaidPlan =
-            sub?.plan == PlanType.unlimited || sub?.plan == PlanType.operator || sub?.plan == PlanType.architect;
+        final isPaidPlan = sub?.plan.isPaid ?? false;
         final isUnlimited = isPaidPlan; // backward-compat alias for UI branching
         final isCancelled = sub?.cancelAtPeriodEnd ?? false;
 
@@ -1549,7 +1538,7 @@ class _PlansSheetState extends State<PlansSheet> {
     }
 
     // Tier ordering
-    const tierOrder = ['unlimited', 'operator', 'architect'];
+    const tierOrder = ['plus', 'unlimited_v2', 'unlimited', 'operator', 'architect'];
     final sortedTierIds = grouped.keys.toList()
       ..sort((a, b) {
         final ai = tierOrder.indexOf(a);
@@ -2064,6 +2053,8 @@ class _PlansSheetState extends State<PlansSheet> {
       case 'architect':
         return true;
       case 'unlimited':
+      case 'plus':
+      case 'unlimited_v2':
         return false;
       default:
         return null;

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -1554,6 +1554,7 @@ class _PlansSheetState extends State<PlansSheet> {
     }
 
     final isYearly = selectedPlan == 'yearly';
+    final savePercent = bestAnnualDiscountPercent(grouped.values);
 
     return Column(
       children: [
@@ -1584,20 +1585,23 @@ class _PlansSheetState extends State<PlansSheet> {
                           fontWeight: FontWeight.w600,
                         ),
                       ),
-                      const SizedBox(width: 8),
-                      Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                        decoration: BoxDecoration(color: Colors.green.shade800, borderRadius: BorderRadius.circular(8)),
-                        child: Text(
-                          context.l10n.savePercent,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 9,
-                            fontWeight: FontWeight.w600,
-                            letterSpacing: 0.3,
+                      if (savePercent != null) ...[
+                        const SizedBox(width: 8),
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                          decoration:
+                              BoxDecoration(color: Colors.green.shade800, borderRadius: BorderRadius.circular(8)),
+                          child: Text(
+                            context.l10n.savePercent(savePercent),
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 9,
+                              fontWeight: FontWeight.w600,
+                              letterSpacing: 0.3,
+                            ),
                           ),
                         ),
-                      ),
+                      ],
                     ],
                   ),
                 ),

--- a/app/lib/providers/usage_provider.dart
+++ b/app/lib/providers/usage_provider.dart
@@ -64,10 +64,7 @@ class UsageProvider with ChangeNotifier {
   // straight to the existing unlimited behavior.
   PhoneCallQuota? get phoneCallQuota => _subscription?.phoneCallQuota;
 
-  bool get _isPaidPlan {
-    final plan = _subscription?.subscription.plan;
-    return plan == PlanType.unlimited || plan == PlanType.operator || plan == PlanType.architect;
-  }
+  bool get _isPaidPlan => _subscription?.subscription.plan.isPaid ?? false;
 
   bool get canAccessPhoneCalls {
     if (_isPaidPlan) return true;
@@ -96,8 +93,9 @@ class UsageProvider with ChangeNotifier {
     if (_forceOutOfCredits) return true;
     if (_subscription == null) return false;
     final plan = _subscription!.subscription.plan;
-    if (plan == PlanType.unlimited || plan == PlanType.operator || plan == PlanType.architect) return false;
-    // For basic plan, check if used is >= limit and limit is not 0 (unlimited).
+    // Plus is paid but metered, so it falls through to the usage check below.
+    if (plan.hasUnlimitedTranscription) return false;
+    // For metered plans, check if used is >= limit and limit is not 0 (unlimited).
     if (_subscription!.transcriptionSecondsLimit > 0 &&
         _subscription!.transcriptionSecondsUsed >= _subscription!.transcriptionSecondsLimit) {
       return true;

--- a/app/lib/utils/plan_pricing.dart
+++ b/app/lib/utils/plan_pricing.dart
@@ -10,13 +10,47 @@ import 'package:collection/collection.dart';
 /// Returns null when either price is missing or the annual plan isn't actually
 /// cheaper, so the caller simply renders no badge.
 String? annualSaveTag(List<Map<String, dynamic>> plans) {
+  final monthsFree = _annualMonthsFree(plans);
+  if (monthsFree == null) return null;
+  return monthsFree == 1 ? '1 Month Free' : '$monthsFree Months Free';
+}
+
+/// Whole-percent discount of a tier's annual price vs paying monthly for a year.
+///
+/// Plus/Unlimited bill 9 of 12 months → 25%; legacy Neo → ~17%. Null when the
+/// prices aren't usable or annual isn't cheaper.
+int? annualDiscountPercent(List<Map<String, dynamic>> plans) {
+  final prices = _monthlyAndYearly(plans);
+  if (prices == null) return null;
+  final (monthlyAmount, yearlyAmount) = prices;
+
+  final percent = ((1 - (yearlyAmount / (monthlyAmount * 12))) * 100).round();
+  return percent <= 0 ? null : percent;
+}
+
+/// Largest annual discount across tiers, for the shared yearly-billing toggle.
+///
+/// Tiers discount differently (Neo ~17%, Plus/Unlimited 25%), so the one shared
+/// badge advertises the best available rather than a stale hardcoded number.
+int? bestAnnualDiscountPercent(Iterable<List<Map<String, dynamic>>> tiers) {
+  final percents = tiers.map(annualDiscountPercent).nonNulls;
+  return percents.isEmpty ? null : percents.reduce((a, b) => a > b ? a : b);
+}
+
+int? _annualMonthsFree(List<Map<String, dynamic>> plans) {
+  final prices = _monthlyAndYearly(plans);
+  if (prices == null) return null;
+  final (monthlyAmount, yearlyAmount) = prices;
+
+  final monthsFree = (12 - (yearlyAmount / monthlyAmount)).round();
+  return monthsFree <= 0 ? null : monthsFree;
+}
+
+(double, double)? _monthlyAndYearly(List<Map<String, dynamic>> plans) {
   final monthly = plans.firstWhereOrNull((p) => p['interval'] == 'month');
   final yearly = plans.firstWhereOrNull((p) => p['interval'] == 'year');
   final monthlyAmount = (monthly?['unit_amount'] as num?)?.toDouble();
   final yearlyAmount = (yearly?['unit_amount'] as num?)?.toDouble();
   if (monthlyAmount == null || yearlyAmount == null || monthlyAmount <= 0) return null;
-
-  final monthsFree = (12 - (yearlyAmount / monthlyAmount)).round();
-  if (monthsFree <= 0) return null;
-  return monthsFree == 1 ? '1 Month Free' : '$monthsFree Months Free';
+  return (monthlyAmount, yearlyAmount);
 }

--- a/app/lib/utils/plan_pricing.dart
+++ b/app/lib/utils/plan_pricing.dart
@@ -1,0 +1,22 @@
+import 'package:collection/collection.dart';
+
+/// "N Months Free" for a tier's annual card, derived from the tier's own prices.
+///
+/// Discounts differ per tier — legacy Neo saves 2 months while Plus and
+/// Unlimited save 3 — so this must never be hardcoded. [plans] is the raw
+/// available-plans payload for a single tier, containing its `month` and `year`
+/// entries with a Stripe `unit_amount`.
+///
+/// Returns null when either price is missing or the annual plan isn't actually
+/// cheaper, so the caller simply renders no badge.
+String? annualSaveTag(List<Map<String, dynamic>> plans) {
+  final monthly = plans.firstWhereOrNull((p) => p['interval'] == 'month');
+  final yearly = plans.firstWhereOrNull((p) => p['interval'] == 'year');
+  final monthlyAmount = (monthly?['unit_amount'] as num?)?.toDouble();
+  final yearlyAmount = (yearly?['unit_amount'] as num?)?.toDouble();
+  if (monthlyAmount == null || yearlyAmount == null || monthlyAmount <= 0) return null;
+
+  final monthsFree = (12 - (yearlyAmount / monthlyAmount)).round();
+  if (monthsFree <= 0) return null;
+  return monthsFree == 1 ? '1 Month Free' : '$monthsFree Months Free';
+}

--- a/app/test/models/subscription_plan_type_test.dart
+++ b/app/test/models/subscription_plan_type_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/models/subscription.dart';
+
+Subscription _subFromWirePlan(String plan) {
+  return Subscription.fromJson({
+    'plan': plan,
+    'status': 'active',
+    'features': <String>[],
+    'cancel_at_period_end': false,
+    'deprecated': false,
+    'limits': <String, dynamic>{},
+  });
+}
+
+void main() {
+  group('PlanType wire mapping', () {
+    test('decodes the mobile consumer tiers instead of falling back to basic', () {
+      // Regression: before the enum carried plus/unlimited_v2, an unknown plan
+      // fell back to PlanType.basic — a paying subscriber was shown as free.
+      expect(_subFromWirePlan('plus').plan, PlanType.plus);
+      expect(_subFromWirePlan('unlimited_v2').plan, PlanType.unlimitedV2);
+    });
+
+    test('decodes the existing tiers', () {
+      expect(_subFromWirePlan('basic').plan, PlanType.basic);
+      expect(_subFromWirePlan('unlimited').plan, PlanType.unlimited);
+      expect(_subFromWirePlan('operator').plan, PlanType.operator);
+      expect(_subFromWirePlan('architect').plan, PlanType.architect);
+    });
+
+    test('still falls back to basic for a genuinely unknown plan', () {
+      expect(_subFromWirePlan('some_future_tier').plan, PlanType.basic);
+    });
+
+    test('serializes back to the backend plan id, not the Dart enum name', () {
+      // PlanType.unlimitedV2.name is 'unlimitedV2'; the backend expects 'unlimited_v2'.
+      expect(PlanType.unlimitedV2.wireName, 'unlimited_v2');
+      expect(PlanType.plus.wireName, 'plus');
+      for (final plan in PlanType.values) {
+        expect(_subFromWirePlan(plan.wireName).plan, plan);
+      }
+    });
+  });
+
+  group('PlanType semantics', () {
+    test('every non-basic tier is paid', () {
+      expect(PlanType.basic.isPaid, isFalse);
+      for (final plan in PlanType.values.where((p) => p != PlanType.basic)) {
+        expect(plan.isPaid, isTrue, reason: '${plan.name} should be paid');
+      }
+    });
+
+    test('plus is paid but metered, so it is not unlimited transcription', () {
+      expect(PlanType.plus.isPaid, isTrue);
+      expect(PlanType.plus.hasUnlimitedTranscription, isFalse);
+    });
+
+    test('unlimited tiers have no transcription cap', () {
+      expect(PlanType.unlimitedV2.hasUnlimitedTranscription, isTrue);
+      expect(PlanType.unlimited.hasUnlimitedTranscription, isTrue);
+      expect(PlanType.operator.hasUnlimitedTranscription, isTrue);
+      expect(PlanType.architect.hasUnlimitedTranscription, isTrue);
+      expect(PlanType.basic.hasUnlimitedTranscription, isFalse);
+    });
+
+    test('only operator and architect grant desktop (mirrors backend)', () {
+      expect(PlanType.operator.grantsDesktop, isTrue);
+      expect(PlanType.architect.grantsDesktop, isTrue);
+      for (final plan in [PlanType.basic, PlanType.unlimited, PlanType.plus, PlanType.unlimitedV2]) {
+        expect(plan.grantsDesktop, isFalse, reason: '${plan.name} must not grant desktop');
+      }
+    });
+  });
+}

--- a/app/test/providers/usage_provider_test.dart
+++ b/app/test/providers/usage_provider_test.dart
@@ -15,6 +15,18 @@ UserSubscriptionResponse _proSubscription() {
   );
 }
 
+UserSubscriptionResponse _subscriptionOn(PlanType plan, {required int used, required int limit}) {
+  return UserSubscriptionResponse(
+    subscription: Subscription(plan: plan, status: SubscriptionStatus.active),
+    transcriptionSecondsUsed: used,
+    transcriptionSecondsLimit: limit,
+    wordsTranscribedUsed: 0,
+    wordsTranscribedLimit: 0,
+    insightsGainedUsed: 0,
+    insightsGainedLimit: 0,
+  );
+}
+
 void main() {
   group('UsageProvider.clearUserData', () {
     test('resets subscription state so the next login cannot inherit the previous account plan', () {
@@ -32,6 +44,33 @@ void main() {
       expect(provider.isOutOfCredits, isFalse);
       expect(provider.error, isNull);
       expect(notified, isTrue);
+    });
+  });
+
+  group('UsageProvider credit gating across tiers', () {
+    test('Plus is metered: running out of transcription seconds blocks capture', () {
+      // Plus is a paid plan but capped at 1500 min/month, so it must NOT be
+      // treated as unlimited the way Neo/Operator/Architect/Unlimited are.
+      final provider = UsageProvider();
+      provider.debugSetSubscription(_subscriptionOn(PlanType.plus, used: 90000, limit: 90000));
+      expect(provider.isOutOfCredits, isTrue);
+
+      provider.debugSetSubscription(_subscriptionOn(PlanType.plus, used: 100, limit: 90000));
+      expect(provider.isOutOfCredits, isFalse);
+    });
+
+    test('Unlimited (v2) never runs out of credits', () {
+      final provider = UsageProvider();
+      provider.debugSetSubscription(_subscriptionOn(PlanType.unlimitedV2, used: 999999, limit: 0));
+      expect(provider.isOutOfCredits, isFalse);
+    });
+
+    test('paid mobile tiers unlock paid-only features', () {
+      final provider = UsageProvider();
+      for (final plan in [PlanType.plus, PlanType.unlimitedV2]) {
+        provider.debugSetSubscription(_subscriptionOn(plan, used: 0, limit: 0));
+        expect(provider.canAccessPhoneCalls, isTrue, reason: '${plan.name} is paid');
+      }
     });
   });
 }

--- a/app/test/utils/plan_pricing_test.dart
+++ b/app/test/utils/plan_pricing_test.dart
@@ -39,4 +39,44 @@ void main() {
       expect(annualSaveTag(_tier(monthly: 0, yearly: 16191)), isNull);
     });
   });
+
+  group('annualDiscountPercent', () {
+    test('Plus and Unlimited discount 25%, not the hardcoded 17%', () {
+      // Regression: the yearly-toggle badge was a hardcoded "Save ~17%" string
+      // in all 49 locales. 17% is the legacy Neo discount; 3 months free is 25%.
+      expect(annualDiscountPercent(_tier(monthly: 1799, yearly: 16191)), 25);
+      expect(annualDiscountPercent(_tier(monthly: 2999, yearly: 26991)), 25);
+    });
+
+    test('legacy Neo still discounts ~17%', () {
+      expect(annualDiscountPercent(_tier(monthly: 1999, yearly: 19999)), 17);
+    });
+
+    test('returns null when annual is not cheaper or prices are unusable', () {
+      expect(annualDiscountPercent(_tier(monthly: 1000, yearly: 12000)), isNull);
+      expect(annualDiscountPercent(_tier(monthly: 1000, yearly: 13000)), isNull);
+      expect(annualDiscountPercent(_tier(monthly: 1799)), isNull);
+      expect(annualDiscountPercent(const []), isNull);
+    });
+  });
+
+  group('bestAnnualDiscountPercent', () {
+    test('advertises the best discount across the shown tiers', () {
+      final neo = _tier(monthly: 1999, yearly: 19999); // 17%
+      final plus = _tier(monthly: 1799, yearly: 16191); // 25%
+      expect(bestAnnualDiscountPercent([neo, plus]), 25);
+      expect(bestAnnualDiscountPercent([neo]), 17);
+    });
+
+    test('ignores tiers with unusable prices', () {
+      final broken = _tier(monthly: 1799);
+      final plus = _tier(monthly: 1799, yearly: 16191);
+      expect(bestAnnualDiscountPercent([broken, plus]), 25);
+    });
+
+    test('returns null when no tier has a usable discount', () {
+      expect(bestAnnualDiscountPercent([_tier(monthly: 1799), const []]), isNull);
+      expect(bestAnnualDiscountPercent(const []), isNull);
+    });
+  });
 }

--- a/app/test/utils/plan_pricing_test.dart
+++ b/app/test/utils/plan_pricing_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/utils/plan_pricing.dart';
+
+List<Map<String, dynamic>> _tier({num? monthly, num? yearly}) {
+  return [
+    if (monthly != null) {'interval': 'month', 'unit_amount': monthly},
+    if (yearly != null) {'interval': 'year', 'unit_amount': yearly},
+  ];
+}
+
+void main() {
+  group('annualSaveTag', () {
+    test('Plus and Unlimited save 3 months, not the hardcoded 2', () {
+      // Regression: the badge was hardcoded to '2 Months Free', which was only
+      // ever right for legacy Neo. Plus ($17.99/mo, $161.91/yr) and Unlimited
+      // ($29.99/mo, $269.91/yr) both bill 9 months for a year.
+      expect(annualSaveTag(_tier(monthly: 1799, yearly: 16191)), '3 Months Free');
+      expect(annualSaveTag(_tier(monthly: 2999, yearly: 26991)), '3 Months Free');
+    });
+
+    test('legacy Neo still shows 2 months', () {
+      expect(annualSaveTag(_tier(monthly: 1999, yearly: 19999)), '2 Months Free');
+    });
+
+    test('singular month is not pluralized', () {
+      expect(annualSaveTag(_tier(monthly: 1000, yearly: 11000)), '1 Month Free');
+    });
+
+    test('returns null when the annual plan is not cheaper', () {
+      expect(annualSaveTag(_tier(monthly: 1000, yearly: 12000)), isNull);
+      expect(annualSaveTag(_tier(monthly: 1000, yearly: 13000)), isNull);
+    });
+
+    test('returns null when a price is missing or unusable', () {
+      expect(annualSaveTag(_tier(monthly: 1799)), isNull);
+      expect(annualSaveTag(_tier(yearly: 16191)), isNull);
+      expect(annualSaveTag(const []), isNull);
+      expect(annualSaveTag(_tier(monthly: 0, yearly: 16191)), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## What

Teach the Flutter app the two new mobile consumer tiers, `plus` and `unlimited_v2`.

The Dart `PlanType` enum predates them, and `_planTypeFromWire` falls back to `PlanType.basic` for anything it doesn't recognize. So the moment the backend stops remapping `plus`/`unlimited_v2` → `unlimited`, **a paying subscriber would render as a free user** and lose every paid gate (phone calls, credit checks, manage-plan UI). This is the client-side prerequisite for retiring that remap.

### Changes
- **`models/subscription.dart`** — added `plus` + `unlimitedV2` with an **explicit wire-name map**. This is load-bearing: the backend id is `unlimited_v2` but the Dart enum name is `unlimitedV2`, so the previous `asNameMap()` / `plan.name` round-trip would have silently broken on exactly the new tier. `toGenerated()` now serializes `wireName`.
- **Centralized the plan predicates** that were duplicated as three-way enum compares across the provider, usage page, settings drawer, and plans sheet:
  - `isPaid` — any non-basic tier
  - `hasUnlimitedTranscription` — **deliberately excludes Plus**, which is paid but metered at 1500 min/month, so a Plus user still correctly hits the out-of-credits path instead of being treated as unlimited
  - `grantsDesktop` — mirrors backend `DESKTOP_ENTITLED_PLAN_TYPES`
- **Plans sheet** — new tiers wired into tier ordering and the desktop-entitlement switch; tier-id comparison now uses `wireName`.

### Annual savings badge (second commit)

The annual plan card hardcoded `'2 Months Free'`. That was only ever correct for legacy Neo ($19.99/mo vs $199.99/yr). The new tiers bill 9 months for a year, so **Plus ($17.99/$161.91) and Unlimited ($29.99/$269.91) were both advertised as 2 months free when they actually give 3.**

The badge is now computed from the tier's own monthly/annual `unit_amount` (already present in the available-plans payload), so it can't drift per tier again. Extracted to `lib/utils/plan_pricing.dart` so the math is unit-testable; renders nothing when a price is missing or annual isn't actually cheaper.

### Yearly-toggle savings percent (third commit)

Same class of bug, second surface: the yearly billing toggle advertised **"Save ~17%"** from a literal baked into all 49 locale ARBs. 17% is the legacy Neo discount — Plus and Unlimited bill 9 of 12 months, which is **25%**.

`savePercent` is now parameterized as `Save ~{percent}%` across every locale, and the value is computed from the best discount among the tiers actually shown (so a Neo-only sheet still reads 17%). The badge is hidden entirely when no shown tier has a usable annual discount. `flutter gen-l10n` reports zero untranslated messages.

## Rollout sequencing (important)

Only lower `PLUS_UNLIMITED_V2_MIN_MOBILE_VERSION` off `99.0.0` **after this build is actually in users' hands**. Lowering it earlier makes every Plus/Unlimited subscriber on an older build render as free.

`PLUS_UNLIMITED_V2_MIN_DESKTOP_VERSION` should stay at `99.0.0` **permanently**. Plus/Unlimited are mobile/web-only tiers (desktop sells Operator/Architect), so the desktop remap to `unlimited` is the intended end state, not temporary compat. Note that macOS `SubscriptionPlanType` (`APIClient+Settings.swift:399`) does not carry these cases and `let plan: SubscriptionPlanType` is non-optional, so lowering the desktop gate would throw a `DecodingError` and break the entire subscription response. Cross-platform users are unaffected: entitlement is computed from the true plan before the display remap, so a Plus user correctly does not receive full desktop access.

## Testing

- `app/test.sh` — **888 tests pass**, including 23 new ones:
  - wire decode for every tier, including the fallback-to-basic regression this PR fixes
  - `wireName` round-trip for all tiers (guards the `unlimited_v2` vs `unlimitedV2` mismatch)
  - tier semantics: paid, unlimited-transcription, desktop entitlement
  - `annualSaveTag`: 3 months for Plus/Unlimited, 2 for legacy Neo, singular "1 Month Free", and null when a price is missing or annual isn't cheaper
  - `annualDiscountPercent` / `bestAnnualDiscountPercent`: 25% for Plus/Unlimited, 17% for Neo, best-of across shown tiers, and the null cases
  - `UsageProvider` credit gating: Plus is metered (out of credits at the cap), Unlimited never is, and both new tiers unlock paid-only features
- `app/scripts/analyze_ratchet.sh` — passes (`prefer_const_constructors` improved 465 → 451).
- `dart analyze lib` — no errors or warnings in any changed file (the 28 remaining errors are pre-existing generated-env files).
- `flutter gen-l10n` — zero untranslated messages across all 49 locales.
- `flutter build bundle` — exit 0 (whole Dart program compiles).
- Not verified on device: rendering a real Plus plan requires the backend to actually send `plus`, which requires lowering the gate — the chicken-and-egg this PR exists to break.

## Product invariants

None affected (`scripts/pr-preflight --suggest` → `none`).

Failure-Class: none
