### PR TITLE
fix(listen): enforce live STT model capabilities

### DIFF
--- a/backend/config/stt_provider_policy.py
+++ b/backend/config/stt_provider_policy.py
@@ -24,6 +24,76 @@ DEEPGRAM_SELF_HOSTED_PROVIDER: Final = 'deepgram_self_hosted'
 MODULATE_PROVIDER: Final = 'modulate'
 PARAKEET_PROVIDER: Final = 'parakeet'
 
+# Velma-2 is the live fallback for every language we can safely send to its
+# automatic-detection mode. Keep this capability at the policy boundary rather
+# than beside one caller: a user may choose multi-language mode independently
+# of their primary language.
+MODULATE_SUPPORTED_LANGUAGES: Final[frozenset[str]] = frozenset(
+    {
+        'multi',
+        'en',
+        'af',
+        'sq',
+        'ar',
+        'az',
+        'eu',
+        'be',
+        'bn',
+        'bs',
+        'bg',
+        'ca',
+        'zh',
+        'hr',
+        'cs',
+        'da',
+        'nl',
+        'et',
+        'fi',
+        'fr',
+        'gl',
+        'de',
+        'el',
+        'gu',
+        'he',
+        'hi',
+        'hu',
+        'id',
+        'it',
+        'ja',
+        'kn',
+        'kk',
+        'ko',
+        'lv',
+        'lt',
+        'mk',
+        'ms',
+        'ml',
+        'mr',
+        'no',
+        'fa',
+        'pl',
+        'pt',
+        'pa',
+        'ro',
+        'ru',
+        'sr',
+        'sk',
+        'sl',
+        'es',
+        'sw',
+        'sv',
+        'tl',
+        'ta',
+        'te',
+        'th',
+        'tr',
+        'uk',
+        'ur',
+        'vi',
+        'cy',
+    }
+)
+
 # This is the single source of truth for provider enablement. Cloud Deepgram is
 # intentionally absent from every serving surface. Self-hosted Deepgram is a
 # distinct product and remains available only to the streaming runtime that has
@@ -56,6 +126,73 @@ DEFAULT_MODELS_BY_SURFACE: Final[Mapping[STTServingSurface, tuple[str, ...]]] = 
     STTServingSurface.PRERECORDED: ('parakeet', 'modulate-velma-2'),
     STTServingSurface.PTT: ('parakeet', 'modulate-velma-2'),
 }
+
+# The Parakeet deployment has distinct batch and real-time models. The batch
+# `parakeet-tdt-0.6b-v3` model can detect 25 languages, while streaming and
+# PTT both use the English-only `parakeet-rnnt-1.1b` model. Keep capabilities
+# tied to the deployed model rather than to the provider token, so a model
+# change must update this policy and its regression coverage together.
+PARAKEET_MODEL_BY_SURFACE: Final[Mapping[STTServingSurface, str]] = {
+    STTServingSurface.STREAMING: 'nvidia/parakeet-rnnt-1.1b',
+    STTServingSurface.PTT: 'nvidia/parakeet-rnnt-1.1b',
+    STTServingSurface.PRERECORDED: 'nvidia/parakeet-tdt-0.6b-v3',
+}
+PARAKEET_SUPPORTED_LANGUAGES_BY_MODEL: Final[Mapping[str, frozenset[str]]] = {
+    'nvidia/parakeet-rnnt-1.1b': frozenset({'en'}),
+    'nvidia/parakeet-tdt-0.6b-v3': frozenset(
+        {
+            'multi',
+            'bg',
+            'hr',
+            'cs',
+            'da',
+            'nl',
+            'en',
+            'et',
+            'fi',
+            'fr',
+            'de',
+            'el',
+            'hu',
+            'it',
+            'lt',
+            'lv',
+            'mt',
+            'pl',
+            'pt',
+            'ro',
+            'ru',
+            'sk',
+            'sl',
+            'es',
+            'sv',
+            'uk',
+        }
+    ),
+}
+
+
+def parakeet_supports_language(surface: STTServingSurface, language: str) -> bool:
+    """Return whether the deployed Parakeet model supports a normalized language."""
+    model = PARAKEET_MODEL_BY_SURFACE[surface]
+    return language.strip().lower() in PARAKEET_SUPPORTED_LANGUAGES_BY_MODEL[model]
+
+
+def normalized_stt_language(language: str | None) -> str:
+    """Return the base language code accepted by provider capability maps."""
+    if not language:
+        return ''
+    return language.split('-')[0].split('_')[0].lower()
+
+
+def modulate_supports_language(language: str | None) -> bool:
+    """Return whether Velma-2 accepts a language code on a serving surface."""
+    return normalized_stt_language(language) in MODULATE_SUPPORTED_LANGUAGES
+
+
+def supports_live_multilingual_mode(language: str | None) -> bool:
+    """Return whether a live user language can enter Modulate auto-detection."""
+    return modulate_supports_language(language)
 
 
 def provider_for_model_token(model: str) -> str | None:

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -46,8 +46,7 @@ from utils.metrics import BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS
 from utils.notifications import send_credit_limit_notification, send_silent_user_notification
 from utils.onboarding import OnboardingHandler
 from utils.pusher import PusherCircuitBreakerOpen
