### PR TITLE
fix(sync): converge durable Cloud Tasks ledger retries

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -4,13 +4,13 @@
     "backend/routers/chat.py": 1580,
     "backend/routers/developer.py": 2184,
     "backend/routers/mcp_sse.py": 1857,
-    "backend/routers/sync.py": 2000,
+    "backend/routers/sync.py": 2024,
     "backend/routers/users.py": 2046
   },
   "raise_justifications": {
     "backend/routers/chat.py": "PTT stereo rejection keeps the serving STT provider boundary explicit in the established chat admission owner.",
     "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first.",
-    "backend/routers/sync.py": "Fresh-sync admission gains a hard daily-audio anti-abuse ceiling gate (is_daily_audio_ceiling_exceeded), mirroring the adjacent hard-restriction gate, plus plan-aware soft-cap wiring; both belong at this existing ingestion owner, not a new module."
+    "backend/routers/sync.py": "Fresh Sync admission and final Cloud Tasks ledger recovery retain their coupled task, lock, ledger, and staged-blob lifecycle in the existing ingestion owner rather than a new module."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -5,10 +5,11 @@
     "backend/utils/memory_ingestion/pipeline.py": 1711,
     "backend/utils/other/storage.py": 1584,
     "backend/utils/retrieval/tools/calendar_tools.py": 1513,
-    "backend/utils/sync/pipeline.py": 2296
+    "backend/utils/sync/pipeline.py": 2299
   },
   "raise_justifications": {
-    "backend/utils/other/storage.py": "delete_app_logo now requires an exact app-logo bucket prefix (startswith) so a foreign URL embedding the prefix later cannot delete an unrelated object on this deletion path (David review on #9873)."
+    "backend/utils/other/storage.py": "delete_app_logo now requires an exact app-logo bucket prefix (startswith) so a foreign URL embedding the prefix later cannot delete an unrelated object on this deletion path (David review on #9873).",
+    "backend/utils/sync/pipeline.py": "Durable-ledger convergence remains beside the Sync pipeline's run-lock ownership and terminal-result transitions instead of splitting one recovery invariant across modules."
   },
   "threshold": 1500
 }

--- a/.github/workflows/backend-hermetic-e2e.yml
+++ b/.github/workflows/backend-hermetic-e2e.yml
@@ -99,3 +99,53 @@ jobs:
 
       - name: Run listen to pusher stack gauntlet
         run: npm run test:listen-pusher-stack:emulator
+
+  sync-cloud-tasks-stack-gauntlet:
+    name: Sync Cloud Tasks Stack Gauntlet
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: backend/.python-version
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/pylock*.toml
+
+      - name: Install backend dependencies in the gauntlet virtualenv
+        working-directory: backend
+        run: |
+          uv venv .venv
+          uv pip sync pylock.toml --python .venv/bin/python
+
+      - name: Set up Node.js for the Firestore emulator
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install pinned Firebase CLI dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Set up Java for the Firestore emulator
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Install Redis server
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes redis-server
+
+      - name: Run Sync Cloud Tasks stack gauntlet
+        run: npm run test:sync-cloud-tasks-stack:emulator

