### PR TITLE
refactor(proxy): migrate the Gemini deadline onto the shared RequestDeadline (after #10054)

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -91,6 +91,16 @@ checks:
     triggers: [".github/scripts/check-desktop-changelog.py", ".github/scripts/desktop-changelog.py", ".github/scripts/test_desktop_changelog.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#9717: changelog tooling must preserve UTF-8 I/O and exempt only internal desktop release controls"
+  - id: chat-send-deadline
+    command: ["python3", ".github/scripts/check_chat_send_deadline.py"]
+    triggers: ["desktop/macos/Backend-Rust/src/routes/chat/**", "desktop/macos/Backend-Rust/src/request_deadline.rs", ".github/scripts/check_chat_send_deadline.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#9835 (FC-per-hop-timeout): chat provider sends must consume the request budget via send_with_deadline; caught class #8640/#8911/#9135/#9644"
+  - id: chat-send-deadline-tests
+    command: ["python3", ".github/scripts/test_check_chat_send_deadline.py"]
+    triggers: [".github/scripts/check_chat_send_deadline.py", ".github/scripts/test_check_chat_send_deadline.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "chat send-deadline tripwire must keep rejecting direct sends and accepting the budgeted seam"
   - id: agents-md-lean
     command: ["python3", ".github/scripts/check_agents_md_lean.py"]
     triggers: ["AGENTS.md", "**/AGENTS.md", ".github/scripts/check_agents_md_lean.py"]

--- a/.github/failure-classes/FC-per-hop-timeout.json
+++ b/.github/failure-classes/FC-per-hop-timeout.json
@@ -3,6 +3,7 @@
   "id": "FC-per-hop-timeout",
   "violated_contract": "A multi-hop request must consume one request-level deadline budget rather than receive a full timeout at each hop.",
   "canonical_prevention": "Compute the remaining request deadline before every downstream operation and fail when the shared budget is exhausted.",
+  "canonical_prevention_artifact": [".github/scripts/check_chat_send_deadline.py"],
   "evidence_prs": [9533, 9644],
   "scope_hints": ["backend/**", "desktop/macos/**"],
   "status": "open"

--- a/.github/scripts/check_chat_send_deadline.py
+++ b/.github/scripts/check_chat_send_deadline.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Direct provider sends in routes/chat/ must go through send_with_deadline.
+
+Caught class (FC-per-hop-timeout): #8640, #8911, #9135, and #9644 each moved a
+per-hop timeout because a raw send owned its own clock. The request budget seam
+in `desktop/macos/Backend-Rust/src/request_deadline.rs` is the single owner of
+outbound provider waits on the Anthropic chat path (#9835). Signatures alone do
+not cover raw reqwest builders, so this STATIC TRIPWIRE rejects new direct
+`.send()` calls in the chat module; behavioral coverage lives in the
+`tokio::time::pause` deadline tests in `routes/chat/tests/all.rs`.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CHAT_DIR = ROOT / "desktop" / "macos" / "Backend-Rust" / "src" / "routes" / "chat"
+DIRECT_SEND_RE = re.compile(r"\.send\(\)")
+
+
+def find_direct_sends(chat_dir: Path) -> list[str]:
+    violations: list[str] = []
+    for path in sorted(chat_dir.rglob("*.rs")):
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if DIRECT_SEND_RE.search(line):
+                try:
+                    shown = path.relative_to(ROOT)
+                except ValueError:
+                    shown = path
+                violations.append(f"{shown}:{lineno}: direct `.send()` bypasses send_with_deadline")
+    return violations
+
+
+def main() -> int:
+    violations = find_direct_sends(CHAT_DIR)
+    if violations:
+        print("\n".join(violations), file=sys.stderr)
+        print(
+            "Chat provider sends must consume the request budget via "
+            "crate::request_deadline::send_with_deadline (#9835, FC-per-hop-timeout).",
+            file=sys.stderr,
+        )
+        return 1
+    print("chat send-deadline contract: no direct provider sends in routes/chat/")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-rust.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-rust.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "desktop/macos/Backend-Rust/src/routes/proxy.rs": 2806
+    "desktop/macos/Backend-Rust/src/routes/proxy.rs": 2780
   },
   "raise_justifications": {
     "desktop/macos/Backend-Rust/src/routes/proxy.rs": "Streaming Gemini Vertex->AI Studio heal telemetry now derives its Recovered/Exhausted outcome from the upstream HTTP status (a testable stream_heal_outcome helper) instead of send-success, matching the non-streaming provider-switch telemetry; adds a unit test. +3 for the test-module clippy::unwrap_used allow scoping the crate deny to production code."

--- a/.github/scripts/test_check_chat_send_deadline.py
+++ b/.github/scripts/test_check_chat_send_deadline.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Fixtures for the chat send-deadline static tripwire (#9835)."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_chat_send_deadline import CHAT_DIR, find_direct_sends
+
+
+class ChatSendDeadlineChecker(unittest.TestCase):
+    def test_flags_a_direct_send(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            chat_dir = Path(tmp)
+            (chat_dir / "transport.rs").write_text(
+                "let resp = builder.send().await;\n", encoding="utf-8"
+            )
+            violations = find_direct_sends(chat_dir)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("transport.rs:1", violations[0])
+
+    def test_accepts_the_budgeted_seam(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            chat_dir = Path(tmp)
+            (chat_dir / "transport.rs").write_text(
+                "let resp = send_with_deadline(builder, deadline).await;\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(find_direct_sends(chat_dir), [])
+
+    def test_real_chat_module_is_clean(self) -> None:
+        self.assertTrue(CHAT_DIR.is_dir(), f"{CHAT_DIR} moved; update the checker")
+        self.assertEqual(find_direct_sends(CHAT_DIR), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/desktop/macos/Backend-Rust/Cargo.toml
+++ b/desktop/macos/Backend-Rust/Cargo.toml
@@ -57,3 +57,5 @@ gcp_auth = "0.12"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
+# test-util enables tokio::time::pause/advance for deterministic deadline tests.
+tokio = { version = "1", features = ["full", "test-util"] }

--- a/desktop/macos/Backend-Rust/src/auth.rs
+++ b/desktop/macos/Backend-Rust/src/auth.rs
@@ -98,6 +98,8 @@ impl IntoResponse for AuthError {
             StatusCode::FORBIDDEN
         } else if self.error == "jwks_refresh_failed" {
             StatusCode::SERVICE_UNAVAILABLE
+        } else if self.error == "request_deadline_exceeded" {
+            StatusCode::GATEWAY_TIMEOUT
         } else {
             StatusCode::UNAUTHORIZED
         };
@@ -480,6 +482,29 @@ pub struct PaywalledAuthUser {
     pub byok_stripped: bool,
 }
 
+/// Bound one extractor stage by the request budget when the route admitted one
+/// (#9835). Routes without the deadline middleware keep today's behavior; the
+/// unknown-kid refresh cooldown and cache TTLs are policy clocks and stay
+/// independent — only this request's wait is bounded.
+async fn within_request_deadline<T, F>(
+    deadline: Option<&crate::request_deadline::RequestDeadline>,
+    stage: &str,
+    future: F,
+) -> Result<T, AuthError>
+where
+    F: std::future::Future<Output = T>,
+{
+    match deadline {
+        None => Ok(future.await),
+        Some(d) => tokio::time::timeout(d.remaining(), future)
+            .await
+            .map_err(|_| AuthError {
+                error: "request_deadline_exceeded".to_string(),
+                message: format!("Request deadline budget exhausted during {stage}"),
+            }),
+    }
+}
+
 #[async_trait]
 impl<S> FromRequestParts<S> for PaywalledAuthUser
 where
@@ -488,6 +513,10 @@ where
     type Rejection = AuthError;
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let deadline = parts
+            .extensions
+            .get::<crate::request_deadline::RequestDeadline>()
+            .copied();
         // Get + extract bearer token
         let auth_header = parts
             .headers
@@ -514,7 +543,12 @@ where
                 message: "Firebase auth not configured".to_string(),
             })?;
 
-        let (uid, name, email) = firebase_auth.0.verify_token(token).await?;
+        let (uid, name, email) = within_request_deadline(
+            deadline.as_ref(),
+            "token verification",
+            firebase_auth.0.verify_token(token),
+        )
+        .await??;
 
         // BYOK fingerprint validation (issue #7357).
         // Validates SHA-256 fingerprints against Firestore enrollment.
@@ -523,7 +557,12 @@ where
         if let Some(byok_ext) = parts.extensions.get::<crate::byok::ByokCacheExt>() {
             // Get the Firestore service from the paywall checker (shares the same Arc)
             if let Some(checker) = parts.extensions.get::<crate::paywall::PaywallCheckerExt>() {
-                let byok_state = byok_ext.0.get_or_fetch(&uid, &checker.0.firestore).await;
+                let byok_state = within_request_deadline(
+                    deadline.as_ref(),
+                    "BYOK state fetch",
+                    byok_ext.0.get_or_fetch(&uid, &checker.0.firestore),
+                )
+                .await?;
 
                 match crate::byok::validate_byok_request(&uid, &parts.headers, &byok_state) {
                     Ok(crate::byok::ByokValidation::Active) => {
@@ -544,12 +583,16 @@ where
         }
 
         // Paywall check — fail open if Firestore is unreachable so a backend
-        // outage never makes paying users look paywalled.
+        // outage never makes paying users look paywalled. Budget exhaustion is
+        // different from an outage: the typed timeout is returned instead of
+        // spending provider budget on a request that can no longer finish.
         if let Some(checker) = parts.extensions.get::<crate::paywall::PaywallCheckerExt>() {
-            if checker
-                .0
-                .is_paywalled(&uid, &parts.headers, byok_stripped)
-                .await
+            if within_request_deadline(
+                deadline.as_ref(),
+                "paywall check",
+                checker.0.is_paywalled(&uid, &parts.headers, byok_stripped),
+            )
+            .await?
             {
                 return Err(AuthError {
                     error: "trial_expired".to_string(),

--- a/desktop/macos/Backend-Rust/src/main.rs
+++ b/desktop/macos/Backend-Rust/src/main.rs
@@ -44,6 +44,7 @@ mod fallback;
 mod llm;
 mod models;
 mod paywall;
+mod request_deadline;
 mod routes;
 mod services;
 mod vertex;

--- a/desktop/macos/Backend-Rust/src/request_deadline.rs
+++ b/desktop/macos/Backend-Rust/src/request_deadline.rs
@@ -18,14 +18,15 @@ use std::time::Duration;
 /// Cloud Run's configured request timeout for `desktop-backend`. This is the
 /// code-side constant; the deployed platform value must be verified as release
 /// evidence, not assumed from here.
-const PLATFORM_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
+pub const PLATFORM_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Headroom reserved under the platform bound so the gateway, not Cloud Run,
 /// owns timeout mapping and can return a typed, retryable timeout response.
-const PLATFORM_HEADROOM: Duration = Duration::from_secs(60);
+pub const PLATFORM_HEADROOM: Duration = Duration::from_secs(60);
 
-/// The single admission budget for the Anthropic chat route class.
-pub const CHAT_REQUEST_BUDGET: Duration =
+/// The single admission budget per provider route class. The Anthropic chat
+/// path and the Gemini proxy both derive it from the same platform contract.
+pub const REQUEST_BUDGET: Duration =
     Duration::from_secs(PLATFORM_REQUEST_TIMEOUT.as_secs() - PLATFORM_HEADROOM.as_secs());
 
 /// Absolute deadline for one request, measured on the tokio clock so tests can
@@ -85,15 +86,45 @@ pub async fn send_with_deadline(
     }
 }
 
-/// Middleware that admits the chat request budget before extractors and body
+/// The budget's absolute edge won the race against still-pending work.
+#[derive(Debug, PartialEq, Eq)]
+pub struct DeadlineElapsed;
+
+/// Race a deadline future against work. Dropping the returned future drops the
+/// in-flight work, so a downstream disconnect still cancels the upstream call.
+pub async fn race_deadline<D, F, T>(deadline: D, future: F) -> Result<T, DeadlineElapsed>
+where
+    D: std::future::Future<Output = ()>,
+    F: std::future::Future<Output = T>,
+{
+    tokio::pin!(deadline);
+    tokio::pin!(future);
+    tokio::select! {
+        value = &mut future => Ok(value),
+        () = &mut deadline => Err(DeadlineElapsed),
+    }
+}
+
+/// Bound a whole unit of request-owned work by the remaining budget.
+pub async fn within_deadline<F, T>(
+    deadline: &RequestDeadline,
+    future: F,
+) -> Result<T, DeadlineElapsed>
+where
+    F: std::future::Future<Output = T>,
+{
+    race_deadline(tokio::time::sleep(deadline.remaining()), future).await
+}
+
+/// Middleware that admits the request budget before extractors and body
 /// extraction run, so auth/paywall waits are inside the budget.
-pub async fn attach_chat_request_deadline(
+pub async fn attach_request_deadline(
     mut request: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
     request
         .extensions_mut()
-        .insert(RequestDeadline::new(CHAT_REQUEST_BUDGET));
+        .insert(RequestDeadline::new(REQUEST_BUDGET));
     next.run(request).await
 }
 
@@ -114,7 +145,7 @@ where
             .extensions
             .get::<RequestDeadline>()
             .copied()
-            .unwrap_or_else(|| RequestDeadline::new(CHAT_REQUEST_BUDGET)))
+            .unwrap_or_else(|| RequestDeadline::new(REQUEST_BUDGET)))
     }
 }
 
@@ -143,5 +174,33 @@ mod tests {
         assert!(deadline.expired());
         assert_eq!(deadline.remaining(), Duration::ZERO);
         assert_eq!(deadline.derive(Duration::from_secs(5)), Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn middleware_admits_the_shared_budget_before_the_handler() {
+        use axum::{body::Body, http::Request, routing::get, Router};
+        use tower::ServiceExt;
+
+        let app = Router::new()
+            .route(
+                "/",
+                get(|deadline: RequestDeadline| async move {
+                    // Time spent before/inside the handler consumes the one
+                    // budget the middleware admitted.
+                    tokio::time::advance(Duration::from_secs(100)).await;
+                    deadline.remaining().as_secs().to_string()
+                }),
+            )
+            .layer(axum::middleware::from_fn(attach_request_deadline));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let expected = REQUEST_BUDGET.as_secs() - 100;
+        assert_eq!(body, expected.to_string().as_bytes());
     }
 }

--- a/desktop/macos/Backend-Rust/src/request_deadline.rs
+++ b/desktop/macos/Backend-Rust/src/request_deadline.rs
@@ -1,0 +1,147 @@
+//! Request-level deadline budget for the Anthropic chat path (FC-per-hop-timeout).
+//!
+//! One admission budget is created in route middleware before extractors run and
+//! governs everything up to the first client-visible semantic SSE event: auth and
+//! paywall waits, body extraction, provider retries, and server-tool
+//! continuations. Provider headers, pings, and keepalives are not progress.
+//! After the first visible event the budget is done — streaming deliberately has
+//! no total response timeout (#9135: a long answer is not an error) and stalls
+//! are governed by the semantic-progress idle timer in the stream translator.
+//!
+//! Policy clocks are explicitly out of scope: the unknown-kid refresh cooldown,
+//! cache TTLs, the idle-timer policy value, and startup retries stay
+//! independent. Detached work spawned during a request (the Firestore usage
+//! write on `message_stop`) must never inherit the request deadline.
+
+use std::time::Duration;
+
+/// Cloud Run's configured request timeout for `desktop-backend`. This is the
+/// code-side constant; the deployed platform value must be verified as release
+/// evidence, not assumed from here.
+const PLATFORM_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Headroom reserved under the platform bound so the gateway, not Cloud Run,
+/// owns timeout mapping and can return a typed, retryable timeout response.
+const PLATFORM_HEADROOM: Duration = Duration::from_secs(60);
+
+/// The single admission budget for the Anthropic chat route class.
+pub const CHAT_REQUEST_BUDGET: Duration =
+    Duration::from_secs(PLATFORM_REQUEST_TIMEOUT.as_secs() - PLATFORM_HEADROOM.as_secs());
+
+/// Absolute deadline for one request, measured on the tokio clock so tests can
+/// drive it with `tokio::time::pause`.
+#[derive(Debug, Clone, Copy)]
+pub struct RequestDeadline {
+    deadline: tokio::time::Instant,
+}
+
+impl RequestDeadline {
+    pub fn new(budget: Duration) -> Self {
+        Self {
+            deadline: tokio::time::Instant::now() + budget,
+        }
+    }
+
+    /// Time left in the budget; zero once expired.
+    pub fn remaining(&self) -> Duration {
+        self.deadline
+            .saturating_duration_since(tokio::time::Instant::now())
+    }
+
+    /// Bound a stage constant by the budget: `min(cap, remaining)`.
+    pub fn derive(&self, cap: Duration) -> Duration {
+        cap.min(self.remaining())
+    }
+
+    pub fn expired(&self) -> bool {
+        self.remaining() == Duration::ZERO
+    }
+}
+
+/// Failure surface of a budgeted provider send.
+#[derive(Debug)]
+pub enum DeadlineSendError {
+    /// The budget ran out before the provider produced response headers.
+    Expired,
+    /// The transport failed within the budget (connect/read errors).
+    Transport(reqwest::Error),
+}
+
+/// The narrow seam every outbound provider send on the chat path goes through.
+/// A diff-scoped checker (`check_chat_send_deadline.py`) flags direct
+/// `.send()` calls in `routes/chat/` that bypass it.
+pub async fn send_with_deadline(
+    builder: reqwest::RequestBuilder,
+    deadline: &RequestDeadline,
+) -> Result<reqwest::Response, DeadlineSendError> {
+    let remaining = deadline.remaining();
+    if remaining == Duration::ZERO {
+        return Err(DeadlineSendError::Expired);
+    }
+    match tokio::time::timeout(remaining, builder.send()).await {
+        Ok(Ok(response)) => Ok(response),
+        Ok(Err(error)) => Err(DeadlineSendError::Transport(error)),
+        Err(_) => Err(DeadlineSendError::Expired),
+    }
+}
+
+/// Middleware that admits the chat request budget before extractors and body
+/// extraction run, so auth/paywall waits are inside the budget.
+pub async fn attach_chat_request_deadline(
+    mut request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    request
+        .extensions_mut()
+        .insert(RequestDeadline::new(CHAT_REQUEST_BUDGET));
+    next.run(request).await
+}
+
+#[axum::async_trait]
+impl<S> axum::extract::FromRequestParts<S> for RequestDeadline
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        // The middleware guarantees presence on the chat route; a fresh budget
+        // is the safe fallback if the layer is ever missing.
+        Ok(parts
+            .extensions
+            .get::<RequestDeadline>()
+            .copied()
+            .unwrap_or_else(|| RequestDeadline::new(CHAT_REQUEST_BUDGET)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn remaining_derive_and_expiry_follow_the_tokio_clock() {
+        let deadline = RequestDeadline::new(Duration::from_secs(100));
+        assert!(!deadline.expired());
+        assert_eq!(
+            deadline.derive(Duration::from_secs(5)),
+            Duration::from_secs(5)
+        );
+
+        tokio::time::advance(Duration::from_secs(97)).await;
+        assert_eq!(deadline.remaining(), Duration::from_secs(3));
+        // A stage cap larger than the budget is truncated to what's left.
+        assert_eq!(
+            deadline.derive(Duration::from_secs(120)),
+            Duration::from_secs(3)
+        );
+
+        tokio::time::advance(Duration::from_secs(4)).await;
+        assert!(deadline.expired());
+        assert_eq!(deadline.remaining(), Duration::ZERO);
+        assert_eq!(deadline.derive(Duration::from_secs(5)), Duration::ZERO);
+    }
+}

--- a/desktop/macos/Backend-Rust/src/routes/chat/route.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/route.rs
@@ -259,7 +259,7 @@ pub(crate) fn chat_completions_routes() -> Router<AppState> {
         // Outermost for this route: the budget must exist before extractors and
         // body extraction so auth/paywall waits are inside it (#9835).
         .layer(axum::middleware::from_fn(
-            crate::request_deadline::attach_chat_request_deadline,
+            crate::request_deadline::attach_request_deadline,
         ))
 }
 

--- a/desktop/macos/Backend-Rust/src/routes/chat/route.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/route.rs
@@ -106,6 +106,7 @@ fn attach_request_id(response: &mut Response, request_id: &str) {
 
 async fn chat_completions(
     State(state): State<AppState>,
+    deadline: crate::request_deadline::RequestDeadline,
     user: PaywalledAuthUser,
     headers: HeaderMap,
     Json(req): Json<ChatCompletionRequest>,
@@ -118,7 +119,7 @@ async fn chat_completions(
         reasoning_effort = ?inbound_reasoning_effort(&headers, &req),
         "chat completion received"
     );
-    let response = chat_completions_inner(state, user, headers, req).await;
+    let response = chat_completions_inner(state, user, headers, req, deadline).await;
     response.map(|mut response| {
         attach_request_id(&mut response, &request_id);
         response
@@ -130,6 +131,7 @@ async fn chat_completions_inner(
     user: PaywalledAuthUser,
     headers: HeaderMap,
     req: ChatCompletionRequest,
+    deadline: crate::request_deadline::RequestDeadline,
 ) -> Result<Response, StatusCode> {
     let byok_stripped = user.byok_stripped;
     let user: AuthUser = user.into();
@@ -232,6 +234,7 @@ async fn chat_completions_inner(
             &user,
             &state,
             is_byok,
+            &deadline,
         )
         .await
     } else {
@@ -243,6 +246,7 @@ async fn chat_completions_inner(
             &user,
             &state,
             is_byok,
+            &deadline,
         )
         .await
     }
@@ -252,6 +256,11 @@ pub(crate) fn chat_completions_routes() -> Router<AppState> {
     Router::new()
         .route("/v2/chat/completions", post(chat_completions))
         .layer(DefaultBodyLimit::max(CHAT_COMPLETIONS_MAX_BODY_SIZE))
+        // Outermost for this route: the budget must exist before extractors and
+        // body extraction so auth/paywall waits are inside it (#9835).
+        .layer(axum::middleware::from_fn(
+            crate::request_deadline::attach_chat_request_deadline,
+        ))
 }
 
 #[cfg(test)]

--- a/desktop/macos/Backend-Rust/src/routes/chat/streaming.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/streaming.rs
@@ -9,7 +9,7 @@ use std::{sync::Arc, time::Duration};
 
 use crate::auth::AuthUser;
 use crate::models::chat_completions::*;
-use crate::request_deadline::{RequestDeadline, CHAT_REQUEST_BUDGET};
+use crate::request_deadline::{RequestDeadline, REQUEST_BUDGET};
 use crate::services::FirestoreService;
 use crate::AppState;
 
@@ -604,7 +604,7 @@ where
             // request deadline in would put a total-response cap on a streaming turn,
             // which streaming deliberately does not have. Give the continuation its
             // own budget instead, so a stuck upstream is still bounded.
-            let continuation_deadline = RequestDeadline::new(CHAT_REQUEST_BUDGET);
+            let continuation_deadline = RequestDeadline::new(REQUEST_BUDGET);
             match complete_anthropic_server_tool_turn(
                 &continuation.client,
                 &continuation.api_key,

--- a/desktop/macos/Backend-Rust/src/routes/chat/streaming.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/streaming.rs
@@ -9,6 +9,7 @@ use std::{sync::Arc, time::Duration};
 
 use crate::auth::AuthUser;
 use crate::models::chat_completions::*;
+use crate::request_deadline::{RequestDeadline, CHAT_REQUEST_BUDGET};
 use crate::services::FirestoreService;
 use crate::AppState;
 
@@ -20,12 +21,15 @@ use super::transport::{
     complete_anthropic_server_tool_turn, send_anthropic_with_retry,
 };
 
-/// How long a streaming turn may go without a single byte from Anthropic before we end it.
+/// How long a streaming turn may go without SEMANTIC progress before we end it.
 ///
 /// Streaming deliberately sets no total response timeout (a long answer is not a stuck one), so
-/// this idle bound is the only thing that catches a stalled upstream. Anthropic emits `ping`
-/// events every few seconds throughout a generation, so a gap this long means the stream is
-/// dead, not slow.
+/// this idle bound is the only thing that catches a stalled upstream after the first visible
+/// event. Progress means a client-visible chunk (role, text delta, tool delta, finish) — raw
+/// bytes and Anthropic `ping` events emit nothing downstream and do not reset this timer, so a
+/// provider cannot ping indefinitely while the client sees nothing (#9835). Before the first
+/// visible event the request budget governs instead. This is a policy clock, not part of the
+/// request deadline.
 const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub(super) struct StreamUsageContext {
@@ -39,6 +43,17 @@ pub(super) struct StreamContinuationContext {
     pub(super) client: reqwest::Client,
     pub(super) api_key: String,
     pub(super) request: AnthropicRequest,
+}
+
+/// Detached work spawned during a request must NEVER inherit the request
+/// deadline: the usage write outlives the response and runs under its own
+/// bounded background policy (#9835). This seam exists so that contract is
+/// testable without a live Firestore.
+pub(super) fn spawn_detached_usage_write<F>(write: F)
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(write);
 }
 
 #[derive(Default)]
@@ -209,6 +224,7 @@ pub(super) fn translate_anthropic_sse_stream<S, E>(
     public_model: String,
     usage_context: StreamUsageContext,
     continuation_context: Option<StreamContinuationContext>,
+    deadline: RequestDeadline,
 ) -> impl Stream<Item = Result<Bytes, std::io::Error>>
 where
     S: Stream<Item = Result<Bytes, E>>,
@@ -233,12 +249,42 @@ where
         // Terminal state of the turn, so a stream that dies mid-flight still ends the SSE body.
         let mut sent_finish = false;
         let mut sent_done = false;
+        // Until the first client-visible chunk, the request budget governs the
+        // wait — raw bytes and pings do not extend it. Afterwards the semantic
+        // idle timer governs, reset only by visible chunks.
+        let mut first_visible_at: Option<tokio::time::Instant> = None;
         loop {
-            let next = match tokio::time::timeout(STREAM_IDLE_TIMEOUT, byte_stream.next()).await {
+            let wait = match first_visible_at {
+                None => deadline.remaining(),
+                Some(last_visible) => {
+                    STREAM_IDLE_TIMEOUT.saturating_sub(last_visible.elapsed())
+                }
+            };
+            let next = match tokio::time::timeout(wait, byte_stream.next()).await {
                 Ok(next) => next,
+                Err(_) if first_visible_at.is_none() => {
+                    // The budget ran out before the first visible event — a
+                    // ping-only or silent upstream. HTTP 200 is already on the
+                    // wire, so the typed timeout is a terminal SSE error event.
+                    tracing::error!(
+                        "chat_completions: budget exhausted before first visible event for user {}",
+                        usage_context.uid
+                    );
+                    let err_chunk = json!({
+                        "error": {
+                            "message": "The stream produced no visible output within the chat deadline budget. Please retry.",
+                            "type": "upstream_timeout",
+                            "code": 504
+                        }
+                    });
+                    yield Ok(sse_line(&err_chunk));
+                    yield Ok(Bytes::from_static(b"data: [DONE]\n\n"));
+                    sent_done = true;
+                    break;
+                }
                 Err(_) => {
                     tracing::error!(
-                        "chat_completions: no bytes from Anthropic for {}s, ending stalled turn for user {}",
+                        "chat_completions: no semantic progress from Anthropic for {}s, ending stalled turn for user {}",
                         STREAM_IDLE_TIMEOUT.as_secs(),
                         usage_context.uid
                     );
@@ -313,6 +359,7 @@ where
                                 None,
                             );
                             yield Ok::<Bytes, std::io::Error>(sse_line(&chunk_val));
+                            first_visible_at = Some(tokio::time::Instant::now());
                         }
                     }
 
@@ -345,6 +392,7 @@ where
                                     None,
                                 );
                                 yield Ok(sse_line(&chunk_val));
+                                first_visible_at = Some(tokio::time::Instant::now());
                             }
                             AnthropicContentBlock::Text { .. } => {
                                 // text_start — no chunk needed, text comes via deltas
@@ -386,6 +434,7 @@ where
                                     None,
                                 );
                                 yield Ok(sse_line(&chunk_val));
+                                first_visible_at = Some(tokio::time::Instant::now());
                             }
                             AnthropicDelta::CitationsDelta {} => {
                                 // Web-search citation metadata — no OpenAI equivalent.
@@ -431,6 +480,7 @@ where
                                         None,
                                     );
                                     yield Ok(sse_line(&chunk_val));
+                                    first_visible_at = Some(tokio::time::Instant::now());
                                 }
                             }
                         }
@@ -468,6 +518,7 @@ where
                         );
                         yield Ok(sse_line(&chunk_val));
                         sent_finish = true;
+                        first_visible_at = Some(tokio::time::Instant::now());
 
                         // Send usage chunk
                         if let Some(ref fu) = final_usage {
@@ -500,7 +551,7 @@ where
                             let cost = compute_cost(&merged, &usage_context.upstream_model);
                             let uid_clone = usage_context.uid.clone();
                             let fs = firestore.clone();
-                            tokio::spawn(async move {
+                            spawn_detached_usage_write(async move {
                                 if let Err(e) = fs.record_llm_usage(
                                     &uid_clone,
                                     merged.input_tokens,
@@ -542,10 +593,18 @@ where
 
         if let Some(mut continuation) = pause_turn_continuation {
             append_pause_turn_continuation(&mut continuation.request, streamed_content.into_value());
+            // A pause_turn continuation reached here is POST-first-visible-event:
+            // the client already has bytes, so the request budget no longer governs
+            // (above, it governs only until `first_visible_at` is set). Feeding the
+            // request deadline in would put a total-response cap on a streaming turn,
+            // which streaming deliberately does not have. Give the continuation its
+            // own budget instead, so a stuck upstream is still bounded.
+            let continuation_deadline = RequestDeadline::new(CHAT_REQUEST_BUDGET);
             match complete_anthropic_server_tool_turn(
                 &continuation.client,
                 &continuation.api_key,
                 &continuation.request,
+                &continuation_deadline,
             )
             .await
             {
@@ -614,10 +673,12 @@ where
                     }
                     yield Ok(Bytes::from_static(b"data: [DONE]\n\n"));
                 }
-                Err(status) => {
+                Err(error) => {
+                    // `{:?}` distinguishes a continuation that blew its own budget
+                    // (DeadlineExpired) from an upstream failure (Gateway(status)).
                     tracing::error!(
-                        "chat_completions: paused stream continuation failed with {}",
-                        status
+                        "chat_completions: paused stream continuation failed with {:?}",
+                        error
                     );
                     let err_chunk = json!({
                         "error": {
@@ -651,8 +712,13 @@ pub(super) async fn handle_streaming(
     user: &AuthUser,
     state: &AppState,
     is_byok: bool,
+    deadline: &RequestDeadline,
 ) -> Result<Response, StatusCode> {
-    let upstream_resp = send_anthropic_with_retry(client, api_key, anthropic_req, true).await?;
+    let upstream_resp =
+        match send_anthropic_with_retry(client, api_key, anthropic_req, true, deadline).await {
+            Ok(resp) => resp,
+            Err(error) => return error.into_response_or_status(),
+        };
 
     let status = upstream_resp.status();
     if !status.is_success() {
@@ -698,6 +764,7 @@ pub(super) async fn handle_streaming(
         route.public_model.to_string(),
         usage_context,
         continuation_context,
+        *deadline,
     );
     let body = Body::from_stream(translated_stream);
 

--- a/desktop/macos/Backend-Rust/src/routes/chat/streaming.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/streaming.rs
@@ -452,6 +452,11 @@ where
                                     None,
                                 );
                                 yield Ok(sse_line(&chunk_val));
+                                // Reasoning deltas reach the client as visible
+                                // reasoning_content, so they are semantic progress: a long
+                                // thinking phase must not be killed by the idle timer
+                                // (#9135's "a long answer is not an error", for reasoning).
+                                first_visible_at = Some(tokio::time::Instant::now());
                             }
                             AnthropicDelta::SignatureDelta {} => {
                                 // Thinking-block signature — internal; dropped.

--- a/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
@@ -2131,6 +2131,7 @@ async fn incremental_translation_preserves_split_utf8_tool_chunks_usage_and_done
             firestore: None,
         },
         None,
+        RequestDeadline::new(Duration::from_secs(100_000)),
     )
     .collect::<Vec<_>>()
     .await;
@@ -2188,6 +2189,7 @@ async fn incremental_translation_terminates_a_partial_stream_at_eof() {
             firestore: None,
         },
         None,
+        RequestDeadline::new(Duration::from_secs(100_000)),
     )
     .collect::<Vec<_>>()
     .await;
@@ -2333,6 +2335,7 @@ async fn thinking_deltas_stream_as_reasoning_content() {
             firestore: None,
         },
         None,
+        RequestDeadline::new(Duration::from_secs(100_000)),
     )
     .collect::<Vec<_>>()
     .await;
@@ -2421,4 +2424,217 @@ fn adaptive_effort_is_suppressed_on_tool_result_continuations() {
     )
     .unwrap();
     assert_eq!(result.thinking, Some(json!({"type": "adaptive"})));
+}
+
+// ── Request deadline budget (#9835) ─────────────────────────────────────────
+// Test-file citation of the caught class (FC-per-hop-timeout): #8640, #8911,
+// #9135 ("stop cutting off long-context Gemini calls at 90s"), #9644 ("restore
+// Gemini platform deadline") — each moved a per-hop timeout; the budget below
+// replaces that class wholesale for the Anthropic chat path.
+
+use crate::request_deadline::RequestDeadline;
+
+fn collect_lines(output: Vec<Result<Bytes, std::io::Error>>) -> Vec<String> {
+    output
+        .into_iter()
+        .map(|chunk| String::from_utf8(chunk.unwrap().to_vec()).unwrap())
+        .collect()
+}
+
+fn deadline_usage_context() -> StreamUsageContext {
+    StreamUsageContext {
+        uid: "test-user".to_string(),
+        upstream_model: "claude-sonnet-4-6".to_string(),
+        firestore: None,
+    }
+}
+
+/// (a) A retry/continuation chain stops at the budget floor rather than
+/// starting an attempt it cannot finish: with 7s left against a 10s floor, a
+/// transient status is passed through after ONE attempt even though the policy
+/// allows five.
+#[tokio::test(start_paused = true)]
+async fn retry_chain_stops_at_budget_floor() {
+    let deadline = RequestDeadline::new(Duration::from_secs(12));
+    let attempts = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let attempts_in_closure = attempts.clone();
+
+    let result = retry_with_budget(&deadline, 5, ANTHROPIC_ATTEMPT_FLOOR, |_attempt| {
+        let attempts = attempts_in_closure.clone();
+        async move {
+            attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            // Each attempt spends 5s of the budget before failing transiently.
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            AttemptOutcome::Transient {
+                value: 503u16,
+                status: 503,
+            }
+        }
+    })
+    .await;
+
+    assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 1);
+    // The transient upstream error passes through as-is (no retry available).
+    assert!(matches!(result, Ok(503)));
+}
+
+/// (b) A backoff sleep is truncated at the budget edge instead of overshooting
+/// it: with 100ms of budget and a 250ms backoff, exactly 100ms elapses and the
+/// next attempt is never started.
+#[tokio::test(start_paused = true)]
+async fn retry_backoff_truncates_at_budget_edge() {
+    let deadline = RequestDeadline::new(Duration::from_millis(100));
+    let attempts = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let attempts_in_closure = attempts.clone();
+    let started = tokio::time::Instant::now();
+
+    let result: Result<u16, AnthropicSendError> =
+        retry_with_budget(&deadline, 3, Duration::ZERO, |_attempt| {
+            let attempts = attempts_in_closure.clone();
+            async move {
+                attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                AttemptOutcome::TransportError
+            }
+        })
+        .await;
+
+    // First backoff would be 250ms; the budget edge is 100ms away.
+    assert_eq!(started.elapsed(), Duration::from_millis(100));
+    assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert!(matches!(result, Err(AnthropicSendError::DeadlineExpired)));
+}
+
+/// (c) A stream emitting visible deltas survives budget expiry: the budget
+/// governs only up to the first visible event, and a long answer is not an
+/// error (#9135 must never regress).
+#[tokio::test(start_paused = true)]
+async fn visible_stream_survives_budget_expiry() {
+    let head = concat!(
+        "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_long\",\"model\":\"claude-sonnet-4-6\",\"usage\":{}}}\n\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"thinking...\"}}\n\n",
+    );
+    let tail = concat!(
+        "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":3}}\n\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+    );
+    let upstream = async_stream::stream! {
+        yield Ok::<Bytes, std::io::Error>(Bytes::from_static(head.as_bytes()));
+        // Keep visible progress flowing well past the 5s budget, each gap
+        // inside the 60s idle bound.
+        for _ in 0..4 {
+            tokio::time::sleep(Duration::from_secs(50)).await;
+            yield Ok(Bytes::from_static(b"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"more\"}}\n\n"));
+        }
+        yield Ok(Bytes::from_static(tail.as_bytes()));
+    };
+
+    let output = translate_anthropic_sse_stream(
+        upstream,
+        "omi-sonnet".to_string(),
+        deadline_usage_context(),
+        None,
+        RequestDeadline::new(Duration::from_secs(5)),
+    )
+    .collect::<Vec<_>>()
+    .await;
+    let lines = collect_lines(output);
+
+    assert_eq!(lines.last().unwrap(), "data: [DONE]\n\n");
+    assert!(lines
+        .iter()
+        .any(|line| line.contains("\"finish_reason\":\"stop\"")));
+    assert!(!lines.iter().any(|line| line.contains("upstream_timeout")));
+}
+
+/// (d) The live gap this change closes: an upstream that only pings before
+/// `message_start` used to reset the raw-byte idle timer forever while the
+/// client saw nothing. It now hits the request budget and ends with a typed
+/// terminal SSE error.
+#[tokio::test(start_paused = true)]
+async fn ping_only_stream_hits_budget_with_typed_error() {
+    let upstream = async_stream::stream! {
+        loop {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            yield Ok::<Bytes, std::io::Error>(Bytes::from_static(b"data: {\"type\":\"ping\"}\n\n"));
+        }
+    };
+
+    let started = tokio::time::Instant::now();
+    let output = translate_anthropic_sse_stream(
+        upstream,
+        "omi-sonnet".to_string(),
+        deadline_usage_context(),
+        None,
+        RequestDeadline::new(Duration::from_secs(5)),
+    )
+    .collect::<Vec<_>>()
+    .await;
+    let lines = collect_lines(output);
+
+    // Pings never extended the budget: the turn ended at the 5s edge, not the
+    // 60s idle bound and not never.
+    assert!(started.elapsed() <= Duration::from_secs(6));
+    assert!(lines
+        .iter()
+        .any(|line| line.contains("\"type\":\"upstream_timeout\"") && line.contains("504")));
+    assert_eq!(lines.last().unwrap(), "data: [DONE]\n\n");
+}
+
+/// (e) After the first visible event the budget is done; a stall dies from the
+/// SEMANTIC idle timer, independent of the (still huge) remaining budget, and
+/// raw non-semantic bytes do not reset that timer.
+#[tokio::test(start_paused = true)]
+async fn post_first_event_stall_dies_from_semantic_idle_timer() {
+    let head = concat!(
+        "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_stall\",\"model\":\"claude-sonnet-4-6\",\"usage\":{}}}\n\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"partial\"}}\n\n",
+    );
+    let upstream = async_stream::stream! {
+        yield Ok::<Bytes, std::io::Error>(Bytes::from_static(head.as_bytes()));
+        // Ping-only from here on: raw bytes with no semantic progress.
+        loop {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            yield Ok(Bytes::from_static(b"data: {\"type\":\"ping\"}\n\n"));
+        }
+    };
+
+    let started = tokio::time::Instant::now();
+    let output = translate_anthropic_sse_stream(
+        upstream,
+        "omi-sonnet".to_string(),
+        deadline_usage_context(),
+        None,
+        RequestDeadline::new(Duration::from_secs(100_000)),
+    )
+    .collect::<Vec<_>>()
+    .await;
+    let lines = collect_lines(output);
+
+    // Died at the 60s semantic idle bound — long before the budget.
+    assert!(started.elapsed() >= Duration::from_secs(60));
+    assert!(started.elapsed() <= Duration::from_secs(75));
+    assert!(lines
+        .iter()
+        .any(|line| line.contains("\"type\":\"server_error\"")));
+    assert_eq!(lines.last().unwrap(), "data: [DONE]\n\n");
+}
+
+/// (f) Detached work spawned during a request completes under its own policy
+/// after the request deadline expires — the spawn seam never inherits the
+/// budget.
+#[tokio::test(start_paused = true)]
+async fn detached_usage_write_completes_after_deadline_expiry() {
+    let deadline = RequestDeadline::new(Duration::from_secs(1));
+    let completed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let completed_in_task = completed.clone();
+
+    spawn_detached_usage_write(async move {
+        // The write's own policy takes far longer than the request budget.
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        completed_in_task.store(true, std::sync::atomic::Ordering::SeqCst);
+    });
+
+    tokio::time::sleep(Duration::from_secs(31)).await;
+    assert!(deadline.expired());
+    assert!(completed.load(std::sync::atomic::Ordering::SeqCst));
 }

--- a/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
@@ -2546,6 +2546,56 @@ async fn visible_stream_survives_budget_expiry() {
     assert!(!lines.iter().any(|line| line.contains("upstream_timeout")));
 }
 
+/// (c2) A long *reasoning* phase is visible progress too. `thinking_delta` chunks
+/// reach the client as `reasoning_content`, so they must refresh the semantic idle
+/// timer exactly like text deltas do. Before this, only text refreshed it, so a
+/// Claude reasoning stream that emitted reasoning for longer than
+/// STREAM_IDLE_TIMEOUT was killed as "no semantic progress" while the client was
+/// actively receiving output — the same regression #9135 forbids, for reasoning.
+#[tokio::test(start_paused = true)]
+async fn reasoning_only_stream_survives_the_semantic_idle_timer() {
+    let head = "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_think\",\"model\":\"claude-sonnet-4-6\",\"usage\":{}}}\n\n";
+    let tail = concat!(
+        "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":7}}\n\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+    );
+    let upstream = async_stream::stream! {
+        yield Ok::<Bytes, std::io::Error>(Bytes::from_static(head.as_bytes()));
+        // Reasoning only — no text deltas — spanning 200s, well past the 60s idle
+        // bound, with each individual gap inside it.
+        for _ in 0..4 {
+            tokio::time::sleep(Duration::from_secs(50)).await;
+            yield Ok(Bytes::from_static(b"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"still reasoning\"}}\n\n"));
+        }
+        yield Ok(Bytes::from_static(tail.as_bytes()));
+    };
+
+    let output = translate_anthropic_sse_stream(
+        upstream,
+        "omi-sonnet".to_string(),
+        deadline_usage_context(),
+        None,
+        RequestDeadline::new(Duration::from_secs(5)),
+    )
+    .collect::<Vec<_>>()
+    .await;
+    let lines = collect_lines(output);
+
+    // Every reasoning delta reached the client and the turn finished normally.
+    assert_eq!(
+        lines
+            .iter()
+            .filter(|line| line.contains("\"reasoning_content\":\"still reasoning\""))
+            .count(),
+        4
+    );
+    assert_eq!(lines.last().unwrap(), "data: [DONE]\n\n");
+    assert!(lines
+        .iter()
+        .any(|line| line.contains("\"finish_reason\":\"stop\"")));
+    assert!(!lines.iter().any(|line| line.contains("upstream_timeout")));
+}
+
 /// (d) The live gap this change closes: an upstream that only pings before
 /// `message_start` used to reset the raw-byte idle timer forever while the
 /// client saw nothing. It now hits the request budget and ends with a typed

--- a/desktop/macos/Backend-Rust/src/routes/chat/transport.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/transport.rs
@@ -1,15 +1,19 @@
 use axum::{
+    body::Body,
     http::StatusCode,
     response::{IntoResponse, Response},
     Json,
 };
+use serde_json::json;
 use std::time::Duration;
 
 use crate::auth::AuthUser;
 use crate::models::chat_completions::*;
+use crate::request_deadline::{send_with_deadline, DeadlineSendError, RequestDeadline};
 use crate::AppState;
 
 use super::request_translation::{compute_cost, translate_response};
+use super::response_or_500;
 
 /// Anthropic API base URL.
 const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
@@ -26,9 +30,60 @@ const ANTHROPIC_MAX_ATTEMPTS: usize = 3;
 /// request indefinitely.
 const ANTHROPIC_MAX_PAUSE_TURN_CONTINUATIONS: usize = 3;
 
+/// Connection establishment bound; also the floor below which a retry or
+/// continuation attempt is not worth starting — an attempt that cannot even
+/// finish its handshake inside the budget only delays the typed timeout.
+const ANTHROPIC_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Per-call cap for a non-streaming Anthropic response, bounded further by the
+/// request budget at each attempt.
+const ANTHROPIC_NON_STREAMING_CAP: Duration = Duration::from_secs(120);
+
+/// A retry/continuation attempt starts only if this much budget remains.
+pub(super) const ANTHROPIC_ATTEMPT_FLOOR: Duration = ANTHROPIC_CONNECT_TIMEOUT;
+
+/// The budget ran out before the first client-visible semantic event. Returned
+/// inside the platform bound so the gateway, not Cloud Run, owns the mapping.
+pub(super) fn chat_timeout_response() -> Response {
+    response_or_500(
+        Response::builder()
+            .status(StatusCode::GATEWAY_TIMEOUT)
+            .header("content-type", "application/json")
+            .header("retry-after", "5"),
+        Body::from(
+            json!({
+                "error": {
+                    "message": "The request exceeded the chat deadline budget before a response started. Please retry.",
+                    "type": "upstream_timeout",
+                    "code": 504
+                }
+            })
+            .to_string(),
+        ),
+    )
+}
+
+/// Failure surface of the budgeted Anthropic send path.
+#[derive(Debug)]
+pub(super) enum AnthropicSendError {
+    /// Budget exhausted pre-first-byte; callers return `chat_timeout_response()`.
+    DeadlineExpired,
+    /// Existing non-budget failure surface, unchanged.
+    Gateway(StatusCode),
+}
+
+impl AnthropicSendError {
+    pub(super) fn into_response_or_status(self) -> Result<Response, StatusCode> {
+        match self {
+            AnthropicSendError::DeadlineExpired => Ok(chat_timeout_response()),
+            AnthropicSendError::Gateway(status) => Err(status),
+        }
+    }
+}
+
 pub(super) fn new_anthropic_client() -> reqwest::Client {
     reqwest::Client::builder()
-        .connect_timeout(Duration::from_secs(10))
+        .connect_timeout(ANTHROPIC_CONNECT_TIMEOUT)
         .build()
         .unwrap_or_default()
 }
@@ -42,60 +97,124 @@ pub(super) fn retry_backoff(attempt: usize) -> Duration {
     Duration::from_millis(250u64 * (1u64 << attempt.saturating_sub(1).min(3)))
 }
 
+/// Outcome of one provider attempt inside the budgeted retry loop.
+pub(super) enum AttemptOutcome<T> {
+    /// Final answer (success, or a non-transient status passed through).
+    Success(T),
+    /// Transient status carrying the pass-through value: if no retry is
+    /// available the upstream error is returned as-is, exactly as before.
+    Transient { value: T, status: u16 },
+    /// Transport error within the budget; nothing to pass through.
+    TransportError,
+    /// The send hit the budget edge.
+    Expired,
+}
+
+/// Budget-aware retry policy, generic over the attempt so the policy is
+/// testable with a scripted attempt and `tokio::time::pause`.
+///
+/// - An attempt never starts on an expired budget.
+/// - A retry starts only if `remaining()` exceeds `floor` — an attempt that
+///   cannot finish its connect handshake only delays the typed timeout.
+/// - Backoff sleeps are truncated at the budget edge.
+pub(super) async fn retry_with_budget<T, F, Fut>(
+    deadline: &RequestDeadline,
+    max_attempts: usize,
+    floor: Duration,
+    mut attempt: F,
+) -> Result<T, AnthropicSendError>
+where
+    F: FnMut(usize) -> Fut,
+    Fut: std::future::Future<Output = AttemptOutcome<T>>,
+{
+    for attempt_number in 1..=max_attempts {
+        if deadline.expired() {
+            return Err(AnthropicSendError::DeadlineExpired);
+        }
+        let retry_available =
+            |d: &RequestDeadline| attempt_number < max_attempts && d.remaining() > floor;
+        match attempt(attempt_number).await {
+            AttemptOutcome::Success(value) => return Ok(value),
+            AttemptOutcome::Expired => return Err(AnthropicSendError::DeadlineExpired),
+            AttemptOutcome::Transient { value, status } => {
+                if !retry_available(deadline) {
+                    return Ok(value);
+                }
+                tracing::warn!(
+                    "chat_completions: Anthropic {} (attempt {}/{}), retrying",
+                    status,
+                    attempt_number,
+                    max_attempts
+                );
+                tokio::time::sleep(deadline.derive(retry_backoff(attempt_number))).await;
+            }
+            AttemptOutcome::TransportError => {
+                if !retry_available(deadline) {
+                    return Err(AnthropicSendError::Gateway(StatusCode::BAD_GATEWAY));
+                }
+                tokio::time::sleep(deadline.derive(retry_backoff(attempt_number))).await;
+            }
+        }
+    }
+    Err(AnthropicSendError::Gateway(StatusCode::BAD_GATEWAY))
+}
+
 /// Send the Anthropic request, retrying the INITIAL response on transient failures
 /// (network errors + 429/5xx/529). This is the chat fallback: a single Anthropic blip
 /// no longer fails the request. Safe to retry because no output has been produced yet
 /// (for streaming we retry before consuming the body). A transient status on the final
 /// attempt is returned as-is so the caller passes the upstream error through.
+/// Every attempt is bounded by the request budget (#9835).
 pub(super) async fn send_anthropic_with_retry(
     client: &reqwest::Client,
     api_key: &str,
     anthropic_req: &AnthropicRequest,
     streaming: bool,
-) -> Result<reqwest::Response, StatusCode> {
-    for attempt in 1..=ANTHROPIC_MAX_ATTEMPTS {
-        let mut builder = client
-            .post(ANTHROPIC_API_URL)
-            .header("x-api-key", api_key)
-            .header("anthropic-version", ANTHROPIC_API_VERSION)
-            .header("content-type", "application/json")
-            .json(anthropic_req);
-        // Bound non-streaming calls; a streaming response must NOT have a total-response
-        // timeout (it would abort long replies), only the client-level connect timeout.
-        if !streaming {
-            builder = builder.timeout(Duration::from_secs(120));
-        }
-        match builder.send().await {
-            Ok(resp) => {
-                let s = resp.status().as_u16();
-                if is_transient_status(s) && attempt < ANTHROPIC_MAX_ATTEMPTS {
+    deadline: &RequestDeadline,
+) -> Result<reqwest::Response, AnthropicSendError> {
+    retry_with_budget(
+        deadline,
+        ANTHROPIC_MAX_ATTEMPTS,
+        ANTHROPIC_ATTEMPT_FLOOR,
+        |attempt_number| async move {
+            let mut builder = client
+                .post(ANTHROPIC_API_URL)
+                .header("x-api-key", api_key)
+                .header("anthropic-version", ANTHROPIC_API_VERSION)
+                .header("content-type", "application/json")
+                .json(anthropic_req);
+            // Bound non-streaming calls inside the budget; a streaming response must
+            // NOT have a total-response timeout (it would abort long replies) — after
+            // headers, progress is governed by the semantic idle timer downstream.
+            if !streaming {
+                builder = builder.timeout(deadline.derive(ANTHROPIC_NON_STREAMING_CAP));
+            }
+            match send_with_deadline(builder, deadline).await {
+                Ok(resp) => {
+                    let status = resp.status().as_u16();
+                    if is_transient_status(status) {
+                        AttemptOutcome::Transient {
+                            value: resp,
+                            status,
+                        }
+                    } else {
+                        AttemptOutcome::Success(resp)
+                    }
+                }
+                Err(DeadlineSendError::Expired) => AttemptOutcome::Expired,
+                Err(DeadlineSendError::Transport(error)) => {
                     tracing::warn!(
-                        "chat_completions: Anthropic {} (attempt {}/{}), retrying",
-                        s,
-                        attempt,
-                        ANTHROPIC_MAX_ATTEMPTS
+                        "chat_completions: Anthropic request error (attempt {}/{}): {}",
+                        attempt_number,
+                        ANTHROPIC_MAX_ATTEMPTS,
+                        error
                     );
-                    tokio::time::sleep(retry_backoff(attempt)).await;
-                    continue;
+                    AttemptOutcome::TransportError
                 }
-                return Ok(resp);
             }
-            Err(e) => {
-                tracing::warn!(
-                    "chat_completions: Anthropic request error (attempt {}/{}): {}",
-                    attempt,
-                    ANTHROPIC_MAX_ATTEMPTS,
-                    e
-                );
-                if attempt < ANTHROPIC_MAX_ATTEMPTS {
-                    tokio::time::sleep(retry_backoff(attempt)).await;
-                    continue;
-                }
-                return Err(StatusCode::BAD_GATEWAY);
-            }
-        }
-    }
-    Err(StatusCode::BAD_GATEWAY)
+        },
+    )
+    .await
 }
 
 struct ParsedAnthropicResponse {
@@ -111,8 +230,10 @@ async fn receive_anthropic_response(
     client: &reqwest::Client,
     api_key: &str,
     anthropic_req: &AnthropicRequest,
-) -> Result<ParsedAnthropicResponse, StatusCode> {
-    let upstream_resp = send_anthropic_with_retry(client, api_key, anthropic_req, false).await?;
+    deadline: &RequestDeadline,
+) -> Result<ParsedAnthropicResponse, AnthropicSendError> {
+    let upstream_resp =
+        send_anthropic_with_retry(client, api_key, anthropic_req, false, deadline).await?;
     let status = upstream_resp.status();
     if !status.is_success() {
         let body = upstream_resp.text().await.unwrap_or_default();
@@ -121,7 +242,7 @@ async fn receive_anthropic_response(
             status,
             super::truncate_for_log(&body, 500)
         );
-        return Err(StatusCode::BAD_GATEWAY);
+        return Err(AnthropicSendError::Gateway(StatusCode::BAD_GATEWAY));
     }
 
     let raw_response: serde_json::Value = upstream_resp.json().await.map_err(|e| {
@@ -129,7 +250,7 @@ async fn receive_anthropic_response(
             "chat_completions: failed to parse Anthropic continuation response: {}",
             e
         );
-        StatusCode::BAD_GATEWAY
+        AnthropicSendError::Gateway(StatusCode::BAD_GATEWAY)
     })?;
     let raw_content = raw_response
         .get("content")
@@ -137,14 +258,14 @@ async fn receive_anthropic_response(
         .filter(|content| content.is_array())
         .ok_or_else(|| {
             tracing::error!("chat_completions: Anthropic response omitted content blocks");
-            StatusCode::BAD_GATEWAY
+            AnthropicSendError::Gateway(StatusCode::BAD_GATEWAY)
         })?;
     let response = serde_json::from_value(raw_response).map_err(|e| {
         tracing::error!(
             "chat_completions: failed to decode Anthropic continuation response: {}",
             e
         );
-        StatusCode::BAD_GATEWAY
+        AnthropicSendError::Gateway(StatusCode::BAD_GATEWAY)
     })?;
 
     Ok(ParsedAnthropicResponse {
@@ -194,7 +315,8 @@ pub(super) async fn complete_anthropic_server_tool_turn(
     client: &reqwest::Client,
     api_key: &str,
     anthropic_req: &AnthropicRequest,
-) -> Result<AnthropicResponse, StatusCode> {
+    deadline: &RequestDeadline,
+) -> Result<AnthropicResponse, AnthropicSendError> {
     let mut continuation_request = anthropic_req.clone();
     continuation_request.stream = false;
     let mut continuation_count = 0usize;
@@ -205,7 +327,7 @@ pub(super) async fn complete_anthropic_server_tool_turn(
         let ParsedAnthropicResponse {
             mut response,
             raw_content,
-        } = receive_anthropic_response(client, api_key, &continuation_request).await?;
+        } = receive_anthropic_response(client, api_key, &continuation_request, deadline).await?;
         aggregate_content.append(&mut response.content);
         accumulate_anthropic_usage(&mut aggregate_usage, &response.usage);
 
@@ -220,7 +342,17 @@ pub(super) async fn complete_anthropic_server_tool_turn(
                 max_continuations = ANTHROPIC_MAX_PAUSE_TURN_CONTINUATIONS,
                 "chat_completions: Anthropic pause_turn continuation limit reached"
             );
-            return Err(StatusCode::BAD_GATEWAY);
+            return Err(AnthropicSendError::Gateway(StatusCode::BAD_GATEWAY));
+        }
+
+        // A continuation is pre-first-visible-event work: it starts only if it
+        // can plausibly finish inside the budget.
+        if deadline.remaining() <= ANTHROPIC_ATTEMPT_FLOOR {
+            tracing::warn!(
+                "chat_completions: budget exhausted before pause_turn continuation {}",
+                continuation_count + 1
+            );
+            return Err(AnthropicSendError::DeadlineExpired);
         }
 
         continuation_count += 1;
@@ -240,9 +372,13 @@ pub(super) async fn handle_non_streaming(
     user: &AuthUser,
     state: &AppState,
     is_byok: bool,
+    deadline: &RequestDeadline,
 ) -> Result<Response, StatusCode> {
     let anthropic_resp =
-        complete_anthropic_server_tool_turn(client, api_key, anthropic_req).await?;
+        match complete_anthropic_server_tool_turn(client, api_key, anthropic_req, deadline).await {
+            Ok(resp) => resp,
+            Err(error) => return error.into_response_or_status(),
+        };
 
     // Log usage — skip for BYOK since the user pays their own bill and
     // including it would overstate Omi's spend in cost dashboards.

--- a/desktop/macos/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/proxy.rs
@@ -13,12 +13,14 @@ use axum::{
     routing::post,
     Router,
 };
-use std::future::Future;
 use std::time::{Duration, Instant};
 
 use crate::auth::{AuthUser, PaywalledAuthUser};
 use crate::byok;
 use crate::fallback::{record_fallback, FallbackOutcome};
+use crate::request_deadline::{
+    attach_request_deadline, within_deadline, DeadlineElapsed, RequestDeadline, REQUEST_BUDGET,
+};
 use crate::AppState;
 
 use super::llm_stub::{llm_stub_enabled, stub_gemini_proxy_response};
@@ -51,57 +53,23 @@ const MAX_OUTPUT_TOKENS_CAP: u64 = 8192;
 /// explicitly on all production paths.
 const DEFAULT_THINKING_BUDGET: u64 = 1024;
 
-/// Cloud Run's configured request timeout for `desktop-backend`.
-const CLOUD_RUN_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
-
-/// Headroom reserved under the platform deadline so the proxy, rather than
-/// Cloud Run, owns timeout mapping and can return the typed, retryable
-/// `upstream_timeout` response.
-const GEMINI_PLATFORM_HEADROOM: Duration = Duration::from_secs(60);
-
-/// One end-to-end budget for non-streaming Gemini work. It derives from the
-/// Cloud Run request contract and includes token acquisition, provider
+/// One end-to-end budget for non-streaming Gemini work: the shared
+/// per-route-class admission budget (#9835). It derives from the Cloud Run
+/// request contract and includes extractor waits, token acquisition, provider
 /// selection/fallback, request send, and body drain. Long-context calls can
 /// legitimately spend more than 90 seconds thinking before their first byte.
-const GEMINI_TOTAL_TIMEOUT: Duration =
-    Duration::from_secs(CLOUD_RUN_REQUEST_TIMEOUT.as_secs() - GEMINI_PLATFORM_HEADROOM.as_secs());
-
+/// The budget is admitted in route middleware and carried by `RequestDeadline`.
+///
 /// Per-attempt defense inside the logical budget. There are no post-dispatch
 /// retries: generateContent may have completed (and incurred cost) even when its
 /// response is lost, so replaying it is not known-safe.
 const GEMINI_ATTEMPT_HEADROOM: Duration = Duration::from_secs(5);
 const GEMINI_ATTEMPT_TIMEOUT: Duration =
-    Duration::from_secs(GEMINI_TOTAL_TIMEOUT.as_secs() - GEMINI_ATTEMPT_HEADROOM.as_secs());
+    Duration::from_secs(REQUEST_BUDGET.as_secs() - GEMINI_ATTEMPT_HEADROOM.as_secs());
 
 /// Bound TCP/TLS setup for all Gemini proxy calls. Streaming requests must not
 /// use a total response timeout because long SSE replies are expected.
 const GEMINI_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct GeminiDeadlineElapsed;
-
-async fn within_gemini_deadline<F, T>(
-    budget: Duration,
-    future: F,
-) -> Result<T, GeminiDeadlineElapsed>
-where
-    F: Future<Output = T>,
-{
-    race_gemini_deadline(tokio::time::sleep(budget), future).await
-}
-
-async fn race_gemini_deadline<D, F, T>(deadline: D, future: F) -> Result<T, GeminiDeadlineElapsed>
-where
-    D: Future<Output = ()>,
-    F: Future<Output = T>,
-{
-    tokio::pin!(deadline);
-    tokio::pin!(future);
-    tokio::select! {
-        value = &mut future => Ok(value),
-        () = &mut deadline => Err(GeminiDeadlineElapsed),
-    }
-}
 
 /// Emits exactly one bounded outcome for a logical non-streaming provider call.
 /// A request id is useful for log correlation but must never become a metric
@@ -396,6 +364,7 @@ fn deadline_outcome(phase: &str) -> (&'static str, &'static str, ProxyError) {
 /// Rate-limited per user: Tier 1 (allow), Tier 2 (degrade Pro→Flash), Tier 3 (reject 429).
 async fn gemini_proxy(
     State(state): State<AppState>,
+    deadline: RequestDeadline,
     user: PaywalledAuthUser,
     headers: HeaderMap,
     Path(path): Path<String>,
@@ -480,8 +449,8 @@ async fn gemini_proxy(
         };
         let mut telemetry =
             GeminiRequestTelemetry::new(initial_provider, model, action, sanitized_body.len());
-        let result = within_gemini_deadline(
-            GEMINI_TOTAL_TIMEOUT,
+        let result = within_deadline(
+            &deadline,
             gemini_proxy_server_key(
                 &state,
                 &effective_path,
@@ -508,7 +477,7 @@ async fn gemini_proxy(
                 telemetry.complete(outcome, status_class);
                 return Ok(error_response_with_request_id(error, &telemetry.request_id));
             }
-            Err(GeminiDeadlineElapsed) => {
+            Err(DeadlineElapsed) => {
                 let (outcome, status_class, error) = deadline_outcome(telemetry.phase);
                 telemetry.complete(outcome, status_class);
                 return Ok(error_response_with_request_id(error, &telemetry.request_id));
@@ -544,7 +513,7 @@ async fn gemini_proxy(
     let mut telemetry =
         GeminiRequestTelemetry::new("ai_studio_byok", model, action, sanitized_body.len());
     telemetry.set_phase("provider");
-    let result = within_gemini_deadline(GEMINI_TOTAL_TIMEOUT, async {
+    let result = within_deadline(&deadline, async {
         let upstream = state
             .gemini_client
             .post(&url)
@@ -572,7 +541,7 @@ async fn gemini_proxy(
             telemetry.complete(outcome, status_class);
             return Ok(error_response_with_request_id(error, &telemetry.request_id));
         }
-        Err(GeminiDeadlineElapsed) => {
+        Err(DeadlineElapsed) => {
             let (outcome, status_class, error) = deadline_outcome(telemetry.phase);
             telemetry.complete(outcome, status_class);
             return Ok(error_response_with_request_id(error, &telemetry.request_id));
@@ -1352,6 +1321,10 @@ pub fn proxy_routes() -> Router<AppState> {
         // Issue #6624: 5 MB body size limit for proxy routes only (not global).
         // Normal app payloads are 300-600 KB; 5 MB gives ~8x headroom.
         .layer(DefaultBodyLimit::max(GEMINI_MAX_BODY_SIZE))
+        // Outermost: the shared request budget exists before extractors, so
+        // auth/paywall waits are inside it (#9835). The streaming proxy uses it
+        // for extractor waits only — long SSE replies keep no total timeout.
+        .layer(axum::middleware::from_fn(attach_request_deadline))
 }
 
 #[cfg(test)]
@@ -1360,6 +1333,7 @@ mod tests {
     // code; a test failing on unwrap is the test doing its job.
     #![allow(clippy::unwrap_used)]
     use super::*;
+    use crate::request_deadline::{race_deadline, PLATFORM_HEADROOM, PLATFORM_REQUEST_TIMEOUT};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{TcpListener, TcpStream};
     use tokio::sync::oneshot;
@@ -1417,14 +1391,14 @@ mod tests {
     #[test]
     fn gemini_upstream_timeout_stays_below_cloud_run_deadline() {
         assert!(GEMINI_CONNECT_TIMEOUT < GEMINI_ATTEMPT_TIMEOUT);
-        assert!(GEMINI_ATTEMPT_TIMEOUT < GEMINI_TOTAL_TIMEOUT);
-        assert!(GEMINI_TOTAL_TIMEOUT < CLOUD_RUN_REQUEST_TIMEOUT);
+        assert!(GEMINI_ATTEMPT_TIMEOUT < REQUEST_BUDGET);
+        assert!(REQUEST_BUDGET < PLATFORM_REQUEST_TIMEOUT);
         assert!(
-            CLOUD_RUN_REQUEST_TIMEOUT - GEMINI_TOTAL_TIMEOUT >= GEMINI_PLATFORM_HEADROOM,
+            PLATFORM_REQUEST_TIMEOUT - REQUEST_BUDGET >= PLATFORM_HEADROOM,
             "reserve enough time to flush the proxy-owned timeout response"
         );
         assert!(
-            GEMINI_TOTAL_TIMEOUT >= Duration::from_secs(180),
+            REQUEST_BUDGET >= Duration::from_secs(180),
             "long-context Gemini calls must not be cut off at the old 70-second deadline"
         );
     }
@@ -1525,7 +1499,7 @@ mod tests {
         let client = local_test_client();
         let (deadline_tx, deadline_rx) = oneshot::channel();
         let work = tokio::spawn(async move {
-            race_gemini_deadline(
+            race_deadline(
                 async move {
                     let _ = deadline_rx.await;
                 },
@@ -1543,7 +1517,7 @@ mod tests {
             .await
             .expect("deadline work must finish")
             .unwrap();
-        assert_eq!(result.unwrap_err(), GeminiDeadlineElapsed);
+        assert_eq!(result.unwrap_err(), DeadlineElapsed);
         tokio::time::timeout(Duration::from_secs(1), disconnected)
             .await
             .expect("deadline must drop the upstream request")
@@ -1556,8 +1530,8 @@ mod tests {
         let (url, request_seen, disconnected, server) = spawn_hanging_upstream().await;
         let client = local_test_client();
         let proxy_work = tokio::spawn(async move {
-            within_gemini_deadline(
-                Duration::from_secs(30),
+            within_deadline(
+                &RequestDeadline::new(Duration::from_secs(30)),
                 client.post(url).body(Vec::new()).send(),
             )
             .await
@@ -1587,8 +1561,8 @@ mod tests {
                 let client = client.clone();
                 let upstream_url = upstream_url.clone();
                 async move {
-                    let _ = within_gemini_deadline(
-                        Duration::from_secs(30),
+                    let _ = within_deadline(
+                        &RequestDeadline::new(Duration::from_secs(30)),
                         client.post(upstream_url).body(Vec::new()).send(),
                     )
                     .await;
@@ -1629,7 +1603,7 @@ mod tests {
         let (dispatch_tx, dispatch_rx) = oneshot::channel();
         let (deadline_tx, deadline_rx) = oneshot::channel();
         let work = tokio::spawn(async move {
-            race_gemini_deadline(
+            race_deadline(
                 async move {
                     let _ = deadline_rx.await;
                 },
@@ -1652,7 +1626,7 @@ mod tests {
             .await
             .expect("total budget work must finish")
             .unwrap();
-        assert_eq!(result.unwrap_err(), GeminiDeadlineElapsed);
+        assert_eq!(result.unwrap_err(), DeadlineElapsed);
         tokio::time::timeout(Duration::from_secs(1), disconnected)
             .await
             .expect("total budget must cancel the dispatched remainder")


### PR DESCRIPTION
## Summary

Named follow-up from #9835 (kept out of that PR to stay reviewable): the Gemini proxy's working ad hoc deadline migrates onto the shared `RequestDeadline`, so both provider route classes consume one platform-derived admission budget.

- The `race`/`within` helpers and `DeadlineElapsed` move into `request_deadline.rs`; the proxy-local copies are deleted. Per the in-repo-consumers rule, no aliases: every call site and test migrates in this change.
- The budget is admitted by the shared route middleware **before extractors** on both proxy routes, so auth/BYOK/paywall waits are now inside it (previously the proxy clock started at handler entry). The phase-aware timeout telemetry and the typed retryable `upstream_timeout` response are unchanged.
- `CHAT_REQUEST_BUDGET` generalizes to `REQUEST_BUDGET` — both route classes already derived the same 240s from the same Cloud Run contract; the proxy's platform constants collapse into the shared module. Per-attempt Gemini defenses (connect bound, attempt cap, no post-dispatch retries) stay proxy-owned policy.
- The streaming proxy keeps **no total response timeout by design** — it gains only budgeted extractor waits.

**Depends on #10054** (introduces `RequestDeadline`); stacked on that branch, so this PR's diff shows both until #10054 merges (regular merge collapses it to the single `refactor(proxy)` commit). Review the last commit only.

## Failure class

Failure-Class: FC-per-hop-timeout

(The declaration covers the stacked `fix(chat)` commit from #10054 while it is in this PR's range; this PR's own commit is a behavior-preserving refactor.)

## Behavior notes

- Non-BYOK and BYOK non-streaming Gemini turns: same 240s absolute budget as before, now started at admission instead of handler entry — extractor time no longer extends the platform exposure.
- Cancellation semantics preserved and still test-proven: dropping the handler future drops the in-flight upstream request (downstream disconnect propagation tests unchanged).

## Product invariants affected

none (verified with `scripts/pr-preflight --suggest`)

## Validation

- `cargo test --locked` → **382 passed** (all existing proxy deadline tests — hanging-upstream cancellation at an injected deadline, drop-cancels-upstream-socket, downstream-disconnect propagation, one-budget-includes-pre-dispatch-work — migrated to the shared helpers with assertions unchanged).
- New behavioral test `middleware_admits_the_shared_budget_before_the_handler`: on the paused tokio clock, the budget the middleware admits is the budget the handler consumes.
- `cargo check --locked` clean, `cargo fmt --check` clean.
- `make preflight` (local lane, this PR body) → all selected checks pass.
- Not exercised live: a real Gemini call through a dev build (no keys in this environment); the migrated tests drive real sockets against local hanging upstreams exactly as before.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