-from utils.stt.streaming import STTService, get_stt_service_for_language
-from config.stt_provider_policy import PARAKEET_PROVIDER, STTServingSurface, provider_is_enabled
+from utils.stt.streaming import get_stt_service_for_language
 from utils.subscription import get_remaining_transcription_seconds, is_trial_paywalled
 from utils.transcribe_decisions import (
     effective_conversation_timeout,
@@ -209,7 +208,6 @@ class ListenSessionRuntime:
             return False
         self.user_has_credits = base.user_has_credits
         self.language = normalize_language(request.language)
-        requested_service = request.stt_service
         single_language_mode = should_force_single_language(
             request.onboarding_mode,
             base.transcription_prefs.get('single_language_mode', False),
@@ -217,16 +215,11 @@ class ListenSessionRuntime:
         self.stt_service, self.stt_language, self.stt_model = get_stt_service_for_language(
             self.language,
             multi_lang_enabled=not single_language_mode,
+            preferred_service=request.stt_service,
         )
         if not self.stt_service or not self.stt_language:
             await request.websocket.close(code=1008, reason=f'The language is not supported, {self.language}')
             return False
-        if (
-            requested_service == 'parakeet'
-            and provider_is_enabled(PARAKEET_PROVIDER, STTServingSurface.STREAMING)
-            and os.getenv('HOSTED_PARAKEET_API_URL')
-        ):
-            self.stt_service = STTService.parakeet
         context = finalize_listen_connect_context(
             base, language=self.language, onboarding_mode=request.onboarding_mode, stt_language=self.stt_language
         )

--- a/backend/testing/e2e/fakes/listen_pusher_wire.py
+++ b/backend/testing/e2e/fakes/listen_pusher_wire.py
@@ -237,6 +237,64 @@ class RejectingParakeetPeer(_LoopbackWebSocketServer):
         raise AssertionError('rejected Parakeet peer must never complete a WebSocket session')
 
 
+class ScriptedModulatePeer(_LoopbackWebSocketServer):
+    """Minimal Velma-2 peer that returns one final utterance per audio frame.
+
+    The production client sends raw PCM binary frames and signals teardown with
+    an empty text frame.  The peer deliberately implements only that wire
+    contract, retaining the real client URL construction and socket lifecycle.
+    """
+
+    def __init__(self, *, segment_text: str = 'Modulate wire-contract transcript.') -> None:
+        super().__init__()
+        self.segment_text = segment_text
+        self._condition = threading.Condition()
+        self.paths: list[str] = []
+        self.audio_chunks: list[bytes] = []
+        self.connection_count = 0
+
+    @property
+    def api_url(self) -> str:
+        return f'ws://127.0.0.1:{self.port}'
+
+    def wait_for_audio(self, count: int, *, timeout: float = 3.0) -> list[bytes]:
+        deadline = time.monotonic() + timeout
+        with self._condition:
+            while len(self.audio_chunks) < count:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(f'expected {count} Modulate audio chunk(s), saw {len(self.audio_chunks)}')
+                self._condition.wait(remaining)
+            return list(self.audio_chunks)
+
+    async def _handle(self, websocket: Any, path: Optional[str] = None) -> None:
+        with self._condition:
+            self.connection_count += 1
+            self.paths.append(_peer_path(websocket, path))
+            self._condition.notify_all()
+        async for message in websocket:
+            if isinstance(message, bytes):
+                with self._condition:
+                    self.audio_chunks.append(message)
+                    self._condition.notify_all()
+                await websocket.send(
+                    json.dumps(
+                        {
+                            'type': 'utterance',
+                            'utterance': {
+                                'text': self.segment_text,
+                                'start_ms': 0,
+                                'duration_ms': 250,
+                                'speaker': 1,
+                            },
+                        },
+                        separators=(',', ':'),
+                    )
+                )
+            elif message == '':
+                await websocket.send(json.dumps({'type': 'done', 'duration_ms': 250}, separators=(',', ':')))
+
+
 class ScriptedPusherPeer(_LoopbackWebSocketServer):
     """Script pusher replies while recording the production binary wire contract."""
 

--- a/backend/testing/e2e/fakes/stt.py
+++ b/backend/testing/e2e/fakes/stt.py
@@ -74,6 +74,7 @@ def install_streaming_stt_fake(monkeypatch, *, die_on_first_send=False):
     """
     from routers.listen import receiver as listen_receiver
     from routers.listen import runtime as listen_runtime
+    from utils.stt.streaming import STTService
 
     sockets = []
 
@@ -94,7 +95,7 @@ def install_streaming_stt_fake(monkeypatch, *, die_on_first_send=False):
     monkeypatch.setattr(
         listen_runtime,
         "get_stt_service_for_language",
-        lambda *_args, **_kwargs: (listen_runtime.STTService.parakeet, "en", "parakeet"),
+        lambda *_args, **_kwargs: (STTService.parakeet, "en", "parakeet"),
     )
     monkeypatch.setattr(listen_receiver, "is_gate_enabled", lambda: False)
     monkeypatch.setattr(listen_runtime, "record_usage", lambda *args, **kwargs: None)

--- a/backend/testing/e2e/listen_test_helpers.py
+++ b/backend/testing/e2e/listen_test_helpers.py
@@ -8,13 +8,18 @@ from anyio import ClosedResourceError, EndOfStream, WouldBlock
 from fakes.firestore import get_mock_firestore
 
 
-def seed_listen_user(uid: str, *, uses_custom_stt: bool = True):
+def seed_listen_user(uid: str, *, uses_custom_stt: bool = True, single_language_mode: bool = False):
+    """Seed the live-route preference fields explicitly for provider-routing tests."""
+
     get_mock_firestore().collection("users").document(uid).set(
         {
             "id": uid,
             "language": "en",
             "private_cloud_sync_enabled": False,
-            "transcription_preferences": {"uses_custom_stt": uses_custom_stt},
+            "transcription_preferences": {
+                "uses_custom_stt": uses_custom_stt,
+                "single_language_mode": single_language_mode,
+            },
         }
     )
 

--- a/backend/testing/e2e/test_listen_pusher_wire_contract.py
+++ b/backend/testing/e2e/test_listen_pusher_wire_contract.py
@@ -1,14 +1,15 @@
 """Hermetic native-listen wire contracts for STT and the pusher bridge.
 
-These tests deliberately keep the HTTP route, listen runtime, Parakeet socket,
-and ``ListenPusherSession`` real.  Only auth/storage and the two remote
-WebSocket peers are controlled by the hermetic E2E harness.
+These tests deliberately keep the HTTP route, listen runtime, provider socket,
+and ``ListenPusherSession`` real. Only auth/storage and remote WebSocket peers
+are controlled by the hermetic E2E harness.
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from typing import Any
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -17,6 +18,7 @@ from fakes.listen_pusher_wire import (
     PUSHER_PROCESS_CONVERSATION,
     PUSHER_TRANSCRIPT,
     RejectingParakeetPeer,
+    ScriptedModulatePeer,
     ScriptedParakeetPeer,
     ScriptedPusherPeer,
     clear_finalization_jobs,
@@ -33,7 +35,11 @@ NATIVE_LISTEN_URL = (
 )
 NATIVE_AUTH_HEADERS = {'Authorization': 'Bearer dev-token'}
 PARAKEET_TRANSCRIPT = 'Parakeet wire-contract transcript.'
+MODULATE_TRANSCRIPT = 'Modulate wire-contract transcript.'
 PCM8_AUDIO_FRAME = b'\x80' * 480
+MULTI_LANGUAGE_PARAKEET_LISTEN_URL = (
+    '/v4/listen?language=es&sample_rate=8000&codec=pcm8&source=omi&stt_service=parakeet&vad_gate=disabled'
+)
 
 
 def _configure_live_wire_contract(monkeypatch: Any, pusher: ScriptedPusherPeer, parakeet_api_url: str) -> None:
@@ -54,6 +60,27 @@ def _configure_live_wire_contract(monkeypatch: Any, pusher: ScriptedPusherPeer, 
     breaker._probe_in_progress = False  # type: ignore[reportPrivateUsage]
 
 
+def _configure_modulate_loopback(monkeypatch: Any, modulate: ScriptedModulatePeer) -> None:
+    """Route only Velma-2's real WebSocket client to the deterministic peer."""
+
+    import utils.stt.streaming as streaming
+
+    original_connect = streaming.websockets.connect
+
+    async def connect_loopback(uri: str, *args: Any, **kwargs: Any) -> Any:
+        parsed = urlsplit(uri)
+        if parsed.hostname == 'modulate-developer-apis.com' and parsed.path == '/api/velma-2-stt-streaming':
+            loopback_uri = f'{modulate.api_url}{parsed.path}'
+            if parsed.query:
+                loopback_uri = f'{loopback_uri}?{parsed.query}'
+            return await original_connect(loopback_uri, *args, **kwargs)
+        return await original_connect(uri, *args, **kwargs)
+
+    monkeypatch.setenv('MODULATE_API_KEY', 'loopback-modulate-key')
+    monkeypatch.setattr(streaming, 'stt_service_models', ('parakeet', 'modulate-velma-2'))
+    monkeypatch.setattr(streaming.websockets, 'connect', connect_loopback)
+
+
 def _open_native_listen(websocket: Any) -> dict[str, Any]:
     """Assert native dependency auth reaches the real accepted-socket runtime."""
 
@@ -70,6 +97,15 @@ def _receive_parakeet_segment(websocket: Any) -> list[dict[str, Any]]:
         lambda payload: isinstance(payload, list) and bool(payload) and payload[0].get('text') == PARAKEET_TRANSCRIPT,
     )
     assert segments[0]['stt_provider'] == 'parakeet-wire-peer'
+    return segments
+
+
+def _receive_modulate_segment(websocket: Any) -> list[dict[str, Any]]:
+    segments = receive_until(
+        websocket,
+        lambda payload: isinstance(payload, list) and bool(payload) and payload[0].get('text') == MODULATE_TRANSCRIPT,
+    )
+    assert segments[0]['speaker'] == 'SPEAKER_00'
     return segments
 
 
@@ -102,7 +138,7 @@ def test_listen_pusher_wire_contract_native_happy_path_and_explicit_parakeet_rou
     try:
         _configure_live_wire_contract(monkeypatch, pusher, parakeet.api_url)
         clear_finalization_jobs(fake_firestore, test_uid)
-        seed_listen_user(test_uid, uses_custom_stt=False)
+        seed_listen_user(test_uid, uses_custom_stt=False, single_language_mode=True)
 
         with client.websocket_connect(NATIVE_LISTEN_URL, headers=NATIVE_AUTH_HEADERS) as websocket:
             session = _open_native_listen(websocket)
@@ -129,6 +165,50 @@ def test_listen_pusher_wire_contract_native_happy_path_and_explicit_parakeet_rou
         parakeet.close()
 
 
+def test_listen_pusher_wire_contract_multilingual_explicit_parakeet_routes_to_modulate(
+    client, test_uid, monkeypatch, fake_firestore
+):
+    """An explicit Parakeet preference cannot bypass streaming language capability."""
+
+    async def pusher_success(_peer, _frame, _websocket):
+        return None
+
+    parakeet = ScriptedParakeetPeer(segment_text=PARAKEET_TRANSCRIPT).start()
+    modulate = ScriptedModulatePeer(segment_text=MODULATE_TRANSCRIPT).start()
+    pusher = ScriptedPusherPeer(pusher_success).start()
+    try:
+        _configure_live_wire_contract(monkeypatch, pusher, parakeet.api_url)
+        _configure_modulate_loopback(monkeypatch, modulate)
+        clear_finalization_jobs(fake_firestore, test_uid)
+        seed_listen_user(test_uid, uses_custom_stt=False)
+
+        with client.websocket_connect(MULTI_LANGUAGE_PARAKEET_LISTEN_URL, headers=NATIVE_AUTH_HEADERS) as websocket:
+            session = _open_native_listen(websocket)
+            pusher.wait_for_connections(1)
+            websocket.send_bytes(PCM8_AUDIO_FRAME)
+            modulate.wait_for_audio(1)
+            _receive_modulate_segment(websocket)
+            transcript = pusher.wait_for_frames(PUSHER_TRANSCRIPT, 1)[0]
+
+        # The live Modulate API represents automatic multi-language selection
+        # by omitting ``language``. The full route reaches that real wire
+        # boundary, while the configured Parakeet peer remains untouched.
+        assert modulate.connection_count == 1
+        modulate_request = urlsplit(modulate.paths[0])
+        assert modulate_request.path == '/api/velma-2-stt-streaming'
+        assert 'language=' not in modulate_request.query
+        assert 'sample_rate=8000' in modulate_request.query
+        assert parakeet.connection_count == 0
+        assert parakeet.paths == []
+        assert transcript.payload['memory_id'] == session['conversation_id']
+        assert transcript.payload['segments'][0]['text'] == MODULATE_TRANSCRIPT
+    finally:
+        clear_finalization_jobs(fake_firestore, test_uid)
+        pusher.close()
+        modulate.close()
+        parakeet.close()
+
+
 def test_listen_pusher_wire_contract_reconnect_replays_one_durable_finalization(
     client, test_uid, monkeypatch, fake_firestore
 ):
@@ -148,7 +228,7 @@ def test_listen_pusher_wire_contract_reconnect_replays_one_durable_finalization(
         timing = install_deterministic_listen_timing(monkeypatch)
         install_fake_firestore_transactions(monkeypatch, fake_firestore)
         clear_finalization_jobs(fake_firestore, test_uid)
-        seed_listen_user(test_uid, uses_custom_stt=False)
+        seed_listen_user(test_uid, uses_custom_stt=False, single_language_mode=True)
 
         with client.websocket_connect(NATIVE_LISTEN_URL, headers=NATIVE_AUTH_HEADERS) as websocket:
             try:
@@ -220,7 +300,7 @@ def test_listen_pusher_wire_contract_terminal_or_fenced_response_is_not_replayed
         timing = install_deterministic_listen_timing(monkeypatch)
         install_fake_firestore_transactions(monkeypatch, fake_firestore)
         clear_finalization_jobs(fake_firestore, test_uid)
-        seed_listen_user(test_uid, uses_custom_stt=False)
+        seed_listen_user(test_uid, uses_custom_stt=False, single_language_mode=True)
 
         with client.websocket_connect(NATIVE_LISTEN_URL, headers=NATIVE_AUTH_HEADERS) as websocket:
             try:
@@ -268,7 +348,7 @@ def test_listen_pusher_wire_contract_provider_connect_failure_is_terminal(
         _configure_live_wire_contract(monkeypatch, pusher, parakeet.api_url)
         install_fake_firestore_transactions(monkeypatch, fake_firestore)
         clear_finalization_jobs(fake_firestore, test_uid)
-        seed_listen_user(test_uid, uses_custom_stt=False)
+        seed_listen_user(test_uid, uses_custom_stt=False, single_language_mode=True)
 
         with client.websocket_connect(NATIVE_LISTEN_URL, headers=NATIVE_AUTH_HEADERS) as websocket:
             failed = receive_until(
@@ -309,7 +389,7 @@ def test_listen_pusher_wire_contract_provider_send_failure_is_terminal_after_pus
         _configure_live_wire_contract(monkeypatch, pusher, parakeet.api_url)
         install_fake_firestore_transactions(monkeypatch, fake_firestore)
         clear_finalization_jobs(fake_firestore, test_uid)
-        seed_listen_user(test_uid, uses_custom_stt=False)
+        seed_listen_user(test_uid, uses_custom_stt=False, single_language_mode=True)
 
         with client.websocket_connect(NATIVE_LISTEN_URL, headers=NATIVE_AUTH_HEADERS) as websocket:
             _open_native_listen(websocket)

--- a/backend/testing/listen_pusher_stack/run.py
+++ b/backend/testing/listen_pusher_stack/run.py
@@ -417,7 +417,10 @@ class Stack:
                 'language': 'en',
                 'private_cloud_sync_enabled': True,
                 'data_protection_level': 'standard',
-                'transcription_preferences': {'uses_custom_stt': False},
+                # This gauntlet exercises the English-only Parakeet stub. Make
+                # the user's single-language choice explicit so selection
+                # requests English rather than multi-language auto-detection.
+                'transcription_preferences': {'uses_custom_stt': False, 'single_language_mode': True},
             }
         )
 

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -461,6 +461,9 @@
         "backend/utils/listen_pusher_session.py",
         "backend/utils/pusher.py",
         "backend/utils/stt/live_failure.py",
+        "backend/utils/stt/streaming.py",
+        "backend/config/stt_provider_policy.py",
+        "backend/charts/parakeet/**",
         "backend/utils/transcribe_decisions.py",
         "backend/pusher/main.py",
         "backend/utils/conversations/finalizer.py",
@@ -475,18 +478,23 @@
         "tests/unit/test_pusher_heartbeat.py",
         "tests/unit/test_pusher_conversation_retry.py",
         "tests/unit/test_live_stt_failure.py",
+        "tests/unit/test_listen_runtime_regressions.py",
         "tests/unit/test_transcribe_decisions.py",
+        "tests/unit/test_stt_provider_policy.py",
+        "tests/unit/test_streaming_deepgram_backoff.py",
         "tests/unit/utils/test_listen_pusher_session.py",
         "tests/unit/test_transcribe_teardown_flush.py",
         "tests/unit/test_listen_pusher_stack_ci_wiring.py",
-        "testing/e2e/test_listen_stt.py"
+        "testing/e2e/test_listen_stt.py",
+        "testing/e2e/test_listen_pusher_wire_contract.py"
       ],
       "checks": [],
       "invariants": [
         "teardown flushes tail audio before pusher close",
         "pending conversation requests retry until ack or give-up limit",
         "pusher heartbeat prevents idle connection drops",
-        "listen-to-pusher boundary changes run the credential-free local Firestore, Redis, and Parakeet-stub stack gauntlet in blocking PR CI"
+        "a client Parakeet preference cannot route a live session to an incompatible model",
+        "listen-to-pusher boundary changes run the credential-free local Firestore, Redis, and Parakeet-stub stack gauntlet in PR CI"
       ]
     },
     {

--- a/backend/tests/unit/test_deepgram_serving_disabled.py
+++ b/backend/tests/unit/test_deepgram_serving_disabled.py
@@ -17,7 +17,7 @@ def test_streaming_ignores_a_stale_deepgram_model_configuration(monkeypatch):
     monkeypatch.setattr(streaming, 'is_dg_self_hosted', False)
     monkeypatch.setenv('HOSTED_PARAKEET_API_URL', 'http://parakeet.internal')
 
-    service, language, model = streaming.get_stt_service_for_language('en')
+    service, language, model = streaming.get_stt_service_for_language('en', multi_lang_enabled=False)
 
     assert service == streaming.STTService.parakeet
     assert language == 'en'

--- a/backend/tests/unit/test_fallback_observability.py
+++ b/backend/tests/unit/test_fallback_observability.py
@@ -138,6 +138,58 @@ def test_stt_selection_fallback_records_on_capability_mismatch(monkeypatch):
     ]
 
 
+def test_explicit_parakeet_preference_fallback_records_when_live_mode_is_incapable(monkeypatch):
+    from utils.stt import streaming as streaming_mod
+
+    counter = FakeCounter()
+    monkeypatch.setattr(fallback_mod, 'OMI_FALLBACK_TOTAL', counter)
+    monkeypatch.setenv('HOSTED_PARAKEET_API_URL', 'http://parakeet.test')
+    monkeypatch.setattr(streaming_mod, 'stt_service_models', ['parakeet', 'modulate-velma-2'])
+
+    service, lang, model = streaming_mod.get_stt_service_for_language(
+        'es', multi_lang_enabled=True, preferred_service='parakeet'
+    )
+
+    assert (service, lang, model) == (streaming_mod.STTService.modulate, 'multi', 'velma-2')
+    assert counter.increments == [
+        (
+            {
+                'component': 'stt_selection',
+                'from_mode': 'parakeet',
+                'to_mode': 'modulate',
+                'reason': 'capability_mismatch',
+                'outcome': 'degraded',
+            },
+            1.0,
+        )
+    ]
+
+
+def test_automatic_parakeet_capability_fallback_records_when_live_mode_is_incapable(monkeypatch):
+    from utils.stt import streaming as streaming_mod
+
+    counter = FakeCounter()
+    monkeypatch.setattr(fallback_mod, 'OMI_FALLBACK_TOTAL', counter)
+    monkeypatch.setenv('HOSTED_PARAKEET_API_URL', 'http://parakeet.test')
+    monkeypatch.setattr(streaming_mod, 'stt_service_models', ['parakeet', 'modulate-velma-2'])
+
+    service, lang, model = streaming_mod.get_stt_service_for_language('es', multi_lang_enabled=True)
+
+    assert (service, lang, model) == (streaming_mod.STTService.modulate, 'multi', 'velma-2')
+    assert counter.increments == [
+        (
+            {
+                'component': 'stt_selection',
+                'from_mode': 'parakeet',
+                'to_mode': 'modulate',
+                'reason': 'capability_mismatch',
+                'outcome': 'degraded',
+            },
+            1.0,
+        )
+    ]
+
+
 def test_hosted_vad_fallback_reason_buckets(monkeypatch):
     import httpx
     import requests

--- a/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
+++ b/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
@@ -1,4 +1,4 @@
-"""Wiring contract for the blocking listen-to-pusher stack gauntlet."""
+"""Wiring contract for the listen-to-pusher stack gauntlet in PR CI."""
 
 from __future__ import annotations
 

--- a/backend/tests/unit/test_listen_runtime_regressions.py
+++ b/backend/tests/unit/test_listen_runtime_regressions.py
@@ -7,6 +7,7 @@ import pytest
 from routers.listen.contracts import ListenRequest
 from routers.listen.runtime import ListenSessionRuntime
 from utils.listen_session_bootstrap import ListenConnectBase
+from utils.stt.streaming import STTService
 
 
 @pytest.fixture
@@ -126,8 +127,8 @@ async def test_bootstrap_forces_single_language_before_selecting_stt_for_onboard
     )
     selected_multi_language_options = []
 
-    def select_stt(language, *, multi_lang_enabled, prefer_parakeet=False):
-        selected_multi_language_options.append((language, multi_lang_enabled))
+    def select_stt(language, *, multi_lang_enabled, preferred_service=None):
+        selected_multi_language_options.append((language, multi_lang_enabled, preferred_service))
         return 'test-stt', 'es', 'test-model'
 
     monkeypatch.setattr(runtime_module, 'load_listen_connect_base', lambda *_args, **_kwargs: _async_result(base))
@@ -138,7 +139,58 @@ async def test_bootstrap_forces_single_language_before_selecting_stt_for_onboard
     monkeypatch.setattr(runtime_module, 'OnboardingHandler', lambda *_args: SimpleNamespace())
 
     assert await runtime._bootstrap() is True
-    assert selected_multi_language_options == [('es', False)]
+    assert selected_multi_language_options == [('es', False, None)]
+
+
+@pytest.mark.anyio
+async def test_bootstrap_passes_explicit_parakeet_through_capability_aware_selection(monkeypatch):
+    import routers.listen.runtime as runtime_module
+
+    request = ListenRequest(
+        websocket=SimpleNamespace(),
+        uid='language-routing-user',
+        language='es',
+        stt_service='parakeet',
+    )
+    runtime = object.__new__(ListenSessionRuntime)
+    runtime.request = request
+    runtime.use_custom_stt = False
+    runtime.state = SimpleNamespace(speaker_id_enabled=False, audio_ring_buffer=None)
+
+    async def bootstrap_persistence_call(*_args, **_kwargs):
+        return False
+
+    runtime.persistence = SimpleNamespace(call=bootstrap_persistence_call)
+    runtime.is_multi_channel = False
+    runtime.has_speech_profile = False
+    runtime._build_components = lambda: None
+
+    base = ListenConnectBase(
+        user_exists=True,
+        user_has_credits=True,
+        transcription_prefs={'single_language_mode': False, 'uses_custom_stt': False},
+        fair_use_init_stage=None,
+        fair_use_track_dg_usage=False,
+        fair_use_dg_budget_exhausted=False,
+    )
+
+    def select_stt(language, *, multi_lang_enabled, preferred_service=None):
+        assert (language, multi_lang_enabled, preferred_service) == ('es', True, 'parakeet')
+        return STTService.modulate, 'multi', 'velma-2'
+
+    monkeypatch.setenv('HOSTED_PARAKEET_API_URL', 'http://parakeet.test')
+    monkeypatch.setattr(runtime_module, 'load_listen_connect_base', lambda *_args, **_kwargs: _async_result(base))
+    monkeypatch.setattr(runtime_module, 'get_stt_service_for_language', select_stt)
+    monkeypatch.setattr(runtime_module, 'FAIR_USE_ENABLED', False)
+    monkeypatch.setattr(runtime_module, 'should_load_speech_profile', lambda **_kwargs: False)
+    monkeypatch.setattr(runtime_module, 'should_enable_speaker_identification', lambda **_kwargs: False)
+
+    assert await runtime._bootstrap() is True
+    assert (runtime.stt_service, runtime.stt_language, runtime.stt_model) == (
+        STTService.modulate,
+        'multi',
+        'velma-2',
+    )
 
 
 def test_runtime_emits_speaker_suggestion_event():

--- a/backend/tests/unit/test_modulate_stt.py
+++ b/backend/tests/unit/test_modulate_stt.py
@@ -12,7 +12,6 @@ from utils.stt.streaming import (
     _build_wav_header,
     get_stt_service_for_language,
     make_stream_callback,
-    modulate_languages,
     sort_segments_by_start,
     sort_transcript_segments_in_place,
 )
@@ -85,7 +84,7 @@ class TestSTTServiceEnum(unittest.TestCase):
 class TestLanguageRouting(unittest.TestCase):
     @patch('utils.stt.streaming.stt_service_models', ['modulate-velma-2'])
     def test_modulate_routing_english(self):
-        service, lang, model = get_stt_service_for_language('en')
+        service, lang, model = get_stt_service_for_language('en', multi_lang_enabled=False)
         self.assertEqual(service, STTService.modulate)
         self.assertEqual(lang, 'en')
         self.assertEqual(model, 'velma-2')
@@ -106,24 +105,24 @@ class TestLanguageRouting(unittest.TestCase):
     @patch.dict('os.environ', {'HOSTED_PARAKEET_API_URL': 'https://parakeet.test'})
     @patch('utils.stt.streaming.stt_service_models', ['dg-nova-3'])
     def test_retired_deepgram_config_uses_non_deepgram_default(self):
-        service, lang, model = get_stt_service_for_language('en')
+        service, lang, model = get_stt_service_for_language('en', multi_lang_enabled=False)
         self.assertEqual(service, STTService.parakeet)
         self.assertEqual(model, 'parakeet')
 
     @patch('utils.stt.streaming.stt_service_models', ['dg-nova-3', 'modulate-velma-2'])
     def test_retired_deepgram_token_is_ignored_before_modulate(self):
-        service, lang, model = get_stt_service_for_language('en')
+        service, lang, model = get_stt_service_for_language('en', multi_lang_enabled=False)
         self.assertEqual(service, STTService.modulate)
         self.assertEqual(model, 'velma-2')
 
     @patch('utils.stt.streaming.stt_service_models', ['modulate-velma-2', 'dg-nova-3'])
     def test_modulate_first_wins(self):
-        service, lang, model = get_stt_service_for_language('en')
+        service, lang, model = get_stt_service_for_language('en', multi_lang_enabled=False)
         self.assertEqual(service, STTService.modulate)
 
     @patch('utils.stt.streaming.stt_service_models', ['dg-nova-3', 'modulate-velma-2'])
     def test_dg_unsupported_falls_through_to_modulate(self):
-        service, lang, model = get_stt_service_for_language('af')
+        service, lang, model = get_stt_service_for_language('af', multi_lang_enabled=False)
         self.assertEqual(service, STTService.modulate)
         self.assertEqual(lang, 'af')
         self.assertEqual(model, 'velma-2')
@@ -1256,17 +1255,19 @@ class TestPassthroughSkipsRemap(unittest.TestCase):
 class TestLanguageRoutingExtended(unittest.TestCase):
     @patch.dict('os.environ', {'HOSTED_PARAKEET_API_URL': 'https://parakeet.test'})
     @patch('utils.stt.streaming.stt_service_models', ['dg-nova-3'])
-    def test_retired_config_does_not_change_language_handling(self):
+    def test_retired_config_falls_back_to_the_capable_single_language_provider(self):
         service, lang, model = get_stt_service_for_language('fr', multi_lang_enabled=False)
-        self.assertEqual(service, STTService.parakeet)
+        self.assertEqual(service, STTService.modulate)
         self.assertEqual(lang, 'fr')
+        self.assertEqual(model, 'velma-2')
 
     @patch.dict('os.environ', {'HOSTED_PARAKEET_API_URL': 'https://parakeet.test'})
     @patch('utils.stt.streaming.stt_service_models', ['dg-nova-3'])
-    def test_retired_config_does_not_reenable_multi_deepgram_mode(self):
+    def test_retired_config_falls_back_to_the_capable_multilingual_provider(self):
         service, lang, model = get_stt_service_for_language('fr', multi_lang_enabled=True)
-        self.assertEqual(service, STTService.parakeet)
-        self.assertEqual(lang, 'fr')
+        self.assertEqual(service, STTService.modulate)
+        self.assertEqual(lang, 'multi')
+        self.assertEqual(model, 'velma-2')
 
     @patch.dict('os.environ', {'HOSTED_PARAKEET_API_URL': 'https://parakeet.test'})
     @patch('utils.stt.streaming.stt_service_models', ['dg-nova-3'])
@@ -1277,32 +1278,32 @@ class TestLanguageRoutingExtended(unittest.TestCase):
 
     @patch('utils.stt.streaming.stt_service_models', ['modulate-velma-2'])
     def test_locale_code_en_us_routes_to_modulate(self):
-        service, lang, model = get_stt_service_for_language('en-US')
+        service, lang, model = get_stt_service_for_language('en-US', multi_lang_enabled=False)
         self.assertEqual(service, STTService.modulate)
         self.assertEqual(lang, 'en')
         self.assertEqual(model, 'velma-2')
 
     @patch('utils.stt.streaming.stt_service_models', ['modulate-velma-2'])
     def test_locale_code_fr_ca_routes_to_modulate(self):
-        service, lang, model = get_stt_service_for_language('fr-CA')
+        service, lang, model = get_stt_service_for_language('fr-CA', multi_lang_enabled=False)
         self.assertEqual(service, STTService.modulate)
         self.assertEqual(lang, 'fr')
 
     @patch('utils.stt.streaming.stt_service_models', ['modulate-velma-2'])
     def test_locale_code_pt_br_routes_to_modulate(self):
-        service, lang, model = get_stt_service_for_language('pt-BR')
+        service, lang, model = get_stt_service_for_language('pt-BR', multi_lang_enabled=False)
         self.assertEqual(service, STTService.modulate)
         self.assertEqual(lang, 'pt')
 
     @patch('utils.stt.streaming.stt_service_models', ['modulate-velma-2'])
     def test_locale_code_zh_cn_routes_to_modulate(self):
-        service, lang, model = get_stt_service_for_language('zh-CN')
+        service, lang, model = get_stt_service_for_language('zh-CN', multi_lang_enabled=False)
         self.assertEqual(service, STTService.modulate)
         self.assertEqual(lang, 'zh')
 
     @patch('utils.stt.streaming.stt_service_models', ['modulate-velma-2'])
     def test_locale_underscore_en_us(self):
-        service, lang, model = get_stt_service_for_language('en_US')
+        service, lang, model = get_stt_service_for_language('en_US', multi_lang_enabled=False)
         self.assertEqual(service, STTService.modulate)
         self.assertEqual(lang, 'en')
 

--- a/backend/tests/unit/test_parakeet_prerecorded.py
+++ b/backend/tests/unit/test_parakeet_prerecorded.py
@@ -511,7 +511,7 @@ class TestStreamingFactoryRouting:
         with patch('utils.stt.streaming.stt_service_models', ['parakeet']), patch.dict(
             os.environ, {'HOSTED_PARAKEET_API_URL': 'http://fake-parakeet:8080'}
         ):
-            service, lang, model = get_stt_service_for_language('en')
+            service, lang, model = get_stt_service_for_language('en', multi_lang_enabled=False)
             assert service == STTService.parakeet
             assert model == 'parakeet'
 

--- a/backend/tests/unit/test_streaming_deepgram_backoff.py
+++ b/backend/tests/unit/test_streaming_deepgram_backoff.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch, AsyncMock
 import pytest
 
 from deepgram import LiveTranscriptionEvents
+from config.stt_provider_policy import STTServingSurface
 from utils.stt.streaming import connect_to_deepgram_with_backoff, process_audio_dg
 from utils.stt.streaming import get_stt_service_for_language, STTService, should_preserve_filler_words
 
@@ -1021,7 +1022,7 @@ class TestGetSttServiceForLanguage:
         with patch('utils.stt.streaming.stt_service_models', ['parakeet']), patch.dict(
             'os.environ', {'HOSTED_PARAKEET_API_URL': 'http://parakeet.test'}
         ):
-            service, lang, model = get_stt_service_for_language('en')
+            service, lang, model = get_stt_service_for_language('en', multi_lang_enabled=False)
 
         assert (service, lang, model) == (STTService.parakeet, 'en', 'parakeet')
 
@@ -1029,7 +1030,7 @@ class TestGetSttServiceForLanguage:
         with patch('utils.stt.streaming.stt_service_models', ['parakeet', 'modulate-velma-2']), patch.dict(
             'os.environ', {'HOSTED_PARAKEET_API_URL': 'http://parakeet.test'}
         ):
-            service, lang, model = get_stt_service_for_language('zh-TW')
+            service, lang, model = get_stt_service_for_language('zh-TW', multi_lang_enabled=False)
 
         assert (service, lang, model) == (STTService.modulate, 'zh', 'velma-2')
 
@@ -1037,7 +1038,7 @@ class TestGetSttServiceForLanguage:
         with patch('utils.stt.streaming.stt_service_models', ['dg-nova-3']), patch.dict(
             'os.environ', {'HOSTED_PARAKEET_API_URL': 'http://parakeet.test'}
         ):
-            service, lang, model = get_stt_service_for_language('en')
+            service, lang, model = get_stt_service_for_language('en', multi_lang_enabled=False)
 
         assert (service, lang, model) == (STTService.parakeet, 'en', 'parakeet')
 
@@ -1052,6 +1053,46 @@ class TestGetSttServiceForLanguage:
             service, lang, model = get_stt_service_for_language(None)
 
         assert (service, lang, model) == (STTService.parakeet, 'en', 'parakeet')
+
+
+@pytest.mark.parametrize(
+    ('language', 'multi_lang_enabled', 'surface', 'preferred_service', 'expected'),
+    [
+        ('multi', False, STTServingSurface.STREAMING, None, (STTService.modulate, 'multi', 'velma-2')),
+        ('en', True, STTServingSurface.STREAMING, None, (STTService.modulate, 'multi', 'velma-2')),
+        ('en', True, STTServingSurface.STREAMING, 'parakeet', (STTService.modulate, 'multi', 'velma-2')),
+        ('es', True, STTServingSurface.STREAMING, 'parakeet', (STTService.modulate, 'multi', 'velma-2')),
+        ('zh-TW', True, STTServingSurface.STREAMING, None, (STTService.modulate, 'multi', 'velma-2')),
+        ('ar', True, STTServingSurface.STREAMING, None, (STTService.modulate, 'multi', 'velma-2')),
+        ('es', False, STTServingSurface.STREAMING, None, (STTService.modulate, 'es', 'velma-2')),
+        ('es', False, STTServingSurface.STREAMING, 'parakeet', (STTService.modulate, 'es', 'velma-2')),
+        ('en', False, STTServingSurface.STREAMING, 'parakeet', (STTService.parakeet, 'en', 'parakeet')),
+        ('es', True, STTServingSurface.PTT, None, (STTService.modulate, 'es', 'velma-2')),
+    ],
+)
+def test_selection_respects_model_capability_and_live_multilingual_mode(
+    language, multi_lang_enabled, surface, preferred_service, expected
+):
+    with patch('utils.stt.streaming.stt_service_models', ['parakeet', 'modulate-velma-2']), patch.dict(
+        'os.environ', {'HOSTED_PARAKEET_API_URL': 'http://parakeet.test'}
+    ):
+        result = get_stt_service_for_language(
+            language,
+            multi_lang_enabled=multi_lang_enabled,
+            surface=surface,
+            preferred_service=preferred_service,
+        )
+
+    assert result == expected
+
+
+def test_explicit_parakeet_preference_reorders_only_a_capable_live_selection():
+    with patch('utils.stt.streaming.stt_service_models', ['modulate-velma-2', 'parakeet']), patch.dict(
+        'os.environ', {'HOSTED_PARAKEET_API_URL': 'http://parakeet.test'}
+    ):
+        result = get_stt_service_for_language('en', multi_lang_enabled=False, preferred_service='parakeet')
+
+    assert result == (STTService.parakeet, 'en', 'parakeet')
 
 
 class TestFillerWordsLanguageBehavior:

--- a/backend/tests/unit/test_stt_provider_policy.py
+++ b/backend/tests/unit/test_stt_provider_policy.py
@@ -1,15 +1,38 @@
 """Regression coverage for the single source of truth governing STT serving."""
 
+from pathlib import Path
+
+import pytest
+import yaml
+
 from config.stt_provider_policy import (
     DEEPGRAM_CLOUD_PROVIDER,
     DEEPGRAM_SELF_HOSTED_PROVIDER,
     MODULATE_PROVIDER,
+    PARAKEET_MODEL_BY_SURFACE,
     PARAKEET_PROVIDER,
     STTServingSurface,
     canonical_model_config,
+    modulate_supports_language,
+    parakeet_supports_language,
     provider_for_model_token,
     provider_is_enabled,
+    supports_live_multilingual_mode,
 )
+
+ROOT = Path(__file__).resolve().parents[3]
+PARAKEET_VALUES_FILES = (
+    ROOT / 'backend/charts/parakeet/dev_omi_parakeet_values.yaml',
+    ROOT / 'backend/charts/parakeet/prod_omi_parakeet_values.yaml',
+)
+
+
+def _chart_env_value(values_path: Path, name: str) -> str | None:
+    values = yaml.safe_load(values_path.read_text(encoding='utf-8'))
+    for entry in values.get('env', []) if isinstance(values, dict) else []:
+        if isinstance(entry, dict) and entry.get('name') == name:
+            return str(entry.get('value')) if 'value' in entry else None
+    return None
 
 
 def test_hosted_deepgram_is_disabled_for_every_serving_surface():
@@ -32,3 +55,29 @@ def test_policy_owns_the_safe_model_order_for_every_serving_surface():
 
 def test_deepgram_model_tokens_are_classified_as_self_hosted_only():
     assert provider_for_model_token('dg-nova-3') == DEEPGRAM_SELF_HOSTED_PROVIDER
+
+
+def test_parakeet_capability_tracks_the_model_selected_for_each_surface():
+    assert parakeet_supports_language(STTServingSurface.STREAMING, 'en')
+    assert not parakeet_supports_language(STTServingSurface.STREAMING, 'es')
+    assert parakeet_supports_language(STTServingSurface.PTT, 'en')
+    assert not parakeet_supports_language(STTServingSurface.PTT, 'multi')
+    assert parakeet_supports_language(STTServingSurface.PRERECORDED, 'es')
+    assert parakeet_supports_language(STTServingSurface.PRERECORDED, 'multi')
+
+
+@pytest.mark.parametrize('values_path', PARAKEET_VALUES_FILES)
+def test_parakeet_chart_models_match_the_capability_policy(values_path: Path):
+    """A model deployment swap must update the policy before routing can change (#10009)."""
+    assert _chart_env_value(values_path, 'PARAKEET_MODEL') == PARAKEET_MODEL_BY_SURFACE[STTServingSurface.PRERECORDED]
+    assert (
+        _chart_env_value(values_path, 'PARAKEET_STREAM_MODEL') == PARAKEET_MODEL_BY_SURFACE[STTServingSurface.STREAMING]
+    )
+    assert PARAKEET_MODEL_BY_SURFACE[STTServingSurface.PTT] == PARAKEET_MODEL_BY_SURFACE[STTServingSurface.STREAMING]
+
+
+def test_live_multilingual_policy_normalizes_supported_locales_and_rejects_unknown_languages():
+    assert supports_live_multilingual_mode('zh-TW')
+    assert supports_live_multilingual_mode('ar')
+    assert modulate_supports_language('es-419')
+    assert not supports_live_multilingual_mode('xx-unsupported')

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -24,6 +24,8 @@ from config.stt_provider_policy import (
     PARAKEET_PROVIDER,
     STTServingSurface,
     default_models_for_surface,
+    normalized_stt_language,
+    parakeet_supports_language,
     provider_is_enabled,
 )
 from models.transcript_segment import TranscriptSegment
@@ -38,36 +40,6 @@ logger = logging.getLogger(__name__)
 
 # Public compatibility export used by chat/router boundaries.
 PrerecordedSTTConfigurationError = _PrerecordedSTTConfigurationError
-
-_parakeet_languages = {
-    'multi',
-    'bg',
-    'hr',
-    'cs',
-    'da',
-    'nl',
-    'en',
-    'et',
-    'fi',
-    'fr',
-    'de',
-    'el',
-    'hu',
-    'it',
-    'lt',
-    'lv',
-    'mt',
-    'pl',
-    'pt',
-    'ro',
-    'ru',
-    'sk',
-    'sl',
-    'es',
-    'sv',
-    'uk',
-}
-
 
 # ---------------------------------------------------------------------------
 # Provider-agnostic ABC — mirrors STTSocket for streaming
@@ -110,7 +82,7 @@ def get_prerecorded_service(language: Optional[str] = 'en') -> Tuple[str, Option
     wins. Disabled-provider tokens are ignored, then policy-owned defaults provide
     the serving fallback.
     """
-    base_lang = language.split('-')[0].split('_')[0].lower() if language else 'en'
+    base_lang = normalized_stt_language(language) or 'en'
 
     def select(models: Sequence[str]) -> Optional[Tuple[str, Optional[str], str]]:
         for m in models:
@@ -120,7 +92,7 @@ def get_prerecorded_service(language: Optional[str] = 'en') -> Tuple[str, Option
                     return PrerecordedSTTService.MODULATE, base_lang, 'velma-2'
                 continue
             if m == 'parakeet' and provider_is_enabled(PARAKEET_PROVIDER, STTServingSurface.PRERECORDED):
-                if base_lang in _parakeet_languages:
+                if parakeet_supports_language(STTServingSurface.PRERECORDED, base_lang):
                     return PrerecordedSTTService.PARAKEET, base_lang, 'parakeet'
         return None
 

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -19,7 +19,11 @@ from config.stt_provider_policy import (
     PARAKEET_PROVIDER,
     STTServingSurface,
     default_models_for_surface,
+    modulate_supports_language,
+    normalized_stt_language,
+    parakeet_supports_language,
     provider_is_enabled,
+    supports_live_multilingual_mode,
 )
 from utils.async_tasks import create_named_task
 from utils.executors import sync_executor, run_blocking
@@ -164,108 +168,9 @@ deepgram_nova3_languages = {
 }
 
 
-modulate_languages = {
-    'multi',
-    'en',
-    'af',
-    'sq',
-    'ar',
-    'az',
-    'eu',
-    'be',
-    'bn',
-    'bs',
-    'bg',
-    'ca',
-    'zh',
-    'hr',
-    'cs',
-    'da',
-    'nl',
-    'et',
-    'fi',
-    'fr',
-    'gl',
-    'de',
-    'el',
-    'gu',
-    'he',
-    'hi',
-    'hu',
-    'id',
-    'it',
-    'ja',
-    'kn',
-    'kk',
-    'ko',
-    'lv',
-    'lt',
-    'mk',
-    'ms',
-    'ml',
-    'mr',
-    'no',
-    'fa',
-    'pl',
-    'pt',
-    'pa',
-    'ro',
-    'ru',
-    'sr',
-    'sk',
-    'sl',
-    'es',
-    'sw',
-    'sv',
-    'tl',
-    'ta',
-    'te',
-    'th',
-    'tr',
-    'uk',
-    'ur',
-    'vi',
-    'cy',
-}
-
-parakeet_languages = {
-    'multi',
-    'bg',
-    'hr',
-    'cs',
-    'da',
-    'nl',
-    'en',
-    'et',
-    'fi',
-    'fr',
-    'de',
-    'el',
-    'hu',
-    'it',
-    'lt',
-    'lv',
-    'mt',
-    'pl',
-    'pt',
-    'ro',
-    'ru',
-    'sk',
-    'sl',
-    'es',
-    'sv',
-    'uk',
-}
-
 # Compatibility export for callers. Its value is owned by stt_provider_policy.
 DEFAULT_STT_SERVICE_MODELS = default_models_for_surface(STTServingSurface.STREAMING)
 stt_service_models = os.getenv('STT_SERVICE_MODELS', ','.join(DEFAULT_STT_SERVICE_MODELS)).split(',')
-
-
-def _normalize_language(language: str | None) -> str:
-    if not language:
-        return ''
-    return language.split('-')[0].split('_')[0].lower()
 
 
 def _stt_selection_from_mode(_language: str, base_lang: str) -> str:
@@ -276,11 +181,43 @@ def _stt_selection_from_mode(_language: str, base_lang: str) -> str:
     return 'none'
 
 
+def _requested_stt_language(
+    language: Optional[str], base_lang: str, *, multi_lang_enabled: bool, surface: STTServingSurface
+) -> str:
+    """Resolve the provider language while retaining PTT's explicit input language.
+
+    Live sessions with multi-language enabled must select a provider's auto-detect
+    mode. PTT does not load the user's transcription preference, so it keeps its
+    explicit language unless the client itself sends the ``multi`` sentinel.
+    """
+    if base_lang == 'multi' or (
+        surface == STTServingSurface.STREAMING
+        and multi_lang_enabled
+        and language
+        and supports_live_multilingual_mode(language)
+    ):
+        return 'multi'
+    return base_lang
+
+
+def _models_with_preferred_service(
+    models: List[str] | Tuple[str, ...], *, preferred_service: Optional[str]
+) -> Tuple[str, ...]:
+    """Honor a recognized client engine preference within the serving policy."""
+    normalized_preference = (preferred_service or '').strip().lower()
+    if normalized_preference != STTService.parakeet.value:
+        return tuple(models)
+    return tuple(model for model in models if model.strip() == STTService.parakeet.value) + tuple(
+        model for model in models if model.strip() != STTService.parakeet.value
+    )
+
+
 def get_stt_service_for_language(
     language: Optional[str],
     multi_lang_enabled: bool = True,
     *,
     surface: STTServingSurface = STTServingSurface.STREAMING,
+    preferred_service: Optional[str] = None,
 ) -> Tuple[Optional[STTService], Optional[str], Optional[str]]:
     """Select a serving STT provider allowed for the requested product surface.
 
@@ -290,10 +227,19 @@ def get_stt_service_for_language(
     """
     # Missing language metadata historically meant English. Preserve that
     # behavior without opening a retired-provider fallback for unknown values.
-    base_lang = _normalize_language(language) or 'en'
+    base_lang = normalized_stt_language(language) or 'en'
+    requested_language = _requested_stt_language(
+        language,
+        base_lang,
+        multi_lang_enabled=multi_lang_enabled,
+        surface=surface,
+    )
 
-    def select(models: List[str] | Tuple[str, ...]) -> Optional[Tuple[STTService, str, str]]:
-        for model in models:
+    def select(
+        models: List[str] | Tuple[str, ...],
+    ) -> Tuple[Optional[Tuple[STTService, str, str]], Optional[str]]:
+        parakeet_fallback_reason: Optional[str] = None
+        for model in _models_with_preferred_service(models, preferred_service=preferred_service):
             model = model.strip()
             if (
                 model.startswith('dg-')
@@ -302,38 +248,60 @@ def get_stt_service_for_language(
             ):
                 dg_model = model.replace('dg-', '', 1)
                 if multi_lang_enabled and language in deepgram_nova3_multi_languages:
-                    return STTService.deepgram, 'multi', dg_model
+                    return (STTService.deepgram, 'multi', dg_model), parakeet_fallback_reason
                 if language in deepgram_nova3_languages:
-                    return STTService.deepgram, language, dg_model
+                    return (STTService.deepgram, language, dg_model), parakeet_fallback_reason
                 continue
-            if (
-                model == 'parakeet'
-                and provider_is_enabled(PARAKEET_PROVIDER, surface)
-                and os.getenv('HOSTED_PARAKEET_API_URL')
-            ):
-                if base_lang in parakeet_languages:
-                    return STTService.parakeet, base_lang or 'en', 'parakeet'
+            if model == 'parakeet':
+                if provider_is_enabled(PARAKEET_PROVIDER, surface) and os.getenv('HOSTED_PARAKEET_API_URL'):
+                    if parakeet_supports_language(surface, requested_language):
+                        return (STTService.parakeet, requested_language, 'parakeet'), parakeet_fallback_reason
+                    parakeet_fallback_reason = 'capability_mismatch'
+                else:
+                    parakeet_fallback_reason = 'config_incomplete'
             if (
                 model == 'modulate-velma-2'
                 and provider_is_enabled(MODULATE_PROVIDER, surface)
-                and base_lang in modulate_languages
+                and modulate_supports_language(requested_language)
             ):
-                return STTService.modulate, base_lang or 'en', 'velma-2'
-        return None
+                return (STTService.modulate, requested_language, 'velma-2'), parakeet_fallback_reason
+        return None, parakeet_fallback_reason
 
-    selected = select(stt_service_models)
+    prefers_parakeet = (preferred_service or '').strip().lower() == STTService.parakeet.value
+
+    def record_selected_fallback(
+        selected: Tuple[STTService, str, str], *, used_default: bool, parakeet_fallback_reason: Optional[str]
+    ) -> None:
+        if selected[0] != STTService.parakeet and (prefers_parakeet or parakeet_fallback_reason):
+            record_fallback(
+                component='stt_selection',
+                from_mode=STTService.parakeet.value,
+                to_mode=selected[0].value,
+                reason=parakeet_fallback_reason
+                or (
+                    'capability_mismatch'
+                    if not parakeet_supports_language(surface, requested_language)
+                    else 'config_incomplete'
+                ),
+                outcome='degraded',
+            )
+        elif used_default:
+            record_fallback(
+                component='stt_selection',
+                from_mode=_stt_selection_from_mode(language or '', base_lang),
+                to_mode=selected[0].value,
+                reason='config_incomplete',
+                outcome='degraded',
+            )
+
+    selected, parakeet_fallback_reason = select(stt_service_models)
     if selected is not None:
+        record_selected_fallback(selected, used_default=False, parakeet_fallback_reason=parakeet_fallback_reason)
         return selected
 
-    selected = select(default_models_for_surface(surface))
+    selected, parakeet_fallback_reason = select(default_models_for_surface(surface))
     if selected is not None:
-        record_fallback(
-            component='stt_selection',
-            from_mode=_stt_selection_from_mode(language or '', base_lang),
-            to_mode=selected[0].value,
-            reason='config_incomplete',
-            outcome='degraded',
-        )
+        record_selected_fallback(selected, used_default=True, parakeet_fallback_reason=parakeet_fallback_reason)
         return selected
 
     record_fallback(

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -15,10 +15,15 @@ description: "Sequence diagrams for the /v4/listen WebSocket and Pusher processi
 ## 1. Connection + Streaming + Transcription
 
 The STT provider is selected at session start via `STT_SERVICE_MODELS` env var
-(e.g., `parakeet,modulate-velma-2`). The first provider supporting the
-requested language wins. Listen startup loads transcription preferences once and
-reuses the embedded user language for translation targeting, avoiding a second
-user-preference read on WebSocket startup. All providers implement the
+(e.g., `parakeet,modulate-velma-2`). The first provider whose deployed model
+supports the requested mode wins: Parakeet's live RNNT model is English-only,
+so multilingual sessions and non-English single-language sessions use Modulate.
+Listen startup loads transcription preferences once and uses its
+multi-language setting to request Modulate auto-detection, avoiding a second
+user-preference read on WebSocket startup. The separately deployed Parakeet
+batch model retains its multilingual capability. A client Parakeet preference
+can prioritize Parakeet only when that live-model capability matches; it never
+overrides the selected service/language/model tuple. All providers implement the
 `STTSocket` ABC and are wrapped by the universal `GatedSTTSocket` VAD gate.
 
 Segments buffered in `realtime_segment_buffers` are sorted by `start` time


### PR DESCRIPTION
## Summary

- Make live STT selection model-aware: the deployed Parakeet RNNT model is English-only, while the batch TDT model retains its broader language set.
- Treat the client Parakeet setting as a capability-constrained preference, remove the runtime override that could bypass selection, and emit bounded fallback telemetry whenever live routing moves from Parakeet to Modulate.
- Lock the deployment-model contract to both Parakeet charts, add a hermetic `/v4/listen` → selector → Modulate WebSocket → pusher regression, and configure the Parakeet-only listen-pusher gauntlet with an explicit English single-language fixture.
- Document the live-provider boundary.

Closes #10009

Failure-Class: none

## Guard rationale

The chart-to-policy test is deliberately specific rather than a shared YAML primitive: it validates the named deployed Parakeet model IDs against the provider capability policy. It would have caught the model/surface mismatch reported in #10009.

## Follow-up

- #10021 tracks making hermetic CI checks merge-required; the checks exist and run in PR CI, but GitHub branch protection currently does not require them.
- #10022 tracks aligning the multi-language preference gate with the broader live-provider capability policy.

## Verification

- `cd backend && env BACKEND_PYTEST_WORKERS=4 bash test.sh` — passed (675 backend unit test files).
- Focused selector, runtime, policy, fallback-observability, and hermetic listen-pusher wire suites — passed.
- `cd backend && .venv/bin/python -m pytest -q testing/e2e/test_listen_stt.py testing/e2e/test_listen_pusher_wire_contract.py` — 18 passed.
- `bash backend/testing/e2e/run.sh -q --tb=short` — 112 passed, 3 skipped.
- `npm run test:listen-pusher-stack:emulator` — passed locally after the explicit single-language fixture correction.
- `cd backend && .venv/bin/python -m pytest -q tests/unit/test_streaming_deepgram_backoff.py tests/unit/test_listen_runtime_regressions.py tests/unit/test_listen_pusher_stack_ci_wiring.py` — 89 passed.
- `cd backend && bash scripts/typecheck.sh` — 0 errors (existing warnings only).
- `cd backend && .venv/bin/python scripts/scan_async_blockers.py --dirs routers utils` — passed with 0 selected blocking findings.
- `cd backend && .venv/bin/python -m pytest -q tests/unit/test_workflow_contracts.py tests/unit/test_backend_unit_selector_output.py tests/unit/test_listen_pusher_stack_ci_wiring.py` — 23 passed.
- `OMI_PR_BODY_FILE=/tmp/pr-10009-body.md make preflight` — passed (19 manifest checks).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
