### PR TITLE
fix(deploy): preserve separator-bearing Cloud Run runtime values

### DIFF
--- a/.github/failure-classes/FC-deploy-input-serialization.json
+++ b/.github/failure-classes/FC-deploy-input-serialization.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-deploy-input-serialization",
+  "violated_contract": "A Cloud Run deployment input must preserve every runtime environment key and value as one intended key-value pair.",
+  "canonical_prevention": "Encode action-input separators at each raw Cloud Run environment serializer and exercise the manifest renderer plus live-contract clone path in deterministic deploy preflight.",
+  "evidence_prs": [9986],
+  "scope_hints": [
+    "backend/scripts/render_backend_runtime_env.py",
+    "backend/scripts/render_cloud_run_clone_env.py",
+    "backend/scripts/pre-deploy-check.sh",
+    "backend/tests/unit/test_render_backend_runtime_env.py",
+    "backend/tests/unit/test_sync_two_lane.py"
+  ],
+  "status": "open"
+}

--- a/backend/scripts/pre-deploy-check.sh
+++ b/backend/scripts/pre-deploy-check.sh
@@ -38,7 +38,6 @@ run_hermetic() {
   python3 -m pytest \
     tests/unit/test_backend_runtime_env_validator.py \
     tests/unit/test_render_backend_runtime_env.py \
-    tests/unit/test_sync_two_lane.py \
     tests/unit/test_repair_cloud_run_traffic.py \
     tests/unit/test_cloud_run_traffic_snapshot.py \
     tests/unit/test_preflight_cloud_run_deploy.py \

--- a/backend/scripts/pre-deploy-check.sh
+++ b/backend/scripts/pre-deploy-check.sh
@@ -37,6 +37,8 @@ run_hermetic() {
   python3 scripts/check_mcp_oauth_deploy_contract.py
   python3 -m pytest \
     tests/unit/test_backend_runtime_env_validator.py \
+    tests/unit/test_render_backend_runtime_env.py \
+    tests/unit/test_sync_two_lane.py \
     tests/unit/test_repair_cloud_run_traffic.py \
     tests/unit/test_cloud_run_traffic_snapshot.py \
     tests/unit/test_preflight_cloud_run_deploy.py \

--- a/backend/scripts/render_backend_runtime_env.py
+++ b/backend/scripts/render_backend_runtime_env.py
@@ -11,6 +11,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = ROOT / 'backend/deploy/runtime_env.yaml'
 ConfigDict = dict[str, Any]
+_DEPLOY_CLOUD_RUN_ENV_SEPARATORS = frozenset({',', '\n', '\r', '\u2028', '\u2029'})
 
 
 def _as_config_dict(value: object) -> ConfigDict | None:
@@ -95,8 +96,16 @@ def _render_env_vars(env_entries: ConfigDict) -> str:
         if value is None:
             # Provisional values belong to services not yet deployed in every environment.
             continue
-        lines.append(f'{name}={value}')
+        lines.append(f'{name}={_escape_deploy_cloud_run_env_value(value)}')
     return '\n'.join(lines)
+
+
+def _escape_deploy_cloud_run_env_value(value: str) -> str:
+    """Encode a value for deploy-cloudrun's escaped key/value input grammar."""
+    return ''.join(
+        f'\\{character}' if character == '\\' or character in _DEPLOY_CLOUD_RUN_ENV_SEPARATORS else character
+        for character in value
+    )
 
 
 def _render_secrets(secret_entries: ConfigDict) -> str:

--- a/backend/scripts/render_cloud_run_clone_env.py
+++ b/backend/scripts/render_cloud_run_clone_env.py
@@ -9,6 +9,8 @@ import os
 from pathlib import Path
 from typing import Any
 
+_DEPLOY_CLOUD_RUN_ENV_SEPARATORS = frozenset({',', '\n', '\r', '\u2028', '\u2029'})
+
 
 def _pairs(value: str) -> dict[str, str]:
     result: dict[str, str] = {}
@@ -43,7 +45,7 @@ def clone_environment(
         if name in remove_names:
             continue
         if 'value' in entry:
-            literals[name] = str(entry['value'])
+            literals[name] = _escape_deploy_cloud_run_env_value(str(entry['value']))
             continue
         secret_ref = entry.get('valueFrom', {}).get('secretKeyRef', {})
         secret_name = secret_ref.get('name')
@@ -63,6 +65,14 @@ def clone_environment(
     return (
         '\n'.join(f'{name}={value}' for name, value in sorted(literals.items())),
         '\n'.join(f'{name}={value}' for name, value in sorted(secrets.items())),
+    )
+
+
+def _escape_deploy_cloud_run_env_value(value: str) -> str:
+    """Encode raw live Cloud Run literals for deploy-cloudrun's input grammar."""
+    return ''.join(
+        f'\\{character}' if character == '\\' or character in _DEPLOY_CLOUD_RUN_ENV_SEPARATORS else character
+        for character in value
     )
 
 

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -48,6 +48,23 @@ def test_provisional_env_var_present_is_rendered(monkeypatch):
     assert rendered == 'OMI_LLM_GATEWAY_URL=http://10.0.0.1'
 
 
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        ('parakeet,modulate-velma-2', r'parakeet\,modulate-velma-2'),
+        (r'C:\models', r'C:\\models'),
+        ('first\nsecond', 'first\\\nsecond'),
+        ('first\rsecond', 'first\\\rsecond'),
+        ('first\u2028second', 'first\\\u2028second'),
+        ('first\u2029second', 'first\\\u2029second'),
+    ],
+)
+def test_render_env_vars_escapes_deploy_cloudrun_separators(value, expected):
+    rendered = _MODULE['_render_env_vars']({'VALUE': {'value': value}})
+
+    assert rendered == f'VALUE={expected}'
+
+
 def test_network_flags_still_required(monkeypatch):
     monkeypatch.delenv('CLOUD_RUN_VPC_NETWORK', raising=False)
     with pytest.raises(ValueError, match='requires'):
@@ -96,6 +113,7 @@ def test_render_dev_emits_memory_maintenance_job_outputs(capsys, monkeypatch):
     out = capsys.readouterr().out
 
     memory_env = _job_env_block(out, 'memory_maintenance_job')
+    assert r'STT_PRERECORDED_MODEL=parakeet\,modulate-velma-2' in out
     assert 'MEMORY_CANONICAL_PROMOTION_CRON_ENABLED=true' in memory_env
     assert 'MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED=true' in memory_env
     assert 'MEMORY_CANONICAL_CONSOLIDATION_ENABLED=true' in memory_env

--- a/backend/tests/unit/test_sync_two_lane.py
+++ b/backend/tests/unit/test_sync_two_lane.py
@@ -149,6 +149,38 @@ def test_cloud_run_clone_removes_retired_source_env():
     assert 'REDIS_DB_HOST=10.0.0.1' in env_vars
 
 
+def test_cloud_run_clone_escapes_inherited_literals_without_reencoding_renderer_overlay():
+    service = {
+        'spec': {
+            'template': {
+                'spec': {
+                    'containers': [
+                        {
+                            'env': [
+                                {
+                                    'name': 'STT_PRERECORDED_MODEL',
+                                    'value': r'parakeet,modulate-velma-2\primary',
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    env_vars, _ = clone_environment(
+        service,
+        r'RENDERED_STT=parakeet\,modulate-velma-2',
+        '',
+    )
+
+    assert env_vars.splitlines() == [
+        r'RENDERED_STT=parakeet\,modulate-velma-2',
+        r'STT_PRERECORDED_MODEL=parakeet\,modulate-velma-2\\primary',
+    ]
+
+
 def test_deploy_contract_routes_both_backfill_budget_alerts():
     action = (Path(__file__).resolve().parents[3] / '.github/actions/sync-backfill-lifecycle/action.yml').read_text()
     manual = (Path(__file__).resolve().parents[3] / '.github/workflows/gcp_backend.yml').read_text()


### PR DESCRIPTION
## Summary

- Escape values for the documented `deploy-cloudrun@v3` `env_vars` grammar at the manifest renderer boundary.
- Escape raw literals inherited by the sync-backfill clone boundary without double-escaping manifest-rendered overlays.
- Run the pure renderer regression in the deterministic backend deploy preflight; cover the dependency-backed clone path in the backend unit suite.
- Record the new deploy-input-serialization failure class.

## Root cause and durable guard

Cloud Run deploy inputs are parsed as comma/newline-separated key-value pairs. The backend renderer emitted a raw comma-bearing STT model value, so the action deployed a phantom variable and a truncated model setting. Both serializers now encode the action grammar, and regression tests exercise the real renderer and clone paths before every backend deployment.

## Verification

- `cd backend && python -m pytest -q tests/unit/test_render_backend_runtime_env.py tests/unit/test_sync_two_lane.py` — 51 passed.
- `cd backend && bash scripts/pre-deploy-check.sh` — 144 passed.
- Bounded pre-push gate — passed, including the diff-scoped backend unit tests and manifest checks.
- GitHub CI — 20/20 checks passed.
- Independent review — approved.

Closes #9984

Failure-Class: new
