### PR TITLE
fix(backend): honor user timezone in conversation metadata + rendering (wrong times/dates in chat)

### DIFF
--- a/backend/tests/unit/test_conversations_to_string.py
+++ b/backend/tests/unit/test_conversations_to_string.py
@@ -1,8 +1,11 @@
 import os
 import sys
+import time
 import types
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
+
+import pytest
 
 os.environ.setdefault(
     "ENCRYPTION_SECRET",
@@ -150,3 +153,71 @@ class TestConversationsToStringTimezone:
         conv = _make_conversation()
         result = conversations_to_string([conv], tz="Not/AZone")
         assert "15 Jan 2026 at 10:00 UTC" in result
+
+
+def _make_naive_conversation(created, started, finished):
+    """A Conversation whose timestamps are timezone-naive (as stored for many rows)."""
+    return Conversation(
+        id="naive-id",
+        created_at=created,
+        started_at=started,
+        finished_at=finished,
+        structured=Structured(title="T", overview="O", category=CategoryEnum.personal),
+        apps_results=[],
+    )
+
+
+class TestConversationsToStringNaiveTimestamps:
+    """Naive stored timestamps must be read as UTC, never as the server's local time.
+
+    ``conversation.created_at`` / ``started_at`` / ``finished_at`` are plain ``datetime``
+    and are frequently naive (stored as naive UTC). Calling ``.astimezone(display_tz)`` on a
+    naive datetime makes Python assume it is in the *server's* local timezone, so the text
+    handed to the chat LLM shows a wrong wall clock whenever the backend host is not on UTC —
+    exactly the "incorrect event time mentions" class of bug the module's ``_as_utc`` guard
+    exists to prevent (issues #4643, #6214). This test forces a non-UTC process timezone so
+    the naive-as-local defect is deterministic regardless of where the suite runs.
+    """
+
+    def setup_method(self):
+        self._old_tz = os.environ.get("TZ")
+        os.environ["TZ"] = "America/Los_Angeles"  # UTC-8 / -7, well away from UTC
+        if hasattr(time, "tzset"):
+            time.tzset()
+
+    def teardown_method(self):
+        if self._old_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = self._old_tz
+        if hasattr(time, "tzset"):
+            time.tzset()
+
+    def test_naive_timestamps_render_as_utc(self):
+        if not hasattr(time, "tzset"):
+            pytest.skip("time.tzset() unavailable on this platform")
+        # Naive 20:00 must be read as 20:00 UTC. The buggy path would treat it as
+        # 20:00 America/Los_Angeles and render 16 Jan ~04:00 UTC instead.
+        conv = _make_naive_conversation(
+            created=datetime(2026, 1, 15, 20, 0),
+            started=datetime(2026, 1, 15, 20, 0),
+            finished=datetime(2026, 1, 15, 20, 30),
+        )
+        result = conversations_to_string([conv])
+        assert "15 Jan 2026 at 20:00 UTC" in result
+        assert "Started: 15 Jan 2026 at 20:00 UTC" in result
+        assert "Finished: 15 Jan 2026 at 20:30 UTC" in result
+        assert "16 Jan" not in result
+
+    def test_naive_timestamps_convert_to_user_tz(self):
+        if not hasattr(time, "tzset"):
+            pytest.skip("time.tzset() unavailable on this platform")
+        # Naive 20:00 (UTC) -> 17:00 in America/Sao_Paulo (UTC-3), independent of server tz.
+        conv = _make_naive_conversation(
+            created=datetime(2026, 1, 15, 20, 0),
+            started=datetime(2026, 1, 15, 20, 0),
+            finished=datetime(2026, 1, 15, 20, 30),
+        )
+        result = conversations_to_string([conv], tz="America/Sao_Paulo")
+        assert "15 Jan 2026 at 17:00 America/Sao_Paulo" in result
+        assert "Finished: 15 Jan 2026 at 17:30 America/Sao_Paulo" in result

--- a/backend/tests/unit/test_temporal_date_in_tz.py
+++ b/backend/tests/unit/test_temporal_date_in_tz.py
@@ -1,0 +1,50 @@
+"""Contract tests for utils.llm.temporal.date_in_tz.
+
+The conversation metadata-extraction prompts (retrieve_metadata_from_message / _from_text /
+_fields_from_transcript in utils/llm/chat.py) ground the model's notion of "today" with the
+conversation's created_at rendered in the user's timezone. They previously did this with a raw
+``created_at.astimezone(ZoneInfo(tz))``, which raises ``ValueError`` when the user has no saved
+timezone (``tz == ''`` -> ``ZoneInfo('')``) — the default conversation path, so timezone-less
+users silently lost search metadata — and reinterprets naive timestamps as server-local time
+(issues #4643, #6214).
+
+Those call sites now delegate to ``date_in_tz``. These tests lock the guarantees they rely on:
+an empty/None/invalid timezone falls back to UTC (never raises), and a naive datetime is read
+as UTC rather than as the process-local time.
+"""
+
+from datetime import datetime, timezone
+
+from utils.llm.temporal import date_in_tz
+
+
+class TestDateInTzTimezoneFallback:
+    def test_empty_string_tz_falls_back_to_utc_without_raising(self):
+        # This is the exact input that made the old chat.py expression raise ValueError.
+        dt = datetime(2026, 1, 15, 23, 30, tzinfo=timezone.utc)
+        assert date_in_tz(dt, "") == "2026-01-15"
+
+    def test_none_tz_falls_back_to_utc(self):
+        dt = datetime(2026, 1, 15, 23, 30, tzinfo=timezone.utc)
+        assert date_in_tz(dt, None) == "2026-01-15"
+
+    def test_invalid_tz_falls_back_to_utc(self):
+        dt = datetime(2026, 1, 15, 23, 30, tzinfo=timezone.utc)
+        assert date_in_tz(dt, "Not/AZone") == "2026-01-15"
+
+    def test_valid_tz_shifts_the_calendar_date(self):
+        # 00:30 UTC on Jan 16 is still Jan 15 in Los Angeles (UTC-8).
+        dt = datetime(2026, 1, 16, 0, 30, tzinfo=timezone.utc)
+        assert date_in_tz(dt, "America/Los_Angeles") == "2026-01-15"
+
+
+class TestDateInTzNaiveDatetime:
+    def test_naive_datetime_is_treated_as_utc(self):
+        # A naive 00:30 must be read as 00:30 UTC. Rendered in Tokyo (UTC+9) that is 09:30
+        # on the same day; the buggy "assume server-local" behavior would vary by host.
+        naive = datetime(2026, 1, 15, 0, 30)
+        assert date_in_tz(naive, "Asia/Tokyo") == "2026-01-15"
+
+    def test_naive_datetime_utc_fallback_matches_wall_date(self):
+        naive = datetime(2026, 1, 15, 23, 30)
+        assert date_in_tz(naive, "") == "2026-01-15"

--- a/backend/utils/conversations/render.py
+++ b/backend/utils/conversations/render.py
@@ -192,7 +192,9 @@ def conversations_to_string(
     people_map: Dict[str, Person] = {p.id: p for p in people} if people else {}
     display_tz, tz_label = resolve_display_tz(tz)
     for i, conversation in enumerate(conversations):
-        formatted_date = conversation.created_at.astimezone(display_tz).strftime("%d %b %Y at %H:%M") + f" {tz_label}"
+        formatted_date = (
+            _as_utc(conversation.created_at).astimezone(display_tz).strftime("%d %b %Y at %H:%M") + f" {tz_label}"
+        )
         conversation_str = (
             f"Conversation #{i + 1}\n"
             f"{formatted_date} ({str(conversation.structured.category.value).capitalize()})\n"
@@ -201,12 +203,12 @@ def conversations_to_string(
         # Add started_at and finished_at if available
         if conversation.started_at:
             formatted_started = (
-                conversation.started_at.astimezone(display_tz).strftime("%d %b %Y at %H:%M") + f" {tz_label}"
+                _as_utc(conversation.started_at).astimezone(display_tz).strftime("%d %b %Y at %H:%M") + f" {tz_label}"
             )
             conversation_str += f"Started: {formatted_started}\n"
         if conversation.finished_at:
             formatted_finished = (
-                conversation.finished_at.astimezone(display_tz).strftime("%d %b %Y at %H:%M") + f" {tz_label}"
+                _as_utc(conversation.finished_at).astimezone(display_tz).strftime("%d %b %Y at %H:%M") + f" {tz_label}"
             )
             conversation_str += f"Finished: {formatted_finished}\n"
 

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -20,6 +20,7 @@ from models.other import Person
 from models.transcript_segment import TranscriptSegment
 from utils.llms.memory import get_prompt_memories
 from utils.llm.usage_tracker import track_usage, Features
+from utils.llm.temporal import date_in_tz
 
 from .clients import get_llm
 import logging
@@ -1154,7 +1155,7 @@ def retrieve_metadata_fields_from_transcript(
 
     Make sure as a first step, you infer and fix any raw transcript errors and then proceed to extract the information from the entire content.
 
-    For context when extracting dates, today is {created_at.astimezone(ZoneInfo(tz)).strftime('%Y-%m-%d')} in {tz} (user's local timezone). {tz} is the user's timezone, respond in user local timezone.
+    For context when extracting dates, today is {date_in_tz(created_at, tz)} in {tz} (user's local timezone). {tz} is the user's timezone, respond in user local timezone.
     If one says "today", it means the current day.
     If one says "tomorrow", it means the next day after today.
     If one says "yesterday", it means the day before today.
@@ -1221,7 +1222,7 @@ def retrieve_metadata_from_message(
     3. Organizations, products, locations, or other entities mentioned
     4. Any dates or time references
 
-    For context when extracting dates, today is {created_at.astimezone(ZoneInfo(tz)).strftime('%Y-%m-%d')} in {tz} (user's local timezone). 
+    For context when extracting dates, today is {date_in_tz(created_at, tz)} in {tz} (user's local timezone). 
     {tz} is the user's timezone, respond in user local timezone.
     If the message mentions "today", it means the current day.
     If the message mentions "tomorrow", it means the next day after today.
@@ -1255,7 +1256,7 @@ def retrieve_metadata_from_text(
     3. Organizations, products, locations, or other entities mentioned
     4. Any dates or time references
 
-    For context when extracting dates, today is {created_at.astimezone(ZoneInfo(tz)).strftime('%Y-%m-%d')} in {tz} (user's local timezone). 
+    For context when extracting dates, today is {date_in_tz(created_at, tz)} in {tz} (user's local timezone). 
     {tz} is the user's timezone, respond in user local timezone.
     If the text mentions "today", it means the current day.
     If the text mentions "tomorrow", it means the next day after today.


### PR DESCRIPTION
## Problem

Two timezone bugs feed the chat/LLM layer wrong dates and times — the "AI mentions the wrong time of day / wrong date" class reported in #4643 (and referenced in the code around #6214). One of them also **silently breaks metadata extraction for any user who hasn't set a timezone**.

## Root cause & fix

### 1. `utils/llm/chat.py` — metadata date-grounding crashes for timezone-less users

`retrieve_metadata_from_message` / `retrieve_metadata_from_text` / `retrieve_metadata_fields_from_transcript` ground the model's notion of "today" with:

```python
today is {created_at.astimezone(ZoneInfo(tz)).strftime('%Y-%m-%d')} in {tz} ...
```

`tz` comes from `save_structured_vector`:

```python
tz = notification_db.get_user_time_zone(uid) or ''
```

So a user who has **not set a timezone** produces `tz == ''`, and `ZoneInfo('')` raises `ValueError` **before the LLM call**:

```
>>> from zoneinfo import ZoneInfo; ZoneInfo('')
ValueError: ZoneInfo keys must be normalized relative paths, got: 
```

`retrieve_metadata_fields_from_transcript` is the **default** path for regular conversations, so those users' `people/topics/entities/dates` vector metadata is never written — degrading search/retrieval. The raw `astimezone` on a possibly-naive `created_at` also reinterprets it as server-local time.

**Fix:** delegate to the module's existing purpose-built helper `date_in_tz(created_at, tz)` (`utils/llm/temporal.py`), which already falls back to UTC for a missing/invalid tz and treats naive datetimes as UTC.

```diff
-today is {created_at.astimezone(ZoneInfo(tz)).strftime('%Y-%m-%d')} in {tz} (user's local timezone).
+today is {date_in_tz(created_at, tz)} in {tz} (user's local timezone).
```

### 2. `utils/conversations/render.py` — naive timestamps rendered as server-local

`conversations_to_string` renders `created_at` / `started_at` / `finished_at` with `.astimezone(display_tz)` but skips the module's own `_as_utc()` guard — the guard that `format_local_time` / `format_local_date` already apply for exactly this reason:

```python
def _as_utc(dt):  # "Treat a naive timestamp as UTC so astimezone cannot reinterpret it as server-local."
    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
```

`created_at`/`started_at`/`finished_at` are plain `datetime` (often naive UTC), so on any non-UTC backend host the conversation text handed to the chat LLM shows the wrong wall clock.

**Fix:** wrap each timestamp in `_as_utc()` before `.astimezone(display_tz)`.

## Tests

- **`test_conversations_to_string.py` → `TestConversationsToStringNaiveTimestamps`** forces a non-UTC process timezone (`America/Los_Angeles`) via `TZ` + `time.tzset()` so the naive-as-local defect is deterministic regardless of where CI runs, and asserts naive timestamps render as UTC and convert correctly to a user tz. These **fail on the pre-fix code**.
- **`test_temporal_date_in_tz.py`** locks the `date_in_tz` contract the `chat.py` fix now relies on: empty / `None` / invalid tz fall back to UTC **without raising** (the exact `''` input that crashed the old expression), and naive datetimes are read as UTC.

## Verification

```
$ python -m pytest tests/unit/test_conversations_to_string.py tests/unit/test_temporal_date_in_tz.py
19 passed

# revert the render.py _as_utc fix -> the two naive tests fail:
$ python -m pytest tests/unit/test_conversations_to_string.py::TestConversationsToStringNaiveTimestamps
2 failed

$ black --line-length 120 --check utils/llm/chat.py utils/conversations/render.py \
    tests/unit/test_conversations_to_string.py tests/unit/test_temporal_date_in_tz.py
All done! 4 files would be left unchanged.
```

Note: I ran the affected backend unit tests and `black` directly (in a fork). The repo's maintainer-only preflight tooling (`make preflight`, `scripts/failure-class`) requires the full monorepo checkout/toolchain and was not run here.

Relates to #4643, #6214

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

