### PR TITLE
ci: publish automatic release eligibility proof

### DIFF
--- a/.github/actions/release-eligibility/action.yml
+++ b/.github/actions/release-eligibility/action.yml
@@ -1,0 +1,50 @@
+name: Verify release eligibility
+description: Publish a release proof only for the exact checked-out main commit.
+inputs:
+  ref:
+    description: GitHub ref that triggered the release proof.
+    required: true
+  sha:
+    description: Immutable commit SHA selected for the release proof.
+    required: true
+  before:
+    description: Previous main commit SHA used as the deterministic-check base.
+    required: true
+  after:
+    description: Push event commit SHA that must equal the release SHA.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Verify exact main release identity
+      shell: bash
+      env:
+        RELEASE_REF: ${{ inputs.ref }}
+        RELEASE_SHA: ${{ inputs.sha }}
+        RELEASE_BEFORE: ${{ inputs.before }}
+        RELEASE_AFTER: ${{ inputs.after }}
+      run: |
+        set -euo pipefail
+        RELEASE_CHECKOUT_SHA="$(git rev-parse --verify HEAD)"
+        python3 .github/scripts/verify_release_eligibility.py \
+          --ref "$RELEASE_REF" \
+          --sha "$RELEASE_SHA" \
+          --before "$RELEASE_BEFORE" \
+          --after "$RELEASE_AFTER" \
+          --checkout-sha "$RELEASE_CHECKOUT_SHA"
+        git cat-file -e "${RELEASE_BEFORE}^{commit}"
+        git cat-file -e "${RELEASE_SHA}^{commit}"
+        git merge-base --is-ancestor "$RELEASE_BEFORE" "$RELEASE_SHA"
+
+    - name: Run canonical deterministic CI preflight
+      shell: bash
+      env:
+        RELEASE_BEFORE: ${{ inputs.before }}
+        RELEASE_SHA: ${{ inputs.sha }}
+      run: |
+        set -euo pipefail
+        python3 .github/scripts/run_checks.py \
+          --lane ci \
+          --base "$RELEASE_BEFORE" \
+          --head "$RELEASE_SHA" \
+          --skip-pr-body-checks

--- a/.github/actions/release-eligibility/action.yml
+++ b/.github/actions/release-eligibility/action.yml
@@ -36,6 +36,15 @@ runs:
         git cat-file -e "${RELEASE_SHA}^{commit}"
         git merge-base --is-ancestor "$RELEASE_BEFORE" "$RELEASE_SHA"
 
+    # The selected canonical checks can invoke backend/scripts/openapi_runner.sh,
+    # which deliberately requires uv. Keep the automatic post-merge proof
+    # self-contained instead of relying on a runner image default.
+    - name: Set up uv for canonical checks
+      uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84
+      with:
+        enable-cache: true
+        cache-dependency-glob: backend/openapi-requirements.txt
+
     - name: Run canonical deterministic CI preflight
       shell: bash
       env:

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -300,6 +300,16 @@ checks:
     triggers: ["desktop/macos/agent/src/runtime/agent-spawn-journal.ts", "desktop/macos/agent/fixtures/spawn-receipt/**", "desktop/macos/agent/tests/spawn-receipt-fixtures.test.ts", "desktop/macos/scripts/check-spawn-receipt-fixtures.sh", "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeSpawnReceipt.swift", "desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift"]
     lanes: ["local", "ci"]
     reason: "cross-language realtime spawn receipt producer/consumer contract"
