### PR TITLE
feat(desktop): Omi Beta as a separate app — run beta and stable side-by-side

### DIFF
--- a/.github/scripts/check-desktop-auto-beta-candidate.py
+++ b/.github/scripts/check-desktop-auto-beta-candidate.py
@@ -53,6 +53,38 @@ def normalized_digest(asset: dict) -> str:
     return digest.removeprefix("sha256:")
 
 
+def _validate_smoke_contract(
+    smoke: dict,
+    *,
+    bundle_id: str,
+    release_tag: str,
+    expected_version: str,
+    expected_build: str,
+    label: str,
+) -> set[str]:
+    """Enforce the shared success/tag/version/build/team/channel contract on a
+    smoke result. The beta artifact must satisfy the same bar as stable, only
+    with its own bundle id."""
+    expected = {
+        "ok": True,
+        "release_tag": release_tag,
+        "expected_channel": "beta",
+        "bundle_id": bundle_id,
+        "version": expected_version,
+        "build": expected_build,
+        "team_id": EXPECTED_TEAM_ID,
+    }
+    for field, value in expected.items():
+        if smoke.get(field) != value:
+            fail(f"{label} smoke result {field} mismatch: expected {value!r}, got {smoke.get(field)!r}")
+
+    checks = set(smoke.get("checks") or [])
+    missing_checks = sorted(REQUIRED_SMOKE_CHECKS - checks)
+    if missing_checks:
+        fail(f"{label} smoke result is missing required checks: {', '.join(missing_checks)}")
+    return checks
+
+
 def validate(args: argparse.Namespace) -> dict:
     match = TAG_RE.match(args.release_tag)
     if not match:
@@ -79,23 +111,14 @@ def validate(args: argparse.Namespace) -> dict:
 
     expected_version = match.group("version")
     expected_build = match.group("build")
-    expected = {
-        "ok": True,
-        "release_tag": args.release_tag,
-        "expected_channel": "beta",
-        "bundle_id": EXPECTED_BUNDLE_ID,
-        "version": expected_version,
-        "build": expected_build,
-        "team_id": EXPECTED_TEAM_ID,
-    }
-    for field, value in expected.items():
-        if smoke.get(field) != value:
-            fail(f"signed smoke result {field} mismatch: expected {value!r}, got {smoke.get(field)!r}")
-
-    checks = set(smoke.get("checks") or [])
-    missing_checks = sorted(REQUIRED_SMOKE_CHECKS - checks)
-    if missing_checks:
-        fail(f"signed smoke result is missing required checks: {', '.join(missing_checks)}")
+    checks = _validate_smoke_contract(
+        smoke,
+        bundle_id=EXPECTED_BUNDLE_ID,
+        release_tag=args.release_tag,
+        expected_version=expected_version,
+        expected_build=expected_build,
+        label="signed",
+    )
 
     callback_canary = smoke.get("notification_callback_canary")
     if not isinstance(callback_canary, dict):
@@ -130,18 +153,21 @@ def validate(args: argparse.Namespace) -> dict:
         fail("published DMG digest does not match the signed artifact smoke")
 
     # Releases that ship the side-by-side Omi Beta identity carry a second smoke
-    # result; when those assets exist they must match it (older releases without
-    # beta assets stay valid).
+    # result; when those assets exist the beta artifact must satisfy the same
+    # contract as stable (older releases without beta assets stay valid).
     beta_assets = {a.get("name") for a in release.get("assets", [])}
     if "Omi.Beta.zip" in beta_assets:
-        if not args.beta_smoke_result or not Path(args.beta_smoke_result).exists():
+        if not getattr(args, "beta_smoke_result", "") or not Path(args.beta_smoke_result).exists():
             fail("release ships Omi Beta assets but no beta smoke result was provided")
         beta_smoke = load_json(args.beta_smoke_result)
-        if beta_smoke.get("bundle_id") != EXPECTED_BETA_BUNDLE_ID:
-            fail(
-                "beta smoke result bundle_id mismatch: expected "
-                f"{EXPECTED_BETA_BUNDLE_ID!r}, got {beta_smoke.get('bundle_id')!r}"
-            )
+        _validate_smoke_contract(
+            beta_smoke,
+            bundle_id=EXPECTED_BETA_BUNDLE_ID,
+            release_tag=args.release_tag,
+            expected_version=expected_version,
+            expected_build=expected_build,
+            label="beta",
+        )
         beta_zip_release = asset_by_name(release, {"Omi.Beta.zip"})
         beta_dmg_release = asset_by_name(release, {"omi-beta.dmg"})
         beta_zip_smoke = smoke_artifact(beta_smoke, "sparkle_zip")

--- a/.github/scripts/check-desktop-auto-beta-candidate.py
+++ b/.github/scripts/check-desktop-auto-beta-candidate.py
@@ -82,7 +82,32 @@ def _validate_smoke_contract(
     missing_checks = sorted(REQUIRED_SMOKE_CHECKS - checks)
     if missing_checks:
         fail(f"{label} smoke result is missing required checks: {', '.join(missing_checks)}")
+
+    _validate_callback_canary(smoke, bundle_id=bundle_id, label=label)
     return checks
+
+
+def _validate_callback_canary(smoke: dict, *, bundle_id: str, label: str) -> None:
+    """The UserNotifications callback canary must run inside the exact artifact
+    being qualified, so its recorded bundle id must match that artifact."""
+    callback_canary = smoke.get("notification_callback_canary")
+    if not isinstance(callback_canary, dict):
+        fail(f"{label} smoke result is missing UserNotifications callback canary evidence")
+    expected_callback_canary = {
+        "schema": 1,
+        "event": "user-notifications-settings-callback-completed",
+        "bundle_id": bundle_id,
+        "main_actor": True,
+        "validated": True,
+    }
+    for field, value in expected_callback_canary.items():
+        if callback_canary.get(field) != value:
+            fail(
+                f"{label} smoke UserNotifications callback canary "
+                f"{field} mismatch: expected {value!r}, got {callback_canary.get(field)!r}"
+            )
+    if not isinstance(callback_canary.get("authorization_status"), int):
+        fail(f"{label} smoke UserNotifications callback canary is missing authorization status")
 
 
 def validate(args: argparse.Namespace) -> dict:
@@ -121,23 +146,6 @@ def validate(args: argparse.Namespace) -> dict:
     )
 
     callback_canary = smoke.get("notification_callback_canary")
-    if not isinstance(callback_canary, dict):
-        fail("signed smoke result is missing UserNotifications callback canary evidence")
-    expected_callback_canary = {
-        "schema": 1,
-        "event": "user-notifications-settings-callback-completed",
-        "bundle_id": EXPECTED_BUNDLE_ID,
-        "main_actor": True,
-        "validated": True,
-    }
-    for field, value in expected_callback_canary.items():
-        if callback_canary.get(field) != value:
-            fail(
-                "signed smoke UserNotifications callback canary "
-                f"{field} mismatch: expected {value!r}, got {callback_canary.get(field)!r}"
-            )
-    if not isinstance(callback_canary.get("authorization_status"), int):
-        fail("signed smoke UserNotifications callback canary is missing authorization status")
 
     zip_release = asset_by_name(release, {"Omi.zip"})
     dmg_release = asset_by_name(release, {"Omi.dmg", "omi.dmg"})

--- a/.github/scripts/check-desktop-auto-beta-candidate.py
+++ b/.github/scripts/check-desktop-auto-beta-candidate.py
@@ -13,6 +13,7 @@ from desktop_release_metadata import fail, parse_metadata
 
 TAG_RE = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)\+(?P<build>\d+)-macos$")
 EXPECTED_BUNDLE_ID = "com.omi.computer-macos"
+EXPECTED_BETA_BUNDLE_ID = "com.omi.computer-macos.beta"
 EXPECTED_TEAM_ID = "9536L8KLMP"
 REQUIRED_SMOKE_CHECKS = {
     "Launch + identity metadata is aligned",
@@ -128,6 +129,30 @@ def validate(args: argparse.Namespace) -> dict:
     if dmg_smoke.get("sha256") != artifact_digests[dmg_release["name"]]:
         fail("published DMG digest does not match the signed artifact smoke")
 
+    # Releases that ship the side-by-side Omi Beta identity carry a second smoke
+    # result; when those assets exist they must match it (older releases without
+    # beta assets stay valid).
+    beta_assets = {a.get("name") for a in release.get("assets", [])}
+    if "Omi.Beta.zip" in beta_assets:
+        if not args.beta_smoke_result or not Path(args.beta_smoke_result).exists():
+            fail("release ships Omi Beta assets but no beta smoke result was provided")
+        beta_smoke = load_json(args.beta_smoke_result)
+        if beta_smoke.get("bundle_id") != EXPECTED_BETA_BUNDLE_ID:
+            fail(
+                "beta smoke result bundle_id mismatch: expected "
+                f"{EXPECTED_BETA_BUNDLE_ID!r}, got {beta_smoke.get('bundle_id')!r}"
+            )
+        beta_zip_release = asset_by_name(release, {"Omi.Beta.zip"})
+        beta_dmg_release = asset_by_name(release, {"omi-beta.dmg"})
+        beta_zip_smoke = smoke_artifact(beta_smoke, "sparkle_zip")
+        beta_dmg_smoke = smoke_artifact(beta_smoke, "dmg")
+        artifact_digests["Omi.Beta.zip"] = normalized_digest(beta_zip_release)
+        artifact_digests["omi-beta.dmg"] = normalized_digest(beta_dmg_release)
+        if beta_zip_smoke.get("sha256") != artifact_digests["Omi.Beta.zip"]:
+            fail("published Omi.Beta.zip digest does not match the beta artifact smoke")
+        if beta_dmg_smoke.get("sha256") != artifact_digests["omi-beta.dmg"]:
+            fail("published omi-beta.dmg digest does not match the beta artifact smoke")
+
     return {
         "passed": True,
         "gate": "desktop-auto-beta-candidate-v1",
@@ -144,6 +169,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--release-json", required=True)
     parser.add_argument("--smoke-result", required=True)
+    parser.add_argument("--beta-smoke-result", default="")
     parser.add_argument("--release-tag", required=True)
     parser.add_argument("--latest-tag", required=True)
     parser.add_argument("--tag-sha", required=True)

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -4,13 +4,13 @@
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4252,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1578,
-    "desktop/macos/Desktop/Sources/OmiApp.swift": 1634
+    "desktop/macos/Desktop/Sources/OmiApp.swift": 1641
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/AuthService.swift": "Apple first-auth name capture signals observers (authNameDidUpdate) and persists the name to Firebase so it survives reinstalls.",
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": "Reach-error card gains a debug bridge action so the actionable failure surface is verifiable in-process.",
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
-    "desktop/macos/Desktop/Sources/OmiApp.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior."
+    "desktop/macos/Desktop/Sources/OmiApp.swift": "Side-by-side Omi Beta: legacy Omi Computer.app cleanup gains a stable-identity guard so the beta app can never terminate or delete a stable install."
   },
   "threshold": 1500
 }

