### PR TITLE
fix(desktop): issue one fault reset control clear

### DIFF
--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+HarnessReset.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+HarnessReset.swift
@@ -11,9 +11,12 @@ extension ChatProvider {
 
   /// Completes a harness reset after its non-production automation entrypoint
   /// has established eligibility. The main-chat transaction sets
-  /// `defaultJournalAlreadyCleared` only after its authoritative owner-scoped
-  /// control clear has succeeded.
-  func resetChatForAuthorizedHarness(defaultJournalAlreadyCleared: Bool = false) async -> String? {
+  /// `journalAlreadyCleared` only after its authoritative owner-scoped control
+  /// clear has succeeded for the active surface.
+  func resetChatForAuthorizedHarness(
+    journalAlreadyCleared: Bool = false,
+    createReplacementSession: (@MainActor () async -> ChatSession?)? = nil
+  ) async -> String? {
     isClearing = true
     defer { isClearing = false }
 
@@ -21,7 +24,7 @@ extension ChatProvider {
       let runtimeChatId = mainChatRuntimeChatId(sessionId: nil)
       let surface = AgentSurfaceReference.mainChat(chatId: runtimeChatId)
       AgentRuntimeStatusStore.shared.clear(surface: surface)
-      if !defaultJournalAlreadyCleared {
+      if !journalAlreadyCleared {
         guard await kernelTurnProjection.clear(surface: surface) else {
           return "failed to clear default kernel journal"
         }
@@ -31,8 +34,10 @@ extension ChatProvider {
       if let session = sessionToDelete {
         let surface = AgentSurfaceReference.mainChat(chatId: session.id)
         AgentRuntimeStatusStore.shared.clear(surface: surface)
-        guard await kernelTurnProjection.clear(surface: surface) else {
-          return "failed to clear session kernel journal"
+        if !journalAlreadyCleared {
+          guard await kernelTurnProjection.clear(surface: surface) else {
+            return "failed to clear session kernel journal"
+          }
         }
       }
       if let session = sessionToDelete {
@@ -41,7 +46,11 @@ extension ChatProvider {
       currentSession = nil
       messages = []
       resetMessagesPagination()
-      _ = await createNewSession()
+      if let createReplacementSession {
+        _ = await createReplacementSession()
+      } else {
+        _ = await createNewSession()
+      }
     }
     return nil
   }
@@ -57,16 +66,26 @@ extension ChatProvider {
 
   /// Performs the owner-scoped reset transaction after the automation entrypoint
   /// has established that the bundle is non-production.
-  func performMainChatHarnessResetTransaction() async -> String? {
+  func performMainChatHarnessResetTransaction(
+    createReplacementSession: (@MainActor () async -> ChatSession?)? = nil
+  ) async -> String? {
     let bundleScope = (Bundle.main.bundleIdentifier ?? "desktop")
       .replacingOccurrences(of: ".", with: "-")
     let resetOwnerID = "desktop-harness-reset-\(bundleScope)"
     return await RuntimeOwnerIdentity.withAutomationOwnerIfMissing(resetOwnerID) { [self] in
-      let clear = await clearOwnerSurfaceStateForAuthorizedHarness(chatId: "default")
+      // Clear the active main-chat surface, not a hard-coded "default". When
+      // the provider is on an app-scoped default chat (default|<app>) or a
+      // non-default session, a hard-coded "default" would clear the wrong
+      // surface and leave the visible/persisted rows for the next ask intact.
+      let activeChatId = mainChatSurfaceReference().externalRefId
+      let clear = await clearOwnerSurfaceStateForAuthorizedHarness(chatId: activeChatId)
       if let error = clear["error"] {
         return error
       }
-      return await resetChatForAuthorizedHarness(defaultJournalAlreadyCleared: true)
+      return await resetChatForAuthorizedHarness(
+        journalAlreadyCleared: true,
+        createReplacementSession: createReplacementSession
+      )
     }
   }
 }

--- a/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
@@ -453,6 +453,108 @@ import XCTest
       )
     }
 
+    func testFaultHarnessResetClearsAppScopedDefaultOnlyOnce() async {
+      let provider = ChatProvider()
+      let expectedChatID = "default|research"
+      var modelReadinessRequests = 0
+      var clearedSurfaceIDs: [String] = []
+
+      let error: String? = await RuntimeOwnerIdentity.withAutomationOwnerIfMissing(
+        "fault-harness-owner"
+      ) {
+        provider.selectedAppId = "research"
+        provider.isInDefaultChat = true
+        provider.kernelTurnProjection = KernelTurnProjection(
+          host: provider,
+          client: AgentClient.Session(harnessMode: "piMono"),
+          ownerIDProvider: {
+            RuntimeOwnerIdentity.currentOwnerId(allowAutomationOverride: true)
+          },
+          journalListOperation: { _, surface, ownerID, afterTurnSeq, limit in
+            XCTAssertFalse(ownerID.isEmpty)
+            XCTAssertEqual(surface.externalRefId, expectedChatID)
+            XCTAssertEqual(afterTurnSeq, 0)
+            XCTAssertEqual(limit, 1)
+            return self.journalPage(
+              conversationId: "fault-app-scoped-default-conversation",
+              turns: [],
+              generation: 9
+            )
+          },
+          journalClearOperation: { _, surface, _, _ in
+            clearedSurfaceIDs.append(surface.externalRefId)
+            return 1
+          },
+          kernelReadyOperation: {
+            modelReadinessRequests += 1
+            return false
+          }
+        )
+
+        return await provider.performMainChatHarnessResetTransaction()
+      }
+
+      XCTAssertNil(error)
+      XCTAssertEqual(modelReadinessRequests, 0)
+      XCTAssertEqual(clearedSurfaceIDs, [expectedChatID])
+    }
+
+    func testFaultHarnessResetClearsSelectedSessionOnlyOnce() async {
+      let provider = ChatProvider()
+      let session = ChatSession(id: "fault-selected-session")
+      var modelReadinessRequests = 0
+      var clearedSurfaceIDs: [String] = []
+      var replacementSessionRequests = 0
+      var sessionWasCleared = false
+
+      let error: String? = await RuntimeOwnerIdentity.withAutomationOwnerIfMissing(
+        "fault-harness-owner"
+      ) {
+        provider.sessions = [session]
+        provider.currentSession = session
+        provider.isInDefaultChat = false
+        provider.kernelTurnProjection = KernelTurnProjection(
+          host: provider,
+          client: AgentClient.Session(harnessMode: "piMono"),
+          ownerIDProvider: {
+            RuntimeOwnerIdentity.currentOwnerId(allowAutomationOverride: true)
+          },
+          journalListOperation: { _, surface, ownerID, afterTurnSeq, limit in
+            XCTAssertFalse(ownerID.isEmpty)
+            XCTAssertEqual(surface.externalRefId, session.id)
+            XCTAssertEqual(afterTurnSeq, 0)
+            XCTAssertEqual(limit, 1)
+            return self.journalPage(
+              conversationId: "fault-selected-session-conversation",
+              turns: [],
+              generation: 9
+            )
+          },
+          journalClearOperation: { _, surface, _, _ in
+            clearedSurfaceIDs.append(surface.externalRefId)
+            return 1
+          },
+          kernelReadyOperation: {
+            modelReadinessRequests += 1
+            return false
+          }
+        )
+
+        let error = await provider.performMainChatHarnessResetTransaction {
+          replacementSessionRequests += 1
+          return ChatSession(id: "fault-replacement-session")
+        }
+        sessionWasCleared = provider.currentSession == nil
+        return error
+      }
+
+      XCTAssertNil(error)
+      XCTAssertEqual(modelReadinessRequests, 0)
+      XCTAssertEqual(clearedSurfaceIDs, [session.id])
+      XCTAssertEqual(replacementSessionRequests, 1)
+      XCTAssertTrue(sessionWasCleared)
+    }
+
     func testClearOwnerSurfaceStateUsesAuthoritativeJournalControlWhenModelReadinessIsUnavailable() async throws {
       let provider = ChatProvider()
       let surface = provider.mainChatSurfaceReference()

--- a/desktop/macos/changelog/unreleased/20260718-fault-reset-control.json
+++ b/desktop/macos/changelog/unreleased/20260718-fault-reset-control.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved desktop chat recovery after a temporary service error"
+}


### PR DESCRIPTION
## Summary
- Clear the active main-chat surface during the credential-free non-production fault reset: app-scoped defaults use `default|<app>`, and selected chats use their session ID.
- Treat that successful control clear as authoritative in both reset branches, preventing a selected-session reset from issuing a second model-ready journal clear against an already-consumed generation.
- Replace the helper-only regression with behavioral coverage for app-scoped defaults and selected sessions; each asserts the target surface and exactly one clear.

## Root cause
The owner-scoped control clear originally targeted a literal `default` chat ID. After routing it to the active surface, the selected-session reset path still issued its normal projection clear because the `defaultJournalAlreadyCleared` bypass only covered default chats. That reintroduced the fault-reset double-clear failure for selected sessions.

## Verification
- `xcrun swift test --package-path Desktop --filter KernelTurnRecordedProjectionTests` — 30 tests passed.
- `./scripts/agent-logic-harness.sh --swift-only` — passed.
- `OMI_PR_BODY_FILE=/tmp/pr-10016-body.md make preflight` — 18 checks passed.
- Pre-push bounded gate passed, including the desktop Swift debug compile.

Failure-Class: FC-split-mutation-authority
