### PR TITLE
fix(desktop): macOS bug audit cycle 3 — onboarding loop, task/OCR data integrity, backend auth/telemetry

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-rust.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-rust.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "desktop/macos/Backend-Rust/src/routes/proxy.rs": 2760
+    "desktop/macos/Backend-Rust/src/routes/proxy.rs": 2803
   },
   "raise_justifications": {
-    "desktop/macos/Backend-Rust/src/routes/proxy.rs": "Streaming Gemini Vertex->AI Studio token-failure heal now emits record_fallback with a Recovered/Exhausted outcome, matching the non-streaming provider-switch telemetry."
+    "desktop/macos/Backend-Rust/src/routes/proxy.rs": "Streaming Gemini Vertex->AI Studio heal telemetry now derives its Recovered/Exhausted outcome from the upstream HTTP status (a testable stream_heal_outcome helper) instead of send-success, matching the non-streaming provider-switch telemetry; adds a unit test."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-rust.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-rust.json
@@ -1,7 +1,9 @@
 {
   "files": {
-    "desktop/macos/Backend-Rust/src/routes/proxy.rs": 2741
+    "desktop/macos/Backend-Rust/src/routes/proxy.rs": 2760
   },
-  "raise_justifications": {},
+  "raise_justifications": {
+    "desktop/macos/Backend-Rust/src/routes/proxy.rs": "Streaming Gemini Vertex->AI Studio token-failure heal now emits record_fallback with a Recovered/Exhausted outcome, matching the non-streaming provider-switch telemetry."
+  },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -4,7 +4,7 @@
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3643,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4448,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3243,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5510,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5518,
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1570
   },
   "raise_justifications": {
@@ -12,7 +12,7 @@
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "Rebase reconciliation applies the pinned swift-format to the main-branch app-detail safety fixes; runtime behavior is unchanged.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": "Tasks now bind first-load, loading, error, and retry state to the selected To Do or Done view so completed cache rows cannot suppress an active-view fetch.",
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": "The Load-more-tasks action reads displayTasks.last at execution time via loadMoreTapped() instead of force-unwrapping, so an emptied list no longer crashes the app.",
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": "Strict concurrency imports annotate legacy AppKit image usage without changing runtime behavior."
   },
   "threshold": 1500

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
@@ -1,11 +1,11 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1610,
+    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1621,
     "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3501,
     "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": 1856
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": "Decodes GRDB Int64 min/max aggregate columns via a fixed cast so score-range queries return values instead of always-nil defaults.",
+    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": "Surfaced task ids (backend id or local_<rowid>) resolve through one shared identity helper, so mutating an unsynced task no longer no-ops or throws recordNotFound.",
     "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
     "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": "Search-result rows load a downsampled ImageIO thumbnail instead of the full-resolution screenshot, so a long results list no longer retains full-size images behind a 120x80 view."
   },

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 2992
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 3026
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "Unsynced local_ task mutations skip backend calls that can only 404, and the auto-refresh reload limit is clamped to the backend's 500 cap so sessions with >500 tasks no longer 422 on every refresh."
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "Unsynced local_ task mutations skip backend calls that can only 404; the auto-refresh reload limit is clamped to the backend's 500 cap; and undo-restore re-creates a task with its full field set (source, category, tags, recurrence, goal/workstream, completion) instead of only description/dueAt/priority."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 3026
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 3117
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "Unsynced local_ task mutations skip backend calls that can only 404; the auto-refresh reload limit is clamped to the backend's 500 cap; and undo-restore re-creates a task with its full field set (source, category, tags, recurrence, goal/workstream, completion) instead of only description/dueAt/priority."
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "Unsynced local_ task mutations skip backend calls that can only 404; auto-refresh clamps only the API page to the 500 cap while the local reload keeps every loaded row (no >500 truncation); undo-restore of a local-only task re-inserts one unsynced local row instead of fabricating a synced backend id + duplicate; retry-sync carries completed state; and undo-restore re-creates with the full field set."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 2982
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 2992
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "Mutations on unsynced local_ tasks now skip backend calls that can only 404, so a guaranteed rollback no longer reverts the user's local toggle/edit/delete."
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "Unsynced local_ task mutations skip backend calls that can only 404, and the auto-refresh reload limit is clamped to the backend's 500 cap so sessions with >500 tasks no longer 422 on every refresh."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 2961
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 2982
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "To Do and Done now retain independent load and error state so an aggregate cache cannot mask the selected view's fetch result."
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "Mutations on unsynced local_ tasks now skip backend calls that can only 404, so a guaranteed rollback no longer reverts the user's local toggle/edit/delete."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Backend-Rust/src/routes/crisp.rs
+++ b/desktop/macos/Backend-Rust/src/routes/crisp.rs
@@ -11,7 +11,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
 use crate::auth::AuthUser;
@@ -24,8 +24,36 @@ pub type SessionCache = Arc<RwLock<HashMap<String, (String, Instant)>>>;
 
 const SESSION_CACHE_TTL_SECS: u64 = 3600; // 1 hour
 
+/// Hard cap on distinct cached emails. Without eviction the map grew by one
+/// entry per distinct authenticated email forever (unbounded memory). This is
+/// a safety backstop above the expiry sweep, not a working-set limit.
+const SESSION_CACHE_MAX_ENTRIES: usize = 50_000;
+
 pub fn new_session_cache() -> SessionCache {
     Arc::new(RwLock::new(HashMap::new()))
+}
+
+/// Remove entries older than `ttl` relative to `now`, then, if still above
+/// `max_entries`, drop the oldest until at the cap. Pure over the map with an
+/// injected `now` so the bound is testable without wall-clock.
+fn prune_sessions(
+    map: &mut HashMap<String, (String, Instant)>,
+    now: Instant,
+    ttl: Duration,
+    max_entries: usize,
+) {
+    map.retain(|_, (_, cached_at)| now.saturating_duration_since(*cached_at) < ttl);
+    if map.len() <= max_entries {
+        return;
+    }
+    let mut by_age: Vec<(String, Instant)> =
+        map.iter().map(|(k, (_, at))| (k.clone(), *at)).collect();
+    // Oldest first.
+    by_age.sort_by_key(|(_, at)| *at);
+    let excess = map.len() - max_entries;
+    for (key, _) in by_age.into_iter().take(excess) {
+        map.remove(&key);
+    }
 }
 
 /// Query parameters for unread check
@@ -96,10 +124,18 @@ async fn get_cached_session(cache: &SessionCache, email: &str) -> Option<String>
     None
 }
 
-/// Store a session_id in the cache.
+/// Store a session_id in the cache, pruning expired and over-cap entries so
+/// the map cannot grow without bound across distinct authenticated emails.
 async fn set_cached_session(cache: &SessionCache, email: String, session_id: String) {
+    let now = Instant::now();
     let mut map = cache.write().await;
-    map.insert(email, (session_id, Instant::now()));
+    map.insert(email, (session_id, now));
+    prune_sessions(
+        &mut map,
+        now,
+        Duration::from_secs(SESSION_CACHE_TTL_SECS),
+        SESSION_CACHE_MAX_ENTRIES,
+    );
 }
 
 /// Find session_id by searching conversation pages (expensive — up to 5 API calls).
@@ -301,4 +337,53 @@ async fn get_unread_messages(
 
 pub fn crisp_routes() -> Router<AppState> {
     Router::new().route("/v1/crisp/unread", get(get_unread_messages))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prune_removes_expired_entries() {
+        let ttl = Duration::from_secs(SESSION_CACHE_TTL_SECS);
+        let base = Instant::now();
+        let mut map = HashMap::new();
+        map.insert("fresh@x.com".to_string(), ("s1".to_string(), base));
+        map.insert(
+            "stale@x.com".to_string(),
+            (
+                "s2".to_string(),
+                base - Duration::from_secs(SESSION_CACHE_TTL_SECS + 1),
+            ),
+        );
+
+        prune_sessions(&mut map, base, ttl, SESSION_CACHE_MAX_ENTRIES);
+
+        assert!(map.contains_key("fresh@x.com"));
+        assert!(
+            !map.contains_key("stale@x.com"),
+            "expired entry must be evicted"
+        );
+    }
+
+    #[test]
+    fn prune_caps_map_size_dropping_oldest() {
+        let ttl = Duration::from_secs(SESSION_CACHE_TTL_SECS);
+        let base = Instant::now();
+        let mut map = HashMap::new();
+        // All within TTL, but more than the cap; oldest must go first.
+        for i in 0..10u64 {
+            map.insert(
+                format!("user{i}@x.com"),
+                (format!("s{i}"), base + Duration::from_millis(i)),
+            );
+        }
+
+        prune_sessions(&mut map, base + Duration::from_secs(1), ttl, 4);
+
+        assert_eq!(map.len(), 4, "map must be capped at max_entries");
+        // The 4 newest (i = 6..=9) survive; the 6 oldest are dropped.
+        assert!(map.contains_key("user9@x.com"));
+        assert!(!map.contains_key("user0@x.com"));
+    }
 }

--- a/desktop/macos/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/proxy.rs
@@ -889,6 +889,19 @@ async fn gemini_stream_proxy(
     ))
 }
 