--- a/.github/scripts/test_check_desktop_auto_beta_candidate.py
+++ b/.github/scripts/test_check_desktop_auto_beta_candidate.py
@@ -67,12 +67,48 @@ def fixtures(root: Path) -> argparse.Namespace:
     return argparse.Namespace(
         release_json=str(release_path),
         smoke_result=str(smoke_path),
+        beta_smoke_result="",
         release_tag=TAG,
         latest_tag=TAG,
         tag_sha=SHA,
         checkout_sha=SHA,
         output=str(root / "result.json"),
     )
+
+
+BETA_ZIP_SHA = "e" * 64
+BETA_DMG_SHA = "f" * 64
+
+
+def beta_fixtures(root: Path) -> argparse.Namespace:
+    """Fixtures for a release that ships the side-by-side Omi Beta assets."""
+    args = fixtures(root)
+    release_path = Path(args.release_json)
+    release = json.loads(release_path.read_text())
+    release["assets"] += [
+        {"name": "Omi.Beta.zip", "digest": f"sha256:{BETA_ZIP_SHA}"},
+        {"name": "omi-beta.dmg", "digest": f"sha256:{BETA_DMG_SHA}"},
+    ]
+    release_path.write_text(json.dumps(release), encoding="utf-8")
+
+    beta_smoke = {
+        "ok": True,
+        "release_tag": TAG,
+        "expected_channel": "beta",
+        "bundle_id": "com.omi.computer-macos.beta",
+        "version": "0.12.99",
+        "build": "12099",
+        "team_id": "9536L8KLMP",
+        "checks": sorted(REQUIRED_SMOKE_CHECKS),
+        "artifacts": [
+            {"label": "sparkle_zip", "sha256": BETA_ZIP_SHA},
+            {"label": "dmg", "sha256": BETA_DMG_SHA},
+        ],
+    }
+    beta_smoke_path = root / "smoke-beta.json"
+    beta_smoke_path.write_text(json.dumps(beta_smoke), encoding="utf-8")
+    args.beta_smoke_result = str(beta_smoke_path)
+    return args
 
 
 def expect_failure(args: argparse.Namespace, fragment: str) -> None:
@@ -116,6 +152,41 @@ def main() -> int:
         smoke["notification_callback_canary"]["validated"] = False
         smoke_path.write_text(json.dumps(smoke))
         expect_failure(args, "callback canary validated mismatch")
+
+    # Releases shipping the side-by-side Omi Beta assets: the beta artifact must
+    # satisfy the same smoke contract as stable, under its own bundle id.
+    with tempfile.TemporaryDirectory() as temp_dir:
+        args = beta_fixtures(Path(temp_dir))
+        result = validate(args)
+        assert result["passed"] is True
+        assert result["artifact_digests"]["Omi.Beta.zip"] == BETA_ZIP_SHA
+        assert result["artifact_digests"]["omi-beta.dmg"] == BETA_DMG_SHA
+
+        missing = argparse.Namespace(**{**vars(args), "beta_smoke_result": ""})
+        expect_failure(missing, "no beta smoke result was provided")
+
+        beta_smoke_path = Path(args.beta_smoke_result)
+        original = beta_smoke_path.read_text()
+
+        beta_smoke = json.loads(original)
+        beta_smoke["bundle_id"] = "com.omi.computer-macos"
+        beta_smoke_path.write_text(json.dumps(beta_smoke))
+        expect_failure(args, "beta smoke result bundle_id mismatch")
+
+        beta_smoke = json.loads(original)
+        beta_smoke["ok"] = False
+        beta_smoke_path.write_text(json.dumps(beta_smoke))
+        expect_failure(args, "beta smoke result ok mismatch")
+
+        beta_smoke = json.loads(original)
+        beta_smoke["checks"] = beta_smoke["checks"][1:]
+        beta_smoke_path.write_text(json.dumps(beta_smoke))
+        expect_failure(args, "beta smoke result is missing required checks")
+
+        beta_smoke = json.loads(original)
+        beta_smoke["artifacts"][0]["sha256"] = "d" * 64
+        beta_smoke_path.write_text(json.dumps(beta_smoke))
+        expect_failure(args, "Omi.Beta.zip digest")
 
     print("automatic desktop beta candidate tests OK")
     return 0

--- a/.github/scripts/test_check_desktop_auto_beta_candidate.py
+++ b/.github/scripts/test_check_desktop_auto_beta_candidate.py
@@ -100,6 +100,14 @@ def beta_fixtures(root: Path) -> argparse.Namespace:
         "build": "12099",
         "team_id": "9536L8KLMP",
         "checks": sorted(REQUIRED_SMOKE_CHECKS),
