### PR TITLE
Anchor the usage endpoint's "today" to the user's timezone instead of the server's UTC day

### DIFF
--- a/backend/database/user_usage.py
+++ b/backend/database/user_usage.py
@@ -1,12 +1,16 @@
-from datetime import datetime, timezone
+import logging
+from datetime import datetime, time, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional, Tuple, cast
 
+import pytz
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
 from ._client import db
 from .firestore_read_metrics import FirestoreReadFamily, FirestoreReadMode, record_firestore_read
 from models.user_usage import UsageStats
+
+logger = logging.getLogger(__name__)
 
 
 def _typed_doc(doc: Any) -> Dict[str, Any]:
@@ -201,17 +205,39 @@ def batch_update_hourly_usage(uid: str, hourly_updates: Dict[datetime, Dict[str,
         batch.commit()
 
 
-def get_today_usage_stats(uid: str, date: datetime) -> Dict[str, Any]:
-    """Aggregates hourly usage stats for a given day from Firestore."""
+def get_today_usage_stats(uid: str, start: datetime, end: datetime) -> Dict[str, Any]:
+    """Aggregates hourly usage stats for the UTC bucket range [start, end).
+
+    The range may span two UTC calendar days when it represents the caller's
+    local "today" rather than a UTC day (see get_current_user_usage) — hourly
+    docs are written keyed by UTC date, so a user whose local midnight doesn't
+    land on a UTC midnight has their day's buckets split across two UTC dates.
+    """
     user_ref = db.collection('users').document(uid)
     hourly_usage_collection = user_ref.collection('hourly_usage')
 
-    query = (
-        hourly_usage_collection.where(filter=FieldFilter('year', '==', date.year))
-        .where(filter=FieldFilter('month', '==', date.month))
-        .where(filter=FieldFilter('day', '==', date.day))
-    )
-    return _aggregate_stats(query)
+    stats: Dict[str, Any] = {
+        'transcription_seconds': 0,
+        'words_transcribed': 0,
+        'insights_gained': 0,
+        'memories_created': 0,
+        'speech_seconds': 0,
+    }
+    cursor = start.replace(hour=0, minute=0, second=0, microsecond=0)
+    while cursor < end:
+        query = (
+            hourly_usage_collection.where(filter=FieldFilter('year', '==', cursor.year))
+            .where(filter=FieldFilter('month', '==', cursor.month))
+            .where(filter=FieldFilter('day', '==', cursor.day))
+        )
+        for doc in query.stream():
+            data = _typed_doc(doc)
+            bucket_hour = cursor.replace(hour=int(data.get('hour', 0)))
+            if start <= bucket_hour < end:
+                for key in stats:
+                    stats[key] += data.get(key, 0)
+        cursor += timedelta(days=1)
+    return stats
 
 
 def _aggregate_stats(query: Any) -> Dict[str, Any]:
@@ -414,13 +440,35 @@ def get_yearly_history(uid: str) -> List[Dict[str, Any]]:
     return history
 
 
-def get_current_user_usage(uid: str, period: str) -> Dict[str, Any]:
-    """Gets usage for the current user for a specific period from Firestore."""
-    now = datetime.now(timezone.utc)
+def get_current_user_usage(
+    uid: str, period: str, tz_name: Optional[str] = None, now: Optional[datetime] = None
+) -> Dict[str, Any]:
+    """Gets usage for the current user for a specific period from Firestore.
+
+    ``tz_name`` (IANA zone, e.g. "America/Los_Angeles") anchors period='today'
+    to the caller's local calendar day instead of the UTC calendar day. Without
+    it, users west of UTC see "today" reset hours before their real midnight,
+    and users east of UTC see the tail of their local yesterday counted as
+    "today" — since usage docs are written on UTC dates but this endpoint is
+    read by a user thinking in their own timezone.
+    """
+    now = now or datetime.now(timezone.utc)
     response: Dict[str, Any] = {}
 
     if period == 'today':
-        response['today'] = UsageStats(**get_today_usage_stats(uid, now)).model_dump()
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        end = start + timedelta(days=1)
+        if tz_name:
+            try:
+                user_tz = pytz.timezone(tz_name)
+                display_date = now.astimezone(user_tz).date()
+                start = user_tz.localize(datetime.combine(display_date, time.min)).astimezone(timezone.utc)
+                end = user_tz.localize(datetime.combine(display_date, time.max)).astimezone(timezone.utc)
+            except Exception as e:
+                # Keep serving the UTC day rather than failing the request, but say so: a stored
+                # zone we cannot parse is a data problem worth seeing, not something to swallow.
+                logger.error('usage today tz fallback to UTC uid=%s tz=%s: %s', uid, tz_name, e)
+        response['today'] = UsageStats(**get_today_usage_stats(uid, start, end)).model_dump()
         response['history'] = get_hourly_history_for_today(uid, now)
     elif period == 'monthly':
         response['monthly'] = UsageStats(**get_monthly_usage_stats(uid, now)).model_dump()

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1041,7 +1041,7 @@ def get_user_usage_stats_endpoint(
     period: UsagePeriod = UsagePeriod.TODAY,
 ):
     """Gets daily and monthly usage stats for the authenticated user."""
-    stats = user_usage_db.get_current_user_usage(uid, period.value)
+    stats = user_usage_db.get_current_user_usage(uid, period.value, tz_name=notification_db.get_user_time_zone(uid))
     return stats
 
 

--- a/backend/tests/unit/test_user_usage.py
+++ b/backend/tests/unit/test_user_usage.py
@@ -129,3 +129,101 @@ def test_monthly_usage_since_observes_every_scanned_hourly_document(mock_db, mon
 
     assert usage['transcription_seconds'] == 40
     assert observed == [(FirestoreReadFamily.LISTEN_MONTHLY_USAGE, FirestoreReadMode.UNBOUNDED, 2)]
+
+
+# ---------------------------------------------------------------------------
+# get_current_user_usage(period='today') — local-day vs UTC-day boundary
+#
+# hourly_usage docs are written keyed by UTC date (utils/analytics.py always
+# stamps `datetime.now(timezone.utc)`). A user behind UTC (e.g. LA, UTC-7 in
+# summer) has the first ~17 hours of their local calendar day stored under the
+# PREVIOUS UTC date. Querying only "the UTC date matching now" silently drops
+# that morning/afternoon usage from what the app displays as "Today".
+# ---------------------------------------------------------------------------
+
+
+class _HourlyQuery:
+    """Firestore query fake that actually applies '==' filters (unlike a bare
+    MagicMock), because get_today_usage_stats now issues a fresh where-chain
+    per UTC calendar day inside a loop and the two chains must select disjoint
+    subsets of `docs` for this test to mean anything."""
+
+    def __init__(self, docs, filters=()):
+        self._docs = docs
+        self._filters = filters
+
+    def where(self, filter):
+        return _HourlyQuery(self._docs, (*self._filters, filter))
+
+    def stream(self):
+        def _match(doc):
+            return all(doc.get(f.field_path) == f.value for f in self._filters)
+
+        return iter([_Snap(d) for d in self._docs if _match(d)])
+
+
+def _setup_hourly_docs(mock_db, docs):
+    mock_db.collection.return_value.document.return_value.collection.return_value = _HourlyQuery(docs)
+
+
+# 8pm local time on LA-calendar-day June 23rd, which is already 3am UTC on June 24th.
+_LA_EVENING_NOW = datetime(2026, 6, 24, 3, 0, tzinfo=timezone.utc)
+
+_LA_HOURLY_DOCS = [
+    # LA-local 2026-06-23 07:00 (7am) -- written under UTC 2026-06-23, the day
+    # BEFORE `now`'s UTC date. A UTC-day-only query misses this entirely.
+    {'year': 2026, 'month': 6, 'day': 23, 'hour': 14, 'transcription_seconds': 600},
+    # LA-local 2026-06-23 18:00 (6pm) -- written under UTC 2026-06-24, which
+    # happens to match `now`'s UTC date.
+    {'year': 2026, 'month': 6, 'day': 24, 'hour': 1, 'transcription_seconds': 300},
+    # LA-local 2026-06-22 20:00 (8pm the day BEFORE) -- must stay excluded from
+    # "today" no matter which boundary logic is used.
+    {'year': 2026, 'month': 6, 'day': 23, 'hour': 3, 'transcription_seconds': 12345},
+]
+
+
+def test_today_usage_local_day_spans_two_utc_dates_for_user_west_of_utc(mock_db):
+    _setup_hourly_docs(mock_db, _LA_HOURLY_DOCS)
+
+    result = user_usage.get_current_user_usage('uid', 'today', tz_name='America/Los_Angeles', now=_LA_EVENING_NOW)
+
+    # Correct local-day total: 600 (7am bucket) + 300 (6pm bucket) = 900.
+    # The pre-fix UTC-day-equality query only ever found the 300 bucket.
+    assert result['today']['transcription_seconds'] == 900, result['today']
+
+
+def test_today_usage_without_timezone_still_falls_back_to_utc_day(mock_db):
+    """No stored timezone -> unchanged UTC-day behavior (no regression for
+    users who never granted notification permissions / have no time_zone)."""
+    _setup_hourly_docs(mock_db, _LA_HOURLY_DOCS)
+
+    result = user_usage.get_current_user_usage('uid', 'today', tz_name=None, now=_LA_EVENING_NOW)
+
+    assert result['today']['transcription_seconds'] == 300, result['today']
+
+
+def test_usage_endpoint_serves_the_users_local_day_not_the_utc_day(mock_db, monkeypatch):
+    """Behavioural proof through the route the app actually calls.
+
+    The two tests above exercise the helper directly and so can only be written against the
+    tz-aware signature. This one goes through GET /v1/users/me/usage, which is the surface the
+    Flutter usage page hits, and therefore fails on unfixed source with a wrong total rather
+    than a signature error: the handler there never consults the stored timezone at all.
+    """
+    import routers.users as users_router
+
+    _setup_hourly_docs(mock_db, _LA_HOURLY_DOCS)
+    monkeypatch.setattr(users_router.notification_db, 'get_user_time_zone', lambda uid: 'America/Los_Angeles')
+
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return _LA_EVENING_NOW if tz is not None else _LA_EVENING_NOW.replace(tzinfo=None)
+
+    monkeypatch.setattr(user_usage, 'datetime', _FrozenDatetime)
+
+    result = users_router.get_user_usage_stats_endpoint(uid='uid')
+
+    # 600 (7am local, filed under the previous UTC date) + 300 (6pm local, filed under today's
+    # UTC date). Serving the UTC day alone finds only the 300.
+    assert result['today']['transcription_seconds'] == 900, result['today']

--- a/backend/tests/unit/test_user_usage.py
+++ b/backend/tests/unit/test_user_usage.py
@@ -21,6 +21,7 @@ os.environ.setdefault(
 
 from database import user_usage  # noqa: E402
 from database.firestore_read_metrics import FirestoreReadFamily, FirestoreReadMode  # noqa: E402
+from routers import users as users_router  # noqa: E402
 
 
 @pytest.fixture
@@ -209,8 +210,11 @@ def test_usage_endpoint_serves_the_users_local_day_not_the_utc_day(mock_db, monk
     tz-aware signature. This one goes through GET /v1/users/me/usage, which is the surface the
     Flutter usage page hits, and therefore fails on unfixed source with a wrong total rather
     than a signature error: the handler there never consults the stored timezone at all.
+
+    `routers.users` is imported at module scope like the other router-level unit tests. The
+    router graph is a heavy import, and paying it inside the test body charges ~26s of CPU to
+    this one test and trips the fast-unit duration guard.
     """
-    import routers.users as users_router
 
     _setup_hourly_docs(mock_db, _LA_HOURLY_DOCS)
     monkeypatch.setattr(users_router.notification_db, 'get_user_time_zone', lambda uid: 'America/Los_Angeles')


### PR DESCRIPTION
`GET /v1/users/me/usage?period=today` computes "today" from the server's UTC calendar day and
never consults the user's stored timezone — even though three other endpoints in this same
router already call `notification_db.get_user_time_zone(uid)` for exactly this "which calendar
day" question.

Hourly usage documents are written keyed by UTC date (`utils/analytics.py` stamps
`datetime.now(timezone.utc)`), so a user behind UTC has the first hours of their local day filed
under the **previous** UTC date. `get_today_usage_stats` queried a single UTC date by
`year`/`month`/`day` equality, so those hours were dropped.

A user in `America/Los_Angeles` checking usage at 8pm local sees only the hours since 5pm local
(UTC midnight). The rest of their day is silently missing from the Today cards on the Flutter
usage page (`app/lib/pages/settings/usage_page.dart` fetches this endpoint with
`period='today'`). Users east of UTC get the mirror image, with part of last night counted as
today.

## The fix

`get_today_usage_stats` now takes a `[start, end)` UTC range and walks the at-most-two UTC
calendar days it spans, summing only the hourly buckets inside the range.
`get_current_user_usage` takes an optional `tz_name` and derives that range from the user's local
midnight, using the same pytz idiom already present in `utils/other/notifications.py` and the
daily-summary endpoint in this router.

Without a stored timezone the behaviour is unchanged, so users with no timezone on file see
exactly what they saw before.

**The query shape is deliberately unchanged.** An id range or an `order_by` would have been a new
unregistered Firestore query shape, and the repo ratchets those
(`scripts/firestore_query_coverage.py`). Reusing the existing equality filters inside the loop
keeps that ratchet green — verified by running it, not assumed.

A timezone that fails to parse now logs and falls back to the UTC day rather than failing the
request. That branch previously swallowed the error silently; a stored zone the server cannot
parse is a data problem worth seeing.

## Known gap, deliberately not fixed here

The same response's `history` field (`get_hourly_history_for_today`) is **still keyed to the UTC
day**, so the hourly chart and the totals above it can disagree near the boundary. Making it
consistent means deciding whether the chart's hour labels become local hours, which changes what
clients render — a contract question rather than a bug fix. I would rather flag it than fold it
in silently. Happy to do it here if you would prefer them land together.

## Tests

`tests/unit/test_user_usage.py`:

- a local day spanning two UTC dates returns the full local-day total for a user west of UTC
- a user with no stored timezone still gets the old UTC-day behaviour
- the endpoint itself serves the local day, exercised through the route the app calls

The third is the behavioural one, and worth explaining. The first two can only be written against
the tz-aware signature, so on unfixed source they fail with a `TypeError` about the new keyword
rather than a wrong number — that proves the parameter is new, not that the old behaviour was
wrong. Going through the router instead produces a real value mismatch, because the handler there
never consults the timezone at all.

## Verification

Run in `backend/`:

- `pytest tests/unit/test_user_usage.py`: 7 passed
- prove-fail: with `database/user_usage.py` and `routers/users.py` reverted to origin/main and
  confirmed byte-identical (`git diff origin/main` empty), the endpoint test fails with
  `assert 300 == 900` — the 7am local bucket, filed under the previous UTC date, is dropped — and
  the four pre-existing tests in the file pass unchanged. Re-applied: 7 passed
- `black --line-length 120 --skip-string-normalization --check`: clean
- `pyright database/user_usage.py routers/users.py`: 0 errors
- `scripts/check_module_stub_pollution.py`: 735 files, 0 violations
- `scripts/scan_import_time_side_effects.py`: 717 files, 0 violations
- `scripts/scan_async_blockers.py --dirs routers utils`: clean
- `scripts/firestore_query_coverage.py --check-ratchet`: pass, no new query shape
- `routers/users.py` is 2046 lines, exactly its ratchet baseline, so no baseline change;
  `database/user_usage.py` is not in any ratchet shard


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