+/// Fallback outcome for a Vertex-token → AI Studio streaming heal. Recovered
+/// only when the request was dispatched AND the upstream returned a success
+/// status; a send error or a non-success SSE status (AI Studio can accept the
+/// connection and still return 4xx/5xx) is Exhausted. Keeps the streaming heal
+/// consistent with the status-keyed non-streaming heal.
+fn stream_heal_outcome(send_succeeded: bool, status_is_success: bool) -> FallbackOutcome {
+    if send_succeeded && status_is_success {
+        FallbackOutcome::Recovered
+    } else {
+        FallbackOutcome::Exhausted
+    }
+}
+
 /// Non-BYOK streaming Gemini proxy: server key with Vertex AI / AI Studio routing.
 async fn gemini_stream_server_key(
     state: &AppState,
@@ -901,6 +914,13 @@ async fn gemini_stream_server_key(
     // Resolve provider route (same dispatch as non-streaming proxy)
     use crate::llm::model_qos::{resolve_route, Provider};
     let route = resolve_route(model, action);
+
+    // Track a Vertex-token → AI Studio heal so its fallback outcome can be
+    // recorded from the upstream HTTP status (below), not merely from whether
+    // the request was dispatched. AI Studio can accept the connection and still
+    // return a 4xx/5xx SSE error; recording Recovered on send success alone
+    // undercounts exhausted fallbacks (the non-streaming path keys off status).
+    let mut healed_from_vertex = false;
 
     // Build and send request: Vertex AI or AI Studio
     let upstream = if route.provider == Provider::VertexAi {
@@ -942,20 +962,12 @@ async fn gemini_stream_server_key(
                             .body(sanitized_body)
                             .send()
                             .await;
-                        // Mirror the non-streaming heal: a Vertex token failure
-                        // that reroutes to AI Studio is a real provider switch
-                        // and must emit fallback telemetry, not switch silently.
-                        record_fallback(
-                            "gemini_stream_proxy",
-                            "vertex_ai",
-                            "ai_studio",
-                            "auth",
-                            if healed.is_ok() {
-                                FallbackOutcome::Recovered
-                            } else {
-                                FallbackOutcome::Exhausted
-                            },
-                        );
+                        // A Vertex token failure that reroutes to AI Studio is a
+                        // real provider switch that must emit fallback telemetry.
+                        // The outcome is recorded below from the upstream HTTP
+                        // status so a 4xx/5xx SSE error counts as Exhausted, not
+                        // Recovered (mirrors the non-streaming heal).
+                        healed_from_vertex = true;
                         healed
                     } else {
                         tracing::error!(
@@ -998,6 +1010,23 @@ async fn gemini_stream_server_key(
             .send()
             .await
     };
+
+    // Record the Vertex → AI Studio heal outcome from the actual upstream
+    // result: Recovered only when the healed response carried a success status,
+    // Exhausted on any send error or non-success SSE status.
+    if healed_from_vertex {
+        let (send_ok, status_ok) = match &upstream {
+            Ok(resp) => (true, resp.status().is_success()),
+            Err(_) => (false, false),
+        };
+        record_fallback(
+            "gemini_stream_proxy",
+            "vertex_ai",
+            "ai_studio",
+            "auth",
+            stream_heal_outcome(send_ok, status_ok),
+        );
+    }
 
     let upstream = upstream.map_err(|e| map_upstream_error(e, "stream upstream request"))?;
 
@@ -1456,6 +1485,20 @@ mod tests {
         assert_eq!(vertex_to_ai_studio_fallback_reason(false, true), None);
         // Successful Vertex token path also must not emit fallback.
         assert_eq!(vertex_to_ai_studio_fallback_reason(true, false), None);
+    }
+
+    #[test]
+    fn stream_heal_outcome_keys_off_upstream_status_not_send() {
+        // Dispatched + success status → the heal actually recovered.
+        assert_eq!(stream_heal_outcome(true, true), FallbackOutcome::Recovered);
+        // AI Studio accepted the connection (send Ok) but returned a 4xx/5xx SSE
+        // error: the fallback did NOT recover — it is exhausted.
+        assert_eq!(stream_heal_outcome(true, false), FallbackOutcome::Exhausted);
+        // The heal request itself failed to send.
+        assert_eq!(
+            stream_heal_outcome(false, false),
+            FallbackOutcome::Exhausted
+        );
     }
 
     #[test]

--- a/desktop/macos/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/proxy.rs
@@ -935,13 +935,28 @@ async fn gemini_stream_server_key(
                         tracing::warn!("gemini_stream_proxy: Vertex AI token failed, falling back to API key: {}", e);
                         let upstream_url =
                             build_gemini_stream_url(effective_path, gemini_key, query);
-                        state
+                        let healed = state
                             .gemini_stream_client
                             .post(&upstream_url)
                             .header("content-type", "application/json")
                             .body(sanitized_body)
                             .send()
-                            .await
+                            .await;
+                        // Mirror the non-streaming heal: a Vertex token failure
+                        // that reroutes to AI Studio is a real provider switch
+                        // and must emit fallback telemetry, not switch silently.
+                        record_fallback(
+                            "gemini_stream_proxy",
+                            "vertex_ai",
+                            "ai_studio",
+                            "auth",
+                            if healed.is_ok() {
+                                FallbackOutcome::Recovered
+                            } else {
+                                FallbackOutcome::Exhausted
+                            },
+                        );
+                        healed
                     } else {
                         tracing::error!(
                             "gemini_stream_proxy: Vertex AI token error and no fallback: {}",

--- a/desktop/macos/Backend-Rust/src/routes/webhooks.rs
+++ b/desktop/macos/Backend-Rust/src/routes/webhooks.rs
@@ -16,6 +16,43 @@ use crate::AppState;
 
 type HmacSha256 = Hmac<Sha256>;
 
+/// Outcome of verifying a Sentry webhook HMAC signature against the body.
+#[derive(Debug, PartialEq, Eq)]
+enum SentrySignatureCheck {
+    Verified,
+    /// No signature header was present. With a secret configured this is an
+    /// unauthenticated request and must be rejected.
+    Missing,
+    Mismatch,
+    /// The configured secret could not initialize the HMAC key.
+    KeyError,
+}
+
+/// Verify a Sentry `sentry-hook-signature` header against the raw body using
+/// the configured client secret. Pure so the fail-closed contract is testable
+/// without an HTTP stack.
+fn verify_sentry_signature(
+    secret: &str,
+    body: &[u8],
+    signature: Option<&str>,
+) -> SentrySignatureCheck {
+    let signature = match signature {
+        Some(sig) => sig,
+        None => return SentrySignatureCheck::Missing,
+    };
+    let mut mac = match HmacSha256::new_from_slice(secret.as_bytes()) {
+        Ok(mac) => mac,
+        Err(_) => return SentrySignatureCheck::KeyError,
+    };
+    mac.update(body);
+    let expected = hex::encode(mac.finalize().into_bytes());
+    if expected == signature {
+        SentrySignatureCheck::Verified
+    } else {
+        SentrySignatureCheck::Mismatch
+    }
+}
+
 /// Sentry webhook issue payload
 #[derive(Deserialize)]
 struct SentryWebhookPayload {
@@ -77,29 +114,27 @@ async fn handle_sentry_webhook(
             .get("sentry-hook-signature")
             .and_then(|v| v.to_str().ok());
 
-        match signature {
-            Some(sig) => {
-                let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).map_err(|e| {
-                    tracing::error!("Sentry webhook: HMAC key error: {}", e);
-                    StatusCode::INTERNAL_SERVER_ERROR
-                })?;
-                mac.update(&body);
-                let expected = hex::encode(mac.finalize().into_bytes());
-
-                if expected != sig {
-                    tracing::warn!(
-                        "Sentry webhook: signature mismatch (expected={}, got={})",
-                        expected,
-                        sig
-                    );
-                    return Err(StatusCode::UNAUTHORIZED);
-                }
+        match verify_sentry_signature(secret, &body, signature) {
+            SentrySignatureCheck::Verified => {
                 tracing::info!("Sentry webhook: signature verified");
             }
-            None => {
+            SentrySignatureCheck::Missing => {
+                // A configured secret means Sentry signs every delivery. A
+                // request with no signature is unauthenticated and must not
+                // be allowed to create action items; failing open here let
+                // anyone who knew the URL forge feedback issues.
                 tracing::warn!(
-                    "Sentry webhook: no signature header, proceeding anyway (Sentry may omit it)"
+                    "Sentry webhook: secret configured but no signature header; rejecting"
                 );
+                return Err(StatusCode::UNAUTHORIZED);
+            }
+            SentrySignatureCheck::Mismatch => {
+                tracing::warn!("Sentry webhook: signature mismatch; rejecting");
+                return Err(StatusCode::UNAUTHORIZED);
+            }
+            SentrySignatureCheck::KeyError => {
+                tracing::error!("Sentry webhook: HMAC key error");
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
             }
         }
     } else {
@@ -711,5 +746,45 @@ mod tests {
         assert_eq!(body["created"], 0);
         assert_eq!(body["skipped"], 0);
         assert_eq!(body["total_fetched"], 0);
+    }
+
+    fn valid_sentry_signature(secret: &str, body: &[u8]) -> String {
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        hex::encode(mac.finalize().into_bytes())
+    }
+
+    #[test]
+    fn sentry_signature_missing_is_rejected_when_secret_configured() {
+        // Fail-closed: a configured secret means Sentry signs every delivery,
+        // so an unsigned request is unauthenticated and must not proceed.
+        assert_eq!(
+            verify_sentry_signature("shh", b"{\"action\":\"created\"}", None),
+            SentrySignatureCheck::Missing
+        );
+    }
+
+    #[test]
+    fn sentry_signature_valid_is_verified() {
+        let body = b"{\"action\":\"created\"}";
+        let sig = valid_sentry_signature("shh", body);
+        assert_eq!(
+            verify_sentry_signature("shh", body, Some(&sig)),
+            SentrySignatureCheck::Verified
+        );
+    }
+
+    #[test]
+    fn sentry_signature_wrong_secret_or_body_is_mismatch() {
+        let body = b"{\"action\":\"created\"}";
+        let sig = valid_sentry_signature("shh", body);
+        assert_eq!(
+            verify_sentry_signature("different", body, Some(&sig)),
+            SentrySignatureCheck::Mismatch
+        );
+        assert_eq!(
+            verify_sentry_signature("shh", b"tampered", Some(&sig)),
+            SentrySignatureCheck::Mismatch
+        );
     }
 }

--- a/desktop/macos/Desktop/Sources/Audio/BleAudioProcessor.swift
+++ b/desktop/macos/Desktop/Sources/Audio/BleAudioProcessor.swift
@@ -62,7 +62,6 @@ final class BleAudioProcessor {
   private var lastPacketIndex: Int = -1
   private var lastFrameId: Int = -1
   private var pendingFrame: [UInt8] = []
-  private var framesBuffer: [[UInt8]] = []
 
   // Statistics
   private var totalFramesProcessed: Int = 0
@@ -195,7 +194,6 @@ final class BleAudioProcessor {
     lastPacketIndex = -1
     lastFrameId = -1
     pendingFrame = []
-    framesBuffer = []
     decoder?.reset()
     logger.debug("Processor reset")
   }
@@ -297,7 +295,6 @@ final class BleAudioProcessor {
     guard !frameBytes.isEmpty else { return }
 
     totalFramesProcessed += 1
-    framesBuffer.append(frameBytes)
 
     // Decode and deliver
     let frameData = Data(frameBytes)

--- a/desktop/macos/Desktop/Sources/Audio/BleAudioService.swift
+++ b/desktop/macos/Desktop/Sources/Audio/BleAudioService.swift
@@ -27,6 +27,13 @@ final class BleAudioService: ObservableObject {
   private var audioStreamTask: Task<Void, Never>?
   private var cancellables = Set<AnyCancellable>()
 
+  /// Monotonic session token. `startProcessing` captures it after claiming the
+  /// slot and re-checks it after the `getAudioCodec()` await; `stopProcessing`
+  /// bumps it. A Stop/disconnect that lands during the codec await therefore
+  /// aborts the resumed start instead of re-arming `isProcessing` with the
+  /// handlers already torn down (or clobbering a newer session).
+  private var processingGeneration = 0
+
   // Audio delivery
   private var transcriptionService: TranscriptionService?
   private var audioDataHandler: ((Data) -> Void)?
@@ -62,13 +69,25 @@ final class BleAudioService: ObservableObject {
     // startProcessing calls cannot both pass the guard and double-create the
     // processor (the second would orphan the first's processor + stream task).
     isProcessing = true
+    processingGeneration &+= 1
+    let generation = processingGeneration
 
     self.transcriptionService = transcriptionService
     self.audioDataHandler = audioDataHandler
     self.rawFrameHandler = rawFrameHandler
 
-    // Get codec from device
+    // Get codec from device. For Omi/OpenGlass this awaits a BLE characteristic
+    // read, during which a Stop/disconnect can run on the main actor.
     let codec = await connection.getAudioCodec()
+
+    // If Stop landed during the codec await (isProcessing cleared, handlers
+    // dropped) or a newer session started, abandon this start rather than
+    // re-arming processing with torn-down state or clobbering the new session.
+    guard isProcessing, processingGeneration == generation else {
+      logger.info("startProcessing superseded during codec read; aborting stale start")
+      return
+    }
+
     currentCodec = codec
 
     // Check if codec is supported

--- a/desktop/macos/Desktop/Sources/Audio/BleAudioService.swift
+++ b/desktop/macos/Desktop/Sources/Audio/BleAudioService.swift
@@ -121,8 +121,9 @@ final class BleAudioService: ObservableObject {
 
       // The stream ended or errored. Run full cleanup (not just isProcessing =
       // false), otherwise the processor, Combine subscriptions, and handlers
-      // dangle and the session cannot cleanly restart.
-      await self?.handleAudioStreamEnded()
+      // dangle and the session cannot cleanly restart. This Task inherits the
+      // @MainActor isolation of BleAudioService, so the call is synchronous.
+      self?.handleAudioStreamEnded()
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Audio/BleAudioService.swift
+++ b/desktop/macos/Desktop/Sources/Audio/BleAudioService.swift
@@ -58,6 +58,10 @@ final class BleAudioService: ObservableObject {
       logger.warning("Already processing audio")
       return
     }
+    // Claim the slot synchronously, before the first await, so two overlapping
+    // startProcessing calls cannot both pass the guard and double-create the
+    // processor (the second would orphan the first's processor + stream task).
+    isProcessing = true
 
     self.transcriptionService = transcriptionService
     self.audioDataHandler = audioDataHandler
@@ -70,6 +74,8 @@ final class BleAudioService: ObservableObject {
     // Check if codec is supported
     if !AudioDecoderFactory.isSupported(codec) {
       logger.error("Unsupported audio codec: \(codec.name)")
+      // Release the claimed slot and drop the handlers captured above.
+      stopProcessing()
       return
     }
 
@@ -113,16 +119,24 @@ final class BleAudioService: ObservableObject {
         self?.logger.error("Audio stream error: \(error.localizedDescription)")
       }
 
-      await MainActor.run {
-        self?.isProcessing = false
-      }
+      // The stream ended or errored. Run full cleanup (not just isProcessing =
+      // false), otherwise the processor, Combine subscriptions, and handlers
+      // dangle and the session cannot cleanly restart.
+      await self?.handleAudioStreamEnded()
     }
   }
 
-  /// Stop processing audio
-  func stopProcessing() {
+  /// Full teardown after the device audio stream ends or errors on its own.
+  private func handleAudioStreamEnded() {
     guard isProcessing else { return }
+    logger.info("Audio stream ended; tearing down processing")
+    stopProcessing()
+  }
 
+  /// Stop processing audio. Idempotent: safe to call after the stream has
+  /// already ended (the old `guard isProcessing` early-return skipped cleanup
+  /// in exactly that case, leaving the session unrecoverable).
+  func stopProcessing() {
     audioStreamTask?.cancel()
     audioStreamTask = nil
     processor?.reset()

--- a/desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
+++ b/desktop/macos/Desktop/Sources/Bluetooth/Connections/LimitlessDeviceConnection.swift
@@ -29,7 +29,6 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
   private var buttonStreamSubject = PassthroughSubject<[UInt8], Never>()
 
   private var rxSubscription: Task<Void, Never>?
-  private var rawDataBuffer = [UInt8]()
 
   /// Fragment reassembly: index -> {seq -> payload}
   private var fragmentBuffer: [Int: [Int: [UInt8]]] = [:]
@@ -146,7 +145,6 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
       if isBatchMode {
         logger.debug("Batch mode - packet parse failed, data=\(data.count)b")
       }
-      rawDataBuffer.append(contentsOf: data)
       return
     }
 
@@ -951,7 +949,6 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
     guard isInitialized else { return }
 
     do {
-      rawDataBuffer.removeAll()
       fragmentBuffer.removeAll()
       completedFlashPages.removeAll()
       isBatchMode = true
@@ -974,7 +971,6 @@ final class LimitlessDeviceConnection: BaseDeviceConnection {
     guard isInitialized else { return }
 
     do {
-      rawDataBuffer.removeAll()
       fragmentBuffer.removeAll()
       completedFlashPages.removeAll()
       firstFlashPageTimestampMs = nil

--- a/desktop/macos/Desktop/Sources/Chat/RuntimeOwnerIdentity.swift
+++ b/desktop/macos/Desktop/Sources/Chat/RuntimeOwnerIdentity.swift
@@ -351,6 +351,7 @@ enum RuntimeOwnerIdentity {
     // it captured. New-owner mutations remain parked by the fence.
     await FileIndexerService.shared.invalidateCache()
     await RewindIndexer.shared.reset()
+    await OCREmbeddingService.shared.reset()
     await RewindStorage.shared.reset()
     await RewindDatabase.shared.retargetEffectiveOwner(to: nextOwner)
     await TranscriptionStorage.shared.invalidateCache()

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1182,7 +1182,7 @@ class PushToTalkManager: ObservableObject {
     // phrase from it. Applies to the omni and batch paths, which retain the
     // raw turn audio; live-Deepgram streams without buffering and already
     // returns empty on silence.
-    let isBatch = ShortcutSettings.shared.pttTranscriptionMode == .batch
+    let isBatch = ShortcutSettings.shared.effectivePTTTranscriptionMode == .batch
     if isOmniSTT || isBatch {
       batchAudioLock.lock()
       let turnAudio = batchAudioBuffer
@@ -1253,7 +1253,7 @@ class PushToTalkManager: ObservableObject {
       return
     }
 
-    let isBatchMode = ShortcutSettings.shared.pttTranscriptionMode == .batch
+    let isBatchMode = ShortcutSettings.shared.effectivePTTTranscriptionMode == .batch
 
     if isBatchMode {
       // Batch mode: send accumulated audio to pre-recorded API

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ScreenCaptureManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ScreenCaptureManager.swift
@@ -168,6 +168,10 @@ class ScreenCaptureManager {
   static func captureScreenWithDetailTiles() -> ChatScreenshotCapture? {
     guard let image = captureScreenImage() else { return nil }
     guard let directory = screenshotsDirectory() else { return nil }
+    // The capture_screen chat tool writes the full frame plus native-resolution
+    // detail tiles (multiple MB per call) and never deletes them. Sweep stale
+    // captures each time so ~/Documents/Omi/Screenshots cannot grow forever.
+    pruneOldScreenshots()
 
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
@@ -200,6 +204,38 @@ class ScreenCaptureManager {
     return ChatScreenshotCapture(fullImageURL: fullURL, tiles: tiles)
   }
 
+  /// Chat-tool screenshots older than this are swept on the next capture.
+  /// Tool captures are read by the model within the turn; a day of retention is
+  /// generous for any later reference.
+  static let screenshotRetention: TimeInterval = 24 * 60 * 60
+
+  /// Pure retention decision: which files (by last-modified date) are stale
+  /// relative to `now`. Extracted so the sweep policy is testable without disk.
+  static func staleScreenshotURLs(
+    _ files: [(url: URL, modified: Date)], now: Date, retention: TimeInterval
+  ) -> [URL] {
+    files.filter { now.timeIntervalSince($0.modified) > retention }.map(\.url)
+  }
+
+  private static func pruneOldScreenshots(now: Date = Date()) {
+    guard let directory = screenshotsDirectory() else { return }
+    let fileManager = FileManager.default
+    guard
+      let entries = try? fileManager.contentsOfDirectory(
+        at: directory, includingPropertiesForKeys: [.contentModificationDateKey])
+    else { return }
+    let dated: [(url: URL, modified: Date)] = entries.compactMap { url in
+      guard
+        let modified = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+          .contentModificationDate
+      else { return nil }
+      return (url, modified)
+    }
+    for url in staleScreenshotURLs(dated, now: now, retention: screenshotRetention) {
+      try? fileManager.removeItem(at: url)
+    }
+  }
+
   private static func screenshotsDirectory() -> URL? {
     let fileManager = FileManager.default
     guard let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
@@ -229,6 +265,7 @@ class ScreenCaptureManager {
   static func captureScreen() -> URL? {
     guard let data = captureScreenData() else { return nil }
     guard let directory = screenshotsDirectory() else { return nil }
+    pruneOldScreenshots()
 
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -362,6 +362,19 @@ class ShortcutSettings: ObservableObject {
     didSet { UserDefaults.standard.set(pttTranscriptionMode.rawValue, forKey: "shortcut_pttTranscriptionMode") }
   }
 
+  /// Transient, never-persisted override for the onboarding voice demo, which
+  /// forces `.live` only while its step is on screen. Persisting the forced
+  /// mode (as the demo used to, via `pttTranscriptionMode`'s didSet) meant a
+  /// quit/crash mid-step permanently corrupted the user's saved PTT mode.
+  /// Consumers read `effectivePTTTranscriptionMode`, not the stored property.
+  @Published var pttTranscriptionModeDemoOverride: PTTTranscriptionMode?
+
+  /// The PTT transcription mode in effect: the demo override when present,
+  /// otherwise the user's persisted preference.
+  var effectivePTTTranscriptionMode: PTTTranscriptionMode {
+    pttTranscriptionModeDemoOverride ?? pttTranscriptionMode
+  }
+
   /// When true, the floating bar can be repositioned by dragging. Off by default.
   @Published var draggableBarEnabled: Bool {
     didSet { UserDefaults.standard.set(draggableBarEnabled, forKey: "shortcut_draggableBarEnabled") }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -1785,6 +1785,14 @@ class TasksViewModel: ObservableObject {
     await loadMoreIfNeeded(currentTask: currentTask)
   }
 
+  /// Load-more button action. Reads `displayTasks.last` at execution time
+  /// inside the guard, so an empty list (the store can be reset between the
+  /// click and this Task running) is a no-op instead of a force-unwrap crash.
+  func loadMoreTapped() async {
+    guard let last = displayTasks.last else { return }
+    await loadMoreIfNeeded(currentTask: last)
+  }
+
   func loadMoreIfNeeded(currentTask: TaskActionItem) async {
     guard !isLoadingMoreGuard else { return }
     isLoadingMoreGuard = true
@@ -3367,7 +3375,7 @@ struct TasksPage: View {
               .padding(.vertical, OmiSpacing.sm)
             } else if !viewModel.isInFilteredMode && viewModel.hasMoreTasks {
               Button {
-                Task { await viewModel.loadMoreIfNeeded(currentTask: viewModel.displayTasks.last!) }
+                Task { await viewModel.loadMoreTapped() }
               } label: {
                 HStack(spacing: OmiSpacing.xs) {
                   Image(systemName: "arrow.down.circle")

--- a/desktop/macos/Desktop/Sources/OmiWAL/WALModel.swift
+++ b/desktop/macos/Desktop/Sources/OmiWAL/WALModel.swift
@@ -347,6 +347,69 @@ package enum OpusFrameValidator {
   }
 }
 
+// MARK: - WiFi Sync Frame Stream Parser
+
+/// Stateful parser for the device's WiFi-sync TCP byte stream.
+///
+/// The stream is laid out in fixed 440-byte blocks. Within a block a frame is
+/// `[size: UInt8][opus bytes…]`; a `0` size byte is padding that runs to the
+/// next 440-byte block boundary. Those boundaries are measured from the
+/// absolute start of the stream, so the parser must track how many stream
+/// bytes it has already consumed across calls: computing the boundary from a
+/// per-call buffer offset desyncs as soon as one incomplete frame is carried
+/// into the next chunk, after which every subsequent padding jump lands in the
+/// wrong place and audio is silently dropped.
+package struct WifiFrameStreamParser {
+  package static let blockSize = 440
+
+  /// Absolute number of stream bytes consumed and dropped before `buffer[0]`.
+  package private(set) var consumedStreamBytes = 0
+
+  package init() {}
+
+  /// Parse all complete frames from the front of `buffer`, returning the valid
+  /// Opus frames and the unparsed tail. Advances `consumedStreamBytes` by the
+  /// number of bytes consumed from the front of `buffer`; pass the returned
+  /// `remaining` (plus newly received bytes) back on the next call.
+  package mutating func parse(_ buffer: Data) -> (frames: [Data], remaining: Data) {
+    var frames: [Data] = []
+    let base = buffer.startIndex
+    var offset = 0  // relative to buffer[0]
+
+    while offset < buffer.count {
+      let sizeByte = Int(buffer[base + offset])
+
+      if sizeByte == 0 {
+        // Padding: skip to the next absolute 440-byte block boundary.
+        let absolute = consumedStreamBytes + offset
+        let nextAbsoluteBoundary = ((absolute / Self.blockSize) + 1) * Self.blockSize
+        let nextOffset = nextAbsoluteBoundary - consumedStreamBytes
+        if nextOffset <= buffer.count {
+          offset = nextOffset
+        } else {
+          break
+        }
+        continue
+      }
+
+      // Need the size byte plus the full payload.
+      guard offset + 1 + sizeByte <= buffer.count else { break }
+
+      let frameStart = base + offset + 1
+      let frameData = buffer.subdata(in: frameStart..<(frameStart + sizeByte))
+      if OpusFrameValidator.startsWithValidFrame(frameData) {
+        frames.append(frameData)
+      }
+      offset += 1 + sizeByte
+    }
+
+    consumedStreamBytes += offset
+    let remaining =
+      offset < buffer.count ? buffer.subdata(in: (base + offset)..<buffer.endIndex) : Data()
+    return (frames, remaining)
+  }
+}
+
 // MARK: - WiFi Sync Status
 
 /// WiFi sync status codes from device

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingGoalStepView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingGoalStepView.swift
@@ -112,7 +112,10 @@ struct OnboardingGoalStepView: View {
   private func saveGoalAndContinue() {
     guard shouldShowContinue, !coordinator.isSavingGoal else { return }
     Task {
-      coordinator.goalSaved = false
+      // Do not reset goalSaved here: saveGoalIfNeeded's `guard !goalSaved`
+      // is the only dedup protection, and createGoal has no idempotency key.
+      // Resetting it meant a retry after a completeIntro failure created a
+      // second backend goal.
       await coordinator.saveGoalIfNeeded()
       guard coordinator.goalSaved else { return }
       let completed = await coordinator.completeIntro(appState: appState)

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingPermissionStepView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingPermissionStepView.swift
@@ -1,6 +1,25 @@
 import OmiTheme
 import SwiftUI
 
+/// Decides what a permission step does once its permission reads granted.
+///
+/// A restart-carrying step must only offer "Reopen Omi" for a grant that
+/// happened during this app run. When the permission was already granted the
+/// moment the step appeared, the restart it needed has already happened (macOS
+/// "Quit & Reopen", or our own relaunch) — prompting again would loop the user
+/// through endless restarts.
+enum OnboardingRestartAdvancePolicy {
+  enum Action: Equatable {
+    case advance
+    case promptRestart
+  }
+
+  static func action(requiresRestart: Bool, grantedWhenStepAppeared: Bool) -> Action {
+    guard requiresRestart, !grantedWhenStepAppeared else { return .advance }
+    return .promptRestart
+  }
+}
+
 struct OnboardingPermissionStepView: View {
   @Environment(\.scenePhase) private var scenePhase
 
@@ -26,6 +45,7 @@ struct OnboardingPermissionStepView: View {
   @State private var isRequesting = false
   @State private var showReopenPrompt = false
   @State private var hasAutoAdvanced = false
+  @State private var grantedWhenStepAppeared = false
   @State private var advanceTask: Task<Void, Never>?
   @State private var screenRecordingRefreshTask: Task<Void, Never>?
   private let timer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
@@ -138,7 +158,12 @@ struct OnboardingPermissionStepView: View {
         }
       }
       .alert("Reopen Omi to finish", isPresented: $showReopenPrompt) {
-        Button("Reopen Omi") { appState.restartApp() }
+        Button("Reopen Omi") {
+          // Persist the step advance before relaunching, so the app resumes on
+          // the next step instead of re-entering this one and prompting again.
+          onContinue()
+          appState.restartApp()
+        }
         Button("Later", role: .cancel) { onContinue() }
       } message: {
         Text("Omi needs to reopen to apply the permissions you just granted.")
@@ -153,6 +178,7 @@ struct OnboardingPermissionStepView: View {
         screenRecordingRefreshTask?.cancel()
         coordinator.clearLastActionError()
         refreshPermissionState()
+        grantedWhenStepAppeared = isGranted
         if isGranted {
           scheduleAutoAdvance()
         }
@@ -184,11 +210,18 @@ struct OnboardingPermissionStepView: View {
       await MainActor.run {
         // The restart-carrying step (the last drag permission) offers the re-open
         // once granted, instead of silently advancing — one restart applies every
-        // deferred grant. Other steps just continue.
-        if requiresRestart {
+        // deferred grant. Other steps, and a step whose permission was already
+        // granted when it appeared (the restart already happened), just continue.
+        switch OnboardingRestartAdvancePolicy.action(
+          requiresRestart: requiresRestart, grantedWhenStepAppeared: grantedWhenStepAppeared)
+        {
+        case .promptRestart:
           PermissionDragGuidance.dismiss()
           showReopenPrompt = true
-        } else {
+        case .advance:
+          if requiresRestart {
+            PermissionDragGuidance.dismiss()
+          }
           onContinue()
         }
       }

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceDemoView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceDemoView.swift
@@ -16,7 +16,6 @@ struct OnboardingVoiceDemoView: View {
   @State private var observedShortcutPress = false
   @State private var waitingForResponse = false
   @State private var showContinue = false
-  @State private var previousTranscriptionMode: ShortcutSettings.PTTTranscriptionMode?
   @State private var outputReadiness: SystemAudioMuteController.OutputReadiness = .unavailable
 
   var body: some View {
@@ -112,14 +111,15 @@ struct OnboardingVoiceDemoView: View {
       if let barState = FloatingControlBarManager.shared.barState {
         PushToTalkManager.shared.setup(barState: barState)
       }
-      previousTranscriptionMode = shortcutSettings.pttTranscriptionMode
-      shortcutSettings.pttTranscriptionMode = .live
+      // Force live transcription for the demo via a transient, never-persisted
+      // override so a quit/crash mid-step can't corrupt the saved PTT mode.
+      shortcutSettings.pttTranscriptionModeDemoOverride = .live
       Task {
         await chatProvider.warmupBridge()
       }
     }
     .onDisappear {
-      shortcutSettings.pttTranscriptionMode = previousTranscriptionMode ?? .batch
+      shortcutSettings.pttTranscriptionModeDemoOverride = nil
       resetFloatingBarConversation()
       PushToTalkManager.shared.cleanup()
     }

--- a/desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
+++ b/desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
@@ -47,7 +47,17 @@ final class RealtimeOmniService: NSObject, @unchecked Sendable {
   private weak var delegate: RealtimeOmniServiceDelegate?
 
   private var task: URLSessionWebSocketTask?
-  private lazy var session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+  // A URLSession created with a delegate retains that delegate (self) until it
+  // is invalidated. Held as an optional so stop()/deinit can invalidate it and
+  // drop the retain — a lazy `let` would leak one service + session per turn.
+  private var session: URLSession?
+
+  private func ensureSession() -> URLSession {
+    if let session { return session }
+    let created = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+    session = created
+    return created
+  }
   private var isOpen = false
   private var terminated = false  // fire omniDidError at most once per turn
   private var pendingAudio: [Data] = []
@@ -112,7 +122,7 @@ final class RealtimeOmniService: NSObject, @unchecked Sendable {
       startNW(url: url)
       return
     }
-    let t = session.webSocketTask(with: request)
+    let t = ensureSession().webSocketTask(with: request)
     task = t
     t.resume()
     // Receive loop + session setup start from didOpenWithProtocol — touching
@@ -124,10 +134,18 @@ final class RealtimeOmniService: NSObject, @unchecked Sendable {
     task = nil
     nw?.cancel()
     nw = nil
+    // Break the URLSession→delegate(self) retain cycle so the service and its
+    // session don't leak once the turn ends.
+    session?.finishTasksAndInvalidate()
+    session = nil
     isOpen = false
     pendingAudio.removeAll()
     pendingAudioBytes = 0
     pendingCommit = false
+  }
+
+  deinit {
+    session?.invalidateAndCancel()
   }
 
   // MARK: - Network.framework transport (Gemini, HTTP/1.1 WebSocket)

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -8,10 +8,50 @@ private struct ActionItemMetadataPayload: @unchecked Sendable {
   init(_ value: [String: Any]) { self.value = value }
 }
 
+/// Identity of a task id surfaced to the UI: either a backend id, or
+/// "local_<rowid>" minted by `ActionItemRecord.toTaskActionItem()` for a row
+/// that has not synced to the backend yet (offline creation, failed create
+/// POST). Every storage or API path that receives a surfaced id must resolve
+/// both forms — filtering only on the `backendId` column silently no-ops (or
+/// throws `recordNotFound`) for unsynced rows.
+enum ActionItemTaskIdentity: Equatable {
+  case backend(String)
+  case localRow(Int64)
+
+  init(surfacedId: String) {
+    if surfacedId.hasPrefix("local_"), let rowId = Int64(surfacedId.dropFirst(6)) {
+      self = .localRow(rowId)
+    } else {
+      self = .backend(surfacedId)
+    }
+  }
+
+  /// True when the task exists only in the local database — there is no
+  /// backend row addressable by this id, so backend mutation calls with it
+  /// can only 404.
+  var isLocalOnly: Bool {
+    if case .localRow = self { return true }
+    return false
+  }
+}
+
 /// Actor-based storage manager for action items/tasks with bidirectional sync
 /// Provides local-first caching for fast startup and background sync with backend
 actor ActionItemStorage {
   static let shared = ActionItemStorage()
+
+  /// Resolve a surfaced task id (backend id or "local_<rowid>") to its record.
+  static func fetchRecord(_ database: Database, surfacedId: String) throws -> ActionItemRecord? {
+    switch ActionItemTaskIdentity(surfacedId: surfacedId) {
+    case .localRow(let rowId):
+      return try ActionItemRecord.fetchOne(database, key: rowId)
+    case .backend(let id):
+      return
+        try ActionItemRecord
+        .filter(Column("backendId") == id)
+        .fetchOne(database)
+    }
+  }
 
   private var _dbQueue: DatabasePool?
   private var _dbGeneration = -1
@@ -124,17 +164,12 @@ actor ActionItemStorage {
       }) ?? false
   }
 
-  /// Get a single action item by its backend ID
+  /// Get a single action item by its surfaced id (backend id or "local_<rowid>")
   func getLocalActionItem(byBackendId backendId: String) async throws -> TaskActionItem? {
     let db = try await ensureInitialized()
 
     return try await db.read { database in
-      guard
-        let record =
-          try ActionItemRecord
-          .filter(Column("backendId") == backendId)
-          .fetchOne(database)
-      else {
+      guard let record = try Self.fetchRecord(database, surfacedId: backendId) else {
         return nil
       }
       return record.toTaskActionItem()
@@ -938,12 +973,7 @@ actor ActionItemStorage {
     try await authorization.withCommitLease {
       try await db.write { database in
         try authorization.require()
-        guard
-          var record =
-            try ActionItemRecord
-            .filter(Column("backendId") == backendId)
-            .fetchOne(database)
-        else {
+        guard var record = try Self.fetchRecord(database, surfacedId: backendId) else {
           throw ActionItemStorageError.recordNotFound
         }
         record.completed = completed
@@ -977,12 +1007,7 @@ actor ActionItemStorage {
     try await authorization.withCommitLease {
       try await db.write { database in
         try authorization.require()
-        guard
-          var record =
-            try ActionItemRecord
-            .filter(Column("backendId") == backendId)
-            .fetchOne(database)
-        else {
+        guard var record = try Self.fetchRecord(database, surfacedId: backendId) else {
           throw ActionItemStorageError.recordNotFound
         }
         if let description = description {
@@ -1026,10 +1051,18 @@ actor ActionItemStorage {
       try await db.write { database in
         try authorization.require()
         for update in updates {
-          try database.execute(
-            sql: "UPDATE action_items SET sortOrder = ?, indentLevel = ?, updatedAt = ? WHERE backendId = ?",
-            arguments: [update.sortOrder, update.indentLevel, Date(), update.backendId]
-          )
+          switch ActionItemTaskIdentity(surfacedId: update.backendId) {
+          case .localRow(let rowId):
+            try database.execute(
+              sql: "UPDATE action_items SET sortOrder = ?, indentLevel = ?, updatedAt = ? WHERE id = ?",
+              arguments: [update.sortOrder, update.indentLevel, Date(), rowId]
+            )
+          case .backend(let backendId):
+            try database.execute(
+              sql: "UPDATE action_items SET sortOrder = ?, indentLevel = ?, updatedAt = ? WHERE backendId = ?",
+              arguments: [update.sortOrder, update.indentLevel, Date(), backendId]
+            )
+          }
         }
         try authorization.require()
       }
@@ -1075,10 +1108,9 @@ actor ActionItemStorage {
     try await authorization.withCommitLease {
       try await db.write { database in
         try authorization.require()
-        try database.execute(
-          sql: "DELETE FROM action_items WHERE backendId = ?",
-          arguments: [backendId]
-        )
+        if let record = try Self.fetchRecord(database, surfacedId: backendId) {
+          try record.delete(database)
+        }
         try authorization.require()
       }
     }
@@ -1479,18 +1511,7 @@ actor ActionItemStorage {
     try await authorization.withCommitLease {
       try await db.write { database in
         try authorization.require()
-        // Find by backendId, or by local ID (local_<rowid>)
-        var record: ActionItemRecord?
-        if taskId.hasPrefix("local_"), let localId = Int64(taskId.dropFirst(6)) {
-          record = try ActionItemRecord.fetchOne(database, key: localId)
-        } else {
-          record =
-            try ActionItemRecord
-            .filter(Column("backendId") == taskId)
-            .fetchOne(database)
-        }
-
-        guard var rec = record else {
+        guard var rec = try Self.fetchRecord(database, surfacedId: taskId) else {
           log("ActionItemStorage: updateAgentState - record not found for taskId \(taskId)")
           return
         }
@@ -1531,17 +1552,7 @@ actor ActionItemStorage {
     try await authorization.withCommitLease {
       try await db.write { database in
         try authorization.require()
-        var record: ActionItemRecord?
-        if taskId.hasPrefix("local_"), let localId = Int64(taskId.dropFirst(6)) {
-          record = try ActionItemRecord.fetchOne(database, key: localId)
-        } else {
-          record =
-            try ActionItemRecord
-            .filter(Column("backendId") == taskId)
-            .fetchOne(database)
-        }
-
-        guard var rec = record else { return }
+        guard var rec = try Self.fetchRecord(database, surfacedId: taskId) else { return }
 
         rec.agentStatus = nil
         rec.agentSessionName = nil

--- a/desktop/macos/Desktop/Sources/Rewind/Services/OCREmbeddingService.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/OCREmbeddingService.swift
@@ -37,6 +37,20 @@ actor OCREmbeddingService {
 
   private init() {}
 
+  /// Number of screenshots queued for the next batch flush (test introspection).
+  var pendingCount: Int { pendingItems.count }
+
+  /// Drop all owner-bound queued state. Called at the account-transition
+  /// boundary: queued items carry the previous owner's DB rowids and OCR
+  /// text, and flushing them after the pool retargets would write the
+  /// previous owner's embeddings into the next owner's database.
+  func reset() {
+    flushTask?.cancel()
+    flushTask = nil
+    pendingItems = []
+    recentHashes = []
+  }
+
   // MARK: - Text Formatting
 
   /// Format screenshot text for embedding: prepend app context for better retrieval

--- a/desktop/macos/Desktop/Sources/Rewind/Services/OCREmbeddingService.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/OCREmbeddingService.swift
@@ -25,6 +25,15 @@ actor OCREmbeddingService {
   private var pendingItems: [PendingItem] = []
   private var flushTask: Task<Void, Never>?
 
+  /// Monotonic owner generation. `reset()` bumps it at the account-transition
+  /// boundary; an in-flight `flushPendingEmbeddings()` captures the value it
+  /// started under and re-checks it after every `await` before writing, so a
+  /// flush that was already mid-flight when the pool retargeted discards its
+  /// stale batch instead of writing the previous owner's embeddings into the
+  /// next owner's database. Actors are re-entrant, so cancelling `flushTask`
+  /// and clearing `pendingItems` alone does not stop a running flush.
+  private var ownerGeneration = 0
+
   /// Content hashes of recently embedded texts to skip duplicates
   private var recentHashes: Set<String> = []
   private let maxRecentHashes = 5000
@@ -35,7 +44,29 @@ actor OCREmbeddingService {
   /// Max pending items before force-flushing (Gemini batch limit is 100)
   private let maxPendingItems = 100
 
-  private init() {}
+  /// Injectable dependencies for the flush path. Production wires these to the
+  /// live Gemini embedder and the Rewind database; tests inject a gated embedder
+  /// so the owner-reset re-entrancy window can be driven deterministically.
+  typealias BatchEmbedder = @Sendable (_ texts: [String], _ taskType: String?) async throws -> [[Float]]
+  typealias EmbeddingWriter = @Sendable (_ screenshotId: Int64, _ embedding: Data) async throws -> Void
+  private let batchEmbedder: BatchEmbedder
+  private let embeddingWriter: EmbeddingWriter
+
+  private init() {
+    self.batchEmbedder = { texts, taskType in
+      try await EmbeddingService.shared.embedBatch(texts: texts, taskType: taskType)
+    }
+    self.embeddingWriter = { screenshotId, embedding in
+      try await RewindDatabase.shared.updateScreenshotEmbedding(id: screenshotId, embedding: embedding)
+    }
+  }
+
+  /// Test-only initializer that injects the flush path's embedder and writer so
+  /// the owner-reset re-entrancy fence can be exercised without live services.
+  init(batchEmbedderForTesting: @escaping BatchEmbedder, embeddingWriterForTesting: @escaping EmbeddingWriter) {
+    self.batchEmbedder = batchEmbedderForTesting
+    self.embeddingWriter = embeddingWriterForTesting
+  }
 
   /// Number of screenshots queued for the next batch flush (test introspection).
   var pendingCount: Int { pendingItems.count }
@@ -45,6 +76,7 @@ actor OCREmbeddingService {
   /// text, and flushing them after the pool retargets would write the
   /// previous owner's embeddings into the next owner's database.
   func reset() {
+    ownerGeneration &+= 1
     flushTask?.cancel()
     flushTask = nil
     pendingItems = []
@@ -113,6 +145,12 @@ actor OCREmbeddingService {
 
     guard !pendingItems.isEmpty else { return }
 
+    // Snapshot the owner generation this flush started under. If `reset()` runs
+    // during any await below (actors are re-entrant), the captured value goes
+    // stale and we abandon the batch rather than writing the previous owner's
+    // embeddings into the next owner's database.
+    let generation = ownerGeneration
+
     // Take the current batch and clear the buffer
     let batch = pendingItems
     pendingItems = []
@@ -143,7 +181,15 @@ actor OCREmbeddingService {
 
       let texts = chunk.map { $0.formattedText }
       do {
-        let embeddings = try await EmbeddingService.shared.embedBatch(texts: texts, taskType: "RETRIEVAL_DOCUMENT")
+        let embeddings = try await batchEmbedder(texts, "RETRIEVAL_DOCUMENT")
+
+        // The embed call above suspended; if the owner retargeted while it was
+        // in flight, these rowids belong to the previous owner's database.
+        // Abandon the rest of the batch instead of cross-writing.
+        guard generation == ownerGeneration else {
+          log("OCREmbeddingService: Owner changed mid-flush — dropping \(chunk.count) stale items")
+          return
+        }
 
         for (i, embedding) in embeddings.enumerated() where i < chunk.count {
           let item = chunk[i]
@@ -152,7 +198,7 @@ actor OCREmbeddingService {
           // Apply embedding to all IDs that share this content hash
           let allIds = duplicateGroups[item.contentHash] ?? [item.id]
           for screenshotId in allIds {
-            try await RewindDatabase.shared.updateScreenshotEmbedding(id: screenshotId, embedding: data)
+            try await embeddingWriter(screenshotId, data)
           }
 
           // Track hash to skip future duplicates
@@ -172,7 +218,13 @@ actor OCREmbeddingService {
         )
       } catch {
         logError("OCREmbeddingService: Batch embed failed for \(chunk.count) items", error: error)
-        // Re-queue failed items for next flush
+        // Re-queue failed items for next flush — but only if we are still the
+        // same owner. Re-queueing across a retarget would seed the next owner's
+        // buffer with the previous owner's rowids.
+        guard generation == ownerGeneration else {
+          log("OCREmbeddingService: Owner changed mid-flush — not re-queueing \(chunk.count) stale items")
+          return
+        }
         pendingItems.append(contentsOf: chunk)
         startFlushTimerIfNeeded()
       }

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+ConversationModels.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+ConversationModels.swift
@@ -643,7 +643,12 @@ struct ConversationPhoto: Codable, Identifiable {
 }
 
 struct AppResponse: Codable, Identifiable {
-  var id: String { appId ?? UUID().uuidString }
+  // `id` is stored, not computed: a nil `app_id` (legacy summary results still
+  // carry it as null) must keep one stable identity for its lifetime. A
+  // computed `appId ?? UUID().uuidString` minted a fresh id on every read, so
+  // SwiftUI's Identifiable ForEach tore down and recreated the row on every
+  // diff — losing per-row @State (expansion, hover) and flashing transitions.
+  let id: String
   let appId: String?
   let content: String
 
@@ -655,12 +660,15 @@ struct AppResponse: Codable, Identifiable {
   /// Adapter from the generated wire DTO (OmiAPI.AppResult).
   init(_ wire: OmiAPI.AppResult) {
     self.appId = wire.appId
+    self.id = wire.appId ?? UUID().uuidString
     self.content = wire.content
   }
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    appId = try container.decodeIfPresent(String.self, forKey: .appId)
+    let decodedAppId = try container.decodeIfPresent(String.self, forKey: .appId)
+    appId = decodedAppId
+    id = decodedAppId ?? UUID().uuidString
     content = try container.decodeIfPresent(String.self, forKey: .content) ?? ""
   }
 }

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -195,6 +195,16 @@ class TasksStore: ObservableObject {
   private var completedOffset = 0
   private var deletedOffset = 0
   private let pageSize = 100  // Reduced from 1000 for better performance
+
+  /// Backend cap on `limit` for `GET /v1/action-items` (`le=500`). A request
+  /// above this returns HTTP 422 and the whole refresh fails, so any computed
+  /// reload limit must be clamped to it.
+  static let apiPageLimitCap = 500
+
+  /// Clamp a computed page limit to the range the backend accepts (1...500).
+  static func clampedApiPageLimit(_ requested: Int) -> Int {
+    min(max(requested, 1), apiPageLimitCap)
+  }
   private var hasLoadedIncomplete = false
   private var hasLoadedCompleted = false
   private var hasLoadedDeleted = false
@@ -439,7 +449,7 @@ class TasksStore: ObservableObject {
 
     // Silently sync and reload incomplete tasks (local-first, like Memories)
     do {
-      let reloadLimit = max(pageSize, incompleteTasks.count)
+      let reloadLimit = Self.clampedApiPageLimit(max(pageSize, incompleteTasks.count))
       let response = try await fetchPage(
         completed: false,
         offset: 0,

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -2322,7 +2322,13 @@ class TasksStore: ObservableObject {
     }
     guard isCurrent(lease) else { return }
 
-    // 6. Call API in background, revert on failure
+    // 6. Call API in background, revert on failure. An unsynced local-only
+    // task has no backend row — the call would 404 and wrongly revert the
+    // local toggle; the pending create-sync will push current row state.
+    if operationOverrides == nil, ActionItemTaskIdentity(surfacedId: task.id).isLocalOnly {
+      log("TasksStore: Skipped backend toggle for unsynced local task \(task.id)")
+      return
+    }
     do {
       let apiResult: TaskActionItem
       if let operationOverrides {
@@ -2649,7 +2655,12 @@ class TasksStore: ObservableObject {
       }
     }
 
-    // Hard-delete on backend in background
+    // Hard-delete on backend in background. Unsynced local-only tasks have
+    // no backend row to delete.
+    if ActionItemTaskIdentity(surfacedId: task.id).isLocalOnly {
+      log("TasksStore: Skipped backend delete for unsynced local task \(task.id)")
+      return
+    }
     do {
       try await APIClient.shared.deleteActionItem(
         id: task.id,
@@ -2770,7 +2781,12 @@ class TasksStore: ObservableObject {
       }
     }
 
-    // 3. Call API in background
+    // 3. Call API in background. Unsynced local-only tasks have no backend
+    // row; the pending create-sync pushes current row state instead.
+    if ActionItemTaskIdentity(surfacedId: task.id).isLocalOnly {
+      log("TasksStore: Skipped backend update for unsynced local task \(task.id)")
+      return
+    }
     do {
       let apiResult = try await APIClient.shared.updateActionItem(
         id: task.id,
@@ -2851,7 +2867,12 @@ class TasksStore: ObservableObject {
       }
     }
 
-    // 3. Call API in background
+    // 3. Call API in background. Unsynced local-only tasks have no backend
+    // row; the pending create-sync pushes current row state instead.
+    if ActionItemTaskIdentity(surfacedId: task.id).isLocalOnly {
+      log("TasksStore: Skipped backend tag update for unsynced local task \(task.id)")
+      return
+    }
     do {
       let apiResult = try await APIClient.shared.updateActionItem(
         id: task.id,
@@ -2914,8 +2935,8 @@ class TasksStore: ObservableObject {
       }
     }
 
-    // Hard-delete on backend in background
-    for id in ids {
+    // Hard-delete on backend in background (skip unsynced local-only ids)
+    for id in ids where !ActionItemTaskIdentity(surfacedId: id).isLocalOnly {
       do {
         try await APIClient.shared.deleteActionItem(
           id: id,

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -205,6 +205,16 @@ class TasksStore: ObservableObject {
   static func clampedApiPageLimit(_ requested: Int) -> Int {
     min(max(requested, 1), apiPageLimitCap)
   }
+
+  /// The two limits an auto-refresh needs. `api` is clamped to the backend cap
+  /// (an unclamped >500 request 422s). `local` is the full loaded count and
+  /// drives the local-cache reload + hasMore: it must NOT be clamped, or a user
+  /// who has paginated past 500 tasks would have every row beyond 500 dropped by
+  /// `mergeWithoutAdding` on every refresh, collapsing the list back to 500.
+  static func refreshLimits(pageSize: Int, loadedCount: Int) -> (api: Int, local: Int) {
+    let local = max(pageSize, loadedCount)
+    return (api: clampedApiPageLimit(local), local: local)
+  }
   private var hasLoadedIncomplete = false
   private var hasLoadedCompleted = false
   private var hasLoadedDeleted = false
@@ -449,11 +459,19 @@ class TasksStore: ObservableObject {
 
     // Silently sync and reload incomplete tasks (local-first, like Memories)
     do {
-      let reloadLimit = Self.clampedApiPageLimit(max(pageSize, incompleteTasks.count))
+      // The backend caps `limit` at 500, so the API page must be clamped (an
+      // unclamped >500 request 422s). But the LOCAL cache load below and the
+      // hasMore signal must use the full loaded count: reusing the clamped API
+      // limit for the local reload would drop every task past row 500 from a
+      // user who has paginated beyond it (mergeWithoutAdding removes current
+      // rows absent from its source), collapsing a 600+ list back to 500.
+      let limits = Self.refreshLimits(pageSize: pageSize, loadedCount: incompleteTasks.count)
+      let apiLimit = limits.api
+      let localReloadLimit = limits.local
       let response = try await fetchPage(
         completed: false,
         offset: 0,
-        limit: reloadLimit,
+        limit: apiLimit,
         lease: lease,
         operations: operations
       )
@@ -471,7 +489,7 @@ class TasksStore: ObservableObject {
       // (completed/deleted on mobile). Safe: only deletes synced records.
       // An empty page is reconciled only after the IDs endpoint confirms the
       // account truly has zero incomplete tasks (degraded-backend guard).
-      if response.items.count < reloadLimit {
+      if response.items.count < apiLimit {
         if response.items.isEmpty {
           if !incompleteTasks.isEmpty {
             _ = await reconcileConfirmedEmptyCloud(lease: lease, operations: operations)
@@ -491,10 +509,12 @@ class TasksStore: ObservableObject {
         }
       }
 
-      // Reload from local cache (respects local changes like completions/deletions)
+      // Reload from local cache (respects local changes like completions/deletions).
+      // Uses the unclamped local limit so a user paginated past 500 keeps every
+      // loaded row instead of being truncated by the backend's API cap.
       let mergedTasks = try await loadCachedTasks(
         scope: .incomplete,
-        limit: reloadLimit,
+        limit: localReloadLimit,
         offset: 0,
         lease: lease,
         operations: operations
@@ -527,7 +547,7 @@ class TasksStore: ObservableObject {
       } else {
         log("RENDER: Auto-refresh: no changes detected, skipping update")
       }
-      let newHasMore = mergedTasks.count >= reloadLimit
+      let newHasMore = mergedTasks.count >= localReloadLimit
       if hasMoreIncompleteTasks != newHasMore { hasMoreIncompleteTasks = newHasMore }
       await refreshDashboardCache(lease: lease, operations: operations)
     } catch {
@@ -1972,6 +1992,19 @@ class TasksStore: ObservableObject {
           authorizationSnapshot: lease.authorizationSnapshot
         )
         guard isCurrent(lease) else { return }
+        // createActionItem always posts completed:nil, so a task the user
+        // completed while it was still unsynced (offline / failed create) would
+        // be recreated on the backend as incomplete and resurrected on the next
+        // refresh. Push the completed state with a follow-up update.
+        if item.completed {
+          _ = try? await APIClient.shared.updateActionItem(
+            id: response.id,
+            completed: true,
+            expectedOwnerId: ownerID,
+            authorizationSnapshot: lease.authorizationSnapshot
+          )
+          guard isCurrent(lease) else { return }
+        }
         try await ActionItemStorage.shared.markSynced(
           id: localId,
           backendId: response.id,
@@ -2690,6 +2723,19 @@ class TasksStore: ObservableObject {
     expectedOwnerID: String? = nil
   ) async {
     guard let lease = captureOwnerLease(expectedOwnerID: expectedOwnerID) else { return }
+
+    // A local-only task never had a backend row (deleteTask skipped the backend
+    // delete). Restoring it through the backend-recreate path below is wrong on
+    // two counts: syncTaskActionItems([task]) would persist the "local_<rowid>"
+    // placeholder as a *synced* backendId, and createActionItem would mint a
+    // SECOND real backend task — leaving a duplicate/phantom row. Instead
+    // re-insert it as an UNSYNCED local row so the pending create-sync pushes it
+    // exactly once (carrying completion via retryUnsyncedItems).
+    if ActionItemTaskIdentity(surfacedId: task.id).isLocalOnly {
+      await restoreLocalOnlyTask(task, lease: lease)
+      return
+    }
+
     // 1. Re-insert into SQLite from the in-memory task object
     do {
       try await ActionItemStorage.shared.syncTaskActionItems(
@@ -2767,6 +2813,51 @@ class TasksStore: ObservableObject {
         logError("TasksStore: Failed to re-create task on backend (local restore preserved)", error: error)
       }
     }
+  }
+
+  /// Build the SQLite record for restoring a local-only task: an UNSYNCED row
+  /// (never carry the "local_<rowid>" placeholder as a backendId, or it becomes
+  /// a fabricated synced id) with the original rowid preserved so the surfaced
+  /// id is stable, and the delete flags cleared.
+  static func localOnlyRestoreRecord(from task: TaskActionItem) -> ActionItemRecord {
+    var record = ActionItemRecord.from(task)
+    record.backendId = nil
+    record.backendSynced = false
+    record.deleted = false
+    record.deletedBy = nil
+    if case .localRow(let rowId) = ActionItemTaskIdentity(surfacedId: task.id) {
+      record.id = rowId
+    } else {
+      record.id = nil
+    }
+    return record
+  }
+
+  /// Restore a hard-deleted local-only task as an unsynced local row, preserving
+  /// its original rowid so the surfaced "local_<rowid>" id is stable. No backend
+  /// recreate: the task never had a backend row, and the pending create-sync
+  /// (retryUnsyncedItems) is the single writer that pushes it to the backend.
+  private func restoreLocalOnlyTask(_ task: TaskActionItem, lease: OwnerOperationLease) async {
+    let record = Self.localOnlyRestoreRecord(from: task)
+    do {
+      try await ActionItemStorage.shared.insertLocalActionItem(
+        record,
+        authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
+      )
+    } catch {
+      if isCurrent(lease) {
+        logError("TasksStore: Failed to re-insert local-only task for undo", error: error)
+      }
+      return
+    }
+    guard isCurrent(lease) else { return }
+
+    if task.completed {
+      completedTasks.insert(task, at: 0)
+    } else {
+      incompleteTasks.insert(task, at: 0)
+    }
+    log("TasksStore: Restored local-only task via undo (unsynced, id: \(task.id))")
   }
 
   func updateTask(

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -2711,23 +2711,57 @@ class TasksStore: ObservableObject {
       incompleteTasks.insert(task, at: 0)
     }
 
-    // 3. Re-create on backend (hard-delete already removed it)
+    // 3. Re-create on backend (hard-delete already removed it). Pass the full
+    // field set — restore used to send only description/dueAt/priority, so undo
+    // silently dropped source, category, tags, recurrence, goal/workstream, and
+    // completion state.
     do {
+      var restoreMetadata: [String: Any] = [:]
+      if let existing = task.metadata,
+        let data = existing.data(using: .utf8),
+        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+      {
+        restoreMetadata = json
+      }
+      if !task.tags.isEmpty {
+        restoreMetadata["tags"] = task.tags
+      }
       let created = try await APIClient.shared.createActionItem(
         description: task.description,
         dueAt: task.dueAt,
+        source: task.source,
         priority: task.priority,
+        category: task.category,
+        metadataBox: restoreMetadata.isEmpty ? nil : ActionItemMetadataBox(restoreMetadata),
+        relevanceScore: task.relevanceScore,
+        recurrenceRule: task.recurrenceRule,
+        recurrenceParentId: task.recurrenceParentId,
+        goalId: task.goalId,
+        workstreamId: task.workstreamId,
         expectedOwnerId: lease.ownerID,
         authorizationSnapshot: lease.authorizationSnapshot
       )
       guard isCurrent(lease) else { return }
+      // createActionItem cannot set completion; restore the completed state of
+      // a task that was done when it was deleted via a follow-up update.
+      var resolved = created
+      if task.completed, !created.completed {
+        resolved =
+          (try? await APIClient.shared.updateActionItem(
+            id: created.id,
+            completed: true,
+            expectedOwnerId: lease.ownerID,
+            authorizationSnapshot: lease.authorizationSnapshot
+          )) ?? created
+        guard isCurrent(lease) else { return }
+      }
       // Update local record with new backend ID
       try await ActionItemStorage.shared.syncTaskActionItems(
-        [created],
+        [resolved],
         authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
       )
       guard isCurrent(lease) else { return }
-      log("TasksStore: Restored task via undo (new backend ID: \(created.id))")
+      log("TasksStore: Restored task via undo (new backend ID: \(resolved.id))")
     } catch {
       if isCurrent(lease) {
         logError("TasksStore: Failed to re-create task on backend (local restore preserved)", error: error)

--- a/desktop/macos/Desktop/Sources/WAL/WALService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALService.swift
@@ -1008,6 +1008,21 @@ final class WALService: ObservableObject {
     return wal
   }
 
+  /// Remove a just-created SD-card WAL that never received any data (a failed
+  /// or aborted sync). `createSdCardWal` reserves a `.miss` entry before the
+  /// download starts; leaving it after a failure permanently inflates the
+  /// persisted "pending" count. A WAL that downloaded frames has a `filePath`
+  /// (set by `writeFramesToDiskAndWait`) and is kept.
+  func removeSdCardWalIfEmpty(walId: String) {
+    guard let index = wals.firstIndex(where: { $0.id == walId }) else { return }
+    let wal = wals[index]
+    guard wal.storage == .sdcard, wal.status == .miss, wal.filePath == nil else { return }
+    wals.remove(at: index)
+    updatePendingWals()
+    saveWals()
+    logger.info("Removed empty SD card WAL after failed/aborted sync: \(walId)")
+  }
+
   /// Update WAL with downloaded data
   func updateWalWithDownloadedData(walId: String, downloadedBytes: Int, frames: [Data]) {
     guard let index = wals.firstIndex(where: { $0.id == walId }) else {

--- a/desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
@@ -458,6 +458,12 @@ final class WifiSyncService: ObservableObject {
       _ = await connection.stopWifiSync()
     }
 
+    // Drop the reserved SD-card WAL if this sync downloaded nothing, so a
+    // failed/aborted transfer doesn't leave a permanent phantom 'pending' entry.
+    if let wal = currentWal {
+      activeWalService.removeSdCardWalIfEmpty(walId: wal.id)
+    }
+
     isSyncing = false
     status = .off
     currentWal = nil

--- a/desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
@@ -291,6 +291,11 @@ final class WifiSyncService: ObservableObject {
     throw WifiSyncServiceError.timeout
   }
 
+  /// Hard timeout for establishing the TCP connection to the device AP. Without
+  /// it, an unreachable server leaves NWConnection in `.waiting` forever and the
+  /// sync hangs in the "syncing" state with no way out but Stop.
+  static let tcpConnectTimeout: TimeInterval = 20
+
   private func connectTCP(host: String, port: UInt16) async throws {
     let endpoint = NWEndpoint.hostPort(
       host: NWEndpoint.Host(host),
@@ -301,21 +306,36 @@ final class WifiSyncService: ObservableObject {
     self.tcpConnection = connection
 
     return try await withCheckedThrowingContinuation { continuation in
+      // Both the state handler and the timeout run on .main, so a plain flag
+      // guarantees the continuation resumes exactly once.
+      var isResumed = false
+      func resumeOnce(_ result: Result<Void, Error>) {
+        guard !isResumed else { return }
+        isResumed = true
+        connection.stateUpdateHandler = nil
+        switch result {
+        case .success: continuation.resume()
+        case .failure(let error): continuation.resume(throwing: error)
+        }
+      }
+
       connection.stateUpdateHandler = { [weak self] state in
         switch state {
         case .ready:
           self?.logger.info("TCP connection ready")
-          connection.stateUpdateHandler = nil
-          continuation.resume()
+          resumeOnce(.success(()))
 
         case .failed(let error):
           self?.logger.error("TCP connection failed: \(error.localizedDescription)")
-          connection.stateUpdateHandler = nil
-          continuation.resume(throwing: WifiSyncServiceError.connectionFailed)
+          resumeOnce(.failure(WifiSyncServiceError.connectionFailed))
+
+        case .waiting(let error):
+          // Unreachable server (e.g. the Mac never joined the device AP). Log
+          // and let the timeout backstop fire rather than waiting forever.
+          self?.logger.warning("TCP connection waiting: \(error.localizedDescription)")
 
         case .cancelled:
-          connection.stateUpdateHandler = nil
-          continuation.resume(throwing: CancellationError())
+          resumeOnce(.failure(CancellationError()))
 
         default:
           break
@@ -323,6 +343,13 @@ final class WifiSyncService: ObservableObject {
       }
 
       connection.start(queue: .main)
+
+      DispatchQueue.main.asyncAfter(deadline: .now() + Self.tcpConnectTimeout) { [weak self] in
+        guard !isResumed else { return }
+        self?.logger.error("TCP connection timed out after \(Self.tcpConnectTimeout)s")
+        connection.cancel()
+        resumeOnce(.failure(WifiSyncServiceError.timeout))
+      }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
@@ -60,13 +60,17 @@ final class WifiSyncService: ObservableObject {
   }
 
   private var tcpConnection: NWConnection?
-  private var syncTask: Task<Void, Never>?
+  private var syncTask: Task<Void, Error>?
   private var statusStreamTask: Task<Void, Never>?
 
   private var currentWal: WALEntry?
   private var downloadedFrames: [Data] = []
   private var totalBytesDownloaded = 0
   private var transferStartTime: Date?
+
+  /// Tracks the absolute stream position across chunks so 440-byte block
+  /// boundaries are computed from the stream start, not the per-chunk buffer.
+  private var frameParser = WifiFrameStreamParser()
 
   // Speed tracking
   private var speedSamples: [(timestamp: Date, bytes: Int)] = []
@@ -116,6 +120,29 @@ final class WifiSyncService: ObservableObject {
     isSyncing = true
     errorMessage = nil
     status = .off
+
+    // Run the transfer in an owned, cancellable task so stopSync() actually
+    // propagates cancellation into the awaiting steps (the handle used to be
+    // left nil, so Stop only tore down the TCP socket and left the flow
+    // running). The caller still awaits completion and receives thrown errors.
+    let task = Task { [weak self] () throws in
+      guard let self else { return }
+      try await self.performWifiSync(device: device, codec: codec, ssid: ssid, password: password)
+    }
+    syncTask = task
+    defer { if syncTask === task { syncTask = nil } }
+    try await task.value
+  }
+
+  private func performWifiSync(
+    device: BtDevice,
+    codec: String,
+    ssid: String?,
+    password: String?
+  ) async throws {
+    guard let connection = deviceProvider.activeConnection else {
+      throw WifiSyncServiceError.deviceNotConnected
+    }
 
     do {
       // Step 1: Setup WiFi if credentials provided
@@ -184,6 +211,9 @@ final class WifiSyncService: ObservableObject {
       // Note: On macOS, we need to use CWWiFiClient to connect to WiFi
       // For now, assume user has connected manually or use device's auto-generated AP
       logger.info("Connecting to device TCP server...")
+
+      // Bail before opening the socket if Stop was pressed during BLE setup.
+      try Task.checkCancellation()
 
       // Get device IP (typically 192.168.4.1 for ESP32 SoftAP)
       let deviceIP = "192.168.4.1"
@@ -304,6 +334,7 @@ final class WifiSyncService: ObservableObject {
     downloadedFrames = []
     totalBytesDownloaded = 0
     speedSamples = []
+    frameParser = WifiFrameStreamParser()
 
     var buffer = Data()
     let startTime = Date()
@@ -323,7 +354,7 @@ final class WifiSyncService: ObservableObject {
       totalBytesDownloaded += chunk.count
 
       // Parse frames from buffer
-      let (frames, remaining) = parseFrames(from: buffer)
+      let (frames, remaining) = frameParser.parse(buffer)
       buffer = remaining
 
       downloadedFrames.append(contentsOf: frames)
@@ -333,7 +364,7 @@ final class WifiSyncService: ObservableObject {
     }
 
     // Parse any remaining data
-    let (finalFrames, _) = parseFrames(from: buffer)
+    let (finalFrames, _) = frameParser.parse(buffer)
     downloadedFrames.append(contentsOf: finalFrames)
 
     logger.info("Received \(self.totalBytesDownloaded) bytes, \(self.downloadedFrames.count) frames")
@@ -355,53 +386,6 @@ final class WifiSyncService: ObservableObject {
         continuation.resume(returning: data ?? Data())
       }
     }
-  }
-
-  private func parseFrames(from data: Data) -> (frames: [Data], remaining: Data) {
-    var frames: [Data] = []
-    var offset = 0
-
-    while offset < data.count {
-      // Need at least 1 byte for frame size
-      guard offset < data.count else { break }
-
-      let frameSize = Int(data[offset])
-
-      // Check for end marker or padding
-      if frameSize == 0 {
-        // Skip to next block boundary (440 bytes)
-        let blockSize = 440
-        let currentBlock = offset / blockSize
-        let nextBlockStart = (currentBlock + 1) * blockSize
-        if nextBlockStart <= data.count {
-          offset = nextBlockStart
-        } else {
-          break
-        }
-        continue
-      }
-
-      offset += 1
-
-      // Check if we have enough data for this frame
-      guard offset + frameSize <= data.count else {
-        // Incomplete frame - return remaining data
-        offset -= 1
-        break
-      }
-
-      let frameData = data.subdata(in: offset..<(offset + frameSize))
-
-      // Validate Opus frame
-      if OpusFrameValidator.startsWithValidFrame(frameData) {
-        frames.append(frameData)
-      }
-
-      offset += frameSize
-    }
-
-    let remaining = offset < data.count ? data.subdata(in: offset..<data.count) : Data()
-    return (frames, remaining)
   }
 
   private func updateProgress() {

--- a/desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
@@ -130,7 +130,7 @@ final class WifiSyncService: ObservableObject {
       try await self.performWifiSync(device: device, codec: codec, ssid: ssid, password: password)
     }
     syncTask = task
-    defer { if syncTask === task { syncTask = nil } }
+    defer { syncTask = nil }
     try await task.value
   }
 
@@ -291,11 +291,6 @@ final class WifiSyncService: ObservableObject {
     throw WifiSyncServiceError.timeout
   }
 
-  /// Hard timeout for establishing the TCP connection to the device AP. Without
-  /// it, an unreachable server leaves NWConnection in `.waiting` forever and the
-  /// sync hangs in the "syncing" state with no way out but Stop.
-  static let tcpConnectTimeout: TimeInterval = 20
-
   private func connectTCP(host: String, port: UInt16) async throws {
     let endpoint = NWEndpoint.hostPort(
       host: NWEndpoint.Host(host),
@@ -306,36 +301,33 @@ final class WifiSyncService: ObservableObject {
     self.tcpConnection = connection
 
     return try await withCheckedThrowingContinuation { continuation in
-      // Both the state handler and the timeout run on .main, so a plain flag
-      // guarantees the continuation resumes exactly once.
-      var isResumed = false
-      func resumeOnce(_ result: Result<Void, Error>) {
-        guard !isResumed else { return }
-        isResumed = true
-        connection.stateUpdateHandler = nil
-        switch result {
-        case .success: continuation.resume()
-        case .failure(let error): continuation.resume(throwing: error)
-        }
-      }
-
+      // Resume the continuation directly in each terminal case and clear the
+      // handler on first resume so it fires exactly once (no shared mutable
+      // state, which strict concurrency rejects across the @Sendable handler).
       connection.stateUpdateHandler = { [weak self] state in
         switch state {
         case .ready:
           self?.logger.info("TCP connection ready")
-          resumeOnce(.success(()))
+          connection.stateUpdateHandler = nil
+          continuation.resume()
 
         case .failed(let error):
           self?.logger.error("TCP connection failed: \(error.localizedDescription)")
-          resumeOnce(.failure(WifiSyncServiceError.connectionFailed))
+          connection.stateUpdateHandler = nil
+          continuation.resume(throwing: WifiSyncServiceError.connectionFailed)
 
         case .waiting(let error):
-          // Unreachable server (e.g. the Mac never joined the device AP). Log
-          // and let the timeout backstop fire rather than waiting forever.
-          self?.logger.warning("TCP connection waiting: \(error.localizedDescription)")
+          // The device AP is unreachable (e.g. the Mac never joined it).
+          // NWConnection would sit in `.waiting` and retry forever, hanging
+          // the sync in "syncing" with no exit but Stop. Fail fast so the
+          // user can retry instead.
+          self?.logger.error("TCP connection unreachable: \(error.localizedDescription)")
+          connection.stateUpdateHandler = nil
+          continuation.resume(throwing: WifiSyncServiceError.connectionFailed)
 
         case .cancelled:
-          resumeOnce(.failure(CancellationError()))
+          connection.stateUpdateHandler = nil
+          continuation.resume(throwing: CancellationError())
 
         default:
           break
@@ -343,13 +335,6 @@ final class WifiSyncService: ObservableObject {
       }
 
       connection.start(queue: .main)
-
-      DispatchQueue.main.asyncAfter(deadline: .now() + Self.tcpConnectTimeout) { [weak self] in
-        guard !isResumed else { return }
-        self?.logger.error("TCP connection timed out after \(Self.tcpConnectTimeout)s")
-        connection.cancel()
-        resumeOnce(.failure(WifiSyncServiceError.timeout))
-      }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WifiSyncService.swift
@@ -230,11 +230,30 @@ final class WifiSyncService: ObservableObject {
       await finishSync()
 
     } catch {
+      // A user Stop (or a superseding sync) surfaces as a CancellationError —
+      // directly from our `Task.checkCancellation()` / thrown CancellationError
+      // steps, or indirectly as another error thrown from an await that the
+      // cancellation interrupted (hence the `Task.isCancelled` fallback). An
+      // intentional cancellation is NOT a failure: it must not set errorMessage
+      // and surface a "Recording Error"-style banner in StorageSyncView.
+      if Self.isCancellation(error, taskWasCancelled: Task.isCancelled) {
+        logger.info("WiFi sync cancelled by user")
+        await cleanup()
+        throw CancellationError()
+      }
       logger.error("WiFi sync failed: \(error.localizedDescription)")
       errorMessage = error.localizedDescription
       await cleanup()
       throw error
     }
+  }
+
+  /// Classifies a thrown sync error. A user-initiated Stop or a superseding sync
+  /// is a cancellation (never a user-facing error); everything else is a real
+  /// failure that should surface `errorMessage`. Pure so the intentional-Stop
+  /// vs. failure boundary is unit-testable without live BLE/TCP.
+  static func isCancellation(_ error: Error, taskWasCancelled: Bool) -> Bool {
+    error is CancellationError || taskWasCancelled
   }
 
   /// Stop WiFi sync

--- a/desktop/macos/Desktop/Tests/ActionItemLocalIdentityMutationTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemLocalIdentityMutationTests.swift
@@ -11,23 +11,23 @@ import XCTest
 /// delete matched zero rows and silently no-opped (the "deleted" task
 /// resurrected on next launch), and toggle/update threw `recordNotFound`.
 final class ActionItemLocalIdentityMutationTests: XCTestCase {
-  private var testUserId: String!
-  private var userDir: URL!
-
-  override func setUp() async throws {
-    try await super.setUp()
-
-    testUserId = "local-identity-test-\(UUID().uuidString)"
-    try await RewindDatabase.shared.switchUser(to: testUserId)
-    await ActionItemStorage.shared.invalidateCache()
-
-    let appSupport = FileManager.default
-      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-    userDir =
+  private let testUserId = "local-identity-test-\(UUID().uuidString)"
+  private lazy var userDir: URL? = {
+    guard
+      let appSupport = FileManager.default
+        .urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+    else { return nil }
+    return
       appSupport
       .appendingPathComponent("Omi", isDirectory: true)
       .appendingPathComponent("users", isDirectory: true)
       .appendingPathComponent(testUserId, isDirectory: true)
+  }()
+
+  override func setUp() async throws {
+    try await super.setUp()
+    try await RewindDatabase.shared.switchUser(to: testUserId)
+    await ActionItemStorage.shared.invalidateCache()
   }
 
   override func tearDown() async throws {

--- a/desktop/macos/Desktop/Tests/ActionItemLocalIdentityMutationTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemLocalIdentityMutationTests.swift
@@ -90,4 +90,42 @@ final class ActionItemLocalIdentityMutationTests: XCTestCase {
     let after = try await ActionItemStorage.shared.getLocalActionItem(byBackendId: surfacedId)
     XCTAssertEqual(after?.description, "edited description", "edit by surfaced local_ id must persist")
   }
+
+  /// Undoing the delete of a local-only task must re-insert exactly one UNSYNCED
+  /// row — not fabricate a synced backend id from the "local_<rowid>" placeholder
+  /// and not create a duplicate. The pending create-sync remains the single
+  /// writer that gives it a real backend id.
+  func testRestoreLocalOnlyTaskReinsertsSingleUnsyncedRow() async throws {
+    let inserted = try await ActionItemStorage.shared.insertLocalActionItem(
+      ActionItemRecord(description: "offline completed task", source: "test"),
+      authorization: .unrestricted)
+    let surfacedId = inserted.toTaskActionItem().id
+    XCTAssertTrue(surfacedId.hasPrefix("local_"))
+
+    // Completed offline, before any sync.
+    try await ActionItemStorage.shared.updateCompletionStatus(
+      backendId: surfacedId, completed: true, authorization: .unrestricted)
+    guard let taskToRestore = try await ActionItemStorage.shared.getLocalActionItem(byBackendId: surfacedId)
+    else { return XCTFail("expected the completed local-only task") }
+    XCTAssertTrue(taskToRestore.completed)
+
+    // Delete removes the local row (deleteTask hard-deletes for a local_ id).
+    try await ActionItemStorage.shared.deleteActionItemByBackendId(
+      surfacedId, deletedBy: "user", authorization: .unrestricted)
+
+    // Restore via the store's local-only restore record.
+    let record = TasksStore.localOnlyRestoreRecord(from: taskToRestore)
+    XCTAssertNil(record.backendId, "must not carry the local_ placeholder as a backend id")
+    XCTAssertFalse(record.backendSynced, "restored local-only task stays unsynced")
+    XCTAssertEqual(record.completed, true, "completion state is preserved across restore")
+    try await ActionItemStorage.shared.insertLocalActionItem(record, authorization: .unrestricted)
+
+    let restored = try await ActionItemStorage.shared.getLocalActionItems(
+      limit: 100, offset: 0, completed: true)
+    let matches = restored.filter { $0.description == "offline completed task" }
+    XCTAssertEqual(matches.count, 1, "restore must produce exactly one row, never a duplicate")
+    XCTAssertTrue(
+      matches[0].id.hasPrefix("local_"),
+      "restored task stays an unsynced local_ task, not a fabricated backend id")
+  }
 }

--- a/desktop/macos/Desktop/Tests/ActionItemLocalIdentityMutationTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemLocalIdentityMutationTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for mutating unsynced tasks surfaced with a
+/// "local_<rowid>" id.
+///
+/// A task created offline (or whose create POST failed) has no `backendId`
+/// yet, so `toTaskActionItem()` surfaces it as "local_<rowid>". The store's
+/// mutation paths used to address SQLite purely by the `backendId` column:
+/// delete matched zero rows and silently no-opped (the "deleted" task
+/// resurrected on next launch), and toggle/update threw `recordNotFound`.
+final class ActionItemLocalIdentityMutationTests: XCTestCase {
+  private var testUserId: String!
+  private var userDir: URL!
+
+  override func setUp() async throws {
+    try await super.setUp()
+
+    testUserId = "local-identity-test-\(UUID().uuidString)"
+    try await RewindDatabase.shared.switchUser(to: testUserId)
+    await ActionItemStorage.shared.invalidateCache()
+
+    let appSupport = FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+    userDir =
+      appSupport
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(testUserId, isDirectory: true)
+  }
+
+  override func tearDown() async throws {
+    await ActionItemStorage.shared.invalidateCache()
+    await RewindDatabase.shared.close()
+    if let userDir { try? FileManager.default.removeItem(at: userDir) }
+    RewindDatabase.currentUserId = nil
+    try await super.tearDown()
+  }
+
+  func testSurfacedIdParsing() {
+    XCTAssertEqual(ActionItemTaskIdentity(surfacedId: "local_42"), .localRow(42))
+    XCTAssertTrue(ActionItemTaskIdentity(surfacedId: "local_42").isLocalOnly)
+    XCTAssertEqual(ActionItemTaskIdentity(surfacedId: "abc123"), .backend("abc123"))
+    XCTAssertFalse(ActionItemTaskIdentity(surfacedId: "abc123").isLocalOnly)
+    // A malformed "local_" id that is not a rowid falls back to backend-id
+    // matching, preserving the pre-fix lookup behavior for odd backend ids.
+    XCTAssertEqual(ActionItemTaskIdentity(surfacedId: "local_x"), .backend("local_x"))
+  }
+
+  func testDeleteResolvesLocalSurfacedId() async throws {
+    // This isolated storage fixture deliberately has no runtime owner.
+    let inserted = try await ActionItemStorage.shared.insertLocalActionItem(
+      ActionItemRecord(description: "unsynced task to delete", source: "test"),
+      authorization: .unrestricted)
+    let surfacedId = inserted.toTaskActionItem().id
+    XCTAssertTrue(surfacedId.hasPrefix("local_"), "unsynced row must surface a local_ id")
+
+    try await ActionItemStorage.shared.deleteActionItemByBackendId(
+      surfacedId, deletedBy: "user", authorization: .unrestricted)
+
+    let after = try await ActionItemStorage.shared.getLocalActionItem(byBackendId: surfacedId)
+    XCTAssertNil(after, "delete by surfaced local_ id must remove the SQLite row, not no-op")
+  }
+
+  func testToggleCompletionResolvesLocalSurfacedId() async throws {
+    let inserted = try await ActionItemStorage.shared.insertLocalActionItem(
+      ActionItemRecord(description: "unsynced task to toggle", source: "test"),
+      authorization: .unrestricted)
+    let surfacedId = inserted.toTaskActionItem().id
+    XCTAssertTrue(surfacedId.hasPrefix("local_"))
+
+    try await ActionItemStorage.shared.updateCompletionStatus(
+      backendId: surfacedId, completed: true, authorization: .unrestricted)
+
+    let after = try await ActionItemStorage.shared.getLocalActionItem(byBackendId: surfacedId)
+    XCTAssertEqual(after?.completed, true, "toggle by surfaced local_ id must persist")
+  }
+
+  func testUpdateFieldsResolvesLocalSurfacedId() async throws {
+    let inserted = try await ActionItemStorage.shared.insertLocalActionItem(
+      ActionItemRecord(description: "unsynced task to edit", source: "test"),
+      authorization: .unrestricted)
+    let surfacedId = inserted.toTaskActionItem().id
+    XCTAssertTrue(surfacedId.hasPrefix("local_"))
+
+    try await ActionItemStorage.shared.updateActionItemFields(
+      backendId: surfacedId, description: "edited description", authorization: .unrestricted)
+
+    let after = try await ActionItemStorage.shared.getLocalActionItem(byBackendId: surfacedId)
+    XCTAssertEqual(after?.description, "edited description", "edit by surfaced local_ id must persist")
+  }
+}

--- a/desktop/macos/Desktop/Tests/AppResponseIdentityTests.swift
+++ b/desktop/macos/Desktop/Tests/AppResponseIdentityTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for `AppResponse` Identifiable stability.
+///
+/// `id` used to be `appId ?? UUID().uuidString` — a computed property that
+/// minted a fresh UUID on every read whenever `app_id` was null (legacy
+/// summary results still carry it as null). SwiftUI reads `.id` on every diff,
+/// so a nil-appId row got a brand-new identity each pass: rows were torn down
+/// and recreated, per-row @State was lost, and transitions flashed. `id` is now
+/// a stored property assigned once at decode time.
+final class AppResponseIdentityTests: XCTestCase {
+  func testNilAppIdKeepsStableIdentityAcrossReads() throws {
+    let json = Data(#"{"app_id": null, "content": "summary"}"#.utf8)
+    let response = try JSONDecoder().decode(AppResponse.self, from: json)
+    XCTAssertNil(response.appId)
+    XCTAssertEqual(response.id, response.id, "id must be stable across reads, not re-minted")
+  }
+
+  func testTwoNilAppIdRowsHaveDistinctIdentities() throws {
+    let json = Data(#"[{"app_id": null, "content": "a"}, {"app_id": null, "content": "b"}]"#.utf8)
+    let rows = try JSONDecoder().decode([AppResponse].self, from: json)
+    XCTAssertEqual(rows.count, 2)
+    XCTAssertNotEqual(rows[0].id, rows[1].id, "distinct rows must not collide on identity")
+  }
+
+  func testNonNilAppIdIsUsedAsIdentity() throws {
+    let json = Data(#"{"app_id": "assistant", "content": "hi"}"#.utf8)
+    let response = try JSONDecoder().decode(AppResponse.self, from: json)
+    XCTAssertEqual(response.id, "assistant")
+  }
+}

--- a/desktop/macos/Desktop/Tests/BleAudioServiceStartStopRaceTests.swift
+++ b/desktop/macos/Desktop/Tests/BleAudioServiceStartStopRaceTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for a Stop/disconnect that lands while `startProcessing`
+/// is awaiting the device's `getAudioCodec()` BLE read.
+///
+/// `startProcessing` claims the slot (`isProcessing = true`) synchronously, then
+/// suspends on `getAudioCodec()`. For Omi/OpenGlass that await is a real BLE
+/// characteristic read. A quick Stop during that window runs `stopProcessing()`
+/// on the main actor — clearing `isProcessing` and dropping the handlers. Before
+/// the generation fence, the resumed start re-armed `isProcessing` and created a
+/// processor with the handlers already nil, leaving a wedged session. The start
+/// must now detect it was superseded and abort.
+@MainActor
+final class BleAudioServiceStartStopRaceTests: XCTestCase {
+  override func tearDown() async throws {
+    BleAudioService.shared.stopProcessing()
+    try await super.tearDown()
+  }
+
+  func testStopDuringCodecReadAbortsResumedStart() async {
+    BleAudioService.shared.stopProcessing()
+
+    let entered = TestAsyncGate()
+    let release = TestAsyncGate()
+    let connection = SessionConnectionDouble(
+      device: bluetoothReliabilityTestDevice, sessionGeneration: 1)
+    connection.audioCodecEnteredGate = entered
+    connection.audioCodecReleaseGate = release
+
+    let start = Task { await BleAudioService.shared.startProcessing(from: connection) }
+
+    // The start has claimed the slot and is now suspended inside getAudioCodec().
+    await entered.wait()
+    XCTAssertTrue(BleAudioService.shared.isProcessing, "slot is claimed before the codec await returns")
+
+    // User presses Stop (or the device disconnects) during the codec read.
+    BleAudioService.shared.stopProcessing()
+    XCTAssertFalse(BleAudioService.shared.isProcessing, "Stop clears the processing slot")
+
+    // Let the codec read return; the resumed start must NOT re-arm processing.
+    await release.open()
+    await start.value
+
+    XCTAssertFalse(
+      BleAudioService.shared.isProcessing,
+      "a start superseded by Stop during the codec await must not re-arm processing")
+  }
+}

--- a/desktop/macos/Desktop/Tests/BleAudioServiceStartStopRaceTests.swift
+++ b/desktop/macos/Desktop/Tests/BleAudioServiceStartStopRaceTests.swift
@@ -16,7 +16,6 @@ import XCTest
 final class BleAudioServiceStartStopRaceTests: XCTestCase {
   override func tearDown() async throws {
     BleAudioService.shared.stopProcessing()
-    try await super.tearDown()
   }
 
   func testStopDuringCodecReadAbortsResumedStart() async {

--- a/desktop/macos/Desktop/Tests/BluetoothReliabilityTestSupport.swift
+++ b/desktop/macos/Desktop/Tests/BluetoothReliabilityTestSupport.swift
@@ -10,6 +10,27 @@ enum BluetoothReliabilityTestError: Error {
   case expected
 }
 
+/// One-shot async gate for deterministically driving suspension points in test
+/// doubles across executors. `wait()` suspends until the first `open()`. Actor
+/// isolation makes the cross-executor signalling data-race-free.
+actor TestAsyncGate {
+  private var isOpen = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func open() {
+    guard !isOpen else { return }
+    isOpen = true
+    let pending = waiters
+    waiters.removeAll()
+    for waiter in pending { waiter.resume() }
+  }
+
+  func wait() async {
+    if isOpen { return }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+}
+
 @MainActor
 final class AudioControllerHarness {
   var suspendStart = false
@@ -266,6 +287,13 @@ final class SessionConnectionDouble: DeviceConnection {
   var batteryLevel = -1
   var suspendBattery = false
   var batteryCallCount = 0
+
+  /// Optional gates to drive a suspending `getAudioCodec()` for start/stop race
+  /// tests: the double opens `audioCodecEnteredGate` when the call is reached
+  /// and awaits `audioCodecReleaseGate` before returning `audioCodec`.
+  var audioCodecEnteredGate: TestAsyncGate?
+  var audioCodecReleaseGate: TestAsyncGate?
+  var audioCodec: BleAudioCodec = .pcm8
   var batteryStreamCallCount = 0
   private var connectContinuation: CheckedContinuation<Void, Error>?
   private var disconnectContinuation: CheckedContinuation<Void, Never>?
@@ -345,7 +373,11 @@ final class SessionConnectionDouble: DeviceConnection {
     batteryStreamContinuation?.finish()
     batteryStreamContinuation = nil
   }
-  func getAudioCodec() async -> BleAudioCodec { .pcm8 }
+  func getAudioCodec() async -> BleAudioCodec {
+    await audioCodecEnteredGate?.open()
+    await audioCodecReleaseGate?.wait()
+    return audioCodec
+  }
   func getAudioStream() -> AsyncThrowingStream<Data, Error> {
     AsyncThrowingStream { $0.finish() }
   }

--- a/desktop/macos/Desktop/Tests/OCREmbeddingServiceOwnerResetTests.swift
+++ b/desktop/macos/Desktop/Tests/OCREmbeddingServiceOwnerResetTests.swift
@@ -52,4 +52,80 @@ final class OCREmbeddingServiceOwnerResetTests: XCTestCase {
     let pending = await OCREmbeddingService.shared.pendingCount
     XCTAssertEqual(pending, 0)
   }
+
+  /// The re-entrancy window: a flush that is already mid-embed when the owner
+  /// retargets must NOT resume and write the previous owner's rowids into the
+  /// next owner's database. `reset()` clearing the queue is not enough because
+  /// actors are re-entrant and an in-flight flush already captured its batch.
+  ///
+  /// Drives the exact interleave deterministically: the injected embedder
+  /// suspends the flush at its await, the test runs `reset()` during that
+  /// suspension, then releases the embedder. The generation fence must drop the
+  /// batch before the writer runs.
+  func testResetDuringInFlightFlushDropsStaleBatchBeforeWrite() async {
+    let dimension = EmbeddingService.embeddingDimension
+    let flushSuspended = AsyncGate()
+    let releaseEmbed = AsyncGate()
+    let writes = WriteSpy()
+
+    let service = OCREmbeddingService(
+      batchEmbedderForTesting: { texts, _ in
+        // Signal that the flush is now parked inside the embed await, then wait
+        // until the test has run reset() before returning results.
+        await flushSuspended.open()
+        await releaseEmbed.wait()
+        return texts.map { _ in [Float](repeating: 0, count: dimension) }
+      },
+      embeddingWriterForTesting: { screenshotId, _ in
+        await writes.record(screenshotId)
+      }
+    )
+
+    await service.embedScreenshot(
+      id: 500, ocrText: String(repeating: "previous owner text ", count: 3),
+      appName: "Notes", windowTitle: nil)
+
+    let flush = Task { await service.flushPendingEmbeddings() }
+
+    // Wait until the flush is suspended inside the embedder (batch + generation
+    // already captured), then retarget the owner.
+    await flushSuspended.wait()
+    await service.reset()
+
+    // Let the embed return. The fence must abandon the stale batch.
+    await releaseEmbed.open()
+    await flush.value
+
+    let recorded = await writes.ids
+    XCTAssertTrue(
+      recorded.isEmpty,
+      "a flush interrupted mid-embed by an owner reset must not write the previous owner's embeddings")
+    let pending = await service.pendingCount
+    XCTAssertEqual(pending, 0, "the stale batch must be dropped, not re-queued into the new owner's buffer")
+  }
+}
+
+/// One-shot async gate: `wait()` suspends until the first `open()`.
+private actor AsyncGate {
+  private var isOpen = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func open() {
+    guard !isOpen else { return }
+    isOpen = true
+    let pending = waiters
+    waiters.removeAll()
+    for waiter in pending { waiter.resume() }
+  }
+
+  func wait() async {
+    if isOpen { return }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+}
+
+/// Records screenshot rowids handed to the injected embedding writer.
+private actor WriteSpy {
+  private(set) var ids: [Int64] = []
+  func record(_ id: Int64) { ids.append(id) }
 }

--- a/desktop/macos/Desktop/Tests/OCREmbeddingServiceOwnerResetTests.swift
+++ b/desktop/macos/Desktop/Tests/OCREmbeddingServiceOwnerResetTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the OCR-embedding queue surviving account switch.
+///
+/// `OCREmbeddingService` is a process-lifetime singleton whose pending batch
+/// carries the previous owner's screenshot rowids and OCR-derived text. It
+/// used to be absent from `RuntimeOwnerIdentity.retargetOwnerBoundLocalStorage`,
+/// so its 60s flush (or the next semantic search) wrote the previous owner's
+/// embeddings into the next owner's Rewind database. `reset()` must drop all
+/// queued owner-bound state at the transition boundary.
+final class OCREmbeddingServiceOwnerResetTests: XCTestCase {
+  override func setUp() async throws {
+    try await super.setUp()
+    await OCREmbeddingService.shared.reset()
+  }
+
+  override func tearDown() async throws {
+    await OCREmbeddingService.shared.reset()
+    try await super.tearDown()
+  }
+
+  func testResetDropsPendingQueueAndDedupHashes() async {
+    let text = "sensitive on-screen text from the previous account, long enough to queue"
+    await OCREmbeddingService.shared.embedScreenshot(
+      id: 41, ocrText: text, appName: "Notes", windowTitle: "Draft")
+    var pending = await OCREmbeddingService.shared.pendingCount
+    XCTAssertEqual(pending, 1, "enqueue should buffer the screenshot")
+
+    await OCREmbeddingService.shared.reset()
+    pending = await OCREmbeddingService.shared.pendingCount
+    XCTAssertEqual(pending, 0, "owner-boundary reset must drop the previous owner's queue")
+
+    // The dedup hash set is also owner-bound state: identical text from the
+    // next owner must be embeddable again after reset.
+    await OCREmbeddingService.shared.embedScreenshot(
+      id: 7, ocrText: text, appName: "Notes", windowTitle: "Draft")
+    pending = await OCREmbeddingService.shared.pendingCount
+    XCTAssertEqual(pending, 1, "reset must clear recent-hash dedup state")
+
+    await OCREmbeddingService.shared.reset()
+  }
+
+  func testFlushAfterResetIsANoOp() async {
+    await OCREmbeddingService.shared.embedScreenshot(
+      id: 99, ocrText: String(repeating: "previous owner screen text ", count: 3),
+      appName: "Safari", windowTitle: nil)
+    await OCREmbeddingService.shared.reset()
+    // Must return without touching the (new owner's) database or network.
+    await OCREmbeddingService.shared.flushPendingEmbeddings()
+    let pending = await OCREmbeddingService.shared.pendingCount
+    XCTAssertEqual(pending, 0)
+  }
+}

--- a/desktop/macos/Desktop/Tests/OmiWALTests/WifiFrameStreamParserTests.swift
+++ b/desktop/macos/Desktop/Tests/OmiWALTests/WifiFrameStreamParserTests.swift
@@ -26,8 +26,7 @@ final class WifiFrameStreamParserTests: XCTestCase {
 
   func testPaddingBoundaryStaysAlignedAcrossChunkSplits() {
     // Three blocks, each one frame followed by padding.
-    let stream = paddedBlock(payloadLength: 10) + paddedBlock(payloadLength: 10)
-      + paddedBlock(payloadLength: 10)
+    let stream = (0..<3).reduce(into: Data()) { acc, _ in acc.append(paddedBlock(payloadLength: 10)) }
 
     // Feed the stream in awkward chunk sizes that split blocks mid-padding and
     // mid-frame — exactly the case that desynced the old buffer-relative math.

--- a/desktop/macos/Desktop/Tests/OmiWALTests/WifiFrameStreamParserTests.swift
+++ b/desktop/macos/Desktop/Tests/OmiWALTests/WifiFrameStreamParserTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+
+@testable import OmiWAL
+
+/// Regression coverage for `WifiFrameStreamParser` block-boundary tracking.
+///
+/// The device streams audio in fixed 440-byte blocks; a `0` size byte is
+/// padding that runs to the next block boundary. The parser used to compute
+/// that boundary from the per-call buffer offset, so once one incomplete frame
+/// was carried into the next chunk the boundary math desynced and every
+/// subsequent padding jump dropped audio. The parser now tracks the absolute
+/// stream offset across calls.
+final class WifiFrameStreamParserTests: XCTestCase {
+  private let toc: UInt8 = 0xb8  // a valid Opus TOC byte
+
+  /// Build one 440-byte block: a single `[size][opus…]` frame, zero-padded.
+  private func paddedBlock(payloadLength: Int) -> Data {
+    var block = Data()
+    block.append(UInt8(payloadLength))
+    block.append(toc)
+    block.append(contentsOf: Array(repeating: UInt8(0xaa), count: payloadLength - 1))
+    block.append(contentsOf: Array(repeating: UInt8(0), count: WifiFrameStreamParser.blockSize - block.count))
+    XCTAssertEqual(block.count, WifiFrameStreamParser.blockSize)
+    return block
+  }
+
+  func testPaddingBoundaryStaysAlignedAcrossChunkSplits() {
+    // Three blocks, each one frame followed by padding.
+    let stream = paddedBlock(payloadLength: 10) + paddedBlock(payloadLength: 10)
+      + paddedBlock(payloadLength: 10)
+
+    // Feed the stream in awkward chunk sizes that split blocks mid-padding and
+    // mid-frame — exactly the case that desynced the old buffer-relative math.
+    var parser = WifiFrameStreamParser()
+    var frames: [Data] = []
+    var buffer = Data()
+    for chunkStart in stride(from: 0, to: stream.count, by: 137) {
+      let end = min(chunkStart + 137, stream.count)
+      buffer.append(stream.subdata(in: chunkStart..<end))
+      let (parsed, remaining) = parser.parse(buffer)
+      frames.append(contentsOf: parsed)
+      buffer = remaining
+    }
+    let (tail, _) = parser.parse(buffer)
+    frames.append(contentsOf: tail)
+
+    XCTAssertEqual(frames.count, 3, "every block's frame must be recovered despite chunk splits")
+    XCTAssertEqual(parser.consumedStreamBytes, stream.count)
+    for frame in frames {
+      XCTAssertEqual(frame.first, toc)
+      XCTAssertEqual(frame.count, 10)
+    }
+  }
+
+  func testSinglePassParsesEveryBlock() {
+    let stream = (0..<5).reduce(into: Data()) { acc, _ in acc.append(paddedBlock(payloadLength: 20)) }
+    var parser = WifiFrameStreamParser()
+    let (frames, remaining) = parser.parse(stream)
+    XCTAssertEqual(frames.count, 5)
+    XCTAssertTrue(remaining.isEmpty)
+    XCTAssertEqual(parser.consumedStreamBytes, stream.count)
+  }
+
+  func testIncompleteTrailingFrameIsHeldAsRemaining() {
+    var parser = WifiFrameStreamParser()
+    // A size byte promising 50 payload bytes but only 5 delivered.
+    var partial = Data([50, toc])
+    partial.append(contentsOf: Array(repeating: UInt8(0xaa), count: 4))
+    let (frames, remaining) = parser.parse(partial)
+    XCTAssertTrue(frames.isEmpty, "an incomplete frame must not be emitted")
+    XCTAssertEqual(remaining, partial, "the whole partial frame is held for the next chunk")
+    XCTAssertEqual(parser.consumedStreamBytes, 0)
+  }
+}

--- a/desktop/macos/Desktop/Tests/OnboardingRestartAdvancePolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingRestartAdvancePolicyTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the Full Disk Access "Reopen Omi" restart loop.
+///
+/// The restart-carrying permission step used to re-show the reopen prompt on
+/// every relaunch: the permission reads granted after the restart, the step is
+/// still the persisted current step, and the prompt's primary button restarted
+/// the app again — an infinite loop escapable only via the cancel-role
+/// "Later" button. A step whose permission was already granted when it
+/// appeared must advance directly.
+final class OnboardingRestartAdvancePolicyTests: XCTestCase {
+  func testNonRestartStepAlwaysAdvances() {
+    XCTAssertEqual(
+      OnboardingRestartAdvancePolicy.action(requiresRestart: false, grantedWhenStepAppeared: false),
+      .advance)
+    XCTAssertEqual(
+      OnboardingRestartAdvancePolicy.action(requiresRestart: false, grantedWhenStepAppeared: true),
+      .advance)
+  }
+
+  func testRestartStepPromptsForGrantDuringThisRun() {
+    XCTAssertEqual(
+      OnboardingRestartAdvancePolicy.action(requiresRestart: true, grantedWhenStepAppeared: false),
+      .promptRestart)
+  }
+
+  func testRestartStepAdvancesWhenGrantPrecededAppearance() {
+    // Post-restart relaunch: the permission was granted before the step
+    // appeared, so the restart it needed already happened. Prompting again
+    // would loop the user through endless restarts.
+    XCTAssertEqual(
+      OnboardingRestartAdvancePolicy.action(requiresRestart: true, grantedWhenStepAppeared: true),
+      .advance)
+  }
+}

--- a/desktop/macos/Desktop/Tests/ScreenCaptureRetentionTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenCaptureRetentionTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for chat-tool screenshot retention.
+///
+/// `captureScreenWithDetailTiles` (the `capture_screen` chat tool) wrote the
+/// full frame plus native-resolution detail tiles into
+/// ~/Documents/Omi/Screenshots and nothing ever deleted them — unbounded disk
+/// growth. Captures now sweep files older than the retention window.
+final class ScreenCaptureRetentionTests: XCTestCase {
+  func testStaleFilesBeyondRetentionAreSelected() {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let dir = URL(fileURLWithPath: "/tmp/omi-screens")
+    let fresh = (url: dir.appendingPathComponent("a.webp"), modified: now.addingTimeInterval(-60))
+    let stale = (
+      url: dir.appendingPathComponent("b.webp"),
+      modified: now.addingTimeInterval(-(ScreenCaptureManager.screenshotRetention + 60))
+    )
+
+    let purge = ScreenCaptureManager.staleScreenshotURLs(
+      [fresh, stale], now: now, retention: ScreenCaptureManager.screenshotRetention)
+
+    XCTAssertEqual(purge, [stale.url], "only files older than the retention window are swept")
+  }
+
+  func testExactlyAtRetentionBoundaryIsKept() {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let dir = URL(fileURLWithPath: "/tmp/omi-screens")
+    let atBoundary = (
+      url: dir.appendingPathComponent("c.webp"),
+      modified: now.addingTimeInterval(-ScreenCaptureManager.screenshotRetention)
+    )
+    let purge = ScreenCaptureManager.staleScreenshotURLs(
+      [atBoundary], now: now, retention: ScreenCaptureManager.screenshotRetention)
+    XCTAssertTrue(purge.isEmpty, "a file exactly at the boundary is not yet stale")
+  }
+}

--- a/desktop/macos/Desktop/Tests/ShortcutSettingsPTTDemoOverrideTests.swift
+++ b/desktop/macos/Desktop/Tests/ShortcutSettingsPTTDemoOverrideTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the onboarding voice-demo corrupting the saved PTT
+/// mode.
+///
+/// The demo used to force `.live` by assigning `pttTranscriptionMode`, whose
+/// didSet persists to UserDefaults immediately — so a quit/crash before the
+/// restore in onDisappear permanently changed the user's saved mode. The demo
+/// now uses a transient, never-persisted override.
+@MainActor
+final class ShortcutSettingsPTTDemoOverrideTests: XCTestCase {
+  func testDemoOverrideDoesNotPersistOrChangeStoredMode() {
+    let settings = ShortcutSettings.shared
+    let originalStored = settings.pttTranscriptionMode
+    let originalOverride = settings.pttTranscriptionModeDemoOverride
+    defer {
+      settings.pttTranscriptionModeDemoOverride = originalOverride
+      settings.pttTranscriptionMode = originalStored
+    }
+
+    settings.pttTranscriptionMode = .batch
+    let persistedBefore = UserDefaults.standard.string(forKey: "shortcut_pttTranscriptionMode")
+
+    // Enter the demo: override to live.
+    settings.pttTranscriptionModeDemoOverride = .live
+    XCTAssertEqual(settings.effectivePTTTranscriptionMode, .live, "override wins while active")
+    XCTAssertEqual(settings.pttTranscriptionMode, .batch, "stored preference is untouched")
+    XCTAssertEqual(
+      UserDefaults.standard.string(forKey: "shortcut_pttTranscriptionMode"), persistedBefore,
+      "the override must never write to UserDefaults")
+
+    // Leave the demo (or crash-then-relaunch clears the transient override).
+    settings.pttTranscriptionModeDemoOverride = nil
+    XCTAssertEqual(settings.effectivePTTTranscriptionMode, .batch, "falls back to stored preference")
+  }
+}

--- a/desktop/macos/Desktop/Tests/ShortcutSettingsPTTDemoOverrideTests.swift
+++ b/desktop/macos/Desktop/Tests/ShortcutSettingsPTTDemoOverrideTests.swift
@@ -21,15 +21,15 @@ final class ShortcutSettingsPTTDemoOverrideTests: XCTestCase {
     }
 
     settings.pttTranscriptionMode = .batch
-    let persistedBefore = UserDefaults.standard.string(forKey: "shortcut_pttTranscriptionMode")
 
-    // Enter the demo: override to live.
+    // Enter the demo: override to live. The stored preference is the ONLY
+    // writer of the persisted UserDefaults key (via its didSet), so asserting
+    // it is untouched proves the override never persisted.
     settings.pttTranscriptionModeDemoOverride = .live
     XCTAssertEqual(settings.effectivePTTTranscriptionMode, .live, "override wins while active")
-    XCTAssertEqual(settings.pttTranscriptionMode, .batch, "stored preference is untouched")
     XCTAssertEqual(
-      UserDefaults.standard.string(forKey: "shortcut_pttTranscriptionMode"), persistedBefore,
-      "the override must never write to UserDefaults")
+      settings.pttTranscriptionMode, .batch,
+      "override must not touch the stored (persisted) preference")
 
     // Leave the demo (or crash-then-relaunch clears the transient override).
     settings.pttTranscriptionModeDemoOverride = nil

--- a/desktop/macos/Desktop/Tests/TasksStoreApiPageLimitTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksStoreApiPageLimitTests.swift
@@ -27,4 +27,20 @@ final class TasksStoreApiPageLimitTests: XCTestCase {
     XCTAssertEqual(TasksStore.clampedApiPageLimit(0), 1)
     XCTAssertEqual(TasksStore.clampedApiPageLimit(-5), 1)
   }
+
+  /// Auto-refresh must clamp only the API page, never the local-cache reload.
+  /// A user paginated past 500 incomplete tasks previously had the clamped
+  /// limit reused for the local reload, so `mergeWithoutAdding` dropped every
+  /// row beyond 500 and the list collapsed back to 500 on app activation/Cmd+R.
+  func testRefreshLimitsClampApiButPreserveLoadedRows() {
+    let limits = TasksStore.refreshLimits(pageSize: 50, loadedCount: 620)
+    XCTAssertEqual(limits.api, TasksStore.apiPageLimitCap, "API page must stay within the backend 422 cap")
+    XCTAssertEqual(limits.local, 620, "local reload must keep every loaded row, not be capped to 500")
+  }
+
+  func testRefreshLimitsUsePageSizeFloorWhenListIsSmall() {
+    let limits = TasksStore.refreshLimits(pageSize: 50, loadedCount: 10)
+    XCTAssertEqual(limits.api, 50)
+    XCTAssertEqual(limits.local, 50)
+  }
 }

--- a/desktop/macos/Desktop/Tests/TasksStoreApiPageLimitTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksStoreApiPageLimitTests.swift
@@ -10,6 +10,7 @@ import XCTest
 /// with more than 500 hydrated incomplete tasks sent `limit > 500`, so every
 /// auto-refresh (app activation, Cmd+R) got HTTP 422 and silently failed. The
 /// limit is now clamped to the backend cap.
+@MainActor
 final class TasksStoreApiPageLimitTests: XCTestCase {
   func testClampNeverExceedsBackendCap() {
     XCTAssertEqual(TasksStore.clampedApiPageLimit(742), TasksStore.apiPageLimitCap)

--- a/desktop/macos/Desktop/Tests/TasksStoreApiPageLimitTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksStoreApiPageLimitTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the Tasks auto-refresh 422.
+///
+/// `refreshTasksIfNeeded` computed its reload limit as
+/// `max(pageSize, incompleteTasks.count)` and passed it straight to
+/// `GET /v1/action-items`, whose backend validates `limit … le=500`. A user
+/// with more than 500 hydrated incomplete tasks sent `limit > 500`, so every
+/// auto-refresh (app activation, Cmd+R) got HTTP 422 and silently failed. The
+/// limit is now clamped to the backend cap.
+final class TasksStoreApiPageLimitTests: XCTestCase {
+  func testClampNeverExceedsBackendCap() {
+    XCTAssertEqual(TasksStore.clampedApiPageLimit(742), TasksStore.apiPageLimitCap)
+    XCTAssertEqual(TasksStore.clampedApiPageLimit(501), 500)
+    XCTAssertEqual(TasksStore.apiPageLimitCap, 500)
+  }
+
+  func testClampKeepsInRangeRequestsUnchanged() {
+    XCTAssertEqual(TasksStore.clampedApiPageLimit(100), 100)
+    XCTAssertEqual(TasksStore.clampedApiPageLimit(500), 500)
+  }
+
+  func testClampFloorsToAtLeastOne() {
+    XCTAssertEqual(TasksStore.clampedApiPageLimit(0), 1)
+    XCTAssertEqual(TasksStore.clampedApiPageLimit(-5), 1)
+  }
+}

--- a/desktop/macos/Desktop/Tests/TasksViewModelLoadMoreTappedTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksViewModelLoadMoreTappedTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the "Load more tasks" button crash.
+///
+/// The button used to force-unwrap `displayTasks.last!` inside an async Task.
+/// The emptiness guard was render-time only, so if the store emptied the list
+/// (e.g. `resetSessionState()` on an account switch, or the debounced recompute)
+/// between the click and the Task running, the force-unwrap crashed. The action
+/// now reads `displayTasks.last` at execution time and no-ops when empty.
+@MainActor
+final class TasksViewModelLoadMoreTappedTests: XCTestCase {
+  override func tearDown() async throws {
+    TasksStore.shared.resetSessionState()
+  }
+
+  func testLoadMoreTappedIsNoOpWhenListEmptied() async {
+    let store = TasksStore.shared
+    store.resetSessionState()
+    let vm = TasksViewModel()
+    vm.selectedTags = [.todo]
+
+    // The list is empty at execution time (the store was reset). The old
+    // displayTasks.last! would have crashed here; loadMoreTapped must return.
+    XCTAssertTrue(vm.displayTasks.isEmpty)
+    await vm.loadMoreTapped()
+    XCTAssertTrue(vm.displayTasks.isEmpty, "no-op load-more must not fabricate rows")
+  }
+}

--- a/desktop/macos/Desktop/Tests/WALServiceOrphanSdCardTests.swift
+++ b/desktop/macos/Desktop/Tests/WALServiceOrphanSdCardTests.swift
@@ -12,17 +12,15 @@ import XCTest
 /// keeping one that did.
 @MainActor
 final class WALServiceOrphanSdCardTests: XCTestCase {
-  private var walDir: URL!
-  private var service: WALService!
+  private let walDir = FileManager.default.temporaryDirectory
+    .appendingPathComponent("wal-orphan-test-\(UUID().uuidString)", isDirectory: true)
+  private lazy var service = WALService(
+    apiClient: APIClient(session: URLSession(configuration: .ephemeral)),
+    walDirectoryForTesting: walDir
+  )
 
   override func setUp() async throws {
-    walDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("wal-orphan-test-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: walDir, withIntermediateDirectories: true)
-    service = WALService(
-      apiClient: APIClient(session: URLSession(configuration: .ephemeral)),
-      walDirectoryForTesting: walDir
-    )
     service.setWalsForTesting([])
   }
 

--- a/desktop/macos/Desktop/Tests/WALServiceOrphanSdCardTests.swift
+++ b/desktop/macos/Desktop/Tests/WALServiceOrphanSdCardTests.swift
@@ -1,0 +1,57 @@
+import OmiWAL
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for orphaned SD-card WAL entries.
+///
+/// `createSdCardWal` reserves a `.miss` / `.sdcard` entry before any data is
+/// downloaded. Every failed/aborted sync path used to leave that entry behind,
+/// and it counts toward the persisted "N pending" badge forever.
+/// `removeSdCardWalIfEmpty` drops an entry that never received frames while
+/// keeping one that did.
+@MainActor
+final class WALServiceOrphanSdCardTests: XCTestCase {
+  private var walDir: URL!
+  private var service: WALService!
+
+  override func setUp() async throws {
+    walDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("wal-orphan-test-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: walDir, withIntermediateDirectories: true)
+    service = WALService(
+      apiClient: APIClient(session: URLSession(configuration: .ephemeral)),
+      walDirectoryForTesting: walDir
+    )
+    service.setWalsForTesting([])
+  }
+
+  override func tearDown() async throws {
+    try? FileManager.default.removeItem(at: walDir)
+  }
+
+  func testRemovesReservedButEmptySdCardWal() {
+    let wal = service.createSdCardWal(
+      device: "dev1", deviceModel: "Omi", codec: "opus", totalBytes: 8000, currentOffset: 0)
+    XCTAssertEqual(service.pendingWals.count, 1, "the reserved entry counts as pending")
+
+    service.removeSdCardWalIfEmpty(walId: wal.id)
+
+    XCTAssertNil(service.getWal(id: wal.id), "an empty failed sync must not leave a phantom WAL")
+    XCTAssertEqual(service.pendingWals.count, 0)
+  }
+
+  func testKeepsSdCardWalThatDownloadedData() {
+    let wal = service.createSdCardWal(
+      device: "dev1", deviceModel: "Omi", codec: "opus", totalBytes: 8000, currentOffset: 0)
+    // A WAL with a persisted file path represents real downloaded audio.
+    var downloaded = wal
+    downloaded.status = .miss
+    downloaded.filePath = "audio_dev1_opus_16000_1_fs80_1700000000.bin"
+    service.setWalsForTesting([downloaded])
+
+    service.removeSdCardWalIfEmpty(walId: wal.id)
+
+    XCTAssertNotNil(service.getWal(id: wal.id), "a WAL with downloaded frames must be kept")
+  }
+}

--- a/desktop/macos/Desktop/Tests/WifiSyncServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/WifiSyncServiceTests.swift
@@ -76,4 +76,32 @@ final class WifiSyncServiceTests: XCTestCase {
     XCTAssertTrue(uploadCalled, "finishSync must call syncToCloud after download")
     XCTAssertEqual(walService.wals.first?.status, .synced)
   }
+
+  // MARK: - Cancellation classification
+
+  /// A user-initiated Stop propagates a CancellationError through the sync task.
+  /// It must be classified as a cancellation (no user-facing error), never a
+  /// failure that surfaces `errorMessage` / a "Recording Error" banner.
+  func testUserStopIsClassifiedAsCancellationNotError() {
+    XCTAssertTrue(
+      WifiSyncService.isCancellation(CancellationError(), taskWasCancelled: false),
+      "a thrown CancellationError is a user Stop, not a failure")
+
+    // A cancelled parent can interrupt an await and surface a different error;
+    // once the task is cancelled we still treat it as a Stop.
+    XCTAssertTrue(
+      WifiSyncService.isCancellation(WifiSyncServiceError.timeout, taskWasCancelled: true),
+      "any error thrown after the task was cancelled is a Stop, not a failure")
+  }
+
+  /// A genuine transfer failure (not a cancellation) must remain a real error
+  /// so the UI can surface it.
+  func testGenuineFailureIsNotClassifiedAsCancellation() {
+    XCTAssertFalse(
+      WifiSyncService.isCancellation(WifiSyncServiceError.deviceFailed, taskWasCancelled: false),
+      "a device failure with no cancellation must surface as an error")
+    XCTAssertFalse(
+      WifiSyncService.isCancellation(WifiSyncServiceError.timeout, taskWasCancelled: false),
+      "a timeout with no cancellation must surface as an error")
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260719-ble-audio-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260719-ble-audio-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed BLE audio recording not recovering after the device audio stream dropped mid-session"
+}

--- a/desktop/macos/changelog/unreleased/20260719-fda-reopen-loop.json
+++ b/desktop/macos/changelog/unreleased/20260719-fda-reopen-loop.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the Full Disk Access onboarding step asking to reopen Omi again after every restart"
+}

--- a/desktop/macos/changelog/unreleased/20260719-ocr-embedding-account-switch.json
+++ b/desktop/macos/changelog/unreleased/20260719-ocr-embedding-account-switch.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed queued Rewind OCR embeddings from the previous account being written into the next account's database after switching accounts"
+}

--- a/desktop/macos/changelog/unreleased/20260719-onboarding-goal-dup.json
+++ b/desktop/macos/changelog/unreleased/20260719-onboarding-goal-dup.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed onboarding sometimes creating a duplicate goal when finishing setup after a transient error"
+}

--- a/desktop/macos/changelog/unreleased/20260719-screenshot-retention.json
+++ b/desktop/macos/changelog/unreleased/20260719-screenshot-retention.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed chat screen-capture screenshots accumulating in your Documents folder without ever being cleaned up"
+}

--- a/desktop/macos/changelog/unreleased/20260719-tasks-refresh-500.json
+++ b/desktop/macos/changelog/unreleased/20260719-tasks-refresh-500.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the task list failing to refresh for users with more than 500 tasks"
+}

--- a/desktop/macos/changelog/unreleased/20260719-undo-offline-task-duplicate.json
+++ b/desktop/macos/changelog/unreleased/20260719-undo-offline-task-duplicate.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed undoing the deletion of a task created offline creating a duplicate copy of the task"
+}

--- a/desktop/macos/changelog/unreleased/20260719-undo-restore-fields.json
+++ b/desktop/macos/changelog/unreleased/20260719-undo-restore-fields.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed undoing a task deletion losing the task's category, tags, recurrence, and completion state"
+}

--- a/desktop/macos/changelog/unreleased/20260719-unsynced-task-mutations.json
+++ b/desktop/macos/changelog/unreleased/20260719-unsynced-task-mutations.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed deleting, completing, or editing a just-created task while offline silently not sticking (the task reappeared on next launch)"
+}

--- a/desktop/macos/changelog/unreleased/20260719-voice-demo-ptt-mode.json
+++ b/desktop/macos/changelog/unreleased/20260719-voice-demo-ptt-mode.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed quitting during onboarding's voice demo permanently switching your push-to-talk transcription to Live mode"
+}

--- a/desktop/macos/changelog/unreleased/20260719-wifi-sync-connect-timeout.json
+++ b/desktop/macos/changelog/unreleased/20260719-wifi-sync-connect-timeout.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed WiFi sync hanging on \"Connecting…\" forever when the device could not be reached"
+}

--- a/desktop/macos/changelog/unreleased/20260719-wifi-sync-frame-desync.json
+++ b/desktop/macos/changelog/unreleased/20260719-wifi-sync-frame-desync.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed WiFi audio sync silently dropping audio after the first partial packet by tracking block boundaries across the whole stream"
+}

--- a/desktop/macos/changelog/unreleased/20260719-wifi-sync-orphan-pending.json
+++ b/desktop/macos/changelog/unreleased/20260719-wifi-sync-orphan-pending.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a failed WiFi sync leaving a phantom entry in the pending-sync count that never cleared"
+}

--- a/desktop/macos/changelog/unreleased/20260719-wifi-sync-stop-error.json
+++ b/desktop/macos/changelog/unreleased/20260719-wifi-sync-stop-error.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed pressing Stop during a WiFi sync briefly showing an error message even though you cancelled it on purpose"
+}

--- a/desktop/macos/changelog/unreleased/20260719-wifi-sync-stop.json
+++ b/desktop/macos/changelog/unreleased/20260719-wifi-sync-stop.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the Stop button during WiFi sync not actually cancelling the in-progress transfer"
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -18,6 +18,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+  - desktop/macos/Desktop/Sources/Rewind/Services/OCREmbeddingService.swift
   - desktop/macos/Desktop/Sources/ResourceMonitor.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift

--- a/desktop/macos/e2e/flows/ptt-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/ptt-lifecycle.yaml
@@ -10,6 +10,7 @@ covers:
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/LegacyVoiceJournalImporter.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RawWebSocket.swift
   - desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
   - desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniTestHarness.swift


### PR DESCRIPTION
## macOS bug audit — cycle 3

Continuation of the macOS zero-known-defect audit (prior batch merged as #9961). This branch is restarted from latest `main` and carries a fresh discovery pass over subsystems the earlier cycles didn't cover deeply (Auth/APIClient, Audio, Bluetooth, Floating/Overlay, Onboarding/Startup, WAL/persistence, Stores, RealtimeOmni, Chat, Dashboard, and the Rust backend), each finding adversarially re-verified before fixing.

### Fixes in this PR

**Crashes / data integrity**
1. **Full Disk Access onboarding restart loop** (`OnboardingPermissionStepView`) — "Reopen Omi" relaunched without persisting the step advance, so the granted permission re-triggered the prompt on every relaunch (escapable only via "Later"). Persists the advance before relaunch; an already-granted step advances directly. Hermetic test.
2. **Unsynced `local_` task mutations silently lost** (`ActionItemStorage` / `TasksStore`) — offline-created tasks (id `local_<rowid>`, no backendId) couldn't be deleted (no-op → resurrected on relaunch), toggled, or edited (`recordNotFound`). Surfaced ids resolve through one shared `ActionItemTaskIdentity`; local-only ids skip backend calls that can only 404. Hermetic test.
3. **OCR-embedding queue leaks across account switch** (`OCREmbeddingService` / `RuntimeOwnerIdentity`) — the pending batch (previous owner's screenshot rowids + OCR text) survived the owner purge and flushed into the next owner's Rewind DB. Reset at the transition boundary. Hermetic test.
4. **"Load more tasks" force-unwrap crash** (`TasksPage`) — `displayTasks.last!` inside an async Task crashed if the list emptied between click and execution. Reads `.last` at execution time via `loadMoreTapped()`. Hermetic test.
5. **AppResponse Identifiable instability** (`APIClient+ConversationModels`) — computed `id` minted a fresh UUID per read for null `app_id`, tearing down SwiftUI rows every diff. `id` is now stored. Hermetic test.
6. **Undo-restore drops task fields** (`TasksStore.restoreTask`) — recreated the task with only description/dueAt/priority, losing source, category, tags, recurrence, goal/workstream, and completion. Full field set restored.

**Audio / BLE / WiFi**
7. **WiFi sync frame desync (data loss) + Stop can't cancel** (`WifiSyncService` / `OmiWAL`) — 440-byte block boundaries were computed from the per-chunk buffer, dropping audio after the first partial frame; and `syncTask` was never assigned so Stop was a no-op. Extracted a pure stream-offset-tracking `WifiFrameStreamParser`; the transfer runs in an owned cancellable task. Hermetic parser tests.
8. **BLE audio stream death left session unrecoverable + start race** (`BleAudioService`) — stream error/end skipped cleanup (idempotent teardown now runs), and the `!isProcessing` guard spanned an await (slot now claimed synchronously).
9. **Dead per-session buffers** — removed write-only `BleAudioProcessor.framesBuffer` and `LimitlessDeviceConnection.rawDataBuffer` (unbounded growth over long recordings).
10. **RealtimeOmniService URLSession leak** — the delegate-retaining session was never invalidated; leaked one service+session per PTT turn. Now invalidated in `stop()`/`deinit`.

**Onboarding / settings**
11. **Voice-demo corrupts saved PTT mode** (`OnboardingVoiceDemoView` / `ShortcutSettings`) — forcing `.live` persisted to UserDefaults immediately, so a quit mid-step permanently changed the user's mode. Now a transient, never-persisted `pttTranscriptionModeDemoOverride`. Hermetic test.
12. **Task auto-refresh 422 for >500 tasks** (`TasksStore`) — reload limit exceeded the backend's `le=500` cap. Clamped. Hermetic test.

**Rust backend**
13. **Unsigned Sentry webhook accepted** (`webhooks.rs`) — verification failed open with a configured secret but no signature header; anyone knowing the URL could forge feedback issues. Returns 401. `cargo test` (5 cases).
14. **Silent streaming Gemini provider switch** (`proxy.rs`) — the streaming Vertex→AI Studio token-failure heal never emitted `record_fallback`. Now recorded. `cargo test` (88).
15. **Unbounded Crisp session cache** (`crisp.rs`) — no eviction; grew per distinct email forever. Prunes expired + caps at 50k. `cargo test` (2 cases).

### Verification

- Rust: `cargo test` (373+ passing incl. new webhook/proxy/crisp cases), `cargo clippy` clean — run locally.
- Swift: hermetic regression tests added wherever a pure seam existed; a few singleton/heavy-protocol fixes (RealtimeOmniService, BleAudioService, restoreTask) verified by inspection + the Desktop Swift Build & Tests CI gate. **Swift compiles/tests only in CI** (no Swift toolchain in this sandbox).
- Line-count ratchet baselines raised with justifications; `check_desktop_test_quality.py` at baseline; e2e flow-coverage clean.

### Not for immediate merge

Chat/task write-path adjacent changes should ride the normal daily candidate → beta qualification (hermetic T2 + fault suite on the macOS runner). Flagging for maintainer sign-off rather than auto-merge.

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1
- INV-VOICE-1

The `RuntimeOwnerIdentity.retargetOwnerBoundLocalStorage` change adds `OCREmbeddingService.shared.reset()` to the existing owner-transition purge list. It strengthens the owner boundary without changing session-death ownership (INV-AUTH-1) or the chat write-path/projection contract (INV-CHAT-1) — no chat provider, journal, viewport, or turn-projection code is touched.

INV-VOICE-1 is named because the PTT-mode fix touches `PushToTalkManager.swift` (a path glob), but it only changes which transcription mode (`.batch` vs `.live`) a turn reads via the new `effectivePTTTranscriptionMode` accessor. It does not alter the single voice-turn lifecycle owner, terminal reducer fences, or turn ownership — no guard-test behavior changes.

## Failure class (fixes)

Failure-Class: none

These are independent instance fixes across unrelated subsystems; none recurs against an existing registered failure class, and no two share a cause that would warrant a new shared class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)