### PR TITLE
fix: exercise fault backend without Firebase auth

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
@@ -1,11 +1,11 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2201,
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4283
+    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2204,
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4310
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": "Non-production owner-bound journal control keeps hermetic fault-reset behavior credential-free without weakening normal model startup credentials.",
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "Non-production owner-bound journal control keeps hermetic fault-reset behavior credential-free without weakening normal model startup credentials."
+    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": "Named non-production fault bundle supplies an inert hermetic model token so fault injection reaches the configured remote 5xx backend without Firebase auth.",
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "Named non-production fault bundle supplies an inert hermetic model token so fault injection reaches the configured remote 5xx backend without Firebase auth."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
@@ -897,7 +897,10 @@ actor AgentBridge {
       isPiMonoHarness
       && AgentRuntimeCredentialPolicy.requiresManagedCredentials(
         requestedCredentials: requiresCredentials,
-        isNonProduction: AppBuild.isNonProduction)
+        isNonProduction: AppBuild.isNonProduction,
+        hermeticFaultModelToken: AgentRuntimeCredentialPolicy.hermeticFaultModelToken(
+          isNonProduction: AppBuild.isNonProduction,
+          bundleIdentifier: AppBuild.bundleIdentifier))
     var acquiredRegistration = false
     do {
       if registeredThisCall {

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -84,13 +84,31 @@ enum AgentRuntimeStartupAdmission {
 
 /// Firebase credentials are mandatory for every production and model runtime
 /// start. The sole exception is a non-production journal-control start, whose
-/// owner-bound RPCs deliberately operate without a model credential.
+/// owner-bound RPCs deliberately operate without a model credential. The
+/// fault suite supplies a separate, inert model token so its named test bundle
+/// can reach the local 5xx endpoint without contacting Firebase.
 enum AgentRuntimeCredentialPolicy {
+  static let hermeticFaultModelTokenEnvironmentKey = "OMI_FAULT_MODEL_AUTH_TOKEN"
+  static let hermeticFaultBundleIdentifier = "com.omi.omi-fault"
+
+  static func hermeticFaultModelToken(
+    isNonProduction: Bool,
+    bundleIdentifier: String,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) -> String? {
+    guard isNonProduction, bundleIdentifier == hermeticFaultBundleIdentifier else { return nil }
+    let token =
+      environment[hermeticFaultModelTokenEnvironmentKey]?
+      .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return token.isEmpty ? nil : token
+  }
+
   static func requiresManagedCredentials(
     requestedCredentials: Bool,
-    isNonProduction: Bool
+    isNonProduction: Bool,
+    hermeticFaultModelToken: String? = nil
   ) -> Bool {
-    requestedCredentials || !isNonProduction
+    (requestedCredentials || !isNonProduction) && hermeticFaultModelToken == nil
   }
 }
 
@@ -2548,6 +2566,11 @@ actor AgentRuntimeProcess {
     proc.arguments = ["--max-old-space-size=256", "--max-semi-space-size=16", bridgePath]
 
     var env = ProcessInfo.processInfo.environment
+    let hermeticFaultModelToken = AgentRuntimeCredentialPolicy.hermeticFaultModelToken(
+      isNonProduction: AppBuild.isNonProduction,
+      bundleIdentifier: AppBuild.bundleIdentifier,
+      environment: env)
+    env.removeValue(forKey: AgentRuntimeCredentialPolicy.hermeticFaultModelTokenEnvironmentKey)
     env["NODE_NO_WARNINGS"] = "1"
     env["HARNESS_MODE"] = preferredHarnessMode
     env["OMI_AGENT_STATE_DIR"] = Self.defaultStateDirectory()
@@ -2595,7 +2618,8 @@ actor AgentRuntimeProcess {
       preferredAdapterId == .piMono
       && AgentRuntimeCredentialPolicy.requiresManagedCredentials(
         requestedCredentials: requiresCredentials,
-        isNonProduction: AppBuild.isNonProduction)
+        isNonProduction: AppBuild.isNonProduction,
+        hermeticFaultModelToken: hermeticFaultModelToken)
     let authService = await MainActor.run { AuthService.shared }
     let forceRefreshToken = preferredAdapterId == .piMono && !DesktopLocalProfile.isEnabled
     let authHeader = try? await Self.startupAuthHeader(
@@ -2608,7 +2632,10 @@ actor AgentRuntimeProcess {
     try assertStartupAuthority(
       authorizationSnapshot,
       expectedAuthorityEpoch: admissionAuthorityEpoch)
-    if let authHeader,
+    if let hermeticFaultModelToken {
+      env["OMI_AUTH_TOKEN"] = hermeticFaultModelToken
+      log("AgentRuntimeProcess: starting non-production fault-model runtime without Firebase auth")
+    } else if let authHeader,
       let token = Self.bearerToken(from: authHeader)
     {
       env["OMI_AUTH_TOKEN"] = token

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -128,6 +128,43 @@ private actor CredentialFreeControlStartProbe {
 }
 
 final class AgentRuntimeProcessTests: XCTestCase {
+  func testHermeticFaultModelTokenIsNonProductionOnlyAndAvoidsFirebaseRefresh() {
+    let environment = [
+      AgentRuntimeCredentialPolicy.hermeticFaultModelTokenEnvironmentKey: "fault-suite-model-token"
+    ]
+
+    let token = AgentRuntimeCredentialPolicy.hermeticFaultModelToken(
+      isNonProduction: true,
+      bundleIdentifier: AgentRuntimeCredentialPolicy.hermeticFaultBundleIdentifier,
+      environment: environment)
+    XCTAssertEqual(token, "fault-suite-model-token")
+    XCTAssertFalse(
+      AgentRuntimeCredentialPolicy.requiresManagedCredentials(
+        requestedCredentials: true,
+        isNonProduction: true,
+        hermeticFaultModelToken: token),
+      "the isolated fault backend must exercise its injected response without Firebase")
+    XCTAssertNil(
+      AgentRuntimeCredentialPolicy.hermeticFaultModelToken(
+        isNonProduction: false,
+        bundleIdentifier: AgentRuntimeCredentialPolicy.hermeticFaultBundleIdentifier,
+        environment: environment),
+      "production must never accept a harness-supplied model token")
+    XCTAssertNil(
+      AgentRuntimeCredentialPolicy.hermeticFaultModelToken(
+        isNonProduction: true,
+        bundleIdentifier: "com.omi.some-other-dev-bundle",
+        environment: environment),
+      "only the named fault bundle may opt into the inert model token")
+    XCTAssertNil(
+      AgentRuntimeCredentialPolicy.hermeticFaultModelToken(
+        isNonProduction: true,
+        bundleIdentifier: AgentRuntimeCredentialPolicy.hermeticFaultBundleIdentifier,
+        environment: [
+          AgentRuntimeCredentialPolicy.hermeticFaultModelTokenEnvironmentKey: "   "
+        ]))
+  }
+
   func testNonProductionJournalControlStartDoesNotRefreshCredentials() async throws {
     let probe = CredentialFreeControlStartProbe()
 

--- a/desktop/macos/changelog/unreleased/20260720-fault-suite-remote-model-auth.json
+++ b/desktop/macos/changelog/unreleased/20260720-fault-suite-remote-model-auth.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the chat fault suite so injected backend errors surface the real HTTP 500 instead of a generic bridge failure"
+}

--- a/desktop/macos/e2e/flows/chat-fault-5xx.yaml
+++ b/desktop/macos/e2e/flows/chat-fault-5xx.yaml
@@ -45,13 +45,15 @@ steps:
         pollMs: "500"
 
   - id: S5
-    name: Assert surfaced error (not silent no-op)
+    name: Assert injected backend 5xx surfaced (not bridge unavailable)
     bridge.action:
       name: main_chat_snapshot
       params:
         limit: "8"
     expect:
       result.detail.has_error: "true"
+      result.detail.error_message:
+        contains: "HTTP 500"
 
   - id: S6
     name: Logs clean

--- a/desktop/macos/scripts/desktop-core-harness.sh
+++ b/desktop/macos/scripts/desktop-core-harness.sh
@@ -561,6 +561,7 @@ start_fault_stack() {
       OMI_PYTHON_API_URL="$OMI_FAULT_URL" \
       OMI_DESKTOP_API_URL="$OMI_FAULT_URL" \
       OMI_AUTH_API_URL="$OMI_FAULT_URL" \
+      OMI_FAULT_MODEL_AUTH_TOKEN="omi-fault-model-token" \
       OMI_AUTOMATION_PORT="$PORT" \
       OMI_APP_NAME="$FAULT_BUNDLE" \
       ./run.sh

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -222,7 +222,7 @@ def recent_traces(ctx: HarnessContext) -> list[dict[str, typing.Any]]:
     return result if isinstance(result, list) else []
 
 
-EXPECTATION_OPERATORS = {"min", "max", "exists"}
+EXPECTATION_OPERATORS = {"min", "max", "exists", "contains"}
 
 
 def _decimal(value: typing.Any) -> Decimal | None:
@@ -259,6 +259,16 @@ def expectation_mismatch(actual: typing.Any, expected: typing.Any) -> str | None
             return f"exists requires a boolean operand, got {operand!r}"
         exists = actual is not None
         return None if exists == operand else f"expected value existence to be {operand!r}, got {exists!r}"
+
+    if "contains" in expected:
+        if len(expected) != 1:
+            return "contains cannot be combined with other expectation operators"
+        operand = expected["contains"]
+        if not isinstance(operand, str):
+            return f"contains requires a string operand, got {operand!r}"
+        if not isinstance(actual, str):
+            return f"contains requires a string actual value, got {actual!r}"
+        return None if operand in actual else f"expected {actual!r} to contain {operand!r}"
 
     actual_number = _decimal(actual)
     if actual_number is None:

--- a/desktop/macos/tests/test-fault-suite-launch-env.sh
+++ b/desktop/macos/tests/test-fault-suite-launch-env.sh
@@ -109,6 +109,7 @@ expected = {
     "OMI_PYTHON_API_URL": fault_url,
     "OMI_DESKTOP_API_URL": fault_url,
     "OMI_AUTH_API_URL": fault_url,
+    "OMI_FAULT_MODEL_AUTH_TOKEN": "omi-fault-model-token",
 }
 for key, value in expected.items():
     assert captured.get(key) == value, (key, captured.get(key), value)

--- a/desktop/macos/tests/test-omi-harness.sh
+++ b/desktop/macos/tests/test-omi-harness.sh
@@ -64,6 +64,14 @@ assert not module.expectation_matches({"result": {}}, {"result.id": {"exists": T
 assert module.expectation_matches({"result": {}}, {"result.id": {"exists": False}})
 assert not module.expectation_matches({"result": {"id": "memory-1"}}, {"result.id": {"exists": "yes"}})
 assert not module.expectation_matches({"result": {"id": 1}}, {"result.id": {"exists": True, "min": 1}})
+assert module.expectation_matches(
+    {"result": {"error_message": "backend request failed with HTTP 500"}},
+    {"result.error_message": {"contains": "HTTP 500"}},
+)
+assert not module.expectation_matches(
+    {"result": {"error_message": "bridge unavailable"}},
+    {"result.error_message": {"contains": "HTTP 500"}},
+)
 
 mismatch = module.expectation_mismatches(
     {"result": {"count": "1"}}, {"result.count": {"minimum": 1}}


### PR DESCRIPTION
## Summary

- let only the named non-production fault bundle use its inert harness model token, so fault injection reaches the configured remote 5xx backend without Firebase auth;
- require the fault flow to assert the actual injected HTTP 500 rather than a generic bridge failure;
- add regression coverage for the scope guard, launch environment, and harness string expectation.

## Product invariants affected

- INV-CHAT-1

## Verification

- `bash desktop/macos/tests/test-fault-suite-launch-env.sh`
- `bash desktop/macos/tests/test-omi-harness.sh`
- `swift test --filter AgentRuntimeProcessTests` — 62 passed

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
