### PR TITLE
fix(backend): parse RATE_LIMIT_SHADOW_MODE as strict "true" opt-in (fail-open rate limiter)

### DIFF
--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -188,6 +188,35 @@ class TestShadowMode(unittest.TestCase):
             self.assertFalse(rlc.RATE_LIMIT_SHADOW)
         importlib.reload(rlc)
 
+    def test_shadow_mode_non_true_values_stay_off(self):
+        """Shadow is opt-in via 'true'; any other value must NOT silently enable it.
+
+        The flag defaults OFF (enforcement active). Only an explicit truthy
+        'true' should turn shadow/log-only mode on. Values like '0', 'off',
+        'no', or an empty string mean "not true", so enforcement must stay on —
+        otherwise setting the env var to disable shadow would fail open and
+        silently drop all rate-limit enforcement.
+        """
+        import utils.rate_limit_config as rlc
+
+        for value in ("0", "off", "no", "", "1", "disabled", "False ", "yes"):
+            with patch.dict(os.environ, {"RATE_LIMIT_SHADOW_MODE": value}):
+                importlib.reload(rlc)
+                self.assertFalse(
+                    rlc.RATE_LIMIT_SHADOW,
+                    f"RATE_LIMIT_SHADOW_MODE={value!r} must not enable shadow mode",
+                )
+        importlib.reload(rlc)
+
+    def test_shadow_mode_true_is_case_insensitive(self):
+        import utils.rate_limit_config as rlc
+
+        for value in ("true", "TRUE", "True"):
+            with patch.dict(os.environ, {"RATE_LIMIT_SHADOW_MODE": value}):
+                importlib.reload(rlc)
+                self.assertTrue(rlc.RATE_LIMIT_SHADOW, f"{value!r} should enable shadow mode")
+        importlib.reload(rlc)
+
 
 class TestGetEffectiveLimit(unittest.TestCase):
     """Test get_effective_limit edge cases."""

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -25,7 +25,7 @@ import os
 # ---------------------------------------------------------------------------
 
 RATE_LIMIT_BOOST: float = float(os.getenv("RATE_LIMIT_BOOST", "1.0"))
-RATE_LIMIT_SHADOW: bool = os.getenv("RATE_LIMIT_SHADOW_MODE", "false").lower() != "false"
+RATE_LIMIT_SHADOW: bool = os.getenv("RATE_LIMIT_SHADOW_MODE", "false").lower() == "true"
 
 # ---------------------------------------------------------------------------
 # Policies: "name" -> (max_requests, window_seconds)


### PR DESCRIPTION
## Problem

`RATE_LIMIT_SHADOW` decides whether per-UID rate limiting runs in shadow/log-only mode (`True`) or actually enforces limits (`False`). The module docstring documents the flag as **defaulting OFF**, enabled only by `RATE_LIMIT_SHADOW_MODE=true`:

```python
# utils/rate_limit_config.py
#   RATE_LIMIT_SHADOW: defaults OFF (enforcement/429 rejections). Set env var
#       RATE_LIMIT_SHADOW_MODE=true to revert to shadow/log-only mode.

RATE_LIMIT_SHADOW: bool = os.getenv("RATE_LIMIT_SHADOW_MODE", "false").lower() != "false"
```

The parse uses `!= "false"`, so **any** value other than the exact string `"false"` evaluates to `True` and silently switches the limiter into log-only mode.

## Root cause

`!= "false"` treats every non-`"false"` string as "shadow on", including the common ways an operator would try to *disable* shadow mode:

| `RATE_LIMIT_SHADOW_MODE` | old `!= "false"` | intended |
|---|---|---|
| unset / `"false"` | `False` ✓ | `False` |
| `"true"` | `True` ✓ | `True` |
| `"0"`, `"off"`, `"no"`, `"1"`, `"disabled"`, `""`, `"false "` | **`True`** ✗ | `False` |

Both consumers branch on this flag to decide whether to enforce:

- `routers/chat.py:1038` — `if not RATE_LIMIT_SHADOW:` closes the WebSocket on limit exceed
- `utils/other/endpoints.py:384` — `if RATE_LIMIT_SHADOW:` logs and returns instead of raising `429`

So an operator setting `RATE_LIMIT_SHADOW_MODE=0` (intending to keep enforcement **on**) instead disables all rate-limit enforcement cluster-wide — a fail-open regression.

## Fix

Parse the flag as a strict `true` opt-in, matching the docstring and the convention used by every other default-off flag in the backend (`FAIR_USE_ENABLED`, `TRIAL_PAYWALL_ENABLED`, `TRANSCRIPT_CHUNK_INDEXING_ENABLED`, `SYNC_BACKFILL_ADMISSION_LIMITS`, …), all of which use `.lower() == 'true'`:

```diff
-RATE_LIMIT_SHADOW: bool = os.getenv("RATE_LIMIT_SHADOW_MODE", "false").lower() != "false"
+RATE_LIMIT_SHADOW: bool = os.getenv("RATE_LIMIT_SHADOW_MODE", "false").lower() == "true"
```

The three documented cases (unset, `"true"`, `"false"`) are unchanged; only the previously mis-parsed non-canonical values are corrected.

## Tests

Added a regression test (`test_shadow_mode_non_true_values_stay_off`) that asserts `"0"`, `"off"`, `"no"`, `""`, `"1"`, `"disabled"`, `"False "`, `"yes"` all keep shadow **OFF**, plus a case-insensitivity check for `"true"`. The existing `TestShadowMode` tests only covered unset/`"true"`/`"false"`, which pass under both the old and new expression — so the defect was uncovered.

## Verification

```
$ python -m pytest tests/unit/test_rate_limiting.py -k "ShadowMode or shadow"
6 passed, 62 deselected

# revert the one-line fix -> the new test fails, confirming the guard:
$ python -m pytest tests/unit/test_rate_limiting.py -k "non_true_values"
1 failed  (AssertionError: RATE_LIMIT_SHADOW_MODE='0' must not enable shadow mode)

$ black --line-length 120 --check utils/rate_limit_config.py tests/unit/test_rate_limiting.py
All done! 2 files would be left unchanged.
```

Note: I ran the affected backend unit tests and `black` directly (in a fork). The repo's maintainer-only preflight tooling (`make preflight`, `scripts/failure-class`) requires the full monorepo checkout / toolchain and was not run here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