+        "notification_callback_canary": {
+            "schema": 1,
+            "event": "user-notifications-settings-callback-completed",
+            "bundle_id": "com.omi.computer-macos.beta",
+            "main_actor": True,
+            "authorization_status": 2,
+            "validated": True,
+        },
         "artifacts": [
             {"label": "sparkle_zip", "sha256": BETA_ZIP_SHA},
             {"label": "dmg", "sha256": BETA_DMG_SHA},
@@ -188,7 +196,44 @@ def main() -> int:
         beta_smoke_path.write_text(json.dumps(beta_smoke))
         expect_failure(args, "Omi.Beta.zip digest")
 
+        # The canary must have run inside the beta artifact itself — evidence
+        # missing entirely, or recorded under the stable bundle id, both fail.
+        beta_smoke = json.loads(original)
+        del beta_smoke["notification_callback_canary"]
+        beta_smoke_path.write_text(json.dumps(beta_smoke))
+        expect_failure(args, "beta smoke result is missing UserNotifications callback canary")
+
+        beta_smoke = json.loads(original)
+        beta_smoke["notification_callback_canary"]["bundle_id"] = "com.omi.computer-macos"
+        beta_smoke_path.write_text(json.dumps(beta_smoke))
+        expect_failure(args, "beta smoke UserNotifications callback canary bundle_id mismatch")
+
+    test_codemagic_beta_smoke_produces_gate_required_canaries()
+
     print("automatic desktop beta candidate tests OK")
+
+
+def test_codemagic_beta_smoke_produces_gate_required_canaries() -> None:
+    """The beta smoke invocation in codemagic.yaml must produce every piece of
+    evidence this gate requires of the beta smoke result. A stable-only flag
+    addition (e.g. the notification callback canary) that skips the beta
+    invocation would otherwise fail-close the first dual-identity release."""
+    codemagic = (Path(__file__).resolve().parents[2] / "codemagic.yaml").read_text(encoding="utf-8")
+    smoke_step = codemagic.split("- name: Smoke signed desktop artifact", 1)[1]
+    smoke_step = smoke_step.split("- name: ", 1)[0]
+    production_branch = smoke_step.split("else", 1)[1]
+    invocations = production_branch.split("scripts/smoke-signed-desktop-artifact.sh")
+    assert len(invocations) >= 3, "expected stable and beta smoke invocations in the production branch"
+    stable_invocation, beta_invocation = invocations[1], invocations[2]
+
+    evidence_flags = ["--launch", "--auth-storage-canary", "--notification-callback-canary", "--tag"]
+    for flag in evidence_flags:
+        assert flag in stable_invocation, f"stable smoke invocation lost {flag}; update this contract test"
+        assert flag in beta_invocation, (
+            f"beta smoke invocation is missing {flag}, but the candidate gate validates the "
+            "evidence it produces — the first dual-identity release would fail qualification"
+        )
+    assert "--expected-bundle-id" in beta_invocation, "beta smoke must assert the beta bundle id"
     return 0
 
 

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -139,10 +139,15 @@ jobs:
           gh release download "$RELEASE_TAG" --repo "$REPO" \
             --pattern 'desktop-smoke-result.json' \
             --dir /tmp/desktop-beta-qualification
+          # Present only on releases that ship the side-by-side Omi Beta identity.
+          gh release download "$RELEASE_TAG" --repo "$REPO" \
+            --pattern 'desktop-smoke-result-beta.json' \
+            --dir /tmp/desktop-beta-qualification 2>/dev/null || true
 
           python3 .github/scripts/check-desktop-auto-beta-candidate.py \
             --release-json /tmp/desktop-beta-qualification/release.json \
             --smoke-result /tmp/desktop-beta-qualification/desktop-smoke-result.json \
+            --beta-smoke-result /tmp/desktop-beta-qualification/desktop-smoke-result-beta.json \
             --release-tag "$RELEASE_TAG" \
             --latest-tag "$LATEST_TAG" \
             --tag-sha "$TARGET_SHA" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ The unit of work is the violated contract, not only the line where the symptom a
 
 ## Safety Rules
 
-- Never kill, stop, or restart the production macOS apps (`/Applications/Omi.app` / `Omi Beta.app`, bundle id `com.omi.computer-macos`). Dev commands target only dev or `omi-*` named test bundles.
+- Never kill, stop, or restart the production macOS apps (`/Applications/Omi.app` / `Omi Beta.app`, bundle ids `com.omi.computer-macos` and `com.omi.computer-macos.beta`). Dev commands target only dev or `omi-*` named test bundles.
 - **Nothing lands on `main` until the user explicitly says so.** Land through PRs only (regular merge, never squash); never push directly to `main`; never push or open PRs unless explicitly asked — commit locally on a feature branch by default. A prior approval never carries over to later changes.
 - **Exception — reverts merge right away.** A user request to revert a merged PR/commit is itself the approval to open and merge the revert PR.
 - **Exception — verified + peer-approved changes may auto-merge.** If you actually exercised the real user-facing path **and** an independent agent review approved it, you may open and merge without a separate go-ahead — except for risky, wide-blast-radius, or hard-to-reverse changes (migrations, release/CI pipeline, schema, access control, data deletion), which always need explicit user sign-off.

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -232,20 +232,87 @@ def _parse_changelog_to_changes(changelog: List[str], release_body: str) -> List
     return changes
 
 
-def _get_sparkle_zip_download_url(release: Dict) -> Optional[str]:
-    """Get the Sparkle ZIP download URL from GitHub release assets."""
+# Assets for the separately-installable "Omi Beta" identity (side-by-side with
+# stable). Releases older than the dual-identity pipeline simply lack them.
+BETA_IDENTITY_SPARKLE_ASSET = "Omi.Beta.zip"
+BETA_IDENTITY_DMG_ASSET = "omi-beta.dmg"
+
+
+def _get_asset_download_url(release: Dict, names: set) -> Optional[str]:
     for asset in release.get("assets", []):
-        if asset.get("name", "") == "Omi.zip":
+        if asset.get("name", "") in names:
             return asset.get("browser_download_url")
     return None
+
+
+def _get_sparkle_zip_download_url(release: Dict) -> Optional[str]:
+    """Get the Sparkle ZIP download URL from GitHub release assets."""
+    return _get_asset_download_url(release, {"Omi.zip"})
 
 
 def _get_dmg_download_url(release: Dict) -> Optional[str]:
-    """Get the DMG installer download URL from GitHub release assets."""
+    """Stable-identity DMG installer URL from GitHub release assets.
+
+    Beta-identity assets are excluded by exact name so their presence can never
+    change which installer stable users receive.
+    """
     for asset in release.get("assets", []):
-        if asset.get("name", "").endswith(".dmg"):
+        name = asset.get("name", "")
+        if name.endswith(".dmg") and name != BETA_IDENTITY_DMG_ASSET:
             return asset.get("browser_download_url")
     return None
+
+
+async def _find_desktop_release_by_tag(tag_name: str) -> Optional[Dict]:
+    """Raw GitHub release by tag, without the isLive filter.
+
+    Pointer entries fabricate their asset list from the registered manifest, so
+    beta-identity asset lookups need the underlying release; the pointer itself
+    already authorizes liveness.
+    """
+    if not tag_name:
+        return None
+    releases = await get_omi_github_releases("github_releases_desktop", tag_filter=DESKTOP_RELEASE_TAG_PATTERN)
+    for release in releases or []:
+        if release.get("tag_name") == tag_name:
+            return release
+    return None
+
+
+async def _resolve_beta_identity_dmg(entry: Dict) -> Optional[str]:
+    """Beta-identity DMG URL for this entry's release, or None when it predates
+    the dual-identity pipeline."""
+    url = _get_asset_download_url(entry["release"], {BETA_IDENTITY_DMG_ASSET})
+    if url:
+        return url
+    tag = (entry.get("version_info") or {}).get("tag_name") or entry["release"].get("tag_name", "")
+    gh_release = await _find_desktop_release_by_tag(tag)
+    if not gh_release:
+        return None
+    return _get_asset_download_url(gh_release, {BETA_IDENTITY_DMG_ASSET})
+
+
+async def _resolve_beta_identity_enclosure(entry: Dict) -> Optional[tuple]:
+    """(download_url, ed_signature) of the Omi Beta artifact for this entry's release.
+
+    Returns None when the release predates the dual-identity pipeline (no beta
+    asset or no beta signature) — the item is then omitted from the beta feed
+    rather than served with a stable-identity artifact.
+    """
+    release = entry["release"]
+    metadata = entry.get("metadata") or {}
+    url = _get_asset_download_url(release, {BETA_IDENTITY_SPARKLE_ASSET})
+    signature = (metadata.get("betaEdSignature") or "").strip()
+    if not url:
+        tag = (entry.get("version_info") or {}).get("tag_name") or release.get("tag_name", "")
+        gh_release = await _find_desktop_release_by_tag(tag)
+        if not gh_release:
+            return None
+        url = _get_asset_download_url(gh_release, {BETA_IDENTITY_SPARKLE_ASSET})
+        signature = (extract_key_value_pairs(gh_release.get("body", "")).get("betaEdSignature") or "").strip()
+    if not url or not signature:
+        return None
+    return url, signature
 
 
 async def _get_legacy_live_desktop_releases(platform: str) -> List[Dict]:
@@ -648,11 +715,20 @@ def _generate_appcast_xml(items: List[Dict], platform: str) -> str:
 
 
 @router.get("/v2/desktop/appcast.xml")
-async def get_desktop_appcast_xml(platform: str = Query(default="macos", pattern="^(macos|windows|linux)$")):
+async def get_desktop_appcast_xml(
+    platform: str = Query(default="macos", pattern="^(macos|windows|linux)$"),
+    identity: str = Query(default="stable", pattern="^(stable|beta)$"),
+):
     """
     Sparkle appcast XML endpoint for desktop auto-updates.
     Returns a single feed with both beta and stable channel items.
     Sparkle clients filter by their configured allowed channels.
+
+    identity=beta is requested only by the separately-installable "Omi Beta" app
+    (its SUFeedURL carries the parameter): it gets beta-channel items only, with
+    beta-identity enclosures, so Sparkle can never replace it with a
+    stable-identity bundle. Legacy stable-identity installs on the beta channel
+    keep the default feed and their current update behavior.
     """
     try:
         desktop_releases = await _get_live_desktop_releases(platform)
@@ -666,6 +742,8 @@ async def get_desktop_appcast_xml(platform: str = Query(default="macos", pattern
 
         for entry in desktop_releases:
             channel = entry["channel"]
+            if identity == "beta" and channel != "beta":
+                continue
             if channel in seen_channels:
                 continue
             seen_channels.add(channel)
@@ -679,7 +757,14 @@ async def get_desktop_appcast_xml(platform: str = Query(default="macos", pattern
             ed_signature = kv.get("edSignature", "")
 
             changes = _parse_changelog_to_changes(changelog, release.get("body", ""))
-            download_url = _get_sparkle_zip_download_url(release)
+            if identity == "beta":
+                beta_enclosure = await _resolve_beta_identity_enclosure(entry)
+                if beta_enclosure is None:
+                    seen_channels.discard(channel)
+                    continue
+                download_url, ed_signature = beta_enclosure
+            else:
+                download_url = _get_sparkle_zip_download_url(release)
 
             if not download_url:
                 seen_channels.discard(channel)
@@ -716,13 +801,18 @@ async def get_desktop_appcast_xml(platform: str = Query(default="macos", pattern
 async def download_latest_desktop_release(
     platform: str = Query(default="macos", pattern="^(macos|windows|linux)$"),
     channel: str = Query(default="stable", pattern="^(beta|stable)$"),
+    identity: str = Query(default="stable", pattern="^(stable|beta)$"),
 ):
     """
     Redirect to the latest desktop release DMG installer.
     Both channels resolve only from their explicit channel pointer or the same
     channel in the legacy release metadata.
     Defaults to stable channel (for macos.omi.me). Use channel=beta for QA.
+    identity=beta serves the separately-installable "Omi Beta" DMG, which runs
+    side-by-side with stable.
     """
+    if identity == "beta":
+        channel = "beta"
     desktop_releases = await _get_live_desktop_releases(platform)
     if not desktop_releases:
         raise HTTPException(status_code=404, detail=f"No live desktop releases found for platform: {platform}")
@@ -731,7 +821,10 @@ async def download_latest_desktop_release(
     for entry in desktop_releases:
         if entry["channel"] != channel:
             continue
-        dmg_url = _get_dmg_download_url(entry["release"])
+        if identity == "beta":
+            dmg_url = await _resolve_beta_identity_dmg(entry)
+        else:
+            dmg_url = _get_dmg_download_url(entry["release"])
         if dmg_url:
             version = entry["version_info"]["version"]
             return HTMLResponse(content=_download_landing_html(dmg_url, channel=channel, version=version))

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -839,8 +839,26 @@ async def download_beta_desktop_release(
     """
     Redirect to the latest beta desktop release DMG installer.
     Convenience endpoint for macos.omi.me/beta (URL map can't add query params).
+
+    Serves the side-by-side "Omi Beta" app. Until the first release that ships
+    beta-identity artifacts is live, it falls back to the stable-identity DMG so
+    the public link keeps working. (Sparkle self-updates stay strict: only this
+    human install landing may fall back.)
     """
-    return await download_latest_desktop_release(platform=platform, channel="beta")
+    try:
+        return await download_latest_desktop_release(platform=platform, channel="beta", identity="beta")
+    except HTTPException as e:
+        if e.status_code != 404:
+            raise
+    record_fallback(
+        component='other',
+        from_mode='desktop_download_beta_identity',
+        to_mode='desktop_download_stable_identity',
+        reason='config_incomplete',
+        outcome='degraded',
+        log=logger,
+    )
+    return await download_latest_desktop_release(platform=platform, channel="beta", identity="stable")
 
 
 def _preview_landing_response(result: Dict[str, Any]) -> HTMLResponse:

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -1229,3 +1229,130 @@ class TestDesktopPreviewEndpoints:
         assert accepted.status_code == 200
         assert accepted.json() == {"success": True, **delisted}
         delist.assert_called_once_with(PREVIEW_SLUG, expected_generation=2)
+
+
+# --- Beta identity (side-by-side "Omi Beta" app) ---
+
+
+def _beta_zip_asset(url="https://example.com/Omi.Beta.zip"):
+    return {"name": "Omi.Beta.zip", "browser_download_url": url}
+
+
+def _beta_dmg_asset(url="https://example.com/omi-beta.dmg"):
+    return {"name": "omi-beta.dmg", "browser_download_url": url}
+
+
+def _live_entry(channel="beta", assets=None, metadata=None, tag="v1.0.0+100-macos"):
+    return {
+        "channel": channel,
+        "release": {"tag_name": tag, "published_at": "2026-03-01T00:00:00Z", "body": "", "assets": assets or []},
+        "version_info": {"version": "1.0.0", "build": "100", "tag_name": tag},
+        "metadata": metadata or {},
+    }
+
+
+class TestBetaIdentityServing:
+    @pytest.mark.asyncio
+    async def test_appcast_identity_beta_serves_beta_enclosure_and_drops_stable_items(self):
+        entries = [
+            _live_entry(channel="stable", assets=[_zip_asset(), _dmg_asset()], metadata={"edSignature": "stable-sig"}),
+            _live_entry(
+                channel="beta",
+                assets=[_zip_asset(), _beta_zip_asset(), _beta_dmg_asset()],
+                metadata={"edSignature": "stable-sig", "betaEdSignature": "beta-sig"},
+            ),
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=entries):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/appcast.xml", params={"identity": "beta"})
+
+        assert resp.status_code == 200
+        xml = resp.text
+        assert xml.count("<item>") == 1
+        assert "Omi.Beta.zip" in xml
+        assert 'edSignature="beta-sig"' in xml
+        assert "stable-sig" not in xml
+
+    @pytest.mark.asyncio
+    async def test_appcast_default_identity_is_unchanged_by_beta_assets(self):
+        entries = [
+            _live_entry(
+                channel="beta",
+                assets=[_zip_asset(), _beta_zip_asset()],
+                metadata={"edSignature": "stable-sig", "betaEdSignature": "beta-sig"},
+            ),
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=entries):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/appcast.xml")
+
+        assert resp.status_code == 200
+        xml = resp.text
+        assert "Omi.Beta.zip" not in xml
+        assert "https://example.com/Omi.zip" in xml
+        assert 'edSignature="stable-sig"' in xml
+
+    @pytest.mark.asyncio
+    async def test_appcast_identity_beta_omits_releases_without_beta_artifacts(self):
+        entries = [_live_entry(channel="beta", assets=[_zip_asset()], metadata={"edSignature": "sig"})]
+        gh_release_without_beta = _make_github_release(
+            "v1.0.0+100-macos", body_kv={"isLive": "true"}, assets=[_zip_asset()]
+        )
+        with (
+            patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=entries),
+            patch(
+                "routers.updates.get_omi_github_releases",
+                new_callable=AsyncMock,
+                return_value=[gh_release_without_beta],
+            ),
+        ):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/appcast.xml", params={"identity": "beta"})
+
+        assert resp.status_code == 200
+        assert resp.text.count("<item>") == 0
+
+    @pytest.mark.asyncio
+    async def test_appcast_identity_beta_resolves_pointer_entries_from_release_by_tag(self):
+        # Pointer entries fabricate their asset list from the manifest; the beta
+        # enclosure must come from the underlying GitHub release looked up by tag.
+        entries = [_live_entry(channel="beta", assets=[_zip_asset()], metadata={"edSignature": "sig"})]
+        gh_release = _make_github_release(
+            "v1.0.0+100-macos",
+            body_kv={"isLive": "false", "betaEdSignature": "beta-sig-from-body"},
+            assets=[_zip_asset(), _beta_zip_asset("https://example.com/by-tag/Omi.Beta.zip")],
+        )
+        with (
+            patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=entries),
+            patch("routers.updates.get_omi_github_releases", new_callable=AsyncMock, return_value=[gh_release]),
+        ):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/appcast.xml", params={"identity": "beta"})
+
+        assert resp.status_code == 200
+        xml = resp.text
+        assert "https://example.com/by-tag/Omi.Beta.zip" in xml
+        assert 'edSignature="beta-sig-from-body"' in xml
+
+    def test_stable_dmg_picker_never_returns_the_beta_dmg(self):
+        release = {
+            "assets": [_beta_dmg_asset(), {"name": "omi.dmg", "browser_download_url": "https://example.com/omi.dmg"}]
+        }
+        assert _get_dmg_download_url(release) == "https://example.com/omi.dmg"
+        assert _get_dmg_download_url({"assets": [_beta_dmg_asset()]}) is None
+
+    @pytest.mark.asyncio
+    async def test_download_latest_identity_beta_serves_beta_dmg(self):
+        entries = [
+            _live_entry(
+                channel="beta",
+                assets=[_zip_asset(), _dmg_asset(), _beta_dmg_asset("https://example.com/dl/omi-beta.dmg")],
+                metadata={"edSignature": "sig"},
+            ),
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=entries):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/download/latest", params={"identity": "beta"})
+
+        assert resp.status_code == 200
+        assert "https://example.com/dl/omi-beta.dmg" in resp.text

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -1356,3 +1356,46 @@ class TestBetaIdentityServing:
 
         assert resp.status_code == 200
         assert "https://example.com/dl/omi-beta.dmg" in resp.text
+
+    @pytest.mark.asyncio
+    async def test_download_beta_endpoint_serves_the_beta_identity_dmg(self):
+        entries = [
+            _live_entry(
+                channel="beta",
+                assets=[_zip_asset(), _dmg_asset(), _beta_dmg_asset("https://example.com/dl/omi-beta.dmg")],
+                metadata={"edSignature": "sig"},
+            ),
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=entries):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/download/beta")
+
+        assert resp.status_code == 200
+        assert "https://example.com/dl/omi-beta.dmg" in resp.text
+
+    @pytest.mark.asyncio
+    async def test_download_beta_endpoint_falls_back_to_stable_identity_before_rollout(self):
+        # Until the first dual-identity release is live, the public beta link keeps
+        # serving the stable-identity DMG instead of breaking.
+        entries = [
+            _live_entry(channel="beta", assets=[_zip_asset(), _dmg_asset()], metadata={"edSignature": "sig"}),
+        ]
+        gh_release_without_beta = _make_github_release(
+            "v1.0.0+100-macos", body_kv={"isLive": "true"}, assets=[_zip_asset(), _dmg_asset()]
+        )
+        with (
+            patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=entries),
+            patch(
+                "routers.updates.get_omi_github_releases",
+                new_callable=AsyncMock,
+                return_value=[gh_release_without_beta],
+            ),
+            patch("routers.updates.record_fallback") as fallback,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/download/beta")
+
+        assert resp.status_code == 200
+        assert "https://example.com/Omi.dmg" in resp.text
+        fallback.assert_called_once()
+        assert fallback.call_args.kwargs["from_mode"] == "desktop_download_beta_identity"

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2060,6 +2060,12 @@ workflows:
             URL_SCHEME="omi-computer"
             DMG_PATH="$BUILD_DIR/$APP_NAME.dmg"
             SPARKLE_ZIP_PATH="$BUILD_DIR/Omi.zip"
+            # Separately-installable beta identity, packaged from the same build
+            # so stable and Omi Beta can run side-by-side.
+            BETA_APP_NAME="Omi Beta"
+            BETA_BUNDLE_ID="com.omi.computer-macos.beta"
+            BETA_SPARKLE_ZIP_PATH="$BUILD_DIR/Omi.Beta.zip"
+            BETA_DMG_PATH="$BUILD_DIR/omi-beta.dmg"
           fi
           echo "VERSION=$VERSION" >> $CM_ENV
           echo "BUILD_NUMBER=$BUILD_NUMBER" >> $CM_ENV
@@ -2069,6 +2075,10 @@ workflows:
           echo "APP_BUNDLE=$BUILD_DIR/$APP_NAME.app" >> $CM_ENV
           echo "DMG_PATH=$DMG_PATH" >> $CM_ENV
           echo "SPARKLE_ZIP_PATH=$SPARKLE_ZIP_PATH" >> $CM_ENV
+          echo "BETA_APP_NAME=${BETA_APP_NAME:-}" >> $CM_ENV
+          echo "BETA_BUNDLE_ID=${BETA_BUNDLE_ID:-}" >> $CM_ENV
+          echo "BETA_SPARKLE_ZIP_PATH=${BETA_SPARKLE_ZIP_PATH:-}" >> $CM_ENV
+          echo "BETA_DMG_PATH=${BETA_DMG_PATH:-}" >> $CM_ENV
           echo "Building OMI Desktop v$VERSION (build $BUILD_NUMBER)"
 
       - name: Set up keychain and import Developer ID certificate
@@ -2742,6 +2752,22 @@ workflows:
           echo "EdDSA signature: $ED_SIGNATURE"
           echo "ED_SIGNATURE=$ED_SIGNATURE" >> $CM_ENV
 
+      - name: Create Omi Beta variant (sign, notarize, package)
+        script: |
+          if [[ "${PREVIEW_MODE:-false}" == "true" ]]; then
+            echo "External previews do not ship an Omi Beta variant."
+            exit 0
+          fi
+          set -euo pipefail
+          scripts/create-omi-beta-variant.sh \
+            --source-app "$APP_BUNDLE" \
+            --build-dir "$BUILD_DIR" \
+            --beta-app-name "$BETA_APP_NAME" \
+            --beta-bundle-id "$BETA_BUNDLE_ID" \
+            --sparkle-zip-out "$BETA_SPARKLE_ZIP_PATH" \
+            --dmg-out "$BETA_DMG_PATH" \
+            --cm-env "$CM_ENV"
+
       - name: Smoke signed desktop artifact
         script: |
           if [[ "${PREVIEW_MODE:-false}" == "true" ]]; then
@@ -2767,6 +2793,19 @@ workflows:
               --auth-storage-canary \
               --notification-callback-canary \
               --result-json "$BUILD_DIR/desktop-smoke-result.json"
+
+            # The Omi Beta variant is what beta users actually install — smoke the
+            # exact signed artifacts under the beta identity as well.
+            OMI_SIGNED_ARTIFACT_SMOKE_ALLOW_PRODUCTION_LAUNCH=1 \
+            scripts/smoke-signed-desktop-artifact.sh \
+              --app "$BUILD_DIR/$BETA_APP_NAME.app" \
+              --zip "$BETA_SPARKLE_ZIP_PATH" \
+              --dmg "$BETA_DMG_PATH" \
+              --tag "$CM_TAG" \
+              --expected-channel beta \
+              --expected-bundle-id "$BETA_BUNDLE_ID" \
+              --auth-storage-canary \
+              --result-json "$BUILD_DIR/desktop-smoke-result-beta.json"
           fi
 
       - name: Publish immutable external preview
@@ -2864,6 +2903,7 @@ workflows:
           isLive: false
           channel: candidate
           edSignature: ${ED_SIGNATURE}
+          betaEdSignature: ${BETA_ED_SIGNATURE}
           changelog: ${CHANGELOG_PIPE}
           KEY_VALUE_END -->"
 
@@ -2879,7 +2919,10 @@ workflows:
               --notes "$RELEASE_NOTES" \
               "$SPARKLE_ZIP_PATH" \
               "$DMG_PATH" \
-              "$BUILD_DIR/desktop-smoke-result.json"
+              "$BETA_SPARKLE_ZIP_PATH" \
+              "$BETA_DMG_PATH" \
+              "$BUILD_DIR/desktop-smoke-result.json" \
+              "$BUILD_DIR/desktop-smoke-result-beta.json"
             echo "GitHub release candidate created: $CM_TAG"
           fi
 
@@ -2916,6 +2959,7 @@ workflows:
       - build/*.dmg
       - build/*.zip
       - build/desktop-smoke-result.json
+      - build/desktop-smoke-result-beta.json
     publishing:
       email:
         recipients:

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2805,7 +2805,9 @@ workflows:
               --expected-channel beta \
               --expected-bundle-id "$BETA_BUNDLE_ID" \
               --expected-feed-url "https://api.omi.me/v2/desktop/appcast.xml?identity=beta" \
+              --launch \
               --auth-storage-canary \
+              --notification-callback-canary \
               --result-json "$BUILD_DIR/desktop-smoke-result-beta.json"
           fi
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2804,6 +2804,7 @@ workflows:
               --tag "$CM_TAG" \
               --expected-channel beta \
               --expected-bundle-id "$BETA_BUNDLE_ID" \
+              --expected-feed-url "https://api.omi.me/v2/desktop/appcast.xml?identity=beta" \
               --auth-storage-canary \
               --result-json "$BUILD_DIR/desktop-smoke-result-beta.json"
           fi

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -257,7 +257,7 @@ See `.claude/settings.json` for connection details.
 
 ### App Names & Build Artifacts
 - `./run.sh` builds **"Omi Dev"** → installs to `/Applications/Omi Dev.app` (bundle ID: `com.omi.desktop-dev`)
-- **"Omi Beta"** (bundle ID: `com.omi.computer-macos`) is built by Codemagic CI only
+- **"Omi"** stable (bundle ID: `com.omi.computer-macos`) and **"Omi Beta"** (bundle ID: `com.omi.computer-macos.beta`, isolated "Omi Beta" storage root, runs side-by-side with stable) are built by Codemagic CI only
 - To check which app is currently running: `ps aux | grep "Omi"`
 
 ### Testing with Named Bundles
@@ -508,7 +508,7 @@ agent-swift screenshot /tmp/evidence.png             # capture app window
 - Argument order: `get <property> <ref>`, `is <condition> <ref>`, `wait <condition> [<target>]`, `find <locator> <value>`.
 - 15 commands: `doctor`, `connect`, `disconnect`, `status`, `snapshot`, `press`, `click`, `fill`, `get`, `find`, `screenshot`, `is`, `wait`, `scroll`, `schema`.
 - No app-side instrumentation needed — works via macOS Accessibility API on any Cocoa/SwiftUI app.
-- Dev bundle ID: `com.omi.desktop-dev`. Prod: `com.omi.computer-macos` (never automate prod).
+- Dev bundle ID: `com.omi.desktop-dev`. Prod: `com.omi.computer-macos` (stable) and `com.omi.computer-macos.beta` (Omi Beta) — never automate prod.
 
 ### Changelog Entries
 

--- a/desktop/macos/Desktop/Sources/AppBuild.swift
+++ b/desktop/macos/Desktop/Sources/AppBuild.swift
@@ -118,6 +118,18 @@ enum AppBuild {
     buildConfiguration.isExternalPreview
   }
 
+  /// Legacy "Omi Computer.app" cleanup force-terminates running
+  /// `com.omi.computer-macos` processes and deletes the old bundle — strictly
+  /// stable-lineage housekeeping. Only the stable identity may run it: Omi Beta
+  /// or a dev bundle doing so would kill the user's running stable app.
+  static var mayRunLegacyStableAppCleanup: Bool {
+    mayRunLegacyStableAppCleanup(bundleIdentifier: bundleIdentifier)
+  }
+
+  static func mayRunLegacyStableAppCleanup(bundleIdentifier: String) -> Bool {
+    bundleIdentifier == productionBundleIdentifier
+  }
+
   /// Only local development bundles expose the loopback automation/debug bridge. Published
   /// preview apps share the non-production namespace but must never expose that bridge.
   static var allowsLocalAutomation: Bool {

--- a/desktop/macos/Desktop/Sources/AppBuild.swift
+++ b/desktop/macos/Desktop/Sources/AppBuild.swift
@@ -2,6 +2,14 @@ import Foundation
 
 enum AppBuild {
   static let productionBundleIdentifier = "com.omi.computer-macos"
+  /// The separately-installable beta app ("Omi Beta.app"). A distinct bundle id gives it
+  /// its own UserDefaults domain, TCC grants, Keychain ACL, and single-instance lock, so
+  /// it runs side-by-side with stable. Must stay in sync with
+  /// `DesktopStorageIdentity.betaProductionBundleIdentifier` (asserted by a unit test).
+  static let betaProductionBundleIdentifier = "com.omi.computer-macos.beta"
+  static let productionFamilyBundleIdentifiers: Set<String> = [
+    productionBundleIdentifier, betaProductionBundleIdentifier,
+  ]
   static let desktopDevBundleIdentifier = "com.omi.desktop-dev"
   static let externalPreviewBundleIdentifierPrefix = "com.omi.preview."
   static let externalPreviewMarkerInfoKey = "OMIExternalPreview"
@@ -37,7 +45,7 @@ enum AppBuild {
 
     var isNonProduction: Bool {
       bundleIdentifier.hasPrefix("com.omi.")
-        && bundleIdentifier != AppBuild.productionBundleIdentifier
+        && !AppBuild.productionFamilyBundleIdentifiers.contains(bundleIdentifier)
     }
 
     var allowsLocalAutomation: Bool {
@@ -94,8 +102,16 @@ enum AppBuild {
     buildConfiguration.isNonProduction
   }
 
+  /// True for every shipped production-family artifact (stable *and* the beta app).
+  /// Use `isBetaProductionBundle` when behavior differs between the two.
   static var isProductionBundle: Bool {
-    bundleIdentifier == productionBundleIdentifier
+    productionFamilyBundleIdentifiers.contains(bundleIdentifier)
+  }
+
+  /// The separately-installable "Omi Beta" app. Its update channel is pinned to beta
+  /// and it keeps its own isolated on-disk state, so it can run beside stable.
+  static var isBetaProductionBundle: Bool {
+    bundleIdentifier == betaProductionBundleIdentifier
   }
 
   static var isExternalPreview: Bool {
@@ -179,6 +195,9 @@ enum AppBuild {
   }
 
   static var currentUpdateChannel: String {
+    // The Omi Beta app is permanently a beta-channel client; a stray defaults value
+    // (imported settings, sync) must never flip it to stable-identity updates.
+    if isBetaProductionBundle { return "beta" }
     let raw = UserDefaults.standard.string(forKey: updateChannelDefaultsKey) ?? "stable"
     return raw == "staging" ? "beta" : raw
   }
@@ -238,6 +257,9 @@ enum AppBuild {
 
   static func prepareUpdateChannelForBackendRouting() {
     guard isProductionBundle else { return }
+    // Beta identity: channel is pinned, so the launch-blocking appcast probes and the
+    // stable-overwrite migration have nothing to decide.
+    guard !isBetaProductionBundle else { return }
 
     migrateBetaChannelOverwrite()
     if UserDefaults.standard.string(forKey: updateChannelDefaultsKey) == nil {

--- a/desktop/macos/Desktop/Sources/AppBuild.swift
+++ b/desktop/macos/Desktop/Sources/AppBuild.swift
@@ -203,7 +203,22 @@ enum AppBuild {
   }
 
   static var manualDownloadURL: URL {
-    URL(string: "https://api.omi.me/v2/desktop/download/latest?channel=\(currentUpdateChannel)")!
+    manualDownloadURL(channel: currentUpdateChannel, isBetaIdentity: isBetaProductionBundle)
+  }
+
+  static func manualDownloadURL(channel: String, isBetaIdentity: Bool) -> URL {
+    var components = URLComponents()
+    components.scheme = "https"
+    components.host = "api.omi.me"
+    components.path = "/v2/desktop/download/latest"
+    var queryItems = [URLQueryItem(name: "channel", value: channel)]
+    if isBetaIdentity {
+      // The Omi Beta app must re-download its own identity, never the stable app.
+      queryItems.append(URLQueryItem(name: "identity", value: "beta"))
+    }
+    components.queryItems = queryItems
+    // Fixed scheme/host/path always produce a URL; the fallback is unreachable.
+    return components.url ?? URL(fileURLWithPath: "/")
   }
 
   static var inferredUpdateChannel: String {

--- a/desktop/macos/Desktop/Sources/ClientDeviceService.swift
+++ b/desktop/macos/Desktop/Sources/ClientDeviceService.swift
@@ -131,8 +131,9 @@ final class ClientDeviceService {
   private var usesUserDefaultsInstallId: Bool {
     guard let bundleIdentifier else { return false }
     // Any non-production com.omi.* bundle (desktop-dev + omi-*) — avoid Keychain.
+    // Production-family bundles (stable + Omi Beta) keep the durable Keychain id.
     return bundleIdentifier.hasPrefix("com.omi.")
-      && bundleIdentifier != AppBuild.productionBundleIdentifier
+      && !AppBuild.productionFamilyBundleIdentifiers.contains(bundleIdentifier)
   }
 
   private func loadOrCreateDevInstallId() -> String {

--- a/desktop/macos/Desktop/Sources/DesktopBackendEnvironment.swift
+++ b/desktop/macos/Desktop/Sources/DesktopBackendEnvironment.swift
@@ -23,7 +23,10 @@ enum DesktopBackendEnvironment {
   ) -> Bool {
     guard !AppBuild.isExternalPreviewBundleIdentifier(bundleIdentifier) else { return false }
     guard !isAffirmative(forceOverride) else { return false }
-    return bundleIdentifier == AppBuild.productionBundleIdentifier && normalizedChannel(updateChannel) == "beta"
+    // Both production-family identities ride the beta ring on the beta channel;
+    // the separately-installable Omi Beta app pins its channel to beta.
+    return AppBuild.productionFamilyBundleIdentifiers.contains(bundleIdentifier)
+      && normalizedChannel(updateChannel) == "beta"
   }
 
   static var shouldUseDevelopmentBackends: Bool {
@@ -50,8 +53,9 @@ enum DesktopBackendEnvironment {
 
     // Named/dev bundles route to the dev backend by default. Explicit launch
     // URLs still win below so local harnesses and intentionally-targeted tests
-    // remain possible.
-    if bundleIdentifier != AppBuild.productionBundleIdentifier {
+    // remain possible. The Omi Beta app is a production-family artifact, not a
+    // dev bundle: it falls through to channel-based routing like stable.
+    if !AppBuild.productionFamilyBundleIdentifiers.contains(bundleIdentifier) {
       return true
     }
 

--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -9,7 +9,12 @@ enum OmiLogPathResolver {
     bundleIdentifier: String?,
     processID: Int32
   ) -> String {
-    guard isNonProduction else { return "/tmp/omi.log" }
+    // Stable and Omi Beta can run at the same time; interleaving one shared log file
+    // would corrupt both transcripts, so each production identity owns its own path.
+    guard isNonProduction else {
+      return bundleIdentifier == AppBuild.betaProductionBundleIdentifier
+        ? "/tmp/omi-beta.log" : "/tmp/omi.log"
+    }
     let rawBundleID = bundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "unknown"
     let safeBundleID = rawBundleID.replacingOccurrences(
       of: #"[^A-Za-z0-9._-]+"#,

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+Controls.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+Controls.swift
@@ -654,23 +654,31 @@ extension SettingsContentView {
             title: "Update Channel", subtitle: updaterViewModel.updateChannel.description,
             settingId: "about.channel"
           ) {
-            SettingsMenuPicker(
-              selection: Binding(
-                get: { updaterViewModel.updateChannel },
-                set: { newChannel in
-                  // Switching beta → stable with a newer build: confirm first
-                  if updaterViewModel.updateChannel == .beta && newChannel == .stable
-                    && updaterViewModel.isDowngradeToStable
-                  {
-                    showDowngradeAlert = true
-                  } else {
-                    updaterViewModel.updateChannel = newChannel
+            if AppBuild.isBetaProductionBundle {
+              // Omi Beta is permanently a beta-channel client; switching it to stable
+              // would make Sparkle replace it with the stable-identity app in place.
+              Text(UpdateChannel.beta.displayName)
+                .scaledFont(size: OmiType.body)
+                .foregroundColor(OmiColors.textSecondary)
+            } else {
+              SettingsMenuPicker(
+                selection: Binding(
+                  get: { updaterViewModel.updateChannel },
+                  set: { newChannel in
+                    // Switching beta → stable with a newer build: confirm first
+                    if updaterViewModel.updateChannel == .beta && newChannel == .stable
+                      && updaterViewModel.isDowngradeToStable
+                    {
+                      showDowngradeAlert = true
+                    } else {
+                      updaterViewModel.updateChannel = newChannel
+                    }
                   }
+                )
+              ) {
+                ForEach(UpdateChannel.allCases, id: \.self) { channel in
+                  Text(channel.displayName).tag(channel)
                 }
-              )
-            ) {
-              ForEach(UpdateChannel.allCases, id: \.self) { channel in
-                Text(channel.displayName).tag(channel)
               }
             }
           }

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -1459,6 +1459,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
   }
 
   private func cleanupLegacyAppBundles() {
+    // Stable-only: this takeover kills running com.omi.computer-macos processes
+    // and deletes the legacy bundle. From Omi Beta or a dev bundle it would
+    // terminate the user's running stable app instead of a stale duplicate.
+    guard AppBuild.mayRunLegacyStableAppCleanup else {
+      log("Skipping legacy app cleanup: not the stable production identity")
+      return
+    }
     let currentPath = Bundle.main.bundlePath
     let oldAppPaths = [
       "/Applications/Omi Computer.app",

--- a/desktop/macos/Desktop/Sources/OmiSupport/DesktopLocalProfile.swift
+++ b/desktop/macos/Desktop/Sources/OmiSupport/DesktopLocalProfile.swift
@@ -8,6 +8,10 @@ import Foundation
 /// `run.sh`, and that relaunch must remain isolated.
 package struct DesktopStorageIdentity: Equatable {
   package static let namedDevelopmentBundlePrefix = "com.omi.omi-"
+  /// The separately-installable "Omi Beta" app. Kept in sync with
+  /// `AppBuild.betaProductionBundleIdentifier` (asserted by a unit test); OmiSupport
+  /// sits below the main target, so the literal is duplicated rather than imported.
+  package static let betaProductionBundleIdentifier = "com.omi.computer-macos.beta"
 
   package let bundleIdentifier: String?
   package let localProfileEnabled: Bool
@@ -38,13 +42,23 @@ package struct DesktopStorageIdentity: Equatable {
     }
   }
 
+  package var isBetaProductionBundle: Bool {
+    bundleIdentifier == Self.betaProductionBundleIdentifier
+  }
+
   package var usesIsolatedStorage: Bool {
-    localProfileEnabled || isNamedDevelopmentBundle
+    localProfileEnabled || isNamedDevelopmentBundle || isBetaProductionBundle
   }
 
   package var applicationSupportPathComponents: [String] {
     if let bundleIdentifier, isNamedDevelopmentBundle {
       return ["Omi Dev Bundles", bundleIdentifier]
+    }
+    // Omi Beta owns a separate root so a live beta and a live stable instance never
+    // share one SQLite database. It deliberately does not claim the legacy shared
+    // `Omi/` data (isolated ⇒ no legacy migration): beta starts fresh.
+    if isBetaProductionBundle {
+      return ["Omi Beta"]
     }
     if localProfileEnabled {
       return [localProfileStorageName ?? "Omi"]

--- a/desktop/macos/Desktop/Sources/SingleInstanceGuard.swift
+++ b/desktop/macos/Desktop/Sources/SingleInstanceGuard.swift
@@ -17,7 +17,9 @@ import Foundation
 /// lock automatically when the process dies, so a crashed instance never leaves a
 /// stale lock behind (unlike a PID file). Keying on the bundle id keeps parallel
 /// *named* dev/test bundles (`com.omi.omi-*`, `com.omi.desktop-dev`) independent of
-/// each other and of production. Keying on the launch mode keeps rewind-only mode
+/// each other and of production — and lets the separately-identified Omi Beta app
+/// (`com.omi.computer-macos.beta`, isolated "Omi Beta" storage root) run beside
+/// stable while still refusing a true duplicate of itself. Keying on the launch mode keeps rewind-only mode
 /// (`--mode=rewind`) and the full app — which the rewind window intentionally spawns
 /// via `open -n` — from evicting one another.
 enum SingleInstanceGuard {

--- a/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
+++ b/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
@@ -462,9 +462,10 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
 
   /// Tells Sparkle which non-default channels this client wants to see.
   /// Channels are additive: the default (stable) channel is always included.
+  /// Reads `AppBuild.currentUpdateChannel` so the Omi Beta identity stays pinned
+  /// to the beta channel no matter what the defaults key says.
   func allowedChannels(for updater: SPUUpdater) -> Set<String> {
-    let raw = UserDefaults.standard.string(forKey: kUpdateChannelKey) ?? "stable"
-    if raw == "beta" || raw == "staging" {
+    if AppBuild.currentUpdateChannel == "beta" {
       return Set(["beta"])
     }
     return Set()  // empty = default (stable) channel only

--- a/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
@@ -301,15 +301,21 @@ final class APIClientRoutingTests: XCTestCase {
   }
 
   func testBetaIdentityBundleRoutesByChannelLikeProduction() {
-    // The Omi Beta app is production-family: the channel decides routing (pinned to
-    // beta at runtime), and it must not take the named-dev-bundle always-dev branch.
-    XCTAssertTrue(
+    // The Omi Beta app is production-family: it must not take the named-dev-bundle
+    // always-dev branch, and on its pinned beta channel it rides the beta release
+    // ring exactly like a stable-identity beta-channel client.
+    XCTAssertFalse(
       DesktopBackendEnvironment.shouldUseDevelopmentBackends(
         bundleIdentifier: AppBuild.betaProductionBundleIdentifier,
         updateChannel: "beta"
       ))
+    XCTAssertTrue(
+      DesktopBackendEnvironment.shouldUseBetaRingBackends(
+        bundleIdentifier: AppBuild.betaProductionBundleIdentifier,
+        updateChannel: "beta"
+      ))
     XCTAssertFalse(
-      DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+      DesktopBackendEnvironment.shouldUseBetaRingBackends(
         bundleIdentifier: AppBuild.betaProductionBundleIdentifier,
         updateChannel: "stable"
       ))

--- a/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
@@ -300,6 +300,21 @@ final class APIClientRoutingTests: XCTestCase {
       ))
   }
 
+  func testBetaIdentityBundleRoutesByChannelLikeProduction() {
+    // The Omi Beta app is production-family: the channel decides routing (pinned to
+    // beta at runtime), and it must not take the named-dev-bundle always-dev branch.
+    XCTAssertTrue(
+      DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+        bundleIdentifier: AppBuild.betaProductionBundleIdentifier,
+        updateChannel: "beta"
+      ))
+    XCTAssertFalse(
+      DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+        bundleIdentifier: AppBuild.betaProductionBundleIdentifier,
+        updateChannel: "stable"
+      ))
+  }
+
   func testNonProductionBundlesDefaultToDevelopmentBackends() {
     XCTAssertTrue(
       DesktopBackendEnvironment.shouldUseDevelopmentBackends(

--- a/desktop/macos/Desktop/Tests/AppBuildBetaIdentityTests.swift
+++ b/desktop/macos/Desktop/Tests/AppBuildBetaIdentityTests.swift
@@ -42,6 +42,19 @@ final class AppBuildBetaIdentityTests: XCTestCase {
       [AppBuild.productionBundleIdentifier, AppBuild.betaProductionBundleIdentifier])
   }
 
+  func testOnlyStableIdentityMayRunLegacyStableAppCleanup() {
+    // The legacy "Omi Computer.app" cleanup force-terminates running stable
+    // processes; Omi Beta running it would kill the side-by-side stable app.
+    XCTAssertTrue(
+      AppBuild.mayRunLegacyStableAppCleanup(bundleIdentifier: AppBuild.productionBundleIdentifier))
+    XCTAssertFalse(
+      AppBuild.mayRunLegacyStableAppCleanup(bundleIdentifier: AppBuild.betaProductionBundleIdentifier))
+    XCTAssertFalse(
+      AppBuild.mayRunLegacyStableAppCleanup(bundleIdentifier: AppBuild.desktopDevBundleIdentifier))
+    XCTAssertFalse(
+      AppBuild.mayRunLegacyStableAppCleanup(bundleIdentifier: "com.omi.omi-feature-test"))
+  }
+
   func testManualDownloadURLCarriesBetaIdentity() {
     XCTAssertEqual(
       AppBuild.manualDownloadURL(channel: "beta", isBetaIdentity: true).absoluteString,

--- a/desktop/macos/Desktop/Tests/AppBuildBetaIdentityTests.swift
+++ b/desktop/macos/Desktop/Tests/AppBuildBetaIdentityTests.swift
@@ -42,6 +42,18 @@ final class AppBuildBetaIdentityTests: XCTestCase {
       [AppBuild.productionBundleIdentifier, AppBuild.betaProductionBundleIdentifier])
   }
 
+  func testManualDownloadURLCarriesBetaIdentity() {
+    XCTAssertEqual(
+      AppBuild.manualDownloadURL(channel: "beta", isBetaIdentity: true).absoluteString,
+      "https://api.omi.me/v2/desktop/download/latest?channel=beta&identity=beta")
+    XCTAssertEqual(
+      AppBuild.manualDownloadURL(channel: "beta", isBetaIdentity: false).absoluteString,
+      "https://api.omi.me/v2/desktop/download/latest?channel=beta")
+    XCTAssertEqual(
+      AppBuild.manualDownloadURL(channel: "stable", isBetaIdentity: false).absoluteString,
+      "https://api.omi.me/v2/desktop/download/latest?channel=stable")
+  }
+
   func testProductionLogPathsAreSeparatePerIdentity() {
     XCTAssertEqual(
       OmiLogPathResolver.logPath(

--- a/desktop/macos/Desktop/Tests/AppBuildBetaIdentityTests.swift
+++ b/desktop/macos/Desktop/Tests/AppBuildBetaIdentityTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// The Omi Beta identity (`com.omi.computer-macos.beta`) must behave as a shipped
+/// production artifact — never as a dev/test bundle — while keeping its own update
+/// channel, storage root, and log path so it can run beside stable.
+final class AppBuildBetaIdentityTests: XCTestCase {
+  func testBetaIdentityIsProductionGrade() {
+    let config = AppBuild.configuration(
+      bundleIdentifier: AppBuild.betaProductionBundleIdentifier,
+      infoDictionary: [:])
+
+    XCTAssertFalse(config.isNonProduction)
+    XCTAssertFalse(config.allowsLocalAutomation)
+    XCTAssertTrue(config.allowsSparkleUpdates)
+    XCTAssertFalse(config.isExternalPreview)
+  }
+
+  func testStableIdentityGatingIsUnchanged() {
+    let config = AppBuild.configuration(
+      bundleIdentifier: AppBuild.productionBundleIdentifier,
+      infoDictionary: [:])
+
+    XCTAssertFalse(config.isNonProduction)
+    XCTAssertFalse(config.allowsLocalAutomation)
+    XCTAssertTrue(config.allowsSparkleUpdates)
+  }
+
+  func testNamedDevBundleStaysNonProduction() {
+    let config = AppBuild.configuration(
+      bundleIdentifier: "com.omi.omi-feature-test",
+      infoDictionary: [:])
+
+    XCTAssertTrue(config.isNonProduction)
+    XCTAssertTrue(config.allowsLocalAutomation)
+  }
+
+  func testProductionFamilyMembership() {
+    XCTAssertEqual(
+      AppBuild.productionFamilyBundleIdentifiers,
+      [AppBuild.productionBundleIdentifier, AppBuild.betaProductionBundleIdentifier])
+  }
+
+  func testProductionLogPathsAreSeparatePerIdentity() {
+    XCTAssertEqual(
+      OmiLogPathResolver.logPath(
+        isNonProduction: false,
+        bundleIdentifier: AppBuild.productionBundleIdentifier,
+        processID: 1),
+      "/tmp/omi.log")
+    XCTAssertEqual(
+      OmiLogPathResolver.logPath(
+        isNonProduction: false,
+        bundleIdentifier: AppBuild.betaProductionBundleIdentifier,
+        processID: 1),
+      "/tmp/omi-beta.log")
+  }
+}

--- a/desktop/macos/Desktop/Tests/AuthTokenStorageTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthTokenStorageTests.swift
@@ -349,9 +349,10 @@ final class AuthTokenStorageTests: XCTestCase {
       source.contains("private let keychainService = \"com.omi.client-device-id\""),
       "ClientDeviceService must not hardcode the shared legacy device-id Keychain service")
     // All non-production bundles must stay on UserDefaults (no Keychain prompt risk).
+    // Stable and the side-by-side Omi Beta identity each use their own scoped service.
     XCTAssertTrue(
-      source.contains("productionBundleIdentifier"),
-      "ClientDeviceService must gate Keychain use to the production bundle only")
+      source.contains("productionFamilyBundleIdentifiers"),
+      "ClientDeviceService must gate Keychain use to production-family bundles only")
   }
 
   /// Regression: named-bundle auth seed must NOT write tokens via `security

--- a/desktop/macos/Desktop/Tests/DesktopStorageIdentityTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopStorageIdentityTests.swift
@@ -63,6 +63,34 @@ final class DesktopStorageIdentityTests: XCTestCase {
     XCTAssertTrue(RewindDatabase.shouldMigrateLegacyStorage(isolatedStorage: false))
   }
 
+  func testBetaProductionIdentityOwnsAnIsolatedRoot() {
+    let beta = DesktopStorageIdentity(
+      bundleIdentifier: DesktopStorageIdentity.betaProductionBundleIdentifier,
+      localProfileEnabled: false,
+      localProfileStorageName: nil)
+
+    XCTAssertTrue(beta.isBetaProductionBundle)
+    XCTAssertTrue(beta.usesIsolatedStorage)
+    XCTAssertEqual(beta.applicationSupportPathComponents, ["Omi Beta"])
+  }
+
+  func testBetaProductionIdentityIgnoresHarnessLocalProfile() {
+    // A shipped Omi Beta must never follow harness environment overrides into
+    // another storage root.
+    let beta = DesktopStorageIdentity(
+      bundleIdentifier: DesktopStorageIdentity.betaProductionBundleIdentifier,
+      localProfileEnabled: true,
+      localProfileStorageName: "Omi Harness")
+
+    XCTAssertEqual(beta.applicationSupportPathComponents, ["Omi Beta"])
+  }
+
+  func testBetaBundleIdentifierStaysInSyncWithAppBuild() {
+    XCTAssertEqual(
+      DesktopStorageIdentity.betaProductionBundleIdentifier,
+      AppBuild.betaProductionBundleIdentifier)
+  }
+
   func testRuntimeManifestIsOwnerOnlyAndContainsNoCredentials() throws {
     let root = FileManager.default.temporaryDirectory
       .appendingPathComponent("omi-runtime-manifest-\(UUID().uuidString)", isDirectory: true)

--- a/desktop/macos/changelog/unreleased/20260719-omi-beta-side-by-side.json
+++ b/desktop/macos/changelog/unreleased/20260719-omi-beta-side-by-side.json
@@ -1,0 +1,3 @@
+{
+  "change": "Omi Beta is now a separate app that can be installed and run alongside stable Omi"
+}

--- a/desktop/macos/scripts/create-omi-beta-variant.sh
+++ b/desktop/macos/scripts/create-omi-beta-variant.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Create the separately-installable "Omi Beta" variant from the signed stable app.
+#
+# The variant is the same binary re-identified (CFBundleIdentifier
+# com.omi.computer-macos.beta + "Omi Beta" name) so it runs beside stable with its
+# own UserDefaults, TCC grants, Keychain ACL, storage root, and single-instance
+# lock. Only the outer bundle signature covers Info.plist, so nested component
+# signatures from the stable signing pass remain valid; the outer bundle is
+# re-signed, then the variant is independently notarized, stapled, packaged as a
+# Sparkle ZIP + DMG, and EdDSA-signed for the appcast.
+#
+# Required env (provided by the Codemagic release workflow):
+#   SIGN_IDENTITY, APP_STORE_CONNECT_KEY_IDENTIFIER, APP_STORE_CONNECT_PRIVATE_KEY,
+#   APP_STORE_CONNECT_ISSUER_ID, SPARKLE_PRIVATE_KEY, DMGBUILD_VERSION
+set -euo pipefail
+
+SOURCE_APP=""
+BUILD_DIR=""
+BETA_APP_NAME="Omi Beta"
+BETA_BUNDLE_ID="com.omi.computer-macos.beta"
+SPARKLE_ZIP_OUT=""
+DMG_OUT=""
+CM_ENV_OUT=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/create-omi-beta-variant.sh --source-app build/omi.app --build-dir build \
+  --sparkle-zip-out build/Omi.Beta.zip --dmg-out build/omi-beta.dmg [--cm-env "$CM_ENV"]
+  [--beta-app-name "Omi Beta"] [--beta-bundle-id com.omi.computer-macos.beta]
+EOF
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-app) SOURCE_APP="$2"; shift 2 ;;
+    --build-dir) BUILD_DIR="$2"; shift 2 ;;
+    --beta-app-name) BETA_APP_NAME="$2"; shift 2 ;;
+    --beta-bundle-id) BETA_BUNDLE_ID="$2"; shift 2 ;;
+    --sparkle-zip-out) SPARKLE_ZIP_OUT="$2"; shift 2 ;;
+    --dmg-out) DMG_OUT="$2"; shift 2 ;;
+    --cm-env) CM_ENV_OUT="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ -n "$SOURCE_APP" && -n "$BUILD_DIR" && -n "$SPARKLE_ZIP_OUT" && -n "$DMG_OUT" ]] || usage
+[[ -d "$SOURCE_APP" ]] || { echo "ERROR: source app not found: $SOURCE_APP" >&2; exit 1; }
+: "${SIGN_IDENTITY:?SIGN_IDENTITY is required}"
+: "${APP_STORE_CONNECT_KEY_IDENTIFIER:?notary key id required}"
+: "${APP_STORE_CONNECT_PRIVATE_KEY:?notary private key required}"
+: "${APP_STORE_CONNECT_ISSUER_ID:?notary issuer required}"
+: "${SPARKLE_PRIVATE_KEY:?Sparkle EdDSA key required}"
+
+BETA_APP="$BUILD_DIR/$BETA_APP_NAME.app"
+PLIST="$BETA_APP/Contents/Info.plist"
+
+notarize_and_staple() {
+  local artifact="$1"
+  mkdir -p ~/private_keys
+  local key_path=~/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_IDENTIFIER}.p8
+  echo -e "$APP_STORE_CONNECT_PRIVATE_KEY" > "$key_path"
+
+  local result status submission_id
+  result=$(xcrun notarytool submit "$artifact" \
+    --key "$key_path" \
+    --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
+    --issuer "$APP_STORE_CONNECT_ISSUER_ID" \
+    --wait \
+    --output-format json)
+  status=$(echo "$result" | python3 -c \
+    "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || echo "")
+  submission_id=$(echo "$result" | python3 -c \
+    "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
+  if [[ "$status" != "Accepted" ]]; then
+    echo "ERROR: notarization failed for $artifact: $status" >&2
+    [[ -n "$submission_id" ]] && xcrun notarytool log "$submission_id" \
+      --key "$key_path" \
+      --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
+      --issuer "$APP_STORE_CONNECT_ISSUER_ID" || true
+    exit 1
+  fi
+}
+
+echo "== Duplicating $SOURCE_APP -> $BETA_APP"
+rm -rf "$BETA_APP"
+ditto "$SOURCE_APP" "$BETA_APP"
+
+echo "== Patching identity"
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $BETA_BUNDLE_ID" "$PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleName $BETA_APP_NAME" "$PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName $BETA_APP_NAME" "$PLIST"
+# Identity-aware feed: the backend serves beta-channel items with beta-identity
+# enclosures only to clients that ask with identity=beta. Legacy stable-identity
+# installs keep the plain URL and their current update behavior.
+/usr/libexec/PlistBuddy -c \
+  "Set :SUFeedURL https://api.omi.me/v2/desktop/appcast.xml?identity=beta" "$PLIST"
+
+echo "== Re-signing outer bundle (nested signatures unchanged)"
+codesign --force --options runtime --timestamp \
+  --sign "$SIGN_IDENTITY" \
+  --entitlements Desktop/Omi-Release.entitlements \
+  "$BETA_APP"
+codesign --verify --deep --strict --verbose=2 "$BETA_APP"
+
+echo "== Notarizing beta app"
+TEMP_ZIP="$BUILD_DIR/notarize-beta-temp.zip"
+ditto -c -k --keepParent "$BETA_APP" "$TEMP_ZIP"
+notarize_and_staple "$TEMP_ZIP"
+rm -f "$TEMP_ZIP"
+xcrun stapler staple "$BETA_APP"
+
+echo "== Creating beta DMG"
+pip3 install --break-system-packages "dmgbuild==${DMGBUILD_VERSION:?}" >/dev/null
+STAGING_DIR="/tmp/omi-beta-dmg-staging-$$"
+mkdir -p "$STAGING_DIR"
+ditto "$BETA_APP" "$STAGING_DIR/$BETA_APP_NAME.app"
+xcrun stapler validate "$STAGING_DIR/$BETA_APP_NAME.app" 2>/dev/null || \
+  xcrun stapler staple "$STAGING_DIR/$BETA_APP_NAME.app"
+dmgbuild -s dmg-assets/dmgbuild_settings.py \
+  -D app_path="$STAGING_DIR/$BETA_APP_NAME.app" \
+  -D app_name="$BETA_APP_NAME" \
+  -D assets_dir="$(pwd)/dmg-assets" \
+  "$BETA_APP_NAME" \
+  "$DMG_OUT"
+rm -rf "$STAGING_DIR"
+
+codesign --force --sign "$SIGN_IDENTITY" "$DMG_OUT"
+echo "== Notarizing beta DMG"
+notarize_and_staple "$DMG_OUT"
+xcrun stapler staple "$DMG_OUT"
+
+echo "== Creating beta Sparkle ZIP"
+ditto -c -k --keepParent "$BETA_APP" "$SPARKLE_ZIP_OUT"
+SPARKLE_BIN="Desktop/.build/artifacts/sparkle/Sparkle/bin"
+BETA_ED_SIGNATURE=""
+if [[ -f "$SPARKLE_BIN/sign_update" ]]; then
+  BETA_ED_SIGNATURE=$(echo "$SPARKLE_PRIVATE_KEY" | \
+    "$SPARKLE_BIN/sign_update" "$SPARKLE_ZIP_OUT" --ed-key-file - 2>/dev/null | \
+    grep "sparkle:edSignature" | \
+    sed 's/.*edSignature="\([^"]*\)".*/\1/')
+fi
+if [[ -z "$BETA_ED_SIGNATURE" ]]; then
+  echo "ERROR: could not generate EdDSA signature for the beta Sparkle ZIP" >&2
+  exit 1
+fi
+echo "Beta EdDSA signature: $BETA_ED_SIGNATURE"
+if [[ -n "$CM_ENV_OUT" ]]; then
+  echo "BETA_ED_SIGNATURE=$BETA_ED_SIGNATURE" >> "$CM_ENV_OUT"
+fi
+
+echo "== Beta variant ready"
+shasum -a 256 "$SPARKLE_ZIP_OUT" "$DMG_OUT"

--- a/desktop/macos/scripts/omi-fault-inject.sh
+++ b/desktop/macos/scripts/omi-fault-inject.sh
@@ -38,7 +38,7 @@
 #   # …exercise the flow; assert the app surfaces a structured error, not a crash/silent no-op…
 #   desktop/macos/scripts/omi-fault-inject.sh stop
 #
-# NEVER point a production bundle (com.omi.computer-macos / Omi Beta) at a fault URL.
+# NEVER point a production bundle (com.omi.computer-macos or com.omi.computer-macos.beta) at a fault URL.
 set -euo pipefail
 
 STATE_DIR="${OMI_FAULT_STATE_DIR:-${TMPDIR:-/tmp}/omi-fault-inject}"

--- a/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
+++ b/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
@@ -13,6 +13,7 @@ EXPECTED_CHANNEL="${OMI_SIGNED_ARTIFACT_SMOKE_CHANNEL:-beta}"
 EXPECTED_TEAM_ID="${OMI_SIGNED_ARTIFACT_SMOKE_TEAM_ID:-9536L8KLMP}"
 EXPECTED_BUNDLE_ID="${OMI_SIGNED_ARTIFACT_SMOKE_BUNDLE_ID:-com.omi.computer-macos}"
 EXPECTED_URL_SCHEME="${OMI_SIGNED_ARTIFACT_SMOKE_URL_SCHEME:-omi-computer}"
+EXPECTED_FEED_URL="${OMI_SIGNED_ARTIFACT_SMOKE_FEED_URL:-https://api.omi.me/v2/desktop/appcast.xml}"
 EXPECTED_PYTHON_API_URL="${OMI_SIGNED_ARTIFACT_SMOKE_PYTHON_API_URL:-https://api.omi.me}"
 EXPECTED_DESKTOP_API_URL="${OMI_SIGNED_ARTIFACT_SMOKE_DESKTOP_API_URL:-https://desktop-backend-hhibjajaja-uc.a.run.app/}"
 IS_EXTERNAL_PREVIEW=false
@@ -54,6 +55,8 @@ Options:
   --expected-channel NAME    Expected channel label for result metadata (default: beta)
   --expected-bundle-id ID    Expected app bundle identifier
   --expected-url-scheme URL  Expected app URL scheme
+  --expected-feed-url URL    Expected SUFeedURL (default: plain shared appcast;
+                             the Omi Beta variant passes its identity-scoped feed)
   --expected-python-api-url URL
                              Expected OMI_PYTHON_API_URL in the artifact
   --expected-desktop-api-url URL
@@ -152,6 +155,7 @@ parse_args() {
       --expected-channel) require_option_value "$1" "${2:-}"; EXPECTED_CHANNEL="$2"; shift 2 ;;
       --expected-bundle-id) require_option_value "$1" "${2:-}"; EXPECTED_BUNDLE_ID="$2"; shift 2 ;;
       --expected-url-scheme) require_option_value "$1" "${2:-}"; EXPECTED_URL_SCHEME="$2"; shift 2 ;;
+      --expected-feed-url) require_option_value "$1" "${2:-}"; EXPECTED_FEED_URL="$2"; shift 2 ;;
       --expected-python-api-url) require_option_value "$1" "${2:-}"; EXPECTED_PYTHON_API_URL="$2"; shift 2 ;;
       --expected-desktop-api-url) require_option_value "$1" "${2:-}"; EXPECTED_DESKTOP_API_URL="$2"; shift 2 ;;
       --preview) IS_EXTERNAL_PREVIEW=true; shift ;;
@@ -373,8 +377,10 @@ assert_bundle_identity() {
     [[ "$automatic_checks" == "false" || "$automatic_checks" == "0" ]] \
       || fail "external preview must disable automatic update checks"
   else
-    [[ "$feed_url" == "https://api.omi.me/v2/desktop/appcast.xml" ]] \
-      || fail "SUFeedURL mismatch: ${feed_url:-missing}"
+    # The Omi Beta variant carries an identity-scoped feed; the expected URL is
+    # passed per artifact (default: the plain shared feed).
+    [[ "$feed_url" == "$EXPECTED_FEED_URL" ]] \
+      || fail "SUFeedURL mismatch: expected $EXPECTED_FEED_URL, got ${feed_url:-missing}"
   fi
   [[ -n "$executable" && -x "$APP_BUNDLE/Contents/MacOS/$executable" ]] || fail "main executable missing or not executable"
 

--- a/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
+++ b/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
@@ -83,7 +83,7 @@ Options:
 
 Optional live-probe environment:
   OMI_SIGNED_ARTIFACT_SMOKE_ALLOW_PRODUCTION_LAUNCH=1
-      Required before --launch can launch com.omi.computer-macos.
+      Required before --launch can launch a production-family bundle id.
   OMI_SIGNED_ARTIFACT_SMOKE_AUTH_PROOF_COMMAND='...'
       Required for --auth. Runs after --launch and must prove app-level auth
       persistence/Keychain restore/restart behavior for the launched artifact.

--- a/desktop/macos/tests/test-signed-artifact-smoke.sh
+++ b/desktop/macos/tests/test-signed-artifact-smoke.sh
@@ -96,4 +96,43 @@ if "$SMOKE" --app "$tmp_app" --tag "bad-tag" >/tmp/omi-smoke-badtag.out 2>/tmp/o
 fi
 grep -q "invalid release tag" /tmp/omi-smoke-badtag.err || fail "bad tag failure should be explicit"
 
+# Omi Beta variant: identity-scoped feed URL is accepted only when passed
+# explicitly; the default expectation stays the plain shared feed.
+beta_app="$tmp_root/Omi Beta.app"
+mkdir -p "$beta_app/Contents/MacOS" "$beta_app/Contents/Resources" "$beta_app/Contents/Frameworks"
+cat > "$beta_app/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key><string>Omi Computer</string>
+  <key>CFBundleIdentifier</key><string>com.omi.computer-macos.beta</string>
+  <key>CFBundleShortVersionString</key><string>0.12.34</string>
+  <key>CFBundleVersion</key><string>12034</string>
+  <key>CFBundleURLTypes</key>
+  <array><dict><key>CFBundleURLSchemes</key><array><string>omi-computer</string></array></dict></array>
+  <key>SUFeedURL</key><string>https://api.omi.me/v2/desktop/appcast.xml?identity=beta</string>
+</dict>
+</plist>
+PLIST
+touch "$beta_app/Contents/MacOS/Omi Computer"
+chmod +x "$beta_app/Contents/MacOS/Omi Computer"
+
+if "$SMOKE" --app "$beta_app" --tag "v0.12.34+12034-macos" \
+  --expected-bundle-id com.omi.computer-macos.beta \
+  >/tmp/omi-smoke-beta-default.out 2>/tmp/omi-smoke-beta-default.err; then
+  fail "beta feed URL must be rejected without --expected-feed-url"
+fi
+grep -q "SUFeedURL mismatch" /tmp/omi-smoke-beta-default.err \
+  || fail "default feed expectation should reject the identity-scoped feed"
+
+if "$SMOKE" --app "$beta_app" --tag "v0.12.34+12034-macos" \
+  --expected-bundle-id com.omi.computer-macos.beta \
+  --expected-feed-url "https://api.omi.me/v2/desktop/appcast.xml?identity=beta" \
+  >/tmp/omi-smoke-beta-feed.out 2>/tmp/omi-smoke-beta-feed.err; then
+  fail "unsigned fixture should still fail later (signing), not pass entirely"
+fi
+grep -q "SUFeedURL mismatch" /tmp/omi-smoke-beta-feed.err \
+  && fail "--expected-feed-url should accept the identity-scoped feed"
+
 echo "signed artifact smoke tests passed"


### PR DESCRIPTION
## Omi Beta as a separate app — run beta and stable side-by-side

Today "beta" and "stable" are the same bundle id (`com.omi.computer-macos`), so the single-instance guard (correctly) refuses a second instance: two live copies would share one Rewind SQLite DB, one UserDefaults domain, and one log. This PR makes Omi Beta a first-class separate identity so both can run at the same time — Chrome-style.

### What changed
**App (Swift)**
- `com.omi.computer-macos.beta` is a production-family identity: production gating (no automation bridge, Sparkle on), pinned `beta` update channel (Settings picker locked), isolated `~/Library/Application Support/Omi Beta/` storage root via `DesktopStorageIdentity`, own `/tmp/omi-beta.log`, Keychain-backed install id. On its pinned beta channel it selects the dedicated beta release ring (`api-beta.omi.me`), same as stable-identity beta-channel clients after the beta-ring change on main.
- Single-instance guard already keys on bundle id → beta+stable coexist; true duplicates still refused per identity. Legacy "Omi Computer.app" cleanup is restricted to the stable identity so Omi Beta can never terminate the running stable app.

**Release pipeline (Codemagic)**
- New step duplicates the signed stable app, re-identifies it as "Omi Beta" (identity-scoped `SUFeedURL?identity=beta`), re-signs the outer bundle (nested signatures stay valid), notarizes, staples, ships `Omi.Beta.zip` + `omi-beta.dmg` with their own smoke result (`desktop-smoke-result-beta.json`, held to the same qualification contract incl. the notification-callback canary) and appcast EdDSA signature (`betaEdSignature`).
- Beta qualification verifies beta asset digests against beta smoke evidence when the assets are present; older releases stay valid. Resolved against main's immutable-candidate release semantics (no delete/recreate).

**Backend (updates.py)**
- `identity=beta` (sent only by the Omi Beta app's feed URL and the beta download entry points, incl. `/v2/desktop/download/beta` and `AppBuild.manualDownloadURL`) serves beta-channel items exclusively with beta-identity enclosures — Sparkle can never replace the beta app with a stable-identity bundle. Pointer entries resolve beta assets from the GitHub release by tag; releases without beta artifacts are omitted from the beta feed. Stable DMG picker excludes `omi-beta.dmg` by exact name. Legacy stable-id beta-channel installs keep today's feed and behavior.

## Failure class

Failure-Class: none

The one `fix:` commit repairs a defect introduced within this PR's own in-flight rebase (the beta smoke invocation predating main's new notification-callback canary); nothing shipped, no recurring shipped failure class applies. The commit adds the contract test binding the codemagic smoke invocations to the candidate gate's required evidence.

## Product invariants affected

- INV-AUTH-1

(cited because the diff touches `ClientDeviceService.swift` — install-id storage selection only: the beta identity keeps the durable Keychain install id like stable. Session-death ownership via `AuthSessionCoordinator.invalidateSession` is untouched; guard test unchanged.)

### Verification
- **Side-by-side, real user path:** built a beta-identity bundle from this branch and ran it beside the running production `omi.app`: both processes alive simultaneously (CGWindowList shows windows owned by "omi" and "Omi Beta"), isolated `Omi Beta/` storage root, `/tmp/omi-beta.log` written. Duplicate copies of the same identity still refused in both directions (guard log lines captured).
- **Swift tests:** `AppBuildBetaIdentityTests`, `DesktopStorageIdentityTests`, `APIClientRoutingTests`, `ExternalPreviewBuildTests` — 81 green after rebasing onto the beta-release-ring + immutable-candidate changes on main.
- **Backend tests:** `tests/unit/test_desktop_updates.py` — 100 green; `scan_async_blockers` clean; `.github/scripts/test_check_desktop_auto_beta_candidate.py` green with both the notification-canary and beta-asset contracts.
- **UNVERIFIED (CI lane):** the new Codemagic packaging steps run on the next candidate build (bash -n checked, YAML validated). Plan after merge: deploy backend → dispatch a candidate → verify `Omi.Beta.zip`/`omi-beta.dmg` on the release → install the real beta DMG beside stable.

### Deploy sequencing
Backend change is additive (unknown `identity` param was previously ignored; identity=beta feed is empty until a dual-identity release exists). Sequence after merge: deploy prod backend → dispatch desktop candidate → first dual-identity release goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
