### PR TITLE
test(account-deletion): cover durable Cloud Tasks wipe lifecycle

### DIFF
--- a/backend/testing/e2e/README.md
+++ b/backend/testing/e2e/README.md
@@ -5,7 +5,7 @@ A manually runnable integration test suite that imports the **real omi FastAPI b
 Current dogfood status:
 
 ```text
-80 passed, 6 skipped, 49 warnings
+113 passed, 3 skipped, 24 warnings
 ```
 
 The run installs a local-only socket guard before importing backend code. Any non-local DNS/socket attempt raises an assertion, so real API calls fail the harness instead of silently leaking. The runner also wraps pytest in a process-level timeout (`E2E_PYTEST_TIMEOUT`, default `120s`) so websocket/provider-seam regressions fail instead of hanging indefinitely.
@@ -39,7 +39,7 @@ This version proves the backend can boot hermetically and that selected core CRU
 | Storage / speech profile | ✅ Green | `google.cloud.storage.Client` is patched to a temp-dir fake; speech-profile presence, signed URL, sample list, and delete paths run through real routes/helpers. |
 | Webhooks | ✅ Partial | Developer webhook config/status routes, disabled no-op behavior, realtime delivery payload, non-2xx failure health recording, timeout/exception health recording, and threshold auto-disable are covered with `httpx.MockTransport`. Marketplace app webhook retry/circuit-breaker behavior remains v2. |
 | Task integrations | ✅ Green | CRUD/default/delete paths plus connected/disconnected/no-token and Todoist success, provider 500, 401 disconnect, and timeout failure paths exercise real task-integration database helpers against fake Firestore. |
-| User/auth/profile/account | ✅ Green | Auth guard, profile, onboarding, language/transcription prefs, people CRUD, notification/assistant settings, AI profile, and BYOK activation/deactivation routes are covered. |
+| User/auth/profile/account | ✅ Green | Auth guard, profile, onboarding, language/transcription prefs, people CRUD, notification/assistant settings, AI profile, and BYOK activation/deactivation routes are covered. Account deletion additionally exercises its real admission route, durable marker, opaque Cloud Tasks payload, worker claim, required-purge retry, and idempotent redelivery against local fakes. Firebase deletion, billing lookup, Twilio, and derived-data purge stay controlled test seams. |
 | Retrieval/search | ✅ Partial | Memory, action-item, conversation summary, and transcript-chunk retrieval routes run through real public APIs with Firestore-backed records and a deterministic in-memory replacement for Pinecone/OpenAI embeddings at the `database.vector_db` client seam. Full Pinecone/Typesense service compatibility remains out of scope. |
 | Failure / edge modes | ✅ Partial | Invalid input and edge-case coverage runs. Redis-unavailable, LLM 500, and STT timeout cases are explicitly skipped or deferred until per-test failure fakes are wired. |
 | Legacy shape compatibility | ✅ Green | Exercises legacy conversation/memory shapes and deterministic fake-store repeated writes. It does not execute production migration scripts. |
@@ -51,6 +51,7 @@ This version proves the backend can boot hermetically and that selected core CRU
 | Firestore | `fake-firestore` `MockFirestore` | In-memory datastore backing the real database modules. |
 | Redis | `fakeredis` | In-memory Redis replacement. |
 | Google Cloud Storage | `google.cloud.storage.Client` patched to a filesystem-backed fake | Enables storage-backed routes without GCS credentials/network. |
+| Cloud Tasks / OIDC | Strict in-memory `tasks_v2.CloudTasksClient` plus a local token-verification seam in the account-deletion lifecycle test | Exercises the production task protobuf, queue payload, OIDC identity/audience, and retry headers without a Cloud Tasks control plane or Google token verification. |
 | Google ADC | `google.auth.default` returns anonymous credentials | Prevents real credential lookup at import time. |
 | Pinecone | `PINECONE_API_KEY` removed globally; targeted retrieval/search tests monkeypatch `database.vector_db.index` to a deterministic in-memory fake | Keeps app import hermetic while allowing route-level vector upsert/query/delete assertions without real Pinecone. |
 | Typesense | Dummy host/port/API key | Lets import-time Typesense client construction succeed; retrieval/search tests rely on vector results and fail-open keyword search rather than real Typesense compatibility. |
@@ -94,6 +95,9 @@ bash backend/testing/e2e/run.sh -k "search or retrieval or embedding or vector"
 # User/auth/profile/account routes
 bash backend/testing/e2e/run.sh -k "user_auth_profile"
 
