### PR TITLE
test(listen): cover durable finalization recovery through Cloud Tasks

### DIFF
--- a/backend/testing/listen_pusher_stack/README.md
+++ b/backend/testing/listen_pusher_stack/README.md
@@ -13,12 +13,17 @@ Homebrew's `openjdk@21` automatically when `java` is not already on `PATH` and
 chooses a per-run Firestore emulator port, so it does not conflict with shared
 developer services.
 
-It starts an isolated Redis and three local ASGI processes while Firebase's
-command owns a fresh Firestore emulator:
+It starts an isolated Redis and local ASGI processes while Firebase's command
+owns a fresh Firestore emulator. The inline scenarios use the real backend,
+pusher, and Parakeet stub; durable scenarios start separate real listener and
+finalization-worker processes with a strict loopback Cloud Tasks client:
 
 ```text
 native /v4/listen client → real backend → real pusher
                                ↘ real Parakeet WS client → local protocol stub
+
+real listener admission → real tasks_v2.Task → strict loopback task record
+                                                   ↘ separate real finalization worker route
 ```
 
 The child-process environment is allowlisted: it has a private empty
@@ -28,32 +33,55 @@ rejects a non-loopback Firestore endpoint.
 
 The test deliberately exercises the production listen runtime (`main:app`),
 real pusher router, binary frames 101/102/103/104/201, Firestore finalization
-jobs, leases, fanout admission/idempotency, recording-session binding, and
-reconnect code.
+jobs, leases, fanout admission/idempotency, recording-session binding,
+reconnect code, and the real Cloud Tasks finalization handler.
 It seeds private-cloud mode only to make the real 103 + 101 audio frames flow;
 the provider/storage leaves are disabled because this harness has no cloud
 credentials.
 
-The pusher entrypoint replaces only these provider-side leaves:
+The pusher entrypoint (for inline scenarios) and the Cloud Tasks entrypoint
+(for durable scenarios) replace only these provider-side leaves:
 
 - conversation LLM processing;
 - memory extraction;
 - external-integration delivery.
 - private-cloud audio storage (the queue and 101/103 frame handling remain real).
 
-The real finalizer still persists through the lifecycle owner, claims and
-completes durable fanout, and sends the real pusher result frame. It does not
-prove LLM/vector output quality, GCS delivery, or downstream integration
-delivery. Trace files record frame metadata and byte counts, never audio or
-transcript text.
+The real finalizer still persists through the lifecycle owner and claims and
+completes durable fanout. Inline pusher scenarios also send the real pusher
+result frame. In durable mode, production code builds the real `tasks_v2.Task`;
+the strict local client
+accepts only its opaque `{job_id, dispatch_generation}` payload, a loopback
+HTTP handler URL, expected OIDC audience/service account, and the production
+dispatch deadline. The harness replaces only OIDC signature verification with
+a local bearer token, while the production FastAPI dependency and retry-count
+header remain in the request path.
+
+It does not prove LLM/vector output quality, GCS delivery, downstream
+integration delivery, Cloud Tasks IAM provisioning, or Google OIDC signature
+verification. Trace files record durable IDs, frame metadata, and byte counts,
+never audio or transcript text.
 
 Scenarios:
 
-1. audio → streaming segment → persisted content → close → durable completed job;
+1. audio → streaming segment → stale live-session lifecycle → persisted content → completed inline job;
 2. completed native UUID reconnect replays the terminal binding without a new job;
 3. a stale empty desktop recording is removed by the next-session lifecycle path and creates no job;
 4. a pusher process loses the first 104 before claim, is restarted, and the
    live backend session replays the same job ID and dispatch generation exactly once.
+5. a session closes during the deferred pending-finalization window; the real
+   recovery path from #9960 enqueues one opaque Cloud Tasks task, then a real
+   worker retry preserves `processing` until it completes the same job;
+6. a worker exhausting its two-attempt test budget atomically dead-letters the
+   job and marks the still-current conversation `failed`/`discarded`, while a
+   later duplicate delivery is fenced;
+7. an integration failure after processing retries only durable fanout, never
+   re-runs completed conversation processing.
+
+The inline compatibility coverage deliberately triggers stale live-session
+finalization before closing. A source close immediately after opcode 104 takes
+a different inline/BYOK cancellation path, tracked in #9995; only the detached
+Cloud Tasks scenarios assert clean-close durability.
 
 This complements, rather than replaces, the storage race test:
 

