### PR TITLE
fix(desktop): use backend IDs for task candidates

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-proactiveassistants.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-proactiveassistants.json
@@ -1,10 +1,10 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift": 1736,
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift": 1742,
     "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": 1645
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift": "Staged tasks now render as id-less 'already captured' evidence via a pure, unit-tested contextEvidencePrompt helper, so they can no longer be echoed back as duplicate_of:0 to update a non-existent backend task.",
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift": "Task candidate context now carries only backend action-item IDs, while local SQLite/staged evidence remains id-less so the model cannot target it for a backend mutation.",
     "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": "stopMonitoring now clears capture-recovery/background-polling state and timers, plus a pure ProactiveCapturePolicy gate, so a stop mid-recovery cannot silently disable capture on the next start."
   },
   "threshold": 1500

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -1537,20 +1537,26 @@ actor TaskAssistant: ProactiveAssistant {
 
   /// Refresh context from local SQLite + cached goals
   private func refreshContext() async -> TaskExtractionContext {
-    var topRelevanceTasks: [(id: Int64, description: String, priority: String?, relevanceScore: Int?)] = []
-    var recentTasks: [(id: Int64, description: String, priority: String?, relevanceScore: Int?)] = []
+    var topRelevanceTasks: [(id: String, description: String, priority: String?, relevanceScore: Int?)] = []
+    var recentTasks: [(id: String, description: String, priority: String?, relevanceScore: Int?)] = []
     var completedTasks: [(id: Int64, description: String)] = []
     var deletedTasks: [(id: Int64, description: String)] = []
 
     // Query both action_items (promoted + manual) and staged_tasks for full context
     do {
-      topRelevanceTasks = try await ActionItemStorage.shared.getTopRelevanceTasks(limit: 30)
+      topRelevanceTasks = try await ActionItemStorage.shared.getTopRelevanceTasks(limit: 30).compactMap {
+        guard let backendId = $0.backendId, !backendId.isEmpty else { return nil }
+        return (id: backendId, description: $0.description, priority: $0.priority, relevanceScore: $0.relevanceScore)
+      }
     } catch {
       logError("Task: Failed to load top relevance tasks", error: error)
     }
 
     do {
-      recentTasks = try await ActionItemStorage.shared.getRecentActiveTasks(limit: 30)
+      recentTasks = try await ActionItemStorage.shared.getRecentActiveTasks(limit: 30).compactMap {
+        guard let backendId = $0.backendId, !backendId.isEmpty else { return nil }
+        return (id: backendId, description: $0.description, priority: $0.priority, relevanceScore: $0.relevanceScore)
+      }
     } catch {
       logError("Task: Failed to load recent tasks", error: error)
     }
@@ -1632,7 +1638,7 @@ actor TaskAssistant: ProactiveAssistant {
 
             results.append(
               TaskSearchResult(
-                id: result.id,
+                taskID: record.backendId,
                 description: record.description,
                 status: status,
                 similarity: Double(result.similarity),
@@ -1653,7 +1659,7 @@ actor TaskAssistant: ProactiveAssistant {
 
             results.append(
               TaskSearchResult(
-                id: result.id,
+                taskID: nil,
                 description: staged.description,
                 status: status,
                 similarity: Double(result.similarity),
@@ -1701,7 +1707,7 @@ actor TaskAssistant: ProactiveAssistant {
 
           results.append(
             TaskSearchResult(
-              id: result.id,
+              taskID: result.backendId,
               description: result.description,
               status: status,
               similarity: nil,
@@ -1718,7 +1724,7 @@ actor TaskAssistant: ProactiveAssistant {
         for result in stagedResults {
           results.append(
             TaskSearchResult(
-              id: result.id,
+              taskID: nil,
               description: result.description,
               status: "active",
               similarity: nil,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskModels.swift
@@ -521,7 +521,8 @@ struct TaskExtractionResult: Codable, AssistantResult {
 
 /// Context injected into the extraction prompt for deduplication
 struct TaskExtractionContext {
-  let activeTasks: [(id: Int64, description: String, priority: String?, relevanceScore: Int?)]
+  /// Only backend action-item IDs are valid duplicate/refinement targets.
+  let activeTasks: [(id: String, description: String, priority: String?, relevanceScore: Int?)]
   let completedTasks: [(id: Int64, description: String)]
   let deletedTasks: [(id: Int64, description: String)]
   /// Descriptions of tasks already staged locally (not yet promoted to the
@@ -535,7 +536,9 @@ struct TaskExtractionContext {
 
 /// Result from vector/FTS search during tool-calling extraction
 struct TaskSearchResult: Codable {
-  let id: Int64
+  /// Stable backend action-item ID when this result can be mutated. Local and
+  /// staged rows remain search evidence but deliberately have no task ID.
+  let taskID: String?
   let description: String
   let status: String  // "active", "completed", "deleted"
   let similarity: Double?  // cosine similarity (nil for FTS-only matches)
@@ -543,7 +546,8 @@ struct TaskSearchResult: Codable {
   let relevanceScore: Int?  // relevance ranking score (higher = more important)
 
   enum CodingKeys: String, CodingKey {
-    case id, description, status, similarity
+    case taskID = "task_id"
+    case description, status, similarity
     case matchType = "match_type"
     case relevanceScore = "relevance_score"
   }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -1095,7 +1095,7 @@ actor ActionItemStorage {
     includeCompleted: Bool = true,
     includeDeleted: Bool = false
   ) async throws -> [(
-    id: Int64, description: String, completed: Bool, deleted: Bool, deletedBy: String?, relevanceScore: Int?
+    backendId: String?, description: String, completed: Bool, deleted: Bool, deletedBy: String?, relevanceScore: Int?
   )] {
     let db = try await ensureInitialized()
     // Sanitize FTS5 query: strip special characters that could be misinterpreted
@@ -1106,7 +1106,7 @@ actor ActionItemStorage {
 
     return try await db.read { database in
       var sql = """
-        SELECT a.id, a.description, a.completed, a.deleted, a.deletedBy, a.relevanceScore
+        SELECT a.backendId, a.description, a.completed, a.deleted, a.deletedBy, a.relevanceScore
         FROM action_items a
         JOIN action_items_fts fts ON fts.rowid = a.id
         WHERE action_items_fts MATCH ?
@@ -1125,7 +1125,7 @@ actor ActionItemStorage {
 
       return try Row.fetchAll(database, sql: sql, arguments: StatementArguments(arguments)).map { row in
         (
-          id: row["id"] as Int64,
+          backendId: row["backendId"] as String?,
           description: row["description"] as String,
           completed: row["completed"] as Bool,
           deleted: row["deleted"] as Bool,
@@ -1138,7 +1138,7 @@ actor ActionItemStorage {
 
   /// Get active tasks with the highest relevance (lowest score = most important)
   func getTopRelevanceTasks(limit: Int = 30) async throws -> [(
-    id: Int64, description: String, priority: String?, relevanceScore: Int?
+    backendId: String?, description: String, priority: String?, relevanceScore: Int?
   )] {
     let db = try await ensureInitialized()
 
@@ -1146,13 +1146,13 @@ actor ActionItemStorage {
       try Row.fetchAll(
         database,
         sql: """
-              SELECT id, description, priority, relevanceScore FROM action_items
+              SELECT backendId, description, priority, relevanceScore FROM action_items
               WHERE completed = 0 AND deleted = 0 AND relevanceScore IS NOT NULL
               ORDER BY relevanceScore ASC LIMIT ?
           """, arguments: [limit]
       ).map { row in
         (
-          id: row["id"] as Int64,
+          backendId: row["backendId"] as String?,
           description: row["description"] as String,
           priority: row["priority"] as String?,
           relevanceScore: row["relevanceScore"] as Int?
@@ -1163,7 +1163,7 @@ actor ActionItemStorage {
 
   /// Get most recently created active tasks
   func getRecentActiveTasks(limit: Int = 30) async throws -> [(
-    id: Int64, description: String, priority: String?, relevanceScore: Int?
+    backendId: String?, description: String, priority: String?, relevanceScore: Int?
   )] {
     let db = try await ensureInitialized()
 
@@ -1171,13 +1171,13 @@ actor ActionItemStorage {
       try Row.fetchAll(
         database,
         sql: """
-              SELECT id, description, priority, relevanceScore FROM action_items
+              SELECT backendId, description, priority, relevanceScore FROM action_items
               WHERE completed = 0 AND deleted = 0
               ORDER BY createdAt DESC LIMIT ?
           """, arguments: [limit]
       ).map { row in
         (
-          id: row["id"] as Int64,
+          backendId: row["backendId"] as String?,
           description: row["description"] as String,
           priority: row["priority"] as String?,
           relevanceScore: row["relevanceScore"] as Int?

--- a/desktop/macos/Desktop/Tests/TaskAssistantContextPromptTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskAssistantContextPromptTests.swift
@@ -13,7 +13,7 @@ import XCTest
 final class TaskAssistantContextPromptTests: XCTestCase {
   func testStagedTasksRenderWithoutAnUpdatableId() {
     let context = TaskExtractionContext(
-      activeTasks: [(id: Int64(42), description: "Review the PR", priority: "high", relevanceScore: 10)],
+      activeTasks: [(id: "action-item-42", description: "Review the PR", priority: "high", relevanceScore: 10)],
       completedTasks: [],
       deletedTasks: [],
       stagedTaskDescriptions: ["Draft the Q3 report"],
@@ -23,7 +23,7 @@ final class TaskAssistantContextPromptTests: XCTestCase {
     let prompt = TaskAssistant.contextEvidencePrompt(context)
 
     // Real backend tasks keep their updatable id.
-    XCTAssertTrue(prompt.contains("[id:42] Review the PR"))
+    XCTAssertTrue(prompt.contains("[id:action-item-42] Review the PR"))
     // Staged tasks appear as id-less evidence.
     XCTAssertTrue(prompt.contains("ALREADY CAPTURED — STAGED"))
     let stagedLine = prompt.split(separator: "\n").first { $0.contains("Draft the Q3 report") }
@@ -33,6 +33,36 @@ final class TaskAssistantContextPromptTests: XCTestCase {
       "A staged task must never be rendered with an updatable id")
     // The specific bug signature must be gone entirely.
     XCTAssertFalse(prompt.contains("[id:0]"), "No task may be rendered with the sentinel id 0")
+  }
+
+  func testSearchResultSerializesOnlyBackendTaskIDs() throws {
+    let localResult = TaskSearchResult(
+      taskID: nil,
+      description: "Unsynced local task",
+      status: "active",
+      similarity: 0.9,
+      matchType: "vector",
+      relevanceScore: 1
+    )
+    let backendResult = TaskSearchResult(
+      taskID: "backend-task-42",
+      description: "Synced task",
+      status: "active",
+      similarity: 0.9,
+      matchType: "vector",
+      relevanceScore: 1
+    )
+
+    let localPayload = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: JSONEncoder().encode(localResult)) as? [String: Any]
+    )
+    let backendPayload = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: JSONEncoder().encode(backendResult)) as? [String: Any]
+    )
+
+    XCTAssertNil(localPayload["id"])
+    XCTAssertNil(localPayload["task_id"])
+    XCTAssertEqual(backendPayload["task_id"] as? String, "backend-task-42")
   }
 
   func testEmptyContextRendersNothing() {

--- a/desktop/macos/Desktop/Tests/TaskIntelligenceContractFixtureTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskIntelligenceContractFixtureTests.swift
@@ -596,6 +596,33 @@ final class TaskIntelligenceSQLiteRoundTripTests: XCTestCase {
     XCTAssertEqual(restored.provenance?.first?.version, "2")
   }
 
+  func testActiveTaskContextExposesOnlyBackendTaskIDs() async throws {
+    _ = try await ActionItemStorage.shared.insertLocalActionItem(
+      ActionItemRecord(
+        backendId: "backend-task-42",
+        backendSynced: true,
+        description: "Review the release PR",
+        source: "test",
+        relevanceScore: 1
+      ),
+      authorization: .unrestricted
+    )
+    _ = try await ActionItemStorage.shared.insertLocalActionItem(
+      ActionItemRecord(
+        description: "Unsynced local task",
+        source: "test",
+        relevanceScore: 2
+      ),
+      authorization: .unrestricted
+    )
+
+    let topTasks = try await ActionItemStorage.shared.getTopRelevanceTasks()
+    let recentTasks = try await ActionItemStorage.shared.getRecentActiveTasks()
+
+    XCTAssertEqual(topTasks.compactMap(\.backendId), ["backend-task-42"])
+    XCTAssertEqual(recentTasks.compactMap(\.backendId), ["backend-task-42"])
+  }
+
   func testCanonicalCandidateOutboxIsHiddenRetryableAndReceiptReconciled() async throws {
     let row = try await StagedTaskStorage.shared.insertLocalStagedTask(
       StagedTaskRecord(

--- a/desktop/macos/changelog/unreleased/20260719-task-candidate-target-ids.json
+++ b/desktop/macos/changelog/unreleased/20260719-task-candidate-target-ids.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed AI-extracted task updates targeting the wrong task"
+}


### PR DESCRIPTION
## Summary

- Use durable backend action-item IDs, rather than local SQLite row IDs, in task extraction's active-task context and duplicate-search result contracts.
- Keep unsynced local and staged task records available as id-less duplicate evidence, so they cannot be selected as candidate mutation targets.
- Add prompt, serialization, and isolated SQLite regression coverage.

## Verification

- `xcrun swift test --package-path Desktop --disable-automatic-resolution --filter TaskAssistantContextPromptTests`
- `xcrun swift test --package-path Desktop --disable-automatic-resolution --filter TaskIntelligenceSQLiteRoundTripTests/testActiveTaskContextExposesOnlyBackendTaskIDs`
- `OMI_APP_NAME="omi-task-canonical-id" OMI_ALLOW_ADHOC_SIGN=1 OMI_SIGN_IDENTITY="-" ./run.sh --yolo` (built, signed, and launched the isolated named bundle)
- `make preflight`

## Failure class

Failure-Class: FC-split-mutation-authority

The backend action-item ID is the authoritative identity for candidate mutations. This repair keeps local SQLite records as evidence only, so they cannot provide a competing mutation target.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

