### PR TITLE
fix(desktop): preserve harness reset owner boundary

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2375,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2832,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4798,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4797,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2423,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1621
   },

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/AuthService.swift": 3303,
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
-    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4183,
+    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4179,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1578,
     "desktop/macos/Desktop/Sources/OmiApp.swift": 1634
   },

--- a/desktop/macos/Desktop/Sources/Chat/RuntimeOwnerIdentity.swift
+++ b/desktop/macos/Desktop/Sources/Chat/RuntimeOwnerIdentity.swift
@@ -435,6 +435,58 @@ enum RuntimeOwnerIdentity {
     }
   }
 
+  /// Installs an automation owner only if the owner is still absent after this
+  /// request has acquired the serialized effective-owner transition fence.
+  /// A preflight outside that fence could otherwise overwrite a real owner
+  /// that signed in while a reset was queued.
+  static func applyAutomationOwnerOverrideIfMissing(
+    _ ownerID: String,
+    defaults: UserDefaults = .standard
+  ) async -> Bool {
+    let trimmed = ownerID.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return false }
+    return await performEffectiveOwnerTransition(
+      defaults: defaults,
+      allowAutomationOverride: true,
+      plannedNextOwner: { _, previousOwner in previousOwner ?? trimmed }
+    ) { defaults in
+      guard persistedOwnerId(defaults: defaults, allowAutomationOverride: true) == nil else {
+        return false
+      }
+      defaults.set(trimmed, forKey: .automationOwnerOverride)
+      return true
+    }
+  }
+
+  /// Temporarily establishes a non-production owner only when no effective
+  /// owner exists. Harness reset operations still execute through the normal
+  /// owner-scoped kernel boundary; they do not bypass it because a faulted
+  /// auth endpoint left the bundle in auth recovery.
+  static func withAutomationOwnerIfMissing<Result: Sendable>(
+    _ ownerID: String,
+    defaults: UserDefaults = .standard,
+    operation: @MainActor () async throws -> Result
+  ) async rethrows -> Result {
+    let normalizedOwnerID = ownerID.trimmingCharacters(in: .whitespacesAndNewlines)
+    precondition(!normalizedOwnerID.isEmpty, "automation owner must not be empty")
+    let installedTemporaryOwner = await applyAutomationOwnerOverrideIfMissing(
+      normalizedOwnerID,
+      defaults: defaults)
+
+    do {
+      let result = try await operation()
+      if installedTemporaryOwner {
+        _ = await clearAutomationOwnerOverride(defaults: defaults)
+      }
+      return result
+    } catch {
+      if installedTemporaryOwner {
+        _ = await clearAutomationOwnerOverride(defaults: defaults)
+      }
+      throw error
+    }
+  }
+
   /// Clear the automation override and heal a legacy synthetic auth_userId if needed.
   @discardableResult
   static func clearAutomationOwnerOverride(

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1568,11 +1568,7 @@ final class DesktopAutomationActionRegistry {
       guard let provider = ChatProvider.mainInstance else {
         return ["error": "main ChatProvider not yet initialized"]
       }
-      let clear = await provider.automationClearOwnerSurfaceState(chatId: "default")
-      if let error = clear["error"] {
-        return ["error": error]
-      }
-      if let error = await provider.automationResetChatForHarness() {
+      if let error = await provider.automationResetMainChatForHarness() {
         return ["error": error]
       }
       return ["reset": "true"]

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2911,8 +2911,7 @@ class FloatingControlBarManager {
     }
     if reset {
       if let provider = sharedFloatingProvider {
-        _ = await provider.automationClearOwnerSurfaceState(chatId: "default")
-        if let error = await provider.automationResetChatForHarness() {
+        if let error = await provider.automationResetMainChatForHarness() {
           return ["error": error]
         }
       }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+HarnessReset.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+HarnessReset.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension ChatProvider {
+  /// Reset isolation must clear the same kernel-owned surface the flow will
+  /// exercise. Fault bundles intentionally have no authenticated owner, so
+  /// establish a temporary non-production owner for this transaction rather
+  /// than bypassing the owner boundary or carrying a synthetic session forward.
+  func automationResetMainChatForHarness() async -> String? {
+    guard AppBuild.isNonProduction else { return nil }
+    let bundleScope = (Bundle.main.bundleIdentifier ?? "desktop")
+      .replacingOccurrences(of: ".", with: "-")
+    let resetOwnerID = "desktop-harness-reset-\(bundleScope)"
+    return await RuntimeOwnerIdentity.withAutomationOwnerIfMissing(resetOwnerID) { [self] in
+      let clear = await automationClearOwnerSurfaceState(chatId: "default")
+      if let error = clear["error"] {
+        return error
+      }
+      return await automationResetChatForHarness()
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
@@ -406,6 +406,49 @@ final class KernelTurnRecordedProjectionTests: XCTestCase {
     XCTAssertEqual(clearCalls.map(\.generation), [7])
   }
 
+  func testTemporaryAutomationOwnerKeepsFaultResetOnKernelBoundary() async {
+    let suiteName = "KernelTurnRecordedProjectionTests.\(UUID().uuidString)"
+    guard let defaults = UserDefaults(suiteName: suiteName) else {
+      return XCTFail("failed to create isolated defaults")
+    }
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    let provider = ChatProvider()
+    let surface = provider.mainChatSurfaceReference()
+    var clearCalls: [(ownerID: String, generation: Int)] = []
+    let projection = KernelTurnProjection(
+      host: provider,
+      client: AgentClient.Session(harnessMode: "piMono"),
+      ownerIDProvider: {
+        RuntimeOwnerIdentity.currentOwnerId(defaults: defaults, allowAutomationOverride: true)
+      },
+      journalListOperation: { _, _, ownerID, _, _ in
+        self.journalPage(conversationId: "fault-conversation", turns: [], generation: 9)
+      },
+      journalClearOperation: { _, _, ownerID, generation in
+        clearCalls.append((ownerID, generation))
+        return 0
+      },
+      kernelReadyOperation: { true }
+    )
+
+    XCTAssertNil(RuntimeOwnerIdentity.currentOwnerId(defaults: defaults, allowAutomationOverride: true))
+    let cleared = await RuntimeOwnerIdentity.withAutomationOwnerIfMissing(
+      "desktop-harness-reset-omi-fault",
+      defaults: defaults
+    ) {
+      await projection.clear(surface: surface)
+    }
+
+    XCTAssertTrue(cleared)
+    XCTAssertEqual(clearCalls.map(\.ownerID), ["desktop-harness-reset-omi-fault"])
+    XCTAssertEqual(clearCalls.map(\.generation), [9])
+    XCTAssertNil(
+      RuntimeOwnerIdentity.currentOwnerId(defaults: defaults, allowAutomationOverride: true),
+      "the temporary owner must not turn an auth-recovery fault bundle into a signed-in session"
+    )
+  }
+
   func testClearFailsClosedWhenGenerationBootstrapFails() async throws {
     struct BootstrapFailure: Error {}
 

--- a/desktop/macos/changelog/unreleased/fault-reset-owner-boundary.json
+++ b/desktop/macos/changelog/unreleased/fault-reset-owner-boundary.json
@@ -1,0 +1,1 @@
+{"change":"Improved beta chat recovery after a failed request."}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -19,6 +19,7 @@ covers:
   - desktop/macos/Desktop/Sources/BrowserExtensionSetup.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
   - desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+  - desktop/macos/Desktop/Sources/Providers/ChatProvider+HarnessReset.swift
   - desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
   - desktop/macos/Desktop/Sources/AnalyticsManager.swift
   - desktop/macos/Desktop/Sources/Chat/AgentBridge.swift


### PR DESCRIPTION
## Summary

- Establish a temporary non-production owner only for ownerless harness reset transactions.
- Route both main-chat and floating-bar reset automation through the same owner-scoped kernel reset.
- Restore ownerless auth recovery after reset without weakening isolation.

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1

## Failure class

Failure-Class: FC-split-mutation-authority

This fixes a split reset authority: ownerless fault recovery must use the same owner-scoped kernel reset coordinator for every harness entry point.

## Verification

- `xcrun swift test --package-path Desktop --filter 'KernelTurnRecordedProjectionTests|RuntimeOwnerIdentityTests'` — 38 passed.
- Independent review passed after addressing the owner-transition race and floating-bar reset caller.

No Stable, prod, or promotion changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