--- a/backend/database/sync_jobs.py
+++ b/backend/database/sync_jobs.py
@@ -603,12 +603,13 @@ def finalize_sync_job(job_id: str, result: Dict[str, Any]) -> Optional[Dict[str,
     return finalized
 
 
-def fenced_finalize_sync_job(
+def _fenced_finalize_sync_job(
     job_id: str,
     run_lock_token: str,
     result: Dict[str, Any],
     *,
     now: Optional[float] = None,
+    allowed_current_statuses: Set[str],
 ) -> FencedSyncJobMutation:
     """Publish a terminal result only while the caller retains the run lock.
 
@@ -623,7 +624,7 @@ def fenced_finalize_sync_job(
         run_lock_token,
         updates,
         now=completed_at,
-        allowed_current_statuses={'processing'},
+        allowed_current_statuses=allowed_current_statuses,
     )
     if mutation.applied and mutation.job is not None:
         _log_sync_job_finalized(
@@ -634,6 +635,45 @@ def fenced_finalize_sync_job(
             failed=failed,
         )
     return mutation
+
+
+def fenced_finalize_sync_job(
+    job_id: str,
+    run_lock_token: str,
+    result: Dict[str, Any],
+    *,
+    now: Optional[float] = None,
+) -> FencedSyncJobMutation:
+    """Publish ordinary worker terminal work only from the processing state."""
+    return _fenced_finalize_sync_job(
+        job_id,
+        run_lock_token,
+        result,
+        now=now,
+        allowed_current_statuses={'processing'},
+    )
+
+
+def fenced_finalize_sync_job_from_durable_ledger(
+    job_id: str,
+    run_lock_token: str,
+    result: Dict[str, Any],
+    *,
+    now: Optional[float] = None,
+) -> FencedSyncJobMutation:
+    """Converge a validated content-ledger completion after a task retry.
+
+    The caller must already have a current run-lock and a valid completed
+    ledger result. Unlike normal worker finalization, its Redis job may have
+    been deliberately reset to ``queued`` before Cloud Tasks redelivered it.
+    """
+    return _fenced_finalize_sync_job(
+        job_id,
+        run_lock_token,
+        result,
+        now=now,
+        allowed_current_statuses={'queued', 'processing'},
+    )
 
 
 def mark_job_completed(job_id: str, result: Dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1697,6 +1697,30 @@ async def run_sync_job(request: Request, task_retry_count: int = Depends(verify_
                     status_code=500,
                     content={'status': 'terminal_cleanup_retry', 'job_status': latest_job.get('status')},
                 )
+            if ledger_fence_active and task_retry_count >= max_attempts - 1:
+                # A pipeline leaf can durably complete the content ledger and
+                # then fail before it publishes the matching Redis terminal
+                # result. This must win even on the task's final delivery:
+                # there may be no later Cloud Tasks retry to converge it.
+                try:
+                    converged = await run_blocking(
+                        db_executor,
+                        bind_or_converge_sync_ledger_completion,
+                        job_id=job_id,
+                        uid=uid,
+                        content_id=content_id,
+                        run_lock_token=lock_token,
+                    )
+                except SyncJobRunLeaseLost:
+                    release_lock = False
+                    logger.warning('event=sync_transcription_job outcome=lease_lost retry_material=preserved')
+                    return JSONResponse(status_code=409, content={'status': 'locked'})
+                if converged is not None:
+                    logger.info('event=sync_transcription_job outcome=reconciled_after_pipeline_exception')
+                    await _delete_staged_blobs_async(blob_paths)
+                    if sync_lane == SyncLane.BACKFILL.value:
+                        await run_blocking(db_executor, release_backfill_slot, uid, job_id)
+                    return JSONResponse(status_code=200, content={'status': 'done', 'reconciled': True})
             failure = failure_from_exception(e, provider=latest_job.get('stt_provider'))
             sync_model = latest_job.get('stt_model')
             if task_retry_count >= max_attempts - 1:

--- a/backend/testing/sync_cloud_tasks_stack/README.md
+++ b/backend/testing/sync_cloud_tasks_stack/README.md
@@ -1,0 +1,77 @@
+# Local Sync Cloud Tasks stack gauntlet
+
+Run this loopback-only gauntlet when changing Sync v2 admission, Cloud Tasks
+dispatch, worker ownership/retry, staged-audio handling, or the Sync content
+ledger:
+
+```bash
+npm run test:sync-cloud-tasks-stack:emulator
+```
+
+It needs the backend virtual environment, root Node dependencies, Redis, and
+Java 21+ for the Firestore emulator. The runner gives Firebase a fresh
+loopback port, starts a private loopback Redis, and starts **separate**
+admission and worker ASGI processes. Their environment is allowlisted and has
+an empty home/cloud configuration; it carries no cloud credentials, provider
+keys, proxies, or developer Redis/Firestore endpoint. Both processes reject
+non-loopback DNS and socket traffic. Each scenario uses a unique synthetic
+user namespace, so concurrent gauntlet invocations cannot share local Sync
+workspace material.
+
+The exercised path is:
+
+```text
+multipart PCM v2 upload → real Sync admission → filesystem staging leaf
+  → real tasks_v2.Task → strict loopback task recorder
+  → separate real OIDC-protected /v2/sync-jobs/run worker
+  → real Redis lock/job state + Firestore content ledger
+  → deterministic VAD/STT/conversation leaves → durable status/readback
+```
+
+Before upload, the isolated admission process seeds a minimal server capture
+using the production conversation encoder, then requests a real signed
+`/v2/sync-capture-manifest`. The upload therefore takes the fresh,
+device-bound admission branch; it does not use a test-only route override.
+
+The recorder accepts only the production `tasks_v2.Task` shape: the configured
+queue and named identity, loopback worker URL, POST/JSON transport, OIDC
+audience/service account, opaque durable body, and 1500-second deadline. It
+keeps the body in admission-process memory and the runner posts it to the
+separate worker over actual loopback HTTP. The worker retains the production
+OIDC dependency's header, audience, identity, and retry-count checks; its
+Google verifier accepts one exact local token, so signature, issuer, and
+expiry verification remain outside this gauntlet.
+
+Scenarios cover:
+
+1. fresh admission, rejected unauthenticated worker delivery, durable
+   completion/readback, once-only fair-use meter, and terminal duplicate ACK;
+2. failure after terminalization keeps staged material until a retry performs
+   exact-job cleanup without reprocessing;
+3. a pre-ledger failure returns the job to queue, then skips its durable
+   processed-segment checkpoint without another STT call or fair-use charge;
+4. a post-ledger failure returns the job to queue, then a later delivery
+   converges the completed ledger without reprocessing;
+5. a first pipeline success on the final Cloud Tasks delivery converges its
+   completed ledger rather than publishing a false terminal failure;
+6. retry-budget exhaustion becomes a truthful durable failure;
+7. concurrent worker deliveries are fenced by the real Redis run lock;
+8. a lost create-task acknowledgement converges through named-task
+   `AlreadyExists`, never falls back inline, and later completes; and
+9. a missing staged blob follows the real expired-input failure path without
+   invoking STT.
+
+Only external/provider leaves are replaced: Cloud Storage is local filesystem
+storage, Cloud Tasks is the local strict recorder, Google OIDC verification
+uses one exact local token, and VAD/STT/conversation processing are deterministic.
+The gauntlet retains production PCM decoding, upload/staging ownership, task
+protobuf construction, route authentication, locks, job/ledger transitions,
+fair-use metering, status polling, and conversation persistence.
+
+It does not prove real GCS, Cloud Tasks IAM/control-plane delivery,
+Google-signed OIDC tokens, production VAD/STT/LLM quality, BYOK, or backfill
+behavior. Those are distinct provider or product surfaces. With `--keep`, the
+runner retains process logs, local staged files, and sanitized JSONL evidence;
+evidence contains metadata only and rejects test UID/transcript sentinels. A
+caller-supplied `--state-dir` is always preserved as well; relative paths are
+resolved before child processes start.

--- a/backend/testing/sync_cloud_tasks_stack/__init__.py
+++ b/backend/testing/sync_cloud_tasks_stack/__init__.py
@@ -1,0 +1,1 @@
+"""Hermetic, process-isolated Sync Cloud Tasks stack gauntlet."""

--- a/backend/testing/sync_cloud_tasks_stack/admission_app.py
+++ b/backend/testing/sync_cloud_tasks_stack/admission_app.py
@@ -1,0 +1,3 @@
+"""Admission-process ASGI entrypoint for the Sync stack gauntlet."""
+
+from .app import app

--- a/backend/testing/sync_cloud_tasks_stack/app.py
+++ b/backend/testing/sync_cloud_tasks_stack/app.py
@@ -1,0 +1,370 @@
+"""Role-configured ASGI entrypoint for the local Sync Cloud Tasks gauntlet.
+
+The admission process keeps the real public Sync route and production task
+protobuf construction.  The worker process keeps the protected worker route,
+lease/ledger transitions, and provider-independent leaves.  They share only
+isolated Redis, Firestore, and filesystem-backed staged blobs.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import time
+import uuid
+import wave
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import google.auth
+from google.auth import credentials as google_auth_credentials
+from google.oauth2 import id_token
+from fastapi import Header, HTTPException, Request, Response
+
+from .events import write_event
+from .storage import configure_storage_dir, patch_google_storage
+
+_LOOPBACK_HOSTS = frozenset({'127.0.0.1', '::1', 'localhost', '0.0.0.0'})
+_ORIGINAL_SOCKET_CONNECT = socket.socket.connect
+_ORIGINAL_SOCKET_CONNECT_EX = socket.socket.connect_ex
+_ORIGINAL_CREATE_CONNECTION = socket.create_connection
+_ORIGINAL_GETADDRINFO = socket.getaddrinfo
+
+
+def _role() -> str:
+    value = os.getenv('OMI_SYNC_STACK_ROLE', '')
+    if value not in {'admission', 'worker'}:
+        raise RuntimeError('OMI_SYNC_STACK_ROLE must be admission or worker')
+    return value
+
+
+ROLE = _role()
+
+
+def _network_host(address: Any) -> str | None:
+    if isinstance(address, tuple) and address:
+        return str(address[0])
+    return None
+
+
+def _assert_loopback(address: Any) -> None:
+    host = _network_host(address)
+    if host is None or host in _LOOPBACK_HOSTS:
+        return
+    raise RuntimeError(f'Sync stack blocked outbound network connection to {host!r}')
+
+
+def _guarded_connect(sock: socket.socket, address: Any) -> Any:
+    _assert_loopback(address)
+    return _ORIGINAL_SOCKET_CONNECT(sock, address)
+
+
+def _guarded_connect_ex(sock: socket.socket, address: Any) -> int:
+    _assert_loopback(address)
+    return _ORIGINAL_SOCKET_CONNECT_EX(sock, address)
+
+
+def _guarded_create_connection(address: Any, *args: Any, **kwargs: Any) -> socket.socket:
+    _assert_loopback(address)
+    return _ORIGINAL_CREATE_CONNECTION(address, *args, **kwargs)
+
+
+def _guarded_getaddrinfo(host: Any, *args: Any, **kwargs: Any) -> Any:
+    if host is not None and str(host) not in _LOOPBACK_HOSTS:
+        raise RuntimeError(f'Sync stack blocked outbound DNS lookup for {host!r}')
+    return _ORIGINAL_GETADDRINFO(host, *args, **kwargs)
+
+
+# Install the no-egress guard before backend imports can instantiate a provider.
+socket.socket.connect = _guarded_connect
+socket.socket.connect_ex = _guarded_connect_ex
+socket.create_connection = _guarded_create_connection
+socket.getaddrinfo = _guarded_getaddrinfo
+
+
+def _anonymous_google_credentials(
+    *_args: Any, **_kwargs: Any
+) -> tuple[google_auth_credentials.AnonymousCredentials, str]:
+    project = os.getenv('GOOGLE_CLOUD_PROJECT') or os.getenv('FIREBASE_PROJECT_ID') or 'demo-omi-sync-stack'
+    return google_auth_credentials.AnonymousCredentials(), project
+
+
+# Firestore emulator traffic must never trigger ADC or metadata discovery.
+google.auth.default = _anonymous_google_credentials
+
+# ``cloud_tasks`` imports the production task helper, so load it only after
+# the no-egress guard is active.
+from .cloud_tasks import CloudTasksRecorder  # noqa: E402
+
+
+def _verify_local_oidc(token: str, _request: Any, *, audience: str | None = None, **_kwargs: Any) -> dict[str, Any]:
+    """Use one exact local token after the production OIDC boundary checks."""
+    expected_identity = os.getenv('SYNC_TASKS_INVOKER_SA', '')
+    expected_token = f'local-sync-oidc:{expected_identity}'
+    expected_audience = os.getenv('SYNC_TASKS_OIDC_AUDIENCE', '')
+    if not expected_identity or token != expected_token or audience != expected_audience:
+        raise ValueError('local Cloud Tasks OIDC verifier rejected the token')
+    write_event('worker', {'event': 'local_oidc_verified', 'audience': audience, 'identity_verified': True})
+    return {'email': expected_identity, 'email_verified': True}
+
+
+_storage_root = os.getenv('OMI_SYNC_STACK_STORAGE_DIR', '').strip()
+if not _storage_root:
+    raise RuntimeError('OMI_SYNC_STACK_STORAGE_DIR is required')
+configure_storage_dir(_storage_root)
+patch_google_storage()
+
+task_recorder: CloudTasksRecorder | None = None
+if ROLE == 'admission':
+    from database import conversations as conversations_db  # noqa: E402
+    from database._client import get_firestore_client  # noqa: E402
+    import utils.cloud_tasks as production_cloud_tasks  # noqa: E402
+
+    task_recorder = CloudTasksRecorder()
+    production_cloud_tasks._tasks_client = task_recorder
+else:
+    # ``verify_cloud_tasks_oidc`` still validates header shape, audience,
+    # service-account identity, and retry count. The local seam replaces the
+    # Google verifier with one exact token; signature, issuer, and expiry
+    # validation remain a production-provider concern.
+    id_token.verify_oauth2_token = _verify_local_oidc
+
+
+from main import app  # noqa: E402
+
+
+def _require_control(
+    request: Request,
+    control_token: str | None = Header(None, alias='X-Omi-Sync-Stack-Control'),
+) -> None:
+    client_host = request.client.host if request.client else None
+    if client_host not in _LOOPBACK_HOSTS or control_token != os.getenv('OMI_SYNC_STACK_CONTROL_TOKEN'):
+        raise HTTPException(status_code=403, detail='Sync stack control is loopback-only')
+
+
+@app.get('/__sync-stack/health', include_in_schema=False)
+def sync_stack_health() -> dict[str, str]:
+    return {'status': 'ok', 'role': ROLE}
+
+
+if ROLE == 'admission':
+    assert task_recorder is not None
+
+    @app.get('/__sync-stack/tasks/{task_id}', include_in_schema=False)
+    def sync_stack_task(
+        task_id: str,
+        request: Request,
+        control_token: str | None = Header(None, alias='X-Omi-Sync-Stack-Control'),
+    ) -> dict[str, Any]:
+        _require_control(request, control_token)
+        captured = task_recorder.task(task_id)
+        if captured is None:
+            raise HTTPException(status_code=404, detail='captured task not found')
+        # Loopback-only control data, never serialized into the evidence files.
+        return {'task_id': captured.task_id, 'url': captured.url, 'body': captured.body}
+
+    @app.post('/__sync-stack/capture-provenance/{conversation_id}', include_in_schema=False, status_code=204)
+    def sync_stack_capture_provenance(
+        conversation_id: str,
+        payload: dict[str, Any],
+        request: Request,
+        control_token: str | None = Header(None, alias='X-Omi-Sync-Stack-Control'),
+    ) -> Response:
+        """Create server-capture provenance through the isolated production encoder."""
+        _require_control(request, control_token)
+        uid = payload.get('uid')
+        device_id = payload.get('device_id')
+        platform = payload.get('platform')
+        if not all(isinstance(value, str) and value for value in (uid, device_id, platform)):
+            raise HTTPException(status_code=422, detail='capture provenance requires uid and device context')
+        now = datetime.now(timezone.utc)
+        capture = {
+            'id': conversation_id,
+            'created_at': now,
+            'started_at': now,
+            'finished_at': now,
+            'source': 'omi',
+            'language': 'en',
+            'structured': {
+                'title': 'Local capture provenance',
+                'overview': '',
+                'emoji': '🧪',
+                'category': 'other',
+                'action_items': [],
+                'events': [],
+            },
+            'transcript_segments': [],
+            'private_cloud_sync_enabled': False,
+            'status': 'completed',
+            'discarded': False,
+            'is_locked': False,
+            'data_protection_level': 'enhanced',
+            'client_device_id': device_id,
+            'client_platform': platform,
+        }
+        encoded_capture = conversations_db.encode_conversation_for_write(uid, capture, level='enhanced')
+        if isinstance(encoded_capture.get('transcript_segments'), list):
+            raise RuntimeError('Sync stack capture provenance was not encrypted by the production encoder')
+        get_firestore_client().collection('users').document(uid).collection('conversations').document(
+            conversation_id
+        ).set(encoded_capture)
+        return Response(status_code=204)
+
+else:
+    from models.conversation import Conversation  # noqa: E402
+    from models.conversation_enums import ConversationStatus  # noqa: E402
+    from models.structured import Structured  # noqa: E402
+    import utils.sync.pipeline as sync_pipeline  # noqa: E402
+    from utils.conversations import lifecycle as lifecycle_service  # noqa: E402
+    from routers import sync as sync_router  # noqa: E402
+
+    def _nonnegative_int(name: str) -> int:
+        raw = os.getenv(name, '0')
+        try:
+            value = int(raw)
+        except ValueError as error:
+            raise RuntimeError(f'{name} must be an integer') from error
+        if value < 0:
+            raise RuntimeError(f'{name} must be non-negative')
+        return value
+
+    _worker_failures_remaining = _nonnegative_int('OMI_SYNC_STACK_WORKER_FAILURES')
+    _pre_ledger_failures_remaining = _nonnegative_int('OMI_SYNC_STACK_PRE_LEDGER_FAILURES')
+    _post_ledger_failures_remaining = _nonnegative_int('OMI_SYNC_STACK_POST_LEDGER_FAILURES')
+    _cleanup_failures_remaining = _nonnegative_int('OMI_SYNC_STACK_CLEANUP_FAILURES')
+    _gate_dir_raw = os.getenv('OMI_SYNC_STACK_PROCESS_GATE_DIR', '').strip()
+    _gate_dir = Path(_gate_dir_raw) if _gate_dir_raw else None
+
+    def _job_id_from_path(path: str) -> str:
+        # Production paths are syncing/<uid>/<job-id>/<file>; never record path.
+        return Path(path).parent.name
+
+    def _local_vad(path: str, *, return_segments: bool = False, **_kwargs: Any) -> Any:
+        """External VAD leaf: prove the production decoder made readable WAV."""
+        with wave.open(path, 'rb') as wav_file:
+            duration = wav_file.getnframes() / float(wav_file.getframerate())
+        segments = [{'start': 0.0, 'end': min(duration, 1.0)}] if duration >= 1.0 else []
+        write_event(
+            'providers', {'event': 'vad_result', 'job_id': _job_id_from_path(path), 'segment_count': len(segments)}
+        )
+        return segments if return_segments else bool(segments)
+
+    def _local_prerecorded(audio_url: str, *, return_language: bool = False, **_kwargs: Any) -> Any:
+        """Deterministic STT leaf; it emits no transcript into evidence."""
+        job_id = audio_url.rsplit('/', 1)[-1]
+        write_event('providers', {'event': 'stt_completed', 'job_id': job_id, 'word_count': 1})
+        words = [
+            {
+                'timestamp': [0.0, 1.0],
+                'speaker': 'SPEAKER_00',
+                'text': os.getenv('OMI_SYNC_STACK_TRANSCRIPT_TOKEN', 'sync-stack-transcript'),
+            }
+        ]
+        return (words, 'en') if return_language else words
+
+    def _wait_for_process_gate(conversation_id: str) -> None:
+        if _gate_dir is None:
+            return
+        _gate_dir.mkdir(parents=True, exist_ok=True)
+        entered = _gate_dir / 'entered'
+        release = _gate_dir / 'release'
+        entered.write_text('entered', encoding='utf-8')
+        write_event('providers', {'event': 'processor_gate_entered', 'conversation_id': conversation_id})
+        deadline = time.monotonic() + 15.0
+        while not release.exists():
+            if time.monotonic() >= deadline:
+                raise RuntimeError('controlled Sync processor gate timed out')
+            time.sleep(0.01)
+
+    def _local_process_conversation(
+        uid: str,
+        language: str | None = None,
+        conversation: Any = None,
+        *,
+        language_code: str | None = None,
+        **_kwargs: Any,
+    ) -> Conversation:
+        """Deterministic process leaf with real lifecycle-backed persistence."""
+        if conversation is None:
+            raise ValueError('Sync stack deterministic processor requires a conversation')
+        conversation_id = getattr(conversation, 'id', None)
+        if not isinstance(conversation_id, str) or not conversation_id:
+            raise ValueError('Sync stack processor requires a durable conversation id')
+        _wait_for_process_gate(conversation_id)
+        effective_language = language_code or language or 'en'
+        started_at = getattr(conversation, 'started_at', None) or datetime.now(timezone.utc)
+        finished_at = getattr(conversation, 'finished_at', None) or started_at
+        completed = Conversation(
+            id=conversation_id,
+            created_at=getattr(conversation, 'created_at', None) or started_at,
+            started_at=started_at,
+            finished_at=finished_at,
+            source=getattr(conversation, 'source', None),
+            language=effective_language,
+            structured=Structured(
+                title='Sync stack deterministic conversation',
+                overview='Deterministic local processor result.',
+                emoji='🧪',
+                category='other',
+            ),
+            transcript_segments=list(getattr(conversation, 'transcript_segments', [])),
+            private_cloud_sync_enabled=bool(getattr(conversation, 'private_cloud_sync_enabled', False)),
+            status=ConversationStatus.completed,
+            is_locked=bool(getattr(conversation, 'is_locked', False)),
+            client_device_id=getattr(conversation, 'client_device_id', None),
+            client_platform=getattr(conversation, 'client_platform', None),
+        )
+        persisted = lifecycle_service.persist_processed_conversation(uid, completed.model_dump())
+        if not persisted:
+            raise RuntimeError('Sync stack deterministic processor lost conversation lifecycle ownership')
+        write_event('providers', {'event': 'conversation_persisted', 'conversation_id': completed.id})
+        return completed
+
+    def _delete_segment_blob_immediately(path: str, *_args: Any, **_kwargs: Any) -> None:
+        sync_pipeline.delete_syncing_temporal_file(path)
+
+    _original_delete_staged_blobs_async = sync_router._delete_staged_blobs_async
+    _original_run_full_pipeline = sync_router._run_full_pipeline_background_async
+    _original_mark_sync_content_completed = sync_pipeline.mark_sync_content_completed
+
+    async def _run_full_pipeline_with_controlled_worker_failure(*args: Any, **kwargs: Any) -> Any:
+        global _worker_failures_remaining
+        if _worker_failures_remaining:
+            _worker_failures_remaining -= 1
+            write_event('worker', {'event': 'intentional_worker_failure'})
+            raise RuntimeError('controlled Sync worker execution failure')
+        return await _original_run_full_pipeline(*args, **kwargs)
+
+    async def _delete_staged_blobs_with_controlled_failure(blob_paths: list[str]) -> None:
+        global _cleanup_failures_remaining
+        if _cleanup_failures_remaining:
+            _cleanup_failures_remaining -= 1
+            write_event('jobs', {'event': 'intentional_cleanup_failure', 'blob_count': len(blob_paths)})
+            raise RuntimeError('controlled Sync staged-cleanup failure')
+        await _original_delete_staged_blobs_async(blob_paths)
+
+    def _mark_sync_content_completed_with_controlled_failure(*args: Any, **kwargs: Any) -> Any:
+        global _pre_ledger_failures_remaining, _post_ledger_failures_remaining
+        if _pre_ledger_failures_remaining:
+            _pre_ledger_failures_remaining -= 1
+            write_event('worker', {'event': 'intentional_pre_ledger_failure'})
+            raise RuntimeError('controlled Sync failure before durable ledger completion')
+        completed = _original_mark_sync_content_completed(*args, **kwargs)
+        if completed and _post_ledger_failures_remaining:
+            _post_ledger_failures_remaining -= 1
+            write_event('worker', {'event': 'intentional_post_ledger_failure'})
+            raise RuntimeError('controlled Sync failure after durable ledger completion')
+        return completed
+
+    # Replace only external/provider leaves.  The decoder, staging/download,
+    # task route, fair-use policy/metering, Redis locks, ledger, and lifecycle
+    # owner remain production code.
+    sync_pipeline.vad_is_empty = _local_vad
+    sync_pipeline.get_prerecorded_service = lambda _language='en': ('parakeet', 'en', 'parakeet')
+    sync_pipeline.prerecorded = _local_prerecorded
+    sync_pipeline.process_conversation = _local_process_conversation
+    sync_pipeline.schedule_syncing_temporal_file_deletion = _delete_segment_blob_immediately
+    sync_pipeline.mark_sync_content_completed = _mark_sync_content_completed_with_controlled_failure
+    sync_router._run_full_pipeline_background_async = _run_full_pipeline_with_controlled_worker_failure
+    sync_router._delete_staged_blobs_async = _delete_staged_blobs_with_controlled_failure

--- a/backend/testing/sync_cloud_tasks_stack/cloud_tasks.py
+++ b/backend/testing/sync_cloud_tasks_stack/cloud_tasks.py
@@ -1,0 +1,166 @@
+"""Strict loopback Cloud Tasks control-plane seam for the Sync gauntlet."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import threading
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+from urllib.parse import urlparse
+
+from google.api_core.exceptions import AlreadyExists
+from google.cloud import tasks_v2
+
+from utils.cloud_tasks import DISPATCH_DEADLINE_SECONDS
+
+from .events import write_event
+
+
+@dataclass(frozen=True)
+class CapturedTask:
+    task_id: str
+    body: dict[str, Any]
+    url: str
+
+
+class CloudTasksRecorder:
+    """The narrow client surface Sync uses while retaining real task creation.
+
+    The production code still builds the ``tasks_v2.Task`` protobuf.  This
+    recorder admits only the configured local worker task and retains its
+    payload in memory for the supervisor to deliver over real loopback HTTP.
+    """
+
+    def __init__(self):
+        raw_lost_acks = os.getenv('OMI_SYNC_STACK_LOST_TASK_ACKS', '0')
+        try:
+            self._lost_acks_remaining = int(raw_lost_acks)
+        except ValueError as error:
+            raise RuntimeError('OMI_SYNC_STACK_LOST_TASK_ACKS must be an integer') from error
+        if self._lost_acks_remaining < 0:
+            raise RuntimeError('OMI_SYNC_STACK_LOST_TASK_ACKS must be non-negative')
+        self._tasks: dict[str, CapturedTask] = {}
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def queue_path(project: str, location: str, queue: str) -> str:
+        return f'projects/{project}/locations/{location}/queues/{queue}'
+
+    @staticmethod
+    def task_path(project: str, location: str, queue: str, task: str) -> str:
+        return f'projects/{project}/locations/{location}/queues/{queue}/tasks/{task}'
+
+    @staticmethod
+    def _configuration() -> tuple[str, str, str, str, str, str]:
+        project = os.getenv('SYNC_TASKS_PROJECT', '')
+        location = os.getenv('SYNC_TASKS_LOCATION', '')
+        queue = os.getenv('SYNC_TASKS_QUEUE', '')
+        handler_url = os.getenv('SYNC_TASKS_HANDLER_URL', '')
+        audience = os.getenv('SYNC_TASKS_OIDC_AUDIENCE', '') or handler_url
+        invoker_sa = os.getenv('SYNC_TASKS_INVOKER_SA', '')
+        if not all((project, location, queue, handler_url, audience, invoker_sa)):
+            raise RuntimeError('Sync loopback Cloud Tasks configuration is incomplete')
+        return project, location, queue, handler_url, audience, invoker_sa
+
+    def create_task(self, *, parent: str, task: tasks_v2.Task, **_kwargs: Any) -> tasks_v2.Task:
+        if not isinstance(task, tasks_v2.Task):
+            raise TypeError(f'expected tasks_v2.Task, got {type(task).__name__}')
+        project, location, queue, handler_url, audience, invoker_sa = self._configuration()
+        if parent != self.queue_path(project, location, queue):
+            raise RuntimeError('Sync task used an unexpected queue parent')
+        try:
+            body = json.loads(bytes(task.http_request.body).decode('utf-8'))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise RuntimeError('Sync task body is not valid JSON') from error
+        if not isinstance(body, dict):
+            raise RuntimeError('Sync task body must be a JSON object')
+        expected_keys = {
+            'schema_version',
+            'job_id',
+            'uid',
+            'raw_blob_paths',
+            'source',
+            'should_lock',
+            'conversation_id',
+            'client_device_id',
+            'client_platform',
+            'enqueued_at',
+            'lane',
+            'capture_time_trust',
+            'recording_age_seconds',
+            'content_id',
+            'ledger_fence_mode',
+        }
+        task_id = body.get('job_id')
+        if (
+            set(body) != expected_keys
+            or not isinstance(task_id, str)
+            or not task_id
+            or not isinstance(body.get('raw_blob_paths'), list)
+            or len(body['raw_blob_paths']) != 1
+            or not all(isinstance(path, str) and path for path in body['raw_blob_paths'])
+        ):
+            raise RuntimeError('Sync task body is not the durable v2 worker schema')
+        expected_name = self.task_path(project, location, queue, task_id)
+        if str(task.name) != expected_name:
+            raise RuntimeError('Sync task name does not match the durable job identity')
+        request = task.http_request
+        parsed_url = urlparse(str(request.url))
+        if (
+            str(request.url) != handler_url
+            or parsed_url.scheme != 'http'
+            or parsed_url.hostname != '127.0.0.1'
+            or parsed_url.port is None
+            or parsed_url.path != '/v2/sync-jobs/run'
+            or parsed_url.query
+            or parsed_url.username
+            or parsed_url.password
+        ):
+            raise RuntimeError('Sync task attempted a non-loopback or unexpected worker route')
+        if int(request.http_method) != int(tasks_v2.HttpMethod.POST):
+            raise RuntimeError('Sync task must use POST')
+        if dict(request.headers) != {'Content-Type': 'application/json'}:
+            raise RuntimeError('Sync task must have only the JSON content-type header')
+        if request.oidc_token.service_account_email != invoker_sa or request.oidc_token.audience != audience:
+            raise RuntimeError('Sync task has an unexpected OIDC binding')
+        if task.dispatch_deadline != timedelta(seconds=DISPATCH_DEADLINE_SECONDS):
+            raise RuntimeError('Sync task has an unexpected dispatch deadline')
+
+        with self._lock:
+            if task_id in self._tasks:
+                write_event('tasks', {'event': 'named_task_deduplicated', 'task_id': task_id})
+                raise AlreadyExists(f'task {task_id} already exists')
+            self._tasks[task_id] = CapturedTask(task_id=task_id, body=body, url=str(request.url))
+            should_lose_ack = self._lost_acks_remaining > 0
+            if should_lose_ack:
+                self._lost_acks_remaining -= 1
+
+        write_event(
+            'tasks',
+            {
+                'event': 'task_captured',
+                'task_id': task_id,
+                'queue': queue,
+                'http_method': 'POST',
+                'url_loopback': True,
+                'url_path': parsed_url.path,
+                'oidc_audience': audience,
+                'oidc_service_account': invoker_sa,
+                'payload_schema_version': body['schema_version'],
+                'payload_keys': sorted(body),
+                'raw_blob_count': len(body['raw_blob_paths']),
+                'dispatch_deadline_seconds': DISPATCH_DEADLINE_SECONDS,
+            },
+        )
+        if should_lose_ack:
+            write_event('tasks', {'event': 'task_ack_lost', 'task_id': task_id})
+            raise RuntimeError('intentional local Cloud Tasks acknowledgement loss')
+        return task
+
+    def task(self, task_id: str) -> CapturedTask | None:
+        with self._lock:
+            captured = self._tasks.get(task_id)
+            return copy.deepcopy(captured) if captured is not None else None

--- a/backend/testing/sync_cloud_tasks_stack/events.py
+++ b/backend/testing/sync_cloud_tasks_stack/events.py
@@ -1,0 +1,72 @@
+"""Sanitized, interprocess-safe JSONL evidence for the Sync stack gauntlet.
+
+The worker handles local test audio and transcript data.  Evidence accepts only
+sanitized metadata, so retained failures are useful without preserving either.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+_FORBIDDEN_KEYS = frozenset(
+    {
+        'audio',
+        'audio_bytes',
+        'body',
+        'file_path',
+        'payload',
+        'raw_blob_paths',
+        'text',
+        'transcript',
+        'uid',
+    }
+)
+
+
+def evidence_dir() -> Path:
+    state_dir = os.getenv('OMI_SYNC_STACK_STATE_DIR', '').strip()
+    if not state_dir:
+        raise RuntimeError('OMI_SYNC_STACK_STATE_DIR is required for Sync stack evidence')
+    path = Path(state_dir) / 'evidence'
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _assert_safe(value: Any, *, key: str | None = None) -> None:
+    if key in _FORBIDDEN_KEYS:
+        raise ValueError(f'unsafe evidence key: {key}')
+    if isinstance(value, dict):
+        for child_key, child_value in value.items():
+            if not isinstance(child_key, str):
+                raise ValueError('evidence keys must be strings')
+            _assert_safe(child_value, key=child_key)
+        return
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            _assert_safe(item)
+        return
+    if isinstance(value, str):
+        for sentinel_name in ('OMI_SYNC_STACK_SENSITIVE_UID', 'OMI_SYNC_STACK_TRANSCRIPT_TOKEN'):
+            sentinel = os.getenv(sentinel_name, '')
+            if sentinel and sentinel in value:
+                raise ValueError(f'unsafe evidence contains {sentinel_name}')
+
+
+def write_event(stream: str, event: dict[str, Any]) -> None:
+    """Append one metadata-only event while serializing independent ASGI roles."""
+    if not stream.replace('_', '').isalnum():
+        raise ValueError(f'invalid evidence stream: {stream!r}')
+    _assert_safe(event)
+    line = json.dumps(event, sort_keys=True, separators=(',', ':'))
+    path = evidence_dir() / f'{stream}.jsonl'
+    with path.open('a', encoding='utf-8') as output:
+        fcntl.flock(output.fileno(), fcntl.LOCK_EX)
+        try:
+            output.write(line + '\n')
+            output.flush()
+        finally:
+            fcntl.flock(output.fileno(), fcntl.LOCK_UN)

--- a/backend/testing/sync_cloud_tasks_stack/run.py
+++ b/backend/testing/sync_cloud_tasks_stack/run.py
@@ -1,0 +1,943 @@
+"""Run the process-isolated Sync Cloud Tasks stack gauntlet.
+
+Invoke through ``run.sh`` so Firebase owns a fresh Firestore emulator.  The
+supervisor starts private Redis plus independent admission and worker ASGI
+processes; it never probes, reuses, or stops developer services.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import secrets
+import shutil
+import signal
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable
+
+import google.auth
+import httpx
+import redis
+from google.auth import credentials as google_auth_credentials
+from google.cloud import firestore
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND = ROOT / 'backend'
+PYTHON = BACKEND / '.venv' / 'bin' / 'python'
+PROJECT = 'demo-omi-sync-cloud-tasks-stack'
+ADMIN_KEY = 'omi-sync-cloud-tasks-stack-admin-'
+LOCAL_OIDC_AUDIENCE = 'https://sync-stack.local/v2/sync-jobs/run'
+LOCAL_INVOKER_SA = 'sync-stack-invoker@demo-omi-sync-cloud-tasks-stack.iam.gserviceaccount.com'
+LOCAL_OIDC_TOKEN = f'local-sync-oidc:{LOCAL_INVOKER_SA}'
+SYNC_QUEUE = 'sync-jobs'
+SENSITIVE_UID = 'sync-stack-sensitive-uid'
+TRANSCRIPT_TOKEN = 'Sync stack transcript verified.'
+DEVICE_HASH = '01234567'
+DEVICE_ID = f'ios_{DEVICE_HASH}'
+ENCRYPTION_SECRET = 'omi_sync_cloud_tasks_stack_test_secret_32_bytes'
+
+
+class StackFailure(AssertionError):
+    """An actionable assertion failure from a local stack scenario."""
+
+
+@dataclass
+class Child:
+    name: str
+    process: subprocess.Popen[bytes]
+    log_path: Path
+
+
+def _anonymous_google_credentials(
+    *_args: Any, **_kwargs: Any
+) -> tuple[google_auth_credentials.AnonymousCredentials, str]:
+    return google_auth_credentials.AnonymousCredentials(), PROJECT
+
+
+# The parent itself uses only the loopback Firestore emulator; never discover ADC.
+google.auth.default = _anonymous_google_credentials
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(('127.0.0.1', 0))
+        return int(probe.getsockname()[1])
+
+
+def _wait_for_port(port: int, *, label: str, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(('127.0.0.1', port), timeout=0.25):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise StackFailure(f'{label} did not listen on 127.0.0.1:{port} within {timeout:.0f}s')
+
+
+def _wait_until(predicate: Callable[[], bool], *, label: str, timeout: float = 25.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.1)
+    raise StackFailure(f'timed out waiting for {label}')
+
+
+def _read_events(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding='utf-8').splitlines():
+        with suppress(json.JSONDecodeError):
+            value = json.loads(line)
+            if isinstance(value, dict):
+                rows.append(value)
+    return rows
+
+
+class Stack:
+    def __init__(
+        self,
+        state_dir: Path,
+        *,
+        task_ack_failures: int = 0,
+        worker_failures: int = 0,
+        pre_ledger_failures: int = 0,
+        post_ledger_failures: int = 0,
+        cleanup_failures: int = 0,
+        hold_processor: bool = False,
+    ):
+        self.state_dir = state_dir
+        self.logs_dir = state_dir / 'logs'
+        self.evidence_dir = state_dir / 'evidence'
+        self.storage_dir = state_dir / 'local-storage'
+        self.gate_dir = state_dir / 'processor-gate' if hold_processor else None
+        self.redis_port = _free_port()
+        self.admission_port = _free_port()
+        self.worker_port = _free_port()
+        self.task_ack_failures = task_ack_failures
+        self.worker_failures = worker_failures
+        self.pre_ledger_failures = pre_ledger_failures
+        self.post_ledger_failures = post_ledger_failures
+        self.cleanup_failures = cleanup_failures
+        self.children: dict[str, Child] = {}
+        self.http = httpx.Client(timeout=15.0, trust_env=False)
+        self.control_token = secrets.token_urlsafe(32)
+        self.uid_namespace = f'{SENSITIVE_UID}-{secrets.token_hex(8)}'
+        self.created_uids: set[str] = set()
+
+        # Runner-side evidence follows the same sanitizer as the ASGI roles.
+        os.environ['OMI_SYNC_STACK_STATE_DIR'] = str(state_dir)
+        os.environ['OMI_SYNC_STACK_SENSITIVE_UID'] = SENSITIVE_UID
+        os.environ['OMI_SYNC_STACK_TRANSCRIPT_TOKEN'] = TRANSCRIPT_TOKEN
+        os.environ['ENCRYPTION_SECRET'] = ENCRYPTION_SECRET
+        os.environ.pop('GOOGLE_APPLICATION_CREDENTIALS', None)
+        os.environ.pop('SERVICE_ACCOUNT_JSON', None)
+        self.env = self._environment()
+        self.firestore = firestore.Client(project=PROJECT)
+
+    def _environment(self) -> dict[str, str]:
+        firestore_host = os.getenv('FIRESTORE_EMULATOR_HOST', '').strip()
+        host = firestore_host.rsplit(':', 1)[0] if ':' in firestore_host else firestore_host
+        if host not in {'127.0.0.1', 'localhost'}:
+            raise StackFailure('FIRESTORE_EMULATOR_HOST must be loopback; run via run.sh')
+        for directory in (self.logs_dir, self.evidence_dir, self.storage_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+        if self.gate_dir is not None:
+            self.gate_dir.mkdir(parents=True, exist_ok=True)
+
+        # Inherit no provider keys, proxy configuration, ADC paths, or cloud CLI state.
+        env = {key: os.environ[key] for key in ('PATH', 'LANG', 'LC_ALL', 'TZ', 'TMPDIR') if os.getenv(key)}
+        isolated_home = self.state_dir / 'home'
+        isolated_config = self.state_dir / 'config'
+        env.update(
+            {
+                'HOME': str(isolated_home),
+                'XDG_CONFIG_HOME': str(isolated_config),
+                'CLOUDSDK_CONFIG': str(isolated_config / 'gcloud'),
+                'NO_PROXY': '127.0.0.1,localhost',
+                'no_proxy': '127.0.0.1,localhost',
+                'FIRESTORE_EMULATOR_HOST': firestore_host,
+                'FIREBASE_AUTH_EMULATOR_HOST': '127.0.0.1:9099',
+                'OMI_HARNESS_INSTANCE': 'sync-cloud-tasks-stack',
+                'OMI_ENV_STAGE': 'offline',
+                'PROVIDER_MODE': 'offline',
+                'LOCAL_DEVELOPMENT': 'true',
+                'FIREBASE_PROJECT_ID': PROJECT,
+                'GOOGLE_CLOUD_PROJECT': PROJECT,
+                'GCLOUD_PROJECT': PROJECT,
+                'FIRESTORE_DATABASE_ID': '(default)',
+                'ENCRYPTION_SECRET': ENCRYPTION_SECRET,
+                'ADMIN_KEY': ADMIN_KEY,
+                'REDIS_DB_HOST': '127.0.0.1',
+                'REDIS_DB_PORT': str(self.redis_port),
+                'REDIS_DB_PASSWORD': '',
+                'SYNC_DISPATCH_MODE': 'cloud_tasks',
+                'SYNC_LEDGER_FENCE_MODE': 'active',
+                'SYNC_TASKS_PROJECT': PROJECT,
+                'SYNC_TASKS_LOCATION': 'local',
+                'SYNC_TASKS_QUEUE': SYNC_QUEUE,
+                'SYNC_TASKS_HANDLER_URL': self.worker_url + '/v2/sync-jobs/run',
+                'SYNC_TASKS_OIDC_AUDIENCE': LOCAL_OIDC_AUDIENCE,
+                'SYNC_TASKS_INVOKER_SA': LOCAL_INVOKER_SA,
+                'SYNC_TASKS_MAX_ATTEMPTS': '2',
+                'HTTP_SYNC_JOBS_RUN_TIMEOUT': '30',
+                'FAIR_USE_ENABLED': 'true',
+                'MAX_DAILY_AUDIO_HOURS': '30',
+                'TRIAL_PAYWALL_ENABLED': 'false',
+                'STT_PRERECORDED_MODEL': 'parakeet',
+                'STT_SERVICE_MODELS': 'parakeet',
+                'HOSTED_PARAKEET_API_URL': 'http://127.0.0.1:1',
+                'BUCKET_TEMPORAL_SYNC_LOCAL': 'sync-temporal',
+                'BUCKET_SPEECH_PROFILES': 'speech-profiles',
+                'BUCKET_POSTPROCESSING': 'postprocessing',
+                'BUCKET_PRIVATE_CLOUD_SYNC': 'omi-private-cloud-sync',
+                'BUCKET_MEMORIES_RECORDINGS': 'memories-recordings',
+                'BUCKET_APP_THUMBNAILS': 'app-thumbnails',
+                'BUCKET_CHAT_FILES': 'chat-files',
+                'BUCKET_DESKTOP_UPDATES': 'desktop-updates',
+                'STRIPE_SECRET_KEY': '',
+                'OMI_SYNC_STACK_STATE_DIR': str(self.state_dir),
+                'OMI_SYNC_STACK_STORAGE_DIR': str(self.storage_dir),
+                'OMI_SYNC_STACK_CONTROL_TOKEN': self.control_token,
+                'OMI_SYNC_STACK_SENSITIVE_UID': SENSITIVE_UID,
+                'OMI_SYNC_STACK_TRANSCRIPT_TOKEN': TRANSCRIPT_TOKEN,
+                'OMI_SYNC_STACK_LOST_TASK_ACKS': str(self.task_ack_failures),
+                'OMI_SYNC_STACK_WORKER_FAILURES': str(self.worker_failures),
+                'OMI_SYNC_STACK_PRE_LEDGER_FAILURES': str(self.pre_ledger_failures),
+                'OMI_SYNC_STACK_POST_LEDGER_FAILURES': str(self.post_ledger_failures),
+                'OMI_SYNC_STACK_CLEANUP_FAILURES': str(self.cleanup_failures),
+                'OMI_SYNC_STACK_PROCESS_GATE_DIR': str(self.gate_dir) if self.gate_dir is not None else '',
+                'PYTHONPATH': str(BACKEND),
+            }
+        )
+        return env
+
+    @property
+    def admission_url(self) -> str:
+        return f'http://127.0.0.1:{self.admission_port}'
+
+    @property
+    def worker_url(self) -> str:
+        return f'http://127.0.0.1:{self.worker_port}'
+
+    @property
+    def control_headers(self) -> dict[str, str]:
+        return {'X-Omi-Sync-Stack-Control': self.control_token}
+
+    def _start(self, name: str, command: list[str], *, role: str | None = None) -> Child:
+        if name in self.children:
+            raise StackFailure(f'{name} is already running')
+        log_path = self.logs_dir / f'{name}.log'
+        process_env = self.env.copy()
+        if role:
+            process_env['OMI_SYNC_STACK_ROLE'] = role
+        output = log_path.open('wb')
+        process = subprocess.Popen(
+            command,
+            cwd=BACKEND,
+            env=process_env,
+            stdin=subprocess.DEVNULL,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        child = Child(name=name, process=process, log_path=log_path)
+        self.children[name] = child
+        return child
+
+    def _assert_health(self, base_url: str, *, role: str) -> None:
+        def healthy() -> bool:
+            try:
+                response = self.http.get(base_url + '/__sync-stack/health', timeout=1.0)
+                body = response.json()
+                return response.status_code == 200 and body == {'status': 'ok', 'role': role}
+            except (httpx.HTTPError, ValueError):
+                return False
+
+        _wait_until(healthy, label=f'Sync {role} health endpoint', timeout=20.0)
+
+    def start(self) -> None:
+        redis_binary = shutil.which('redis-server')
+        if not redis_binary:
+            raise StackFailure('redis-server is required; install Redis and retry')
+        self._start(
+            'redis',
+            [
+                redis_binary,
+                '--bind',
+                '127.0.0.1',
+                '--port',
+                str(self.redis_port),
+                '--save',
+                '',
+                '--appendonly',
+                'no',
+                '--protected-mode',
+                'yes',
+            ],
+        )
+        _wait_for_port(self.redis_port, label='isolated Redis')
+        redis.Redis(host='127.0.0.1', port=self.redis_port).ping()
+        self._start(
+            'worker',
+            [
+                str(PYTHON),
+                '-m',
+                'uvicorn',
+                'testing.sync_cloud_tasks_stack.worker_app:app',
+                '--host',
+                '127.0.0.1',
+                '--port',
+                str(self.worker_port),
+            ],
+            role='worker',
+        )
+        _wait_for_port(self.worker_port, label='Sync worker', timeout=120.0)
+        self._assert_health(self.worker_url, role='worker')
+        self._start(
+            'admission',
+            [
+                str(PYTHON),
+                '-m',
+                'uvicorn',
+                'testing.sync_cloud_tasks_stack.admission_app:app',
+                '--host',
+                '127.0.0.1',
+                '--port',
+                str(self.admission_port),
+            ],
+            role='admission',
+        )
+        _wait_for_port(self.admission_port, label='Sync admission', timeout=45.0)
+        self._assert_health(self.admission_url, role='admission')
+
+    def stop(self, name: str) -> None:
+        child = self.children.pop(name, None)
+        if child is None or child.process.poll() is not None:
+            return
+        with suppress(ProcessLookupError):
+            os.killpg(child.process.pid, signal.SIGTERM)
+        try:
+            child.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            with suppress(ProcessLookupError):
+                os.killpg(child.process.pid, signal.SIGKILL)
+            child.process.wait(timeout=5)
+
+    def close(self) -> None:
+        for name in list(self.children):
+            self.stop(name)
+        self.http.close()
+
+    def cleanup_workspace_files(self) -> None:
+        sync_root = (BACKEND / 'syncing').resolve()
+        for uid in self.created_uids:
+            target = (sync_root / uid).resolve()
+            if target.parent != sync_root or not uid.startswith(SENSITIVE_UID):
+                raise StackFailure(f'refusing unexpected Sync cleanup target: {target}')
+            if target.exists():
+                shutil.rmtree(target)
+
+    def seed_user(self, uid: str) -> None:
+        self.created_uids.add(uid)
+        self.firestore.collection('users').document(uid).set(
+            {
+                'id': uid,
+                'language': 'en',
+                'private_cloud_sync_enabled': False,
+                'data_protection_level': 'enhanced',
+                'transcription_preferences': {'uses_custom_stt': False},
+                'subscription': {'plan': 'basic', 'status': 'active'},
+            }
+        )
+        self.firestore.collection('users').document(uid).collection('fair_use_state').document('current').set(
+            {'stage': 'none'}
+        )
+
+    def scenario_uid(self, scenario: str) -> str:
+        """Give each stack instance a private Sync workspace namespace."""
+        return f'{self.uid_namespace}-{scenario}'
+
+    def evidence_events(self, stream: str) -> list[dict[str, Any]]:
+        return _read_events(self.evidence_dir / f'{stream}.jsonl')
+
+    def task_control(self, task_id: str) -> dict[str, Any]:
+        response = self.http.get(
+            self.admission_url + f'/__sync-stack/tasks/{task_id}', headers=self.control_headers, timeout=5.0
+        )
+        if response.status_code != 200:
+            raise StackFailure(f'captured task {task_id} unavailable: HTTP {response.status_code}')
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise StackFailure('captured task control endpoint returned a non-object')
+        return payload
+
+    def staged_blob_path(self, blob_path: str) -> Path:
+        relative = PurePosixPath(blob_path)
+        if relative.is_absolute() or '..' in relative.parts:
+            raise StackFailure('task yielded an unsafe staged blob path')
+        return self.storage_dir / 'sync-temporal' / Path(*relative.parts)
+
+    def fair_use_meter_ms(self, uid: str) -> int:
+        values = redis.Redis(host='127.0.0.1', port=self.redis_port).hgetall(f'fair_use:v2:bucket:sync_fresh:{uid}')
+        return sum(int(value) for value in values.values())
+
+
+def _pcm16_upload_bytes() -> bytes:
+    """One second of framed PCM16 accepted by the production v2 decoder."""
+    frame = struct.pack('<h', 1200) * 1600
+    return b''.join(struct.pack('<I', len(frame)) + frame for _ in range(10))
+
+
+def _fresh_pcm_filename() -> str:
+    return f'audio_omi_pcm16_16000_1_fs160_{int(time.time()) - 60}.bin'
+
+
+def _record_job_event(event: dict[str, Any]) -> None:
+    from testing.sync_cloud_tasks_stack.events import write_event
+
+    write_event('jobs', event)
+
+
+def _auth_headers(uid: str) -> dict[str, str]:
+    return {'Authorization': f'Bearer {ADMIN_KEY}{uid}'}
+
+
+def _seed_capture_conversation(stack: Stack, uid: str, conversation_id: str) -> None:
+    """Seed real encoded provenance inside the isolated admission process."""
+    response = stack.http.post(
+        stack.admission_url + f'/__sync-stack/capture-provenance/{conversation_id}',
+        json={'uid': uid, 'device_id': DEVICE_ID, 'platform': 'ios'},
+        headers=stack.control_headers,
+        timeout=10.0,
+    )
+    if response.status_code != 204:
+        raise StackFailure(f'isolated capture provenance seed returned HTTP {response.status_code}')
+
+
+def _submit_and_capture_task(stack: Stack, uid: str) -> tuple[str, dict[str, Any]]:
+    stack.seed_user(uid)
+    filename = _fresh_pcm_filename()
+    audio = _pcm16_upload_bytes()
+    capture_conversation_id = f'sync-stack-capture-{uuid.uuid4().hex}'
+    _seed_capture_conversation(stack, uid, capture_conversation_id)
+    common_headers = {
+        **_auth_headers(uid),
+        'X-App-Platform': 'ios',
+        'X-Device-Id-Hash': DEVICE_HASH,
+    }
+    manifest_response = stack.http.post(
+        stack.admission_url + '/v2/sync-capture-manifest',
+        json={
+            'conversation_id': capture_conversation_id,
+            'files': [{'name': filename, 'sha256': hashlib.sha256(audio).hexdigest()}],
+        },
+        headers=common_headers,
+        timeout=10.0,
+    )
+    if manifest_response.status_code != 200:
+        raise StackFailure(f'fresh capture manifest returned HTTP {manifest_response.status_code}')
+    manifest_body = manifest_response.json()
+    manifest = manifest_body.get('manifest') if isinstance(manifest_body, dict) else None
+    if not isinstance(manifest, str) or not manifest:
+        raise StackFailure('fresh capture manifest response omitted its signed manifest')
+    response = stack.http.post(
+        stack.admission_url + f'/v2/sync-local-files?conversation_id={capture_conversation_id}',
+        files=[('files', (filename, audio, 'application/octet-stream'))],
+        headers={**common_headers, 'X-Omi-Sync-Capture-Manifest': manifest},
+        timeout=20.0,
+    )
+    if response.status_code != 202:
+        raise StackFailure(f'Sync admission returned HTTP {response.status_code}: {response.text[:160]}')
+    admitted = response.json()
+    job_id = admitted.get('job_id') if isinstance(admitted, dict) else None
+    if not isinstance(job_id, str) or admitted.get('status') != 'queued' or admitted.get('lane') != 'fresh':
+        raise StackFailure('Sync admission did not return one queued fresh job')
+
+    captured: dict[str, Any] = {}
+
+    def task_captured() -> bool:
+        nonlocal captured
+        try:
+            captured = stack.task_control(job_id)
+        except (httpx.HTTPError, StackFailure):
+            return False
+        return isinstance(captured.get('body'), dict)
+
+    _wait_until(task_captured, label=f'Cloud Tasks capture for job {job_id}', timeout=10.0)
+    _assert_task_contract(stack, job_id, uid, capture_conversation_id, captured)
+    _assert_unauthenticated_delivery_is_rejected(stack, uid, job_id, captured)
+    return job_id, captured
+
+
+def _assert_task_contract(stack: Stack, job_id: str, uid: str, conversation_id: str, captured: dict[str, Any]) -> None:
+    body = captured.get('body')
+    if not isinstance(body, dict):
+        raise StackFailure('captured task body is missing')
+    raw_paths = body.get('raw_blob_paths')
+    if (
+        body.get('job_id') != job_id
+        or body.get('uid') != uid
+        or body.get('conversation_id') != conversation_id
+        or body.get('client_device_id') != DEVICE_ID
+        or body.get('client_platform') != 'ios'
+        or body.get('lane') != 'fresh'
+        or body.get('capture_time_trust') != 'device_bound'
+        or body.get('ledger_fence_mode') != 'active'
+        or body.get('should_lock') is not False
+        or not isinstance(raw_paths, list)
+        or len(raw_paths) != 1
+        or not isinstance(raw_paths[0], str)
+        or not stack.staged_blob_path(raw_paths[0]).is_file()
+    ):
+        raise StackFailure('captured task did not preserve the fresh durable Sync worker contract')
+    recording_age_seconds = body.get('recording_age_seconds')
+    if (
+        not isinstance(recording_age_seconds, int)
+        or isinstance(recording_age_seconds, bool)
+        or not 0 <= recording_age_seconds <= 300
+    ):
+        raise StackFailure('fresh task did not preserve a recent device-bound recording age')
+    events = [
+        event
+        for event in stack.evidence_events('tasks')
+        if event.get('event') == 'task_captured' and event.get('task_id') == job_id
+    ]
+    if len(events) != 1:
+        raise StackFailure(f'expected one captured task event for {job_id}, saw {len(events)}')
+
+
+def _post_task(task: dict[str, Any], *, retry_count: int, include_auth: bool = True) -> httpx.Response:
+    body = task.get('body')
+    url = task.get('url')
+    if not isinstance(body, dict) or not isinstance(url, str):
+        raise StackFailure('task control response is malformed')
+    headers = {'X-CloudTasks-TaskRetryCount': str(retry_count)}
+    if include_auth:
+        headers['Authorization'] = f'Bearer {LOCAL_OIDC_TOKEN}'
+    with httpx.Client(timeout=35.0, trust_env=False) as client:
+        return client.post(url, json=body, headers=headers)
+
+
+def _deliver_task(task: dict[str, Any], *, retry_count: int) -> httpx.Response:
+    response = _post_task(task, retry_count=retry_count)
+    _record_job_event(
+        {
+            'event': 'worker_delivery',
+            'task_id': task.get('task_id'),
+            'retry_count': retry_count,
+            'http_status': response.status_code,
+        }
+    )
+    return response
+
+
+def _job_status(stack: Stack, uid: str, job_id: str) -> dict[str, Any]:
+    response = stack.http.get(
+        stack.admission_url + f'/v2/sync-local-files/{job_id}', headers=_auth_headers(uid), timeout=5.0
+    )
+    if response.status_code != 200:
+        raise StackFailure(f'Sync status poll returned HTTP {response.status_code}')
+    body = response.json()
+    if not isinstance(body, dict):
+        raise StackFailure('Sync status poll returned a non-object')
+    return body
+
+
+def _assert_unauthenticated_delivery_is_rejected(stack: Stack, uid: str, job_id: str, task: dict[str, Any]) -> None:
+    denied = _post_task(task, retry_count=0, include_auth=False)
+    if denied.status_code != 403:
+        raise StackFailure(f'unauthenticated worker delivery returned HTTP {denied.status_code}, expected 403')
+    if _job_status(stack, uid, job_id).get('status') != 'queued':
+        raise StackFailure('rejected worker delivery changed the queued Sync job state')
+
+
+def _poll_terminal_job(stack: Stack, uid: str, job_id: str, *, timeout: float = 20.0) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+
+    def terminal() -> bool:
+        nonlocal result
+        result = _job_status(stack, uid, job_id)
+        return result.get('status') in {'completed', 'partial_failure', 'failed'}
+
+    _wait_until(terminal, label=f'terminal Sync job {job_id}', timeout=timeout)
+    return result
+
+
+def _assert_durable_success(stack: Stack, uid: str, job_id: str) -> str:
+    status = _poll_terminal_job(stack, uid, job_id)
+    result = status.get('result')
+    if status.get('status') != 'completed' or not isinstance(result, dict):
+        raise StackFailure(f'Sync worker did not publish a durable completed result for {job_id}')
+    conversations = [*(result.get('new_memories') or []), *(result.get('updated_memories') or [])]
+    if len(conversations) != 1 or not isinstance(conversations[0], str):
+        raise StackFailure('deterministic worker did not produce exactly one durable conversation id')
+    conversation_id = conversations[0]
+    response = stack.http.get(
+        stack.admission_url + f'/v1/conversations/{conversation_id}', headers=_auth_headers(uid), timeout=10.0
+    )
+    if response.status_code != 200:
+        raise StackFailure(f'durable conversation read returned HTTP {response.status_code}')
+    conversation = response.json()
+    segments = conversation.get('transcript_segments') if isinstance(conversation, dict) else None
+    if (
+        not isinstance(conversation, dict)
+        or conversation.get('status') != 'completed'
+        or not isinstance(segments, list)
+        or len(segments) != 1
+        or segments[0].get('text') != TRANSCRIPT_TOKEN
+    ):
+        raise StackFailure('durable conversation did not contain the deterministic worker result')
+    task = stack.task_control(job_id)
+    body = task.get('body')
+    if not isinstance(body, dict) or body.get('conversation_id') != conversation_id:
+        raise StackFailure('worker did not merge/reprocess the conversation selected during fresh admission')
+    content_id = body.get('content_id')
+    if not isinstance(content_id, str):
+        raise StackFailure('task content id is missing')
+    ledger = (
+        stack.firestore.collection('users').document(uid).collection('sync_content_ledger').document(content_id).get()
+    )
+    ledger_data = ledger.to_dict() if ledger.exists else None
+    if not isinstance(ledger_data, dict) or ledger_data.get('status') != 'completed':
+        raise StackFailure('Firestore Sync content ledger was not durably completed')
+    _record_job_event(
+        {
+            'event': 'durable_job_verified',
+            'job_id': job_id,
+            'status': 'completed',
+            'conversation_id': conversation_id,
+            'ledger_status': 'completed',
+        }
+    )
+    return conversation_id
+
+
+def _stt_invocation_count(stack: Stack, job_id: str) -> int:
+    return sum(
+        1
+        for event in stack.evidence_events('providers')
+        if event.get('event') == 'stt_completed' and event.get('job_id') == job_id
+    )
+
+
+def _assert_metered_once(stack: Stack, uid: str) -> None:
+    if stack.fair_use_meter_ms(uid) != 1000:
+        raise StackFailure('fresh Sync task did not meter exactly one second once')
+
+
+def _assert_not_metered(stack: Stack, uid: str) -> None:
+    if stack.fair_use_meter_ms(uid) != 0:
+        raise StackFailure('worker failure before pipeline execution unexpectedly recorded speech usage')
+
+
+def _happy_path_and_terminal_duplicate(stack: Stack) -> None:
+    uid = stack.scenario_uid('duplicate')
+    job_id, task = _submit_and_capture_task(stack, uid)
+    first = _deliver_task(task, retry_count=0)
+    if first.status_code != 200 or first.json().get('status') != 'done':
+        raise StackFailure('first worker delivery did not complete through the separate worker route')
+    _assert_durable_success(stack, uid, job_id)
+    _assert_metered_once(stack, uid)
+    if _stt_invocation_count(stack, job_id) != 1:
+        raise StackFailure('first completed worker delivery did not invoke STT exactly once')
+    duplicate = _deliver_task(task, retry_count=1)
+    if duplicate.status_code != 200 or duplicate.json().get('status') != 'acked':
+        raise StackFailure('terminal duplicate was not ACKed by the separate worker route')
+    _assert_metered_once(stack, uid)
+    if _stt_invocation_count(stack, job_id) != 1:
+        raise StackFailure('terminal duplicate re-ran the provider pipeline')
+
+
+def _cleanup_retry_preserves_terminal_work(stack: Stack) -> None:
+    uid = stack.scenario_uid('cleanup-retry')
+    job_id, task = _submit_and_capture_task(stack, uid)
+    raw_path = task['body']['raw_blob_paths'][0]
+    staged_path = stack.staged_blob_path(raw_path)
+    first = _deliver_task(task, retry_count=0)
+    if first.status_code != 500:
+        raise StackFailure('controlled terminal cleanup failure did not request Cloud Tasks retry')
+    _assert_durable_success(stack, uid, job_id)
+    _assert_metered_once(stack, uid)
+    if not staged_path.is_file() or _stt_invocation_count(stack, job_id) != 1:
+        raise StackFailure('terminal cleanup retry did not preserve staged material and one STT invocation')
+    retry = _deliver_task(task, retry_count=1)
+    if retry.status_code != 200 or retry.json().get('status') != 'acked':
+        raise StackFailure('terminal cleanup retry was not ACKed')
+    if staged_path.exists() or _stt_invocation_count(stack, job_id) != 1:
+        raise StackFailure('terminal cleanup retry did not clean exact material without reprocessing')
+    _assert_metered_once(stack, uid)
+
+
+def _content_ledger_data(stack: Stack, uid: str, task: dict[str, Any]) -> dict[str, Any]:
+    body = task.get('body')
+    content_id = body.get('content_id') if isinstance(body, dict) else None
+    if not isinstance(content_id, str):
+        raise StackFailure('Sync task omitted durable content identity')
+    ledger = (
+        stack.firestore.collection('users').document(uid).collection('sync_content_ledger').document(content_id).get()
+    )
+    ledger_data = ledger.to_dict() if ledger.exists else None
+    if not isinstance(ledger_data, dict):
+        raise StackFailure('Sync content ledger was not durably readable')
+    return ledger_data
+
+
+def _pre_ledger_failure_retries_once(stack: Stack) -> None:
+    uid = stack.scenario_uid('transient-retry')
+    job_id, task = _submit_and_capture_task(stack, uid)
+    first = _deliver_task(task, retry_count=0)
+    if first.status_code != 500 or first.json().get('status') != 'retry':
+        raise StackFailure('controlled pre-ledger failure did not request a durable retry')
+    if _job_status(stack, uid, job_id).get('status') != 'queued':
+        raise StackFailure('pre-ledger worker failure did not return the job to queued')
+    if not stack.staged_blob_path(task['body']['raw_blob_paths'][0]).is_file():
+        raise StackFailure('pre-ledger worker failure deleted staged input')
+    ledger_data = _content_ledger_data(stack, uid, task)
+    if ledger_data.get('status') != 'processing' or len(ledger_data.get('processed_segment_ids') or []) != 1:
+        raise StackFailure('pre-ledger retry did not preserve the durable processed-segment checkpoint')
+    _assert_metered_once(stack, uid)
+    if _stt_invocation_count(stack, job_id) != 1:
+        raise StackFailure('pre-ledger failure did not execute the initial provider pipeline exactly once')
+    retry = _deliver_task(task, retry_count=1)
+    if retry.status_code != 200 or retry.json().get('status') != 'done':
+        raise StackFailure('pre-ledger retry did not complete the durable job')
+    _assert_durable_success(stack, uid, job_id)
+    _assert_metered_once(stack, uid)
+    if _stt_invocation_count(stack, job_id) != 1:
+        raise StackFailure('pre-ledger retry re-ran a completed Sync segment')
+
+
+def _post_ledger_failure_converges_once(stack: Stack) -> None:
+    uid = stack.scenario_uid('post-ledger-retry')
+    job_id, task = _submit_and_capture_task(stack, uid)
+    first = _deliver_task(task, retry_count=0)
+    if first.status_code != 500 or first.json().get('status') != 'retry':
+        raise StackFailure('controlled post-ledger failure did not request a durable retry')
+    if _job_status(stack, uid, job_id).get('status') != 'queued':
+        raise StackFailure('post-ledger worker failure did not return the job to queued')
+    if not stack.staged_blob_path(task['body']['raw_blob_paths'][0]).is_file():
+        raise StackFailure('post-ledger worker failure deleted staged input')
+    if _content_ledger_data(stack, uid, task).get('status') != 'completed':
+        raise StackFailure('controlled retry did not fail after durable content-ledger completion')
+    _assert_metered_once(stack, uid)
+    if _stt_invocation_count(stack, job_id) != 1:
+        raise StackFailure('post-ledger failure did not execute the initial provider pipeline exactly once')
+    retry = _deliver_task(task, retry_count=1)
+    if retry.status_code != 200 or retry.json().get('status') != 'done' or retry.json().get('reconciled') is not True:
+        raise StackFailure('post-ledger retry did not converge through the durable content ledger')
+    _assert_durable_success(stack, uid, job_id)
+    _assert_metered_once(stack, uid)
+    if _stt_invocation_count(stack, job_id) != 1:
+        raise StackFailure('post-ledger retry re-ran a completed Sync segment')
+
+
+def _final_attempt_post_ledger_failure_converges(stack: Stack) -> None:
+    """A final task delivery must not overwrite its own completed ledger."""
+    uid = stack.scenario_uid('final-attempt-ledger')
+    job_id, task = _submit_and_capture_task(stack, uid)
+    first = _deliver_task(task, retry_count=0)
+    if first.status_code != 500 or first.json().get('status') != 'retry':
+        raise StackFailure('pre-pipeline first delivery did not request a durable retry')
+    if _job_status(stack, uid, job_id).get('status') != 'queued':
+        raise StackFailure('pre-pipeline first delivery did not return the job to queued')
+    _assert_not_metered(stack, uid)
+    if _stt_invocation_count(stack, job_id) != 0:
+        raise StackFailure('pre-pipeline first delivery unexpectedly invoked STT')
+
+    final = _deliver_task(task, retry_count=1)
+    if final.status_code != 200 or final.json().get('status') != 'done' or final.json().get('reconciled') is not True:
+        raise StackFailure('final delivery did not converge its completed durable content ledger')
+    _assert_durable_success(stack, uid, job_id)
+    _assert_metered_once(stack, uid)
+    if _stt_invocation_count(stack, job_id) != 1:
+        raise StackFailure('final durable-ledger convergence re-ran the provider pipeline')
+    if stack.staged_blob_path(task['body']['raw_blob_paths'][0]).exists():
+        raise StackFailure('final durable-ledger convergence did not clean staged input')
+
+
+def _retry_budget_terminalizes_truthfully(stack: Stack) -> None:
+    uid = stack.scenario_uid('terminal-failure')
+    job_id, task = _submit_and_capture_task(stack, uid)
+    first = _deliver_task(task, retry_count=0)
+    if first.status_code != 500 or first.json().get('status') != 'retry':
+        raise StackFailure('first controlled worker failure did not request retry')
+    final = _deliver_task(task, retry_count=1)
+    if final.status_code != 200 or final.json().get('status') != 'failed_final':
+        raise StackFailure('retry-budget exhaustion did not terminalize through the worker route')
+    status = _poll_terminal_job(stack, uid, job_id)
+    if status.get('status') != 'failed':
+        raise StackFailure('retry-budget exhaustion did not publish truthful failed job state')
+    if stack.staged_blob_path(task['body']['raw_blob_paths'][0]).exists():
+        raise StackFailure('terminal failure did not release staged material')
+    _assert_not_metered(stack, uid)
+    duplicate = _deliver_task(task, retry_count=2)
+    if duplicate.status_code != 200 or duplicate.json().get('status') != 'acked':
+        raise StackFailure('terminal failed job was not safely ACKed on duplicate delivery')
+    _assert_not_metered(stack, uid)
+
+
+def _concurrent_delivery_is_lease_fenced(stack: Stack) -> None:
+    if stack.gate_dir is None:
+        raise StackFailure('concurrent scenario requires a processor gate')
+    uid = stack.scenario_uid('concurrent')
+    job_id, task = _submit_and_capture_task(stack, uid)
+    first_result: list[httpx.Response] = []
+
+    def first_delivery() -> None:
+        first_result.append(_deliver_task(task, retry_count=0))
+
+    thread = threading.Thread(target=first_delivery, daemon=True)
+    thread.start()
+    _wait_until(lambda: (stack.gate_dir / 'entered').exists(), label='first worker processor gate')
+    second = _deliver_task(task, retry_count=1)
+    if second.status_code != 409 or second.json().get('status') != 'locked':
+        raise StackFailure('concurrent worker delivery did not observe the real run lock')
+    (stack.gate_dir / 'release').write_text('release', encoding='utf-8')
+    thread.join(timeout=35.0)
+    if thread.is_alive() or len(first_result) != 1:
+        raise StackFailure('first gated worker delivery did not finish')
+    first = first_result[0]
+    if first.status_code != 200 or first.json().get('status') != 'done':
+        raise StackFailure('lease-owning worker delivery did not finish successfully')
+    _assert_durable_success(stack, uid, job_id)
+    _assert_metered_once(stack, uid)
+    if _stt_invocation_count(stack, job_id) != 1:
+        raise StackFailure('concurrent delivery ran the provider pipeline more than once')
+
+
+def _ambiguous_enqueue_and_expired_blob(stack: Stack) -> None:
+    uid = stack.scenario_uid('lost-ack')
+    job_id, task = _submit_and_capture_task(stack, uid)
+    task_events = stack.evidence_events('tasks')
+    if sum(event.get('event') == 'task_captured' and event.get('task_id') == job_id for event in task_events) != 1:
+        raise StackFailure('lost create acknowledgement created more than one named task')
+    if not any(event.get('event') == 'task_ack_lost' and event.get('task_id') == job_id for event in task_events):
+        raise StackFailure('ambiguous enqueue scenario did not exercise the lost acknowledgement')
+    if not any(
+        event.get('event') == 'named_task_deduplicated' and event.get('task_id') == job_id for event in task_events
+    ):
+        raise StackFailure('ambiguous enqueue did not converge through named-task AlreadyExists')
+    if _job_status(stack, uid, job_id).get('status') != 'queued':
+        raise StackFailure('ambiguous named enqueue fell back or terminalized before delivery')
+    delivered = _deliver_task(task, retry_count=0)
+    if delivered.status_code != 200 or delivered.json().get('status') != 'done':
+        raise StackFailure('ambiguous named enqueue task did not later complete normally')
+    _assert_durable_success(stack, uid, job_id)
+
+    expired_uid = stack.scenario_uid('expired-blob')
+    expired_job, expired_task = _submit_and_capture_task(stack, expired_uid)
+    staged = stack.staged_blob_path(expired_task['body']['raw_blob_paths'][0])
+    staged.unlink()
+    expired = _deliver_task(expired_task, retry_count=0)
+    if expired.status_code != 200 or expired.json() != {'status': 'dropped', 'reason': 'staged_audio_expired'}:
+        raise StackFailure('missing staged blob did not take the durable expired-input path')
+    if _poll_terminal_job(stack, expired_uid, expired_job).get('status') != 'failed':
+        raise StackFailure('expired staged blob did not publish a failed Sync job')
+    if _stt_invocation_count(stack, expired_job) != 0:
+        raise StackFailure('expired staged blob unexpectedly invoked STT')
+
+
+def _assert_evidence_is_sanitized(stack: Stack) -> None:
+    # A deliberate pre-pipeline failure has no provider event; all scenarios
+    # must still produce task, worker, durable-job, and storage evidence.
+    expected_streams = {'tasks', 'jobs', 'worker', 'storage'}
+    present = {path.stem for path in stack.evidence_dir.glob('*.jsonl')}
+    if not expected_streams.issubset(present):
+        raise StackFailure(f'missing sanitized evidence streams: {sorted(expected_streams - present)}')
+    for path in stack.evidence_dir.glob('*.jsonl'):
+        content = path.read_text(encoding='utf-8')
+        if SENSITIVE_UID in content or TRANSCRIPT_TOKEN in content:
+            raise StackFailure(f'sensitive uid or transcript leaked into evidence: {path.name}')
+        for line in content.splitlines():
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise StackFailure(f'non-JSON evidence line in {path.name}') from error
+            if not isinstance(value, dict):
+                raise StackFailure(f'non-object evidence event in {path.name}')
+
+
+def _run_scenario(
+    state_dir: Path,
+    *,
+    task_ack_failures: int = 0,
+    worker_failures: int = 0,
+    pre_ledger_failures: int = 0,
+    post_ledger_failures: int = 0,
+    cleanup_failures: int = 0,
+    hold_processor: bool = False,
+    scenario: Callable[[Stack], None],
+) -> None:
+    stack = Stack(
+        state_dir,
+        task_ack_failures=task_ack_failures,
+        worker_failures=worker_failures,
+        pre_ledger_failures=pre_ledger_failures,
+        post_ledger_failures=post_ledger_failures,
+        cleanup_failures=cleanup_failures,
+        hold_processor=hold_processor,
+    )
+    try:
+        stack.start()
+        scenario(stack)
+        _assert_evidence_is_sanitized(stack)
+    finally:
+        stack.close()
+        stack.cleanup_workspace_files()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--state-dir', type=Path, help='directory for sanitized evidence and private process logs')
+    parser.add_argument('--keep', action='store_true', help='preserve state after a successful run')
+    args = parser.parse_args()
+    if not PYTHON.exists():
+        raise SystemExit(f'missing backend virtual environment: {PYTHON}; run backend/scripts/sync-python-deps.sh')
+    created_state_dir = args.state_dir is None
+    state_dir = (args.state_dir or Path(tempfile.mkdtemp(prefix='omi-sync-cloud-tasks-stack-'))).resolve()
+    state_dir.mkdir(parents=True, exist_ok=True)
+    succeeded = False
+    try:
+        _run_scenario(state_dir / 'happy-duplicate', scenario=_happy_path_and_terminal_duplicate)
+        _run_scenario(state_dir / 'cleanup-retry', cleanup_failures=1, scenario=_cleanup_retry_preserves_terminal_work)
+        _run_scenario(state_dir / 'pre-ledger-retry', pre_ledger_failures=1, scenario=_pre_ledger_failure_retries_once)
+        _run_scenario(
+            state_dir / 'post-ledger-retry', post_ledger_failures=1, scenario=_post_ledger_failure_converges_once
+        )
+        _run_scenario(
+            state_dir / 'final-attempt-ledger',
+            worker_failures=1,
+            post_ledger_failures=1,
+            scenario=_final_attempt_post_ledger_failure_converges,
+        )
+        _run_scenario(state_dir / 'terminal-failure', worker_failures=2, scenario=_retry_budget_terminalizes_truthfully)
+        _run_scenario(state_dir / 'concurrent', hold_processor=True, scenario=_concurrent_delivery_is_lease_fenced)
+        _run_scenario(state_dir / 'lost-ack-expired', task_ack_failures=1, scenario=_ambiguous_enqueue_and_expired_blob)
+        succeeded = True
+        print(f'Sync Cloud Tasks stack gauntlet passed; sanitized evidence: {state_dir}')
+        return 0
+    except Exception:
+        print(f'Sync Cloud Tasks stack gauntlet failed; state retained: {state_dir}', file=sys.stderr)
+        raise
+    finally:
+        if succeeded and created_state_dir and not args.keep:
+            shutil.rmtree(state_dir)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/testing/sync_cloud_tasks_stack/run.sh
+++ b/backend/testing/sync_cloud_tasks_stack/run.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Run through Firebase so Firestore is isolated and torn down automatically.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$repo_root"
+
+if [[ ! -x backend/.venv/bin/python ]]; then
+  echo "Missing backend/.venv. Run backend/scripts/sync-python-deps.sh first." >&2
+  exit 1
+fi
+
+if ! java -version >/dev/null 2>&1; then
+  jdk_prefix="$(brew --prefix openjdk@21 2>/dev/null || true)"
+  if [[ -n "$jdk_prefix" && -x "$jdk_prefix/libexec/openjdk.jdk/Contents/Home/bin/java" ]]; then
+    export JAVA_HOME="$jdk_prefix/libexec/openjdk.jdk/Contents/Home"
+    export PATH="$JAVA_HOME/bin:$PATH"
+  fi
+fi
+if ! java -version >/dev/null 2>&1; then
+  echo "Firebase's Firestore emulator needs Java 21+. Install it with: brew install openjdk@21" >&2
+  exit 1
+fi
+
+emulator_port="$(node -e 'const net = require("net"); const server = net.createServer(); server.listen(0, "127.0.0.1", () => { console.log(server.address().port); server.close(); });')"
+emulator_config="$(mktemp "${TMPDIR:-/tmp}/omi-sync-cloud-tasks-firebase.XXXXXX")"
+trap 'rm -f "$emulator_config"' EXIT
+node -e 'require("fs").writeFileSync(process.argv[1], JSON.stringify({emulators: {firestore: {host: "127.0.0.1", port: Number(process.argv[2])}}}))' \
+  "$emulator_config" "$emulator_port"
+
+runner_command="PYTHONPATH=backend backend/.venv/bin/python -m testing.sync_cloud_tasks_stack.run"
+for argument in "$@"; do
+  printf -v escaped_argument ' %q' "$argument"
+  runner_command+="$escaped_argument"
+done
+
+npx --no-install firebase emulators:exec --only firestore --project demo-omi-sync-cloud-tasks-stack --config "$emulator_config" \
+  "$runner_command"

--- a/backend/testing/sync_cloud_tasks_stack/storage.py
+++ b/backend/testing/sync_cloud_tasks_stack/storage.py
@@ -1,0 +1,161 @@
+"""Filesystem-backed replacement for the external GCS boundary.
+
+Production storage helpers still own blob naming and lifecycle decisions.  This
+module replaces only the cloud client leaf before those helpers import it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+
+from google.cloud.exceptions import NotFound as BlobNotFound
+
+from .events import write_event
+
+_storage_dir: Path | None = None
+
+
+def configure_storage_dir(path: str | Path) -> Path:
+    """Set up the shared local bucket root once per ASGI process."""
+    global _storage_dir
+    root = Path(path).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    _storage_dir = root
+    return root
+
+
+def storage_dir() -> Path:
+    if _storage_dir is None:
+        configured = os.getenv('OMI_SYNC_STACK_STORAGE_DIR', '').strip()
+        if not configured:
+            raise RuntimeError('OMI_SYNC_STACK_STORAGE_DIR is required for local storage')
+        return configure_storage_dir(configured)
+    return _storage_dir
+
+
+def _safe_blob_path(bucket: str, name: str) -> Path:
+    relative = PurePosixPath(name)
+    if relative.is_absolute() or '..' in relative.parts:
+        raise ValueError('local storage rejects absolute or parent blob paths')
+    return storage_dir() / bucket / Path(*relative.parts)
+
+
+class LocalBlob:
+    """Subset of the Google Cloud Storage blob API exercised by Sync v2."""
+
+    def __init__(self, bucket: 'LocalBucket', name: str):
+        self.bucket = bucket
+        self.name = name
+        self.metadata: Any = None
+        self.cache_control: str | None = None
+        self.content_type: str | None = None
+
+    @property
+    def path(self) -> Path:
+        return _safe_blob_path(self.bucket.name, self.name)
+
+    @property
+    def public_url(self) -> str:
+        return 'sync-stack://local-blob'
+
+    def exists(self, *_args: Any, **_kwargs: Any) -> bool:
+        return self.path.exists()
+
+    def reload(self, *_args: Any, **_kwargs: Any) -> None:
+        if not self.exists():
+            raise BlobNotFound(self.name)
+
+    def upload_from_filename(self, filename: str, *_args: Any, **_kwargs: Any) -> None:
+        destination = self.path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(filename, destination)
+        write_event(
+            'storage', {'event': 'blob_uploaded', 'bucket': self.bucket.name, 'bytes': destination.stat().st_size}
+        )
+
+    def download_to_filename(self, filename: str, *_args: Any, **_kwargs: Any) -> None:
+        if not self.exists():
+            raise BlobNotFound(self.name)
+        destination = Path(filename)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(self.path, destination)
+        write_event(
+            'storage', {'event': 'blob_downloaded', 'bucket': self.bucket.name, 'bytes': self.path.stat().st_size}
+        )
+
+    def upload_from_string(
+        self, data: bytes | str, content_type: str | None = None, *_args: Any, **_kwargs: Any
+    ) -> None:
+        destination = self.path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        payload = data.encode() if isinstance(data, str) else data
+        destination.write_bytes(payload)
+        self.content_type = content_type
+        write_event('storage', {'event': 'blob_uploaded', 'bucket': self.bucket.name, 'bytes': len(payload)})
+
+    def download_as_bytes(self, *_args: Any, **_kwargs: Any) -> bytes:
+        if not self.exists():
+            raise BlobNotFound(self.name)
+        payload = self.path.read_bytes()
+        write_event('storage', {'event': 'blob_downloaded', 'bucket': self.bucket.name, 'bytes': len(payload)})
+        return payload
+
+    def delete(self, *_args: Any, **_kwargs: Any) -> None:
+        if self.path.exists():
+            self.path.unlink()
+        write_event('storage', {'event': 'blob_deleted', 'bucket': self.bucket.name})
+
+    def generate_signed_url(self, *_args: Any, **_kwargs: Any) -> str:
+        # The deterministic STT leaf consumes this opaque local-only value.
+        job_id = PurePosixPath(self.name).parent.name
+        return f'sync-stack://staged/{job_id}' if job_id else 'sync-stack://staged'
+
+    def make_public(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def patch(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+class LocalBucket:
+    def __init__(self, name: str):
+        self.name = name
+        (storage_dir() / name).mkdir(parents=True, exist_ok=True)
+
+    def blob(self, name: str) -> LocalBlob:
+        return LocalBlob(self, name)
+
+    def list_blobs(self, prefix: str = '', *_args: Any, **_kwargs: Any) -> Iterable[LocalBlob]:
+        root = storage_dir() / self.name
+        if not root.exists():
+            return []
+        blobs: list[LocalBlob] = []
+        for path in root.rglob('*'):
+            if path.is_file():
+                name = path.relative_to(root).as_posix()
+                if name.startswith(prefix):
+                    blobs.append(LocalBlob(self, name))
+        return blobs
+
+
+class LocalStorageClient:
+    """Lazy storage client instantiated by the production storage helpers."""
+
+    def __init__(self, *_args: Any, **_kwargs: Any):
+        storage_dir()
+
+    def bucket(self, name: str) -> LocalBucket:
+        return LocalBucket(name)
+
+    def get_bucket(self, name: str) -> LocalBucket:
+        return self.bucket(name)
+
+
+def patch_google_storage() -> None:
+    """Install the local client before ``utils.other.storage`` is imported."""
+    from google.cloud import storage
+
+    storage.Client = LocalStorageClient

--- a/backend/testing/sync_cloud_tasks_stack/worker_app.py
+++ b/backend/testing/sync_cloud_tasks_stack/worker_app.py
@@ -1,0 +1,3 @@
+"""Worker-process ASGI entrypoint for the Sync stack gauntlet."""
+
+from .app import app

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -212,18 +212,29 @@
     {
       "id": "sync_cloud_tasks",
       "risk": "high",
-      "sources": ["backend/routers/sync.py", "backend/utils/sync/pipeline.py", "backend/database/sync_jobs.py", "backend/utils/sync/*.py"],
+      "sources": [
+        "backend/routers/sync.py",
+        "backend/utils/sync/pipeline.py",
+        "backend/database/sync_jobs.py",
+        "backend/utils/sync/*.py",
+        "backend/testing/sync_cloud_tasks_stack/**",
+        ".github/workflows/backend-hermetic-e2e.yml",
+        "package.json",
+        "package-lock.json"
+      ],
       "tests": [
         "tests/unit/test_sync_v2.py",
         "tests/unit/test_sync_cloud_tasks.py",
         "tests/unit/test_audio_merge_tasks.py",
-        "tests/unit/test_sync_fair_use_gate.py"
+        "tests/unit/test_sync_fair_use_gate.py",
+        "tests/unit/test_sync_cloud_tasks_stack_ci_wiring.py"
       ],
       "checks": [],
       "invariants": [
         "task retries do not double-count usage or completed segments",
         "segment failures cannot be reported as completed work",
-        "enqueued jobs retain staged blobs until handler completion"
+        "enqueued jobs retain staged blobs until handler completion",
+        "fresh v2 Sync admission runs a credential-free local Firestore, Redis, storage, and separate Cloud Tasks-worker stack gauntlet in blocking PR CI"
       ]
     },
     {

--- a/backend/tests/unit/test_sync_cloud_tasks.py
+++ b/backend/tests/unit/test_sync_cloud_tasks.py
@@ -385,6 +385,32 @@ class TestFencedJobMutations:
             assert redis_client.ttl(job_key) == terminal_ttl
         assert redis_client.smembers(f'{sync_jobs.PROCESSED_SEGMENTS_KEY_PREFIX}{job_id}') == set()
 
+    def test_durable_ledger_finalizer_converges_a_current_queued_retry(self):
+        """A durable-ledger recovery may finish the queued retry that owns its new lease."""
+        redis_client = fakeredis.FakeRedis()
+        sync_jobs, _ = _load_sync_jobs(redis_client)
+        job_id = 'job-queued-recovery'
+        _seed_fenced_job(
+            redis_client,
+            sync_jobs,
+            job_id,
+            {'job_id': job_id, 'status': 'queued', 'lane': 'fresh', 'result': None},
+            owner='2:recovery-owner',
+        )
+        result = {'total_segments': 1, 'failed_segments': 0, 'provider': 'deepgram', 'model': 'nova-3'}
+
+        ordinary = sync_jobs.fenced_finalize_sync_job(job_id, '2:recovery-owner', result, now=101.0)
+        assert ordinary.outcome is sync_jobs.FencedSyncJobMutationOutcome.INVALID_STATE
+
+        converged = sync_jobs.fenced_finalize_sync_job_from_durable_ledger(
+            job_id,
+            '2:recovery-owner',
+            result,
+            now=102.0,
+        )
+        assert converged.applied is True
+        assert converged.job['status'] == 'completed'
+
     def test_fenced_failed_and_queued_retry_primitives_publish_while_owner_matches(self):
         redis_client = fakeredis.FakeRedis()
         sync_jobs, _ = _load_sync_jobs(redis_client)
@@ -1635,7 +1661,7 @@ async def test_post_terminal_retired_claim_cleanup_retries_through_terminal_bran
         )
         module._run_full_pipeline_background_async = _terminalize_then_fail_retired_cleanup
 
-        first = await module.run_sync_job(request, task_retry_count=0)
+        first = await module.run_sync_job(request, task_retry_count=2)
 
         assert first.status_code == 500
         assert json.loads(first.body) == {'status': 'terminal_cleanup_retry', 'job_status': 'partial_failure'}
@@ -1643,6 +1669,12 @@ async def test_post_terminal_retired_claim_cleanup_retries_through_terminal_bran
         module._finalize_sync_job_failure.assert_not_awaited()
         module.delete_sync_job_run_lock_epoch.assert_not_called()
         module._delete_staged_blobs_async.assert_not_awaited()
+        module.bind_or_converge_sync_ledger_completion.assert_called_once_with(
+            job_id='job-1',
+            uid='test-uid',
+            content_id='content-1',
+            run_lock_token='1:lock-token',
+        )
 
         module.release_sync_content_claim_after_job_retired.reset_mock()
         module.release_sync_content_claim_after_job_retired.side_effect = None
@@ -1796,6 +1828,93 @@ async def test_duplicate_terminal_task_releases_only_retryable_matching_claim(st
         else:
             module.release_sync_content_claim_after_job_retired.assert_not_called()
         module.release_sync_content_claim.assert_not_called()
+    finally:
+        sys.modules.pop('routers.sync', None)
+        sys.modules.pop('utils.sync.pipeline', None)
+        for mod_name, orig in saved_modules.items():
+            if orig is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = orig
+
+
+@pytest.mark.asyncio
+async def test_sync_task_final_attempt_converges_a_ledger_completed_by_the_failing_pipeline():
+    """A final Cloud Tasks delivery cannot overwrite its own durable completion."""
+
+    module, saved_modules, _, _, _, _ = _load_sync_router_for_fast_path()
+    request = _configure_task_handler(
+        module,
+        pipeline_error=RuntimeError('failure after durable ledger completion'),
+        latest_job={
+            'job_id': 'job-1',
+            'status': 'processing',
+            'stt_provider': 'deepgram',
+            'stt_model': 'nova-3',
+        },
+    )
+
+    try:
+        module.bind_or_converge_sync_ledger_completion = MagicMock(
+            side_effect=[None, {'total_segments': 1, 'outcome': 'success'}]
+        )
+
+        response = await module.run_sync_job(request, task_retry_count=2)
+
+        assert response.status_code == 200
+        assert json.loads(response.body) == {'status': 'done', 'reconciled': True}
+        expected_bind = unittest.mock.call(
+            job_id='job-1',
+            uid='test-uid',
+            content_id='content-1',
+            run_lock_token='1:lock-token',
+        )
+        assert module.bind_or_converge_sync_ledger_completion.call_args_list == [expected_bind, expected_bind]
+        module._run_full_pipeline_background_async.assert_awaited_once()
+        module._finalize_sync_job_failure.assert_not_awaited()
+        module.fenced_mark_job_queued_for_retry.assert_not_called()
+        module._delete_staged_blobs_async.assert_awaited_once_with(['staged/audio.opus'])
+        module.release_job_run_lock.assert_called_once_with('job-1', '1:lock-token')
+    finally:
+        sys.modules.pop('routers.sync', None)
+        sys.modules.pop('utils.sync.pipeline', None)
+        for mod_name, orig in saved_modules.items():
+            if orig is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = orig
+
+
+@pytest.mark.asyncio
+async def test_sync_task_final_attempt_ledger_bind_loss_preserves_retry_material():
+    """A final recovery bind that loses ownership must not consume or clean the task."""
+
+    module, saved_modules, _, _, _, _ = _load_sync_router_for_fast_path()
+    request = _configure_task_handler(
+        module,
+        pipeline_error=RuntimeError('failure after a competing ledger update'),
+        latest_job={
+            'job_id': 'job-1',
+            'status': 'processing',
+            'stt_provider': 'deepgram',
+            'stt_model': 'nova-3',
+        },
+    )
+
+    try:
+        module.bind_or_converge_sync_ledger_completion = MagicMock(
+            side_effect=[None, module.SyncJobRunLeaseLost('newer ledger owner')]
+        )
+
+        response = await module.run_sync_job(request, task_retry_count=2)
+
+        assert response.status_code == 409
+        assert json.loads(response.body) == {'status': 'locked'}
+        module._run_full_pipeline_background_async.assert_awaited_once()
+        module._finalize_sync_job_failure.assert_not_awaited()
+        module.fenced_mark_job_queued_for_retry.assert_not_called()
+        module._delete_staged_blobs_async.assert_not_awaited()
+        module.release_job_run_lock.assert_not_called()
     finally:
         sys.modules.pop('routers.sync', None)
         sys.modules.pop('utils.sync.pipeline', None)

--- a/backend/tests/unit/test_sync_cloud_tasks_stack_ci_wiring.py
+++ b/backend/tests/unit/test_sync_cloud_tasks_stack_ci_wiring.py
@@ -1,0 +1,43 @@
+"""Static wiring contract for the blocking Sync Cloud Tasks stack gauntlet.
+
+Behavior is proved by the emulator stack itself.  This test prevents its
+package script, high-risk workflow contract, or blocking CI job from silently
+disconnecting.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_sync_cloud_tasks_stack_gauntlet_has_a_deterministic_hermetic_ci_job() -> None:
+    workflow = (_REPO_ROOT / '.github' / 'workflows' / 'backend-hermetic-e2e.yml').read_text(encoding='utf-8')
+    package = json.loads((_REPO_ROOT / 'package.json').read_text(encoding='utf-8'))
+    contracts = json.loads((_REPO_ROOT / 'backend' / 'testing' / 'workflow_contracts.json').read_text(encoding='utf-8'))
+
+    assert "- 'package.json'" in workflow
+    assert "- 'package-lock.json'" in workflow
+    assert '  sync-cloud-tasks-stack-gauntlet:' in workflow
+    job = workflow.split('  sync-cloud-tasks-stack-gauntlet:\n', 1)[1]
+
+    assert 'timeout-minutes: 20' in job
+    assert 'uses: actions/setup-python@v6' in job
+    assert 'uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84' in job
+    assert 'uv venv .venv' in job
+    assert 'uv pip sync pylock.toml --python .venv/bin/python' in job
+    assert 'uses: actions/setup-node@v7' in job
+    assert "node-version: '22'" in job
+    assert 'cache-dependency-path: package-lock.json' in job
+    assert 'npm ci --ignore-scripts' in job
+    assert 'uses: actions/setup-java@v5' in job
+    assert "java-version: '21'" in job
+    assert 'sudo apt-get install --yes redis-server' in job
+    assert 'npm run test:sync-cloud-tasks-stack:emulator' in job
+
+    assert package['scripts']['test:sync-cloud-tasks-stack:emulator'] == 'backend/testing/sync_cloud_tasks_stack/run.sh'
+    sync_contract = next(contract for contract in contracts['workflows'] if contract['id'] == 'sync_cloud_tasks')
+    assert 'backend/testing/sync_cloud_tasks_stack/**' in sync_contract['sources']
+    assert 'tests/unit/test_sync_cloud_tasks_stack_ci_wiring.py' in sync_contract['tests']

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -37,6 +37,7 @@ from database.sync_jobs import (
     add_processed_segment_if_run_owner,
     delete_sync_job_run_lock_epoch,
     fenced_finalize_sync_job,
+    fenced_finalize_sync_job_from_durable_ledger,
     fenced_mark_job_failed,
     fenced_mark_job_processing,
     fenced_update_sync_job,
@@ -480,7 +481,9 @@ def bind_or_converge_sync_ledger_completion(
     if not binding.completed or not is_valid_completed_sync_content_result(binding.result):
         raise SyncJobRunLeaseLost(f'sync content ledger owner lost: job={job_id}')
 
-    finalized = _finalize_sync_job_for_run(job_id, run_lock_token, binding.result)
+    finalized = _require_run_owner(
+        fenced_finalize_sync_job_from_durable_ledger(job_id, run_lock_token, binding.result), job_id=job_id
+    )
     delete_sync_job_run_lock_epoch(job_id)
     return finalized
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "test:memory-firestore-python-apply:emulator": "firebase emulators:exec --only firestore --project demo-memory \"python3 backend/scripts/firestore_python_apply_emulator_test.py\"",
     "test:listen-lifecycle:emulator": "firebase emulators:exec --only firestore --project demo-listen \"backend/.venv/bin/python backend/scripts/listen_lifecycle_emulator_test.py\"",
     "test:listen-pusher-stack:emulator": "backend/testing/listen_pusher_stack/run.sh",
+    "test:sync-cloud-tasks-stack:emulator": "backend/testing/sync_cloud_tasks_stack/run.sh",
     "test:memory-vector-repair-outbox:emulator": "firebase emulators:exec --only firestore --project demo-memory \"python3 backend/scripts/vector_repair_outbox_emulator_test.py\"",
     "test:memory-vector-repair-outbox-rules:emulator": "firebase emulators:exec --only firestore --project demo-memory \"node backend/scripts/firestore_rules_emulator_test.mjs\"",
     "test:memory-vector-repair-outbox-lease:emulator": "firebase emulators:exec --only firestore --project demo-memory \"python3 backend/scripts/vector_repair_outbox_lease_emulator_test.py\"",


### PR DESCRIPTION
## What changed and why

Adds a blocking, two-process hermetic gauntlet for fresh Sync v2 Cloud Tasks
admission and worker execution. It also repairs the durable-ledger recovery
boundary: a valid ledger completion can now converge a queued retry, and a
first successful pipeline on the final task delivery cannot be overwritten by
a false terminal failure.

Closes #10001
Closes #10004

## Product invariants affected

none

## How it was verified

- `BACKEND_PYTEST_WORKERS=4 bash backend/test.sh` — passed.
- `npm run test:sync-cloud-tasks-stack:emulator` — passed with separate
  admission/worker processes, private Redis, Firestore emulator, local
  storage, strict task recorder, and real loopback worker delivery.
- `npm run test:sync-cloud-tasks-stack:emulator -- --state-dir <relative-dir>`
  — passed; retained caller-owned evidence/state and then removed only the
  generated temporary directory after inspection.
- Focused Sync/CI-wiring suite — 288 passed.
- Two independent code reviews — approved with no blockers.
- `make preflight` and `scripts/pr-preflight --pr-body-file /tmp/pr-body-10001.md`
  — passed against the committed diff.

## Tests

- The gauntlet covers fresh admission, unauthenticated worker rejection,
  terminal and cleanup duplicates, pre- and post-ledger retries, final-attempt
  ledger convergence, retry exhaustion, concurrent delivery fencing, named
  task acknowledgement loss, and expired staged input.
- Unit regressions prove ordinary finalization remains processing-only,
  durable-ledger recovery can finalize a queued retry, final-attempt recovery
  wins over false failure, lease loss preserves retry material, and terminal
  cleanup keeps precedence.
- `test_sync_cloud_tasks_stack_ci_wiring.py` prevents the package script,
  high-risk workflow contract, or blocking CI job from disconnecting.

## Failure class (fixes)

Failure-Class: FC-split-mutation-authority

## New guards

The stack gauntlet and its CI-wiring tripwire would have caught incident
#10004. They are Sync-specific rather than a shared primitive because this
route alone couples the Cloud Tasks payload, Redis run lease, Firestore content
ledger, fair-use meter, and staged-blob lifecycle.

The product-file ratchet baselines advance only for the two existing Sync
owners. Their one-line justifications record why the coupled recovery stays
there instead of splitting this small repair across more modules.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

