### PR TITLE
fix(backend): latch clean upstream STT close as terminal (#10028)

### DIFF
--- a/backend/tests/unit/test_modulate_stt.py
+++ b/backend/tests/unit/test_modulate_stt.py
@@ -531,8 +531,19 @@ class TestRecvLoop(unittest.TestCase):
 
     def test_invalid_json_skipped(self):
         sock = self._run_recv(['not json', '{{bad'])
-        self.assertFalse(sock.is_connection_dead)
+        # Invalid frames produce no segments; the subsequent clean upstream close
+        # (message stream exhausted with no `done`) latches the socket dead.
         self.assertEqual(self.segments, [])
+        self.assertTrue(sock.is_connection_dead)
+
+    def test_clean_close_without_done_marks_dead(self):
+        # A provider that ends its WebSocket cleanly without a `done`/`error`
+        # message must latch the socket dead so the listen loop stops treating
+        # the session as ready (regression for the "Listening" zombie state).
+        sock = self._run_recv([])
+        self.assertTrue(sock.is_connection_dead)
+        self.assertIn('closed cleanly by upstream', sock.death_reason)
+        self.assertTrue(sock._done_event.is_set())
 
     def test_error_message_marks_dead(self):
         msg = json.dumps({'type': 'error', 'error': 'rate limit'})
@@ -793,6 +804,51 @@ class TestProcessAudioParakeet(unittest.TestCase):
                 assert socket.send(b'overflow') is False
                 assert socket.is_connection_dead is True
                 assert socket.death_reason == 'parakeet ws send queue full'
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+    def test_receive_loop_clean_upstream_close_marks_dead(self):
+        # The Parakeet /v3/stream socket closing cleanly mid-session (recv loop
+        # exhausts without an exception) must latch dead, not leave the session
+        # in a ready "Listening" zombie state until the next audio frame fails.
+        from utils.stt.streaming import ParakeetWebSocketSocket
+
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def empty_ws():
+                return
+                yield  # pragma: no cover - makes this an async generator
+
+            async def run():
+                socket = ParakeetWebSocketSocket(lambda _segments: None, 'ws://parakeet.local/v3/stream', 16000)
+                await socket._receive_loop(empty_ws())
+                assert socket.is_connection_dead is True
+                assert socket.death_reason == 'parakeet ws closed cleanly by upstream'
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+    def test_receive_loop_close_after_finalize_stays_alive(self):
+        # A clean close after we locally finalized is the normal end of stream
+        # and must NOT be reported as a connection death.
+        from utils.stt.streaming import ParakeetWebSocketSocket
+
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def empty_ws():
+                return
+                yield  # pragma: no cover - makes this an async generator
+
+            async def run():
+                socket = ParakeetWebSocketSocket(lambda _segments: None, 'ws://parakeet.local/v3/stream', 16000)
+                socket.finalize()
+                await socket._receive_loop(empty_ws())
+                assert socket.is_connection_dead is False
 
             loop.run_until_complete(run())
         finally:

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -791,6 +791,15 @@ class SafeModulateSocket(STTSocket):
             self._mark_dead(f'ws recv closed: {e}')
         except Exception as e:
             self._mark_dead(f'ws recv error: {e}')
+        else:
+            # The `async for` exhausted without a `done`/`error` message and
+            # without an exception: the provider closed the transport cleanly
+            # mid-stream. All explicit-termination paths above `break`, and local
+            # finish() sets `_closed`, so reaching here means an unexpected close.
+            if not self._closed and not self._done_event.is_set():
+                logger.warning('Modulate stream closed cleanly by upstream before done')
+                self._done_event.set()
+                self._mark_dead('modulate stream closed cleanly by upstream')
 
     def _handle_partial_utterance(self, msg: Dict[str, Any]) -> None:
         # Modulate sends cumulative partial_utterance messages during streaming
@@ -1299,6 +1308,14 @@ class ParakeetWebSocketSocket(STTSocket):
             if not self._closed:
                 logger.error(f"Parakeet WS recv error: {e}")
                 self._mark_dead(f"parakeet ws recv: {e}")
+        else:
+            # A clean upstream close (loop exhausts without an exception) is only
+            # reached when the provider transport actually ended; a healthy stream
+            # blocks in `async for`. If we did not close/finalize locally, latch it
+            # as dead so the listen loop stops treating the session as ready.
+            if not self._closed and not getattr(self, '_finalized', False):
+                logger.warning('Parakeet WS closed cleanly by upstream before finalize')
+                self._mark_dead('parakeet ws closed cleanly by upstream')
 
 
 async def process_audio_parakeet(


### PR DESCRIPTION
## Problem

Issue #10028. In the `/v4/listen` STT pipeline, when an active **Parakeet** (`ParakeetWebSocketSocket`) or **Modulate** (`SafeModulateSocket`) upstream WebSocket ends **cleanly** (the provider closes the transport with no exception and, for Modulate, no `done`/`error` message), the streaming wrapper's receive loop simply falls out of its `async for` without latching the connection as dead.

`is_connection_dead` therefore stays `False`, and the mobile socket keeps reporting `ready`/"Listening" until the device sends another audio frame and the *next* provider send finally fails. That extends the "Listening" zombie state after the backend has already observed its upstream transport disappear.

## Root cause

Both receive loops only mark the socket dead inside their `except` handlers. A clean loop exhaustion (the exact signature of an unexpected clean upstream close mid-session) has no terminal handling. A healthy stream never exhausts `async for` — it blocks waiting for messages — so reaching loop end is unambiguously a real transport close.

## Fix

Add an `else` branch to each receive loop that latches the socket dead on clean exhaustion, excluding local drain/finalization:

- **Parakeet** (`ParakeetWebSocketSocket._receive_loop`): mark dead unless we already closed or called `finish()`/`finalize()` (`_closed` / `_finalized`).
- **Modulate** (`SafeModulateSocket._recv_loop`): mark dead and set `_done_event` unless we already closed (`finish()`) or a legitimate `done`/`error` already terminated the stream (`_done_event` set). All explicit-termination paths `break` after setting those guards, so only an unexpected close reaches the `else`.

Once latched, the existing `is_connection_dead` gate on the send path (e.g. `chat.py`) trips at the clean-close boundary instead of waiting for a send to raise.

## Scope note

This implements the wrapper-latch portion of #10028. The issue also proposes an active monitor to propagate the terminal `stt_failed` + WebSocket 1011 *without any further client frame*; that touches the core listen receiver and is intentionally left out of this surgical change to keep blast radius small. Filed here as PR-only for review, not auto-merged.

## Tests

- `TestRecvLoop::test_clean_close_without_done_marks_dead` (Modulate) — new regression.
- `TestRecvLoop::test_invalid_json_skipped` — updated to assert the now-correct dead-latch on exhaustion.
- `TestProcessAudioParakeet::test_receive_loop_clean_upstream_close_marks_dead` — new regression.
- `TestProcessAudioParakeet::test_receive_loop_close_after_finalize_stays_alive` — guards against false positives on normal finalization.

Ran locally (Python 3.12, hermetic): the STT socket suites pass — `TestRecvLoop`, `TestUtteranceResults`, `TestProcessAudioParakeet` = 18 passed. (The `Prerecorded` cases in the same file fail only because `httpx` was absent in the ad-hoc venv, unrelated to this change.)

Failure-Class: none

🤖 automated by hourly watchdog; opened for review, not merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

