### PR TITLE
fix(dev-harness): prevent quote-root command injection

### DIFF
--- a/.github/failure-classes/FC-shell-source-path-interpolation.json
+++ b/.github/failure-classes/FC-shell-source-path-interpolation.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "id": "FC-shell-source-path-interpolation",
+  "violated_contract": "A repository checkout path must never be interpolated into shell program text where path characters can change shell syntax or execute commands.",
+  "canonical_prevention": "Derive the resolver path inside the shell program or pass paths as shell data, and exercise the real Make target from a quote-containing temporary checkout with a controlled marker command.",
+  "evidence_prs": [10017],
+  "scope_hints": [
+    "Makefile",
+    "scripts/dev-harness/_resolve_python.sh",
+    "scripts/dev-harness/tests/test_python_resolver.py"
+  ],
+  "status": "open"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 HOOKS_DIR := $(shell git rev-parse --git-path hooks)
 PYTHON ?= $(shell bash -c 'source "$$(git rev-parse --show-toplevel)/scripts/dev-harness/_resolve_python.sh"; dev_harness_python')
+# Export so recipes use $$PYTHON (shell variable expansion) instead of $(PYTHON)
+# (Make text interpolation). Shell variable expansion treats the resolved path
+# as data and cannot be broken by quote or command-substitution characters in
+# the checkout root, unlike Make interpolation into recipe shell text.
+export PYTHON
 DESKTOP_USER ?= alice
 DESKTOP_APP_NAME ?=
 
@@ -59,20 +64,20 @@ dev-logs:
 	bash scripts/dev-harness/dev-logs.sh
 
 list-memory-scenarios:
-	"$(PYTHON)" scripts/dev-harness/list-memory-scenarios.py
+	"$$PYTHON" scripts/dev-harness/list-memory-scenarios.py
 
 seed-memory-scenario:
-	"$(PYTHON)" scripts/dev-harness/seed-memory-scenario.py $(SCENARIO)
+	"$$PYTHON" scripts/dev-harness/seed-memory-scenario.py $(SCENARIO)
 
 reset-memory-scenario:
-	"$(PYTHON)" scripts/dev-harness/reset-memory-scenario.py $(SCENARIO)
+	"$$PYTHON" scripts/dev-harness/reset-memory-scenario.py $(SCENARIO)
 
 desktop-run-local:
 	@if [ -n "$(DESKTOP_APP_NAME)" ]; then \
-		PYTHON="$(PYTHON)" OMI_APP_NAME="$(DESKTOP_APP_NAME)" bash scripts/dev-harness/desktop-run-local.sh "$(DESKTOP_USER)"; \
+		PYTHON="$$PYTHON" OMI_APP_NAME="$(DESKTOP_APP_NAME)" bash scripts/dev-harness/desktop-run-local.sh "$(DESKTOP_USER)"; \
 	else \
-		PYTHON="$(PYTHON)" bash scripts/dev-harness/desktop-run-local.sh "$(DESKTOP_USER)"; \
+		PYTHON="$$PYTHON" bash scripts/dev-harness/desktop-run-local.sh "$(DESKTOP_USER)"; \
 	fi
 
 run-canonical-promotion:
-	PYTHON="$(PYTHON)" PYTHONPATH="scripts/dev-harness:backend$(if $(PYTHONPATH),:$(PYTHONPATH),)" "$(PYTHON)" scripts/dev-harness/run-canonical-promotion.py "$(PROMOTION_USER)"
+	PYTHON="$$PYTHON" PYTHONPATH="scripts/dev-harness:backend$(if $(PYTHONPATH),:$(PYTHONPATH),)" "$$PYTHON" scripts/dev-harness/run-canonical-promotion.py "$(PROMOTION_USER)"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-ROOT := $(shell git rev-parse --show-toplevel)
 HOOKS_DIR := $(shell git rev-parse --git-path hooks)
-PYTHON ?= $(shell bash -c 'source "$(ROOT)/scripts/dev-harness/_resolve_python.sh"; dev_harness_python')
+PYTHON ?= $(shell bash -c 'source "$$(git rev-parse --show-toplevel)/scripts/dev-harness/_resolve_python.sh"; dev_harness_python')
 DESKTOP_USER ?= alice
 DESKTOP_APP_NAME ?=
 

--- a/scripts/dev-harness/tests/test_python_resolver.py
+++ b/scripts/dev-harness/tests/test_python_resolver.py
@@ -122,3 +122,38 @@ def test_make_harness_targets_run_resolved_python_from_checkout_with_spaces(tmp_
         "scripts/dev-harness/reset-memory-scenario.py sample",
         "scripts/dev-harness/run-canonical-promotion.py alice",
     ]
