### PR TITLE
fix(deploy): budget Pusher rollout readiness

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -202,6 +202,11 @@ checks:
     triggers: ["backend/**/*.py", "backend/testing/workflow_contracts.json", ".github/workflows/**/*.yml", ".github/actions/detect-changes/**", "scripts/pre-push", "scripts/changed-files"]
     lanes: ["local", "ci"]
     reason: "workflow boundary sources changed"
+  - id: pusher-rollout-readiness-budget
+    command: ["python3", "backend/scripts/verify_pusher_rollout_budget.py"]
+    triggers: ["backend/charts/pusher/**", ".github/workflows/gcp_backend_pusher.yml", ".github/workflows/gcp_backend_pusher_auto_deploy.yml", "backend/scripts/verify_pusher_rollout_budget.py", "backend/tests/unit/test_verify_pusher_rollout_budget.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#9988: Pusher's Kubernetes deadline and workflow wait must cover chart-derived availability at the HPA ceiling"
   - id: conversation-lifecycle-write-guard
     command: ["python3", "backend/scripts/check_conversation_lifecycle_writes.py"]
     triggers: ["backend/**/*.py", "backend/scripts/check_conversation_lifecycle_writes.py"]

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -235,7 +235,9 @@ jobs:
             python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service llm-gateway
           else
             helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-pusher ./backend/charts/pusher -f ./backend/charts/pusher/${{ vars.ENV }}_omi_pusher_values.yaml --set-string "image.tag=${GITHUB_SHA::7}"
-            if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-pusher --timeout=300s; then
+            # Must cover the chart-derived Pusher rollout budget (fourteen
+            # availability waves at the current production HPA ceiling).
+            if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-pusher --timeout=9600s; then
               python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service pusher || true
               exit 1
             fi

--- a/.github/workflows/gcp_backend_pusher_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_pusher_auto_deploy.yml
@@ -71,7 +71,9 @@ jobs:
       - name: Deploy Pusher to GKE cluster using Helm
         run: |
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-pusher ./backend/charts/pusher -f ./backend/charts/pusher/${{ vars.ENV }}_omi_pusher_values.yaml --set-string "image.tag=${GITHUB_SHA::7}"
-          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-pusher --timeout=300s
+          # Must cover the chart-derived Pusher rollout budget; the CI guard
+          # recalculates the required value from committed chart inputs.
+          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-pusher --timeout=9600s
 
       - name: Show Output
         run: echo "Pusher deployed to development environment"

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -2,6 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Keep every rollout availability delay explicit. CI derives the healthy
+# rollout budget from these values and the HPA ceiling, rather than inheriting
+# Kubernetes defaults that can make a healthy rollout look stalled.
+minReadySeconds: 0
+progressDeadlineSeconds: 9600
+
 # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
 replicaCount: 1
 
@@ -303,7 +309,9 @@ readinessProbe:
     path: /health
     port: 8080
   failureThreshold: 3
+  initialDelaySeconds: 0
   periodSeconds: 10
+  successThreshold: 1
   timeoutSeconds: 5
 
 startupProbe:
@@ -311,6 +319,7 @@ startupProbe:
     path: /health
     port: 8080
   failureThreshold: 60
+  initialDelaySeconds: 0
   periodSeconds: 10
   timeoutSeconds: 5
 

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -2,6 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# At the 40-pod HPA ceiling, Pusher needs fourteen waves. The committed probe
+# and availability settings make that a 8960s healthy-rollout budget; retain
+# one 640s per-pod allowance of scheduler headroom above it. CI recalculates
+# this bound from the chart whenever any rollout input changes.
+minReadySeconds: 0
+progressDeadlineSeconds: 9600
+
 # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
 replicaCount: 1
 
@@ -319,7 +326,9 @@ readinessProbe:
     path: /health
     port: 8080
   failureThreshold: 3
+  initialDelaySeconds: 0
   periodSeconds: 10
+  successThreshold: 1
   timeoutSeconds: 5
 
 startupProbe:
@@ -327,6 +336,7 @@ startupProbe:
     path: /health
     port: 8080
   failureThreshold: 60
+  initialDelaySeconds: 0
   periodSeconds: 10
   timeoutSeconds: 5
 

--- a/backend/charts/pusher/templates/deployment.yaml
+++ b/backend/charts/pusher/templates/deployment.yaml
@@ -5,7 +5,10 @@ metadata:
   labels:
     {{- include "pusher.labels" . | nindent 4 }}
 spec:
-  minReadySeconds: {{ required "minReadySeconds is required" .Values.minReadySeconds }}
+  {{- if not (hasKey .Values "minReadySeconds") }}
+  {{- fail "minReadySeconds is required" }}
+  {{- end }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
   progressDeadlineSeconds: {{ required "progressDeadlineSeconds is required" .Values.progressDeadlineSeconds }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/backend/charts/pusher/templates/deployment.yaml
+++ b/backend/charts/pusher/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "pusher.labels" . | nindent 4 }}
 spec:
+  minReadySeconds: {{ required "minReadySeconds is required" .Values.minReadySeconds }}
+  progressDeadlineSeconds: {{ required "progressDeadlineSeconds is required" .Values.progressDeadlineSeconds }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}

--- a/backend/scripts/verify_pusher_rollout_budget.py
+++ b/backend/scripts/verify_pusher_rollout_budget.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Fail closed when Pusher rollout waits cannot cover the committed chart budget.
+
+The Pusher deployment rolls several replicas in sequence. A healthy pod may
+use its full startup, readiness, and minimum-ready allowance, so Kubernetes'
+progress deadline and the ``kubectl rollout status`` wait must both cover every
+wave at the HPA ceiling. This is intentionally stdlib-only because it runs in
+the shared pre-push and repository-check lanes before backend dependencies are
+installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ENVIRONMENTS = ("dev", "prod")
+WORKFLOW_ENVIRONMENTS = {
+    ".github/workflows/gcp_backend_pusher.yml": ("dev", "prod"),
+    ".github/workflows/gcp_backend_pusher_auto_deploy.yml": ("dev",),
+}
+ROLLOUT_TIMEOUT_PATTERN = re.compile(
+    r"rollout\s+status\s+deploy/\$\{\{\s*vars\.ENV\s*\}\}-omi-pusher\s+--timeout=(\d+)s"
+)
+PROGRESS_DEADLINE_TEMPLATE_PATTERN = re.compile(
+    r"^  progressDeadlineSeconds:\s*\{\{[^}]*\.Values\.progressDeadlineSeconds\b[^}]*\}\}\s*$",
+    re.MULTILINE,
+)
+MIN_READY_TEMPLATE_PATTERN = re.compile(
+    r"^  minReadySeconds:\s*\{\{[^}]*\.Values\.minReadySeconds\b[^}]*\}\}\s*$", re.MULTILINE
+)
+MAPPING_ENTRY_PATTERN = re.compile(r"^(?P<indent> *)(?P<key>[^\s#][^:]*):(?:\s*(?P<value>.*))?$")
+
+
+class ContractError(ValueError):
+    """Raised when committed chart inputs cannot establish a safe budget."""
+
+
+@dataclass(frozen=True)
+class MappingEntry:
+    line_number: int
+    indent: int
+    key: str
+    value: str
+
+
+@dataclass(frozen=True)
+class RolloutBudget:
+    environment: str
+    replica_ceiling: int
+    pods_in_flight: int
+    waves: int
+    startup_seconds_per_pod: int
+    readiness_seconds_per_pod: int
+    min_ready_seconds: int
+    availability_seconds_per_pod: int
+    required_seconds: int
+    progress_deadline_seconds: int
+
+
+def _strip_comment(value: str) -> str:
+    """Return one simple scalar value without its trailing YAML comment."""
+
+    return value.split("#", 1)[0].strip().strip("\"'")
+
+
+def _mapping_entries(path: Path) -> list[MappingEntry]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise ContractError(f"could not read {path}: {exc}") from exc
+
+    entries: list[MappingEntry] = []
+    for line_number, raw_line in enumerate(lines, start=1):
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        match = MAPPING_ENTRY_PATTERN.match(raw_line)
+        if match is None:
+            continue
+        entries.append(
+            MappingEntry(
+                line_number=line_number,
+                indent=len(match.group("indent")),
+                key=match.group("key").strip(),
+                value=_strip_comment(match.group("value") or ""),
+            )
+        )
+    return entries
+
+
+def _mapping_value(entries: list[MappingEntry], path: tuple[str, ...], source: Path) -> str:
+    """Read a scalar from the small mapping-only subset used by rollout values.
+
+    This deliberately does not become a general YAML parser.  The fields used
+    here are scalar mappings, while using stdlib keeps this CI/pre-push guard
+    available before PyYAML is installed.
+    """
+
+    start = 0
+    end = len(entries)
+    parent_indent = -1
+    selected: MappingEntry | None = None
+
+    for index, key in enumerate(path):
+        children = [entry for entry in entries[start:end] if entry.indent > parent_indent]
+        if not children:
+            raise ContractError(f"{source}: missing mapping {'/'.join(path[:index])}")
+        child_indent = min(entry.indent for entry in children)
+        matches = [entry for entry in children if entry.indent == child_indent and entry.key == key]
+        if len(matches) != 1:
+            qualifier = "missing" if not matches else "ambiguous"
+            raise ContractError(f"{source}: {qualifier} scalar {'/'.join(path[: index + 1])}")
+        selected = matches[0]
+
+        selected_index = entries.index(selected, start, end)
+        start = selected_index + 1
+        end = next(
+            (
+                candidate_index
+                for candidate_index in range(start, end)
+                if entries[candidate_index].indent <= selected.indent
+            ),
+            end,
+        )
+        parent_indent = selected.indent
+
+    assert selected is not None
+    if not selected.value:
+        raise ContractError(f"{source}:{selected.line_number}: {'/'.join(path)} must be an explicit scalar")
+    return selected.value
+
+
+def _positive_int(value: str, *, field: str, source: Path) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise ContractError(f"{source}: {field} must be an integer, got {value!r}") from exc
+    if parsed <= 0:
+        raise ContractError(f"{source}: {field} must be positive, got {parsed}")
+    return parsed
+
+
+def _nonnegative_int(value: str, *, field: str, source: Path) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise ContractError(f"{source}: {field} must be an integer, got {value!r}") from exc
+    if parsed < 0:
+        raise ContractError(f"{source}: {field} must not be negative, got {parsed}")
+    return parsed
+
+
+def _int_or_percent(value: str, *, replicas: int, round_up: bool, field: str, source: Path) -> int:
+    if value.endswith("%"):
+        percent = _nonnegative_int(value[:-1], field=field, source=source)
+        scaled = replicas * percent / 100
+        return math.ceil(scaled) if round_up else math.floor(scaled)
+    return _nonnegative_int(value, field=field, source=source)
+
+
+def rollout_budget(root: Path, environment: str) -> RolloutBudget:
+    """Derive a bounded healthy-rollout allowance from one values file.
+
+    Readiness failures can continue indefinitely, so they cannot be converted
+    into an honest finite rollout deadline. The bounded healthy envelope uses
+    the committed readiness failure and success thresholds; an outage that
+    exceeds that envelope remains a stalled rollout and should still fail.
+    """
+
+    values_path = root / "backend" / "charts" / "pusher" / f"{environment}_omi_pusher_values.yaml"
+    entries = _mapping_entries(values_path)
+
+    autoscaling_enabled = _mapping_value(entries, ("autoscaling", "enabled"), values_path).lower()
+    if autoscaling_enabled not in {"true", "false"}:
+        raise ContractError(f"{values_path}: autoscaling/enabled must be true or false")
+    if autoscaling_enabled == "true":
+        min_replicas = _positive_int(
+            _mapping_value(entries, ("autoscaling", "minReplicas"), values_path),
+            field="autoscaling/minReplicas",
+            source=values_path,
+        )
+        replica_ceiling = _positive_int(
+            _mapping_value(entries, ("autoscaling", "maxReplicas"), values_path),
+            field="autoscaling/maxReplicas",
+            source=values_path,
+        )
+        if replica_ceiling < min_replicas:
+            raise ContractError(
+                f"{values_path}: autoscaling/maxReplicas={replica_ceiling} must be at least minReplicas={min_replicas}"
+            )
+    else:
+        replica_ceiling = _positive_int(
+            _mapping_value(entries, ("replicaCount",), values_path),
+            field="replicaCount",
+            source=values_path,
+        )
+
+    strategy_type = _mapping_value(entries, ("strategy", "type"), values_path)
+    if strategy_type != "RollingUpdate":
+        raise ContractError(f"{values_path}: strategy/type must be RollingUpdate, got {strategy_type!r}")
+    max_surge = _int_or_percent(
+        _mapping_value(entries, ("strategy", "rollingUpdate", "maxSurge"), values_path),
+        replicas=replica_ceiling,
+        round_up=True,
+        field="strategy/rollingUpdate/maxSurge",
+        source=values_path,
+    )
+    max_unavailable = _int_or_percent(
+        _mapping_value(entries, ("strategy", "rollingUpdate", "maxUnavailable"), values_path),
+        replicas=replica_ceiling,
+        round_up=False,
+        field="strategy/rollingUpdate/maxUnavailable",
+        source=values_path,
+    )
+    pods_in_flight = max_surge + max_unavailable
+    if pods_in_flight <= 0:
+        raise ContractError(f"{values_path}: RollingUpdate must allow at least one pod in flight")
+
+    startup_failure_threshold = _positive_int(
+        _mapping_value(entries, ("startupProbe", "failureThreshold"), values_path),
+        field="startupProbe/failureThreshold",
+        source=values_path,
+    )
+    startup_initial_delay_seconds = _nonnegative_int(
+        _mapping_value(entries, ("startupProbe", "initialDelaySeconds"), values_path),
+        field="startupProbe/initialDelaySeconds",
+        source=values_path,
+    )
+    startup_period_seconds = _positive_int(
+        _mapping_value(entries, ("startupProbe", "periodSeconds"), values_path),
+        field="startupProbe/periodSeconds",
+        source=values_path,
+    )
+    startup_timeout_seconds = _positive_int(
+        _mapping_value(entries, ("startupProbe", "timeoutSeconds"), values_path),
+        field="startupProbe/timeoutSeconds",
+        source=values_path,
+    )
+    startup_seconds_per_pod = startup_initial_delay_seconds + startup_failure_threshold * max(
+        startup_period_seconds, startup_timeout_seconds
+    )
+
+    readiness_failure_threshold = _positive_int(
+        _mapping_value(entries, ("readinessProbe", "failureThreshold"), values_path),
+        field="readinessProbe/failureThreshold",
+        source=values_path,
+    )
+    readiness_initial_delay_seconds = _nonnegative_int(
+        _mapping_value(entries, ("readinessProbe", "initialDelaySeconds"), values_path),
+        field="readinessProbe/initialDelaySeconds",
+        source=values_path,
+    )
+    readiness_period_seconds = _positive_int(
+        _mapping_value(entries, ("readinessProbe", "periodSeconds"), values_path),
+        field="readinessProbe/periodSeconds",
+        source=values_path,
+    )
+    readiness_success_threshold = _positive_int(
+        _mapping_value(entries, ("readinessProbe", "successThreshold"), values_path),
+        field="readinessProbe/successThreshold",
+        source=values_path,
+    )
+    readiness_timeout_seconds = _positive_int(
+        _mapping_value(entries, ("readinessProbe", "timeoutSeconds"), values_path),
+        field="readinessProbe/timeoutSeconds",
+        source=values_path,
+    )
+    readiness_seconds_per_pod = readiness_initial_delay_seconds + (
+        readiness_failure_threshold + readiness_success_threshold
+    ) * max(readiness_period_seconds, readiness_timeout_seconds)
+    min_ready_seconds = _nonnegative_int(
+        _mapping_value(entries, ("minReadySeconds",), values_path),
+        field="minReadySeconds",
+        source=values_path,
+    )
+    availability_seconds_per_pod = startup_seconds_per_pod + readiness_seconds_per_pod + min_ready_seconds
+    waves = math.ceil(replica_ceiling / pods_in_flight)
+    required_seconds = waves * availability_seconds_per_pod
+    progress_deadline_seconds = _positive_int(
+        _mapping_value(entries, ("progressDeadlineSeconds",), values_path),
+        field="progressDeadlineSeconds",
+        source=values_path,
+    )
+
+    return RolloutBudget(
+        environment=environment,
+        replica_ceiling=replica_ceiling,
+        pods_in_flight=pods_in_flight,
+        waves=waves,
+        startup_seconds_per_pod=startup_seconds_per_pod,
+        readiness_seconds_per_pod=readiness_seconds_per_pod,
+        min_ready_seconds=min_ready_seconds,
+        availability_seconds_per_pod=availability_seconds_per_pod,
+        required_seconds=required_seconds,
+        progress_deadline_seconds=progress_deadline_seconds,
+    )
+
+
+def validate_template(root: Path) -> list[str]:
+    template = root / "backend" / "charts" / "pusher" / "templates" / "deployment.yaml"
+    try:
+        text = template.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"could not read {template}: {exc}"]
+    errors: list[str] = []
+    if not MIN_READY_TEMPLATE_PATTERN.search(text):
+        errors.append(f"{template}: Deployment spec must render minReadySeconds from .Values.minReadySeconds")
+    if not PROGRESS_DEADLINE_TEMPLATE_PATTERN.search(text):
+        errors.append(
+            f"{template}: Deployment spec must render progressDeadlineSeconds from .Values.progressDeadlineSeconds"
+        )
+    return errors
+
+
+def workflow_timeout_seconds(path: Path) -> int:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ContractError(f"could not read {path}: {exc}") from exc
+    found = [int(value) for value in ROLLOUT_TIMEOUT_PATTERN.findall(text)]
+    if len(found) != 1:
+        raise ContractError(f"{path}: expected exactly one numeric Pusher rollout status timeout, found {len(found)}")
+    return found[0]
+
+
+def validate(root: Path = ROOT) -> list[str]:
+    """Return every static contract violation for chart and workflow changes."""
+
+    errors = validate_template(root)
+    budgets: dict[str, RolloutBudget] = {}
+    for environment in ENVIRONMENTS:
+        try:
+            budget = rollout_budget(root, environment)
+        except ContractError as exc:
+            errors.append(str(exc))
+            continue
+        budgets[environment] = budget
+        if budget.progress_deadline_seconds < budget.required_seconds:
+            errors.append(
+                f"{environment} Pusher progressDeadlineSeconds={budget.progress_deadline_seconds}s is below the "
+                f"{budget.required_seconds}s healthy rollout budget ({budget.waves} waves x "
+                f"{budget.availability_seconds_per_pod}s availability allowance)"
+            )
+
+    for relative_path, environments in WORKFLOW_ENVIRONMENTS.items():
+        path = root / relative_path
+        try:
+            timeout_seconds = workflow_timeout_seconds(path)
+        except ContractError as exc:
+            errors.append(str(exc))
+            continue
+        required_seconds = max(
+            (budgets[environment].required_seconds for environment in environments if environment in budgets), default=0
+        )
+        if not required_seconds:
+            continue
+        if timeout_seconds < required_seconds:
+            environment_label = ", ".join(environments)
+            errors.append(
+                f"{relative_path}: Pusher rollout timeout={timeout_seconds}s is below the {required_seconds}s "
+                f"healthy rollout budget for {environment_label}"
+            )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT, help="Repository root (for hermetic fixture tests).")
+    args = parser.parse_args()
+    root = args.root.resolve()
+
+    errors = validate(root)
+    if errors:
+        print("FAIL: Pusher rollout readiness budget")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("OK: Pusher rollout readiness budget is covered.")
+    for environment in ENVIRONMENTS:
+        budget = rollout_budget(root, environment)
+        print(
+            f"- {environment}: {budget.waves} waves x {budget.availability_seconds_per_pod}s "
+            f"({budget.startup_seconds_per_pod}s startup + {budget.readiness_seconds_per_pod}s readiness + "
+            f"{budget.min_ready_seconds}s min-ready) = {budget.required_seconds}s; progress deadline "
+            f"{budget.progress_deadline_seconds}s"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -548,6 +548,22 @@
       ]
     },
     {
+      "id": "pusher_rollout_readiness",
+      "risk": "high",
+      "sources": [
+        "backend/charts/pusher/**",
+        ".github/workflows/gcp_backend_pusher.yml",
+        ".github/workflows/gcp_backend_pusher_auto_deploy.yml",
+        "backend/scripts/verify_pusher_rollout_budget.py"
+      ],
+      "tests": ["tests/unit/test_verify_pusher_rollout_budget.py"],
+      "checks": [],
+      "invariants": [
+        "Pusher's Kubernetes progress deadline and CI rollout wait both cover every configured healthy-availability wave at the committed HPA ceiling",
+        "a chart change to Pusher startup/readiness/min-ready, HPA, or RollingUpdate inputs cannot silently make a healthy rollout appear failed"
+      ]
+    },
+    {
       "id": "rendered_gke_deployment_identity",
       "risk": "high",
       "sources": [

--- a/backend/tests/unit/test_rendered_deployment_contract.py
+++ b/backend/tests/unit/test_rendered_deployment_contract.py
@@ -142,6 +142,50 @@ def test_dev_pusher_rollout_preserves_the_existing_replica(contracts: SimpleName
     assert rolling_update["maxSurge"] == 1
 
 
+@pytest.mark.parametrize("environment", ("dev", "prod"))
+def test_pusher_explicit_zero_min_ready_seconds_renders(contracts: SimpleNamespace, environment: str):
+    helm = shutil.which("helm")
+    assert helm is not None, "helm must be installed for the rendered deployment contract"
+    contract = next(contract for contract in contracts.CONTRACTS if contract.service == "pusher")
+
+    documents = contracts.render_chart(contract, environment, helm)
+    deployment = contracts.deployment_for(documents, contracts.release_name(contract, environment))
+
+    assert deployment is not None
+    assert deployment["spec"]["minReadySeconds"] == 0
+
+
+def test_pusher_rejects_a_missing_min_ready_seconds(contracts: SimpleNamespace, tmp_path: Path):
+    helm = shutil.which("helm")
+    assert helm is not None, "helm must be installed for the rendered deployment contract"
+    contract = next(contract for contract in contracts.CONTRACTS if contract.service == "pusher")
+    values = contracts.values_file(contract, "dev")
+    missing_min_ready_values = tmp_path / values.name
+    original = values.read_text(encoding="utf-8")
+    assert original.count("minReadySeconds: 0\n") == 1
+    missing_min_ready_values.write_text(original.replace("minReadySeconds: 0\n", "", 1), encoding="utf-8")
+
+    result = contracts.subprocess.run(
+        [
+            helm,
+            "template",
+            contracts.release_name(contract, "dev"),
+            str(contracts.chart_dir(contract)),
+            "-f",
+            str(missing_min_ready_values),
+            "--set-string",
+            f"image.tag={contracts.CONTRACT_IMAGE_TAG}",
+        ],
+        cwd=contracts.ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "minReadySeconds is required" in result.stderr
+
+
 def test_first_party_charts_reject_missing_image_tag_when_helm_is_available(contracts: SimpleNamespace):
     helm = shutil.which("helm")
     assert helm is not None, "helm must be installed for the rendered deployment contract"

--- a/backend/tests/unit/test_verify_pusher_rollout_budget.py
+++ b/backend/tests/unit/test_verify_pusher_rollout_budget.py
@@ -1,0 +1,222 @@
+"""Regression coverage for the static Pusher rollout-readiness guard."""
+
+from __future__ import annotations
+
+import runpy
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "backend" / "scripts" / "verify_pusher_rollout_budget.py"
+FIXTURE_FILES = (
+    "backend/charts/pusher/dev_omi_pusher_values.yaml",
+    "backend/charts/pusher/prod_omi_pusher_values.yaml",
+    "backend/charts/pusher/templates/deployment.yaml",
+    ".github/workflows/gcp_backend_pusher.yml",
+    ".github/workflows/gcp_backend_pusher_auto_deploy.yml",
+)
+
+
+@pytest.fixture(scope="module")
+def verifier() -> SimpleNamespace:
+    return SimpleNamespace(**runpy.run_path(str(SCRIPT)))
+
+
+@pytest.fixture
+def rollout_fixture(tmp_path: Path) -> Path:
+    for relative in FIXTURE_FILES:
+        source = REPO_ROOT / relative
+        destination = tmp_path / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, destination)
+    return tmp_path
+
+
+def replace_once(path: Path, before: str, after: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    assert text.count(before) == 1, f"expected exactly one {before!r} in {path}"
+    path.write_text(text.replace(before, after, 1), encoding="utf-8")
+
+
+def replace_probe_once(path: Path, probe: str, before: str, after: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    start = text.index(f"{probe}:")
+    end = text.index("\n\n", start)
+    section = text[start:end]
+    assert section.count(before) == 1, f"expected exactly one {before!r} in {probe} of {path}"
+    path.write_text(text[:start] + section.replace(before, after, 1) + text[end:], encoding="utf-8")
+
+
+def test_current_chart_and_workflows_cover_the_rollout_budget(verifier: SimpleNamespace) -> None:
+    assert verifier.validate(REPO_ROOT) == []
+
+    prod = verifier.rollout_budget(REPO_ROOT, "prod")
+    assert (
+        prod.replica_ceiling,
+        prod.pods_in_flight,
+        prod.waves,
+        prod.startup_seconds_per_pod,
+        prod.readiness_seconds_per_pod,
+        prod.min_ready_seconds,
+        prod.availability_seconds_per_pod,
+    ) == (40, 3, 14, 600, 40, 0, 640)
+    assert prod.required_seconds == 8960
+    assert prod.progress_deadline_seconds == 9600
+
+
+def test_rejects_workflow_wait_shorter_than_the_chart_budget(verifier: SimpleNamespace, rollout_fixture: Path) -> None:
+    workflow = rollout_fixture / ".github/workflows/gcp_backend_pusher.yml"
+    replace_once(workflow, "--timeout=9600s", "--timeout=300s")
+
+    errors = verifier.validate(rollout_fixture)
+
+    assert any(
+        "gcp_backend_pusher.yml: Pusher rollout timeout=300s is below the 8960s healthy rollout budget" in error
+        for error in errors
+    )
+
+
+def test_rejects_progress_deadline_shorter_than_the_chart_budget(
+    verifier: SimpleNamespace, rollout_fixture: Path
+) -> None:
+    values = rollout_fixture / "backend/charts/pusher/prod_omi_pusher_values.yaml"
+    replace_once(values, "progressDeadlineSeconds: 9600", "progressDeadlineSeconds: 8959")
+
+    errors = verifier.validate(rollout_fixture)
+
+    assert any(
+        "prod Pusher progressDeadlineSeconds=8959s is below the 8960s healthy rollout budget" in error
+        for error in errors
+    )
+
+
+@pytest.mark.parametrize(
+    ("before", "after", "required_seconds"),
+    [
+        ("failureThreshold: 60", "failureThreshold: 80", 11760),
+        ("maxReplicas: 40", "maxReplicas: 46", 10240),
+        ("maxSurge: 2", "maxSurge: 1", 12800),
+    ],
+)
+def test_chart_budget_changes_cannot_outgrow_the_deadline_or_wait(
+    verifier: SimpleNamespace,
+    rollout_fixture: Path,
+    before: str,
+    after: str,
+    required_seconds: int,
+) -> None:
+    values = rollout_fixture / "backend/charts/pusher/prod_omi_pusher_values.yaml"
+    replace_once(values, before, after)
+
+    errors = verifier.validate(rollout_fixture)
+
+    assert any(
+        f"prod Pusher progressDeadlineSeconds=9600s is below the {required_seconds}s healthy rollout budget" in error
+        for error in errors
+    )
+    assert any(
+        f"gcp_backend_pusher.yml: Pusher rollout timeout=9600s is below the {required_seconds}s healthy rollout budget"
+        in error
+        for error in errors
+    )
+
+
+@pytest.mark.parametrize(
+    ("probe", "before", "after", "required_seconds"),
+    [
+        ("startupProbe", "initialDelaySeconds: 0", "initialDelaySeconds: 100", 10360),
+        ("startupProbe", "timeoutSeconds: 5", "timeoutSeconds: 15", 13160),
+        ("readinessProbe", "failureThreshold: 3", "failureThreshold: 10", 9940),
+        ("readinessProbe", "initialDelaySeconds: 0", "initialDelaySeconds: 50", 9660),
+        ("readinessProbe", "periodSeconds: 10", "periodSeconds: 25", 9800),
+        ("readinessProbe", "successThreshold: 1", "successThreshold: 6", 9660),
+        ("readinessProbe", "timeoutSeconds: 5", "timeoutSeconds: 25", 9800),
+    ],
+)
+def test_probe_availability_delays_cannot_outgrow_the_deadline_or_wait(
+    verifier: SimpleNamespace,
+    rollout_fixture: Path,
+    probe: str,
+    before: str,
+    after: str,
+    required_seconds: int,
+) -> None:
+    values = rollout_fixture / "backend/charts/pusher/prod_omi_pusher_values.yaml"
+    replace_probe_once(values, probe, before, after)
+
+    errors = verifier.validate(rollout_fixture)
+
+    assert any(
+        f"prod Pusher progressDeadlineSeconds=9600s is below the {required_seconds}s healthy rollout budget" in error
+        for error in errors
+    )
+    assert any(
+        f"gcp_backend_pusher.yml: Pusher rollout timeout=9600s is below the {required_seconds}s healthy rollout budget"
+        in error
+        for error in errors
+    )
+
+
+def test_min_ready_delay_cannot_outgrow_the_deadline_or_wait(verifier: SimpleNamespace, rollout_fixture: Path) -> None:
+    values = rollout_fixture / "backend/charts/pusher/prod_omi_pusher_values.yaml"
+    replace_once(values, "minReadySeconds: 0", "minReadySeconds: 100")
+
+    errors = verifier.validate(rollout_fixture)
+
+    assert any(
+        "prod Pusher progressDeadlineSeconds=9600s is below the 10360s healthy rollout budget" in error
+        for error in errors
+    )
+    assert any(
+        "gcp_backend_pusher.yml: Pusher rollout timeout=9600s is below the 10360s healthy rollout budget" in error
+        for error in errors
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "before", "expected"),
+    [
+        ("backend/charts/pusher/prod_omi_pusher_values.yaml", "minReadySeconds: 0\n", "missing scalar minReadySeconds"),
+        (
+            "backend/charts/pusher/prod_omi_pusher_values.yaml",
+            "  successThreshold: 1\n",
+            "missing scalar readinessProbe/successThreshold",
+        ),
+    ],
+)
+def test_rejects_implicit_availability_delay_defaults(
+    verifier: SimpleNamespace, rollout_fixture: Path, path: str, before: str, expected: str
+) -> None:
+    values = rollout_fixture / path
+    replace_once(values, before, "")
+
+    errors = verifier.validate(rollout_fixture)
+
+    assert any(expected in error for error in errors)
+
+
+def test_rejects_template_that_does_not_render_the_chart_deadline(
+    verifier: SimpleNamespace, rollout_fixture: Path
+) -> None:
+    template = rollout_fixture / "backend/charts/pusher/templates/deployment.yaml"
+    replace_once(
+        template,
+        'minReadySeconds: {{ required "minReadySeconds is required" .Values.minReadySeconds }}',
+        "minReadySeconds: 0",
+    )
+    replace_once(
+        template,
+        'progressDeadlineSeconds: {{ required "progressDeadlineSeconds is required" .Values.progressDeadlineSeconds }}',
+        "progressDeadlineSeconds: 9600",
+    )
+
+    errors = verifier.validate(rollout_fixture)
+
+    assert any(
+        "Deployment spec must render progressDeadlineSeconds from .Values.progressDeadlineSeconds" in error
+        for error in errors
+    )
+    assert any("Deployment spec must render minReadySeconds from .Values.minReadySeconds" in error for error in errors)

--- a/backend/tests/unit/test_verify_pusher_rollout_budget.py
+++ b/backend/tests/unit/test_verify_pusher_rollout_budget.py
@@ -204,7 +204,7 @@ def test_rejects_template_that_does_not_render_the_chart_deadline(
     template = rollout_fixture / "backend/charts/pusher/templates/deployment.yaml"
     replace_once(
         template,
-        'minReadySeconds: {{ required "minReadySeconds is required" .Values.minReadySeconds }}',
+        "minReadySeconds: {{ .Values.minReadySeconds }}",
         "minReadySeconds: 0",
     )
     replace_once(

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -1,7 +1,7 @@
 import importlib.util
 import json
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import pytest
 
@@ -58,6 +58,8 @@ def test_workflow_contract_sources_select_adjacent_tests(selector_and_all_tests)
         "scripts/voice-provider-probe.sh": "tests/unit/test_voice_provider_probe.py",
         ".github/workflows/desktop_backend_auto_dev.yml": "tests/unit/test_voice_provider_probe.py",
         "backend/charts/pusher/templates/deployment.yaml": "tests/unit/test_rendered_deployment_contract.py",
+        ".github/workflows/gcp_backend_pusher.yml": "tests/unit/test_verify_pusher_rollout_budget.py",
+        "backend/scripts/verify_pusher_rollout_budget.py": "tests/unit/test_verify_pusher_rollout_budget.py",
         "backend/scripts/validate_rendered_deployment_contract.py": "tests/unit/test_rendered_deployment_contract.py",
         ".github/workflows/gcp_backend_auto_dev.yml": "tests/unit/test_verify_backend_release_vector.py",
         ".github/workflows/gcp_llm_gateway.yml": "tests/unit/test_preflight_cloud_run_deploy.py",
@@ -172,10 +174,13 @@ def test_every_external_workflow_contract_source_triggers_backend_unit_workflow(
         for source in workflow.get("sources", [])
         if not source.startswith("backend/")
     }
+    triggers = re.findall(r"^\s*-\s+['\"]([^'\"]+)['\"]\s*$", workflow_text, flags=re.MULTILINE)
     missing = {
         source
         for source in external_sources
-        if f"- '{source}'" not in workflow_text and f'- "{source}"' not in workflow_text
+        if not any(
+            source == trigger or ("*" not in source and PurePosixPath(source).match(trigger)) for trigger in triggers
+        )
     }
 
     assert missing == set()


### PR DESCRIPTION
## What changed and why

Closes #9988.

Pusher could be healthy yet fail deployment because its two GitHub Actions waits and Kubernetes' implicit 600-second progress deadline were shorter than the chart's rollout-readiness budget. The chart now declares a 9600-second deadline, both deployment entry points wait that long, and a checked-in guard derives the required bound from Pusher's HPA ceiling, rolling strategy, startup probe, readiness probe, and `minReadySeconds`.

The chart makes every timing input used by the guard explicit. The guard uses a bounded healthy availability envelope: startup initial delay plus its probe window, then readiness initial delay plus its configured failure/success probe window, then `minReadySeconds`. A readiness outage can be unbounded in reality, so it must remain a stalled rollout rather than being disguised as a finite healthy deadline.

## Product invariants affected

none

## How it was verified

- `python3 backend/scripts/verify_pusher_rollout_budget.py` — current dev and prod values pass; prod derives fourteen 640-second availability waves (8960 seconds) at its HPA maximum of 40 under the 9600-second deadline.
- `helm template` and `helm lint` for both Pusher values files — each renders `spec.minReadySeconds: 0` and `spec.progressDeadlineSeconds: 9600`.
- `actionlint -shellcheck "" .github/workflows/gcp_backend_pusher.yml .github/workflows/gcp_backend_pusher_auto_deploy.yml` — both edited workflows are valid.

## Tests

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_verify_pusher_rollout_budget.py -q` — 17 passed, including mutations for undersized waits/deadlines, the HPA maximum, startup initial delay/timeout, readiness failure/initial-delay/period/success/timeout settings, `minReadySeconds`, and rolling strategy.
- `backend/.venv/bin/python -m pytest backend/tests/unit/test_rendered_deployment_contract.py backend/tests/unit/test_workflow_contracts.py -q` — 30 passed.
- `python3 .github/scripts/test_run_checks.py` and `python3 backend/scripts/check_workflow_contracts.py --changed-files <(git diff --name-only)` — passed.
- `make preflight` and the bounded `scripts/pre-push` gate — passed.

## Failure class (fixes)

Failure-Class: none

## New guards

This is the Pusher-specific analogue of the healthy-rollout failures fixed in [#9915](https://github.com/BasedHardware/omi/pull/9915) and [#9939](https://github.com/BasedHardware/omi/pull/9939); it is not a shared primitive because the bound is deliberately derived from Pusher's own chart inputs and deploy writers.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

