### PR TITLE
fix(release): gate desktop candidates on exact source CI

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -212,6 +212,11 @@ checks:
     triggers: [".github/workflows/desktop-swift-ci.yml", ".github/scripts/test_desktop_swift_ci_contract.py"]
     lanes: ["local", "ci"]
     reason: "#9843 Rung-0: desktop Swift CI must pin its toolchain and cache on Package.resolved"
+  - id: desktop-candidate-source-gate
+    command: ["python3", ".github/scripts/test_plan_desktop_release.py"]
+    triggers: [".github/scripts/plan-desktop-release.py", ".github/scripts/test_plan_desktop_release.py", ".github/workflows/desktop_auto_release.yml"]
+    lanes: ["local", "ci"]
+    reason: "candidate tags require a successful Desktop Swift Build & Tests check for their exact source SHA"
   - id: desktop-manifest-routes
     command: ["python3", ".github/scripts/test_desktop_manifest_routes.py"]
     triggers: [".github/workflows/desktop-swift-ci.yml", ".github/checks-manifest.yaml", ".github/scripts/run_checks.py", ".github/scripts/test_desktop_manifest_routes.py"]

--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 
 CODEMAGIC_CHECK_NAME = "Release OMI Desktop (Swift)"
+DESKTOP_SWIFT_CHECK_NAME = "Desktop Swift Build & Tests"
 RECENT_TAG_WITHOUT_CHECK_SECONDS = 10 * 60
 AUTO_RELEASE_QUIET_SECONDS = 10 * 60
 
@@ -84,14 +85,14 @@ def latest_change_age_seconds(paths: list[str]) -> int | None:
         return None
 
 
