### PR TITLE
fix(backend): enforce Plus plan transcription cap (remaining-seconds treated it as unlimited)

### DIFF
--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -103,6 +103,47 @@ def test_bounded_transcription_plan_reads_monthly_usage_and_enforces_cap(monkeyp
     monthly_usage.assert_called_once_with('uid')
 
 
+def _stub_remaining_deps(monkeypatch, subscription_module, plan, used_seconds):
+    monkeypatch.setattr(subscription_module, 'is_trial_paywalled', lambda uid, source=None: False)
+    monkeypatch.setattr(subscription_module.users_db, 'is_byok_active', lambda uid: False, raising=False)
+    monkeypatch.setattr(subscription_module, 'get_byok_key', lambda provider: None)
+    monkeypatch.setattr(
+        subscription_module.users_db,
+        'get_user_valid_subscription',
+        lambda uid: SimpleNamespace(plan=plan),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        subscription_module,
+        'get_monthly_usage_for_subscription',
+        lambda uid: {'transcription_seconds': used_seconds},
+    )
+
+
+def test_remaining_transcription_seconds_enforces_plus_bounded_cap(monkeypatch, subscription_module):
+    # Plus is a paid plan but carries a bounded 1500-min/month transcription cap. The
+    # remaining seconds must be reported (so the freemium on-device switch can fire), not
+    # short-circuited to None as if the plan were unlimited.
+    cap = subscription_module.PLUS_TIER_MONTHLY_SECONDS_LIMIT
+    assert cap and cap > 0  # Plus is bounded by construction
+    _stub_remaining_deps(monkeypatch, subscription_module, PlanType.plus, used_seconds=cap - 10000)
+    assert subscription_module.get_remaining_transcription_seconds('uid') == 10000
+
+
+def test_remaining_transcription_seconds_zero_at_plus_cap(monkeypatch, subscription_module):
+    cap = subscription_module.PLUS_TIER_MONTHLY_SECONDS_LIMIT
+    _stub_remaining_deps(monkeypatch, subscription_module, PlanType.plus, used_seconds=cap + 5000)
+    assert subscription_module.get_remaining_transcription_seconds('uid') == 0
+
+
+def test_remaining_transcription_seconds_none_for_unlimited_paid_plan(monkeypatch, subscription_module):
+    # Genuinely-unlimited paid plans (transcription_seconds unset) must still report None,
+    # i.e. dropping the is_paid_plan short-circuit must not start capping them.
+    for plan in (PlanType.architect, PlanType.operator, PlanType.unlimited, PlanType.unlimited_v2):
+        _stub_remaining_deps(monkeypatch, subscription_module, plan, used_seconds=10_000_000)
+        assert subscription_module.get_remaining_transcription_seconds('uid') is None, plan
+
+
 def test_plus_and_unlimited_v2_price_ids_resolve(monkeypatch, subscription_module):
     monkeypatch.setenv("STRIPE_PLUS_MONTHLY_PRICE_ID", "price_plus_monthly")
     monkeypatch.setenv("STRIPE_PLUS_ANNUAL_PRICE_ID", "price_plus_annual")

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -1241,13 +1241,16 @@ def get_remaining_transcription_seconds(uid: str, source: Optional[str] = None) 
     if not subscription:
         # No subscription = use basic limits
         limits = get_basic_plan_limits()
-    elif is_paid_plan(subscription.plan):
-        return None  # Unlimited
     else:
+        # Resolve the plan's limits and let the transcription_seconds check below decide
+        # unlimited-ness. Do NOT short-circuit on is_paid_plan(): Plus is a paid plan that
+        # still carries a bounded monthly transcription cap (PLUS_TIER_MONTHLY_SECONDS_LIMIT),
+        # so treating every paid plan as unlimited leaked its cap and never triggered the
+        # freemium on-device switch. This mirrors has_transcription_credits().
         limits = get_plan_limits(subscription.plan)
 
     if not limits.transcription_seconds or limits.transcription_seconds <= 0:
-        return None  # Unlimited (limit is 0 or not set)
+        return None  # Unlimited (limit is 0 or not set — operator/architect/neo/unlimited_v2)
 
     usage = get_monthly_usage_for_subscription(uid)
     used_seconds = usage.get('transcription_seconds', 0)


### PR DESCRIPTION
## Problem

`get_remaining_transcription_seconds()` (`utils/subscription.py`) short-circuits to `None` ("unlimited") for **every** paid plan:

```python
subscription = users_db.get_user_valid_subscription(uid)
if not subscription:
    limits = get_basic_plan_limits()
elif is_paid_plan(subscription.plan):
    return None  # Unlimited
else:
    limits = get_plan_limits(subscription.plan)
```

But **Plus** is a paid plan (it's in `PAID_PLAN_TYPES`) that carries a **bounded** monthly transcription cap:

```python
get_plan_limits(PlanType.plus).transcription_seconds
    == PLUS_TIER_MONTHLY_SECONDS_LIMIT
    == PLUS_TIER_MINUTES_LIMIT_PER_MONTH * 60
    == 1500 * 60 == 90000
```

and the plan is literally sold as *"1,500 minutes of transcription per month"*. So Plus subscribers are treated as unlimited: the function never returns a bounded remaining value, and the freemium auto-switch to on-device transcription in `routers/listen/runtime.py` (which fires when `remaining <= FREEMIUM_THRESHOLD_SECONDS`) **never triggers** — a Plus user runs unbounded cloud transcription past the cap they're sold.

## Root cause

Every *other* paid plan — operator, architect, neo/`unlimited`, `unlimited_v2` — has `transcription_seconds = None` in `get_plan_limits`, so the existing `if not limits.transcription_seconds` guard already reports them as unlimited. **Plus is the only paid plan with a bounded cap**, and the blanket `is_paid_plan()` short-circuit swallows it.

The sibling `has_transcription_credits()` gets this right — it does **not** short-circuit on `is_paid_plan`; it resolves `get_plan_limits(plan)` and gates on `transcription_seconds`. `fair_use.py` likewise excludes Plus from its unlimited-transcription set. The two functions disagreed only for Plus.

## Fix

Drop the `is_paid_plan()` short-circuit and let the `transcription_seconds` check decide unlimited-ness — mirroring `has_transcription_credits()`:

```diff
-elif is_paid_plan(subscription.plan):
-    return None  # Unlimited
-else:
-    limits = get_plan_limits(subscription.plan)
+else:
+    limits = get_plan_limits(subscription.plan)
```

Behavior change is limited to Plus. Unlimited paid plans still return `None` (their `transcription_seconds` is unset); the no-subscription and basic paths are unchanged.

## Tests

Added to `tests/unit/test_subscription_plans.py` (existing coverage only tested the sibling `has_transcription_credits`, so `get_remaining_transcription_seconds` for a bounded paid plan was uncovered):

- `test_remaining_transcription_seconds_enforces_plus_bounded_cap` — Plus, usage `cap - 10000` → `10000` (was `None`).
- `test_remaining_transcription_seconds_zero_at_plus_cap` — usage over cap → `0`.
- `test_remaining_transcription_seconds_none_for_unlimited_paid_plan` — architect/operator/neo/unlimited_v2 still return `None` (guards against over-capping).

## Verification

```
$ python -m pytest tests/unit/test_subscription_plans.py
12 passed

# revert the fix -> the two Plus tests fail (the unlimited-paid guard still passes):
2 failed, 1 passed, ...
```

`black --line-length 120 --check utils/subscription.py tests/unit/test_subscription_plans.py` → clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

