### PR TITLE
Route DELETE /v1/personas/{persona_id} to delete_persona instead of the thumbnail uploader

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -2193,7 +2193,6 @@ def reject_app(app_id: str, uid: str, secret_key: str = Header(...)):
     return {'status': 'ok'}
 
 
-@router.delete('/v1/personas/{persona_id}', tags=['v1'], response_model=AppThumbnailUploadResponse)
 @router.post('/v1/app/thumbnails', tags=['v1'], response_model=AppThumbnailUploadResponse)
 @max_part_size(APP_IMAGE_MAX_PART_SIZE)
 async def upload_app_thumbnail_endpoint(file: UploadFile = File(...), uid: str = Depends(auth.get_current_user_uid)):
@@ -2227,6 +2226,7 @@ async def upload_app_thumbnail_endpoint(file: UploadFile = File(...), uid: str =
             os.remove(temp_path)
 
 
+@router.delete('/v1/personas/{persona_id}', tags=['v1'], response_model=AppMutationResponse)
 def delete_persona(persona_id: str, secret_key: str = Header(...)):
     if secret_key != os.getenv('ADMIN_KEY'):
         raise HTTPException(status_code=403, detail='You are not authorized to perform this action')

--- a/backend/tests/unit/test_persona_delete_route_dispatch.py
+++ b/backend/tests/unit/test_persona_delete_route_dispatch.py
@@ -1,0 +1,71 @@
+"""DELETE /v1/personas/{persona_id} must dispatch to delete_persona, not the thumbnail uploader.
+
+The route decorator was stacked on `upload_app_thumbnail_endpoint`:
+
+    @router.delete('/v1/personas/{persona_id}', ..., response_model=AppThumbnailUploadResponse)
+    @router.post('/v1/app/thumbnails', ..., response_model=AppThumbnailUploadResponse)
+    async def upload_app_thumbnail_endpoint(file: UploadFile = File(...), uid=Depends(...)):
+
+so the persona delete path was served by the thumbnail handler, which requires a multipart file
+body and authenticates with a regular Firebase uid. Meanwhile the real `delete_persona` below it
+carried no decorator at all and was unreachable, taking its admin `secret_key` gate with it.
+
+These assertions are route-table facts rather than source-text checks: they read the registered
+routes off the app and assert which endpoint function each one resolves to, so the test fails if
+the decorator ever drifts onto the wrong function again.
+"""
+
+import os
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+from routers import apps as apps_router  # noqa: E402
+
+
+def _routes_for(path: str, method: str):
+    return [
+        r
+        for r in apps_router.router.routes
+        if getattr(r, "path", None) == path and method in getattr(r, "methods", set())
+    ]
+
+
+def test_persona_delete_dispatches_to_delete_persona():
+    matches = _routes_for("/v1/personas/{persona_id}", "DELETE")
+
+    assert len(matches) == 1, f"expected exactly one DELETE route, got {len(matches)}"
+    assert matches[0].endpoint is apps_router.delete_persona, (
+        "DELETE /v1/personas/{persona_id} resolves to " f"{matches[0].endpoint.__name__}, not delete_persona"
+    )
+
+
+def test_persona_delete_keeps_its_admin_secret_key_gate():
+    """The intended handler is admin-gated; the thumbnail handler is not.
+
+    Reaching the wrong endpoint silently swapped an ADMIN_KEY header check for a regular
+    per-user Firebase dependency, so assert the served handler still takes secret_key.
+    """
+    endpoint = _routes_for("/v1/personas/{persona_id}", "DELETE")[0].endpoint
+
+    assert "secret_key" in endpoint.__annotations__, f"{endpoint.__name__} has no secret_key parameter"
+    assert "file" not in endpoint.__annotations__, f"{endpoint.__name__} unexpectedly requires a file upload"
+
+
+def test_thumbnail_upload_still_serves_its_own_post_route():
+    """Removing the misplaced decorator must not disturb the route it was stacked on."""
+    matches = _routes_for("/v1/app/thumbnails", "POST")
+
+    assert len(matches) == 1
+    assert matches[0].endpoint is apps_router.upload_app_thumbnail_endpoint
+
+
+def test_thumbnail_uploader_no_longer_serves_any_delete_route():
+    delete_routes = [
+        r
+        for r in apps_router.router.routes
+        if "DELETE" in getattr(r, "methods", set())
+        and getattr(r, "endpoint", None) is apps_router.upload_app_thumbnail_endpoint
+    ]
+
+    assert delete_routes == [], "the thumbnail uploader is still registered for a DELETE route"


### PR DESCRIPTION
The route decorator is stacked on the wrong function:

```python
@router.delete('/v1/personas/{persona_id}', tags=['v1'], response_model=AppThumbnailUploadResponse)
@router.post('/v1/app/thumbnails', tags=['v1'], response_model=AppThumbnailUploadResponse)
@max_part_size(APP_IMAGE_MAX_PART_SIZE)
async def upload_app_thumbnail_endpoint(file: UploadFile = File(...), uid: str = Depends(auth.get_current_user_uid)):
```

So `DELETE /v1/personas/{persona_id}` is served by the **thumbnail uploader**. Thirty-four lines
below, the function meant to serve it carries no decorator at all:

```python
def delete_persona(persona_id: str, secret_key: str = Header(...)):
```

## Three consequences, all live on main

1. **No persona can be deleted through the API.** The request reaches a handler that requires a
   multipart file body and then uploads a thumbnail. `delete_persona_db` is never called.
2. **`delete_persona` is unreachable dead code.**
3. **The admin gate went with it.** `delete_persona` checks `secret_key` against `ADMIN_KEY` and
   403s otherwise. The handler actually serving the route authenticates with a regular per-user
   Firebase uid, so the route's intended auth and its real auth disagree.

The `response_model` was wrong for the same reason — a delete documented as returning
`AppThumbnailUploadResponse`. It now uses `AppMutationResponse` (`{status: str}`), matching both
what `delete_persona` returns and what the sibling `DELETE /v1/apps/{app_id}` already declares.

Moving the decorator restores the intended dispatch without touching either handler's body. The
`POST /v1/app/thumbnails` route it was stacked on is unaffected.

The path is not present in `docs/api-reference/app-client-openapi.json`, so no published client
contract moves and no spec regeneration is needed.

## Tests

`tests/unit/test_persona_delete_route_dispatch.py` reads the registered route table off the router
and asserts which endpoint each path resolves to. These are route-table facts, not source-text
checks, so they fail if the decorator ever drifts onto the wrong function again:

- `DELETE /v1/personas/{persona_id}` resolves to `delete_persona`, and to exactly one route
- the served handler still takes `secret_key` and does not require a file upload
- `POST /v1/app/thumbnails` still resolves to `upload_app_thumbnail_endpoint`
- the thumbnail uploader serves no DELETE route at all

## Verification

Run in `backend/`:

- `pytest tests/unit/test_persona_delete_route_dispatch.py`: 4 passed
- prove-fail: with `routers/apps.py` reverted to origin/main and confirmed byte-identical
  (`git diff origin/main` empty), three tests fail, the first with

  ```
  AssertionError: DELETE /v1/personas/{persona_id} resolves to upload_app_thumbnail_endpoint, not delete_persona
  MultipartMaxPartSizeRoute(path='/v1/personas/{persona_id}', name='upload_app_thumbnail_endpoint', methods=['DELETE'])
  AssertionError: upload_app_thumbnail_endpoint has no secret_key parameter
  assert 'secret_key' in {'file': <class 'fastapi.datastructures.UploadFile'>, 'uid': <class 'str'>}
  ```

  while the thumbnail POST test passes both ways. Re-applied: 4 passed
- pytest with `test_apps_marketplace_poison_guard.py` and `test_app_home_url_null_manifest.py`:
  11 passed
- `pytest tests/unit/test_route_policy_inventory.py`: 24 passed, so the route-table change does not
  disturb the policy inventory contract
- `black --line-length 120 --skip-string-normalization --check`: clean
- `pyright routers/apps.py`: 0 errors
- `scripts/check_module_stub_pollution.py`: 736 files, 0 violations
- `routers/apps.py` is 2335 lines, exactly its ratchet baseline, so no baseline change


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

