### PR TITLE
fix(desktop): allow hermetic fault reset control

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
@@ -1,11 +1,11 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2173,
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4242
+    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2201,
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4283
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": "Non-production owner-bound journal control keeps hermetic fault-reset behavior credential-free without weakening normal model startup credentials.",
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior."
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "Non-production owner-bound journal control keeps hermetic fault-reset behavior credential-free without weakening normal model startup credentials."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
@@ -1,10 +1,10 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2109,
+    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2173,
     "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4242
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior.",
+    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": "Non-production owner-bound journal control keeps hermetic fault-reset behavior credential-free without weakening normal model startup credentials.",
     "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior."
   },
   "threshold": 1500

--- a/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
@@ -702,6 +702,7 @@ actor AgentBridge {
     let kind: LifecycleOperationKind
     let generation: UInt64
     let authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot
+    let requiresCredentials: Bool
     var waiters: [CheckedContinuation<Void, Error>] = []
   }
 
@@ -806,20 +807,29 @@ actor AgentBridge {
 
   func start() async throws {
     let authorizationSnapshot = try captureAuthorization()
-    try await start(authorizationSnapshot: authorizationSnapshot)
+    try await start(authorizationSnapshot: authorizationSnapshot, requiresCredentials: true)
   }
 
   private func start(
-    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot,
+    requiresCredentials: Bool = true
   ) async throws {
     try await runLifecycleOperation(
       .start,
-      authorizationSnapshot: authorizationSnapshot)
+      authorizationSnapshot: authorizationSnapshot,
+      requiresCredentials: requiresCredentials)
+  }
+
+  private func startJournalControl(
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot
+  ) async throws {
+    try await start(authorizationSnapshot: authorizationSnapshot, requiresCredentials: false)
   }
 
   private func runLifecycleOperation(
     _ requestedKind: LifecycleOperationKind,
-    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot,
+    requiresCredentials: Bool = true
   ) async throws {
     while let flight = lifecycleFlight {
       guard flight.authorizationSnapshot == authorizationSnapshot else {
@@ -831,7 +841,10 @@ actor AgentBridge {
       else {
         throw BridgeError.stopped
       }
-      if requestedKind == .start || flight.kind == .restart { return }
+      if requestedKind == .start, !requiresCredentials || flight.requiresCredentials {
+        return
+      }
+      if flight.kind == .restart { return }
     }
 
     guard stopTask == nil else { throw BridgeError.restarting }
@@ -841,14 +854,16 @@ actor AgentBridge {
       id: flightID,
       kind: requestedKind,
       generation: generation,
-      authorizationSnapshot: authorizationSnapshot)
+      authorizationSnapshot: authorizationSnapshot,
+      requiresCredentials: requiresCredentials)
     do {
       switch requestedKind {
       case .start:
         try await performStart(
           authorizationSnapshot: authorizationSnapshot,
           flightID: flightID,
-          generation: generation)
+          generation: generation,
+          requiresCredentials: requiresCredentials)
       case .restart:
         try await performRestart(
           authorizationSnapshot: authorizationSnapshot,
@@ -865,7 +880,8 @@ actor AgentBridge {
   private func performStart(
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot,
     flightID: UUID,
-    generation: UInt64
+    generation: UInt64,
+    requiresCredentials: Bool
   ) async throws {
     let ownerID = authorizationSnapshot.ownerID
     let processWasAlive = await runtime.isAlive
@@ -874,6 +890,7 @@ actor AgentBridge {
       generation: generation,
       authorizationSnapshot: authorizationSnapshot)
     let registeredThisCall = !registered || !processWasAlive
+    let requiresManagedCredentials = requiresCredentials && isPiMonoHarness
     var acquiredRegistration = false
     do {
       if registeredThisCall {
@@ -900,7 +917,7 @@ actor AgentBridge {
       let authorityNeedsSynchronization =
         !status.isSynchronized(
           ownerID: ownerID,
-          requiresCredentials: isPiMonoHarness)
+          requiresCredentials: requiresManagedCredentials)
         || synchronizedRuntimeAuthorityEpoch != status.epoch
         || synchronizedRuntimeAuthorityOwnerID != ownerID
       if authorityNeedsSynchronization {
@@ -917,7 +934,7 @@ actor AgentBridge {
         guard
           synchronized.isSynchronized(
             ownerID: ownerID,
-            requiresCredentials: isPiMonoHarness)
+            requiresCredentials: requiresManagedCredentials)
         else {
           throw BridgeError.authMissing
         }
@@ -964,7 +981,8 @@ actor AgentBridge {
       try await performStart(
         authorizationSnapshot: authorizationSnapshot,
         flightID: flightID,
-        generation: generation)
+        generation: generation,
+        requiresCredentials: true)
       return
     }
     try await runtime.restart(
@@ -1419,6 +1437,30 @@ actor AgentBridge {
     )
   }
 
+  func listJournalTurnsForControl(
+    surface: AgentSurfaceReference,
+    ownerID: String? = nil,
+    afterTurnSeq: Int = 0,
+    limit: Int = 100,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
+  ) async throws -> AgentRuntimeProcess.JournalOperationResult {
+    guard AppBuild.isNonProduction else {
+      throw BridgeError.agentError("Journal control is disabled on production bundles")
+    }
+    let authorization = try resolveAuthorization(
+      authorizationSnapshot,
+      expectedOwnerID: ownerID)
+    try await startJournalControl(authorizationSnapshot: authorization)
+    return try await runtime.listJournalTurns(
+      clientId: clientId,
+      surface: surface,
+      ownerID: ownerID,
+      afterTurnSeq: afterTurnSeq,
+      limit: limit,
+      authorizationSnapshot: authorization
+    )
+  }
+
   func importRemoteJournalTurn(
     surface: AgentSurfaceReference,
     ownerID: String? = nil,
@@ -1448,6 +1490,28 @@ actor AgentBridge {
       authorizationSnapshot,
       expectedOwnerID: ownerID)
     try await start(authorizationSnapshot: authorization)
+    return try await runtime.clearJournalTurns(
+      clientId: clientId,
+      surface: surface,
+      ownerID: ownerID,
+      expectedGeneration: expectedGeneration,
+      authorizationSnapshot: authorization
+    )
+  }
+
+  func clearJournalTurnsForControl(
+    surface: AgentSurfaceReference,
+    ownerID: String? = nil,
+    expectedGeneration: Int? = nil,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
+  ) async throws -> Int {
+    guard AppBuild.isNonProduction else {
+      throw BridgeError.agentError("Journal control is disabled on production bundles")
+    }
+    let authorization = try resolveAuthorization(
+      authorizationSnapshot,
+      expectedOwnerID: ownerID)
+    try await startJournalControl(authorizationSnapshot: authorization)
     return try await runtime.clearJournalTurns(
       clientId: clientId,
       surface: surface,

--- a/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
@@ -823,6 +823,9 @@ actor AgentBridge {
   private func startJournalControl(
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot
   ) async throws {
+    guard AppBuild.isNonProduction else {
+      throw BridgeError.agentError("Journal control is disabled on production bundles")
+    }
     try await start(authorizationSnapshot: authorizationSnapshot, requiresCredentials: false)
   }
 
@@ -890,14 +893,19 @@ actor AgentBridge {
       generation: generation,
       authorizationSnapshot: authorizationSnapshot)
     let registeredThisCall = !registered || !processWasAlive
-    let requiresManagedCredentials = requiresCredentials && isPiMonoHarness
+    let requiresManagedCredentials =
+      isPiMonoHarness
+      && AgentRuntimeCredentialPolicy.requiresManagedCredentials(
+        requestedCredentials: requiresCredentials,
+        isNonProduction: AppBuild.isNonProduction)
     var acquiredRegistration = false
     do {
       if registeredThisCall {
         try await runtime.registerClient(
           clientId: clientId,
           harnessMode: harnessMode,
-          authorizationSnapshot: authorizationSnapshot)
+          authorizationSnapshot: authorizationSnapshot,
+          requiresCredentials: requiresCredentials)
         acquiredRegistration = true
         try assertLifecycleFlightCurrent(
           id: flightID,
@@ -921,7 +929,9 @@ actor AgentBridge {
         || synchronizedRuntimeAuthorityEpoch != status.epoch
         || synchronizedRuntimeAuthorityOwnerID != ownerID
       if authorityNeedsSynchronization {
-        await synchronizeRuntimeAuthority(authorizationSnapshot: authorizationSnapshot)
+        await synchronizeRuntimeAuthority(
+          authorizationSnapshot: authorizationSnapshot,
+          requiresCredentials: requiresManagedCredentials)
         try assertLifecycleFlightCurrent(
           id: flightID,
           generation: generation,
@@ -1000,7 +1010,9 @@ actor AgentBridge {
       id: flightID,
       generation: generation,
       authorizationSnapshot: authorizationSnapshot)
-    await synchronizeRuntimeAuthority(authorizationSnapshot: authorizationSnapshot)
+    await synchronizeRuntimeAuthority(
+      authorizationSnapshot: authorizationSnapshot,
+      requiresCredentials: isPiMonoHarness)
     try assertLifecycleFlightCurrent(
       id: flightID,
       generation: generation,
@@ -1899,28 +1911,44 @@ actor AgentBridge {
   /// harness must replace it before the first owner-scoped RPC; pi-mono also
   /// receives the credential it needs, while local adapters use an owner-only
   /// handshake and remain independent of managed-cloud token availability.
-  private func synchronizeRuntimeAuthority(
-    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot
+  nonisolated static func synchronizeAuthorityForStart(
+    requiresCredentials: Bool,
+    refreshCredentials: () async throws -> Bool,
+    refreshOwner: () async -> Void
   ) async {
-    guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return }
-    guard isPiMonoHarness else {
-      await runtime.refreshRuntimeOwner(
-        expectedOwnerId: authorizationSnapshot.ownerID,
-        authorizationSnapshot: authorizationSnapshot)
+    guard requiresCredentials else {
+      await refreshOwner()
       return
     }
-    ensureTokenRefreshTask(authorizationSnapshot: authorizationSnapshot)
     do {
-      if try await refreshAuthToken(authorizationSnapshot: authorizationSnapshot) == false {
-        await runtime.refreshRuntimeOwner(
-          expectedOwnerId: authorizationSnapshot.ownerID,
-          authorizationSnapshot: authorizationSnapshot)
+      if try await refreshCredentials() == false {
+        await refreshOwner()
       }
     } catch {
-      await runtime.refreshRuntimeOwner(
-        expectedOwnerId: authorizationSnapshot.ownerID,
-        authorizationSnapshot: authorizationSnapshot)
+      await refreshOwner()
     }
+  }
+
+  private func synchronizeRuntimeAuthority(
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot,
+    requiresCredentials: Bool
+  ) async {
+    guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return }
+    if requiresCredentials {
+      ensureTokenRefreshTask(authorizationSnapshot: authorizationSnapshot)
+    }
+    await Self.synchronizeAuthorityForStart(
+      requiresCredentials: requiresCredentials,
+      refreshCredentials: { [weak self] in
+        guard let self else { return false }
+        return try await self.refreshAuthToken(authorizationSnapshot: authorizationSnapshot)
+      },
+      refreshOwner: { [weak self] in
+        guard let self else { return }
+        await self.runtime.refreshRuntimeOwner(
+          expectedOwnerId: authorizationSnapshot.ownerID,
+          authorizationSnapshot: authorizationSnapshot)
+      })
   }
 
   func testPlaywrightConnection() async throws -> Bool {
@@ -1979,13 +2007,13 @@ actor AgentBridge {
       defaults: .standard,
       isAuthorizationCurrent: {
         RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot)
-      }
-    ) { entries in
-      try await runtime.importLegacyMainChatSessions(
-        clientId: clientId,
-        entries: entries,
-        authorizationSnapshot: authorizationSnapshot)
-    }
+      },
+      importer: { entries in
+        try await runtime.importLegacyMainChatSessions(
+          clientId: clientId,
+          entries: entries,
+          authorizationSnapshot: authorizationSnapshot)
+      })
     guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return }
     switch outcome {
     case .noAliases:

--- a/desktop/macos/Desktop/Sources/Chat/AgentClient.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentClient.swift
@@ -273,6 +273,20 @@ enum AgentClient {
       )
     }
 
+    func listJournalTurnsForControl(
+      surface: AgentSurfaceReference,
+      ownerID: String? = nil,
+      afterTurnSeq: Int = 0,
+      limit: Int = 100
+    ) async throws -> AgentRuntimeProcess.JournalOperationResult {
+      try await bridge.listJournalTurnsForControl(
+        surface: surface,
+        ownerID: ownerID,
+        afterTurnSeq: afterTurnSeq,
+        limit: limit
+      )
+    }
+
     func importRemoteJournalTurn(
       surface: AgentSurfaceReference,
       ownerID: String? = nil,
@@ -287,6 +301,18 @@ enum AgentClient {
       expectedGeneration: Int? = nil
     ) async throws -> Int {
       try await bridge.clearJournalTurns(
+        surface: surface,
+        ownerID: ownerID,
+        expectedGeneration: expectedGeneration
+      )
+    }
+
+    func clearJournalTurnsForControl(
+      surface: AgentSurfaceReference,
+      ownerID: String? = nil,
+      expectedGeneration: Int? = nil
+    ) async throws -> Int {
+      try await bridge.clearJournalTurnsForControl(
         surface: surface,
         ownerID: ownerID,
         expectedGeneration: expectedGeneration

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -82,6 +82,18 @@ enum AgentRuntimeStartupAdmission {
   }
 }
 
+/// Firebase credentials are mandatory for every production and model runtime
+/// start. The sole exception is a non-production journal-control start, whose
+/// owner-bound RPCs deliberately operate without a model credential.
+enum AgentRuntimeCredentialPolicy {
+  static func requiresManagedCredentials(
+    requestedCredentials: Bool,
+    isNonProduction: Bool
+  ) -> Bool {
+    requestedCredentials || !isNonProduction
+  }
+}
+
 /// Serializes the pipe read and sequence assignment performed by Foundation's
 /// readability callback. The callback may be re-entered on different threads;
 /// sequencing only after `availableData` would still allow a later read to be
@@ -282,6 +294,14 @@ actor AgentRuntimeProcess {
     targetHasExtension: Bool
   ) -> Bool {
     useExtension && !token.isEmpty && targetHasExtension
+  }
+
+  nonisolated static func startupAuthHeader(
+    requiresCredentials: Bool,
+    fetchAuthHeader: () async throws -> String?
+  ) async throws -> String? {
+    guard requiresCredentials else { return nil }
+    return try await fetchAuthHeader()
   }
 
   nonisolated static func validateRuntimeHandshake(
@@ -628,7 +648,8 @@ actor AgentRuntimeProcess {
   func registerClient(
     clientId: String,
     harnessMode: String,
-    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil,
+    requiresCredentials: Bool = true
   ) async throws {
     guard !isRestarting else {
       throw BridgeError.restarting
@@ -671,7 +692,8 @@ actor AgentRuntimeProcess {
       try await startProcess(
         preferredHarnessMode: harnessMode,
         authorizationSnapshot: authorizationSnapshot,
-        admissionAuthorityEpoch: admissionAuthorityEpoch)
+        admissionAuthorityEpoch: admissionAuthorityEpoch,
+        requiresCredentials: requiresCredentials)
       try assertAuthorization(authorizationSnapshot)
       try assertClientRegistration(clientId: clientId, registrationID: registrationID)
     } catch {
@@ -763,7 +785,8 @@ actor AgentRuntimeProcess {
       try await startProcess(
         preferredHarnessMode: harnessMode,
         authorizationSnapshot: authorizationSnapshot,
-        admissionAuthorityEpoch: runtimeOwnerAuthorityEpoch)
+        admissionAuthorityEpoch: runtimeOwnerAuthorityEpoch,
+        requiresCredentials: true)
       try assertAuthorization(authorizationSnapshot)
       try assertClientRegistration(clientId: clientId, registrationID: registrationID)
     } catch {
@@ -815,7 +838,9 @@ actor AgentRuntimeProcess {
   private func finishStopFlight(id: UUID) {
     guard let flight = stopFlight, flight.id == id else { return }
     stopFlight = nil
-    flight.waiters.forEach { $0.resume() }
+    for waiter in flight.waiters {
+      waiter.resume()
+    }
   }
 
   private func assertClientRegistration(
@@ -2401,7 +2426,8 @@ actor AgentRuntimeProcess {
   private func startProcess(
     preferredHarnessMode: String,
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot,
-    admissionAuthorityEpoch: UInt64
+    admissionAuthorityEpoch: UInt64,
+    requiresCredentials: Bool
   ) async throws {
     let startupIsInFlight: Bool
     if bridgeLifecycle.state == .starting {
@@ -2428,7 +2454,8 @@ actor AgentRuntimeProcess {
         return try await self.performStartProcess(
           preferredHarnessMode: preferredHarnessMode,
           authorizationSnapshot: authorizationSnapshot,
-          admissionAuthorityEpoch: admissionAuthorityEpoch)
+          admissionAuthorityEpoch: admissionAuthorityEpoch,
+          requiresCredentials: requiresCredentials)
       }
     } catch {
       if [.starting, .failedStart].contains(bridgeLifecycle.state) {
@@ -2458,7 +2485,8 @@ actor AgentRuntimeProcess {
   private func performStartProcess(
     preferredHarnessMode: String,
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot,
-    admissionAuthorityEpoch: UInt64
+    admissionAuthorityEpoch: UInt64,
+    requiresCredentials: Bool
   ) async throws -> StartupReceipt {
     // `startProcess` owns the launch through `startupSingleFlight`. Do not use
     // the reducer's `.starting` state as a join signal here: the launch owner
@@ -2563,11 +2591,20 @@ actor AgentRuntimeProcess {
       log("AgentRuntimeProcess: pi-mono BYOK active, forwarding \(byok.values.count) usable user keys")
     }
 
+    let requiresPiMonoCredentials =
+      preferredAdapterId == .piMono
+      && AgentRuntimeCredentialPolicy.requiresManagedCredentials(
+        requestedCredentials: requiresCredentials,
+        isNonProduction: AppBuild.isNonProduction)
     let authService = await MainActor.run { AuthService.shared }
     let forceRefreshToken = preferredAdapterId == .piMono && !DesktopLocalProfile.isEnabled
-    let authHeader = try? await authService.getAuthHeader(
-      forceRefresh: forceRefreshToken,
-      expectedUserId: authorizationSnapshot.ownerID)
+    let authHeader = try? await Self.startupAuthHeader(
+      requiresCredentials: requiresPiMonoCredentials,
+      fetchAuthHeader: {
+        try await authService.getAuthHeader(
+          forceRefresh: forceRefreshToken,
+          expectedUserId: authorizationSnapshot.ownerID)
+      })
     try assertStartupAuthority(
       authorizationSnapshot,
       expectedAuthorityEpoch: admissionAuthorityEpoch)
@@ -2575,7 +2612,7 @@ actor AgentRuntimeProcess {
       let token = Self.bearerToken(from: authHeader)
     {
       env["OMI_AUTH_TOKEN"] = token
-    } else if preferredAdapterId == .piMono && env["OMI_AGENT_ALLOW_CONTROL_ONLY"] != "1" {
+    } else if requiresPiMonoCredentials {
       log("AgentRuntimeProcess: pi-mono start refused, Firebase ID token is missing")
       throw BridgeError.authMissing
     } else if preferredAdapterId == .piMono {
@@ -3332,7 +3369,9 @@ actor AgentRuntimeProcess {
   }
 
   private func cancelAuthorizedToolExecutionTasks() {
-    activeAuthorizedToolExecutionTasks.values.forEach { $0.cancel() }
+    for task in activeAuthorizedToolExecutionTasks.values {
+      task.cancel()
+    }
   }
 
   private func cancelAndDrainAuthorizedToolExecutionTasks() async {
@@ -3346,7 +3385,9 @@ actor AgentRuntimeProcess {
   nonisolated static func cancelAndAwaitPhysicalExecutionTasks(
     _ tasks: [Task<Void, Never>]
   ) async {
-    tasks.forEach { $0.cancel() }
+    for task in tasks {
+      task.cancel()
+    }
     for task in tasks { await task.value }
   }
 

--- a/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
+++ b/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
@@ -246,6 +246,12 @@ final class KernelTurnProjection {
     }
   }
 
+  /// Attach the owner-bound client for a non-production journal control action
+  /// without starting a model session or scheduling projection refresh work.
+  func attachControlClient(_ client: AgentClient.Session) {
+    self.client = client
+  }
+
   /// Synchronous owner teardown. Suspended work retains its old epoch and can
   /// neither mutate checkpoints nor project owner A rows after owner B starts.
   func invalidateOwnerState() {
@@ -697,10 +703,16 @@ final class KernelTurnProjection {
     return nil
   }
 
-  func clear(surface: AgentSurfaceReference, ownerID: String? = nil) async -> Bool {
+  func clear(
+    surface: AgentSurfaceReference,
+    ownerID: String? = nil,
+    requiresModelReadiness: Bool = true
+  ) async -> Bool {
     guard let lease = captureOwnerLease(ownerID: ownerID), let host else { return false }
     let kernelReady =
-      if let kernelReadyOperation {
+      if !requiresModelReadiness {
+        client != nil
+      } else if let kernelReadyOperation {
         await kernelReadyOperation()
       } else {
         await host.ensureBridgeStartedForKernel()
@@ -713,13 +725,24 @@ final class KernelTurnProjection {
       }
       var expectedGeneration = checkpointKey.flatMap { generationByConversation[$0] }
       if expectedGeneration.map({ $0 <= 0 }) ?? true {
-        let page = try await listJournalTurns(
-          client: client,
-          surface: surface,
-          ownerID: lease.ownerID,
-          afterTurnSeq: 0,
-          limit: 1
-        )
+        let page: AgentRuntimeProcess.JournalOperationResult
+        if let journalListOperation {
+          page = try await journalListOperation(client, surface, lease.ownerID, 0, 1)
+        } else if requiresModelReadiness {
+          page = try await client.listJournalTurns(
+            surface: surface,
+            ownerID: lease.ownerID,
+            afterTurnSeq: 0,
+            limit: 1
+          )
+        } else {
+          page = try await client.listJournalTurnsForControl(
+            surface: surface,
+            ownerID: lease.ownerID,
+            afterTurnSeq: 0,
+            limit: 1
+          )
+        }
         guard isCurrent(lease),
           !page.conversationId.isEmpty,
           page.conversationGeneration > 0
@@ -740,8 +763,14 @@ final class KernelTurnProjection {
           lease.ownerID,
           expectedGeneration
         )
-      } else {
+      } else if requiresModelReadiness {
         _ = try await client.clearJournalTurns(
+          surface: surface,
+          ownerID: lease.ownerID,
+          expectedGeneration: expectedGeneration
+        )
+      } else {
+        _ = try await client.clearJournalTurnsForControl(
           surface: surface,
           ownerID: lease.ownerID,
           expectedGeneration: expectedGeneration
@@ -762,7 +791,10 @@ final class KernelTurnProjection {
   }
 
   func clearOwnerSurfaceState(chatId: String = "default") async -> Bool {
-    await clear(surface: .mainChat(chatId: chatId))
+    await clear(
+      surface: .mainChat(chatId: chatId),
+      requiresModelReadiness: false
+    )
   }
 
   @discardableResult

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -6171,7 +6171,7 @@ class ChatProvider: ObservableObject {
     guard AppBuild.isNonProduction else {
       return ["error": "clear_owner_surface_state is disabled on production bundles"]
     }
-    _ = await ensureBridgeStartedForKernel()
+    kernelTurnProjection.attachControlClient(resolvedAgentClient())
     guard await kernelTurnProjection.clearOwnerSurfaceState(chatId: chatId) else {
       return ["error": "kernel owner surface clear failed", "chat_id": chatId]
     }

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -99,7 +99,75 @@ private actor GatedRuntimeStartupHarness {
   func launches() -> Int { launchCount }
 }
 
+private enum CredentialRefreshShouldNotRun: Error {
+  case invoked
+}
+
+private actor CredentialFreeControlStartProbe {
+  private var startupCredentialFetches = 0
+  private var runtimeCredentialRefreshes = 0
+  private var ownerSynchronizations = 0
+
+  func attemptStartupCredentialFetch() throws -> String? {
+    startupCredentialFetches += 1
+    throw CredentialRefreshShouldNotRun.invoked
+  }
+
+  func attemptRuntimeCredentialRefresh() throws -> Bool {
+    runtimeCredentialRefreshes += 1
+    throw CredentialRefreshShouldNotRun.invoked
+  }
+
+  func synchronizeOwner() {
+    ownerSynchronizations += 1
+  }
+
+  func snapshot() -> (startupCredentialFetches: Int, runtimeCredentialRefreshes: Int, ownerSynchronizations: Int) {
+    (startupCredentialFetches, runtimeCredentialRefreshes, ownerSynchronizations)
+  }
+}
+
 final class AgentRuntimeProcessTests: XCTestCase {
+  func testNonProductionJournalControlStartDoesNotRefreshCredentials() async throws {
+    let probe = CredentialFreeControlStartProbe()
+
+    XCTAssertFalse(
+      AgentRuntimeCredentialPolicy.requiresManagedCredentials(
+        requestedCredentials: false,
+        isNonProduction: true))
+    XCTAssertTrue(
+      AgentRuntimeCredentialPolicy.requiresManagedCredentials(
+        requestedCredentials: false,
+        isNonProduction: false),
+      "production must never permit a credential-free runtime start")
+    XCTAssertTrue(
+      AgentRuntimeCredentialPolicy.requiresManagedCredentials(
+        requestedCredentials: true,
+        isNonProduction: true),
+      "normal model starts must remain credential-required")
+
+    let authHeader = try await AgentRuntimeProcess.startupAuthHeader(
+      requiresCredentials: false,
+      fetchAuthHeader: {
+        try await probe.attemptStartupCredentialFetch()
+      })
+    XCTAssertNil(authHeader)
+
+    await AgentBridge.synchronizeAuthorityForStart(
+      requiresCredentials: false,
+      refreshCredentials: {
+        try await probe.attemptRuntimeCredentialRefresh()
+      },
+      refreshOwner: {
+        await probe.synchronizeOwner()
+      })
+
+    let snapshot = await probe.snapshot()
+    XCTAssertEqual(snapshot.startupCredentialFetches, 0)
+    XCTAssertEqual(snapshot.runtimeCredentialRefreshes, 0)
+    XCTAssertEqual(snapshot.ownerSynchronizations, 1)
+  }
+
   func testKernelJournalMutationClosesTheRuntimeReplayBoundary() async throws {
     let runtime = AgentRuntimeProcess()
     let turn = try XCTUnwrap(
@@ -364,13 +432,13 @@ final class AgentRuntimeProcessTests: XCTestCase {
     let startBody = String(bridgeSource[startRange.lowerBound..<restartRange.lowerBound])
     let handshakeRange = try XCTUnwrap(
       startBody.range(
-        of: "await synchronizeRuntimeAuthority(authorizationSnapshot: authorizationSnapshot)"))
+        of: "await synchronizeRuntimeAuthority(\n          authorizationSnapshot: authorizationSnapshot,"))
     let migrationRange = try XCTUnwrap(
       startBody.range(
         of: "await migrateLegacyMainChatSessionsIfNeeded("))
     XCTAssertLessThan(handshakeRange.lowerBound, migrationRange.lowerBound)
-    XCTAssertTrue(bridgeSource.contains("guard isPiMonoHarness else"))
-    XCTAssertTrue(bridgeSource.contains("await runtime.refreshRuntimeOwner("))
+    XCTAssertTrue(bridgeSource.contains("synchronizeAuthorityForStart("))
+    XCTAssertTrue(bridgeSource.contains("runtime.refreshRuntimeOwner("))
   }
 
   func testRuntimeStartupSingleFlightLaunchesExactlyOnceForConcurrentSameKey() async throws {
@@ -637,11 +705,13 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertTrue(
       bridgeSource.contains(
         "AgentRuntimeProcess.adapterId(forHarnessMode: harnessMode) == AgentAdapterId.piMono.rawValue"))
-    XCTAssertTrue(bridgeSource.contains("guard isPiMonoHarness else"))
+    XCTAssertTrue(
+      bridgeSource.contains(
+        "isPiMonoHarness\n      && AgentRuntimeCredentialPolicy.requiresManagedCredentials"))
     XCTAssertTrue(bridgeSource.contains("if adapterId == AgentAdapterId.piMono.rawValue"))
     XCTAssertTrue(
       bridgeSource.contains(
-        "ensureTokenRefreshTask(authorizationSnapshot: authorizationSnapshot)"))
+        "if requiresCredentials {\n      ensureTokenRefreshTask(authorizationSnapshot: authorizationSnapshot)"))
     XCTAssertFalse(bridgeSource.contains("guard isPiMonoHarness else { return false }"))
     XCTAssertFalse(bridgeSource.contains(#"harnessMode == "piMono""#))
   }

--- a/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
@@ -449,6 +449,48 @@ final class KernelTurnRecordedProjectionTests: XCTestCase {
     )
   }
 
+  func testClearOwnerSurfaceStateUsesAuthoritativeJournalControlWhenModelReadinessIsUnavailable() async throws {
+    let provider = ChatProvider()
+    let surface = provider.mainChatSurfaceReference()
+    provider.projectJournalTurn(
+      try turn(
+        surface: surface,
+        turnId: "visible-before-reset",
+        turnSeq: 1,
+        content: "This must be cleared only after the journal confirms it"
+      ))
+    var modelReadinessRequests = 0
+    var clearCalls: [(ownerID: String, generation: Int)] = []
+    let projection = KernelTurnProjection(
+      host: provider,
+      client: AgentClient.Session(harnessMode: "piMono"),
+      ownerIDProvider: { "fault-harness-owner" },
+      journalListOperation: { _, _, ownerID, afterTurnSeq, limit in
+        XCTAssertEqual(ownerID, "fault-harness-owner")
+        XCTAssertEqual(afterTurnSeq, 0)
+        XCTAssertEqual(limit, 1)
+        return self.journalPage(conversationId: "fault-harness-conversation", turns: [], generation: 9)
+      },
+      journalClearOperation: { _, _, ownerID, expectedGeneration in
+        clearCalls.append((ownerID, expectedGeneration))
+        return 1
+      },
+      kernelReadyOperation: {
+        modelReadinessRequests += 1
+        return false
+      }
+    )
+
+    let cleared = await projection.clearOwnerSurfaceState(chatId: "default")
+
+    XCTAssertTrue(cleared)
+    XCTAssertEqual(modelReadinessRequests, 0)
+    XCTAssertEqual(clearCalls.map(\.ownerID), ["fault-harness-owner"])
+    XCTAssertEqual(clearCalls.map(\.generation), [9])
+    XCTAssertTrue(provider.messages.isEmpty)
+  }
+
+
   func testClearFailsClosedWhenGenerationBootstrapFails() async throws {
     struct BootstrapFailure: Error {}
 

--- a/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
@@ -490,7 +490,6 @@ final class KernelTurnRecordedProjectionTests: XCTestCase {
     XCTAssertTrue(provider.messages.isEmpty)
   }
 
-
   func testClearFailsClosedWhenGenerationBootstrapFails() async throws {
     struct BootstrapFailure: Error {}
 

--- a/desktop/macos/changelog/unreleased/fault-reset-credential-control.json
+++ b/desktop/macos/changelog/unreleased/fault-reset-credential-control.json
@@ -1,0 +1,1 @@
+{"change":"Fixed beta chat recovery after a failed request."}


### PR DESCRIPTION
## Summary
- let non-production fault qualification reset owner-bound journal state without starting a credential-requiring model session
- propagate that credential-free policy through runtime launch and authority synchronization, so a reset cannot refresh or invalidate a faulted Firebase session
- preserve normal credential requirements for chat/model runtime startup and restart

## Product invariants affected
- INV-AUTH-1
- INV-CHAT-1

## Verification
- `xcrun swift test --package-path Desktop --filter AgentRuntimeProcessTests --filter KernelTurnRecordedProjectionTests`
- `make preflight`

Failure-Class: FC-split-mutation-authority

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