--- a/backend/testing/listen_pusher_stack/cloud_tasks.py
+++ b/backend/testing/listen_pusher_stack/cloud_tasks.py
@@ -1,0 +1,176 @@
+"""Strict loopback Cloud Tasks seam for the listen finalization gauntlet.
+
+The production enqueue code still constructs the real ``tasks_v2.Task``.  This
+client accepts only the finalization task shape, persists sanitized metadata,
+and never has credentials or a route beyond the local ASGI process.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from contextlib import contextmanager
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Iterator
+from urllib.parse import urlparse
+
+from fastapi import HTTPException, Request
+from google.api_core.exceptions import AlreadyExists
+from google.cloud import tasks_v2
+
+from utils import cloud_tasks
+from utils.cloud_tasks import DISPATCH_DEADLINE_SECONDS
+
+FINALIZATION_HANDLER_PATH = '/v1/conversation-finalization-jobs/run'
+TASK_EVENTS_FILE = 'cloud_tasks.jsonl'
+LOCAL_TASK_TOKEN_ENV = 'OMI_STACK_LOCAL_TASK_TOKEN'
+
+
+def _state_dir() -> Path:
+    value = os.getenv('OMI_STACK_STATE_DIR')
+    if not value:
+        raise RuntimeError('OMI_STACK_STATE_DIR is required for the loopback Cloud Tasks client')
+    return Path(value)
+
+
+def _append_event(event: dict[str, Any]) -> None:
+    path = _state_dir() / TASK_EVENTS_FILE
+    with path.open('a', encoding='utf-8') as output:
+        output.write(json.dumps(event, sort_keys=True) + '\n')
+
+
+def _read_task_names() -> set[str]:
+    path = _state_dir() / TASK_EVENTS_FILE
+    if not path.exists():
+        return set()
+    names: set[str] = set()
+    for line in path.read_text(encoding='utf-8').splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if (
+            isinstance(event, dict)
+            and event.get('event') == 'task_enqueued'
+            and isinstance(event.get('task_name'), str)
+        ):
+            names.add(event['task_name'])
+    return names
+
+
+@contextmanager
+def _task_event_lock() -> Iterator[None]:
+    """Serialize named-task creation across listener processes."""
+    path = _state_dir() / 'cloud_tasks.lock'
+    with path.open('a+', encoding='utf-8') as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+class StrictLoopbackTasksClient:
+    """The narrow ``CloudTasksClient`` surface the finalization enqueue uses."""
+
+    def queue_path(self, project: str, location: str, queue: str) -> str:
+        return f'projects/{project}/locations/{location}/queues/{queue}'
+
+    def task_path(self, project: str, location: str, queue: str, task_id: str) -> str:
+        return f'{self.queue_path(project, location, queue)}/tasks/{task_id}'
+
+    def create_task(self, *, parent: str, task: Any) -> Any:
+        project = os.getenv('SYNC_TASKS_PROJECT', '')
+        location = os.getenv('SYNC_TASKS_LOCATION', '')
+        queue = os.getenv('LISTEN_FINALIZATION_TASKS_QUEUE', '')
+        handler_url = os.getenv('LISTEN_FINALIZATION_TASKS_HANDLER_URL', '')
+        invoker_sa = os.getenv('LISTEN_FINALIZATION_TASKS_INVOKER_SA', '')
+        expected_parent = self.queue_path(project, location, queue)
+        if parent != expected_parent:
+            raise RuntimeError(f'finalization task used unexpected parent {parent!r}')
+        if not all((project, location, queue, handler_url, invoker_sa)):
+            raise RuntimeError('loopback finalization task configuration is incomplete')
+
+        request = task.http_request
+        parsed_url = urlparse(str(request.url))
+        if (
+            str(request.url) != handler_url
+            or parsed_url.scheme != 'http'
+            or parsed_url.hostname != '127.0.0.1'
+            or parsed_url.port is None
+            or parsed_url.path != FINALIZATION_HANDLER_PATH
+            or parsed_url.query
+            or parsed_url.username
+            or parsed_url.password
+        ):
+            raise RuntimeError('loopback task attempted a non-local or unexpected finalization route')
+        if int(request.http_method) != int(tasks_v2.HttpMethod.POST):
+            raise RuntimeError('finalization task must use POST')
+        if dict(request.headers) != {'Content-Type': 'application/json'}:
+            raise RuntimeError('finalization task must have only the JSON content-type header')
+        if request.oidc_token.service_account_email != invoker_sa or request.oidc_token.audience != handler_url:
+            raise RuntimeError('finalization task has an unexpected OIDC binding')
+        if task.dispatch_deadline != timedelta(seconds=DISPATCH_DEADLINE_SECONDS):
+            raise RuntimeError('finalization task has an unexpected dispatch deadline')
+
+        try:
+            payload = json.loads(bytes(request.body).decode('utf-8'))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise RuntimeError('finalization task body is not valid JSON') from error
+        if (
+            not isinstance(payload, dict)
+            or set(payload) != {'job_id', 'dispatch_generation'}
+            or not isinstance(payload.get('job_id'), str)
+            or not payload['job_id']
+            or not isinstance(payload.get('dispatch_generation'), int)
+            or isinstance(payload['dispatch_generation'], bool)
+            or payload['dispatch_generation'] < 1
+        ):
+            raise RuntimeError('finalization task body is not the opaque durable schema')
+
+        task_name = str(task.name)
+        expected_name = self.task_path(
+            project, location, queue, f"listen-finalization-{payload['job_id']}-{payload['dispatch_generation']}"
+        )
+        if task_name != expected_name:
+            raise RuntimeError('finalization task name does not match its opaque durable identity')
+        with _task_event_lock():
+            if task_name in _read_task_names():
+                raise AlreadyExists(f'loopback task already exists: {task_name}')
+            _append_event(
+                {
+                    'event': 'task_enqueued',
+                    'task_name': task_name,
+                    'url': handler_url,
+                    'payload': payload,
+                }
+            )
+        return task
+
+
+def install_loopback_tasks_client() -> None:
+    """Patch only client construction; task building remains production code."""
+    cloud_tasks._get_tasks_client = StrictLoopbackTasksClient  # type: ignore[method-assign]
+
+
+def install_loopback_task_auth() -> None:
+    """Keep the production dependency but replace only JWT crypto for local delivery."""
+
+    def verify(request: Request, *, audience: str, invoker_sa: str, log_failure: bool = True) -> int:
+        del log_failure
+        expected_audience = os.getenv('LISTEN_FINALIZATION_TASKS_HANDLER_URL', '')
+        expected_invoker = os.getenv('LISTEN_FINALIZATION_TASKS_INVOKER_SA', '')
+        expected_token = os.getenv(LOCAL_TASK_TOKEN_ENV, '')
+        if audience != expected_audience or invoker_sa != expected_invoker or not expected_token:
+            raise HTTPException(status_code=403, detail='Loopback task dispatch not configured')
+        if request.headers.get('authorization') != f'Bearer {expected_token}':
+            raise HTTPException(status_code=403, detail='Invalid loopback task identity')
+        try:
+            retry_count = int(request.headers.get('x-cloudtasks-taskretrycount', '0'))
+        except ValueError:
+            return 0
+        return max(retry_count, 0)
+
+    cloud_tasks._verify_cloud_tasks_oidc = verify  # type: ignore[assignment]

--- a/backend/testing/listen_pusher_stack/finalization_worker_app.py
+++ b/backend/testing/listen_pusher_stack/finalization_worker_app.py
@@ -1,0 +1,14 @@
+"""Instrumented Cloud Tasks worker entrypoint for durable finalization scenarios.
+
+This is a separate process from the listener. The production FastAPI route,
+Firestore leases, and finalizer ownership remain real; only JWT crypto and
+provider-side work are replaced with deterministic local seams.
+"""
+
+from testing.listen_pusher_stack.cloud_tasks import install_loopback_task_auth
+from testing.listen_pusher_stack.finalizer_leaves import install_finalizer_leaves
+
+install_loopback_task_auth()
+install_finalizer_leaves()
+
+from main import app  # noqa: E402

--- a/backend/testing/listen_pusher_stack/finalizer_leaves.py
+++ b/backend/testing/listen_pusher_stack/finalizer_leaves.py
@@ -1,0 +1,103 @@
+"""Controlled provider leaves for the durable finalization worker harness."""
+
+from __future__ import annotations
+
+import json
+import os
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from models.conversation_enums import ConversationStatus
+from utils.conversations import finalizer
+from utils.conversations import lifecycle as lifecycle_service
+
+_failure_budget: dict[str, int] = {}
+
+
+def _record(event: dict[str, Any]) -> None:
+    state_dir = os.getenv('OMI_STACK_STATE_DIR')
+    if not state_dir:
+        return
+    path = Path(state_dir) / 'finalizer.jsonl'
+    with path.open('a', encoding='utf-8') as output:
+        output.write(json.dumps(event, sort_keys=True) + '\n')
+
+
+def _parse_failure_budget() -> dict[str, int]:
+    raw = os.getenv('OMI_STACK_FINALIZATION_FAILURES', '{}')
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise RuntimeError('OMI_STACK_FINALIZATION_FAILURES must be JSON') from error
+    if not isinstance(payload, dict) or set(payload) - {'process', 'integration'}:
+        raise RuntimeError('OMI_STACK_FINALIZATION_FAILURES supports only process and integration budgets')
+    if any(not isinstance(value, int) or isinstance(value, bool) or value < 0 for value in payload.values()):
+        raise RuntimeError('OMI_STACK_FINALIZATION_FAILURES values must be non-negative integers')
+    return {stage: int(payload.get(stage, 0)) for stage in ('process', 'integration')}
+
+
+def _consume_failure(stage: str, conversation_id: str, **metadata: Any) -> bool:
+    remaining = _failure_budget.get(stage, 0)
+    if remaining <= 0:
+        return False
+    _failure_budget[stage] = remaining - 1
+    _record(
+        {
+            'event': 'provider_leaf',
+            'stage': stage,
+            'outcome': 'controlled_failure',
+            'conversation_id': conversation_id,
+        }
+        | metadata
+    )
+    return True
+
+
+def _offline_process_conversation(uid: str, _language: str, conversation: Any, **_kwargs: Any) -> Any:
+    conversation_id = str(conversation.id)
+    if _consume_failure('process', conversation_id):
+        raise RuntimeError('controlled finalization processing failure')
+    conversation.status = ConversationStatus.completed
+    persisted = lifecycle_service.persist_processed_conversation(uid, conversation.model_dump())
+    _record(
+        {
+            'event': 'provider_leaf',
+            'stage': 'process',
+            'outcome': 'completed',
+            'conversation_id': conversation_id,
+            'persisted': bool(persisted),
+        }
+    )
+    return conversation
+
+
+def _offline_extract_memories(_uid: str, conversation: Any) -> None:
+    _record(
+        {'event': 'provider_leaf', 'stage': 'memory', 'outcome': 'skipped', 'conversation_id': str(conversation.id)}
+    )
+
+
+async def _offline_trigger_integrations(_uid: str, conversation: Any, *, idempotency_key: str, **_kwargs: Any) -> None:
+    conversation_id = str(conversation.id)
+    fanout_key_sha256 = sha256(idempotency_key.encode()).hexdigest()
+    if _consume_failure('integration', conversation_id, fanout_key_sha256=fanout_key_sha256):
+        raise RuntimeError('controlled finalization integration failure')
+    _record(
+        {
+            'event': 'provider_leaf',
+            'stage': 'integration',
+            'outcome': 'completed',
+            'conversation_id': conversation_id,
+            'fanout_key_sha256': fanout_key_sha256,
+        }
+    )
+
+
+def install_finalizer_leaves() -> None:
+    """Install only controlled provider leaves before the real ASGI app imports."""
+    global _failure_budget
+    _failure_budget = _parse_failure_budget()
+    finalizer.process_conversation = _offline_process_conversation
+    finalizer.extract_memories = _offline_extract_memories
+    finalizer.trigger_external_integrations = _offline_trigger_integrations

--- a/backend/testing/listen_pusher_stack/listener_app.py
+++ b/backend/testing/listen_pusher_stack/listener_app.py
@@ -1,0 +1,11 @@
+"""Instrumented listener entrypoint for durable finalization scenarios.
+
+The production FastAPI application and task construction remain real. Only the
+Cloud Tasks transport client is replaced by a strict loopback boundary.
+"""
+
+from testing.listen_pusher_stack.cloud_tasks import install_loopback_tasks_client
+
+install_loopback_tasks_client()
+
+from main import app  # noqa: E402

--- a/backend/testing/listen_pusher_stack/run.py
+++ b/backend/testing/listen_pusher_stack/run.py
@@ -1,8 +1,9 @@
 """Run isolated high-fidelity tests for the listen -> pusher chain.
 
 Run through ``run.sh`` so Firebase supplies a fresh Firestore emulator.  This
