### PR TITLE
Return the actual newest X posts when filtering by kind

### DIFF
--- a/backend/database/x_posts.py
+++ b/backend/database/x_posts.py
@@ -126,7 +126,7 @@ def get_x_posts(uid: str, limit: int = 100, kind: Optional[str] = None) -> List[
     coll = _posts_ref(uid)
     if kind:
         docs: List[Dict[str, Any]] = []
-        for d in coll.where(filter=FieldFilter('kind', '==', kind)).limit(limit * 3).stream():
+        for d in coll.where(filter=FieldFilter('kind', '==', kind)).stream():
             raw: object = d.to_dict()
             if isinstance(raw, dict):
                 docs.append(cast(Dict[str, Any], raw))

--- a/backend/tests/unit/test_x_posts_kind_filter_limit_before_sort.py
+++ b/backend/tests/unit/test_x_posts_kind_filter_limit_before_sort.py
@@ -1,0 +1,103 @@
+"""Regression test: get_x_posts(kind=...) must sort before truncating, not after.
+
+database.x_posts.get_x_posts's kind-filtered branch runs:
+
+    coll.where(filter=FieldFilter('kind', '==', kind)).limit(limit * 3).stream()
+
+with no ``order_by`` (a kind filter + order_by would need a new composite
+index, so the module deliberately sorts in Python instead -- see the
+function's own docstring). But ``.limit()`` without a matching ``order_by``
+returns an ARBITRARY ``limit * 3`` matching documents, not the newest ones --
+Firestore is free to return matches in any order (in practice, often
+insertion/document-id order, and these documents are keyed by tweet
+snowflake id, which increases over time, i.e. oldest-first). Once an account
+has more than ``limit * 3`` posts of a kind, the true newest posts can fall
+outside that arbitrary pre-sort window and never reach the Python sort at
+all. GET /v1/x/posts (routers/x_connector.py, docstring: "newest first") and
+the MCP tool get_x_posts then silently return stale posts instead of the
+newest ones, with no error.
+
+The fix drops the premature ``.limit(limit * 3)`` so every matching document
+is sorted before the final ``limit`` slice -- matching the sibling
+(non-kind-filtered) branch two lines down, which already orders at the
+Firestore level before limiting.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import database.x_posts as x_posts
+
+
+class _FakeDoc:
+    def __init__(self, doc_id, data):
+        self.id = doc_id
+        self._data = data
+
+    def to_dict(self):
+        return self._data
+
+
+class _FakeKindQuery:
+    """Mimics coll.where(kind==X)[.limit(n)].stream() with no order_by.
+
+    Firestore gives no ordering guarantee absent an explicit order_by. This
+    fake models that by streaming matches in insertion order (oldest tweet
+    id first) and genuinely truncating on `.limit(n)` -- exactly like
+    Firestore truncates before any Python-side sort ever gets a chance to
+    run. It records the calls made so the test can assert what was actually
+    asked of "Firestore", not just what came back.
+    """
+
+    def __init__(self, docs):
+        self._docs = docs
+        self.limit_calls = []
+        self._limit = None
+
+    def where(self, **kwargs):
+        return self
+
+    def limit(self, n):
+        self.limit_calls.append(n)
+        self._limit = n
+        return self
+
+    def stream(self):
+        docs = self._docs if self._limit is None else self._docs[: self._limit]
+        return iter(docs)
+
+
+def _make_fake(monkeypatch, num_docs):
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    # id '0' is oldest, id '{num_docs-1}' is newest -- streamed oldest-first,
+    # the order Firestore returns absent an order_by on these doc-id-keyed,
+    # monotonically-increasing-over-time records.
+    docs = [
+        _FakeDoc(str(i), {'id': str(i), 'kind': 'tweet', 'created_at': base + timedelta(days=i)})
+        for i in range(num_docs)
+    ]
+    fake = _FakeKindQuery(docs)
+    monkeypatch.setattr(x_posts, '_posts_ref', lambda uid: fake)
+    return fake
+
+
+def test_kind_filter_returns_true_newest_beyond_prelimit_window(monkeypatch):
+    """10 tweets exist; limit=2 (pre-sort window would be 2*3=6) must still return the 2 newest."""
+    fake = _make_fake(monkeypatch, num_docs=10)
+
+    result = x_posts.get_x_posts('u1', limit=2, kind='tweet')
+
+    # True newest two tweets are ids '9' and '8'. The bug's pre-sort
+    # `.limit(2*3=6)` keeps only ids '0'..'5' (the SIX OLDEST out of 10), so
+    # the "newest" the Python sort can find among them tops out at id '5'.
+    assert [r['id'] for r in result] == ['9', '8']
+
+
+def test_kind_filter_within_prelimit_window_still_correct(monkeypatch):
+    """Sibling/normal-path sanity check: when matches fit inside the old *3 window, order is fine
+    either way -- this must pass both before and after the fix, proving the fix doesn't regress
+    the common case."""
+    fake = _make_fake(monkeypatch, num_docs=4)  # 4 <= limit*3 (2*3=6), fits in the old window too
+
+    result = x_posts.get_x_posts('u1', limit=2, kind='tweet')
+
+    assert [r['id'] for r in result] == ['3', '2']


### PR DESCRIPTION
`get_x_posts` promises "newest first" in its own docstring and again in the `GET /v1/x/posts`
docstring, but the kind-filtered branch cannot deliver it.

```python
for d in coll.where(filter=FieldFilter('kind', '==', kind)).limit(limit * 3).stream():
    ...
docs.sort(key=lambda x: str(x.get('created_at') or ''), reverse=True)
return docs[:limit]
```

Firestore gives no ordering guarantee without an explicit `order_by`, so `.limit(limit * 3)`
truncates to an **arbitrary** window of matching documents before the Python sort ever runs. Once
a user has more than `limit * 3` posts of that kind, the genuinely newest posts can fall entirely
outside that window and never reach the sort. The endpoint then returns older posts, correctly
sorted among themselves, with no error.

A user with 500 bookmarks calling `GET /v1/x/posts?kind=bookmark&limit=100` gets up to 300
arbitrarily selected bookmarks re-sorted, not their 100 newest.

The unfiltered branch three lines below already does it in the right order, ordering at the query
and then limiting:

```python
query = coll.order_by('created_at', direction=firestore.Query.DESCENDING).limit(limit)
```

## Why removing the limit is the right fix, not a new unbounded read

This is the part worth a second look, since dropping a `.limit()` normally deserves suspicion.
Removing it restores the approach this function's own docstring already describes:

> A kind filter + order_by would require a composite index, so when filtering by kind we use the
> single-field equality query (auto-indexed) and sort in Python — post volumes per user are small
> enough for this to be cheap.

The `.limit(limit * 3)` contradicted that documented approach while silently breaking the
ordering contract. The query shape is otherwise unchanged: still a single-field equality filter
on the same automatic index, so **no new index is required**.

Bounding the query properly instead would mean an `order_by` alongside the `kind` equality
filter, which needs a composite index this repo does not declare (`firestore.indexes.json` has no
`x_posts` entries at all). That is a serving-schema change, not a bug fix, so I am flagging it as
a follow-up rather than smuggling it in here. Worth doing if per-user post volumes ever stop
being small.

## Affected surfaces

Both registered unconditionally in `main.py`:

- `GET /v1/x/posts?kind=...` (`routers/x_connector.py`)
- the `get_x_posts` MCP tool (`routers/mcp_sse.py`)

## Tests

`tests/unit/test_x_posts_kind_filter_limit_before_sort.py`:

- with more posts than the old pre-sort window, the true newest are returned
- a kind filter whose matches fit inside the old window still returns the same result

The fake query builder records `.limit()` calls and truncates in insertion order, which is what
makes the unordered-limit behaviour observable in a hermetic test rather than only in production.

## Verification

Run in `backend/`:

- pytest new test plus `test_x_posts_sort_mixed_created_at.py`, `test_x_posts_list_endpoint.py`
  and `test_mcp_sse_pagination_bounds.py`: 14 passed
- prove-fail: with `database/x_posts.py` reverted to origin/main and confirmed byte-identical
  (`git diff origin/main` empty), the bug-path test fails with `assert ['5', '4'] == ['9', '8']`
  (ten posts, oldest to newest; `limit=2` should return the two newest, but the `limit=6` window
  only ever contains the six oldest), while the within-window test still passes both ways.
  Re-applied: 2 passed
- `black --line-length 120 --skip-string-normalization --check`: clean
- `pyright database/x_posts.py`: 0 errors
- `scripts/check_module_stub_pollution.py`: 736 files, 0 violations
- `database/x_posts.py` is not in the product file line-count ratchet baseline; line count
  unchanged at 184


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