+
+
+def test_make_harness_does_not_execute_checkout_name_and_resolves_python(tmp_path: Path) -> None:
+    repo = tmp_path / "omi pr-10017'; touch injected-marker; #"
+    marker = repo / "injected-marker"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    shutil.copy2(MAKEFILE, repo / "Makefile")
+
+    resolver = repo / "scripts/dev-harness/_resolve_python.sh"
+    resolver.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(RESOLVER, resolver)
+
+    calls = repo / "python calls.log"
+    python = repo / "backend/.venv/bin/python"
+    python.parent.mkdir(parents=True, exist_ok=True)
+    python.write_text('#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$HARNESS_PYTHON_CALLS"\n', encoding="utf-8")
+    python.chmod(python.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env.pop("PYTHON", None)
+    env["HARNESS_PYTHON_CALLS"] = str(calls)
+    result = subprocess.run(
+        ["make", "-C", str(repo), "list-memory-scenarios"],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+
+    assert not marker.exists()
+    assert result.returncode == 0, result.stderr
+    assert calls.read_text(encoding="utf-8").splitlines() == ["scripts/dev-harness/list-memory-scenarios.py"]

--- a/scripts/dev-harness/tests/test_python_resolver.py
+++ b/scripts/dev-harness/tests/test_python_resolver.py
@@ -157,3 +157,44 @@ def test_make_harness_does_not_execute_checkout_name_and_resolves_python(tmp_pat
     assert not marker.exists()
     assert result.returncode == 0, result.stderr
     assert calls.read_text(encoding="utf-8").splitlines() == ["scripts/dev-harness/list-memory-scenarios.py"]
+
+
+def test_make_harness_does_not_execute_double_quote_in_checkout_name(tmp_path: Path) -> None:
+    """A double quote in the checkout root must not break recipe shell quoting.
+
+    Recipes now use $$PYTHON (shell variable expansion) instead of $(PYTHON)
+    (Make text interpolation). Shell variable expansion treats the resolved
+    path as data, so quote characters cannot escape the recipe's quoting.
+    """
+    repo = tmp_path / 'omi "; touch double-quote-marker; #'
+    marker = repo / "double-quote-marker"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    shutil.copy2(MAKEFILE, repo / "Makefile")
+
+    resolver = repo / "scripts/dev-harness/_resolve_python.sh"
+    resolver.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(RESOLVER, resolver)
+
+    calls = repo / "python calls.log"
+    python = repo / "backend/.venv/bin/python"
+    python.parent.mkdir(parents=True, exist_ok=True)
+    python.write_text('#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$HARNESS_PYTHON_CALLS"\n', encoding="utf-8")
+    python.chmod(python.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env.pop("PYTHON", None)
+    env["HARNESS_PYTHON_CALLS"] = str(calls)
+    result = subprocess.run(
+        ["make", "-C", str(repo), "list-memory-scenarios"],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+
+    assert not marker.exists()
+    assert result.returncode == 0, result.stderr
+    assert calls.read_text(encoding="utf-8").splitlines() == ["scripts/dev-harness/list-memory-scenarios.py"]


### PR DESCRIPTION
## Summary
- Prevent Make's Python resolver expansion from interpolating the checkout root into `bash -c` source text.
- Resolve the harness script path inside Bash via `git rev-parse --show-toplevel` instead.
- Add a regression test using a checkout name containing a single quote and controlled `touch injected-marker` payload; it confirms no marker runs and the canonical `backend/.venv/bin/python` still handles the Make target.

## Root cause and durable guard
PR #10017 embedded `$(ROOT)` inside an outer single-quoted `bash -c` program. A single quote in the checkout root terminated that shell quoting and allowed subsequent path text to execute as shell syntax. The Makefile no longer interpolates the root into the shell program; the regression executes the real Make target in a maliciously named temporary Git checkout.

## Red/green proof
- **Red (before fix):** the controlled reproduction against `c16c21d1dbb0063e5f200374d808dad779a9bf3b` returned `marker_exists=True` after `make -n list-memory-scenarios` in a checkout named with `'; touch …; #`.
- **Green:** the new focused regression passes with no marker and records the resolved canonical venv invocation.

## Verification
- `env -u PYTHON python3 -m pytest scripts/dev-harness/tests/test_python_resolver.py -q` (4 passed)
- `env -u PYTHON make preflight`
- `bash -n scripts/dev-harness/_resolve_python.sh`
- quote-root Make dry run and `git diff --check`

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