-supervisor owns only the Redis, backend, pusher, and Parakeet child processes
-that it starts; it never probes or stops user services.
+supervisor owns only the Redis, listener/backend, finalization-worker, pusher,
+and Parakeet child processes that it starts; it never probes or stops user
+services.
 """
 
 from __future__ import annotations
@@ -22,20 +23,25 @@ import uuid
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from hashlib import sha256
 from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import urlencode
 
+import httpx
 import redis
 import websockets
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
+
+from testing.listen_pusher_stack.cloud_tasks import FINALIZATION_HANDLER_PATH, LOCAL_TASK_TOKEN_ENV, TASK_EVENTS_FILE
 
 ROOT = Path(__file__).resolve().parents[3]
 BACKEND = ROOT / 'backend'
 PYTHON = BACKEND / '.venv' / 'bin' / 'python'
 ADMIN_KEY = 'omi-listen-pusher-stack-admin-'
 PROJECT = 'demo-omi-listen-stack'
+LOCAL_TASK_TOKEN = 'listen-pusher-stack-loopback-task'
 
 
 class StackFailure(AssertionError):
@@ -55,9 +61,19 @@ def _free_port() -> int:
         return int(probe.getsockname()[1])
 
 
-def _wait_for_port(port: int, *, label: str, timeout: float = 20.0) -> None:
+def _wait_for_port(
+    port: int,
+    *,
+    label: str,
+    timeout: float = 20.0,
+    child: 'Child | None' = None,
+) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
+        if child and child.process.poll() is not None:
+            raise StackFailure(
+                f'{label} exited with status {child.process.returncode} before listening; inspect {child.log_path}'
+            )
         try:
             with socket.create_connection(('127.0.0.1', port), timeout=0.25):
                 return
@@ -87,11 +103,28 @@ def _read_events(path: Path) -> list[dict[str, Any]]:
     return rows
 
 
+def _append_event(path: Path, event: dict[str, Any]) -> None:
+    with path.open('a', encoding='utf-8') as output:
+        output.write(json.dumps(event, sort_keys=True) + '\n')
+
+
 class Stack:
-    def __init__(self, state_dir: Path):
+    def __init__(
+        self,
+        state_dir: Path,
+        *,
+        finalization_mode: str = 'inline',
+        finalizer_failures: dict[str, int] | None = None,
+    ):
+        if finalization_mode not in {'inline', 'cloud_tasks'}:
+            raise ValueError(f'unsupported finalization mode: {finalization_mode}')
         self.state_dir = state_dir
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.finalization_mode = finalization_mode
+        self.finalizer_failures = finalizer_failures or {}
         self.redis_port = _free_port()
         self.backend_port = _free_port()
+        self.finalization_worker_port = _free_port()
         self.pusher_port = _free_port()
         self.parakeet_port = _free_port()
         self.children: dict[str, Child] = {}
@@ -135,12 +168,33 @@ class Stack:
                 'HOSTED_PARAKEET_API_URL': f'http://127.0.0.1:{self.parakeet_port}',
                 'STT_SERVICE_MODELS': 'parakeet',
                 'TRIAL_PAYWALL_ENABLED': 'false',
-                'LISTEN_FINALIZATION_DISPATCH_MODE': 'inline',
+                'LISTEN_FINALIZATION_DISPATCH_MODE': self.finalization_mode,
                 'OMI_STACK_STATE_DIR': str(self.state_dir),
                 'PYTHONPATH': str(BACKEND),
+                # Child logs are evidence when a process fails to bind; avoid
+                # losing a short Python traceback in the file buffer.
+                'PYTHONUNBUFFERED': '1',
             }
         )
+        if self.finalization_mode == 'cloud_tasks':
+            handler_url = self.finalization_handler_url
+            env.update(
+                {
+                    'SYNC_TASKS_PROJECT': PROJECT,
+                    'SYNC_TASKS_LOCATION': 'us-central1',
+                    'LISTEN_FINALIZATION_TASKS_QUEUE': 'conversation-finalization',
+                    'LISTEN_FINALIZATION_TASKS_HANDLER_URL': handler_url,
+                    'LISTEN_FINALIZATION_TASKS_INVOKER_SA': 'listen-finalizer@demo-omi-listen-stack.iam.gserviceaccount.com',
+                    'LISTEN_FINALIZATION_TASKS_MAX_ATTEMPTS': '2',
+                    LOCAL_TASK_TOKEN_ENV: LOCAL_TASK_TOKEN,
+                    'OMI_STACK_FINALIZATION_FAILURES': json.dumps(self.finalizer_failures, sort_keys=True),
+                }
+            )
         return env
+
+    @property
+    def finalization_handler_url(self) -> str:
+        return f'http://127.0.0.1:{self.finalization_worker_port}{FINALIZATION_HANDLER_PATH}'
 
     def _start(self, name: str, command: list[str], *, extra_env: dict[str, str] | None = None) -> Child:
         if name in self.children:
@@ -167,7 +221,7 @@ class Stack:
         redis_binary = shutil.which('redis-server')
         if not redis_binary:
             raise StackFailure('redis-server is required; install Redis and retry')
-        self._start(
+        redis_child = self._start(
             'redis',
             [
                 redis_binary,
@@ -181,9 +235,9 @@ class Stack:
                 'yes',
             ],
         )
-        _wait_for_port(self.redis_port, label='isolated Redis')
+        _wait_for_port(self.redis_port, label='isolated Redis', child=redis_child)
         redis.Redis(host='127.0.0.1', port=self.redis_port).ping()
-        self._start(
+        parakeet_child = self._start(
             'parakeet',
             [
                 str(PYTHON),
@@ -196,11 +250,11 @@ class Stack:
                 str(self.parakeet_port),
             ],
         )
-        _wait_for_port(self.parakeet_port, label='Parakeet stub')
+        _wait_for_port(self.parakeet_port, label='Parakeet stub', child=parakeet_child)
         pusher_env = (
             {'OMI_STACK_DROP_PUBLISHING_ON_OPCODE': str(pusher_drop_opcode)} if pusher_drop_opcode is not None else None
         )
-        self._start(
+        pusher_child = self._start(
             'pusher',
             [
                 str(PYTHON),
@@ -214,17 +268,40 @@ class Stack:
             ],
             extra_env=pusher_env,
         )
-        _wait_for_port(self.pusher_port, label='pusher')
-        self._start(
-            'backend',
-            [str(PYTHON), '-m', 'uvicorn', 'main:app', '--host', '127.0.0.1', '--port', str(self.backend_port)],
+        _wait_for_port(self.pusher_port, label='pusher', child=pusher_child)
+        backend_app = (
+            'testing.listen_pusher_stack.listener_app:app' if self.finalization_mode == 'cloud_tasks' else 'main:app'
         )
-        _wait_for_port(self.backend_port, label='listen backend', timeout=45.0)
+        backend_child = self._start(
+            'backend',
+            [str(PYTHON), '-m', 'uvicorn', backend_app, '--host', '127.0.0.1', '--port', str(self.backend_port)],
+        )
+        _wait_for_port(self.backend_port, label='listen backend', timeout=45.0, child=backend_child)
+        if self.finalization_mode == 'cloud_tasks':
+            worker_child = self._start(
+                'finalization-worker',
+                [
+                    str(PYTHON),
+                    '-m',
+                    'uvicorn',
+                    'testing.listen_pusher_stack.finalization_worker_app:app',
+                    '--host',
+                    '127.0.0.1',
+                    '--port',
+                    str(self.finalization_worker_port),
+                ],
+            )
+            _wait_for_port(
+                self.finalization_worker_port,
+                label='finalization worker',
+                timeout=45.0,
+                child=worker_child,
+            )
 
     def restart_pusher(self, *, drop_opcode: int | None = None) -> None:
         self.stop('pusher')
         pusher_env = {'OMI_STACK_DROP_PUBLISHING_ON_OPCODE': str(drop_opcode)} if drop_opcode is not None else None
-        self._start(
+        pusher_child = self._start(
             'pusher',
             [
                 str(PYTHON),
@@ -238,7 +315,7 @@ class Stack:
             ],
             extra_env=pusher_env,
         )
-        _wait_for_port(self.pusher_port, label='restarted pusher')
+        _wait_for_port(self.pusher_port, label='restarted pusher', child=pusher_child)
 
     def stop(self, name: str) -> None:
         child = self.children.pop(name, None)
@@ -254,12 +331,81 @@ class Stack:
             child.process.wait(timeout=5)
 
     def close(self) -> None:
-        for name in list(self.children):
+        for name in reversed(list(self.children)):
             self.stop(name)
 
     @property
     def pusher_events(self) -> list[dict[str, Any]]:
         return _read_events(self.state_dir / 'pusher.jsonl')
+
+    @property
+    def finalizer_events(self) -> list[dict[str, Any]]:
+        return _read_events(self.state_dir / 'finalizer.jsonl')
+
+    @property
+    def finalization_tasks(self) -> list[dict[str, Any]]:
+        return [
+            event for event in _read_events(self.state_dir / TASK_EVENTS_FILE) if event.get('event') == 'task_enqueued'
+        ]
+
+    def wait_for_finalization_task(self, *, count: int = 1, timeout: float = 20.0) -> dict[str, Any]:
+        tasks: list[dict[str, Any]] = []
+
+        def enqueued() -> bool:
+            nonlocal tasks
+            tasks = self.finalization_tasks
+            return len(tasks) >= count
+
+        _wait_until(enqueued, label='loopback Cloud Tasks enqueue', timeout=timeout)
+        return tasks[count - 1]
+
+    async def deliver_finalization_task(self, task: dict[str, Any], *, retry_count: int) -> tuple[int, dict[str, Any]]:
+        if self.finalization_mode != 'cloud_tasks':
+            raise StackFailure('only the Cloud Tasks stack can deliver finalization tasks')
+        if task.get('url') != self.finalization_handler_url:
+            raise StackFailure('loopback task handler URL did not match the real backend route')
+        payload = task.get('payload')
+        if not isinstance(payload, dict) or set(payload) != {'job_id', 'dispatch_generation'}:
+            raise StackFailure('loopback task payload was not opaque durable routing data')
+        async with httpx.AsyncClient(timeout=10.0, trust_env=False) as client:
+            response = await client.post(
+                self.finalization_handler_url,
+                json=payload,
+                headers={
+                    'Authorization': f'Bearer {LOCAL_TASK_TOKEN}',
+                    'X-CloudTasks-TaskRetryCount': str(retry_count),
+                },
+            )
+        try:
+            body = response.json()
+        except json.JSONDecodeError as error:
+            raise StackFailure(f'finalization worker returned non-JSON status={response.status_code}') from error
+        if not isinstance(body, dict):
+            raise StackFailure(f'finalization worker returned non-object JSON status={response.status_code}')
+        _append_event(
+            self.state_dir / 'cloud_tasks_deliveries.jsonl',
+            {
+                'event': 'task_delivered',
+                'task_name': task.get('task_name'),
+                'retry_count': retry_count,
+                'status_code': response.status_code,
+                'status': body.get('status'),
+            },
+        )
+        return response.status_code, body
+
+    async def finalization_status(self, uid: str, conversation_id: str) -> dict[str, Any]:
+        async with httpx.AsyncClient(timeout=10.0, trust_env=False) as client:
+            response = await client.get(
+                f'http://127.0.0.1:{self.backend_port}/v1/conversations/{conversation_id}/finalization',
+                headers={'Authorization': f'Bearer {ADMIN_KEY}{uid}'},
+            )
+        if response.status_code != 200:
+            raise StackFailure(f'finalization status endpoint returned {response.status_code}: {response.text[:120]}')
+        body = response.json()
+        if not isinstance(body, dict):
+            raise StackFailure('finalization status endpoint returned non-object JSON')
+        return body
 
     def seed_user(self, uid: str) -> None:
         # Private cloud is enabled solely to exercise 103 + 101.  The pusher
@@ -296,6 +442,13 @@ class Stack:
         self.firestore.collection('users').document(uid).collection('conversations').document(conversation_id).update(
             {'finished_at': datetime.now(timezone.utc) - timedelta(seconds=121)}
         )
+
+
+def _one_job(stack: Stack, uid: str, conversation_id: str) -> dict[str, Any]:
+    jobs = stack.jobs_for(uid, conversation_id)
+    if len(jobs) != 1:
+        raise StackFailure(f'expected one finalization job, observed {len(jobs)}')
+    return jobs[0]
 
 
 async def _receive_until(websocket: Any, predicate: Callable[[Any], bool], *, label: str, timeout: float = 15.0) -> Any:
@@ -375,6 +528,20 @@ def _wait_for_job(
 
 def _assert_local_provider_admission(stack: Stack, conversation_id: str) -> None:
     """Assert local seams were reached once, without claiming external delivery."""
+
+    def provider_leaves_flushed() -> bool:
+        events = stack.pusher_events
+        return any(
+            event.get('event') == 'integration_fanout_skipped' and event.get('conversation_id') == conversation_id
+            for event in events
+        ) and any(
+            event.get('event') == 'audio_storage_skipped' and event.get('conversation_id') == conversation_id
+            for event in events
+        )
+
+    # Pusher flushes its private-cloud queue during the real session teardown.
+    # Wait for that observable completion rather than racing the process cleanup.
+    _wait_until(provider_leaves_flushed, label='local provider admission')
     events = stack.pusher_events
     fanouts = [
         event
@@ -400,6 +567,21 @@ async def _normal_and_terminal_reconnect(stack: Stack) -> None:
     if first_session.get('conversation_id') != session_id or first_session.get('status') != 'in_progress':
         raise StackFailure('new desktop recording did not bind its requested native session UUID')
     await _record_audio(websocket)
+    # Inline compatibility mode owns finalization in the live pusher WebSocket,
+    # so trigger the normal stale-recording lifecycle while that connection is
+    # still active. Immediate-close durability is exercised separately through
+    # the Cloud Tasks scenarios below, where the worker is detached from this
+    # client connection.
+    stack.age_conversation(uid, session_id)
+    await _receive_until(
+        websocket,
+        lambda payload: isinstance(payload, dict)
+        and payload.get('type') == 'memory_created'
+        and payload.get('conversation_id') == session_id
+        and payload.get('lifecycle_phase') == 'completed',
+        label='inline finalization completion',
+        timeout=25.0,
+    )
     await websocket.close(code=1000)
     job = _wait_for_job(stack, uid, session_id, 'completed')
     conversation = stack.conversation(uid, session_id)
@@ -495,10 +677,202 @@ async def _pusher_restart_replay(stack: Stack) -> None:
     await websocket.close(code=1000)
 
 
-async def run_scenarios(stack: Stack) -> None:
+async def _cloud_task_for_clean_desktop_close(stack: Stack, uid: str, conversation_id: str) -> dict[str, Any]:
+    stack.seed_user(uid)
+    websocket, session = await _connect(stack, uid, conversation_id)
+    if session.get('conversation_id') != conversation_id:
+        raise StackFailure('cloud-task recording did not preserve its native session identity')
+    await _record_audio(websocket)
+    await websocket.close(code=1000)
+    return stack.wait_for_finalization_task()
+
+
+def _assert_opaque_task(task: dict[str, Any], job: dict[str, Any], stack: Stack) -> None:
+    payload = task.get('payload')
+    if payload != {'job_id': job.get('id'), 'dispatch_generation': job.get('dispatch_generation')}:
+        raise StackFailure('Cloud Tasks handoff did not preserve the opaque durable job identity')
+    if task.get('url') != stack.finalization_handler_url:
+        raise StackFailure('Cloud Tasks handoff did not target the loopback worker route')
+
+
+def _provider_events(stack: Stack, conversation_id: str, stage: str, outcome: str) -> list[dict[str, Any]]:
+    return [
+        event
+        for event in stack.finalizer_events
+        if event.get('event') == 'provider_leaf'
+        and event.get('conversation_id') == conversation_id
+        and event.get('stage') == stage
+        and event.get('outcome') == outcome
+    ]
+
+
+async def _shutdown_window_retries_through_cloud_tasks(stack: Stack) -> None:
+    """#9960's early shutdown wake must redispatch the timed-out recording."""
+    uid = 'stack-cloud-shutdown-retry'
+    conversation_id = str(uuid.uuid4())
+    stack.seed_user(uid)
+
+    websocket, _ = await _connect(stack, uid, conversation_id)
+    await _record_audio(websocket)
+    stack.age_conversation(uid, conversation_id)
+    # A non-clean disconnect leaves this recording pending.  The following
+    # session wakes process_pending before its seven-second delay expires.
+    await websocket.close(code=1001)
+    if stack.finalization_tasks:
+        raise StackFailure('abnormal close unexpectedly bypassed the pending-finalization recovery path')
+
+    recovery_session, _ = await _connect(stack, uid, None)
+    await recovery_session.close(code=1000)
+    # The production shutdown event shortens the seven-second pending delay.
+    # Keep this below seven seconds so the scenario fails if that work becomes
+    # an unconditional sleep again.
+    task = stack.wait_for_finalization_task(timeout=5.0)
+    job = _one_job(stack, uid, conversation_id)
+    _assert_opaque_task(task, job, stack)
+    if job.get('status') != 'queued' or job.get('attempt_count') != 0:
+        raise StackFailure('shutdown recovery did not leave one queued durable finalization job')
+
+    status_code, body = await stack.deliver_finalization_task(task, retry_count=0)
+    if (status_code, body) != (500, {'status': 'retry'}):
+        raise StackFailure(f'first Cloud Tasks delivery did not request a retry: {(status_code, body)}')
+    retry_job = _one_job(stack, uid, conversation_id)
+    retry_conversation = stack.conversation(uid, conversation_id)
+    if retry_job.get('status') != 'queued' or retry_job.get('attempt_count') != 1:
+        raise StackFailure('retryable worker failure did not return the same job to the durable queue')
+    if not retry_conversation or retry_conversation.get('status') != 'processing':
+        raise StackFailure('retryable worker failure changed the conversation before a successful finalization')
+    retry_status = await stack.finalization_status(uid, conversation_id)
+    if retry_status.get('status') != 'queued' or not retry_status.get('retryable'):
+        raise StackFailure('client finalization status did not expose the retryable durable state')
+
+    status_code, body = await stack.deliver_finalization_task(task, retry_count=1)
+    if (status_code, body) != (200, {'status': 'done'}):
+        raise StackFailure(f'retry Cloud Tasks delivery did not complete: {(status_code, body)}')
+    completed_job = _one_job(stack, uid, conversation_id)
+    completed_conversation = stack.conversation(uid, conversation_id)
+    if completed_job.get('status') != 'completed' or completed_job.get('attempt_count') != 2:
+        raise StackFailure('successful retry did not complete the exact durable job')
+    if completed_job.get('fanout_status') != 'completed':
+        raise StackFailure('successful retry did not complete durable fanout')
+    if not completed_conversation or completed_conversation.get('status') != 'completed':
+        raise StackFailure('successful retry did not complete the recovered conversation')
+    completed_status = await stack.finalization_status(uid, conversation_id)
+    if completed_status.get('status') != 'completed' or not completed_status.get('terminal'):
+        raise StackFailure('client finalization status did not expose the completed terminal state')
+    if len(stack.finalization_tasks) != 1:
+        raise StackFailure('worker retry created a second Cloud Tasks handoff')
+    if len(_provider_events(stack, conversation_id, 'process', 'controlled_failure')) != 1:
+        raise StackFailure('controlled processing failure was not observed exactly once')
+    if len(_provider_events(stack, conversation_id, 'process', 'completed')) != 1:
+        raise StackFailure('recovered processing did not execute exactly once')
+
+
+async def _terminal_cloud_tasks_failure_dead_letters(stack: Stack) -> None:
+    uid = 'stack-cloud-dead-letter'
+    conversation_id = str(uuid.uuid4())
+    task = await _cloud_task_for_clean_desktop_close(stack, uid, conversation_id)
+    job = _one_job(stack, uid, conversation_id)
+    _assert_opaque_task(task, job, stack)
+
+    first = await stack.deliver_finalization_task(task, retry_count=0)
+    if first != (500, {'status': 'retry'}):
+        raise StackFailure(f'first terminal-path delivery did not request a retry: {first}')
+    final = await stack.deliver_finalization_task(task, retry_count=1)
+    if final != (200, {'status': 'dead_letter'}):
+        raise StackFailure(f'final delivery did not dead-letter the exhausted job: {final}')
+
+    dead_letter = _one_job(stack, uid, conversation_id)
+    conversation = stack.conversation(uid, conversation_id)
+    if (
+        dead_letter.get('status') != 'dead_letter'
+        or dead_letter.get('attempt_count') != 2
+        or dead_letter.get('task_retry_count') != 2
+    ):
+        raise StackFailure('exhausted worker delivery did not record its terminal durable state')
+    if not conversation or {
+        'status': conversation.get('status'),
+        'discarded': conversation.get('discarded'),
+        'finalization_status': conversation.get('finalization_status'),
+    } != {'status': 'failed', 'discarded': True, 'finalization_status': 'dead_letter'}:
+        raise StackFailure('dead-lettering did not atomically close the processing conversation')
+    projection = await stack.finalization_status(uid, conversation_id)
+    if projection.get('status') != 'dead_letter' or not projection.get('terminal') or projection.get('retryable'):
+        raise StackFailure('client finalization status did not expose the dead-letter terminal state')
+
+    redelivery = await stack.deliver_finalization_task(task, retry_count=2)
+    if redelivery != (200, {'status': 'dropped', 'reason': 'dead_letter'}):
+        raise StackFailure(f'dead-letter redelivery was not safely fenced: {redelivery}')
+    if len(_provider_events(stack, conversation_id, 'process', 'controlled_failure')) != 2:
+        raise StackFailure('dead-letter path did not consume exactly the configured attempt budget')
+    if len(stack.finalization_tasks) != 1:
+        raise StackFailure('dead-letter path created a new finalization generation')
+
+
+async def _integration_retry_preserves_processed_conversation(stack: Stack) -> None:
+    uid = 'stack-cloud-integration-retry'
+    conversation_id = str(uuid.uuid4())
+    task = await _cloud_task_for_clean_desktop_close(stack, uid, conversation_id)
+    first = await stack.deliver_finalization_task(task, retry_count=0)
+    if first != (500, {'status': 'retry'}):
+        raise StackFailure(f'integration failure delivery did not request a retry: {first}')
+    after_failure = _one_job(stack, uid, conversation_id)
+    conversation = stack.conversation(uid, conversation_id)
+    if after_failure.get('status') != 'queued' or not conversation or conversation.get('status') != 'completed':
+        raise StackFailure('integration failure did not retain completed processing work for fanout retry')
+    fanout_key = after_failure.get('fanout_key')
+    if not isinstance(fanout_key, str) or not fanout_key:
+        raise StackFailure('integration failure did not retain a durable fanout idempotency key')
+
+    final = await stack.deliver_finalization_task(task, retry_count=1)
+    if final != (200, {'status': 'done'}):
+        raise StackFailure(f'integration retry did not complete finalization: {final}')
+    completed = _one_job(stack, uid, conversation_id)
+    if completed.get('status') != 'completed' or completed.get('fanout_status') != 'completed':
+        raise StackFailure('integration retry did not complete the durable fanout boundary')
+    if completed.get('fanout_key') != fanout_key:
+        raise StackFailure('integration retry changed the durable fanout idempotency key')
+    if len(_provider_events(stack, conversation_id, 'process', 'completed')) != 1:
+        raise StackFailure('fanout retry re-ran completed conversation processing')
+    if len(_provider_events(stack, conversation_id, 'integration', 'controlled_failure')) != 1:
+        raise StackFailure('controlled integration failure was not observed exactly once')
+    if len(_provider_events(stack, conversation_id, 'integration', 'completed')) != 1:
+        raise StackFailure('integration retry did not deliver the durable fanout exactly once')
+    integration_attempts = [
+        event
+        for event in stack.finalizer_events
+        if event.get('event') == 'provider_leaf'
+        and event.get('conversation_id') == conversation_id
+        and event.get('stage') == 'integration'
+    ]
+    fanout_key_hashes = {event.get('fanout_key_sha256') for event in integration_attempts}
+    expected_fanout_key_hash = sha256(fanout_key.encode('utf-8')).hexdigest()
+    if len(integration_attempts) != 2 or fanout_key_hashes != {expected_fanout_key_hash}:
+        raise StackFailure('integration retry did not preserve one idempotency key across both delivery attempts')
+
+
+async def run_inline_scenarios(stack: Stack) -> None:
     await _normal_and_terminal_reconnect(stack)
     await _empty_recording(stack)
     await _pusher_restart_replay(stack)
