### PR TITLE
fix(desktop): owner-bind home suggestion generation end to end

### DIFF
--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -636,7 +636,8 @@ extension APIClient {
     startDate: Date? = nil,
     endDate: Date? = nil,
     folderId: String? = nil,
-    starred: Bool? = nil
+    starred: Bool? = nil,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
   ) async throws -> [ServerConversation] {
     var queryItems: [String] = [
       "limit=\(limit)",
@@ -652,7 +653,7 @@ extension APIClient {
     )
 
     let endpoint = "v1/conversations?\(queryItems.joined(separator: "&"))"
-    return try await get(endpoint)
+    return try await get(endpoint, authorizationSnapshot: authorizationSnapshot)
   }
 
   /// Fetches a single conversation by ID
@@ -902,13 +903,22 @@ extension APIClient {
 extension APIClient {
 
   /// Fetches all active goals (up to 4). Uses 5-second cache to deduplicate parallel calls.
-  func getGoals() async throws -> [Goal] {
-    if let cache = goalsCache, let time = goalsCacheTime, Date().timeIntervalSince(time) < 5 {
+  func getGoals(authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil) async throws
+    -> [Goal]
+  {
+    // The short-lived shared cache is not owner-validated; owner-bound callers
+    // must always hit the network under their snapshot.
+    if authorizationSnapshot == nil, let cache = goalsCache, let time = goalsCacheTime,
+      Date().timeIntervalSince(time) < 5
+    {
       return cache
     }
-    let goals: [Goal] = try await get("v1/goals/all")
-    goalsCache = goals
-    goalsCacheTime = Date()
+    let goals: [Goal] = try await get(
+      "v1/goals/all", authorizationSnapshot: authorizationSnapshot)
+    if authorizationSnapshot == nil {
+      goalsCache = goals
+      goalsCacheTime = Date()
+    }
     return goals
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift
@@ -54,7 +54,11 @@ protocol HomeSuggestionGenerating: Sendable {
   /// Returns personalized questions, or an empty array when the user's
   /// context is too thin to reference anything real. Throws on transport
   /// failure so the caller can retry later without burning the daily slot.
-  func generatePersonalizedQuestions() async throws -> [String]
+  /// Every context read must be bound to `snapshot` so a mid-generation
+  /// account switch can never return another owner's data.
+  func generatePersonalizedQuestions(
+    snapshot: RuntimeOwnerAuthorizationSnapshot
+  ) async throws -> [String]
 }
 
 // MARK: - Store
@@ -95,7 +99,7 @@ final class HomeSuggestionsStore: ObservableObject {
     self.defaults = defaults
     self.generator = generator ?? GeminiHomeSuggestionGenerator()
     self.now = now
-    publishCache(for: currentOwnerID())
+    publishCache(for: RuntimeOwnerIdentity.currentOwnerId() ?? "signed-out")
     ownerObserver = NotificationCenter.default.addObserver(
       forName: .runtimeOwnerDidChange, object: nil, queue: .main
     ) { [weak self] _ in
@@ -110,13 +114,20 @@ final class HomeSuggestionsStore: ObservableObject {
   }
 
   /// Publish the current owner's cached questions and generate fresh ones at
-  /// most once per day per owner. Transport failures leave the cache
-  /// untouched so a later call retries; a successful-but-empty generation is
-  /// cached to hold one attempt per day.
+  /// most once per day per owner. The owner-authorization snapshot captured
+  /// up front bounds every context fetch, the cache write, and the publish,
+  /// so a mid-generation account switch drops the result entirely. Transport
+  /// failures leave the cache untouched so a later call retries; a
+  /// successful-but-empty generation is cached to hold one attempt per day.
   func refreshIfNeeded() async {
-    let ownerID = currentOwnerID()
+    guard let snapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else {
+      // Signed out or mid account transition — never render a previous
+      // owner's questions.
+      personalizedQuestions = []
+      return
+    }
+    let ownerID = snapshot.ownerID
     publishCache(for: ownerID)
-    guard ownerID != "signed-out" else { return }
 
     let today = Self.dayStampFormatter.string(from: now())
     if let cache = loadCache(for: ownerID), cache.dayStamp == today { return }
@@ -126,13 +137,15 @@ final class HomeSuggestionsStore: ObservableObject {
     defer { generatingOwnerID = nil }
 
     do {
-      let generated = try await generator.generatePersonalizedQuestions()
+      let generated = try await generator.generatePersonalizedQuestions(snapshot: snapshot)
+      guard RuntimeOwnerIdentity.isAuthorizationCurrent(snapshot) else {
+        log("HomeSuggestions: dropped generation result after account switch")
+        return
+      }
       let questions = Array(HomeSuggestionComposer.sanitize(generated).prefix(2))
       let entry = CacheEntry(questions: questions, dayStamp: today)
-      defaults.set(try? JSONEncoder().encode(entry), forKey: cacheKey(ownerID: ownerID))
-      if currentOwnerID() == ownerID {
-        personalizedQuestions = questions
-      }
+      defaults.set(try? JSONEncoder().encode(entry), forKey: Self.cacheKey(ownerID: ownerID))
+      personalizedQuestions = questions
       log("HomeSuggestions: generated \(questions.count) personalized questions for \(today)")
     } catch {
       log(
@@ -141,16 +154,12 @@ final class HomeSuggestionsStore: ObservableObject {
     }
   }
 
-  private func currentOwnerID() -> String {
-    defaults.string(forKey: .authUserId) ?? "signed-out"
-  }
-
-  private func cacheKey(ownerID: String) -> String {
+  static func cacheKey(ownerID: String) -> String {
     "homePersonalizedSuggestions.v1.\(ownerID)"
   }
 
   private func loadCache(for ownerID: String) -> CacheEntry? {
-    guard let data = defaults.data(forKey: cacheKey(ownerID: ownerID)) else { return nil }
+    guard let data = defaults.data(forKey: Self.cacheKey(ownerID: ownerID)) else { return nil }
     return try? JSONDecoder().decode(CacheEntry.self, from: data)
   }
 
@@ -180,18 +189,22 @@ struct GeminiHomeSuggestionGenerator: HomeSuggestionGenerating {
     )
   }
 
-  func generatePersonalizedQuestions() async throws -> [String] {
+  func generatePersonalizedQuestions(
+    snapshot: RuntimeOwnerAuthorizationSnapshot
+  ) async throws -> [String] {
     async let memoriesFetch = { () async -> [ServerMemory] in
-      (try? await APIClient.shared.getMemories(limit: 200)) ?? []
+      (try? await APIClient.shared.getMemories(limit: 200, authorizationSnapshot: snapshot)) ?? []
     }()
     async let conversationsFetch = { () async -> [ServerConversation] in
-      (try? await APIClient.shared.getConversations(limit: 30, statuses: [.completed])) ?? []
+      (try? await APIClient.shared.getConversations(
+        limit: 30, statuses: [.completed], authorizationSnapshot: snapshot)) ?? []
     }()
     async let actionItemsFetch = { () async -> ActionItemsListResponse? in
-      try? await APIClient.shared.getActionItems(limit: 50, completed: false)
+      try? await APIClient.shared.getActionItems(
+        limit: 50, completed: false, authorizationSnapshot: snapshot)
     }()
     async let goalsFetch = { () async -> [Goal] in
-      (try? await APIClient.shared.getGoals()) ?? []
+      (try? await APIClient.shared.getGoals(authorizationSnapshot: snapshot)) ?? []
     }()
 
     let (memories, conversations, actionItems, goals) = await (

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Memories.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Memories.swift
@@ -499,7 +499,8 @@ extension APIClient {
     category: String? = nil,
     tags: [String]? = nil,
     includeDismissed: Bool = false,
-    deviceScope: String? = nil
+    deviceScope: String? = nil,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
   ) async throws -> [ServerMemory] {
     var endpoint = "v3/memories?limit=\(limit)&offset=\(offset)"
     if let category = category {
@@ -514,7 +515,7 @@ extension APIClient {
     if let deviceScope = deviceScope {
       endpoint += "&device_scope=\(deviceScope)"
     }
-    return try await get(endpoint)
+    return try await get(endpoint, authorizationSnapshot: authorizationSnapshot)
   }
 
   /// Fetches memories plus server-authoritative capability headers.

--- a/desktop/macos/Desktop/Tests/HomeSuggestionsStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeSuggestionsStoreTests.swift
@@ -117,7 +117,9 @@ private final class StubSuggestionGenerator: HomeSuggestionGenerating, @unchecke
     continuation?.resume()
   }
 
-  func generatePersonalizedQuestions() async throws -> [String] {
+  func generatePersonalizedQuestions(
+    snapshot: RuntimeOwnerAuthorizationSnapshot
+  ) async throws -> [String] {
     let (behavior, gated) = lock.withLock { () -> (Behavior, Bool) in
       _callCount += 1
       let gated = gateNextCall
@@ -140,17 +142,21 @@ private final class StubSuggestionGenerator: HomeSuggestionGenerating, @unchecke
 
 @MainActor
 final class HomeSuggestionsStoreTests: XCTestCase {
-  private func makeDefaults(owner: String?) throws -> (UserDefaults, () -> Void) {
+  private let ownerFixture = RuntimeOwnerAuthorityTestFixture()
+
+  override func tearDown() async throws {
+    await ownerFixture.restore()
+  }
+
+  private func makeDefaults() throws -> (UserDefaults, () -> Void) {
     let suite = "HomeSuggestionsStoreTests.\(UUID().uuidString)"
     let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
-    if let owner {
-      defaults.set(owner, forKey: .authUserId)
-    }
     return (defaults, { defaults.removePersistentDomain(forName: suite) })
   }
 
   func testRefreshGeneratesOncePerDayAndRepublishesFromCache() async throws {
-    let (defaults, cleanup) = try makeDefaults(owner: "owner-a")
+    await ownerFixture.establish(authOwnerID: "owner-a")
+    let (defaults, cleanup) = try makeDefaults()
     defer { cleanup() }
     let generator = StubSuggestionGenerator(
       behavior: .respond(["How do I unblock the Atlas launch?", "Is the EE hiring loop on track?"]))
@@ -178,7 +184,8 @@ final class HomeSuggestionsStoreTests: XCTestCase {
   }
 
   func testRefreshRegeneratesOnNextDay() async throws {
-    let (defaults, cleanup) = try makeDefaults(owner: "owner-a")
+    await ownerFixture.establish(authOwnerID: "owner-a")
+    let (defaults, cleanup) = try makeDefaults()
     defer { cleanup() }
     let generator = StubSuggestionGenerator(behavior: .respond(["Day one question?"]))
     var currentDay = Date(timeIntervalSince1970: 1_700_000_000)
@@ -195,7 +202,8 @@ final class HomeSuggestionsStoreTests: XCTestCase {
   }
 
   func testRefreshSkipsWhenSignedOut() async throws {
-    let (defaults, cleanup) = try makeDefaults(owner: nil)
+    await ownerFixture.establish(authOwnerID: nil)
+    let (defaults, cleanup) = try makeDefaults()
     defer { cleanup() }
     let generator = StubSuggestionGenerator(behavior: .respond(["Should not appear?"]))
     let store = HomeSuggestionsStore(defaults: defaults, generator: generator)
@@ -207,7 +215,8 @@ final class HomeSuggestionsStoreTests: XCTestCase {
   }
 
   func testTransportFailureRetriesButEmptySuccessHoldsForTheDay() async throws {
-    let (defaults, cleanup) = try makeDefaults(owner: "owner-a")
+    await ownerFixture.establish(authOwnerID: "owner-a")
+    let (defaults, cleanup) = try makeDefaults()
     defer { cleanup() }
     let generator = StubSuggestionGenerator(behavior: .fail)
     let day = Date(timeIntervalSince1970: 1_700_000_000)
@@ -229,8 +238,9 @@ final class HomeSuggestionsStoreTests: XCTestCase {
     XCTAssertEqual(store.personalizedQuestions, [])
   }
 
-  func testOwnerSwitchNeverPublishesAnotherOwnersQuestions() async throws {
-    let (defaults, cleanup) = try makeDefaults(owner: "owner-a")
+  func testOwnerSwitchDuringGenerationDropsResultEntirely() async throws {
+    await ownerFixture.establish(authOwnerID: "owner-a")
+    let (defaults, cleanup) = try makeDefaults()
     defer { cleanup() }
     let generator = StubSuggestionGenerator(behavior: .respond(["Owner A's private question?"]))
     let store = HomeSuggestionsStore(defaults: defaults, generator: generator)
@@ -238,23 +248,32 @@ final class HomeSuggestionsStoreTests: XCTestCase {
     generator.gateNext()
     let refreshTask = Task { await store.refreshIfNeeded() }
 
-    // Switch accounts while owner A's generation is in flight.
+    // Switch accounts while owner A's generation is in flight. The transition
+    // revokes the authorization snapshot captured at refresh start.
     while generator.callCount == 0 {
       await Task.yield()
     }
-    defaults.set("owner-b", forKey: .authUserId)
+    await ownerFixture.establish(authOwnerID: "owner-b")
     generator.resumeGatedCall()
     await refreshTask.value
 
     XCTAssertEqual(
       store.personalizedQuestions, [],
-      "owner A's late result must not be published for owner B"
+      "a result finishing after an account switch must not be published"
+    )
+    XCTAssertNil(
+      defaults.data(forKey: HomeSuggestionsStore.cacheKey(ownerID: "owner-a")),
+      "a result finishing after an account switch must not be cached under the original owner"
+    )
+    XCTAssertNil(
+      defaults.data(forKey: HomeSuggestionsStore.cacheKey(ownerID: "owner-b")),
+      "a result finishing after an account switch must not be cached under the new owner"
     )
 
-    // Owner A's result was still cached under owner A, so switching back
-    // publishes it without regenerating.
-    defaults.set("owner-a", forKey: .authUserId)
+    // The dropped attempt burned nothing: owner A regenerates on return.
+    await ownerFixture.establish(authOwnerID: "owner-a")
     await store.refreshIfNeeded()
+    XCTAssertEqual(generator.callCount, 2)
     XCTAssertEqual(store.personalizedQuestions, ["Owner A's private question?"])
   }
 }

--- a/desktop/macos/changelog/unreleased/20260719-home-suggestions-owner-binding.json
+++ b/desktop/macos/changelog/unreleased/20260719-home-suggestions-owner-binding.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed personalized home suggestions so switching accounts mid-refresh can never show or store another account's questions"
+}


### PR DESCRIPTION
## What

Follow-up to #10058 fixing a cross-account boundary defect the agent cross-review caught: the personalized home-suggestion refresh validated the owner only before *publishing*, and its context fetches carried no owner authority. An account switch during the multi-second generation could fetch context under the new owner's session yet cache the questions under the original owner's key — later rendering one account's personalized questions to the other.

## Fix — repair the failure-class boundary with the canonical primitive

- `refreshIfNeeded` captures a `RuntimeOwnerAuthorizationSnapshot` up front (nil → clear chips and bail; never render across a transition).
- Every context fetch is owner-bound: `getMemories`, `getConversations`, and `getGoals` gain the optional `authorizationSnapshot` parameter that `getActionItems` already had, threaded to `APIClient.get`, so post-switch responses are rejected at the request layer.
- The snapshot is revalidated after generation **before the cache write** as well as before the publish — a mid-generation switch drops the result entirely (cached under neither owner).
- The shared 5-second goals cache is bypassed for owner-bound callers because it is not owner-validated.

## Product invariants affected

- INV-AUTH-1 — touched `APIClient.swift` at the auth boundary, but only to thread the optional `authorizationSnapshot` through `getConversations`/`getGoals`. Owner-bound requests use the session-preserving policy (`signOutOn401: false`), so session death remains owned by `AuthSessionCoordinator`; no session-invalidation behavior changes and the INV-AUTH-1 guard tests are untouched.

## Failure class

Failure-Class: none

No registry class covers delayed owner-bound work under stale authorization; the reusable guard surface (`RuntimeOwnerAuthorizationSnapshot` + owner-bound `RequestAuthPolicy`) already exists and this fix converges on it rather than adding a one-off check.

## Verification

- `xcrun swift test --filter HomeSuggestion`: 9/9 passed, including the new `testOwnerSwitchDuringGenerationDropsResultEntirely`, which drives a real `RuntimeOwnerAuthorityTestFixture` transition mid-generation and asserts nothing is published or cached under either owner, then a clean regeneration after switching back.
- Named bundle `omi-suggestions`: cleared the cached questions, relaunched with the fixed binary, and the dashboard regenerated through the owner-bound fetches (log: `HomeSuggestions: generated 2 personalized questions for 2026-07-19`) and rendered the three chips (window capture verified).
- `make preflight` green with this body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

