### PR TITLE
Track the account-merge background tasks in migrate_app_owner instead of dropping them

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import asyncio
 import time
 from html import escape
 from datetime import datetime, timezone
@@ -16,7 +15,7 @@ from fastapi.responses import HTMLResponse
 
 from langchain_core.messages import SystemMessage, HumanMessage
 from utils.apps import fetch_app_chat_tools_from_manifest
-from utils.executors import db_executor, llm_executor, storage_executor, run_blocking
+from utils.executors import db_executor, llm_executor, storage_executor, run_blocking, start_background_task
 from utils.http_client import get_webhook_client
 from utils.multipart import APP_IMAGE_MAX_PART_SIZE, MultipartMaxPartSizeRoute, max_part_size
 from utils.mcp_client import (
@@ -1684,9 +1683,10 @@ def get_twitter_initial_message(username: str, uid: str = Depends(auth.get_curre
 async def migrate_app_owner(old_id, uid: str = Depends(auth.get_current_user_uid)):
     await run_blocking(db_executor, migrate_app_owner_id_db, uid, old_id)
 
-    # Start async tasks to migrate memories and update persona connected accounts
-    asyncio.create_task(run_blocking(db_executor, migrate_memories, old_id, uid))
-    asyncio.create_task(update_omi_persona_connected_accounts(uid))
+    # Tracked background tasks (not bare asyncio.create_task): keeps a live reference
+    # and logs a failed migration instead of silently dropping it.
+    start_background_task(run_blocking(db_executor, migrate_memories, old_id, uid), name=f"migrate_memories:{uid}")
+    start_background_task(update_omi_persona_connected_accounts(uid), name=f"migrate_persona_accounts:{uid}")
 
     return {"status": "ok", "message": "Migration started"}
 

--- a/backend/tests/unit/test_apps_migrate_owner_background_tasks.py
+++ b/backend/tests/unit/test_apps_migrate_owner_background_tasks.py
@@ -1,0 +1,82 @@
+"""Regression: POST /v1/apps/migrate-owner must schedule its post-merge background
+work (memory migration, persona connected-account sync) via the tracked
+start_background_task helper, not a bare asyncio.create_task().
+
+This endpoint fires when a user links an anonymous account to Google/Apple and the
+credential already belongs to an existing account (app/lib/providers/auth_provider.dart
+-> migrateAppOwnerId). The client gets {"status": "ok"} back immediately while the
+memory migration and persona sync continue in the background.
+
+A bare asyncio.create_task() with its result discarded is exactly the fire-and-forget
+footgun utils/executors.py warns about: the task has no reachable reference (so it can
+be garbage-collected mid-flight) and, if the coroutine raises, nothing in the app ever
+logs it -- the memory migration silently never completes while the API already told the
+client "Migration started". start_background_task keeps a tracked reference and logs any
+failure via 'background_task failed: ...'.
+
+No live services: run_blocking still runs on the real (in-process) db_executor thread
+pool, but the functions it calls are monkeypatched to pure Python fakes.
+"""
+
+import asyncio
+import logging
+
+import routers.apps as apps_mod
+import utils.executors as executors_mod
+
+
+def test_migrate_owner_schedules_tracked_background_tasks(monkeypatch, caplog):
+    calls = {'migrate_memories': False, 'persona_sync': False}
+
+    def fake_migrate_app_owner_id_db(new_id, old_id):
+        return None
+
+    def fake_migrate_memories(old_id, new_id):
+        calls['migrate_memories'] = True
+        raise RuntimeError('boom-migrate-memories')
+
+    async def fake_update_persona(uid):
+        calls['persona_sync'] = True
+        raise RuntimeError('boom-persona-sync')
+
+    monkeypatch.setattr(apps_mod, 'migrate_app_owner_id_db', fake_migrate_app_owner_id_db)
+    monkeypatch.setattr(apps_mod, 'migrate_memories', fake_migrate_memories)
+    monkeypatch.setattr(apps_mod, 'update_omi_persona_connected_accounts', fake_update_persona)
+
+    # Spy on asyncio.create_task (used directly by the buggy code, and internally by
+    # start_background_task in the fixed code) so the test can await whatever tasks get
+    # created either way, with no reliance on wall-clock sleeps.
+    created_tasks = []
+    real_create_task = asyncio.create_task
+
+    def spying_create_task(coro, *args, **kwargs):
+        task = real_create_task(coro, *args, **kwargs)
+        created_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(asyncio, 'create_task', spying_create_task)
+
+    baseline_tracked = executors_mod.get_background_task_count()
+
+    async def scenario():
+        result = await apps_mod.migrate_app_owner('old-uid', uid='new-uid')
+        # Checked before any further await: start_background_task adds to the shared
+        # registry synchronously at schedule time, so this is timing-independent.
+        tracked_delta = executors_mod.get_background_task_count() - baseline_tracked
+        await asyncio.gather(*created_tasks, return_exceptions=True)
+        return result, tracked_delta
+
+    caplog.set_level(logging.ERROR, logger='utils.executors')
+    result, tracked_delta = asyncio.run(scenario())
+
+    assert result == {"status": "ok", "message": "Migration started"}
+    assert calls == {'migrate_memories': True, 'persona_sync': True}
+    assert len(created_tasks) == 2
+
+    assert tracked_delta == 2, (
+        'migrate_app_owner must schedule its background work via start_background_task '
+        '(tracked) instead of a bare asyncio.create_task() (untracked, GC-vulnerable)'
+    )
+    assert 'background_task failed' in caplog.text, 'a failed background migration must be logged, not dropped'
+    assert 'boom-migrate-memories' in caplog.text
+    assert 'boom-persona-sync' in caplog.text


### PR DESCRIPTION
When a user merges an anonymous account into an existing one, their memories can silently fail
to transfer, with nothing in the logs to diagnose it from.

`migrate_app_owner` schedules two pieces of background work with bare `asyncio.create_task` and
discards both return values:

```python
# Start async tasks to migrate memories and update persona connected accounts
asyncio.create_task(run_blocking(db_executor, migrate_memories, old_id, uid))
asyncio.create_task(update_omi_persona_connected_accounts(uid))
```

`backend/AGENTS.md` and `utils/executors.py` both name this exact pattern as forbidden for
production background work:

> Never use bare `asyncio.create_task()` for production background work.

A bare task keeps no reference, so it can be garbage collected mid-flight, and its exception
goes to asyncio's default handler, which this app never surfaces. Nothing else holds a reference
to either task, and neither call is wrapped in `try/except`.

## This is a live user path

`apps.router` is registered in `main.py`, and `app/lib/providers/auth_provider.dart` calls
`migrateAppOwnerId(oldUserId)` against `POST /v1/apps/migrate-owner` whenever a user links
Google or Apple and Firebase reports `credential-already-in-use`. That is the ordinary
anonymous-to-existing account merge during onboarding, not a dev or admin tool.

Returning immediately is correct and intended; the endpoint is meant to be fire and forget. The
defect is that the work is untracked. `migrate_memories` reassigns every Firestore memory doc
from the old uid to the new uid, so if it raises, the user sees a successful account link while
the memories tied to their old account never arrive, and there is no log line, metric, or Sentry
event pointing at it.

## The fix

Uses the repo's own tracked-task helper, which keeps a live reference and logs
`background_task failed: <name>` from a done-callback. This matches the existing usage in
`routers/x_connector.py`.

```python
# Tracked background tasks (not bare asyncio.create_task): keeps a live reference
# and logs a failed migration instead of silently dropping it.
start_background_task(run_blocking(db_executor, migrate_memories, old_id, uid), name=f"migrate_memories:{uid}")
start_background_task(update_omi_persona_connected_accounts(uid), name=f"migrate_persona_accounts:{uid}")
```

The now-unused `import asyncio` is removed. The only remaining occurrence of that string in the
file is inside the new comment, and `python -c "import routers.apps"` confirms the module still
imports.

## Tests

`tests/unit/test_apps_migrate_owner_background_tasks.py`:

- both jobs are scheduled through `start_background_task` and are tracked, asserted as a
  `get_background_task_count()` delta of 2 measured synchronously after the handler returns
- when both jobs raise, the failures are logged rather than silently dropped

The test monkeypatches the three db/helper functions to pure-Python fakes and spies on
`asyncio.create_task` so the scheduled work is awaited deterministically. No sleeps, no
`sys.modules` mutation.

## Verification

Run in `backend/`:

- prove-fail: with `routers/apps.py` reverted to origin/main and confirmed byte-identical
  (`git diff origin/main` empty), the test fails with
  `migrate_app_owner must schedule its background work via start_background_task (tracked)
  instead of a bare asyncio.create_task() (untracked, GC-vulnerable)` and `assert 0 == 2`.
  Re-applied: 1 passed
- the earlier assertions in the same test (response shape, both fakes invoked, two tasks
  created) pass on unfixed code too, so only the tracking and logging assertions move
- apps sibling suites standalone: `test_apps_marketplace_poison_guard.py` 4 passed,
  `test_app_home_url_null_manifest.py` 3 passed, `test_app_integrations_async.py` 3 passed
- `black --line-length 120 --skip-string-normalization --check`: clean
- `pyright routers/apps.py`: 0 errors
- `scripts/check_module_stub_pollution.py`: 733 files, 0 violations
- `scripts/scan_async_blockers.py --dirs routers utils`: 0 findings in scope
- `routers/apps.py` is still exactly 2335 lines, equal to its ratchet baseline, so no baseline
  bump is needed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

