### PR TITLE
fix(desktop): classify suggestion context outages instead of caching an empty day

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift
@@ -170,9 +170,48 @@ final class HomeSuggestionsStore: ObservableObject {
 
 // MARK: - Gemini generation
 
+enum HomeSuggestionGenerationError: Error {
+  /// Context fetches failed and nothing usable arrived — a transport or auth
+  /// outage, not a thin-context account. Must not burn the daily slot.
+  case contextUnavailable
+}
+
 struct GeminiHomeSuggestionGenerator: HomeSuggestionGenerating {
   private struct Response: Decodable {
     let questions: [String]
+  }
+
+  /// Classifies the four context fetches (nil = that fetch failed) so an
+  /// outage is distinguishable from an account that genuinely has no data.
+  enum ContextClassification: Equatable {
+    /// Every source is empty and at least one fetch failed: treat as an
+    /// outage and throw so the store retries later instead of caching an
+    /// empty day.
+    case unavailable
+    /// Every fetch succeeded and there is genuinely nothing to reference.
+    case thin
+    /// Enough real context arrived (partial fetch failures are tolerated).
+    case available(memories: String, conversations: String, tasks: String, goals: String)
+  }
+
+  static func classifyContext(
+    memories: String?,
+    conversations: String?,
+    tasks: String?,
+    goals: String?
+  ) -> ContextClassification {
+    let sources = [memories, conversations, tasks, goals]
+    let anyFailed = sources.contains(nil)
+    let combined = sources.compactMap { $0 }.joined()
+    if combined.isEmpty {
+      return anyFailed ? .unavailable : .thin
+    }
+    return .available(
+      memories: memories ?? "",
+      conversations: conversations ?? "",
+      tasks: tasks ?? "",
+      goals: goals ?? ""
+    )
   }
 
   private var responseSchema: GeminiRequest.GenerationConfig.ResponseSchema {
@@ -192,37 +231,51 @@ struct GeminiHomeSuggestionGenerator: HomeSuggestionGenerating {
   func generatePersonalizedQuestions(
     snapshot: RuntimeOwnerAuthorizationSnapshot
   ) async throws -> [String] {
-    async let memoriesFetch = { () async -> [ServerMemory] in
-      (try? await APIClient.shared.getMemories(limit: 200, authorizationSnapshot: snapshot)) ?? []
+    // nil = that fetch failed (vs. succeeded with no data) — the distinction
+    // drives outage-vs-thin classification below.
+    async let memoriesFetch = { () async -> [ServerMemory]? in
+      try? await APIClient.shared.getMemories(limit: 200, authorizationSnapshot: snapshot)
     }()
-    async let conversationsFetch = { () async -> [ServerConversation] in
-      (try? await APIClient.shared.getConversations(
-        limit: 30, statuses: [.completed], authorizationSnapshot: snapshot)) ?? []
+    async let conversationsFetch = { () async -> [ServerConversation]? in
+      try? await APIClient.shared.getConversations(
+        limit: 30, statuses: [.completed], authorizationSnapshot: snapshot)
     }()
     async let actionItemsFetch = { () async -> ActionItemsListResponse? in
       try? await APIClient.shared.getActionItems(
         limit: 50, completed: false, authorizationSnapshot: snapshot)
     }()
-    async let goalsFetch = { () async -> [Goal] in
-      (try? await APIClient.shared.getGoals(authorizationSnapshot: snapshot)) ?? []
+    async let goalsFetch = { () async -> [Goal]? in
+      try? await APIClient.shared.getGoals(authorizationSnapshot: snapshot)
     }()
 
     let (memories, conversations, actionItems, goals) = await (
       memoriesFetch, conversationsFetch, actionItemsFetch, goalsFetch
     )
 
-    let memoryContext = memories.map { $0.content }.joined(separator: "\n")
-    let conversationContext =
-      conversations
-      .compactMap { $0.structured.overview.isEmpty ? nil : $0.structured.overview }
-      .joined(separator: "\n")
-    let tasksContext = (actionItems?.items ?? []).map { $0.description }.joined(separator: "\n")
-    let goalsContext = goals.map { $0.title }.joined(separator: "\n")
+    let classification = Self.classifyContext(
+      memories: memories.map { $0.map { $0.content }.joined(separator: "\n") },
+      conversations: conversations.map {
+        $0.compactMap { $0.structured.overview.isEmpty ? nil : $0.structured.overview }
+          .joined(separator: "\n")
+      },
+      tasks: actionItems.map { $0.items.map { $0.description }.joined(separator: "\n") },
+      goals: goals.map { $0.map { $0.title }.joined(separator: "\n") }
+    )
 
-    if memoryContext.isEmpty && conversationContext.isEmpty && tasksContext.isEmpty
-      && goalsContext.isEmpty
-    {
+    let memoryContext: String
+    let conversationContext: String
+    let tasksContext: String
+    let goalsContext: String
+    switch classification {
+    case .unavailable:
+      throw HomeSuggestionGenerationError.contextUnavailable
+    case .thin:
       return []
+    case .available(let memories, let conversations, let tasks, let goals):
+      memoryContext = memories
+      conversationContext = conversations
+      tasksContext = tasks
+      goalsContext = goals
     }
 
     let dateFormatter = DateFormatter()

--- a/desktop/macos/Desktop/Tests/HomeSuggestionsStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeSuggestionsStoreTests.swift
@@ -77,6 +77,54 @@ final class HomeSuggestionComposerTests: XCTestCase {
   }
 }
 
+// MARK: - Context classification
+
+final class GeminiHomeSuggestionGeneratorClassificationTests: XCTestCase {
+  func testAllFetchesFailedClassifiesAsUnavailable() {
+    XCTAssertEqual(
+      GeminiHomeSuggestionGenerator.classifyContext(
+        memories: nil, conversations: nil, tasks: nil, goals: nil),
+      .unavailable,
+      "an outage must throw upstream, not cache an empty day"
+    )
+  }
+
+  func testEmptySuccessesMixedWithFailuresClassifyAsUnavailable() {
+    XCTAssertEqual(
+      GeminiHomeSuggestionGenerator.classifyContext(
+        memories: "", conversations: nil, tasks: nil, goals: nil),
+      .unavailable,
+      "partial outage with no usable context must retry later"
+    )
+  }
+
+  func testAllFetchesSucceededEmptyClassifiesAsThin() {
+    XCTAssertEqual(
+      GeminiHomeSuggestionGenerator.classifyContext(
+        memories: "", conversations: "", tasks: "", goals: ""),
+      .thin,
+      "a genuinely empty account holds the daily slot"
+    )
+  }
+
+  func testPartialFailureWithRealContextClassifiesAsAvailable() {
+    XCTAssertEqual(
+      GeminiHomeSuggestionGenerator.classifyContext(
+        memories: nil, conversations: "Discussed the Atlas launch", tasks: "", goals: nil),
+      .available(memories: "", conversations: "Discussed the Atlas launch", tasks: "", goals: "")
+    )
+  }
+
+  func testFullContextClassifiesAsAvailable() {
+    XCTAssertEqual(
+      GeminiHomeSuggestionGenerator.classifyContext(
+        memories: "Nik runs Omi", conversations: "Hiring sync", tasks: "Ship v2", goals: "50k"),
+      .available(
+        memories: "Nik runs Omi", conversations: "Hiring sync", tasks: "Ship v2", goals: "50k")
+    )
+  }
+}
+
 // MARK: - Store
 
 private final class StubSuggestionGenerator: HomeSuggestionGenerating, @unchecked Sendable {

--- a/desktop/macos/changelog/unreleased/20260719-home-suggestions-outage-retry.json
+++ b/desktop/macos/changelog/unreleased/20260719-home-suggestions-outage-retry.json
@@ -1,0 +1,3 @@
+{
+  "change": "Personalized home suggestions now retry after a network outage instead of staying empty for the rest of the day"
+}


### PR DESCRIPTION
## What

Second follow-up to #10058 (after #10061), fixing a failure-classification defect the agent cross-review caught: `GeminiHomeSuggestionGenerator` swallowed context-fetch failures with `try?`, so a transport or auth outage looked identical to an account with no data — the store cached the "successful" empty generation and stopped retrying personalized suggestions until the next day.

## Fix

- Fetch results are now optional (`nil` = fetch failed, `[]` = succeeded with no data).
- A pure `classifyContext` seam decides the outcome:
  - `.unavailable` — every source empty and at least one fetch failed → throws `HomeSuggestionGenerationError.contextUnavailable`; the store's existing failure path leaves the daily cache unwritten and the next dashboard visit retries.
  - `.thin` — all four fetches succeeded and produced nothing → the only path that caches the empty day.
  - `.available` — real context arrived (partial fetch failures tolerated) → generate.

## Product invariants affected

none

## Failure class

Failure-Class: none

No registry class covers fail-open error swallowing that converts an outage into a cached negative result; the fix introduces the narrow classification seam plus behavioral tests rather than a new global guard.

## Verification

- `xcrun swift test --filter HomeSuggestion`: 14/14 passed — five new classification tests (all-failed → unavailable, mixed empty+failed → unavailable, all-empty success → thin, partial failure with content → available, full context → available) plus the existing composer/store suites.
- Named bundle `omi-suggestions` relaunched with this binary: dashboard renders the three chips from today's cache (correct same-day cache-hit, no regeneration), window capture via the automation bridge.
- `make preflight` green with this body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