+# Durable account-deletion Cloud Tasks lifecycle
+bash backend/testing/e2e/run.sh -k "account_deletion_cloud_tasks"
+
 # Mobile-facing lifecycle / client compatibility
 bash backend/testing/e2e/run.sh -k "mobile_lifecycle"
 
@@ -126,6 +130,7 @@ run.sh
         ├── test_crud.py
         ├── test_conversation_processing.py
         ├── test_conversation_processing_deterministic.py
+        ├── test_account_deletion_cloud_tasks.py
         ├── test_failure_modes.py
         ├── test_harness_guards.py
         ├── test_listen_stt.py

--- a/backend/testing/e2e/test_account_deletion_cloud_tasks.py
+++ b/backend/testing/e2e/test_account_deletion_cloud_tasks.py
@@ -1,0 +1,339 @@
+"""Hermetic Cloud Tasks lifecycle coverage for durable account deletion."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Callable
+
+import pytest
+from google.cloud import tasks_v2
+
+_PROJECT = "test-e2e-project"
+_LOCATION = "us-central1"
+_QUEUE = "account-deletion"
+_HANDLER_URL = "http://127.0.0.1:8765/v1/users/account-deletion-wipes/run"
+_INVOKER_SERVICE_ACCOUNT = "account-deletion-worker@example.invalid"
+_LOCAL_TASK_TOKEN = "local-account-deletion-cloud-task"
+
+
+class _CapturedCloudTasksClient:
+    """Strict local substitute for the Cloud Tasks client used by this workflow."""
+
+    def __init__(self) -> None:
+        self.create_calls: list[tuple[str, Any]] = []
+        self.queue_path_calls: list[tuple[str, str, str]] = []
+        self.task_path_calls: list[tuple[str, str, str, str]] = []
+        self._assert_pending_marker: Callable[[str], None] | None = None
+
+    def queue_path(self, project: str, location: str, queue: str) -> str:
+        assert (project, location, queue) == (_PROJECT, _LOCATION, _QUEUE)
+        self.queue_path_calls.append((project, location, queue))
+        return f"projects/{project}/locations/{location}/queues/{queue}"
+
+    def task_path(self, project: str, location: str, queue: str, task_id: str) -> str:
+        assert (project, location, queue) == (_PROJECT, _LOCATION, _QUEUE)
+        self.task_path_calls.append((project, location, queue, task_id))
+        return f"projects/{project}/locations/{location}/queues/{queue}/tasks/{task_id}"
+
+    def create_task(self, *, parent: str, task: Any) -> None:
+        from utils.cloud_tasks import DISPATCH_DEADLINE_SECONDS
+
+        assert parent == f"projects/{_PROJECT}/locations/{_LOCATION}/queues/{_QUEUE}"
+        assert isinstance(task, tasks_v2.Task)
+        assert task.http_request.http_method == tasks_v2.HttpMethod.POST
+        assert task.http_request.url == _HANDLER_URL
+        assert task.http_request.headers == {"Content-Type": "application/json"}
+        assert task.http_request.oidc_token.service_account_email == _INVOKER_SERVICE_ACCOUNT
+        assert task.http_request.oidc_token.audience == _HANDLER_URL
+        assert task.dispatch_deadline.seconds == DISPATCH_DEADLINE_SECONDS
+        payload = json.loads(task.http_request.body)
+        assert set(payload) == {"job_id"}
+        wipe_job_id = payload["job_id"]
+        assert isinstance(wipe_job_id, str) and re.fullmatch(r"[0-9a-f]{32}", wipe_job_id)
+        job_hash = hashlib.sha256(wipe_job_id.encode("utf-8")).hexdigest()[:32]
+        expected_name = (
+            rf"projects/{_PROJECT}/locations/{_LOCATION}/queues/{_QUEUE}/tasks/account-delete-{job_hash}-[0-9a-f]{{32}}"
+        )
+        assert re.fullmatch(expected_name, task.name)
+        if self._assert_pending_marker is not None:
+            self._assert_pending_marker(wipe_job_id)
+        self.create_calls.append((parent, task))
+
+    def expect_pending_marker(self, fake_firestore: Any, uid: str) -> None:
+        """Require durable pending state before the production task handoff returns."""
+
+        def assert_pending_marker(wipe_job_id: str) -> None:
+            snapshot = fake_firestore.collection("account_deletions").document(uid).get()
+            assert snapshot.exists
+            marker = snapshot.to_dict()
+            assert marker["wipe_status"] == "pending"
+            assert marker["wipe_job_id"] == wipe_job_id
+
+        self._assert_pending_marker = assert_pending_marker
+
+
+@pytest.fixture()
+def account_deletion_identity(monkeypatch, fake_firestore, fresh_uid):
+    """Authenticate as an isolated user and clean its durable deletion record."""
+
+    from fakes.firestore import clear_user_data
+
+    admin_key = "account-deletion-e2e-admin:"
+    marker = fake_firestore.collection("account_deletions").document(fresh_uid)
+
+    def clear_marker() -> None:
+        if marker.get().exists:
+            marker.delete()
+
+    monkeypatch.setenv("ADMIN_KEY", admin_key)
+    clear_marker()
+    try:
+        yield fresh_uid, {"Authorization": f"Bearer {admin_key}{fresh_uid}"}
+    finally:
+        clear_user_data(fresh_uid)
+        clear_marker()
+
+
+@pytest.fixture()
+def cloud_tasks_client(monkeypatch):
+    """Route production task construction to a strict in-memory client."""
+
+    from utils import cloud_tasks
+
+    client = _CapturedCloudTasksClient()
+    monkeypatch.setattr(cloud_tasks, "_get_tasks_client", lambda: client)
+    return client
+
+
+def _configure_durable_account_deletion(monkeypatch) -> None:
+    """Enable the production Cloud Tasks path with only local configuration."""
+
+    monkeypatch.setenv("ACCOUNT_DELETION_DISPATCH_MODE", "cloud_tasks")
+    monkeypatch.setenv("SYNC_TASKS_PROJECT", _PROJECT)
+    monkeypatch.setenv("SYNC_TASKS_LOCATION", _LOCATION)
+    monkeypatch.setenv("SYNC_TASKS_INVOKER_SA", _INVOKER_SERVICE_ACCOUNT)
+    monkeypatch.setenv("ACCOUNT_DELETION_TASKS_QUEUE", _QUEUE)
+    monkeypatch.setenv("ACCOUNT_DELETION_HANDLER_URL", _HANDLER_URL)
+    monkeypatch.setenv("ACCOUNT_DELETION_TASKS_OIDC_AUDIENCE", _HANDLER_URL)
+    monkeypatch.setenv("ACCOUNT_DELETION_TASKS_MAX_ATTEMPTS", "2")
+
+    from utils import cloud_tasks
+
+    def verify_local_task_token(token: str, _request: Any, audience: str) -> dict[str, Any]:
+        assert token == _LOCAL_TASK_TOKEN
+        assert audience == _HANDLER_URL
+        return {"email": _INVOKER_SERVICE_ACCOUNT, "email_verified": True}
+
+    monkeypatch.setattr(cloud_tasks.id_token, "verify_oauth2_token", verify_local_task_token)
+
+
+def _worker_headers(retry_count: int) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {_LOCAL_TASK_TOKEN}",
+        "X-CloudTasks-TaskRetryCount": str(retry_count),
+    }
+
+
+def _seed_deletable_user(fake_firestore, test_uid: str) -> None:
+    user = fake_firestore.collection("users").document(test_uid)
+    user.set({"uid": test_uid, "name": "Hermetic deletion user"})
+    user.collection("memories").document("deletion-memory").set({"id": "deletion-memory", "uid": test_uid})
+
+
+def _assert_user_data_deleted(fake_firestore, test_uid: str) -> None:
+    user = fake_firestore.collection("users").document(test_uid)
+    assert not user.get().exists
+    assert not user.collection("memories").document("deletion-memory").get().exists
+
+
+def _stub_external_deletion_boundaries(monkeypatch) -> None:
+    """Keep Firebase, Twilio, billing, and vector service calls inside the harness."""
+
+    from services.users import account_deletion
+
+    monkeypatch.setattr(account_deletion.auth, "delete_account", lambda _uid: None)
+    monkeypatch.setattr(account_deletion.users_db, "get_user_subscription", lambda _uid: None)
+    monkeypatch.setattr(account_deletion, "delete_user_caller_ids", lambda _uid: None)
+
+
+def _assert_enqueued_task_schema(tasks_client: _CapturedCloudTasksClient, wipe_job_id: str) -> dict[str, str]:
+    """Prove the production queue request is durable, scoped, and opaque."""
+
+    assert tasks_client.queue_path_calls == [(_PROJECT, _LOCATION, _QUEUE)]
+    assert len(tasks_client.task_path_calls) == 1
+    project, location, queue, task_id = tasks_client.task_path_calls[0]
+    assert (project, location, queue) == (_PROJECT, _LOCATION, _QUEUE)
+    job_hash = hashlib.sha256(wipe_job_id.encode("utf-8")).hexdigest()[:32]
+    assert re.fullmatch(rf"account-delete-{job_hash}-[0-9a-f]{{32}}", task_id)
+
+    assert len(tasks_client.create_calls) == 1
+    parent, task = tasks_client.create_calls[0]
+    assert parent == f"projects/{_PROJECT}/locations/{_LOCATION}/queues/{_QUEUE}"
+    assert task.name.endswith(f"/tasks/{task_id}")
+
+    payload = json.loads(task.http_request.body)
+    assert payload == {"job_id": wipe_job_id}
+    return payload
+
+
+def _read_marker(fake_firestore, test_uid: str) -> dict[str, Any]:
+    snapshot = fake_firestore.collection("account_deletions").document(test_uid).get()
+    assert snapshot.exists
+    return snapshot.to_dict()
+
+
+def _observe_claim_transitions(monkeypatch, fake_firestore, test_uid: str) -> list[dict[str, Any]]:
+    """Observe the real transaction's durable claim state without replacing it."""
+
+    import routers.users as users_router
+
+    production_claim = users_router.claim_deletion_wipe_for_task
+    claimed_markers: list[dict[str, Any]] = []
+
+    def observe_claim(uid: str) -> str:
+        outcome = production_claim(uid)
+        if outcome == "claimed":
+            claimed_markers.append(_read_marker(fake_firestore, test_uid))
+        return outcome
+
+    monkeypatch.setattr(users_router, "claim_deletion_wipe_for_task", observe_claim)
+    return claimed_markers
+
+
+def test_account_deletion_cloud_task_completes_once_and_redelivery_is_acked(
+    client,
+    fake_firestore,
+    monkeypatch,
+    account_deletion_identity,
+    cloud_tasks_client,
+):
+    """Admission -> opaque task -> worker claim -> completed redelivery is one real lifecycle."""
+
+    from services.users import account_deletion
+
+    test_uid, auth_headers = account_deletion_identity
+    _configure_durable_account_deletion(monkeypatch)
+    _stub_external_deletion_boundaries(monkeypatch)
+    purge_calls: list[str] = []
+
+    def successful_purge(uid: str) -> dict[str, list[dict[str, str]]]:
+        purge_calls.append(uid)
+        return {"required_failures": [], "best_effort_failures": []}
+
+    monkeypatch.setattr(
+        account_deletion,
+        "purge_derived_user_data",
+        successful_purge,
+    )
+    _seed_deletable_user(fake_firestore, test_uid)
+    cloud_tasks_client.expect_pending_marker(fake_firestore, test_uid)
+    claimed_markers = _observe_claim_transitions(monkeypatch, fake_firestore, test_uid)
+
+    admitted = client.delete("/v1/users/delete-account", headers=auth_headers)
+    assert admitted.status_code == 200, admitted.text
+    assert admitted.json() == {"status": "ok", "message": "Account deletion started"}
+
+    pending_marker = _read_marker(fake_firestore, test_uid)
+    assert pending_marker["wipe_status"] == "pending"
+    wipe_job_id = pending_marker["wipe_job_id"]
+    assert re.fullmatch(r"[0-9a-f]{32}", wipe_job_id)
+    payload = _assert_enqueued_task_schema(cloud_tasks_client, wipe_job_id)
+
+    unauthenticated = client.post("/v1/users/account-deletion-wipes/run", json=payload)
+    assert unauthenticated.status_code == 403, unauthenticated.text
+
+    completed = client.post(
+        "/v1/users/account-deletion-wipes/run", json=payload, headers=_worker_headers(retry_count=0)
+    )
+    assert completed.status_code == 200, completed.text
+    assert completed.json() == {"status": "done"}
+    assert _read_marker(fake_firestore, test_uid)["wipe_status"] == "completed"
+    _assert_user_data_deleted(fake_firestore, test_uid)
+    assert len(claimed_markers) == 1
+    assert claimed_markers[0]["wipe_status"] == "retrying"
+    assert "wipe_claimed_at" in claimed_markers[0]
+    assert purge_calls == [test_uid]
+
+    redelivery = client.post(
+        "/v1/users/account-deletion-wipes/run", json=payload, headers=_worker_headers(retry_count=1)
+    )
+    assert redelivery.status_code == 200, redelivery.text
+    assert redelivery.json() == {"status": "dropped", "reason": "completed"}
+    assert _read_marker(fake_firestore, test_uid)["wipe_status"] == "completed"
+    assert len(claimed_markers) == 1
+    assert purge_calls == [test_uid]
+
+
+def test_account_deletion_cloud_task_retries_required_purge_failure_without_losing_the_job(
+    client,
+    fake_firestore,
+    monkeypatch,
+    account_deletion_identity,
+    cloud_tasks_client,
+):
+    """A required purge failure returns retry, preserves data, and later completes the same job."""
+
+    from services.users import account_deletion
+
+    test_uid, auth_headers = account_deletion_identity
+    _configure_durable_account_deletion(monkeypatch)
+    _stub_external_deletion_boundaries(monkeypatch)
+    purge_calls: list[str] = []
+    purge_results = iter(
+        [
+            {
+                "required_failures": [{"operation": "conversation_vectors", "error": "fake unavailable"}],
+                "best_effort_failures": [],
+            },
+            {"required_failures": [], "best_effort_failures": []},
+        ]
+    )
+
+    def controlled_purge(uid: str) -> dict[str, list[dict[str, str]]]:
+        purge_calls.append(uid)
+        return next(purge_results)
+
+    monkeypatch.setattr(account_deletion, "purge_derived_user_data", controlled_purge)
+    _seed_deletable_user(fake_firestore, test_uid)
+    cloud_tasks_client.expect_pending_marker(fake_firestore, test_uid)
+    claimed_markers = _observe_claim_transitions(monkeypatch, fake_firestore, test_uid)
+
+    admitted = client.delete("/v1/users/delete-account", headers=auth_headers)
+    assert admitted.status_code == 200, admitted.text
+    wipe_job_id = _read_marker(fake_firestore, test_uid)["wipe_job_id"]
+    payload = _assert_enqueued_task_schema(cloud_tasks_client, wipe_job_id)
+
+    failed_delivery = client.post(
+        "/v1/users/account-deletion-wipes/run", json=payload, headers=_worker_headers(retry_count=0)
+    )
+    assert failed_delivery.status_code == 500, failed_delivery.text
+    assert failed_delivery.json() == {"status": "retry"}
+    assert _read_marker(fake_firestore, test_uid)["wipe_status"] == "failed"
+    user = fake_firestore.collection("users").document(test_uid)
+    assert user.get().exists
+    assert user.collection("memories").document("deletion-memory").get().exists
+    assert len(claimed_markers) == 1
+    assert claimed_markers[0]["wipe_status"] == "retrying"
+    assert "wipe_claimed_at" in claimed_markers[0]
+    assert purge_calls == [test_uid]
+
+    retried_delivery = client.post(
+        "/v1/users/account-deletion-wipes/run", json=payload, headers=_worker_headers(retry_count=1)
+    )
+    assert retried_delivery.status_code == 200, retried_delivery.text
+    assert retried_delivery.json() == {"status": "done"}
+    assert _read_marker(fake_firestore, test_uid)["wipe_status"] == "completed"
+    _assert_user_data_deleted(fake_firestore, test_uid)
+    assert len(claimed_markers) == 2
+    assert all(marker["wipe_status"] == "retrying" and "wipe_claimed_at" in marker for marker in claimed_markers)
+    assert purge_calls == [test_uid, test_uid]
+
+    redelivery = client.post(
+        "/v1/users/account-deletion-wipes/run", json=payload, headers=_worker_headers(retry_count=2)
+    )
+    assert redelivery.status_code == 200, redelivery.text
+    assert redelivery.json() == {"status": "dropped", "reason": "completed"}
+    assert len(claimed_markers) == 2
+    assert purge_calls == [test_uid, test_uid]

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -296,7 +296,8 @@
         "tests/unit/test_sync_cloud_tasks.py",
         "tests/unit/test_backend_runtime_env_validator.py",
         "tests/unit/test_claim_deletion_wipe_txn.py",
-        "tests/unit/test_delete_account_purge_storage.py"
+        "tests/unit/test_delete_account_purge_storage.py",
+        "testing/e2e/test_account_deletion_cloud_tasks.py"
       ],
       "checks": [],
       "invariants": [


### PR DESCRIPTION
## Summary

- Add a hermetic Cloud Tasks account-deletion lifecycle test that drives the real admission route, task protobuf, OIDC dependency, durable marker transitions, retry, and idempotent redelivery.
- Record the high-risk workflow contract and document the strict local Cloud Tasks/OIDC seam in the E2E harness.

## Verification

- `BACKEND_PYTEST_WORKERS=4 bash backend/test.sh` — passed (675 isolated test files).
- `bash backend/testing/e2e/run.sh -q --tb=short` — passed (113 passed, 3 skipped).
- `make preflight` — passed.

## Product invariants affected

None.

Closes #10025

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

