### PR TITLE
fix(dev-harness): resolve canonical Python venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,13 +60,13 @@ dev-logs:
 	bash scripts/dev-harness/dev-logs.sh
 
 list-memory-scenarios:
-	$(PYTHON) scripts/dev-harness/list-memory-scenarios.py
+	"$(PYTHON)" scripts/dev-harness/list-memory-scenarios.py
 
 seed-memory-scenario:
-	$(PYTHON) scripts/dev-harness/seed-memory-scenario.py $(SCENARIO)
+	"$(PYTHON)" scripts/dev-harness/seed-memory-scenario.py $(SCENARIO)
 
 reset-memory-scenario:
-	$(PYTHON) scripts/dev-harness/reset-memory-scenario.py $(SCENARIO)
+	"$(PYTHON)" scripts/dev-harness/reset-memory-scenario.py $(SCENARIO)
 
 desktop-run-local:
 	@if [ -n "$(DESKTOP_APP_NAME)" ]; then \
@@ -76,4 +76,4 @@ desktop-run-local:
 	fi
 
 run-canonical-promotion:
-	PYTHON="$(PYTHON)" PYTHONPATH="scripts/dev-harness:backend$(if $(PYTHONPATH),:$(PYTHONPATH),)" $(PYTHON) scripts/dev-harness/run-canonical-promotion.py "$(PROMOTION_USER)"
+	PYTHON="$(PYTHON)" PYTHONPATH="scripts/dev-harness:backend$(if $(PYTHONPATH),:$(PYTHONPATH),)" "$(PYTHON)" scripts/dev-harness/run-canonical-promotion.py "$(PROMOTION_USER)"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ROOT := $(shell git rev-parse --show-toplevel)
 HOOKS_DIR := $(shell git rev-parse --git-path hooks)
-PYTHON ?= $(shell if [ -x backend/venv/bin/python ]; then printf backend/venv/bin/python; else printf python3; fi)
+PYTHON ?= $(shell bash -c 'source "$(ROOT)/scripts/dev-harness/_resolve_python.sh"; dev_harness_python')
 DESKTOP_USER ?= alice
 DESKTOP_APP_NAME ?=
 

--- a/docs/runbooks/local-emulator-manual-qa.md
+++ b/docs/runbooks/local-emulator-manual-qa.md
@@ -38,7 +38,7 @@ Non-secret keys in `backend/.env.local-dev` are **ignored** — see `make dev-st
 ### Useful commands
 
 ```bash
-make dev-init      # one-time venv + template copy
+make dev-init      # one-time backend/.venv setup + template copy
 make dev           # services + auto-seed
 make dev-status    # endpoints, provider mode, seeded users
 make dev-verify    # signed-in check + chat smoke + no aud errors

