### PR TITLE
fix(ci): sync new issues to project Status 'Someday' not removed 'Backlog'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           project_field: Status
           # Optional unless that project_field was set up. Then this field is required.
           # The value to modify in the project field
-          project_value: Backlog
+          project_value: Someday
           # Optional, labels to work with. Read below to see how to configure it.
           # If this value is set, the action will be applied only to issues with such label(s).
           labels: |


### PR DESCRIPTION
## What
Change the `GitHub Issue Sync` workflow (`.github/workflows/main.yml`) to assign newly opened `task`-labeled issues to org project 1 with Status **`Someday`** instead of the removed **`Backlog`** option.

## Why
Org project 1 no longer has a `Backlog` Status option, so every `task`-labeled sync fails at the fetch-project-values step. Issue #9736 evidence:

> `Error: Project value 'Backlog' does not exist. Available values are ["Someday","Next Week","TODO (This week)","In progress","In review","Done"]`

`Someday` is the current option that preserves the backlog semantics (items were historically routed to `Backlog`, not the active-week queue); `TODO (This week)` would wrongly promote every synced item into the active week. Nothing else — project number, field, token, event triggers, or label filter — changes.

## Verified
- Reproduced live: run **29678923243** (2026-07-19, `task`-labeled issue) failed with the exact error above; runs on non-`task` issues pass only because the action skips them (`Label 'bug' does not match ... Skipping`).
- Confirmed the current file still had `project_value: Backlog`.
- Confirmed `Someday` is a valid current Status from the CI error's own "Available values" list.
- `python3 -c yaml.safe_load` parses the edited workflow cleanly; single-line change, no other keys touched.

Auto-generated from issue feedback by the mini issues-improver. Review before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

