### PR TITLE
fix(app): keep terminal WAL corruption out of pending

### DIFF
--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -55,8 +55,6 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
     return Consumer3<SyncProvider, UserProvider, DeviceProvider>(
       builder: (context, syncProvider, userProvider, deviceProvider, _) {
         final syncState = syncProvider.syncState;
-        final pendingWals = syncProvider.pendingWals;
-        final syncedWals = syncProvider.syncedWals;
         final hasAnyRecording = syncProvider.allWals.isNotEmpty;
         // Compute the filtered list once per build and pass it down — the
         // SliverList.builder uses it via index, so calling it again inside
@@ -82,7 +80,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
                 icon: FaIcon(FontAwesomeIcons.circleInfo, color: Color(0xFF8E8E93), size: 18),
                 onPressed: () => _showInfoSheet(context),
               ),
-              if (pendingWals.isNotEmpty || syncedWals.isNotEmpty)
+              if (syncProvider.clearableWalsCount > 0)
                 IconButton(
                   icon: FaIcon(FontAwesomeIcons.ellipsis, color: Color(0xFF8E8E93), size: 18),
                   onPressed: () => _showManageStorageSheet(context, syncProvider),
@@ -526,6 +524,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
 
   Widget _buildWalListItem(SyncProvider syncProvider, List<Wal> wals, int i) {
     final wal = wals[i];
+    final state = wal.syncDisplayState;
     final isFirst = i == 0;
     final isLast = i == wals.length - 1;
     return Container(
@@ -544,7 +543,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
             // Index suffix because `wal.id` (device_timerStart) is not unique
             // across SD-card + on-phone copies of the same recording.
             key: ValueKey('${wal.id}#$i'),
-            direction: wal.isSyncing ? DismissDirection.none : DismissDirection.endToStart,
+            direction: state == WalSyncDisplayState.syncing ? DismissDirection.none : DismissDirection.endToStart,
             confirmDismiss: (direction) {
               final uploading = wal.syncDisplayState == WalSyncDisplayState.uploaded;
               return OmiConfirmDialog.show(
@@ -820,8 +819,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
             confirmColor: Colors.red,
           );
           if (confirmed == true && context.mounted) {
-            await provider.deleteAllSyncedWals();
-            await provider.deleteAllPendingWals();
+            await provider.deleteAllClearableWals();
             if (context.mounted) {
               ScaffoldMessenger.of(
                 context,
@@ -883,7 +881,7 @@ class _ManageStorageSheet extends StatelessWidget {
   Widget build(BuildContext context) {
     final syncedCount = provider.syncedWals.length;
     final pendingCount = provider.pendingDeletableWals.length;
-    final totalCount = syncedCount + pendingCount;
+    final totalCount = provider.clearableWalsCount;
 
     return Container(
       decoration: const BoxDecoration(

--- a/app/lib/pages/conversations/sync_page.dart
+++ b/app/lib/pages/conversations/sync_page.dart
@@ -58,11 +58,12 @@ class WalListItem extends StatelessWidget {
 
   (Color, String) _rowStatus(BuildContext context, bool hasError) {
     final l = context.l10n;
-    if (wal.isSyncing) {
+    final state = wal.syncDisplayState;
+    if (state == WalSyncDisplayState.syncing) {
       return (Colors.grey.shade300, l.syncStatusBackingUp);
     }
     if (hasError) return (Colors.redAccent, l.failedStatus);
-    switch (wal.syncDisplayState) {
+    switch (state) {
       case WalSyncDisplayState.synced:
         return (Colors.grey.shade500, l.syncStatusConversationCreated);
       case WalSyncDisplayState.uploaded:
@@ -80,15 +81,15 @@ class WalListItem extends StatelessWidget {
   }
 
   Widget _trailing(BuildContext context, SyncProvider syncProvider, bool hasError) {
-    if (wal.isSyncing) {
+    final state = wal.syncDisplayState;
+    if (state == WalSyncDisplayState.syncing) {
       return const SizedBox(
         width: 16,
         height: 16,
         child: CircularProgressIndicator(strokeWidth: 2, valueColor: AlwaysStoppedAnimation(Colors.deepPurpleAccent)),
       );
     }
-    final st = wal.syncDisplayState;
-    if (hasError || st == WalSyncDisplayState.failed || st == WalSyncDisplayState.retrying) {
+    if (hasError || state == WalSyncDisplayState.failed || state == WalSyncDisplayState.retrying) {
       return GestureDetector(
         onTap: () => syncProvider.syncWal(wal),
         child: Container(
@@ -112,11 +113,12 @@ class WalListItem extends StatelessWidget {
     return Consumer<SyncProvider>(
       builder: (context, syncProvider, child) {
         final hasError = syncProvider.failedWal?.id == wal.id;
+        final displayState = wal.syncDisplayState;
         final (statusColor, statusLabel) = _rowStatus(context, hasError);
         final timeStr = dateTimeFormat('h:mm a', DateTime.fromMillisecondsSinceEpoch(wal.timerStart * 1000));
         final duration = secondsToHumanReadable(wal.seconds, context);
         final source = _sourceLabel(context);
-        final showBar = wal.isSyncing &&
+        final showBar = displayState == WalSyncDisplayState.syncing &&
             wal.status != WalStatus.synced &&
             wal.syncStartedAt != null &&
             wal.storage != WalStorage.flashPage;
@@ -126,7 +128,8 @@ class WalListItem extends StatelessWidget {
           decoration: BoxDecoration(color: const Color(0xFF1C1C1E), borderRadius: BorderRadius.circular(16)),
           child: Dismissible(
             key: Key(wal.id),
-            direction: wal.isSyncing ? DismissDirection.none : DismissDirection.endToStart,
+            direction:
+                displayState == WalSyncDisplayState.syncing ? DismissDirection.none : DismissDirection.endToStart,
             confirmDismiss: (direction) {
               final uploading = wal.syncDisplayState == WalSyncDisplayState.uploaded;
               return OmiConfirmDialog.show(
@@ -406,8 +409,7 @@ class _SyncPageState extends State<SyncPage> {
             confirmColor: Colors.red,
           );
           if (confirmed == true && context.mounted) {
-            await provider.deleteAllSyncedWals();
-            await provider.deleteAllPendingWals();
+            await provider.deleteAllClearableWals();
             if (context.mounted) {
               ScaffoldMessenger.of(
                 context,
@@ -688,6 +690,7 @@ class _SyncPageState extends State<SyncPage> {
         children: [
           chip(WalStatusFilter.pending, context.l10n.pending, syncProvider.pendingStatusCount),
           chip(WalStatusFilter.synced, context.l10n.synced, syncProvider.syncedStatusCount),
+          chip(WalStatusFilter.corrupted, context.l10n.failedStatus, syncProvider.corruptedStatusCount),
         ],
       ),
     );
@@ -695,6 +698,7 @@ class _SyncPageState extends State<SyncPage> {
 
   Widget _buildEmptyFilterState(BuildContext context, WalStatusFilter filter) {
     final isPending = filter == WalStatusFilter.pending;
+    final isCorrupted = filter == WalStatusFilter.corrupted;
     return Container(
       margin: const EdgeInsets.all(20),
       padding: const EdgeInsets.all(32),
@@ -702,13 +706,25 @@ class _SyncPageState extends State<SyncPage> {
       child: Column(
         children: [
           _buildFaIcon(
-            isPending ? FontAwesomeIcons.circleCheck : FontAwesomeIcons.clockRotateLeft,
+            isPending
+                ? FontAwesomeIcons.circleCheck
+                : isCorrupted
+                    ? FontAwesomeIcons.triangleExclamation
+                    : FontAwesomeIcons.clockRotateLeft,
             size: 24,
-            color: isPending ? Colors.green : Colors.grey,
+            color: isPending
+                ? Colors.green
+                : isCorrupted
+                    ? Colors.redAccent
+                    : Colors.grey,
           ),
           const SizedBox(height: 16),
           Text(
-            isPending ? context.l10n.noPendingRecordings : context.l10n.noProcessedRecordings,
+            isPending
+                ? context.l10n.noPendingRecordings
+                : isCorrupted
+                    ? context.l10n.syncStatusFileUnavailable
+                    : context.l10n.noProcessedRecordings,
             style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w500),
           ),
           if (isPending) ...[
@@ -1069,7 +1085,7 @@ class _ManageStorageSheet extends StatelessWidget {
   Widget build(BuildContext context) {
     final syncedCount = provider.syncedWals.length;
     final pendingCount = provider.pendingDeletableWals.length;
-    final totalCount = syncedCount + pendingCount;
+    final totalCount = provider.clearableWalsCount;
 
     return Container(
       decoration: const BoxDecoration(

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -15,7 +15,7 @@ import 'package:omi/utils/audio_player_utils.dart';
 import 'package:omi/utils/conversation_sync_utils.dart';
 import 'package:omi/utils/waveform_utils.dart';
 
-enum WalStatusFilter { pending, synced }
+enum WalStatusFilter { pending, synced, corrupted }
 
 enum WalDisplayFilter { all, pending, synced }
 
@@ -58,9 +58,11 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
 
   // `uploaded` is not yet backed up (the server job is still processing), so
   // it counts as pending — keeps it visible in the legacy SyncPage and in
-  // pending counts until the reconciler confirms it `synced`.
+  // pending counts until the reconciler confirms it `synced`. `corrupted` is
+  // terminal: retain it in All and Needs Attention, never present it as work
+  // that sync can still complete.
   bool _isPending(Wal w) =>
-      w.status == WalStatus.miss || w.status == WalStatus.uploaded || w.status == WalStatus.corrupted || w.isSyncing;
+      w.status != WalStatus.corrupted && (w.status == WalStatus.miss || w.status == WalStatus.uploaded || w.isSyncing);
 
   // Memoized status-filtered partitions of _allWals. Returning a stable
   // List<Wal> reference between rebuilds is load-bearing — downstream the
@@ -78,10 +80,11 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   // — but there are none today; if any are added, route them through
   // refreshWals or bump a version counter here.
   //
-  // Both partitions are computed in a single pass to avoid two iterations
-  // over a potentially 50k-item list. Both caches share the same stamp.
+  // All three partitions are computed in a single pass to avoid three iterations
+  // over a potentially 50k-item list. All caches share the same stamp.
   List<Wal>? _pendingWalsCache;
   List<Wal>? _syncedWalsCache;
+  List<Wal>? _corruptedWalsCache;
   int _filteredWalsCacheStamp = 0;
 
   void _ensureFilteredCaches() {
@@ -89,15 +92,19 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     if (_pendingWalsCache != null && _filteredWalsCacheStamp == stamp) return;
     final pending = <Wal>[];
     final synced = <Wal>[];
+    final corrupted = <Wal>[];
     for (final w in _allWals) {
       if (w.status == WalStatus.synced) {
         synced.add(w);
+      } else if (w.status == WalStatus.corrupted) {
+        corrupted.add(w);
       } else if (_isPending(w)) {
         pending.add(w);
       }
     }
     _pendingWalsCache = pending;
     _syncedWalsCache = synced;
+    _corruptedWalsCache = corrupted;
     _filteredWalsCacheStamp = stamp;
   }
 
@@ -111,10 +118,16 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     return _syncedWalsCache!;
   }
 
+  /// Terminally unavailable recordings. They remain reachable for review or
+  /// deletion, but never count as retryable pending work.
+  List<Wal> get corruptedWals {
+    _ensureFilteredCaches();
+    return _corruptedWalsCache!;
+  }
+
   List<Wal> get uploadedWals => _allWals.where((w) => w.status == WalStatus.uploaded).toList();
 
-  List<Wal> get pendingDeletableWals =>
-      _allWals.where((w) => !w.isSyncing && (w.status == WalStatus.miss || w.status == WalStatus.corrupted)).toList();
+  List<Wal> get pendingDeletableWals => _allWals.where((w) => !w.isSyncing && w.status == WalStatus.miss).toList();
 
   // Count-only accessors for status-chip badges. Read length from the
   // shared cached partitions so the chips don't trigger an extra iteration
@@ -131,16 +144,28 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     return _syncedWalsCache!.length;
   }
 
+  int get corruptedStatusCount {
+    _ensureFilteredCaches();
+    return _corruptedWalsCache!.length;
+  }
+
+  /// Recordings that the storage sheet's Clear All action can remove.
+  int get clearableWalsCount => syncedWals.length + pendingDeletableWals.length + corruptedWals.length;
+
   /// True while a fair-use (429) cooldown is active — uploads are paused.
   bool get isRateLimited => SyncRateLimiter.instance.isLimited;
   DateTime? get rateLimitedUntil => SyncRateLimiter.instance.until;
   RateLimitReason? get rateLimitReason => SyncRateLimiter.instance.reason;
 
   List<Wal> get filteredByStatusWals {
-    if (_statusFilter == WalStatusFilter.pending) {
-      return pendingWals;
+    switch (_statusFilter) {
+      case WalStatusFilter.pending:
+        return pendingWals;
+      case WalStatusFilter.synced:
+        return syncedWals;
+      case WalStatusFilter.corrupted:
+        return corruptedWals;
     }
-    return syncedWals;
   }
 
   // ─────────────────────────────────────────
@@ -189,7 +214,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
         case WalDisplayFilter.all:
           return true;
         case WalDisplayFilter.pending:
-          return w.syncDisplayState != WalSyncDisplayState.synced;
+          return w.status != WalStatus.corrupted && w.syncDisplayState != WalSyncDisplayState.synced;
         case WalDisplayFilter.synced:
           return w.syncDisplayState == WalSyncDisplayState.synced;
       }
@@ -461,6 +486,16 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
 
   Future<void> deleteAllPendingWals() async {
     await _walService.getSyncs().deleteAllPendingWals();
+    await refreshWals();
+  }
+
+  /// Clears every local recording category. Unlike the retryable Pending
+  /// action, this deliberately includes terminally corrupted phone WALs.
+  Future<void> deleteAllClearableWals() async {
+    final syncs = _walService.getSyncs();
+    await syncs.deleteAllSyncedWals();
+    await syncs.deleteAllPendingWals();
+    await syncs.deleteAllCorruptedWals();
     await refreshWals();
   }
 

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -123,7 +123,10 @@ class LocalWalSyncImpl implements LocalWalSync {
   SyncLocalFilesResponse? _accumulatedResponse;
   SyncLocalFilesResponse? get accumulatedResponse => _accumulatedResponse;
 
-  LocalWalSyncImpl(this.listener);
+  final SyncUploadGate? _uploadGateOverride;
+  SyncUploadGate get _uploadGate => _uploadGateOverride ?? SyncUploadGate.instance;
+
+  LocalWalSyncImpl(this.listener, {SyncUploadGate? uploadGate}) : _uploadGateOverride = uploadGate;
 
   @visibleForTesting
   List<WalFrame> get testFrames => _frames;
@@ -568,8 +571,21 @@ class LocalWalSyncImpl implements LocalWalSync {
 
   @override
   Future<void> deleteAllPendingWals() async {
-    final pendingWals = _wals.where((w) => w.status == WalStatus.miss || w.status == WalStatus.corrupted).toList();
+    final pendingWals = _wals.where((w) => w.status == WalStatus.miss).toList();
     for (final wal in pendingWals) {
+      await _deleteWal(wal);
+    }
+    await _saveWalsToFile();
+    listener.onWalUpdated();
+  }
+
+  /// Removes terminally unavailable recordings when the user explicitly
+  /// clears all local recordings. They are intentionally excluded from the
+  /// retryable Pending action.
+  @override
+  Future<void> deleteAllCorruptedWals() async {
+    final corruptedWals = _wals.where((w) => w.status == WalStatus.corrupted).toList();
+    for (final wal in corruptedWals) {
       await _deleteWal(wal);
     }
     await _saveWalsToFile();
@@ -695,7 +711,7 @@ class LocalWalSyncImpl implements LocalWalSync {
         Logger.debug("sync id ${wal.id} ${wal.timerStart}");
         if (wal.filePath == null) {
           Logger.debug("file path is not found. wal id ${wal.id}");
-          wal.status = WalStatus.corrupted;
+          wal.markCorrupted();
           corruptedCount++;
           DebugLogManager.logWarning('WAL corrupted: file path missing', {'walId': wal.id});
           continue;
@@ -707,7 +723,7 @@ class LocalWalSyncImpl implements LocalWalSync {
         try {
           if (fullPath == null) {
             Logger.debug("could not construct file path for wal id ${wal.id}");
-            wal.status = WalStatus.corrupted;
+            wal.markCorrupted();
             corruptedCount++;
             DebugLogManager.logWarning('WAL corrupted: cannot construct path', {'walId': wal.id});
             continue;
@@ -716,7 +732,7 @@ class LocalWalSyncImpl implements LocalWalSync {
           File file = File(fullPath);
           if (!file.existsSync()) {
             Logger.debug("file $fullPath does not exist");
-            wal.status = WalStatus.corrupted;
+            wal.markCorrupted();
             corruptedCount++;
             DebugLogManager.logWarning('WAL corrupted: file not found on disk', {
               'walId': wal.id,
@@ -728,7 +744,7 @@ class LocalWalSyncImpl implements LocalWalSync {
           wal.isSyncing = true;
           batchWals.add(wal);
         } catch (e) {
-          wal.status = WalStatus.corrupted;
+          wal.markCorrupted();
           corruptedCount++;
           Logger.debug(e.toString());
           DebugLogManager.logError(e, null, 'WAL corrupted: unexpected error - ${e.toString()}', {'walId': wal.id});
@@ -754,11 +770,7 @@ class LocalWalSyncImpl implements LocalWalSync {
         // wait for server-side processing here; the reconciler resolves the
         // job_id later. Only WALs that actually became files (batchWals) are
         // mutated — corrupted ones already short-circuited above.
-        final result = await SyncUploadGate.instance.upload(
-          files,
-          lane: batchLane,
-          conversationId: batchWals.first.conversationId,
-        );
+        final result = await _uploadGate.upload(files, lane: batchLane, conversationId: batchWals.first.conversationId);
 
         if (result.completed != null) {
           // 200 fast-path: server processed synchronously and returned a result.
@@ -863,20 +875,20 @@ class LocalWalSyncImpl implements LocalWalSync {
     File? walFile;
     if (wal.filePath == null) {
       Logger.debug("file path is not found. wal id ${wal.id}");
-      wal.status = WalStatus.corrupted;
+      wal.markCorrupted();
       DebugLogManager.logWarning('Single WAL corrupted: file path missing', {'walId': wal.id});
     } else {
       try {
         final fullPath = await Wal.getFilePath(wal.filePath);
         if (fullPath == null) {
           Logger.debug("could not construct file path for wal id ${wal.id}");
-          wal.status = WalStatus.corrupted;
+          wal.markCorrupted();
           DebugLogManager.logWarning('Single WAL corrupted: cannot construct path', {'walId': wal.id});
         } else {
           File file = File(fullPath);
           if (!file.existsSync()) {
             Logger.debug("file $fullPath does not exist");
-            wal.status = WalStatus.corrupted;
+            wal.markCorrupted();
             DebugLogManager.logWarning('Single WAL corrupted: file not found', {'walId': wal.id});
           } else {
             walFile = file;
@@ -884,7 +896,7 @@ class LocalWalSyncImpl implements LocalWalSync {
           }
         }
       } catch (e) {
-        wal.status = WalStatus.corrupted;
+        wal.markCorrupted();
         print(e.toString());
         DebugLogManager.logError(e, null, 'Single WAL corrupted: unexpected error - ${e.toString()}', {
           'walId': wal.id,
@@ -913,11 +925,7 @@ class LocalWalSyncImpl implements LocalWalSync {
         // conversation batching.
         if (pendingForConversation.length > 1) lane = SyncUploadLane.backfill;
       }
-      final result = await SyncUploadGate.instance.upload(
-        [walFile],
-        lane: lane,
-        conversationId: walToSync.conversationId,
-      );
+      final result = await _uploadGate.upload([walFile], lane: lane, conversationId: walToSync.conversationId);
 
       if (result.completed != null) {
         final r = result.completed!;
@@ -1030,7 +1038,7 @@ class LocalWalSyncImpl implements LocalWalSync {
                 w.retryCount += 1;
                 w.lastRetryAt = nowSecs;
               } else {
-                w.status = WalStatus.corrupted; // nothing left to recover
+                w.markCorrupted(); // nothing left to recover
               }
               DebugLogManager.logEvent('reconcile_revert', {
                 'walId': w.id,

--- a/app/lib/services/wals/wal.dart
+++ b/app/lib/services/wals/wal.dart
@@ -137,6 +137,9 @@ class Wal {
   /// user. The sync page renders an explicit label + icon for every value so a
   /// not-yet-synced recording is never visually identical to a failed one.
   WalSyncDisplayState get syncDisplayState {
+    // Corruption is terminal. It must not be visually downgraded to an active
+    // upload if a transient flag was left behind by an interrupted attempt.
+    if (status == WalStatus.corrupted) return WalSyncDisplayState.corrupted;
     if (isSyncing) return WalSyncDisplayState.syncing;
     switch (status) {
       case WalStatus.uploaded:
@@ -152,6 +155,16 @@ class Wal {
       case WalStatus.inProgress:
         return WalSyncDisplayState.waiting;
     }
+  }
+
+  /// Marks this recording as terminally unavailable and clears any transient
+  /// upload presentation left by an interrupted attempt.
+  void markCorrupted() {
+    status = WalStatus.corrupted;
+    isSyncing = false;
+    syncStartedAt = null;
+    syncEtaSeconds = null;
+    syncSpeedKBps = null;
   }
 
   Wal({

--- a/app/lib/services/wals/wal_interfaces.dart
+++ b/app/lib/services/wals/wal_interfaces.dart
@@ -67,6 +67,7 @@ abstract class LocalWalSync implements IWalSync {
   Future<List<Wal>> getAllWals();
   Future<void> deleteAllSyncedWals();
   Future<void> deleteAllPendingWals();
+  Future<void> deleteAllCorruptedWals();
 
   /// Ingest a pre-processed audio frame from an AudioSource.
   /// The frame contains headerless payload and a source-specific sync key.

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -205,6 +205,10 @@ class WalSyncs implements IWalSync {
     await _ringSync.deleteAllPendingWals();
   }
 
+  /// Terminal corruption is produced by the phone-local WAL owner. Device
+  /// stores keep their existing pending-deletion semantics.
+  Future<void> deleteAllCorruptedWals() => _phoneSync.deleteAllCorruptedWals();
+
   @override
   void start() {
     _phoneSync.start();

--- a/app/test/providers/sync_provider_terminal_wal_state_test.dart
+++ b/app/test/providers/sync_provider_terminal_wal_state_test.dart
@@ -1,0 +1,174 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/http/api/conversations.dart' show SyncUploadLane;
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/providers/sync_provider.dart';
+import 'package:omi/services/wals/local_wal_sync.dart';
+import 'package:omi/services/wals/sync_rate_limiter.dart';
+import 'package:omi/services/wals/sync_upload_gate.dart';
+import 'package:omi/services/wals/wal.dart';
+import 'package:omi/services/wals/wal_interfaces.dart';
+import 'package:omi/utils/wal_file_manager.dart';
+
+class _Listener implements IWalSyncListener {
+  @override
+  void onWalSynced(Wal wal, {ServerConversation? conversation}) {}
+
+  @override
+  void onWalUpdated() {}
+}
+
+class _LocalSyncs {
+  _LocalSyncs(this.phone);
+
+  final LocalWalSyncImpl phone;
+
+  Future<List<Wal>> getAllWals() => phone.getAllWals();
+
+  Future<void> deleteAllSyncedWals() => phone.deleteAllSyncedWals();
+
+  Future<void> deleteAllPendingWals() => phone.deleteAllPendingWals();
+
+  Future<void> deleteAllCorruptedWals() => phone.deleteAllCorruptedWals();
+}
+
+class _WalService implements IWalService {
+  _WalService(this.syncs);
+
+  final _LocalSyncs syncs;
+
+  @override
+  dynamic getSyncs() => syncs;
+
+  @override
+  void start() {}
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  void subscribe(IWalServiceListener subscription, Object context) {}
+
+  @override
+  void unsubscribe(Object context) {}
+}
+
+Wal _wal({required int timerStart, required String? filePath}) {
+  return Wal(
+    timerStart: timerStart,
+    codec: BleAudioCodec.opus,
+    seconds: 60,
+    status: WalStatus.miss,
+    storage: WalStorage.disk,
+    device: 'omi',
+    filePath: filePath,
+  );
+}
+
+SyncUploadGate _offlineGate() {
+  return SyncUploadGate(
+    limiter: SyncRateLimiter.instance,
+    uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+      throw StateError('unexpected upload in terminal WAL-state test');
+    },
+    fairUseStatusLoader: () async => {'stage': 'none'},
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late LocalWalSyncImpl localSync;
+  SyncProvider? provider;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    tempDir = await Directory.systemTemp.createTemp('terminal_wal_state_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') return tempDir.path;
+        return null;
+      },
+    );
+    await WalFileManager.init();
+
+    localSync = LocalWalSyncImpl(_Listener(), uploadGate: _offlineGate());
+  });
+
+  tearDown(() async {
+    provider?.dispose();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    SyncRateLimiter.instance.clear();
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test('terminal corruption leaves Pending but remains visible and individually manageable', () async {
+    final missingFile = _wal(timerStart: 1000, filePath: 'missing_audio.bin');
+    missingFile
+      ..isSyncing = true
+      ..syncStartedAt = DateTime.now()
+      ..syncEtaSeconds = 10
+      ..syncSpeedKBps = 12;
+    localSync.testWals = [missingFile];
+
+    final syncProvider = SyncProvider(
+      walService: _WalService(_LocalSyncs(localSync)),
+      uploadGate: _offlineGate(),
+      startBackgroundSync: false,
+    );
+    provider = syncProvider;
+    await syncProvider.initialized;
+    expect(syncProvider.pendingWals, [missingFile]);
+
+    await localSync.syncAll();
+    expect(missingFile.status, WalStatus.corrupted);
+    expect(missingFile.isSyncing, isFalse);
+    expect(missingFile.syncStartedAt, isNull);
+    expect(missingFile.syncEtaSeconds, isNull);
+    expect(missingFile.syncSpeedKBps, isNull);
+
+    // A persisted stale flag must not reclassify or lock a terminal row.
+    missingFile.isSyncing = true;
+
+    final retryable = _wal(timerStart: 2000, filePath: null);
+    localSync.testWals = [missingFile, retryable];
+    await syncProvider.refreshWals();
+
+    expect(syncProvider.pendingWals, [retryable]);
+    expect(syncProvider.pendingStatusCount, 1);
+    expect(syncProvider.filteredByStatusWals, [retryable]);
+    expect(syncProvider.pendingDeletableWals, [retryable]);
+    expect(syncProvider.corruptedWals, [missingFile]);
+    expect(syncProvider.corruptedStatusCount, 1);
+    expect(syncProvider.needsAttentionWalsCount, 1);
+    expect(syncProvider.walsForDisplayFilter(WalDisplayFilter.pending), [retryable]);
+    expect(syncProvider.walsForDisplayFilter(WalDisplayFilter.all), containsAll([missingFile, retryable]));
+
+    syncProvider.setStatusFilter(WalStatusFilter.corrupted);
+    expect(syncProvider.filteredByStatusWals, [missingFile]);
+
+    await syncProvider.deleteAllPendingWals();
+
+    expect(syncProvider.allWals, [missingFile]);
+    expect(syncProvider.pendingWals, isEmpty);
+    expect(syncProvider.needsAttentionWalsCount, 1);
+
+    await syncProvider.deleteAllClearableWals();
+
+    expect(syncProvider.allWals, isEmpty);
+  });
+}

--- a/app/test/unit/wal_sync_display_state_test.dart
+++ b/app/test/unit/wal_sync_display_state_test.dart
@@ -24,11 +24,15 @@ void main() {
   }
 
   group('Wal.syncDisplayState', () {
-    test('isSyncing wins over every status', () {
-      for (final s in WalStatus.values) {
+    test('isSyncing wins over every non-terminal status', () {
+      for (final s in WalStatus.values.where((status) => status != WalStatus.corrupted)) {
         final w = makeWal(status: s, isSyncing: true);
         expect(w.syncDisplayState, WalSyncDisplayState.syncing, reason: 'status=$s');
       }
+    });
+
+    test('corrupted wins over a stale syncing flag', () {
+      expect(makeWal(status: WalStatus.corrupted, isSyncing: true).syncDisplayState, WalSyncDisplayState.corrupted);
     });
 
     test('uploaded -> uploaded (processing on server)', () {

--- a/app/test/unit/wal_upload_resilience_test.dart
+++ b/app/test/unit/wal_upload_resilience_test.dart
@@ -4,10 +4,13 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:omi/backend/http/api/conversations.dart' show SyncUploadLane;
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/services/wals/local_wal_sync.dart';
+import 'package:omi/services/wals/sync_rate_limiter.dart';
+import 'package:omi/services/wals/sync_upload_gate.dart';
 import 'package:omi/services/wals/wal.dart';
 import 'package:omi/services/wals/wal_interfaces.dart';
 import 'package:omi/utils/wal_file_manager.dart';
@@ -25,8 +28,9 @@ import 'package:omi/utils/wal_file_manager.dart';
 ///      backoff. These tests document that retry cap is NOT enforced by
 ///      syncAll(), so the team knows it must be added separately.
 ///
-/// Tests avoid real HTTP by using WAL configurations where files.isEmpty is
-/// always true (null/missing paths), so syncLocalFilesV2 is never reached.
+/// Every upload attempt uses a deterministic local failure gate. The tests
+/// exercise the production state machine without live HTTP or wall-clock
+/// timeouts.
 
 class _MockListener implements IWalSyncListener {
   int walUpdatedCount = 0;
@@ -77,10 +81,25 @@ void main() {
 
     await WalFileManager.init();
     listener = _MockListener();
-    sync = LocalWalSyncImpl(listener);
+    SyncRateLimiter.instance.clear();
+    sync = LocalWalSyncImpl(
+      listener,
+      uploadGate: SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+          throw StateError('deterministic test upload failure');
+        },
+        fairUseStatusLoader: () async => {'stage': 'none'},
+      ),
+    );
   });
 
   tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    SyncRateLimiter.instance.clear();
     if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
   });
 
@@ -116,24 +135,25 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  // deleteAllPendingWals — miss + corrupted are both "pending"
+  // deleteAllPendingWals — terminal corruption stays visible for individual
+  // review/delete instead of being silently grouped with retryable work.
   // -------------------------------------------------------------------------
 
   group('deleteAllPendingWals', () {
-    test('removes miss and corrupted WALs but preserves synced', () async {
+    test('removes miss but preserves terminal corrupted and synced WALs', () async {
       final syncedWal = _makeWal(timerStart: 9000, status: WalStatus.synced, filePath: null);
+      final corruptedWal = _makeWal(timerStart: 2000, status: WalStatus.corrupted, filePath: null);
       sync.testWals = [
         _makeWal(timerStart: 1000, status: WalStatus.miss, filePath: null),
-        _makeWal(timerStart: 2000, status: WalStatus.corrupted, filePath: null),
+        corruptedWal,
         syncedWal,
       ];
 
       await sync.deleteAllPendingWals();
 
       final remaining = await sync.getAllWals();
-      expect(remaining.length, 1);
-      expect(remaining.first.status, WalStatus.synced);
-      expect(remaining.first.timerStart, 9000);
+      expect(remaining, containsAll([corruptedWal, syncedWal]));
+      expect(remaining, hasLength(2));
     });
 
     test('no-op when no pending WALs exist', () async {
@@ -143,14 +163,25 @@ void main() {
 
       expect((await sync.getAllWals()).length, 1);
     });
+
+    test('terminal clear removes only corrupted WALs', () async {
+      final missingWal = _makeWal(timerStart: 1000, status: WalStatus.miss, filePath: null);
+      final corruptedWal = _makeWal(timerStart: 2000, status: WalStatus.corrupted, filePath: null);
+      final syncedWal = _makeWal(timerStart: 3000, status: WalStatus.synced, filePath: null);
+      sync.testWals = [missingWal, corruptedWal, syncedWal];
+
+      await sync.deleteAllCorruptedWals();
+
+      expect(await sync.getAllWals(), containsAll([missingWal, syncedWal]));
+      expect(await sync.getAllWals(), hasLength(2));
+    });
   });
 
   // -------------------------------------------------------------------------
   // syncAll pre-upload file checks
   //
-  // Both cases below are "zombie miss" sub-types: the WAL passes the
-  // syncAll() miss filter but fails the file-existence check, so it is
-  // marked corrupted and no HTTP upload is attempted.
+  // Both cases below pass the syncAll() miss filter but fail local file
+  // validation, so they become terminal corruption before any upload.
   // -------------------------------------------------------------------------
 
   group('syncAll: pre-upload file validation', () {
@@ -174,6 +205,11 @@ void main() {
       // (OS cleanup, user cleared app storage, etc.).
       // The file does NOT exist in tempDir, so existsSync() returns false.
       final wal = _makeWal(timerStart: 2000, filePath: 'ghost_audio_2000.bin');
+      wal
+        ..isSyncing = true
+        ..syncStartedAt = DateTime.now()
+        ..syncEtaSeconds = 10
+        ..syncSpeedKBps = 12;
       sync.testWals = [wal];
 
       await sync.syncAll();
@@ -183,6 +219,12 @@ void main() {
         WalStatus.corrupted,
         reason: 'missing file must be marked corrupted, not silently re-queued',
       );
+      expect(await sync.getMissingWals(), isEmpty, reason: 'terminal corruption must leave the retry queue');
+      expect(await sync.syncAll(), isNull, reason: 'a second sync must not retry terminal corruption');
+      expect(wal.isSyncing, isFalse);
+      expect(wal.syncStartedAt, isNull);
+      expect(wal.syncEtaSeconds, isNull);
+      expect(wal.syncSpeedKBps, isNull);
     });
 
     test('corrupted WAL is excluded from syncAll retry pool', () async {
@@ -216,12 +258,8 @@ void main() {
 
     test('valid file on disk is NOT marked corrupted', () async {
       // Write an actual file so existsSync() returns true.
-      // syncAll() will then try to upload, but files.isNotEmpty means
-      // it would call syncLocalFilesV2 — we stop here and just verify
-      // the pre-check does not corrupt a valid WAL.
-      //
-      // NOTE: The actual upload is NOT tested here (requires HTTP mock).
-      // This test only exercises the file-existence guard path.
+      // syncAll() reaches the injected deterministic upload failure only after
+      // production file validation accepts the file.
       const filename = 'valid_audio_5000.bin';
       final file = File('${tempDir.path}/$filename');
       await file.writeAsBytes([0xAA, 0xBB]); // Any content — just needs to exist
@@ -229,20 +267,14 @@ void main() {
       final wal = _makeWal(timerStart: 5000, filePath: filename);
       sync.testWals = [wal];
 
-      // Attempt syncAll; it will try to upload but fail with a network error.
-      // We catch the error and only check that the WAL was NOT pre-marked corrupted.
-      try {
-        await sync.syncAll().timeout(const Duration(seconds: 3));
-      } catch (_) {
-        // Expected: network call fails in test environment
-      }
+      final result = await sync.syncAll();
 
-      // No server in test environment — upload fails, WAL stays miss.
+      expect(result?.localUploadFailures, 1);
       expect(
         sync.testWals.first.status,
         WalStatus.miss,
         reason: 'a WAL whose file exists must not be corrupted by pre-upload checks; '
-            'upload failure in this environment leaves it as miss',
+            'a failed upload leaves it retryable as miss',
       );
     });
   });
@@ -273,16 +305,15 @@ void main() {
       expect(wal.retryCount, 0);
       sync.testWals = [wal];
 
-      // syncAll() will reach syncLocalFilesV2, which fails (no server in test env).
+      // syncAll() reaches the deterministic local upload failure.
       // The catch block at local_wal_sync.dart:661 resets isSyncing but does NOT:
       //   - increment retryCount
       //   - change status
       //   - apply any backoff
-      try {
-        await sync.syncAll().timeout(const Duration(seconds: 5));
-      } catch (_) {}
+      final result = await sync.syncAll();
 
       final stuck = sync.testWals.first;
+      expect(result?.localUploadFailures, 1);
       expect(
         stuck.status,
         WalStatus.miss,
@@ -316,10 +347,9 @@ void main() {
       // syncAll will still attempt the upload — retryCount is never consulted.
       // We verify by observing that isSyncing is cleared after the attempt,
       // meaning syncAll processed the WAL (not skipped it).
-      try {
-        await sync.syncAll().timeout(const Duration(seconds: 5));
-      } catch (_) {}
+      final result = await sync.syncAll();
 
+      expect(result?.localUploadFailures, 1);
       expect(
         sync.testWals.first.isSyncing,
         false,


### PR DESCRIPTION
## Summary

- Keep terminal phone-WAL corruption out of retryable Pending queues while preserving it in the All/attention view and a distinct legacy Failed filter.
- Clear stale upload presentation when a WAL becomes terminal, and make Clear All deliberately remove terminal local WALs without redefining them as pending work.
- Replace the WAL upload-resilience tests' network-dependent timeouts with an injected deterministic upload gate and add a composed local-transition → provider/filter/bulk-clear regression.

## Failure class

Failure-Class: none

No existing registry class covers this mobile WAL state mismatch. The local uploader could correctly mark unreadable files as terminal while UI partitions and bulk cleanup still treated that state as retryable pending work. This PR makes the WAL model the canonical terminal transition, partitions terminal state explicitly, and exercises the production missing-file transition through UI-facing filters and clear actions.

## Verification

- `env FLUTTER_ROOT=/opt/homebrew/share/flutter /opt/homebrew/bin/dart --packages=/opt/homebrew/share/flutter/packages/flutter_tools/.dart_tool/package_config.json /opt/homebrew/share/flutter/packages/flutter_tools/bin/flutter_tools.dart test --no-pub test/unit/wal_sync_display_state_test.dart test/unit/wal_upload_resilience_test.dart test/providers/sync_provider_terminal_wal_state_test.dart` — 24 passed.
- `/opt/homebrew/bin/dart analyze lib/services/wals/wal.dart lib/services/wals/wal_interfaces.dart lib/services/wals/local_wal_sync.dart lib/services/wals/wal_syncs.dart lib/providers/sync_provider.dart lib/pages/conversations/sync_page.dart lib/pages/conversations/auto_sync_page.dart test/unit/wal_sync_display_state_test.dart test/unit/wal_upload_resilience_test.dart test/providers/sync_provider_terminal_wal_state_test.dart` — exit 0; only pre-existing informational lint hints.
- `make preflight`.
- `scripts/pr-preflight --pr-body-file /tmp/pr-6978-body.md`.

The normal local Flutter runner is blocked by the bundled Dart runtime stalling before startup on macOS 26.5.1; this uses the working system-Dart Flutter Tools path for the hermetic test set. CI remains the full-suite authority.

## Product invariants affected

None.

Closes #6978


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