--- a/scripts/dev-harness/_resolve_python.sh
+++ b/scripts/dev-harness/_resolve_python.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Print the interpreter for local dev-harness commands. PYTHON is an explicit
+# caller choice; otherwise prefer the canonical venv while retaining support
+# for existing checkouts that use the legacy backend/venv location.
+dev_harness_python() {
+  if [ -n "${PYTHON:-}" ]; then
+    printf '%s\n' "$PYTHON"
+    return
+  fi
+
+  local repo_root candidate
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  for candidate in "$repo_root/backend/.venv/bin/python" "$repo_root/backend/venv/bin/python"; do
+    if [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  printf '%s\n' "python3"
+}

--- a/scripts/dev-harness/desktop-run-local.sh
+++ b/scripts/dev-harness/desktop-run-local.sh
@@ -3,13 +3,12 @@ set -euo pipefail
 
 # shellcheck source=_source_local_dev_env.sh
 source "$(dirname "$0")/_source_local_dev_env.sh"
+# shellcheck source=_resolve_python.sh
+source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 USER_PROFILE="${1:-alice}"
 
-PYTHON_BIN="${PYTHON:-backend/venv/bin/python}"
-if [ ! -x "$PYTHON_BIN" ]; then
-  PYTHON_BIN="python3"
-fi
+PYTHON_BIN="$(dev_harness_python)"
 
 PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" - <<'PY' "$USER_PROFILE"
 from __future__ import annotations

--- a/scripts/dev-harness/dev-check.sh
+++ b/scripts/dev-harness/dev-check.sh
@@ -2,13 +2,12 @@
 set -euo pipefail
 # shellcheck source=_source_local_dev_env.sh
 source "$(dirname "$0")/_source_local_dev_env.sh"
+# shellcheck source=_resolve_python.sh
+source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 if git ls-files --error-unmatch backend/.env.local-dev >/dev/null 2>&1; then
   echo "backend/.env.local-dev is tracked by git — remove it from the index before committing secrets" >&2
   exit 1
 fi
-PYTHON_BIN="${PYTHON:-backend/venv/bin/python}"
-if [ ! -x "$PYTHON_BIN" ]; then
-  PYTHON_BIN="python3"
-fi
+PYTHON_BIN="$(dev_harness_python)"
 PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m dev_harness.cli check

--- a/scripts/dev-harness/dev-down.sh
+++ b/scripts/dev-harness/dev-down.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 # shellcheck source=_source_local_dev_env.sh
 source "$(dirname "$0")/_source_local_dev_env.sh"
+# shellcheck source=_resolve_python.sh
+source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
-PYTHON_BIN="${PYTHON:-backend/venv/bin/python}"
-if [ ! -x "$PYTHON_BIN" ]; then
-  PYTHON_BIN="python3"
-fi
+PYTHON_BIN="$(dev_harness_python)"
 PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m dev_harness.cli down

--- a/scripts/dev-harness/dev-init.sh
+++ b/scripts/dev-harness/dev-init.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# shellcheck source=_resolve_python.sh
+source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 
 echo "Omi local dev harness — one-time setup"
@@ -13,17 +15,19 @@ else
   echo "Keeping existing $secrets_file (not overwritten)"
 fi
 
-if [ ! -d backend/venv ]; then
-  python3 -m venv backend/venv
-  echo "Created backend/venv"
+PYTHON_BIN="$(dev_harness_python)"
+if [ "$PYTHON_BIN" = "python3" ]; then
+  python3 -m venv backend/.venv
+  PYTHON_BIN="$(dev_harness_python)"
+  echo "Created backend/.venv"
 fi
 
-if [ ! -x backend/venv/bin/pip ]; then
-  echo "backend/venv is incomplete; recreate it with: python3 -m venv backend/venv" >&2
+if ! "$PYTHON_BIN" -m pip --version >/dev/null; then
+  echo "${PYTHON_BIN%/bin/python} is incomplete; recreate it with: python3 -m venv backend/.venv" >&2
   exit 1
 fi
 
-backend/venv/bin/pip install -q -r backend/requirements.txt
+"$PYTHON_BIN" -m pip install -q -r backend/requirements.txt
 echo "Backend Python dependencies installed"
 
 hook=".git/hooks/pre-commit"

--- a/scripts/dev-harness/dev-logs.sh
+++ b/scripts/dev-harness/dev-logs.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 # shellcheck source=_source_local_dev_env.sh
 source "$(dirname "$0")/_source_local_dev_env.sh"
+# shellcheck source=_resolve_python.sh
+source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
-PYTHON_BIN="${PYTHON:-backend/venv/bin/python}"
-if [ ! -x "$PYTHON_BIN" ]; then
-  PYTHON_BIN="python3"
-fi
+PYTHON_BIN="$(dev_harness_python)"
 PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m dev_harness.cli logs

--- a/scripts/dev-harness/dev-reset.sh
+++ b/scripts/dev-harness/dev-reset.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 # shellcheck source=_source_local_dev_env.sh
 source "$(dirname "$0")/_source_local_dev_env.sh"
+# shellcheck source=_resolve_python.sh
+source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
-PYTHON_BIN="${PYTHON:-backend/venv/bin/python}"
-if [ ! -x "$PYTHON_BIN" ]; then
-  PYTHON_BIN="python3"
-fi
+PYTHON_BIN="$(dev_harness_python)"
 PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m dev_harness.cli reset

--- a/scripts/dev-harness/dev-status.sh
+++ b/scripts/dev-harness/dev-status.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 # shellcheck source=_source_local_dev_env.sh
 source "$(dirname "$0")/_source_local_dev_env.sh"
+# shellcheck source=_resolve_python.sh
+source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
-PYTHON_BIN="${PYTHON:-backend/venv/bin/python}"
-if [ ! -x "$PYTHON_BIN" ]; then
-  PYTHON_BIN="python3"
-fi
+PYTHON_BIN="$(dev_harness_python)"
 PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m dev_harness.cli status

--- a/scripts/dev-harness/dev-summary.sh
+++ b/scripts/dev-harness/dev-summary.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 # shellcheck source=_source_local_dev_env.sh
 source "$(dirname "$0")/_source_local_dev_env.sh"
+# shellcheck source=_resolve_python.sh
+source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
-PYTHON_BIN="${PYTHON:-backend/venv/bin/python}"
-if [ ! -x "$PYTHON_BIN" ]; then
-  PYTHON_BIN="python3"
-fi
+PYTHON_BIN="$(dev_harness_python)"
 PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m dev_harness.cli summary

--- a/scripts/dev-harness/dev-up.sh
+++ b/scripts/dev-harness/dev-up.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 # shellcheck source=_source_local_dev_env.sh
 source "$(dirname "$0")/_source_local_dev_env.sh"
+# shellcheck source=_resolve_python.sh
+source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
-PYTHON_BIN="${PYTHON:-backend/venv/bin/python}"
-if [ ! -x "$PYTHON_BIN" ]; then
-  PYTHON_BIN="python3"
-fi
+PYTHON_BIN="$(dev_harness_python)"
 PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m dev_harness.cli up

--- a/scripts/dev-harness/tests/test_python_resolver.py
+++ b/scripts/dev-harness/tests/test_python_resolver.py
@@ -10,6 +10,7 @@ import pytest
 
 HARNESS_ROOT = Path(__file__).resolve().parents[1]
 RESOLVER = HARNESS_ROOT / "_resolve_python.sh"
+MAKEFILE = HARNESS_ROOT.parents[1] / "Makefile"
 
 
 def _make_executable(path: Path) -> None:
@@ -78,3 +79,46 @@ def test_resolver_honors_explicit_python_override(tmp_path: Path, monkeypatch: p
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "custom-python"
+
+
+def test_make_harness_targets_run_resolved_python_from_checkout_with_spaces(tmp_path: Path) -> None:
+    repo = tmp_path / "omi pr-10017 space"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    shutil.copy2(MAKEFILE, repo / "Makefile")
+
+    resolver = repo / "scripts/dev-harness/_resolve_python.sh"
+    resolver.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(RESOLVER, resolver)
+
+    calls = repo / "python calls.log"
+    python = repo / "backend/.venv/bin/python"
+    python.parent.mkdir(parents=True, exist_ok=True)
+    python.write_text('#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$HARNESS_PYTHON_CALLS"\n', encoding="utf-8")
+    python.chmod(python.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ | {"HARNESS_PYTHON_CALLS": str(calls)}
+    targets = (
+        ("list-memory-scenarios", []),
+        ("seed-memory-scenario", ["SCENARIO=sample"]),
+        ("reset-memory-scenario", ["SCENARIO=sample"]),
+        ("run-canonical-promotion", ["PROMOTION_USER=alice"]),
+    )
+    for target, variables in targets:
+        result = subprocess.run(
+            ["make", "-C", str(repo), *variables, target],
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+
+    assert calls.read_text(encoding="utf-8").splitlines() == [
+        "scripts/dev-harness/list-memory-scenarios.py",
+        "scripts/dev-harness/seed-memory-scenario.py sample",
+        "scripts/dev-harness/reset-memory-scenario.py sample",
+        "scripts/dev-harness/run-canonical-promotion.py alice",
+    ]

--- a/scripts/dev-harness/tests/test_python_resolver.py
+++ b/scripts/dev-harness/tests/test_python_resolver.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HARNESS_ROOT = Path(__file__).resolve().parents[1]
+RESOLVER = HARNESS_ROOT / "_resolve_python.sh"
+
+
+def _make_executable(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _resolve_python(repo: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    resolver = repo / "scripts/dev-harness/_resolve_python.sh"
+    resolver.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(RESOLVER, resolver)
+    monkeypatch.delenv("PYTHON", raising=False)
+    result = subprocess.run(
+        ["bash", "-c", 'source "$1"; dev_harness_python', "bash", str(resolver)],
+        cwd=repo,
+        env=os.environ.copy(),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_resolver_prefers_repo_venvs_and_only_uses_python3_without_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    modern = repo / "backend/.venv/bin/python"
+    legacy = repo / "backend/venv/bin/python"
+
+    _make_executable(modern)
+    _make_executable(legacy)
+    assert _resolve_python(repo, monkeypatch) == str(modern)
+
+    modern.unlink()
+    assert _resolve_python(repo, monkeypatch) == str(legacy)
+
+    legacy.unlink()
+    assert _resolve_python(repo, monkeypatch) == "python3"
+
+
+def test_resolver_honors_explicit_python_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _make_executable(repo / "backend/.venv/bin/python")
+    monkeypatch.setenv("PYTHON", "custom-python")
+
+    resolver = repo / "scripts/dev-harness/_resolve_python.sh"
+    resolver.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(RESOLVER, resolver)
+    result = subprocess.run(
+        ["bash", "-c", 'source "$1"; dev_harness_python', "bash", str(resolver)],
+        cwd=repo,
+        env=os.environ.copy(),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "custom-python"


### PR DESCRIPTION
## Summary
- Centralize local dev-harness interpreter resolution: explicit `PYTHON`, then `backend/.venv/bin/python`, legacy `backend/venv/bin/python`, then `python3`.
- Route all harness commands and Makefile harness Python targets through the resolver; `dev-init` creates the canonical `.venv` when neither venv exists.
- Add focused resolver coverage for precedence and fallback behavior.

## Root cause and durable guard
Harness commands and Makefile targets had inconsistent hard-coded legacy `backend/venv` defaults. A single resolver owns precedence now, with a hermetic regression test covering every selection branch.

## Verification
- `/Users/dazheng/workspace/omi/backend/.venv/bin/python -m pytest -q scripts/dev-harness/tests/test_python_resolver.py` — 2 passed
- `bash -n` for the resolver plus all 9 harness consumers — pass
- `git diff --cached --check` — pass
- `make preflight` — passed (9 deterministic checks)

## Failure-Class
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