+
+
+def _run_stack_scenario(
+    state_dir: Path,
+    *,
+    finalization_mode: str,
+    finalizer_failures: dict[str, int] | None,
+    scenario: Callable[[Stack], Any],
+) -> None:
+    stack = Stack(
+        state_dir,
+        finalization_mode=finalization_mode,
+        finalizer_failures=finalizer_failures,
+    )
+    try:
+        stack.start()
+        asyncio.run(scenario(stack))
+    finally:
+        stack.close()
 
 
 def main() -> int:
@@ -510,17 +884,37 @@ def main() -> int:
         raise SystemExit(f'missing backend virtual environment: {PYTHON}; run backend/scripts/sync-python-deps.sh')
     state_dir = args.state_dir or Path(tempfile.mkdtemp(prefix='omi-listen-pusher-stack-'))
     state_dir.mkdir(parents=True, exist_ok=True)
-    stack = Stack(state_dir)
     try:
-        stack.start()
-        asyncio.run(run_scenarios(stack))
+        _run_stack_scenario(
+            state_dir / 'inline',
+            finalization_mode='inline',
+            finalizer_failures=None,
+            scenario=run_inline_scenarios,
+        )
+        _run_stack_scenario(
+            state_dir / 'cloud-shutdown-retry',
+            finalization_mode='cloud_tasks',
+            finalizer_failures={'process': 1},
+            scenario=_shutdown_window_retries_through_cloud_tasks,
+        )
+        _run_stack_scenario(
+            state_dir / 'cloud-dead-letter',
+            finalization_mode='cloud_tasks',
+            finalizer_failures={'process': 2},
+            scenario=_terminal_cloud_tasks_failure_dead_letters,
+        )
+        _run_stack_scenario(
+            state_dir / 'cloud-integration-retry',
+            finalization_mode='cloud_tasks',
+            finalizer_failures={'integration': 1},
+            scenario=_integration_retry_preserves_processed_conversation,
+        )
         print(f'listen-pusher stack gauntlet passed; evidence: {state_dir}')
         return 0
     except Exception as error:
         print(f'listen-pusher stack gauntlet failed; evidence retained: {state_dir}', file=sys.stderr)
         raise
     finally:
