### PR TITLE
fix(backend): emit valid ISO-8601 for DG budget resets_at (drop double offset+Z)

### DIFF
--- a/backend/tests/unit/test_fair_use_engine.py
+++ b/backend/tests/unit/test_fair_use_engine.py
@@ -623,6 +623,22 @@ class TestDgBudget:
 
     @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
     @patch.object(fair_use_mod, 'FAIR_USE_RESTRICT_DAILY_DG_MS', 1800000)
+    def test_get_dg_budget_status_resets_at_is_valid_iso8601(self):
+        # resets_at is emitted to API clients (routers/fair_use_admin). tomorrow is tz-aware,
+        # so a naive `isoformat() + 'Z'` produced an invalid "…+00:00Z" that both carries an
+        # offset and a Zulu suffix — datetime.fromisoformat rejects it.
+        _mock_redis.get.return_value = b'600000'
+        result = fair_use_mod.get_dg_budget_status('user1')
+        resets_at = result['resets_at']
+        assert '+00:00Z' not in resets_at, f'malformed offset+Z timestamp: {resets_at!r}'
+        # Must be parseable as ISO-8601 (the reason a client would consume this field).
+        parsed = datetime.fromisoformat(resets_at.replace('Z', '+00:00'))
+        assert parsed.tzinfo is not None
+        # Next-midnight-UTC contract: time component is zeroed.
+        assert (parsed.hour, parsed.minute, parsed.second, parsed.microsecond) == (0, 0, 0, 0)
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'FAIR_USE_RESTRICT_DAILY_DG_MS', 1800000)
     def test_get_dg_budget_status_exhausted(self):
         _mock_redis.get.return_value = b'2000000'
         result = fair_use_mod.get_dg_budget_status('user1')

--- a/backend/utils/fair_use.py
+++ b/backend/utils/fair_use.py
@@ -714,7 +714,10 @@ def get_dg_budget_status(uid: str) -> Dict[str, Any]:
         result['used_ms'] = used_ms
         result['remaining_ms'] = remaining
         result['exhausted'] = remaining <= 0
-        result['resets_at'] = tomorrow.isoformat() + 'Z'
+        # tomorrow is tz-aware, so isoformat() already yields a "+00:00" offset; append the
+        # Zulu suffix by replacing that offset rather than concatenating (which would emit an
+        # invalid "…+00:00Z" that datetime.fromisoformat rejects). Matches models/integrations._serialize_datetime.
+        result['resets_at'] = tomorrow.isoformat().replace('+00:00', 'Z')
     except Exception as e:
         logger.error(f'fair_use: Redis error reading DG budget for {uid}: {e}')
 


### PR DESCRIPTION
## Problem

`get_dg_budget_status` (`utils/fair_use.py`) returns a `resets_at` timestamp to API clients (via `routers/fair_use_admin`). It is built as:

```python
now = datetime.now(timezone.utc)
tomorrow = (now + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
result['resets_at'] = tomorrow.isoformat() + 'Z'
```

`tomorrow` is **timezone-aware**, so `isoformat()` already emits a `+00:00` offset. Appending `'Z'` yields a string that carries **both** an offset and a Zulu suffix:

```
2026-07-20T00:00:00+00:00Z
```

That is not valid ISO-8601, and Python's own parser rejects it:

```python
>>> datetime.fromisoformat("2026-07-20T00:00:00+00:00Z")
ValueError: Invalid isoformat string: '2026-07-20T00:00:00+00:00Z'
```

Any client that parses `resets_at` with a strict ISO-8601 parser breaks.

## Root cause

`isoformat() + 'Z'` is only correct for a **naive** datetime. The codebase already knows this — `models/integrations._serialize_datetime` guards it:

```python
def _serialize_datetime(value):
    if value.tzinfo is None:
        return value.isoformat() + 'Z'
    return value.astimezone(timezone.utc).isoformat().replace('+00:00', 'Z')
```

`fair_use.py` used the naive-only form on an aware value.

## Fix

```diff
-result['resets_at'] = tomorrow.isoformat() + 'Z'
+result['resets_at'] = tomorrow.isoformat().replace('+00:00', 'Z')   # -> 2026-07-20T00:00:00Z
```

## Tests

The existing `test_get_dg_budget_status_returns_correct_fields` only asserted `resets_at.endswith('Z')` — which the malformed `…+00:00Z` value still satisfies, so the bug was uncovered. Added `test_get_dg_budget_status_resets_at_is_valid_iso8601`, which asserts the value contains no `+00:00Z` and round-trips through `datetime.fromisoformat`.

## Verification

Exercised the **real** `get_dg_budget_status` (mocked `redis_client`):

```
fixed:   resets_at = 2026-07-20T00:00:00Z      -> datetime.fromisoformat() OK
reverted: resets_at = 2026-07-20T00:00:00+00:00Z -> new assertion fails (as intended)
```

`black --line-length 120 --check utils/fair_use.py tests/unit/test_fair_use_engine.py` → clean.

Note: the full `tests/unit/test_fair_use_engine.py` collection pulls the backend's heavy deps (google-cloud, firebase-admin, anthropic, …); I verified the fixed function on the real code path with those leaves stubbed. The added assertion runs in CI where the full deps are present.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

