### PR TITLE
Bound the OAuth callback failure_class metric label to a closed set

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -228,6 +228,26 @@ def _failure_class(error: Optional[object]) -> str:
     return value[:80] or error.__class__.__name__.lower()
 
 
+# RFC 6749 §4.1.2.1 error codes a provider may echo on the callback. The raw
+# `error` param is attacker-controlled free text and must never become a
+# Prometheus label value directly — that is unbounded cardinality on a
+# module-level (process-lifetime) metric registry.
+_OAUTH_ERROR_CODES = {
+    "access_denied",
+    "invalid_request",
+    "invalid_scope",
+    "unauthorized_client",
+    "unsupported_response_type",
+    "server_error",
+    "temporarily_unavailable",
+}
+
+
+def _bounded_provider_error(error: str) -> str:
+    normalized = error.strip().lower().replace(" ", "_")[:64]
+    return normalized if normalized in _OAUTH_ERROR_CODES else "provider_error_other"
+
+
 def _log_auth_event(
     *,
     provider: Optional[str],
@@ -369,7 +389,7 @@ async def auth_callback_google(
             stage="provider_callback_received",
             outcome="failed",
             auth_flow_id=auth_flow_id,
-            failure_class=error,
+            failure_class=_bounded_provider_error(error),
             status_code=400,
         )
         raise HTTPException(status_code=400, detail=f"Auth error: {error}")
@@ -458,7 +478,7 @@ async def auth_callback_apple_post(
             stage="provider_callback_received",
             outcome="failed",
             auth_flow_id=auth_flow_id,
-            failure_class=error,
+            failure_class=_bounded_provider_error(error),
             status_code=400,
         )
         raise HTTPException(status_code=400, detail=f"Auth error: {error}")

--- a/backend/tests/unit/test_auth_callback_failure_class_cardinality.py
+++ b/backend/tests/unit/test_auth_callback_failure_class_cardinality.py
@@ -1,0 +1,123 @@
+"""Regression test: the OAuth callback ``error`` param must not become an
+unbounded Prometheus label value.
+
+``routers/auth.py``'s Google/Apple callback handlers echo the provider's
+``error`` query/form parameter straight into ``AUTH_FLOW_EVENTS.labels(...)``
+via ``failure_class``. That endpoint requires no prior authentication (it is
+the public OAuth redirect target), so an attacker fully controls the raw
+string. ``prometheus_client`` never evicts a label-value combination once
+seen — ``Counter._metrics`` is a plain dict that only grows for the life of
+the process — so every distinct ``error=`` value an attacker sends creates a
+brand-new, permanent time series on ``auth_flow_events_total``. That is
+exactly the "Prometheus labels: static low-cardinality only ... never
+uid/session_id"-style violation backend/AGENTS.md calls out, just carried by
+a free-form provider error string instead of a uid.
+
+The fix bounds the echoed value to the closed RFC 6749 §4.1.2.1 OAuth error
+vocabulary (``_bounded_provider_error``), defaulting anything else to a
+single ``"provider_error_other"`` bucket.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_test_secret_for_ci_only_0123456789")
+os.environ.setdefault("OPENAI_API_KEY", "sk-fake")
+os.environ.setdefault("PINECONE_API_KEY", "fake")
+
+# Sanctioned pattern (backend/docs/test_isolation.md): import the router module
+# normally at module scope. No sys.modules mutation, no import-hook stubbing —
+# routers.auth is import-pure and its real deps (firebase_admin, jwt,
+# cryptography) are already installed.
+import routers.auth as auth_mod  # noqa: E402
+from utils.metrics import AUTH_FLOW_EVENTS  # noqa: E402
+
+_ATTACKER_VALUE_COUNT = 40
+
+
+def _series_count() -> int:
+    """Number of distinct label-value combinations Counter has ever recorded.
+
+    ``prometheus_client`` caches one child metric per unique label tuple in
+    ``Counter._metrics`` and never evicts it — this is the process-lifetime
+    structure whose growth we are bounding.
+    """
+    return len(AUTH_FLOW_EVENTS._metrics)
+
+
+async def _drive_google_callback(request, error_values):
+    """Fire the real (unauthenticated) callback handler for every value on one
+    event loop, the way concurrent attacker requests would actually arrive."""
+
+    async def _one(error_value):
+        try:
+            await auth_mod.auth_callback_google(request=request, code=None, state=None, error=error_value)
+        except HTTPException:
+            pass
+
+    await asyncio.gather(*(_one(value) for value in error_values))
+
+
+def _run(coro):
+    # Match this test suite's established idiom (see test_auth_redirect_uri.py):
+    # reuse/extend the current event loop rather than asyncio.run(), which closes
+    # its loop and clears the thread's "current loop" — that would break sibling
+    # test files that still call asyncio.get_event_loop().run_until_complete(...)
+    # after this module runs in the same pytest session.
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestGoogleCallbackFailureClassCardinality:
+    def test_distinct_attacker_error_values_do_not_grow_cardinality_unboundedly(self):
+        """Bug path: N distinct, attacker-chosen ``error=`` values must collapse
+        into a small bounded set of label values, not N new series."""
+        request = MagicMock()
+        before = _series_count()
+
+        values = [f"unique-payload-{i}" for i in range(_ATTACKER_VALUE_COUNT)]
+        _run(_drive_google_callback(request, values))
+
+        growth = _series_count() - before
+        assert growth <= 5, (
+            f"AUTH_FLOW_EVENTS grew by {growth} distinct series for {_ATTACKER_VALUE_COUNT} distinct "
+            f"attacker-controlled error values (expected a small bounded bucket, "
+            f"not one series per request)"
+        )
+
+    def test_repeated_known_error_value_does_not_grow_cardinality(self):
+        """Sibling normal-path case: a real provider sending the same standard
+        OAuth error code repeatedly must not grow cardinality either — this
+        passes on both the fixed and unfixed code, since a Counter never grows
+        cardinality for a *repeated* label tuple."""
+        request = MagicMock()
+        before = _series_count()
+
+        values = ["access_denied"] * _ATTACKER_VALUE_COUNT
+        _run(_drive_google_callback(request, values))
+
+        growth = _series_count() - before
+        assert growth <= 1, f"AUTH_FLOW_EVENTS grew by {growth} for {_ATTACKER_VALUE_COUNT} calls with the same value"
+
+
+class TestBoundedProviderErrorHelper:
+    """Direct check that the bounding helper itself has a closed output range."""
+
+    def test_arbitrary_input_maps_into_closed_set(self):
+        outputs = {auth_mod._bounded_provider_error(f"garbage-{i}") for i in range(_ATTACKER_VALUE_COUNT)}
+        allowed = auth_mod._OAUTH_ERROR_CODES | {"provider_error_other"}
+        assert outputs <= allowed
+        # Many distinct garbage inputs must not produce many distinct outputs.
+        assert len(outputs) <= 1
+
+    def test_known_oauth_codes_pass_through_unchanged(self):
+        for code in auth_mod._OAUTH_ERROR_CODES:
+            assert auth_mod._bounded_provider_error(code) == code
+
+    def test_case_and_whitespace_normalized(self):
+        assert auth_mod._bounded_provider_error("  Access_Denied  ") == "access_denied"


### PR DESCRIPTION
Both provider callbacks echo the provider's `error` parameter straight into a Prometheus label:

```python
failure_class=error,
```

`_log_auth_event` passes that into
`AUTH_FLOW_EVENTS.labels(provider=..., stage=..., outcome=..., failure_class=...)`, and
`AUTH_FLOW_EVENTS` is a module-level `Counter` whose labelnames include `failure_class`. The only
bounding on the way is `_failure_class`, which for a plain string does
`.strip().lower().replace(' ', '_')[:80]` — that truncates length, not the number of distinct
values.

`GET /v1/auth/callback/google` and `POST /v1/auth/callback/apple` are unauthenticated, correctly
so: they are the provider's redirect target and run before any Omi session exists. `error` is a
plain query/form parameter on those routes. `prometheus_client` never evicts a label tuple once
created, so each distinct `error` value becomes a permanent series for the life of the process.

That is the case `backend/AGENTS.md` rules out directly:

> **Prometheus labels**: static low-cardinality only (e.g. "pusher", "listen") — never uid/session_id.

Same defect, just carried by free-form provider text instead of a uid.

## The fix

Keep the observability that matters, drop the part that cannot be bounded. The seven RFC 6749
§4.1.2.1 codes a provider can legitimately echo pass through unchanged; anything else buckets to
`provider_error_other`.

```python
_OAUTH_ERROR_CODES = {
    "access_denied", "invalid_request", "invalid_scope", "unauthorized_client",
    "unsupported_response_type", "server_error", "temporarily_unavailable",
}

def _bounded_provider_error(error: str) -> str:
    normalized = error.strip().lower().replace(" ", "_")[:64]
    return normalized if normalized in _OAUTH_ERROR_CODES else "provider_error_other"
```

This mirrors the allowlist already used in `utils/translation_core/metrics.py`, and the
`safe_provider = provider if provider in {...} else "unknown"` line a few lines above in this same
function.

Nothing is lost for debugging: the `HTTPException` detail still carries the raw value, so the
specific string stays visible in the response and the request log. It just stops minting a metric
series.

## Tests

`tests/unit/test_auth_callback_failure_class_cardinality.py`:

- forty distinct attacker-chosen error values produce a small bounded number of series
- the same known error value repeated does not grow cardinality
- the seven known OAuth codes pass through unchanged
- arbitrary input maps into the closed set

## Verification

Run in `backend/`:

- `pytest tests/unit/test_auth_callback_failure_class_cardinality.py`: 5 passed
- prove-fail: with `routers/auth.py` reverted to origin/main and confirmed byte-identical
  (`git diff origin/main` empty), the cardinality test fails with `AUTH_FLOW_EVENTS grew by 41
  distinct series for 40 distinct attacker-controlled error values` / `assert 41 <= 5`, while the
  repeated-known-value test passes both ways. Re-applied: 5 passed
- pytest together with `test_auth_redirect_uri.py` and `test_oauth_callback_uid_guard.py`: 65 passed
- the test imports `routers.auth` at module scope, so the router import is collection cost rather
  than per-test CPU; slowest test in the file is 0.02s and it clears the fast-unit duration guard
- `black --line-length 120 --skip-string-normalization --check`: clean
- `scripts/check_module_stub_pollution.py`: 736 files, 0 violations
- `scripts/scan_async_blockers.py --dirs routers utils`: clean
- `routers/auth.py` is not in the product file line-count ratchet baseline


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

