### PR TITLE
fix: prevent startup notification callback crash

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-proactiveassistants.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-proactiveassistants.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift": 1742,
-    "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": 1645
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": 1669
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift": "Task candidate context now carries only backend action-item IDs, while local SQLite/staged evidence remains id-less so the model cannot target it for a backend mutation.",
-    "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": "stopMonitoring now clears capture-recovery/background-polling state and timers, plus a pure ProactiveCapturePolicy gate, so a stop mid-recovery cannot silently disable capture on the next start."
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": "A nonisolated UserNotifications callback bridge now performs an explicit MainActor hop so macOS callback queues cannot trap the public app at launch."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -277,38 +277,62 @@ public class ProactiveAssistantsPlugin: NSObject {
     }
 
     // Request notification permission in parallel, but only for first-time users.
-    // Denied users should not be put through repeated startup repair loops.
-    UNUserNotificationCenter.current().getNotificationSettings { settings in
-      DispatchQueue.main.async {
-        guard settings.authorizationStatus == .notDetermined else {
-          log("Skipping startup notification authorization request (auth=\(settings.authorizationStatus.rawValue))")
-          return
-        }
-
-        // Only attempt the launch-services repair-capable authorization once per
-        // app version on this non-user-initiated path. Otherwise users stuck in the
-        // launch-disabled + notDetermined state re-run lsregister + killall
-        // usernoted/NotificationCenter on every launch/wake (issue #9082). The
-        // user-initiated "Fix" flows and onboarding prompt remain unaffected.
-        guard NotificationRegistrationRepair.shouldAttemptStartupRepair() else {
-          log("Skipping startup notification repair — already attempted for this app version")
-          return
-        }
-        NotificationRegistrationRepair.markStartupRepairAttempted()
-
-        NotificationRegistrationRepair.requestAuthorizationRepairingLaunchServices(
-          reason: "launch_disabled_error_startup",
-          previousStatus: "notDetermined"
-        ) { granted in
-          if !granted {
-            log("Notification permission not granted - screen analysis will work but notifications will be disabled")
-          }
-        }
-      }
-    }
+    // This must enter UserNotifications through a nonisolated bridge: its callback
+    // queue is not main, and a closure lexically created here would inherit MainActor.
+    Self.queryStartupNotificationSettings(
+      query: Self.systemNotificationSettingsQuery,
+      handler: Self.handleStartupNotificationAuthorizationStatus
+    )
 
     // Start monitoring immediately — don't wait for notification permission callback
     continueStartMonitoring(completion: completion)
+  }
+
+  /// The only production registration point for UserNotifications. It is
+  /// nonisolated so the system callback cannot inherit the class's MainActor.
+  nonisolated private static func systemNotificationSettingsQuery(
+    completion: @escaping @Sendable (UNAuthorizationStatus) -> Void
+  ) {
+    UNUserNotificationCenter.current().getNotificationSettings { settings in
+      completion(settings.authorizationStatus)
+    }
+  }
+
+  /// Registers the system callback outside MainActor, then hands only its
+  /// authorization status to a MainActor handler. `query` is injected so the
+  /// off-main callback contract is exercised without a system permission prompt.
+  nonisolated static func queryStartupNotificationSettings(
+    query: @escaping @Sendable (@escaping @Sendable (UNAuthorizationStatus) -> Void) -> Void,
+    handler: @escaping @MainActor @Sendable (UNAuthorizationStatus) -> Void
+  ) {
+    query { authorizationStatus in
+      Task { @MainActor in
+        handler(authorizationStatus)
+      }
+    }
+  }
+
+  @MainActor
+  private static func handleStartupNotificationAuthorizationStatus(_ authorizationStatus: UNAuthorizationStatus) {
+    guard authorizationStatus == .notDetermined else {
+      log("Skipping startup notification authorization request (auth=\(authorizationStatus.rawValue))")
+      return
+    }
+
+    guard NotificationRegistrationRepair.shouldAttemptStartupRepair() else {
+      log("Skipping startup notification repair — already attempted for this app version")
+      return
+    }
+    NotificationRegistrationRepair.markStartupRepairAttempted()
+
+    NotificationRegistrationRepair.requestAuthorizationRepairingLaunchServices(
+      reason: "launch_disabled_error_startup",
+      previousStatus: "notDetermined"
+    ) { granted in
+      if !granted {
+        log("Notification permission not granted - screen analysis will work but notifications will be disabled")
+      }
+    }
   }
 
   /// Repair LaunchServices registration when notification authorization fails with "not allowed".

--- a/desktop/macos/Desktop/Tests/ProactiveAssistantsNotificationSettingsTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveAssistantsNotificationSettingsTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class ProactiveAssistantsNotificationSettingsTests: XCTestCase {
+  func testNotificationSettingsCallbackDeliveredOffMainHopsToMainActor() async {
+    let result = await withCheckedContinuation { continuation in
+      ProactiveAssistantsPlugin.queryStartupNotificationSettings(
+        query: { completion in
+          DispatchQueue.global(qos: .userInitiated).async {
+            completion(.notDetermined)
+          }
+        },
+        handler: { status in
+          continuation.resume(returning: (Thread.isMainThread, status))
+        }
+      )
+    }
+
+    XCTAssertTrue(result.0)
+    XCTAssertEqual(result.1, .notDetermined)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260719-notification-startup-callback-crash.json
+++ b/desktop/macos/changelog/unreleased/20260719-notification-startup-callback-crash.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a crash that could occur while checking notification permission at startup"
+}


### PR DESCRIPTION
## Summary

- prevent the macOS startup crash caused by UserNotifications delivering its settings callback off-main;
- isolate the system callback in a nonisolated bridge and explicitly hand the result to MainActor;
- add a deterministic off-main callback regression.

## Verification

- Swift source parse, formatting, and diff checks passed.
- The focused Swift test build reaches the new test but is blocked by an unrelated pre-existing actor-isolation compile failure in `ActionItemLocalIdentityMutationTests.swift:117`.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