-        stack.close()
         if not args.keep and not sys.exc_info()[0]:
             shutil.rmtree(state_dir)
 


### PR DESCRIPTION
## Summary

- Add a process-isolated listen → pusher finalization gauntlet beginning at the real `/v4/listen` endpoint, with isolated Redis and Firestore, the real pusher/router, and the local Parakeet protocol stub.
- Preserve production Cloud Tasks task construction, capture it with a strict loopback client, and deliver it to a separate process running the real protected finalization route.
- Cover pending-finalization recovery, retry-to-completion, terminal dead-letter/fencing, and fanout-only retry without replaying completed processing.

Closes #9985
Refs #9809, #9440, #9995

## Confidence gap closed

Before this change, tests did not execute the durable handoff as one composed path: real listener admission → production `tasks_v2.Task` construction → protected worker route → Firestore lease/finalizer transitions. That left transport shape, retry headers, handler authentication, and durable processing/fanout behavior insufficiently coupled. The new harness rejects invalid task shape locally while blocking cloud credentials and non-loopback providers.

## Scope note

The inline compatibility scenario triggers stale live-session finalization before source close. A clean source close immediately after opcode 104 exposed a separate inline/BYOK cancellation gap, tracked by #9995; this PR does not claim to fix it. Clean-close durability is exercised through the detached Cloud Tasks worker path.

## Verification

- `npm run test:listen-pusher-stack:emulator`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH="$JAVA_HOME/bin:$PATH" npm run test:listen-lifecycle:emulator`
- `cd backend && .venv/bin/python -m pytest -q tests/unit/test_conversation_finalization_jobs.py tests/unit/test_listen_finalization_cloud_tasks.py tests/unit/test_listen_process_pending_shutdown.py tests/unit/utils/test_listen_pusher_session.py` (101 passed)
- `BACKEND_PYTEST_WORKERS=4 bash backend/test.sh`
- `make preflight`
- `scripts/pr-preflight --pr-body-file /tmp/pr-body-9985.md`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

