### PR TITLE
feat(desktop): personalize home suggestion chips from user context

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift
@@ -1,0 +1,256 @@
+import Foundation
+
+// MARK: - Composition
+
+/// Builds the three home ask-bar suggestion chips: a fixed universal first
+/// question plus two personalized follow-ups generated from the user's own
+/// memories, conversations, tasks, and goals.
+enum HomeSuggestionComposer {
+  static let universalFirstQuestion = "What should I do today?"
+
+  /// Longest personalized question that still fits a single chip line.
+  static let maxPersonalizedLength = 72
+
+  /// Universal first-slot questions (current and legacy onboarding wording)
+  /// that must not repeat in the personalized slots.
+  private static let universalQuestions: Set<String> = [
+    "what should i do today?",
+    "what should i focus on today to achieve my goals?",
+  ]
+
+  static let staticFallbacks = [
+    "What did I spend my time on this week?",
+    "What's the highest-leverage thing I can do next?",
+  ]
+
+  /// Trim, drop empties/duplicates/universal repeats, and drop questions too
+  /// long to render on one chip line.
+  static func sanitize(_ questions: [String]) -> [String] {
+    var seen = Set<String>()
+    return
+      questions
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { question in
+        guard !question.isEmpty, question.count <= maxPersonalizedLength else { return false }
+        let key = question.lowercased()
+        guard !universalQuestions.contains(key), !seen.contains(key) else { return false }
+        seen.insert(key)
+        return true
+      }
+  }
+
+  /// The three chips: universal first, then personalized questions, topped up
+  /// from onboarding-scan suggestions and static fallbacks when fewer than
+  /// two personalized questions are available.
+  static func compose(personalized: [String], onboarding: [String]) -> [String] {
+    let rest = sanitize(personalized + onboarding + staticFallbacks)
+    return [universalFirstQuestion] + rest.prefix(2)
+  }
+}
+
+// MARK: - Generation seam
+
+protocol HomeSuggestionGenerating: Sendable {
+  /// Returns personalized questions, or an empty array when the user's
+  /// context is too thin to reference anything real. Throws on transport
+  /// failure so the caller can retry later without burning the daily slot.
+  func generatePersonalizedQuestions() async throws -> [String]
+}
+
+// MARK: - Store
+
+/// Owns the two personalized home suggestion chips: generates them at most
+/// once per day per account and caches them per owner so an account switch
+/// never shows another account's questions.
+@MainActor
+final class HomeSuggestionsStore: ObservableObject {
+  static let shared = HomeSuggestionsStore()
+
+  @Published private(set) var personalizedQuestions: [String] = []
+
+  private struct CacheEntry: Codable {
+    let questions: [String]
+    let dayStamp: String
+  }
+
+  private static let dayStampFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter
+  }()
+
+  private let defaults: UserDefaults
+  private let generator: any HomeSuggestionGenerating
+  private let now: () -> Date
+  private var generatingOwnerID: String?
+  private nonisolated(unsafe) var ownerObserver: NSObjectProtocol?
+
+  init(
+    defaults: UserDefaults = .standard,
+    generator: (any HomeSuggestionGenerating)? = nil,
+    now: @escaping () -> Date = Date.init
+  ) {
+    self.defaults = defaults
+    self.generator = generator ?? GeminiHomeSuggestionGenerator()
+    self.now = now
+    publishCache(for: currentOwnerID())
+    ownerObserver = NotificationCenter.default.addObserver(
+      forName: .runtimeOwnerDidChange, object: nil, queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor in
+        await self?.refreshIfNeeded()
+      }
+    }
+  }
+
+  deinit {
+    if let ownerObserver { NotificationCenter.default.removeObserver(ownerObserver) }
+  }
+
+  /// Publish the current owner's cached questions and generate fresh ones at
+  /// most once per day per owner. Transport failures leave the cache
+  /// untouched so a later call retries; a successful-but-empty generation is
+  /// cached to hold one attempt per day.
+  func refreshIfNeeded() async {
+    let ownerID = currentOwnerID()
+    publishCache(for: ownerID)
+    guard ownerID != "signed-out" else { return }
+
+    let today = Self.dayStampFormatter.string(from: now())
+    if let cache = loadCache(for: ownerID), cache.dayStamp == today { return }
+    guard generatingOwnerID == nil else { return }
+
+    generatingOwnerID = ownerID
+    defer { generatingOwnerID = nil }
+
+    do {
+      let generated = try await generator.generatePersonalizedQuestions()
+      let questions = Array(HomeSuggestionComposer.sanitize(generated).prefix(2))
+      let entry = CacheEntry(questions: questions, dayStamp: today)
+      defaults.set(try? JSONEncoder().encode(entry), forKey: cacheKey(ownerID: ownerID))
+      if currentOwnerID() == ownerID {
+        personalizedQuestions = questions
+      }
+      log("HomeSuggestions: generated \(questions.count) personalized questions for \(today)")
+    } catch {
+      log(
+        "HomeSuggestions: generation failed (will retry on next visit): \(error.localizedDescription)"
+      )
+    }
+  }
+
+  private func currentOwnerID() -> String {
+    defaults.string(forKey: .authUserId) ?? "signed-out"
+  }
+
+  private func cacheKey(ownerID: String) -> String {
+    "homePersonalizedSuggestions.v1.\(ownerID)"
+  }
+
+  private func loadCache(for ownerID: String) -> CacheEntry? {
+    guard let data = defaults.data(forKey: cacheKey(ownerID: ownerID)) else { return nil }
+    return try? JSONDecoder().decode(CacheEntry.self, from: data)
+  }
+
+  private func publishCache(for ownerID: String) {
+    personalizedQuestions = loadCache(for: ownerID)?.questions ?? []
+  }
+}
+
+// MARK: - Gemini generation
+
+struct GeminiHomeSuggestionGenerator: HomeSuggestionGenerating {
+  private struct Response: Decodable {
+    let questions: [String]
+  }
+
+  private var responseSchema: GeminiRequest.GenerationConfig.ResponseSchema {
+    GeminiRequest.GenerationConfig.ResponseSchema(
+      type: "object",
+      properties: [
+        "questions": .init(
+          type: "array",
+          description: "Up to two short personalized questions, empty when context is too thin",
+          items: .init(type: "string", properties: nil, required: nil)
+        )
+      ],
+      required: ["questions"]
+    )
+  }
+
+  func generatePersonalizedQuestions() async throws -> [String] {
+    async let memoriesFetch = { () async -> [ServerMemory] in
+      (try? await APIClient.shared.getMemories(limit: 200)) ?? []
+    }()
+    async let conversationsFetch = { () async -> [ServerConversation] in
+      (try? await APIClient.shared.getConversations(limit: 30, statuses: [.completed])) ?? []
+    }()
+    async let actionItemsFetch = { () async -> ActionItemsListResponse? in
+      try? await APIClient.shared.getActionItems(limit: 50, completed: false)
+    }()
+    async let goalsFetch = { () async -> [Goal] in
+      (try? await APIClient.shared.getGoals()) ?? []
+    }()
+
+    let (memories, conversations, actionItems, goals) = await (
+      memoriesFetch, conversationsFetch, actionItemsFetch, goalsFetch
+    )
+
+    let memoryContext = memories.map { $0.content }.joined(separator: "\n")
+    let conversationContext =
+      conversations
+      .compactMap { $0.structured.overview.isEmpty ? nil : $0.structured.overview }
+      .joined(separator: "\n")
+    let tasksContext = (actionItems?.items ?? []).map { $0.description }.joined(separator: "\n")
+    let goalsContext = goals.map { $0.title }.joined(separator: "\n")
+
+    if memoryContext.isEmpty && conversationContext.isEmpty && tasksContext.isEmpty
+      && goalsContext.isEmpty
+    {
+      return []
+    }
+
+    let dateFormatter = DateFormatter()
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+    dateFormatter.dateFormat = "EEEE, MMMM d, yyyy"
+
+    let prompt = """
+      Today is \(dateFormatter.string(from: Date())).
+
+      USER MEMORIES:
+      \(memoryContext.isEmpty ? "None" : memoryContext)
+
+      RECENT CONVERSATION SUMMARIES:
+      \(conversationContext.isEmpty ? "None" : conversationContext)
+
+      OPEN TASKS:
+      \(tasksContext.isEmpty ? "None" : tasksContext)
+
+      ACTIVE GOALS:
+      \(goalsContext.isEmpty ? "None" : goalsContext)
+
+      Write up to 2 suggested questions this user would genuinely want to ask right now.
+
+      Rules:
+      - Each question must reference something concrete and current from the context above by name — a project, person, goal, task, or topic.
+      - Phrase them in first person, as the user asking their assistant (e.g. "How do I unblock the Atlas launch?").
+      - Keep each under 48 characters so it fits on one line.
+      - No generic productivity questions ("What should I focus on?", "How can I be more productive?") — the first suggestion slot already covers that.
+      - Skip anything sensitive or awkward to show on a home screen.
+      - Return an empty list if the context doesn't contain enough real, current material.
+      """
+
+    let client = try GeminiClient()
+    let responseText = try await client.sendRequest(
+      prompt: prompt,
+      systemPrompt:
+        "You write the suggested questions shown under the ask bar of omi, the user's personal AI assistant. The questions are ones the user would tap to ask about their own life and work.",
+      responseSchema: responseSchema
+    )
+
+    guard let data = responseText.data(using: .utf8) else { return [] }
+    return try JSONDecoder().decode(Response.self, from: data).questions
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -221,6 +221,7 @@ struct DashboardPage: View {
   @ObservedObject var memoriesViewModel: MemoriesViewModel
   var taskChatCoordinator: TaskChatCoordinator? = nil
   @ObservedObject private var deviceProvider = DeviceProvider.shared
+  @ObservedObject private var homeSuggestionsStore = HomeSuggestionsStore.shared
   @StateObject private var intelligenceStore = DashboardIntelligenceStore()
   @Binding var selectedIndex: Int
   @State private var citedConversation: ServerConversation? = nil
@@ -476,6 +477,7 @@ struct DashboardPage: View {
           }
         }
         Task { await homeStatusStore.refreshIfNeeded() }
+        Task { await homeSuggestionsStore.refreshIfNeeded() }
       }
       .onDisappear {
         intelligenceStore.setRecommendationActionHandler(nil)
@@ -486,6 +488,7 @@ struct DashboardPage: View {
         appState.checkAllPermissions()
         syncCaptureState()
         Task { await homeStatusStore.refreshIfNeeded() }
+        Task { await homeSuggestionsStore.refreshIfNeeded() }
       }
       .onReceive(NotificationCenter.default.publisher(for: .assistantMonitoringStateDidChange)) { _ in
         syncCaptureState()
@@ -1029,13 +1032,10 @@ struct DashboardPage: View {
   }
 
   private var homeSuggestedQuestions: [String] {
-    let saved = PostOnboardingPromptSuggestions.suggestions()
-    let fallback = [
-      "What should I focus on today to achieve my goals?",
-      "What did I spend my time on this week?",
-      "What's the highest-leverage thing I can do next?",
-    ]
-    return Array((saved.isEmpty ? fallback : saved).prefix(3))
+    HomeSuggestionComposer.compose(
+      personalized: homeSuggestionsStore.personalizedQuestions,
+      onboarding: PostOnboardingPromptSuggestions.suggestions()
+    )
   }
 
   private var homeSuggestionList: some View {

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingPromptSuggestions.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingPromptSuggestions.swift
@@ -42,7 +42,7 @@ enum OnboardingPromptSuggestionBuilder {
     var suggestions: [String] = []
 
     // Universal first question — always relevant, not tied to a random project
-    suggestions.append("What should I focus on today to achieve my goals?")
+    suggestions.append(HomeSuggestionComposer.universalFirstQuestion)
 
     if !coordinator.emailSummary.isEmpty {
       suggestions.append("What email follow-ups matter most today?")

--- a/desktop/macos/Desktop/Tests/HomeSuggestionsStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeSuggestionsStoreTests.swift
@@ -1,0 +1,260 @@
+import XCTest
+
+@testable import Omi_Computer
+
+// MARK: - Composer
+
+final class HomeSuggestionComposerTests: XCTestCase {
+  func testComposeUsesPersonalizedPairAfterUniversalFirst() {
+    let chips = HomeSuggestionComposer.compose(
+      personalized: ["How do I unblock the Atlas launch?", "Is the hiring loop for EE on track?"],
+      onboarding: ["What email follow-ups matter most today?"]
+    )
+
+    XCTAssertEqual(
+      chips,
+      [
+        "What should I do today?",
+        "How do I unblock the Atlas launch?",
+        "Is the hiring loop for EE on track?",
+      ]
+    )
+  }
+
+  func testComposeFallsBackToOnboardingThenStatic() {
+    let onboardingSaved = [
+      "What should I focus on today to achieve my goals?",
+      "What email follow-ups matter most today?",
+      "Where can I find focus time this week?",
+    ]
+    XCTAssertEqual(
+      HomeSuggestionComposer.compose(personalized: [], onboarding: onboardingSaved),
+      [
+        "What should I do today?",
+        "What email follow-ups matter most today?",
+        "Where can I find focus time this week?",
+      ]
+    )
+
+    XCTAssertEqual(
+      HomeSuggestionComposer.compose(personalized: [], onboarding: []),
+      [
+        "What should I do today?",
+        "What did I spend my time on this week?",
+        "What's the highest-leverage thing I can do next?",
+      ]
+    )
+  }
+
+  func testComposeTopsUpSinglePersonalizedQuestionFromFallbacks() {
+    let chips = HomeSuggestionComposer.compose(
+      personalized: ["How do I unblock the Atlas launch?"],
+      onboarding: []
+    )
+
+    XCTAssertEqual(
+      chips,
+      [
+        "What should I do today?",
+        "How do I unblock the Atlas launch?",
+        "What did I spend my time on this week?",
+      ]
+    )
+  }
+
+  func testSanitizeDropsLongDuplicateUniversalAndEmptyQuestions() {
+    let sanitized = HomeSuggestionComposer.sanitize([
+      "  How do I unblock the Atlas launch?  ",
+      "how do i unblock the atlas launch?",
+      "What should I do today?",
+      "WHAT SHOULD I FOCUS ON TODAY TO ACHIEVE MY GOALS?",
+      "",
+      "   ",
+      String(repeating: "x", count: HomeSuggestionComposer.maxPersonalizedLength + 1),
+    ])
+
+    XCTAssertEqual(sanitized, ["How do I unblock the Atlas launch?"])
+  }
+}
+
+// MARK: - Store
+
+private final class StubSuggestionGenerator: HomeSuggestionGenerating, @unchecked Sendable {
+  enum Behavior {
+    case respond([String])
+    case fail
+  }
+
+  private let lock = NSLock()
+  private var _behavior: Behavior
+  private var _callCount = 0
+  private var pendingContinuation: CheckedContinuation<Void, Never>?
+  private var gateNextCall = false
+
+  init(behavior: Behavior) {
+    _behavior = behavior
+  }
+
+  var callCount: Int {
+    lock.withLock { _callCount }
+  }
+
+  func setBehavior(_ behavior: Behavior) {
+    lock.withLock { _behavior = behavior }
+  }
+
+  /// Make the next generation call suspend until `resumeGatedCall()`.
+  func gateNext() {
+    lock.withLock { gateNextCall = true }
+  }
+
+  func resumeGatedCall() {
+    let continuation = lock.withLock { () -> CheckedContinuation<Void, Never>? in
+      let pending = pendingContinuation
+      pendingContinuation = nil
+      return pending
+    }
+    continuation?.resume()
+  }
+
+  func generatePersonalizedQuestions() async throws -> [String] {
+    let (behavior, gated) = lock.withLock { () -> (Behavior, Bool) in
+      _callCount += 1
+      let gated = gateNextCall
+      gateNextCall = false
+      return (_behavior, gated)
+    }
+
+    if gated {
+      await withCheckedContinuation { continuation in
+        lock.withLock { pendingContinuation = continuation }
+      }
+    }
+
+    switch behavior {
+    case .respond(let questions): return questions
+    case .fail: throw URLError(.notConnectedToInternet)
+    }
+  }
+}
+
+@MainActor
+final class HomeSuggestionsStoreTests: XCTestCase {
+  private func makeDefaults(owner: String?) throws -> (UserDefaults, () -> Void) {
+    let suite = "HomeSuggestionsStoreTests.\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+    if let owner {
+      defaults.set(owner, forKey: .authUserId)
+    }
+    return (defaults, { defaults.removePersistentDomain(forName: suite) })
+  }
+
+  func testRefreshGeneratesOncePerDayAndRepublishesFromCache() async throws {
+    let (defaults, cleanup) = try makeDefaults(owner: "owner-a")
+    defer { cleanup() }
+    let generator = StubSuggestionGenerator(
+      behavior: .respond(["How do I unblock the Atlas launch?", "Is the EE hiring loop on track?"]))
+    let day = Date(timeIntervalSince1970: 1_700_000_000)
+    let store = HomeSuggestionsStore(defaults: defaults, generator: generator, now: { day })
+
+    await store.refreshIfNeeded()
+    XCTAssertEqual(generator.callCount, 1)
+    XCTAssertEqual(
+      store.personalizedQuestions,
+      ["How do I unblock the Atlas launch?", "Is the EE hiring loop on track?"]
+    )
+
+    await store.refreshIfNeeded()
+    XCTAssertEqual(generator.callCount, 1, "same-day refresh must not regenerate")
+
+    // A fresh store over the same defaults publishes from cache without generating.
+    let rehydrated = HomeSuggestionsStore(defaults: defaults, generator: generator, now: { day })
+    XCTAssertEqual(
+      rehydrated.personalizedQuestions,
+      ["How do I unblock the Atlas launch?", "Is the EE hiring loop on track?"]
+    )
+    await rehydrated.refreshIfNeeded()
+    XCTAssertEqual(generator.callCount, 1)
+  }
+
+  func testRefreshRegeneratesOnNextDay() async throws {
+    let (defaults, cleanup) = try makeDefaults(owner: "owner-a")
+    defer { cleanup() }
+    let generator = StubSuggestionGenerator(behavior: .respond(["Day one question?"]))
+    var currentDay = Date(timeIntervalSince1970: 1_700_000_000)
+    let store = HomeSuggestionsStore(defaults: defaults, generator: generator, now: { currentDay })
+
+    await store.refreshIfNeeded()
+    XCTAssertEqual(generator.callCount, 1)
+
+    generator.setBehavior(.respond(["Day two question?"]))
+    currentDay = currentDay.addingTimeInterval(60 * 60 * 24)
+    await store.refreshIfNeeded()
+    XCTAssertEqual(generator.callCount, 2)
+    XCTAssertEqual(store.personalizedQuestions, ["Day two question?"])
+  }
+
+  func testRefreshSkipsWhenSignedOut() async throws {
+    let (defaults, cleanup) = try makeDefaults(owner: nil)
+    defer { cleanup() }
+    let generator = StubSuggestionGenerator(behavior: .respond(["Should not appear?"]))
+    let store = HomeSuggestionsStore(defaults: defaults, generator: generator)
+
+    await store.refreshIfNeeded()
+
+    XCTAssertEqual(generator.callCount, 0)
+    XCTAssertEqual(store.personalizedQuestions, [])
+  }
+
+  func testTransportFailureRetriesButEmptySuccessHoldsForTheDay() async throws {
+    let (defaults, cleanup) = try makeDefaults(owner: "owner-a")
+    defer { cleanup() }
+    let generator = StubSuggestionGenerator(behavior: .fail)
+    let day = Date(timeIntervalSince1970: 1_700_000_000)
+    let store = HomeSuggestionsStore(defaults: defaults, generator: generator, now: { day })
+
+    await store.refreshIfNeeded()
+    XCTAssertEqual(generator.callCount, 1)
+
+    // Failure left no cache entry, so the next refresh retries.
+    await store.refreshIfNeeded()
+    XCTAssertEqual(generator.callCount, 2)
+
+    // A successful-but-empty generation is cached and holds until tomorrow.
+    generator.setBehavior(.respond([]))
+    await store.refreshIfNeeded()
+    XCTAssertEqual(generator.callCount, 3)
+    await store.refreshIfNeeded()
+    XCTAssertEqual(generator.callCount, 3)
+    XCTAssertEqual(store.personalizedQuestions, [])
+  }
+
+  func testOwnerSwitchNeverPublishesAnotherOwnersQuestions() async throws {
+    let (defaults, cleanup) = try makeDefaults(owner: "owner-a")
+    defer { cleanup() }
+    let generator = StubSuggestionGenerator(behavior: .respond(["Owner A's private question?"]))
+    let store = HomeSuggestionsStore(defaults: defaults, generator: generator)
+
+    generator.gateNext()
+    let refreshTask = Task { await store.refreshIfNeeded() }
+
+    // Switch accounts while owner A's generation is in flight.
+    while generator.callCount == 0 {
+      await Task.yield()
+    }
+    defaults.set("owner-b", forKey: .authUserId)
+    generator.resumeGatedCall()
+    await refreshTask.value
+
+    XCTAssertEqual(
+      store.personalizedQuestions, [],
+      "owner A's late result must not be published for owner B"
+    )
+
+    // Owner A's result was still cached under owner A, so switching back
+    // publishes it without regenerating.
+    defaults.set("owner-a", forKey: .authUserId)
+    await store.refreshIfNeeded()
+    XCTAssertEqual(store.personalizedQuestions, ["Owner A's private question?"])
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260719-personalized-home-suggestions.json
+++ b/desktop/macos/changelog/unreleased/20260719-personalized-home-suggestions.json
@@ -1,0 +1,3 @@
+{
+  "change": "Home suggestions now open with \"What should I do today?\" followed by two questions personalized from your memories, tasks, and goals"
+}

--- a/desktop/macos/e2e/flows/home-stage.yaml
+++ b/desktop/macos/e2e/flows/home-stage.yaml
@@ -5,6 +5,7 @@ description: Redesigned Home stage transitions (hub/chat/connect) via automation
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
 preconditions:
   - automation_bridge_ready

--- a/desktop/macos/e2e/flows/onboarding-flow.yaml
+++ b/desktop/macos/e2e/flows/onboarding-flow.yaml
@@ -10,6 +10,7 @@ covers:
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingFlow.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingStepScaffold.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
+  - desktop/macos/Desktop/Sources/Onboarding/OnboardingPromptSuggestions.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingExportsStepView.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingDataSourcesStepView.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingFileScanStepView.swift


### PR DESCRIPTION
## Omi Beta as a separate app — run beta and stable side-by-side

Today "beta" and "stable" are the same bundle id (`com.omi.computer-macos`), so the single-instance guard (correctly) refuses a second instance: two live copies would share one Rewind SQLite DB, one UserDefaults domain, and one log. This PR makes Omi Beta a first-class separate identity so both can run at the same time — for everyone, Chrome-style.

### What changed
**App (Swift)**
- `com.omi.computer-macos.beta` is a production-family identity: production gating (no automation bridge, Sparkle on), pinned `beta` update channel (Settings picker locked), isolated `~/Library/Application Support/Omi Beta/` storage root via `DesktopStorageIdentity`, own `/tmp/omi-beta.log`, Keychain-backed install id, channel-based backend routing (beta → dev backend, same as today's beta channel).
- Single-instance guard already keys on bundle id → beta+stable coexist; true duplicates still refused per identity.

**Release pipeline (Codemagic)**
- New step duplicates the signed stable app, re-identifies it as "Omi Beta" (identity-aware `SUFeedURL?identity=beta`), re-signs the outer bundle (nested signatures stay valid), notarizes, staples, ships `Omi.Beta.zip` + `omi-beta.dmg` with their own smoke result (`desktop-smoke-result-beta.json`) and appcast EdDSA signature (`betaEdSignature` in release KEY_VALUE).
- Beta qualification (`check-desktop-auto-beta-candidate.py`) verifies beta asset digests against beta smoke evidence when the assets are present; older releases stay valid.

**Backend (updates.py)**
- `identity=beta` (sent only by the Omi Beta app's feed URL) serves beta-channel items exclusively with beta-identity enclosures — Sparkle can never replace the beta app with a stable-identity bundle. Pointer entries resolve beta assets from the GitHub release by tag; releases without beta artifacts are omitted from the beta feed. Stable DMG picker excludes `omi-beta.dmg` by exact name. Legacy stable-id beta-channel installs keep today's feed and behavior (no forced migration).

### Product invariants
- INV-AUTH-1: cited because the diff touches `ClientDeviceService.swift` (install-id storage selection only — the beta identity now keeps the durable Keychain install id like stable). Session-death ownership (`AuthSessionCoordinator.invalidateSession`) is untouched; no behavior change for existing identities, so the guard test is unchanged.

### Verification
- **Side-by-side, real user path:** built a beta-identity bundle locally (`com.omi.computer-macos.beta`) and ran it beside the running production `omi.app`: both processes alive simultaneously (CGWindowList shows windows owned by "omi" pid 11071 and "Omi Beta" pid 8076), `Omi Beta/` storage root created, `/tmp/omi-beta.log` written.
- **Guard:** second beta instance refused (`SingleInstanceGuard: another com.omi.computer-macos.beta … exiting`); duplicate stable copy ("omi 2.app", same id) still refused — that was the original symptom, correct for true duplicates.
- **Swift tests:** `AppBuildBetaIdentityTests`, `DesktopStorageIdentityTests`, `APIClientRoutingTests`, `ExternalPreviewBuildTests` — 79 green post-rebase (includes #10050's AppBuild changes).
- **Backend tests:** `tests/unit/test_desktop_updates.py` — 97 green (6 new beta-identity tests); `scan_async_blockers` clean.
- **UNVERIFIED (CI lane):** the new Codemagic packaging steps run on the next candidate build (script bash -n checked, YAML validated). Plan: after merge, deploy backend, dispatch a candidate, verify the release carries `Omi.Beta.zip`/`omi-beta.dmg`, then install the real beta DMG beside stable.

### Deploy sequencing
Backend change is additive (unknown `identity` param was previously ignored; identity=beta feed is empty until a dual-identity release exists). Sequence after merge: deploy prod backend → dispatch desktop candidate → first dual-identity release goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