+  - id: release-eligibility-contract
+    command: ["python3", ".github/scripts/check_release_eligibility.py"]
+    triggers: [".github/workflows/release-eligibility.yml", ".github/actions/release-eligibility/**", ".github/scripts/verify_release_eligibility.py", ".github/scripts/check_release_eligibility.py", ".github/scripts/test_check_release_eligibility.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#9989 keeps the automatic release proof main-scoped, SHA-bound, and routed through the canonical deterministic CI runner"
+  - id: release-eligibility-contract-fixtures
+    command: ["python3", ".github/scripts/test_check_release_eligibility.py"]
+    triggers: [".github/workflows/release-eligibility.yml", ".github/actions/release-eligibility/**", ".github/scripts/verify_release_eligibility.py", ".github/scripts/check_release_eligibility.py", ".github/scripts/test_check_release_eligibility.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#9989 exercises non-main, ambiguous SHA, mismatched checkout, and workflow-contract rejection cases"
 
 exempt:
   - path: ".github/scripts/check-desktop-auto-beta-candidate.py"

--- a/.github/scripts/check_release_eligibility.py
+++ b/.github/scripts/check_release_eligibility.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Keep the automatic main-SHA release proof bound to canonical CI checks."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = Path(".github/workflows/release-eligibility.yml")
+ACTION_PATH = Path(".github/actions/release-eligibility/action.yml")
+
+
+def require_fragment(errors: list[str], text: str, fragment: str, message: str) -> None:
+    if fragment not in text:
+        errors.append(message)
+
+
+def mapping_block(text: str, key: str, indent: int) -> str | None:
+    """Return a YAML mapping block with the repository's fixed indentation."""
+
+    lines = text.splitlines()
+    marker = f"{' ' * indent}{key}:"
+    try:
+        start = lines.index(marker)
+    except ValueError:
+        return None
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if line and len(line) - len(line.lstrip()) <= indent:
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def named_step_block(text: str, name: str, indent: int) -> str | None:
+    """Return one named step block, stopping at the next peer step."""
+
+    lines = text.splitlines()
+    marker = f"{' ' * indent}- name: {name}"
+    try:
+        start = lines.index(marker)
+    except ValueError:
+        return None
+    body = [lines[start]]
+    peer = f"{' ' * indent}- "
+    for line in lines[start + 1 :]:
+        if line.startswith(peer):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def validate_required_step(errors: list[str], text: str, name: str, indent: int, label: str) -> str:
+    """Require a critical step to run normally and fail closed."""
+
+    step = named_step_block(text, name, indent)
+    if step is None:
+        errors.append(f"release eligibility is missing its {label} step")
+        return ""
+    field_indent = " " * (indent + 2)
+    if re.search(rf"(?m)^{re.escape(field_indent)}[\"']?(?:if|continue-on-error)[\"']?:", step):
+        errors.append(f"release eligibility {label} step must not be conditionally skipped or tolerated")
+    script_indent = f"{field_indent}  "
+    if not re.search(rf"(?m)^{re.escape(script_indent)}set -euo pipefail$", step):
+        errors.append(f"release eligibility {label} step must enable strict shell failure handling")
+    if re.search(r"\|\|\s*(?:true\b|:|exit\s+0\b)|\bset\s+\+(?:e|o\s+(?:errexit|pipefail))\b", step):
+        errors.append(f"release eligibility {label} step must not contain a shell fail-open path")
+    return step
+
+
+def validate_workflow(text: str) -> list[str]:
+    errors: list[str] = []
+    push = re.search(r"(?ms)^  push:\n(?P<body>(?:    .*\n?)*)", text)
+    if push is None or "    branches: [main]" not in push.group("body"):
+        errors.append("release eligibility must trigger only on pushes to main")
+    elif re.search(r"(?m)^    (?:paths|paths-ignore|tags|tags-ignore|branches-ignore):", push.group("body")):
+        errors.append("release eligibility must not path-filter or otherwise narrow main pushes")
+    on_block = mapping_block(text, "on", 0)
+    trigger_keys = (
+        []
+        if on_block is None
+        else [
+            match.group("key").strip("\"'")
+            for match in re.finditer(r"(?m)^  (?P<key>[\"']?[A-Za-z_]+[\"']?):", on_block)
+        ]
+    )
+    if trigger_keys != ["push"]:
+        errors.append("release eligibility must declare only the automatic push trigger")
+    require_fragment(errors, text, "name: Release Eligibility", "release eligibility workflow is missing its unique check name")
+    require_fragment(
+        errors,
+        text,
+        "  release-eligibility:\n    name: Release Eligibility",
+        "release eligibility workflow is missing its uniquely named result job",
+    )
+    job = mapping_block(text, "release-eligibility", 2)
+    if job is None:
+        errors.append("release eligibility workflow is missing its result job")
+    elif re.search(r"(?m)^    [\"']?(?:if|continue-on-error)[\"']?:", job):
+        errors.append("release eligibility result job must not be conditionally skipped or tolerated")
+    require_fragment(
+        errors,
+        text,
+        "uses: actions/checkout@v7\n        with:\n          ref: ${{ github.sha }}\n          fetch-depth: 0",
+        "release eligibility must check out the exact GitHub SHA with complete history",
+    )
+    require_fragment(
+        errors,
+        text,
+        "uses: ./.github/actions/release-eligibility",
+        "release eligibility workflow must use the canonical release-eligibility action",
+    )
+    for name, expression in {
+        "ref": "${{ github.ref }}",
+        "sha": "${{ github.sha }}",
+        "before": "${{ github.event.before }}",
+        "after": "${{ github.event.after }}",
+    }.items():
+        require_fragment(
+            errors,
+            text,
+            f"          {name}: {expression}",
+            f"release eligibility must pass {name} as {expression}",
+        )
+    invocation = named_step_block(text, "Verify release eligibility", 6)
+    if invocation is None:
+        errors.append("release eligibility workflow is missing its action invocation step")
+    elif re.search(r"(?m)^        [\"']?(?:if|continue-on-error)[\"']?:", invocation):
+        errors.append("release eligibility action invocation must not be conditionally skipped or tolerated")
+    permissions = mapping_block(text, "permissions", 0)
+    if permissions is None or [line.strip() for line in permissions.splitlines() if line.strip()] != ["contents: read"]:
+        errors.append("release eligibility must use only repository contents: read permissions")
+    if re.search(r"(?m)^    permissions:", job or ""):
+        errors.append("release eligibility result job must not override least-privilege workflow permissions")
+    return errors
+
+
+def validate_action(text: str) -> list[str]:
+    errors: list[str] = []
+    for name in ("ref", "sha", "before", "after"):
+        require_fragment(
+            errors,
+            text,
+            f"  {name}:\n",
+            f"release eligibility action is missing required {name} input",
+        )
+    for env_name, expression in {
+        "RELEASE_REF": "${{ inputs.ref }}",
+        "RELEASE_SHA": "${{ inputs.sha }}",
+        "RELEASE_BEFORE": "${{ inputs.before }}",
+        "RELEASE_AFTER": "${{ inputs.after }}",
+    }.items():
+        require_fragment(
+            errors,
+            text,
+            f"        {env_name}: {expression}",
+            f"release eligibility action must bind {env_name} from {expression}",
+        )
+    identity_step = validate_required_step(
+        errors,
+        text,
+        "Verify exact main release identity",
+        4,
+        "identity validation",
+    )
+    preflight_step = validate_required_step(
+        errors,
+        text,
+        "Run canonical deterministic CI preflight",
+        4,
+        "canonical preflight",
+    )
+    for fragment, message in (
+        ("RELEASE_CHECKOUT_SHA=\"$(git rev-parse --verify HEAD)\"", "release eligibility must resolve checkout SHA"),
+        (".github/scripts/verify_release_eligibility.py", "release eligibility must validate immutable release identity"),
+        ("--ref \"$RELEASE_REF\"", "release identity validator must receive the triggering ref"),
+        ("--sha \"$RELEASE_SHA\"", "release identity validator must receive the immutable release SHA"),
+        ("--before \"$RELEASE_BEFORE\"", "release identity validator must receive the deterministic-check base SHA"),
+        ("--after \"$RELEASE_AFTER\"", "release identity validator must receive the push event SHA"),
+        ("--checkout-sha \"$RELEASE_CHECKOUT_SHA\"", "release identity validator must receive the checkout SHA"),
+        ("git cat-file -e \"${RELEASE_BEFORE}^{commit}\"", "release eligibility must verify the base identity is a commit"),
+        ("git cat-file -e \"${RELEASE_SHA}^{commit}\"", "release eligibility must verify the release identity is a commit"),
+        ("git merge-base --is-ancestor \"$RELEASE_BEFORE\" \"$RELEASE_SHA\"", "release eligibility must require the base SHA to be an ancestor"),
+        (".github/scripts/run_checks.py", "release eligibility must call the canonical deterministic check runner"),
+        ("--lane ci", "release eligibility must use the CI check lane"),
+        ("--base \"$RELEASE_BEFORE\"", "release eligibility must use the event base SHA"),
+        ("--head \"$RELEASE_SHA\"", "release eligibility must use the immutable release SHA as check head"),
+        ("--skip-pr-body-checks", "release eligibility must use the canonical post-merge preflight mode"),
+    ):
+        require_fragment(errors, text, fragment, message)
+    for step, fragment, message in (
+        (identity_step, ".github/scripts/verify_release_eligibility.py", "identity validation step must run the immutable identity verifier"),
+        (identity_step, "git merge-base --is-ancestor", "identity validation step must enforce main ancestry"),
+        (preflight_step, ".github/scripts/run_checks.py", "canonical preflight step must run the deterministic check runner"),
+    ):
+        require_fragment(errors, step, fragment, message)
+    return errors
+
+
+def validate(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    workflow = root / WORKFLOW_PATH
+    action = root / ACTION_PATH
+    if not workflow.is_file():
+        return [f"release eligibility workflow is missing: {WORKFLOW_PATH}"]
+    if not action.is_file():
+        return [f"release eligibility action is missing: {ACTION_PATH}"]
+    errors.extend(validate_workflow(workflow.read_text(encoding="utf-8")))
+    errors.extend(validate_action(action.read_text(encoding="utf-8")))
+    return errors
+
+
+def main() -> int:
+    errors = validate()
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print("release eligibility contract passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_release_eligibility.py
+++ b/.github/scripts/check_release_eligibility.py
@@ -11,6 +11,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = Path(".github/workflows/release-eligibility.yml")
 ACTION_PATH = Path(".github/actions/release-eligibility/action.yml")
+UV_SETUP_ACTION = "astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84"
 
 
 def require_fragment(errors: list[str], text: str, fragment: str, message: str) -> None:
@@ -68,6 +69,27 @@ def validate_required_step(errors: list[str], text: str, name: str, indent: int,
         errors.append(f"release eligibility {label} step must enable strict shell failure handling")
     if re.search(r"\|\|\s*(?:true\b|:|exit\s+0\b)|\bset\s+\+(?:e|o\s+(?:errexit|pipefail))\b", step):
         errors.append(f"release eligibility {label} step must not contain a shell fail-open path")
+    return step
+
+
+def validate_required_uses_step(
+    errors: list[str], text: str, name: str, indent: int, label: str, action: str
+) -> str:
+    """Require an action step to remain unconditional and pinned."""
+
+    step = named_step_block(text, name, indent)
+    if step is None:
+        errors.append(f"release eligibility is missing its {label} step")
+        return ""
+    field_indent = " " * (indent + 2)
+    if re.search(rf"(?m)^{re.escape(field_indent)}[\"']?(?:if|continue-on-error)[\"']?:", step):
+        errors.append(f"release eligibility {label} step must not be conditionally skipped or tolerated")
+    require_fragment(
+        errors,
+        step,
+        f"uses: {action}",
+        f"release eligibility {label} step must use the pinned setup action",
+    )
     return step
 
 
@@ -173,6 +195,18 @@ def validate_action(text: str) -> list[str]:
         4,
         "canonical preflight",
     )
+    uv_step = validate_required_uses_step(
+        errors,
+        text,
+        "Set up uv for canonical checks",
+        4,
+        "uv setup",
+        UV_SETUP_ACTION,
+    )
+    uv_marker = "    - name: Set up uv for canonical checks"
+    preflight_marker = "    - name: Run canonical deterministic CI preflight"
+    if uv_marker in text and preflight_marker in text and text.index(uv_marker) > text.index(preflight_marker):
+        errors.append("release eligibility must set up uv before the canonical preflight")
     for fragment, message in (
         ("RELEASE_CHECKOUT_SHA=\"$(git rev-parse --verify HEAD)\"", "release eligibility must resolve checkout SHA"),
         (".github/scripts/verify_release_eligibility.py", "release eligibility must validate immutable release identity"),
@@ -194,6 +228,12 @@ def validate_action(text: str) -> list[str]:
     for step, fragment, message in (
         (identity_step, ".github/scripts/verify_release_eligibility.py", "identity validation step must run the immutable identity verifier"),
         (identity_step, "git merge-base --is-ancestor", "identity validation step must enforce main ancestry"),
+        (uv_step, "enable-cache: true", "release eligibility uv setup must enable the deterministic dependency cache"),
+        (
+            uv_step,
+            "cache-dependency-glob: backend/openapi-requirements.txt",
+            "release eligibility uv setup must key the OpenAPI dependency cache",
+        ),
         (preflight_step, ".github/scripts/run_checks.py", "canonical preflight step must run the deterministic check runner"),
     ):
         require_fragment(errors, step, fragment, message)

--- a/.github/scripts/test_check_release_eligibility.py
+++ b/.github/scripts/test_check_release_eligibility.py
@@ -171,6 +171,60 @@ class WorkflowContractTests(unittest.TestCase):
         )
         self.assertIn("release identity validator must receive the checkout SHA", CHECKER.validate(root))
 
+    def test_uv_setup_is_required_and_fail_closed_before_canonical_preflight(self) -> None:
+        cases = (
+            (
+                "missing setup",
+                "    - name: Set up uv for canonical checks\n      uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84\n      with:\n        enable-cache: true\n        cache-dependency-glob: backend/openapi-requirements.txt\n\n",
+                "",
+                "release eligibility is missing its uv setup step",
+            ),
+            (
+                "unpinned-or-wrong setup",
+                "uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84",
+                "uses: astral-sh/setup-uv@v7",
+                "release eligibility uv setup step must use the pinned setup action",
+            ),
+            (
+                "conditional setup",
+                "    - name: Set up uv for canonical checks\n      uses:",
+                "    - name: Set up uv for canonical checks\n      if: github.ref == 'refs/heads/main'\n      uses:",
+                "release eligibility uv setup step must not be conditionally skipped or tolerated",
+            ),
+            (
+                "missing OpenAPI cache key",
+                "cache-dependency-glob: backend/openapi-requirements.txt",
+                "cache-dependency-glob: backend/pylock.toml",
+                "release eligibility uv setup must key the OpenAPI dependency cache",
+            ),
+            (
+                "setup after preflight",
+                "    - name: Set up uv for canonical checks\n      uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84\n      with:\n        enable-cache: true\n        cache-dependency-glob: backend/openapi-requirements.txt\n\n",
+                "",
+                "release eligibility must set up uv before the canonical preflight",
+            ),
+        )
+        for name, old, new, expected in cases:
+            with self.subTest(name=name):
+                root = self.fixture_root()
+                action = root / ".github/actions/release-eligibility/action.yml"
+                text = action.read_text(encoding="utf-8")
+                if name == "setup after preflight":
+                    self.assertIn(old, text)
+                    uv_start = text.index(old)
+                    preflight_start = text.index("    - name: Run canonical deterministic CI preflight")
+                    text = (
+                        text[:uv_start]
+                        + text[uv_start + len(old) : preflight_start]
+                        + text[preflight_start:]
+                        + old
+                    )
+                else:
+                    self.assertIn(old, text)
+                    text = text.replace(old, new, 1)
+                action.write_text(text, encoding="utf-8")
+                self.assertIn(expected, CHECKER.validate(root))
+
     def test_critical_action_steps_cannot_be_skipped_or_fail_open(self) -> None:
         cases = (
             (

--- a/.github/scripts/test_check_release_eligibility.py
+++ b/.github/scripts/test_check_release_eligibility.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Fixtures for the automatic main-SHA release eligibility proof."""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPT_DIR.parents[1]
+CHECKER_PATH = SCRIPT_DIR / "check_release_eligibility.py"
+VERIFIER_PATH = SCRIPT_DIR / "verify_release_eligibility.py"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CHECKER = load_module("check_release_eligibility", CHECKER_PATH)
+VERIFIER = load_module("verify_release_eligibility", VERIFIER_PATH)
+
+SHA = "a" * 40
+BASE_SHA = "b" * 40
+
+
+class ReleaseIdentityTests(unittest.TestCase):
+    def identity(self, **overrides: str):
+        values = {
+            "ref": "refs/heads/main",
+            "sha": SHA,
+            "before": BASE_SHA,
+            "after": SHA,
+            "checkout_sha": SHA,
+        }
+        values.update(overrides)
+        return VERIFIER.ReleaseIdentity(**values)
+
+    def test_accepts_exact_main_sha_identity(self) -> None:
+        VERIFIER.validate(self.identity())
+
+    def test_rejects_non_main_ref(self) -> None:
+        with self.assertRaisesRegex(VERIFIER.ReleaseEligibilityError, "refs/heads/main"):
+            VERIFIER.validate(self.identity(ref="refs/heads/release"))
+
+    def test_rejects_ambiguous_or_non_sha_release_identity(self) -> None:
+        for value in ("main", "a" * 7, "A" * 40, "0" * 40):
+            with self.subTest(value=value), self.assertRaisesRegex(VERIFIER.ReleaseEligibilityError, "release SHA"):
+                VERIFIER.validate(self.identity(sha=value))
+
+    def test_rejects_event_or_checkout_sha_mismatch(self) -> None:
+        with self.assertRaisesRegex(VERIFIER.ReleaseEligibilityError, "event after SHA"):
+            VERIFIER.validate(self.identity(after="c" * 40))
+        with self.assertRaisesRegex(VERIFIER.ReleaseEligibilityError, "checked-out SHA"):
+            VERIFIER.validate(self.identity(checkout_sha="c" * 40))
+
+
+class WorkflowContractTests(unittest.TestCase):
+    def fixture_root(self) -> Path:
+        temp = Path(tempfile.mkdtemp())
+        workflow = temp / ".github/workflows/release-eligibility.yml"
+        action = temp / ".github/actions/release-eligibility/action.yml"
+        workflow.parent.mkdir(parents=True)
+        action.parent.mkdir(parents=True)
+        shutil.copy2(ROOT / ".github/workflows/release-eligibility.yml", workflow)
+        shutil.copy2(ROOT / ".github/actions/release-eligibility/action.yml", action)
+        self.addCleanup(shutil.rmtree, temp)
+        return temp
+
+    def test_current_workflow_and_action_are_valid(self) -> None:
+        self.assertEqual(CHECKER.validate(), [])
+
+    def test_non_main_push_trigger_is_rejected(self) -> None:
+        root = self.fixture_root()
+        workflow = root / ".github/workflows/release-eligibility.yml"
+        workflow.write_text(workflow.read_text(encoding="utf-8").replace("branches: [main]", "branches: [development]"), encoding="utf-8")
+        self.assertIn("release eligibility must trigger only on pushes to main", CHECKER.validate(root))
+
+    def test_path_filter_is_rejected(self) -> None:
+        root = self.fixture_root()
+        workflow = root / ".github/workflows/release-eligibility.yml"
+        workflow.write_text(
+            workflow.read_text(encoding="utf-8").replace("branches: [main]", "branches: [main]\n    paths: ['backend/**']"),
+            encoding="utf-8",
+        )
+        self.assertIn("release eligibility must not path-filter or otherwise narrow main pushes", CHECKER.validate(root))
+
+    def test_manual_dispatch_is_rejected(self) -> None:
+        root = self.fixture_root()
+        workflow = root / ".github/workflows/release-eligibility.yml"
+        workflow.write_text(
+            workflow.read_text(encoding="utf-8").replace("on:\n", "on:\n  workflow_dispatch:\n", 1),
+            encoding="utf-8",
+        )
+        self.assertIn("release eligibility must declare only the automatic push trigger", CHECKER.validate(root))
+
+    def test_quoted_extra_trigger_is_rejected(self) -> None:
+        root = self.fixture_root()
+        workflow = root / ".github/workflows/release-eligibility.yml"
+        workflow.write_text(
+            workflow.read_text(encoding="utf-8").replace("on:\n", "on:\n  'workflow_dispatch':\n", 1),
+            encoding="utf-8",
+        )
+        self.assertIn("release eligibility must declare only the automatic push trigger", CHECKER.validate(root))
+
+    def test_conditional_result_job_is_rejected(self) -> None:
+        root = self.fixture_root()
+        workflow = root / ".github/workflows/release-eligibility.yml"
+        workflow.write_text(
+            workflow.read_text(encoding="utf-8").replace("    runs-on: ubuntu-latest", "    if: github.ref == 'refs/heads/main'\n    runs-on: ubuntu-latest"),
+            encoding="utf-8",
+        )
+        self.assertIn("release eligibility result job must not be conditionally skipped or tolerated", CHECKER.validate(root))
+
+    def test_result_job_continue_on_error_is_rejected(self) -> None:
+        root = self.fixture_root()
+        workflow = root / ".github/workflows/release-eligibility.yml"
+        workflow.write_text(
+            workflow.read_text(encoding="utf-8").replace("    runs-on: ubuntu-latest", "    continue-on-error: true\n    runs-on: ubuntu-latest"),
+            encoding="utf-8",
+        )
+        self.assertIn("release eligibility result job must not be conditionally skipped or tolerated", CHECKER.validate(root))
+
+    def test_action_invocation_cannot_be_skipped_or_tolerated(self) -> None:
+        for field in ("if: github.ref == 'refs/heads/main'", "continue-on-error: true"):
+            with self.subTest(field=field):
+                root = self.fixture_root()
+                workflow = root / ".github/workflows/release-eligibility.yml"
+                workflow.write_text(
+                    workflow.read_text(encoding="utf-8").replace(
+                        "      - name: Verify release eligibility\n        uses:",
+                        f"      - name: Verify release eligibility\n        {field}\n        uses:",
+                    ),
+                    encoding="utf-8",
+                )
+                self.assertIn(
+                    "release eligibility action invocation must not be conditionally skipped or tolerated",
+                    CHECKER.validate(root),
+                )
+
+    def test_least_privilege_permissions_are_enforced(self) -> None:
+        root = self.fixture_root()
+        workflow = root / ".github/workflows/release-eligibility.yml"
+        workflow.write_text(
+            workflow.read_text(encoding="utf-8").replace("  contents: read", "  contents: read\n  actions: write"),
+            encoding="utf-8",
+        )
+        self.assertIn("release eligibility must use only repository contents: read permissions", CHECKER.validate(root))
+
+    def test_ambiguous_workflow_sha_is_rejected(self) -> None:
+        root = self.fixture_root()
+        workflow = root / ".github/workflows/release-eligibility.yml"
+        workflow.write_text(workflow.read_text(encoding="utf-8").replace("sha: ${{ github.sha }}", "sha: main"), encoding="utf-8")
+        self.assertIn("release eligibility must pass sha as ${{ github.sha }}", CHECKER.validate(root))
+
+    def test_missing_checkout_sha_binding_is_rejected(self) -> None:
+        root = self.fixture_root()
+        action = root / ".github/actions/release-eligibility/action.yml"
+        action.write_text(
+            action.read_text(encoding="utf-8").replace("--checkout-sha \"$RELEASE_CHECKOUT_SHA\"", "--checkout-sha main"),
+            encoding="utf-8",
+        )
+        self.assertIn("release identity validator must receive the checkout SHA", CHECKER.validate(root))
+
+    def test_critical_action_steps_cannot_be_skipped_or_fail_open(self) -> None:
+        cases = (
+            (
+                "identity condition",
+                "    - name: Verify exact main release identity\n      shell:",
+                "    - name: Verify exact main release identity\n      if: github.ref == 'refs/heads/main'\n      shell:",
+                "release eligibility identity validation step must not be conditionally skipped or tolerated",
+            ),
+            (
+                "identity tolerance",
+                "    - name: Verify exact main release identity\n      shell:",
+                "    - name: Verify exact main release identity\n      continue-on-error: true\n      shell:",
+                "release eligibility identity validation step must not be conditionally skipped or tolerated",
+            ),
+            (
+                "identity fail open",
+                "git cat-file -e \"${RELEASE_SHA}^{commit}\"",
+                "git cat-file -e \"${RELEASE_SHA}^{commit}\" || true",
+                "release eligibility identity validation step must not contain a shell fail-open path",
+            ),
+            (
+                "identity alternate fail open",
+                "git cat-file -e \"${RELEASE_SHA}^{commit}\"",
+                "git cat-file -e \"${RELEASE_SHA}^{commit}\" || :",
+                "release eligibility identity validation step must not contain a shell fail-open path",
+            ),
+            (
+                "preflight condition",
+                "    - name: Run canonical deterministic CI preflight\n      shell:",
+                "    - name: Run canonical deterministic CI preflight\n      if: github.ref == 'refs/heads/main'\n      shell:",
+                "release eligibility canonical preflight step must not be conditionally skipped or tolerated",
+            ),
+            (
+                "preflight tolerance",
+                "    - name: Run canonical deterministic CI preflight\n      shell:",
+                "    - name: Run canonical deterministic CI preflight\n      continue-on-error: true\n      shell:",
+                "release eligibility canonical preflight step must not be conditionally skipped or tolerated",
+            ),
+            (
+                "preflight fail open",
+                "--skip-pr-body-checks",
+                "--skip-pr-body-checks || true",
+                "release eligibility canonical preflight step must not contain a shell fail-open path",
+            ),
+            (
+                "preflight disables strict errors",
+                "        set -euo pipefail\n        python3 .github/scripts/run_checks.py",
+                "        set -euo pipefail\n        set +e\n        python3 .github/scripts/run_checks.py",
+                "release eligibility canonical preflight step must not contain a shell fail-open path",
+            ),
+            (
+                "missing ancestry",
+                "        git merge-base --is-ancestor \"$RELEASE_BEFORE\" \"$RELEASE_SHA\"\n",
+                "",
+                "release eligibility must require the base SHA to be an ancestor",
+            ),
+        )
+        for name, old, new, expected in cases:
+            with self.subTest(name=name):
+                root = self.fixture_root()
+                action = root / ".github/actions/release-eligibility/action.yml"
+                action.write_text(action.read_text(encoding="utf-8").replace(old, new, 1), encoding="utf-8")
+                self.assertIn(expected, CHECKER.validate(root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/verify_release_eligibility.py
+++ b/.github/scripts/verify_release_eligibility.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Fail closed unless a release proof names the exact checked-out main commit."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+
+
+MAIN_REF = "refs/heads/main"
+SHA_RE = re.compile(r"[0-9a-f]{40}\Z")
+ZERO_SHA = "0" * 40
+
+
+class ReleaseEligibilityError(ValueError):
+    """The workflow context cannot safely identify one release commit."""
+
+
+@dataclass(frozen=True)
+class ReleaseIdentity:
+    ref: str
+    sha: str
+    before: str
+    after: str
+    checkout_sha: str
+
+
+def require_full_sha(label: str, value: str) -> None:
+    if not SHA_RE.fullmatch(value):
+        raise ReleaseEligibilityError(f"{label} must be a full 40-character lowercase hexadecimal SHA")
+    if value == ZERO_SHA:
+        raise ReleaseEligibilityError(f"{label} must not be the all-zero initial-push sentinel")
+
+
+def validate(identity: ReleaseIdentity) -> None:
+    """Reject refs and identities that cannot prove one immutable main commit."""
+
+    if identity.ref != MAIN_REF:
+        raise ReleaseEligibilityError(f"release eligibility requires ref {MAIN_REF}, got {identity.ref!r}")
+
+    require_full_sha("release SHA", identity.sha)
+    require_full_sha("release base SHA", identity.before)
+    require_full_sha("event after SHA", identity.after)
+    require_full_sha("checkout SHA", identity.checkout_sha)
+
+    if identity.sha != identity.after:
+        raise ReleaseEligibilityError("release SHA must equal the push event after SHA")
+    if identity.sha != identity.checkout_sha:
+        raise ReleaseEligibilityError("release SHA must equal the checked-out SHA")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ref", required=True)
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--before", required=True)
+    parser.add_argument("--after", required=True)
+    parser.add_argument("--checkout-sha", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    identity = ReleaseIdentity(
+        ref=args.ref,
+        sha=args.sha,
+        before=args.before,
+        after=args.after,
+        checkout_sha=args.checkout_sha,
+    )
+    try:
+        validate(identity)
+    except ReleaseEligibilityError as exc:
+        print(f"release eligibility failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"release eligibility identity verified: sha={identity.sha}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/release-eligibility.yml
+++ b/.github/workflows/release-eligibility.yml
@@ -1,0 +1,27 @@
+name: Release Eligibility
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  release-eligibility:
+    name: Release Eligibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact main SHA
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Verify release eligibility
+        uses: ./.github/actions/release-eligibility
+        with:
+          ref: ${{ github.ref }}
+          sha: ${{ github.sha }}
+          before: ${{ github.event.before }}
+          after: ${{ github.event.after }}


### PR DESCRIPTION
## Summary

- Publish an automatic, always-present `Release Eligibility` check for each push to `main`.
- Bind the proof to the full event SHA, exact checkout SHA, and an actual commit object before invoking the existing deterministic CI manifest runner.
- Provision the pinned `uv` setup used by the canonical OpenAPI runner, so the fresh post-merge proof does not depend on an ambient runner installation.
- Add static and behavioral contract tests that reject non-main refs, non-SHA identities, manual triggers, skipped/ignored critical steps, missing or unpinned `uv`, and drift from the canonical preflight entrypoint.

## Root cause and durable guard

Deploy workflows could identify a source independently, but no unique CI result proved that the exact `main` SHA had completed the repository's deterministic release checks. The new native GitHub check reuses `run_checks.py --lane ci --skip-pr-body-checks` rather than duplicating test selection.

The proof is fail-closed: its event, SHA, checkout, ancestry, permissions, `uv` setup, and both critical action steps are statically guarded against conditional execution, ignored failures, and manual triggers. The action installs the same pinned `uv` version and cache configuration already used by the OpenAPI contract workflow.

## Verification

- `python3 .github/scripts/test_check_release_eligibility.py` — 17 passed.
- `python3 .github/scripts/check_release_eligibility.py` — passed.
- `make preflight` — passed.
- Independent review — approved.

Closes #9989
