### PR TITLE
Stop a legacy conversation record from 500ing the MCP single-conversation fetch

### DIFF
--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -552,7 +552,14 @@ def get_conversation_by_id(
 
     populate_speaker_names(uid, [conversation])
 
-    return conversation
+    # A legacy/poisoned record (e.g. a structured.category no longer in CategoryEnum)
+    # must not 500 this single-item fetch via response_model coercion — mirror the
+    # per-record guard already used by the list/search siblings above.
+    try:
+        return FullConversation.model_validate(conversation)
+    except Exception as e:  # noqa: BLE001 - malformed legacy record must not 500
+        logger.warning(f"Conversation {conversation_id} failed MCP response validation: {e}")
+        raise HTTPException(status_code=404, detail="Conversation not found")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_mcp_conversation_by_id_poison.py
+++ b/backend/tests/unit/test_mcp_conversation_by_id_poison.py
@@ -1,0 +1,103 @@
+"""Unit test for the MCP get_conversation_by_id poison-record guard (routers/mcp.py).
+
+A single malformed conversation record (e.g. a structured.category no longer in
+CategoryEnum) must not 500 GET /v1/mcp/conversations/{conversation_id} via
+response_model coercion. The sibling list/search endpoints
+(get_conversations, search_conversations) already validate each record
+individually and skip the bad ones (see test_mcp_conversations_poison.py); this
+single-item endpoint had no such guard and returned the raw, unvalidated dict,
+letting FastAPI's response_model serialization raise a ResponseValidationError
+(-> HTTP 500) for a conversation whose stored category predates a CategoryEnum
+rename/consolidation (e.g. a legacy 'romance' value before it became
+'romantic').
+
+``routers.mcp`` imports cleanly in this environment (no import-time side
+effects), so this test imports it directly at module scope and uses
+``monkeypatch.setattr`` on its module-level ``conversations_db`` /
+``populate_speaker_names`` references plus FastAPI ``app.dependency_overrides``
+— the sanctioned seams from ``backend/docs/test_isolation.md`` — instead of
+stubbing ``sys.modules``.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from routers import mcp as rest
+
+NOW = datetime(2026, 6, 11, tzinfo=timezone.utc)
+UID = "user-1"
+
+
+def _conversation(conv_id='conv-good', category='technology'):
+    return {
+        'id': conv_id,
+        'started_at': NOW,
+        'finished_at': NOW,
+        'structured': {
+            'title': 'Standup',
+            'overview': 'Daily sync',
+            'category': category,
+        },
+        'language': 'en',
+    }
+
+
+@pytest.fixture
+def mcp_test_client(monkeypatch):
+    # populate_speaker_names normally reads the user profile / person records;
+    # neutralize it so the test only exercises the response-shape guard.
+    monkeypatch.setattr(rest, 'populate_speaker_names', lambda uid, conversations: None)
+
+    app = FastAPI()
+    app.include_router(rest.router)
+    app.dependency_overrides[rest.get_uid_from_mcp_api_key] = lambda: UID
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestGetConversationByIdPoisonRecord:
+    """A single malformed conversation record must not 500 the MCP single-item fetch."""
+
+    def test_poisoned_category_returns_404_not_500(self, monkeypatch, mcp_test_client):
+        # structured.category holds a legacy value that predates a CategoryEnum
+        # rename/consolidation and is therefore not a valid CategoryEnum member today.
+        monkeypatch.setattr(
+            rest.conversations_db,
+            'get_conversation',
+            lambda uid, conversation_id: _conversation('conv-poison', category='not_a_real_category'),
+        )
+
+        resp = mcp_test_client.get('/v1/mcp/conversations/conv-poison')
+
+        # Without the per-record guard, response_model coercion 500s here.
+        assert resp.status_code == 404, f"expected 404, got {resp.status_code}: {resp.text}"
+
+    def test_valid_conversation_returns_200(self, monkeypatch, mcp_test_client):
+        monkeypatch.setattr(
+            rest.conversations_db,
+            'get_conversation',
+            lambda uid, conversation_id: _conversation('conv-good', category='technology'),
+        )
+
+        resp = mcp_test_client.get('/v1/mcp/conversations/conv-good')
+
+        assert resp.status_code == 200, f"expected 200, got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        assert body['id'] == 'conv-good'
+        assert body['structured']['category'] == 'technology'
+
+    def test_direct_call_poisoned_category_raises_http_404(self, monkeypatch):
+        """Direct-call form (mirrors the sibling list-endpoint test style)."""
+        monkeypatch.setattr(rest, 'populate_speaker_names', lambda uid, conversations: None)
+        monkeypatch.setattr(
+            rest.conversations_db,
+            'get_conversation',
+            lambda uid, conversation_id: _conversation('conv-poison', category='not_a_real_category'),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            rest.get_conversation_by_id(conversation_id='conv-poison', uid=UID)
+
+        assert exc_info.value.status_code == 404


### PR DESCRIPTION
`GET /v1/mcp/conversations/{conversation_id}` declares `response_model=FullConversation` and
returns the raw Firestore document:

```python
conversation = conversations_db.get_conversation(uid, conversation_id)
...
return conversation
```

`FullConversation.structured.category` is a required, non-Optional `CategoryEnum` with no
validator. Any stored conversation whose `structured.category` is not a current enum member fails
response_model coercion, which surfaces as an unhandled **HTTP 500**.

That is not hypothetical for legacy data — the enum itself carries `romance = 'romantic'`, so the
stored value and the member name have already diverged once.

## The siblings already guard this

The list and search endpoints in this same file handle exactly this case about sixty lines above,
with the reasoning written down:

```python
# Validate each record individually so one malformed conversation (e.g. a category
# no longer in CategoryEnum) cannot 500 the whole page via response_model coercion.
```

The single-item fetch never got the same treatment, so a conversation the list endpoint quietly
skips takes down the by-id fetch instead.

## The fix

Validate explicitly and convert a failure into the 404 the route already returns for a missing
conversation — which is also how the list path effectively treats such a record: it is not
returned.

The declared contract does not move. `response_model=FullConversation` and the 200 schema are
unchanged, and 404 is already documented for this path, so an undocumented 500 becomes an
already-documented 404 and no spec regeneration is needed.

The broad `except` is deliberate and narrow in scope: pydantic can raise more than
`ValidationError` while coercing a nested legacy record, and the whole point is that no shape of
malformed stored data should be able to 500 this route. The failure is logged with the
conversation id so a real data problem stays visible rather than being silently swallowed.

## Tests

`tests/unit/test_mcp_conversation_by_id_poison.py`:

- a poisoned category returns 404 rather than 500 through the app
- the same case raises `HTTPException(404)` on a direct handler call
- a valid conversation still returns 200 unchanged

## Verification

Run in `backend/`:

- `pytest tests/unit/test_mcp_conversation_by_id_poison.py`: 3 passed
- prove-fail: with `routers/mcp.py` reverted to origin/main and confirmed byte-identical
  (`git diff origin/main` empty), the poisoned cases fail with
  `expected 404, got 500: Internal Server Error` / `assert 500 == 404` and
  `DID NOT RAISE HTTPException`, while the valid-record test passes both ways. Re-applied: 3 passed
- pytest with `test_mcp_conversations_poison.py` and `test_mcp_data_endpoints.py`: 39 passed
- the test imports `routers.mcp` at module scope, so the router import is collection cost rather
  than per-test CPU and the file clears the fast-unit duration guard
- `black --line-length 120 --skip-string-normalization --check`: clean
- `scripts/check_module_stub_pollution.py`: 736 files, 0 violations
- `routers/mcp.py` is 797 lines and is not in the product file line-count ratchet baseline

## Related, not fixed here

`routers/developer.py`'s `update_conversation_endpoint` has the same CategoryEnum exposure in its
PATCH-and-refetch path, and arguably worse: the write already succeeds before the re-fetch 500s,
so a successful mutation looks failed to the client. Same fix shape would apply. Left for a
follow-up rather than bundled in.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