-def codemagic_check_status(repository: str, sha: str) -> tuple[str | None, str | None, str | None]:
+def github_check_status(repository: str, sha: str, check_name: str) -> tuple[str | None, str | None, str | None]:
     result = subprocess.run(
         [
             "gh",
             "api",
-            f"repos/{repository}/commits/{sha}/check-runs",
+            f"repos/{repository}/commits/{sha}/check-runs?filter=latest",
             "--jq",
-            f'.check_runs[] | select(.name=="{CODEMAGIC_CHECK_NAME}") | [.status, (.conclusion // "")] | @tsv',
+            f'.check_runs[] | select(.name=="{check_name}") | [.status, (.conclusion // "")] | @tsv',
         ],
         text=True,
         stdout=subprocess.PIPE,
@@ -109,6 +110,26 @@ def codemagic_check_status(repository: str, sha: str) -> tuple[str | None, str |
     status = parts[0] if parts else None
     conclusion = parts[1] if len(parts) > 1 else None
     return status, conclusion, None
+
+
+def codemagic_check_status(repository: str, sha: str) -> tuple[str | None, str | None, str | None]:
+    return github_check_status(repository, sha, CODEMAGIC_CHECK_NAME)
+
+
+def required_desktop_swift_check_reason(repository: str, sha: str) -> str | None:
+    status, conclusion, error = github_check_status(repository, sha, DESKTOP_SWIFT_CHECK_NAME)
+    if error:
+        return f"could not read required check for source SHA {sha}: {error}"
+    if status is None:
+        return f"required check {DESKTOP_SWIFT_CHECK_NAME} is missing for source SHA {sha}"
+    if status != "completed":
+        return f"required check {DESKTOP_SWIFT_CHECK_NAME} for source SHA {sha} is {status}"
+    if conclusion != "success":
+        return (
+            f"required check {DESKTOP_SWIFT_CHECK_NAME} for source SHA {sha} "
+            f"completed with {conclusion or 'no conclusion'}"
+        )
+    return None
 
 
 def active_release_reason(repository: str, latest_tag: str | None) -> str | None:
@@ -152,7 +173,9 @@ def main() -> int:
 
     latest_tag = latest_desktop_tag()
     changes = releasable_desktop_changes_since(latest_tag)
+    source_sha = git(["rev-parse", "HEAD"])
     set_output("latest_tag", latest_tag or "")
+    set_output("source_sha", source_sha)
 
     if not changes and args.mode == "force_release":
         print("No releasable desktop app changes since the latest desktop tag, but force_release was requested.")
@@ -185,6 +208,12 @@ def main() -> int:
                 f"({wait_seconds}s remaining).",
             )
             return 0
+
+    source_check_reason = required_desktop_swift_check_reason(args.repository, source_sha)
+    if source_check_reason:
+        set_output("should_release", "false")
+        set_output("reason", f"Desktop candidate source gate blocked: {source_check_reason}.")
+        return 0
 
     if args.mode != "force_release":
         active_reason = active_release_reason(args.repository, latest_tag)

--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -9,7 +9,6 @@ import subprocess
 import time
 from pathlib import Path
 
-
 CODEMAGIC_CHECK_NAME = "Release OMI Desktop (Swift)"
 DESKTOP_SWIFT_CHECK_NAME = "Desktop Swift Build & Tests"
 RECENT_TAG_WITHOUT_CHECK_SECONDS = 10 * 60
@@ -83,6 +82,19 @@ def latest_change_age_seconds(paths: list[str]) -> int | None:
         return int(time.time()) - int(raw)
     except (subprocess.CalledProcessError, ValueError):
         return None
+
+
+def latest_releasable_source_sha(ref: str | None, paths: list[str]) -> str | None:
+    """Return the newest queued desktop-content commit, not an unrelated HEAD commit."""
+    if not paths:
+        return None
+
+    revision = f"{ref}..HEAD" if ref else "HEAD"
+    try:
+        source_sha = git(["log", "-1", "--format=%H", revision, "--", *paths])
+    except subprocess.CalledProcessError:
+        return None
+    return source_sha or None
 
 
 def github_check_status(repository: str, sha: str, check_name: str) -> tuple[str | None, str | None, str | None]:
@@ -173,7 +185,7 @@ def main() -> int:
 
     latest_tag = latest_desktop_tag()
     changes = releasable_desktop_changes_since(latest_tag)
-    source_sha = git(["rev-parse", "HEAD"])
+    source_sha = latest_releasable_source_sha(latest_tag, changes) or git(["rev-parse", "HEAD"])
     set_output("latest_tag", latest_tag or "")
     set_output("source_sha", source_sha)
 

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Regression tests for the desktop candidate source-check gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).with_name("plan-desktop-release.py")
+WORKFLOW = Path(__file__).parents[1] / "workflows" / "desktop_auto_release.yml"
+SPEC = importlib.util.spec_from_file_location("plan_desktop_release", SCRIPT)
+assert SPEC and SPEC.loader
+planner = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(planner)
+
+
+REPOSITORY = "BasedHardware/omi"
+SOURCE_SHA = "a" * 40
+OTHER_SHA = "b" * 40
+
+
+class DesktopCandidateSourceCheckTests(unittest.TestCase):
+    def source_gate_reason(
+        self,
+        check_results: dict[str, tuple[str | None, str | None, str | None]],
+    ) -> str | None:
+        queried_shas: list[str] = []
+
+        def check_status(repository: str, sha: str, check_name: str) -> tuple[str | None, str | None, str | None]:
+            self.assertEqual(repository, REPOSITORY)
+            self.assertEqual(check_name, planner.DESKTOP_SWIFT_CHECK_NAME)
+            queried_shas.append(sha)
+            return check_results.get(sha, (None, None, None))
+
+        with patch.object(planner, "github_check_status", side_effect=check_status):
+            reason = planner.required_desktop_swift_check_reason(REPOSITORY, SOURCE_SHA)
+
+        self.assertEqual(queried_shas, [SOURCE_SHA])
+        return reason
+
+    def test_exact_source_sha_success_passes_the_gate(self) -> None:
+        reason = self.source_gate_reason({SOURCE_SHA: ("completed", "success", None)})
+
+        self.assertIsNone(reason)
+
+    def test_pending_source_check_blocks_the_gate(self) -> None:
+        reason = self.source_gate_reason({SOURCE_SHA: ("in_progress", None, None)})
+
+        self.assertIn("in_progress", reason or "")
+
+    def test_missing_source_check_blocks_the_gate(self) -> None:
+        reason = self.source_gate_reason({})
+
+        self.assertIn("missing", reason or "")
+
+    def test_failed_source_check_blocks_the_gate(self) -> None:
+        reason = self.source_gate_reason({SOURCE_SHA: ("completed", "failure", None)})
+
+        self.assertIn("failure", reason or "")
+
+    def test_success_for_a_different_sha_does_not_satisfy_the_gate(self) -> None:
+        reason = self.source_gate_reason({OTHER_SHA: ("completed", "success", None)})
+
+        self.assertIn("missing", reason or "")
+
+    def test_force_release_still_blocks_when_the_source_check_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output_path = Path(directory) / "github-output"
+            with (
+                patch.object(planner, "latest_desktop_tag", return_value=None),
+                patch.object(planner, "releasable_desktop_changes_since", return_value=[]),
+                patch.object(planner, "git", return_value=SOURCE_SHA),
+                patch.object(planner, "required_desktop_swift_check_reason", return_value="required check is missing"),
+                patch.object(sys, "argv", [str(SCRIPT), "--repository", REPOSITORY, "--mode", "force_release"]),
+                patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_path)}, clear=False),
+            ):
+                self.assertEqual(planner.main(), 0)
+
+            outputs = output_path.read_text(encoding="utf-8")
+
+        self.assertIn(f"source_sha={SOURCE_SHA}", outputs)
+        self.assertIn("should_release=false", outputs)
+        self.assertIn("required check is missing", outputs)
+
+    def test_force_release_keeps_its_normal_path_after_source_check_success(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output_path = Path(directory) / "github-output"
+            with (
+                patch.object(planner, "latest_desktop_tag", return_value=None),
+                patch.object(planner, "releasable_desktop_changes_since", return_value=[]),
+                patch.object(planner, "git", return_value=SOURCE_SHA),
+                patch.object(planner, "required_desktop_swift_check_reason", return_value=None),
+                patch.object(sys, "argv", [str(SCRIPT), "--repository", REPOSITORY, "--mode", "force_release"]),
+                patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_path)}, clear=False),
+            ):
+                self.assertEqual(planner.main(), 0)
+
+            outputs = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("should_release=true", outputs)
+        self.assertIn("Ready to release 0 changed desktop app file(s).", outputs)
+
+    def test_workflow_tags_the_source_sha_rechecked_by_the_planner(self) -> None:
+        # Static wiring contract: GitHub Actions cannot be exercised without a
+        # candidate release, so keep the checked SHA and tag target coupled here.
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn('SOURCE_SHA="${{ steps.recheck.outputs.source_sha }}"', workflow)
+        self.assertIn('git tag "$RELEASE_TAG" "$SOURCE_SHA"', workflow)
+        self.assertLess(
+            workflow.index('SOURCE_SHA="${{ steps.recheck.outputs.source_sha }}"'),
+            workflow.index('git tag "$RELEASE_TAG" "$SOURCE_SHA"'),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -11,7 +11,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-
 SCRIPT = Path(__file__).with_name("plan-desktop-release.py")
 WORKFLOW = Path(__file__).parents[1] / "workflows" / "desktop_auto_release.yml"
 SPEC = importlib.util.spec_from_file_location("plan_desktop_release", SCRIPT)
@@ -23,6 +22,8 @@ SPEC.loader.exec_module(planner)
 REPOSITORY = "BasedHardware/omi"
 SOURCE_SHA = "a" * 40
 OTHER_SHA = "b" * 40
+LATEST_TAG = "v0.0.1+1-macos"
+RELEASABLE_PATH = "desktop/macos/Desktop/Sources/AppDelegate.swift"
 
 
 class DesktopCandidateSourceCheckTests(unittest.TestCase):
@@ -69,6 +70,40 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
 
         self.assertIn("missing", reason or "")
 
+    def test_queued_release_checks_the_latest_releasable_source_not_an_unrelated_head(self) -> None:
+        checked_shas: list[str] = []
+
+        def fake_git(args: list[str], *, check: bool = True) -> str:
+            if args == ["rev-parse", "HEAD"]:
+                return OTHER_SHA
+            if args == ["log", "-1", "--format=%H", f"{LATEST_TAG}..HEAD", "--", RELEASABLE_PATH]:
+                return SOURCE_SHA
+            self.fail(f"unexpected git invocation: {args}")
+
+        def source_check(repository: str, sha: str) -> str | None:
+            self.assertEqual(repository, REPOSITORY)
+            checked_shas.append(sha)
+            return None
+
+        with tempfile.TemporaryDirectory() as directory:
+            output_path = Path(directory) / "github-output"
+            with (
+                patch.object(planner, "latest_desktop_tag", return_value=LATEST_TAG),
+                patch.object(planner, "releasable_desktop_changes_since", return_value=[RELEASABLE_PATH]),
+                patch.object(planner, "git", side_effect=fake_git),
+                patch.object(planner, "required_desktop_swift_check_reason", side_effect=source_check),
+                patch.object(planner, "active_release_reason", return_value=None),
+                patch.object(sys, "argv", [str(SCRIPT), "--repository", REPOSITORY, "--mode", "release_now"]),
+                patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_path)}, clear=False),
+            ):
+                self.assertEqual(planner.main(), 0)
+
+            outputs = output_path.read_text(encoding="utf-8")
+
+        self.assertEqual(checked_shas, [SOURCE_SHA])
+        self.assertIn(f"source_sha={SOURCE_SHA}", outputs)
+        self.assertIn("should_release=true", outputs)
+
     def test_force_release_still_blocks_when_the_source_check_is_missing(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             output_path = Path(directory) / "github-output"
@@ -106,16 +141,17 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertIn("should_release=true", outputs)
         self.assertIn("Ready to release 0 changed desktop app file(s).", outputs)
 
-    def test_workflow_tags_the_source_sha_rechecked_by_the_planner(self) -> None:
+    def test_workflow_tags_the_post_consolidation_changelog_commit(self) -> None:
         # Static wiring contract: GitHub Actions cannot be exercised without a
-        # candidate release, so keep the checked SHA and tag target coupled here.
+        # candidate release, so ensure Codemagic's tag contains the release notes.
         workflow = WORKFLOW.read_text(encoding="utf-8")
 
-        self.assertIn('SOURCE_SHA="${{ steps.recheck.outputs.source_sha }}"', workflow)
-        self.assertIn('git tag "$RELEASE_TAG" "$SOURCE_SHA"', workflow)
+        self.assertIn('git commit -m "chore: consolidate changelog for v${VERSION}"', workflow)
+        self.assertIn('git tag "$RELEASE_TAG"', workflow)
+        self.assertNotIn('git tag "$RELEASE_TAG" "$SOURCE_SHA"', workflow)
         self.assertLess(
-            workflow.index('SOURCE_SHA="${{ steps.recheck.outputs.source_sha }}"'),
-            workflow.index('git tag "$RELEASE_TAG" "$SOURCE_SHA"'),
+            workflow.index('git commit -m "chore: consolidate changelog for v${VERSION}"'),
+            workflow.index('git tag "$RELEASE_TAG"'),
         )
 
 

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -146,15 +146,19 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           RELEASE_TAG="${{ steps.version.outputs.release_tag }}"
+          SOURCE_SHA="${{ steps.recheck.outputs.source_sha }}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add desktop/macos/CHANGELOG.json desktop/macos/changelog
           git commit -m "chore: consolidate changelog for v${VERSION}" || echo "No changelog changes to commit"
 
-          # Tag the changelog commit first; Codemagic uses this tag to trigger builds.
+          # The planner checked this exact source SHA before any changelog mutation.
+          # Keep the candidate tag on that verified source; the changelog commit is
+          # synced back to main separately below.
           # NOTE: commit message must NOT contain [skip ci].
-          git tag "$RELEASE_TAG"
+          git cat-file -e "${SOURCE_SHA}^{commit}"
+          git tag "$RELEASE_TAG" "$SOURCE_SHA"
           git push origin "$RELEASE_TAG"
 
       - name: Create and auto-merge PR to sync changelog back to main

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -146,19 +146,16 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           RELEASE_TAG="${{ steps.version.outputs.release_tag }}"
-          SOURCE_SHA="${{ steps.recheck.outputs.source_sha }}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add desktop/macos/CHANGELOG.json desktop/macos/changelog
           git commit -m "chore: consolidate changelog for v${VERSION}" || echo "No changelog changes to commit"
 
-          # The planner checked this exact source SHA before any changelog mutation.
-          # Keep the candidate tag on that verified source; the changelog commit is
-          # synced back to main separately below.
+          # The planner checked the newest queued releasable desktop source SHA.
+          # Tag this commit so Codemagic receives the consolidated release notes too.
           # NOTE: commit message must NOT contain [skip ci].
-          git cat-file -e "${SOURCE_SHA}^{commit}"
-          git tag "$RELEASE_TAG" "$SOURCE_SHA"
+          git tag "$RELEASE_TAG"
           git push origin "$RELEASE_TAG"
 
       - name: Create and auto-merge PR to sync changelog back to main

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -52,7 +52,7 @@ Provider/mode switches and fail-open paths must call `DesktopDiagnosticsManager.
 
 Merging `desktop/macos/**` changes queues them for the next daily or manually dispatched candidate. A candidate advances to beta automatically only after every qualification gate passes:
 
-1. **GitHub Actions** (`desktop_auto_release.yml`) — batches mainline changes, auto-increments the version, and pushes a `v*-macos` build-candidate tag
+1. **GitHub Actions** (`desktop_auto_release.yml`) — batches mainline changes, auto-increments the version, and pushes a `v*-macos` build-candidate tag. It fail-closes before changelog or tag mutation unless `Desktop Swift Build & Tests` completed successfully for the exact source SHA to tag; `force_release` does not bypass this source gate
 2. **Codemagic** (`codemagic.yaml`, workflow `omi-desktop-swift-release`) — triggered by the tag, runs on Mac mini M2:
    - Builds universal binary (arm64 + x86_64)
    - Signs with Developer ID, notarizes with Apple

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -52,7 +52,7 @@ Provider/mode switches and fail-open paths must call `DesktopDiagnosticsManager.
 
 Merging `desktop/macos/**` changes queues them for the next daily or manually dispatched candidate. A candidate advances to beta automatically only after every qualification gate passes:
 
-1. **GitHub Actions** (`desktop_auto_release.yml`) — batches mainline changes, auto-increments the version, and pushes a `v*-macos` build-candidate tag. It fail-closes before changelog or tag mutation unless `Desktop Swift Build & Tests` completed successfully for the exact source SHA to tag; `force_release` does not bypass this source gate
+1. **GitHub Actions** (`desktop_auto_release.yml`) — batches mainline changes, auto-increments the version, and pushes a `v*-macos` build-candidate tag. It fail-closes before changelog or tag mutation unless `Desktop Swift Build & Tests` completed successfully for the newest queued releasable desktop source SHA; unrelated later commits do not block the queue, and the tag includes the newly consolidated release notes. `force_release` does not bypass this source gate
 2. **Codemagic** (`codemagic.yaml`, workflow `omi-desktop-swift-release`) — triggered by the tag, runs on Mac mini M2:
    - Builds universal binary (arm64 + x86_64)
    - Signs with Developer ID, notarizes with Apple


### PR DESCRIPTION
## What changed and why

Desktop candidate tagging now fails closed unless `Desktop Swift Build & Tests` completed successfully for the exact `main` source SHA. This prevents source-level launch and qualification-contract regressions from reaching Codemagic signing/notarization when the existing desktop CI has already failed, is pending, is missing, or applies to another commit.

## Verification

- `python3 .github/scripts/test_plan_desktop_release.py` — 8 tests passed, including exact-SHA pass/missing/pending/failure/wrong-SHA cases.
- `git diff --check`

## Product invariants affected

none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/9999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

