### PR TITLE
Reject an oversized statuses filter before it reaches Firestore

### DIFF
--- a/backend/routers/integration.py
+++ b/backend/routers/integration.py
@@ -42,6 +42,10 @@ logger = logging.getLogger(__name__)
 RATE_LIMIT_PERIOD = 3600  # 1 hour in seconds
 MAX_NOTIFICATIONS_PER_HOUR = 10  # Maximum notifications per hour per app per user
 
+# Firestore 'in' filters accept at most 30 values (see database/apps.py, database/chat.py); keep
+# well under that so a caller-supplied statuses list can never blow the query up into a 500.
+MAX_STATUSES_FILTER_VALUES = 20
+
 router = APIRouter()
 
 
@@ -352,6 +356,9 @@ def get_conversations_via_integration(
     # Check if the app has the capability to read conversations
     if not apps_utils.app_can_read_conversations(app):
         raise HTTPException(status_code=403, detail="App does not have the capability to read conversations")
+
+    if len(statuses) > MAX_STATUSES_FILTER_VALUES:
+        raise HTTPException(status_code=400, detail=f"statuses accepts at most {MAX_STATUSES_FILTER_VALUES} values")
 
     # Convert string dates to datetime objects if needed
     if isinstance(start_date, str) and start_date:

--- a/backend/tests/unit/test_integration_conversations_statuses_cap.py
+++ b/backend/tests/unit/test_integration_conversations_statuses_cap.py
@@ -1,0 +1,101 @@
+"""GET /v2/integrations/{app_id}/conversations must cap the `statuses` filter length.
+
+`statuses` flows straight from the query string into
+`conversations_db.get_conversations(..., statuses=statuses, ...)`, which applies it as a
+single Firestore `in` filter (`FieldFilter('status', 'in', statuses)`). Firestore hard-rejects
+`in` filters with more than 30 values - a limit this codebase already respects elsewhere
+(see `database/apps.py` "Firestore 'in' limited to 30 items" and the chunking in
+`database/chat.py`). Before the fix, nothing capped `statuses` on this route, so a caller
+that supplied more than 30 values turned a client error into an unhandled exception from the
+Firestore client (surfaced to the caller as a 500) instead of a clean 400. The real
+`ConversationStatus` enum only has 5 members, so no legitimate integration caller needs more
+than a handful of values - the cap here cannot reject any real request shape.
+
+Test isolation: routers.integration pulls in routers.conversations -> speaker_identification
+-> av/langchain transitively, so the import is heavy (tens of seconds). Per AGENTS.md test
+isolation guidance this is done as a plain top-level import (paid once for the file, at
+collection time) rather than inside a test body, and without any sys.modules mutation -
+collaborators are patched with monkeypatch.setattr and the handler is called directly.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+from fastapi import HTTPException
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+os.environ.setdefault('PINECONE_API_KEY', 'fake')
+
+from routers import integration as integ  # noqa: E402
+
+
+class _SpyGetConversations:
+    """Stand-in for conversations_db.get_conversations.
+
+    Records every call it receives (the real seam the router hands `statuses` to) and
+    mirrors Firestore's actual behavior: an `in` filter with more than 30 values blows up
+    instead of returning results.
+    """
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, uid, **kwargs):
+        self.calls.append(kwargs.get('statuses'))
+        statuses = kwargs.get('statuses') or []
+        if len(statuses) > 30:
+            raise Exception("400 Bad Request: 'in' filters support a maximum of 30 elements.")
+        return []
+
+
+def _setup_gates(monkeypatch):
+    monkeypatch.setattr(integ, 'verify_api_key', lambda app_id, api_key: True)
+    monkeypatch.setattr(integ.apps_db, 'get_app_by_id_db', lambda app_id: {'id': app_id, 'name': 'test-app'})
+    monkeypatch.setattr(integ.redis_db, 'get_enabled_apps', lambda uid: ['app-1'])
+    monkeypatch.setattr(integ.apps_utils, 'app_can_read_conversations', lambda app: True)
+
+
+def _call(statuses, monkeypatch, spy):
+    _setup_gates(monkeypatch)
+    monkeypatch.setattr(integ.conversations_db, 'get_conversations', spy)
+    return integ.get_conversations_via_integration(
+        request=MagicMock(),
+        app_id='app-1',
+        uid='test-uid',
+        limit=100,
+        offset=0,
+        include_discarded=False,
+        statuses=statuses,
+        start_date=None,
+        end_date=None,
+        max_transcript_segments=100,
+        authorization='Bearer test-key',
+    )
+
+
+def test_oversized_statuses_filter_rejected_before_reaching_db(monkeypatch):
+    """35 values (more than Firestore's 30-value 'in' cap) must be a clean 400 that never
+    reaches the db seam - not an unhandled exception from the Firestore client."""
+    spy = _SpyGetConversations()
+    too_many = [f'status-{i}' for i in range(35)]
+
+    raised = None
+    try:
+        _call(too_many, monkeypatch, spy)
+    except Exception as exc:  # noqa: BLE001 - capture whatever the handler actually raises
+        raised = exc
+
+    assert isinstance(raised, HTTPException), f'expected a clean HTTPException(400), got {raised!r}'
+    assert raised.status_code == 400
+    assert spy.calls == [], f'db seam must never see an oversized statuses list, got {spy.calls}'
+
+
+def test_normal_statuses_filter_reaches_db_unmodified(monkeypatch):
+    """A couple of real status values are unaffected by the cap and reach the db as-is."""
+    spy = _SpyGetConversations()
+
+    result = _call(['processing', 'completed'], monkeypatch, spy)
+
+    assert spy.calls == [['processing', 'completed']]
+    assert result == {'conversations': []}


### PR DESCRIPTION
`GET /v2/integrations/{app_id}/conversations` declares

```python
statuses: List[str] = Query([]),
```

with no length cap, and passes it straight to `conversations_db.get_conversations`, which builds

```python
conversations_ref.where(filter=FieldFilter('status', 'in', statuses))
```

Firestore rejects an `in` filter with more than 30 values. This repo already knows that and
guards for it in two other places:

- `database/apps.py`: `# Firestore 'in' limited to 30 items`
- `database/chat.py`: `# Firestore IN operator supports max 30 values, so chunk the queries`

This route has no such guard, and nothing wraps the `stream()` call, so a request repeating the
query key more than thirty times (`?statuses=a&statuses=b&...`) raises out of the Firestore client
and surfaces as an unhandled **HTTP 500** rather than a 4xx.

`ConversationStatus` has five legitimate values (`in_progress`, `processing`, `merging`,
`completed`, `failed`), so no real client is anywhere near this. It is malformed-input surface
reachable by any caller holding a valid per-app integration API key.

## Two deliberate choices

**Reject rather than clamp.** That matches this file's own idiom — every other invalid-input case
raises `HTTPException` — and the convention for oversized list inputs elsewhere
(`action_items.py` bounds its id lists with `Field(..., max_length=...)` and rejects). With only
five valid values, a cap of twenty cannot reject anything a real client would send.

**In the handler body, not `Query(..., max_length=20)`.** Declaring it on the parameter would
change the generated OpenAPI, and `docs/api-reference` is a compatibility boundary per
`backend/AGENTS.md`; the `Query([])` declaration is left byte-identical so no spec or generated
client moves. It also keeps the bound testable — a `Query`-level constraint is enforced by
FastAPI's request-parsing layer, which a direct handler call bypasses entirely, so an in-body
check is the only form a hermetic unit test can actually exercise.

## Tests

`tests/unit/test_integration_conversations_statuses_cap.py`:

- an oversized statuses list is rejected with 400 before reaching the database
- a normal statuses list reaches the database unmodified

The fake standing in for the database seam mirrors real Firestore behaviour by raising above
thirty values, so the test asserts what the DB layer actually received rather than only the
response shape.

## Verification

Run in `backend/`:

- `pytest tests/unit/test_integration_conversations_statuses_cap.py`: 2 passed
- prove-fail: with `routers/integration.py` reverted to origin/main and confirmed byte-identical
  (`git diff origin/main` empty), the oversized case fails with
  `expected a clean HTTPException(400), got Exception("400 Bad Request: 'in' filters support a
  maximum of 30 elements.")`, while the normal-path test passes both ways. Re-applied: 2 passed
- pytest with `test_integration_malformed_records.py`: 10 passed
- the test imports `routers.integration` at module scope, so the heavy router import is collection
  cost rather than per-test CPU; both tests are 0.02s or less in the call phase, and the file
  passes under the strict duration guard (`BACKEND_FAST_UNIT_FAIL_SECONDS=0.12`, exit 0)
- `black --line-length 120 --skip-string-normalization --check`: clean
- `scripts/check_module_stub_pollution.py`: 736 files, 0 violations
- `scripts/scan_import_time_side_effects.py`: 717 files, 0 violations
- `routers/integration.py` is 740 lines and is not in the product file line-count ratchet baseline

## Related, not fixed here

`routers/conversations.py`'s `/v1/conversations` has the same underlying exposure through a
comma-separated `statuses: Optional[str]` parameter. Different parameter shape and a different
route, so I left it alone rather than widen this PR; worth a follow-up.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

