### PR TITLE
fix(backend): weekly score window spans 8 days instead of the documented 7 (off-by-one)

### DIFF
--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -1058,7 +1058,10 @@ def get_scores(uid: str, date: Optional[str] = None) -> Dict[str, Any]:
 
     day_start = day
     day_end = day + timedelta(days=1)
-    week_start = day - timedelta(days=7)
+    # "7 days ending on that date" is inclusive of `day`, so the window is
+    # [day-6, day+1) — mirroring the one-day daily window [day, day+1). Using
+    # day-7 spanned 8 calendar days and over-counted the weekly totals.
+    week_start = day - timedelta(days=6)
 
     col = db.collection('users').document(uid).collection(action_items_collection)
 

--- a/backend/tests/unit/test_desktop_migration.py
+++ b/backend/tests/unit/test_desktop_migration.py
@@ -1634,6 +1634,41 @@ class TestScoreComputation:
         # Verify created_at was used in filter calls (for weekly query)
         assert 'created_at' in captured_filters, f"Expected created_at in filters, got: {captured_filters}"
 
+    def test_weekly_window_spans_seven_days_ending_on_date(self):
+        """The weekly window is the 7 days ending on `date`, i.e. [date-6, date+1).
+
+        Regression: it was [date-7, date+1) — 8 calendar days — which over-counted
+        every task created on the date-7 day, inconsistent with the docstring and
+        with the one-day daily window [date, date+1).
+        """
+        from datetime import timedelta
+
+        mock_col = MagicMock()
+        empty = MagicMock()
+        empty.where.return_value = empty
+        empty.stream.return_value = []
+        mock_col.where.return_value = empty
+        mock_col.stream.return_value = []
+
+        captured = []  # (field, op, value)
+        original_ff = action_items_db.FieldFilter
+
+        def tracking_filter(field, op, value):
+            captured.append((field, op, value))
+            return original_ff(field, op, value)
+
+        with patch.object(action_items_db, 'db') as patched_db, patch.object(
+            action_items_db, 'FieldFilter', side_effect=tracking_filter
+        ):
+            patched_db.collection.return_value.document.return_value.collection.return_value = mock_col
+            action_items_db.get_scores('test-uid', date='2026-07-19')
+
+        day = datetime(2026, 7, 19, tzinfo=timezone.utc)
+        created_at_lower = [v for (f, op, v) in captured if f == 'created_at' and op == '>=']
+        assert created_at_lower, f"no created_at >= filter captured: {captured}"
+        # 7 days ending on 2026-07-19 -> lower bound is 2026-07-13 (day-6), not 2026-07-12 (day-7).
+        assert created_at_lower[0] == day - timedelta(days=6), created_at_lower[0]
+
     def test_default_tab_daily_when_highest(self):
         """default_tab is 'daily' when daily has tasks and highest score."""
         mock_col = MagicMock()


### PR DESCRIPTION
## Problem

`get_scores()` (`database/action_items.py`) documents its weekly window as *"tasks created in the 7 days ending on that date"*, but builds it a day too wide:

```python
day_start  = day
day_end    = day + timedelta(days=1)
week_start = day - timedelta(days=7)
...
weekly_q = col.where(FieldFilter('created_at', '>=', week_start)).where(FieldFilter('created_at', '<', day_end))
```

`created_at ∈ [day-7, day+1)` spans **8 calendar days** (`day-7 … day` inclusive). So every task created on the `day-7` date is pulled into the weekly totals, inflating `weekly.total_tasks` and skewing `weekly.score`.

## Root cause

The adjacent **daily** window is built as `[day, day+1)` — exactly one day. That establishes the intended construction: an N-day window ending on `day` is `[day-(N-1), day+1)`. For the 7-day weekly window that is `[day-6, day+1)`, but the code uses `day-7`.

Concrete: for `date="2026-07-19"`, the query lower bound is `2026-07-12T00:00Z`, so a task created `2026-07-12` is counted — even though "7 days ending 2026-07-19" is `2026-07-13 … 2026-07-19`.

## Fix

```diff
-week_start = day - timedelta(days=7)
+week_start = day - timedelta(days=6)
```

This preserves the `created_at` field choice — the *"matches Rust backend which uses created_at"* comment is about the **field**, not the window size, and the Rust backend (`desktop/macos/Backend-Rust`) has no weekly-score window at all — and only corrects the span from 8 days to 7.

## Tests

The existing `get_scores` coverage (`test_desktop_migration.py::TestScoreComputation`) only asserted the weekly query uses the `created_at` field, never the window bounds. Added `test_weekly_window_spans_seven_days_ending_on_date`, which captures the `FieldFilter` calls and asserts the `created_at >=` lower bound for `date=2026-07-19` is `2026-07-13` (day-6), not `2026-07-12` (day-7).

## Verification

Exercised the **real** `get_scores` with a mocked `db` + a `FieldFilter` tracker:

```
fixed:    created_at >= 2026-07-13T00:00Z   (window spans 7 days)
reverted: created_at >= 2026-07-12T00:00Z   (window spans 8 days) -> new assertion fails
```

`black --line-length 120 --check database/action_items.py tests/unit/test_desktop_migration.py` → clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

