### PR TITLE
fix(listen): preserve finalization after source close

### DIFF
--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -3,7 +3,7 @@ import asyncio
 import json
 import time
 from collections import deque
-from typing import Any, Coroutine, Dict, List, Optional, Set, TypedDict, cast
+from typing import Any, Dict, List, Optional, TypedDict, cast
 
 from fastapi import APIRouter
 from fastapi.websockets import WebSocketDisconnect, WebSocket
@@ -25,7 +25,7 @@ from utils.conversations.finalizer import (
     ConversationFinalizationError,
     finalize_persisted_conversation,
 )
-from utils.executors import db_executor, storage_executor, run_blocking
+from utils.executors import db_executor, storage_executor, run_blocking, start_background_task
 from utils.async_tasks import (
     supervise_tasks,
     drain_tasks,
@@ -135,10 +135,23 @@ async def _process_conversation_task(
         set_byok_uid(uid)
 
     async def send_result(result: Dict[str, Any]) -> None:
+        """Attempt the optional live acknowledgement after durable work.
+
+        The Firestore finalization transition is authoritative. A listener can
+        close after handing opcode 104 to pusher, so a failed result write must
+        never turn an already-completed durable job into a worker failure.
+        """
         data = bytearray()
         data.extend(struct.pack("I", 201))
         data.extend(bytes(json.dumps(result), "utf-8"))
-        await websocket.send_bytes(bytes(data))
+        try:
+            await websocket.send_bytes(bytes(data))
+        except (RuntimeError, WebSocketDisconnect):
+            logger.info(
+                'pusher finalization result undeliverable after source close uid=%s conversation=%s',
+                uid,
+                conversation_id,
+            )
 
     job_id: Optional[str] = None
     generation: Optional[int] = None
@@ -332,25 +345,6 @@ async def _websocket_util_trigger(
     except Exception:
         journey_attempt.finish('failure')
         raise
-
-    # Track background tasks to cancel on cleanup (prevents memory leaks from fire-and-forget tasks)
-    bg_tasks: Set[asyncio.Task[Any]] = set()
-
-    def spawn(coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any]:
-        """Create a tracked background task that will be cancelled on cleanup."""
-        task = asyncio.create_task(coro)
-        bg_tasks.add(task)
-
-        def on_done(t: asyncio.Task[Any]) -> None:
-            bg_tasks.discard(t)
-            if t.cancelled():
-                return
-            exc = t.exception()
-            if exc:
-                logger.error(f"Unhandled exception in background task: {exc} {uid}")
-
-        task.add_done_callback(on_done)
-        return task
 
     # Bounded queues — prevent unbounded memory growth during backpressure
     speaker_sample_queue: deque[_SpeakerSampleRequest] = deque(maxlen=SPEAKER_SAMPLE_QUEUE_WARN_SIZE)
@@ -672,7 +666,11 @@ async def _websocket_util_trigger(
                     dispatch_generation = res.get('dispatch_generation')
                     if conversation_id:
                         logger.info(f"Pusher received process_conversation request: {conversation_id} {uid}")
-                        spawn(
+                        # Durable finalization already has a Firestore owner. It
+                        # must survive an originating listen socket close after
+                        # this handoff, so pusher owns it at process scope. Its
+                        # lifespan drains tracked tasks on process shutdown.
+                        start_background_task(
                             _process_conversation_task(
                                 uid,
                                 conversation_id,
@@ -681,7 +679,8 @@ async def _websocket_util_trigger(
                                 byok_keys,
                                 finalization_job_id if isinstance(finalization_job_id, str) else None,
                                 dispatch_generation if isinstance(dispatch_generation, int) else None,
-                            )
+                            ),
+                            name=f'pusher_finalization:{uid}:{conversation_id}',
                         )
                     continue
 
@@ -855,9 +854,8 @@ async def _websocket_util_trigger(
         shutdown_event.set()
         websocket_active = False
 
-        all_to_cancel = list(bg_tasks) + [t for t in bg_main_tasks if not t.done()]
+        all_to_cancel = [t for t in bg_main_tasks if not t.done()]
         await drain_tasks(all_to_cancel, timeout=5.0, label="pusher_cleanup", cancel=True)
-        bg_tasks.clear()
 
         PUSHER_ACTIVE_WS_CONNECTIONS.dec()
 

--- a/backend/testing/listen_pusher_stack/README.md
+++ b/backend/testing/listen_pusher_stack/README.md
@@ -69,25 +69,27 @@ Scenarios:
 3. a stale empty desktop recording is removed by the next-session lifecycle path and creates no job;
 4. a pusher process loses the first 104 before claim, is restarted, and the
    live backend session replays the same job ID and dispatch generation exactly once.
-5. concurrent public `POST /v1/conversations/{id}/finalize` retries produce one
+5. source close immediately after the inline opcode-104 handoff waits until the
+   pusher connection cleanup has run, then proves the already-claimed durable
+   finalizer still completes without a later listen session;
+6. concurrent public `POST /v1/conversations/{id}/finalize` retries produce one
    opaque named task and one outbox job, prove the `AlreadyExists` boundary,
    then survive listener restart before the detached worker completes and safely
    ACKs a duplicate delivery. A bounded test-entrypoint read barrier makes the
    intended stale-read race deterministic without replacing the route,
    lifecycle transaction, or task construction;
-6. a session closes during the deferred pending-finalization window; the real
+7. a session closes during the deferred pending-finalization window; the real
    recovery path from #9960 enqueues one opaque Cloud Tasks task, then a real
    worker retry preserves `processing` until it completes the same job;
-7. a worker exhausting its two-attempt test budget atomically dead-letters the
+8. a worker exhausting its two-attempt test budget atomically dead-letters the
    job and marks the still-current conversation `failed`/`discarded`, while a
    later duplicate delivery is fenced;
-8. an integration failure after processing retries only durable fanout, never
+9. an integration failure after processing retries only durable fanout, never
    re-runs completed conversation processing.
 
-The inline compatibility coverage deliberately triggers stale live-session
-finalization before closing. A source close immediately after opcode 104 takes
-a different inline/BYOK cancellation path, tracked in #9995; only the detached
-Cloud Tasks scenarios assert clean-close durability.
+Inline source-close coverage uses a file-gated local provider leaf only to make
+the post-claim timing deterministic. It retains the real listener, pusher
+router, Firestore claim/completion, and connection cleanup paths.
 
 This complements, rather than replaces, the storage race test:
 

--- a/backend/testing/listen_pusher_stack/pusher_app.py
+++ b/backend/testing/listen_pusher_stack/pusher_app.py
@@ -8,6 +8,7 @@ call LLMs, vector stores, or user integrations.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from pathlib import Path
@@ -49,6 +50,13 @@ def _offline_extract_memories(_uid: str, _conversation: Any) -> None:
 
 
 async def _offline_trigger_integrations(_uid: str, conversation: Any, *, idempotency_key: str, **_kwargs: Any) -> None:
+    release_file = os.getenv('OMI_STACK_INLINE_FINALIZATION_RELEASE_FILE')
+    if release_file:
+        release_path = Path(release_file)
+        _record({'event': 'inline_finalization_hold_entered', 'conversation_id': str(conversation.id)})
+        while not release_path.exists():
+            await asyncio.sleep(0.01)
+        _record({'event': 'inline_finalization_hold_released', 'conversation_id': str(conversation.id)})
     _record(
         {
             'event': 'integration_fanout_skipped',
@@ -68,6 +76,7 @@ from routers import pusher as pusher_router  # noqa: E402  (patch finalizer firs
 
 _receive_bytes = pusher_router.WebSocket.receive_bytes
 _send_bytes = pusher_router.WebSocket.send_bytes
+_drain_tasks = pusher_router.drain_tasks
 
 
 def _offline_store_audio_chunks(chunks: list[dict[str, Any]], _uid: str, conversation_id: str, _level: str) -> None:
@@ -135,5 +144,15 @@ async def _observed_send_bytes(websocket: Any, data: bytes) -> None:
 
 pusher_router.WebSocket.receive_bytes = _observed_receive_bytes
 pusher_router.WebSocket.send_bytes = _observed_send_bytes
+
+
+async def _observed_drain_tasks(*args: Any, **kwargs: Any) -> int:
+    result = await _drain_tasks(*args, **kwargs)
+    if kwargs.get('label') == 'pusher_cleanup':
+        _record({'event': 'pusher_cleanup_completed'})
+    return result
+
+
+pusher_router.drain_tasks = _observed_drain_tasks
 
 from pusher.main import app  # noqa: E402

--- a/backend/testing/listen_pusher_stack/run.py
+++ b/backend/testing/listen_pusher_stack/run.py
@@ -120,11 +120,14 @@ class Stack:
         *,
         finalization_mode: str = 'inline',
         finalizer_failures: dict[str, int] | None = None,
+        hold_inline_finalization: bool = False,
         rest_finalization_race_uid: str | None = None,
         rest_finalization_race_parties: int = 0,
     ):
         if finalization_mode not in {'inline', 'cloud_tasks'}:
             raise ValueError(f'unsupported finalization mode: {finalization_mode}')
+        if hold_inline_finalization and finalization_mode != 'inline':
+            raise ValueError('inline finalization hold requires inline dispatch')
         if rest_finalization_race_parties and not rest_finalization_race_uid:
             raise ValueError('REST finalization race requires a target user')
         if rest_finalization_race_parties < 0:
@@ -135,6 +138,8 @@ class Stack:
         self.state_dir.mkdir(parents=True, exist_ok=True)
         self.finalization_mode = finalization_mode
         self.finalizer_failures = finalizer_failures or {}
+        self.hold_inline_finalization = hold_inline_finalization
+        self.inline_finalization_release_file = self.state_dir / 'release-inline-finalization'
         self.rest_finalization_race_uid = rest_finalization_race_uid
         self.rest_finalization_race_parties = rest_finalization_race_parties
         self.rest_finalization_race_conversation_id = (
@@ -208,6 +213,8 @@ class Stack:
                     'OMI_STACK_FINALIZATION_FAILURES': json.dumps(self.finalizer_failures, sort_keys=True),
                 }
             )
+        if self.hold_inline_finalization:
+            env['OMI_STACK_INLINE_FINALIZATION_RELEASE_FILE'] = str(self.inline_finalization_release_file)
         if self.rest_finalization_race_uid is not None and self.rest_finalization_race_conversation_id is not None:
             env.update(
                 {
@@ -496,6 +503,11 @@ class Stack:
             {'finished_at': datetime.now(timezone.utc) - timedelta(seconds=121)}
         )
 
+    def release_inline_finalization(self) -> None:
+        if not self.hold_inline_finalization:
+            raise StackFailure('inline finalization hold was not configured')
+        self.inline_finalization_release_file.touch()
+
 
 def _one_job(stack: Stack, uid: str, conversation_id: str) -> dict[str, Any]:
     jobs = stack.jobs_for(uid, conversation_id)
@@ -683,6 +695,55 @@ async def _normal_and_terminal_reconnect(stack: Stack) -> None:
     jobs = stack.jobs_for(uid, session_id)
     if len(jobs) != 1 or jobs[0].get('id') != job.get('id'):
         raise StackFailure('terminal reconnect changed the original durable finalization job')
+
+
+async def _inline_finalization_survives_source_close(stack: Stack) -> None:
+    """#9995: closing listen after 104 cannot cancel pusher's durable owner."""
+    if not stack.hold_inline_finalization:
+        raise StackFailure('inline source-close recovery requires a held finalizer')
+
+    uid = 'stack-inline-source-close'
+    conversation_id = str(uuid.uuid4())
+    stack.seed_user(uid)
+    websocket, _ = await _connect(stack, uid, conversation_id)
+    await _record_audio(websocket)
+    stack.age_conversation(uid, conversation_id)
+
+    def pusher_received_finalization() -> bool:
+        return any(
+            event.get('event') == 'frame'
+            and event.get('direction') == 'in'
+            and event.get('opcode') == 104
+            and event.get('conversation_id') == conversation_id
+            for event in stack.pusher_events
+        )
+
+    _wait_until(pusher_received_finalization, label='inline finalization handoff')
+    _wait_until(
+        lambda: any(
+            event.get('event') == 'inline_finalization_hold_entered' and event.get('conversation_id') == conversation_id
+            for event in stack.pusher_events
+        ),
+        label='claimed inline finalization hold',
+    )
+    processing = _wait_for_job(stack, uid, conversation_id, 'processing')
+    if processing.get('attempt_count') != 1:
+        raise StackFailure('source-close finalization was not claimed exactly once before disconnect')
+
+    await websocket.close(code=1000)
+    _wait_until(
+        lambda: any(event.get('event') == 'pusher_cleanup_completed' for event in stack.pusher_events),
+        label='source pusher cleanup',
+    )
+    stack.release_inline_finalization()
+
+    completed = _wait_for_job(stack, uid, conversation_id, 'completed')
+    conversation = stack.conversation(uid, conversation_id)
+    if completed.get('attempt_count') != 1 or completed.get('fanout_status') != 'completed':
+        raise StackFailure('source-close finalization did not complete the original durable job')
+    if not conversation or conversation.get('status') != 'completed':
+        raise StackFailure('source-close finalization did not complete its conversation without a later session')
+    _assert_local_provider_admission(stack, conversation_id)
 
 
 async def _empty_recording(stack: Stack) -> None:
@@ -1058,6 +1119,7 @@ def _run_stack_scenario(
     *,
     finalization_mode: str,
     finalizer_failures: dict[str, int] | None,
+    hold_inline_finalization: bool = False,
     rest_finalization_race_uid: str | None = None,
     rest_finalization_race_parties: int = 0,
     scenario: Callable[[Stack], Any],
@@ -1066,6 +1128,7 @@ def _run_stack_scenario(
         state_dir,
         finalization_mode=finalization_mode,
         finalizer_failures=finalizer_failures,
+        hold_inline_finalization=hold_inline_finalization,
         rest_finalization_race_uid=rest_finalization_race_uid,
         rest_finalization_race_parties=rest_finalization_race_parties,
     )
@@ -1091,6 +1154,13 @@ def main() -> int:
             finalization_mode='inline',
             finalizer_failures=None,
             scenario=run_inline_scenarios,
+        )
+        _run_stack_scenario(
+            state_dir / 'inline-source-close',
+            finalization_mode='inline',
+            finalizer_failures=None,
+            hold_inline_finalization=True,
+            scenario=_inline_finalization_survives_source_close,
         )
         _run_stack_scenario(
             state_dir / 'cloud-rest-restart',

--- a/backend/testing/listen_pusher_stack/run.py
+++ b/backend/testing/listen_pusher_stack/run.py
@@ -726,8 +726,10 @@ async def _inline_finalization_survives_source_close(stack: Stack) -> None:
         ),
         label='claimed inline finalization hold',
     )
-    processing = _wait_for_job(stack, uid, conversation_id, 'processing')
-    if processing.get('attempt_count') != 1:
+    # The durable claim transitions the job to 'leased' (the only non-terminal
+    # processing state); 'processing' is a conversation status, not a job status.
+    claimed = _wait_for_job(stack, uid, conversation_id, 'leased')
+    if claimed.get('attempt_count') != 1:
         raise StackFailure('source-close finalization was not claimed exactly once before disconnect')
 
     await websocket.close(code=1000)

--- a/backend/tests/unit/test_listen_finalization_cloud_tasks.py
+++ b/backend/tests/unit/test_listen_finalization_cloud_tasks.py
@@ -657,6 +657,35 @@ async def test_pusher_claims_the_durable_job_before_finalizing(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_pusher_keeps_a_completed_job_terminal_when_source_result_delivery_fails(monkeypatch):
+    """#9995: source disconnect after 104 cannot reclassify durable success."""
+    websocket = _PusherWebSocket()
+
+    async def closed_send(_payload: bytes) -> None:
+        raise RuntimeError('Cannot call send once closed')
+
+    websocket.send_bytes = closed_send
+    completed = MagicMock(return_value=True)
+    retryable = MagicMock()
+    monkeypatch.setattr(pusher_router, 'run_blocking', _inline_run_blocking)
+    monkeypatch.setattr(
+        jobs_db,
+        'claim_finalization_job',
+        lambda *args, **kwargs: {'status': 'claimed', 'lease_epoch': 7, 'attempt_count': 1},
+    )
+    monkeypatch.setattr(jobs_db, 'mark_finalization_completed', completed)
+    monkeypatch.setattr(jobs_db, 'mark_finalization_retryable', retryable)
+    monkeypatch.setattr(pusher_router, 'finalize_persisted_conversation', AsyncMock())
+
+    await pusher_router._process_conversation_task(
+        'uid-1', 'conversation-1', 'en', websocket, finalization_job_id='job-1', dispatch_generation=3
+    )
+
+    completed.assert_called_once_with('job-1', 3, 7)
+    retryable.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_pusher_closes_a_fenced_finalization_without_fanout(monkeypatch):
     websocket = _PusherWebSocket()
     monkeypatch.setattr(pusher_router, 'run_blocking', _inline_run_blocking)

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -161,10 +161,12 @@ This is the normal path when the client stays connected but stops speaking.
 **Key design rule (#6061):** Listen NEVER processes conversations locally.
 All conversation processing routes through pusher or the dedicated durable
 finalizer worker. Before either handoff, listen persists a Firestore
-finalization job. The legacy live pusher path claims that same job; when the
-durable dispatch flag is enabled, Cloud Tasks wakes the worker using only the
-opaque job id and generation. `pending_conversation_requests` remains a
-low-latency reconnect aid, not the durable source of truth.
+finalization job. The legacy live pusher path claims that same job and
+transfers it to pusher process-scoped ownership, so closing the originating
+listener after the opcode-104 handoff cannot cancel it. When the durable
+dispatch flag is enabled, Cloud Tasks wakes the worker using only the opaque
+job id and generation. `pending_conversation_requests` remains a low-latency
+reconnect aid, not the durable source of truth.
 
 Before a job can become `completed`, the finalizer atomically claims a durable
 fanout boundary with a persistent idempotency key. It passes that key to the


### PR DESCRIPTION
## Summary

- Keep inline/BYOK finalization under pusher process ownership after the originating listen WebSocket closes, instead of cancelling it during connection cleanup.
- Treat the opcode-201 live acknowledgement as best-effort so a closed source connection cannot reclassify an already-completed Firestore job as a worker failure.
- Add a deterministic hermetic listener → pusher → Firestore regression: claim a held job, close the source after opcode 104 and pusher cleanup, then prove the original job and conversation complete without another session.

## Product invariants affected

None.

## Failure class

Failure-Class: none

No existing failure class covers cancellation of durable work by the wrong WebSocket lifetime owner. This repair converges finalization on the existing process-scoped task owner and proves the real ownership boundary through the hermetic stack.

## Verification

- `backend/.venv/bin/pytest -q backend/tests/unit/test_listen_finalization_cloud_tasks.py` — 68 passed.
- `npm run test:listen-pusher-stack:emulator` — passed, including the new post-opcode-104 source-close scenario.
- `make preflight` — passed.
- `backend/test.sh` — ran the 683-file suite; one unrelated existing fast-unit timing guard failed in `tests/unit/test_audio_merge_tasks.py::TestEnqueueAudioMergeJob::test_schema_v2_task_named_by_conversation_and_fingerprint` (0.14s over its 0.12s budget). All targeted finalization tests above passed.

Closes #9995


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

