### PR TITLE
fix(desktop): refresh memory search projection

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -3,7 +3,7 @@
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1939,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3643,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4448,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3243,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3298,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5510,
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1570
   },
@@ -11,7 +11,7 @@
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": "Syncs the local rating shadow to external message.rating changes so an un-rate tap is no longer swallowed after a server refresh.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "Rebase reconciliation applies the pinned swift-format to the main-branch app-detail safety fixes; runtime behavior is unchanged.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": "Bridge memory search now awaits the active initial or pagination projection before refreshing, preventing an immediate post-navigation marker search from using stale lifecycle capability state.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": "Tasks now bind first-load, loading, error, and retry state to the selected To Do or Done view so completed cache rows cannot suppress an active-view fetch.",
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": "Strict concurrency imports annotate legacy AppKit image usage without changing runtime behavior."
   },

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1435,13 +1435,13 @@ class MemoriesViewModel: ObservableObject {
     guard !didRegisterAutomationActions else { return }
     didRegisterAutomationActions = true
     let registry = DesktopAutomationActionRegistry.shared
-
     registry.register(
       name: "memories_search",
       summary: "Set memories search query and return filtered result count",
       params: ["query"]
     ) { [weak self] params in
       guard let self else { return ["error": "memories view model deallocated"] }
+      await self.refreshMemoriesIfNeeded()
       let query = params["query"] ?? ""
       self.searchText = query
       let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -100,8 +100,12 @@ class MemoriesViewModel: ObservableObject {
   @Published var memories: [ServerMemory] = [] {
     didSet { recomputeCaches() }
   }
-  @Published var isLoading = false
-  @Published var isLoadingMore = false
+  @Published var isLoading = false {
+    didSet { resumeMemoryLoadLifecycleWaitersIfIdle() }
+  }
+  @Published var isLoadingMore = false {
+    didSet { resumeMemoryLoadLifecycleWaitersIfIdle() }
+  }
   @Published var hasMoreMemories = true
   @Published var errorMessage: String?
   @Published var searchText = "" {
@@ -197,6 +201,14 @@ class MemoriesViewModel: ObservableObject {
   private var deleteTask: Task<Void, Never>? = nil
   private var cancellables = Set<AnyCancellable>()
   private var hasLoadedInitially = false
+
+  /// A cache-first initial load can clear `isLoading` while its authoritative
+  /// API projection is still syncing. Automation search must wait for that
+  /// lifecycle to finish instead of treating the temporarily hidden spinner as
+  /// an idle projection.
+  private var inFlightInitialMemoryLoads = 0
+  private var memoryLoadLifecycleWaiters: [CheckedContinuation<Void, Never>] = []
+  private(set) var memoryLoadLifecycleWaiterCount = 0
 
   /// Whether the memories page is currently visible.
   /// Auto-refresh only runs when active to avoid unnecessary API calls.
@@ -545,15 +557,23 @@ class MemoriesViewModel: ObservableObject {
     displayLimit = pageSize
   }
 
-  /// Refresh memories if already loaded (for auto-refresh)
-  private func refreshMemoriesIfNeeded() async {
+  /// Refresh memories if already loaded (for auto-refresh).
+  ///
+  /// The automation bridge invokes this immediately before a lifecycle-scoped
+  /// SQLite search. Await an active initial/paginated load first so that search
+  /// cannot observe the stale capability projection which that load is about to
+  /// replace.
+  func refreshMemoriesIfNeeded() async {
     refreshInvocations += 1
     // Skip if user is signed out (tokens are cleared)
     guard AuthState.shared.isSignedIn else { return }
     // Skip if page is not visible
     guard isActive else { return }
 
-    // Skip if currently loading or haven't loaded initially
+    await waitForMemoryLoadLifecycleToSettle()
+
+    // An initial request may fail, in which case there is no authoritative
+    // projection to refresh yet.
     guard !isLoading, !isLoadingMore, hasLoadedInitially else { return }
 
     // Skip if there's a pending delete (avoid interfering with undo)
@@ -588,6 +608,32 @@ class MemoriesViewModel: ObservableObject {
     } catch {
       // Silently ignore errors during auto-refresh
       logError("MemoriesViewModel: Auto-refresh failed", error: error)
+    }
+  }
+
+  private var isMemoryLoadLifecycleActive: Bool {
+    inFlightInitialMemoryLoads > 0 || isLoading || isLoadingMore
+  }
+
+  private func waitForMemoryLoadLifecycleToSettle() async {
+    guard isMemoryLoadLifecycleActive else { return }
+    await withCheckedContinuation { continuation in
+      guard isMemoryLoadLifecycleActive else {
+        continuation.resume()
+        return
+      }
+      memoryLoadLifecycleWaiters.append(continuation)
+      memoryLoadLifecycleWaiterCount = memoryLoadLifecycleWaiters.count
+    }
+  }
+
+  private func resumeMemoryLoadLifecycleWaitersIfIdle() {
+    guard !isMemoryLoadLifecycleActive else { return }
+    let waiters = memoryLoadLifecycleWaiters
+    memoryLoadLifecycleWaiters.removeAll()
+    memoryLoadLifecycleWaiterCount = 0
+    for waiter in waiters {
+      waiter.resume()
     }
   }
 
@@ -821,6 +867,12 @@ class MemoriesViewModel: ObservableObject {
   /// 4. Sync to local cache in background
   func loadMemories() async {
     guard !isLoading else { return }
+
+    inFlightInitialMemoryLoads += 1
+    defer {
+      inFlightInitialMemoryLoads -= 1
+      resumeMemoryLoadLifecycleWaitersIfIdle()
+    }
 
     isLoading = true
     errorMessage = nil
@@ -1114,7 +1166,10 @@ class MemoriesViewModel: ObservableObject {
     isLoadingMore = true
     // Clear the flag on every exit path, including stale-scope guard returns,
     // so pagination is not permanently blocked by `guard !isLoadingMore`.
-    defer { isLoadingMore = false }
+    defer {
+      isLoadingMore = false
+      resumeMemoryLoadLifecycleWaitersIfIdle()
+    }
     let token = currentScopeToken
     let requestedOffset = currentOffset
     let requestedRawOffset = rawBackendOffset

--- a/desktop/macos/Desktop/Tests/DesktopAutomationSecondaryActionTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopAutomationSecondaryActionTests.swift
@@ -167,6 +167,20 @@ final class DesktopAutomationSecondaryActionTests: XCTestCase {
     XCTAssertTrue(source.contains("filteredFromDatabase.first(where:"))
   }
 
+  func testMemorySearchRefreshesTheVisibleMemoriesProjection() throws {
+    let pageURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/MainWindow/Pages/MemoriesPage.swift")
+    // omi-test-quality: source-inspection -- static contract: bridge search must refresh its projection before lifecycle-scoped SQLite search
+    let source = try String(contentsOf: pageURL, encoding: .utf8)
+    let body = try actionBody(named: "memories_search", in: source)
+    XCTAssertTrue(
+      body.contains("await self.refreshMemoriesIfNeeded()"),
+      "A bridge search must refresh the active MemoriesViewModel before it reads lifecycle-scoped local cache."
+    )
+  }
+
   func testMemoryCrudActionsUseNonProdGuard() throws {
     let source = try bridgeSource()
     for action in [

--- a/desktop/macos/Desktop/Tests/MemoriesViewModelObserverTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoriesViewModelObserverTests.swift
@@ -59,6 +59,25 @@ final class MemoriesViewModelObserverTests: XCTestCase {
     )
   }
 
+  func testRefreshWaitsForActiveInitialLoadBeforeReturning() async {
+    let viewModel = MemoriesViewModel()
+    viewModel.isActive = true
+    viewModel.isLoading = true
+
+    // Force the bridge-search interleave: its refresh reaches the view model
+    // while navigation's initial load still owns the projection. This must
+    // suspend at the lifecycle barrier rather than silently no-op.
+    let refresh = Task { await viewModel.refreshMemoriesIfNeeded() }
+    await Task.yield()
+    XCTAssertEqual(viewModel.memoryLoadLifecycleWaiterCount, 1)
+
+    viewModel.isLoading = false
+    await refresh.value
+
+    XCTAssertEqual(viewModel.memoryLoadLifecycleWaiterCount, 0)
+    XCTAssertEqual(viewModel.refreshInvocations, 1)
+  }
+
   func testConversationDeletedNotificationTriggersCascadeHandler() async throws {
     let conversationId = "conv-cascade-test"
     let linkedMemory = makeMemory(id: "mem-linked", conversationId: conversationId)

--- a/desktop/macos/changelog/unreleased/20260719-memory-search-projection-refresh.json
+++ b/desktop/macos/changelog/unreleased/20260719-memory-search-projection-refresh.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a desktop memory search edge case so newly added memories remain searchable and their visibility can be updated."
+}

--- a/desktop/macos/e2e/flows/memory-depth.yaml
+++ b/desktop/macos/e2e/flows/memory-depth.yaml
@@ -1,7 +1,7 @@
 version: 2
 name: memory-depth
 tier: 2
-description: Memory search, tag filter, and visibility toggle after create
+description: Memory search, tag filter, and visibility toggle after an immediate post-navigation create
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -11,7 +11,7 @@ preconditions:
 
 steps:
   - id: S1
-    name: Navigate to Memories
+    name: Navigate to Memories and begin its initial projection
     bridge.navigate:
       target: memories
       activateApp: false
@@ -19,7 +19,7 @@ steps:
       state.selectedTabIndex: 3
 
   - id: S2
-    name: Create hermetic test memory
+    name: Create hermetic test memory while the initial projection may still be loading
     bridge.action:
       name: create_test_memory
       params:
@@ -29,7 +29,7 @@ steps:
       result.detail.created: "true"
 
   - id: S3
-    name: Search for harness memory
+    name: Search for the marker after the initial-load/create interleave
     bridge.action:
       name: memories_search
       params:


### PR DESCRIPTION
## Summary
- Refresh the active Memories projection before a bridge search reads lifecycle-scoped cache.
- Keep Tier-2 marker-memory search and visibility toggle on the authoritative page capability path.

## Root cause
`create_test_memory` synchronized an explicit-tier server record directly into SQLite, but the active `MemoriesViewModel` could still hold the previous lifecycle capability. Its subsequent bridge search selected the legacy cache scope, excluding the newly-created explicit record; visibility then could not resolve the marker.

## Durable guard
- The bridge search refreshes the visible `MemoriesViewModel` projection before querying scoped local storage.
- Focused regression test locks the refresh wiring; the real named-bundle `memory-depth` bridge flow exercises create → search → tag filter → visibility toggle → delete.

## Verification
- `xcrun swift test --package-path Desktop --filter 'DesktopAutomationSecondaryActionTests|MemoryAuthoritativeTierSyncTests|MemoryLayerFilterTests'` — 51 tests passed.
- `xcrun swift build -c debug --package-path Desktop` — passed.
- `./scripts/agent-logic-harness.sh --cross-surface-smoke` — passed.
- Named bundle `com.omi.omi-memory-depth-fix`: `./scripts/omi-harness run e2e/flows/memory-depth.yaml --lane bridge` — PASS (S3 result_count=1; S5 toggled=true).

## Failure-Class
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

