### PR TITLE
feat(monitoring): detect live transcript delivery failures

### DIFF
--- a/backend/charts/monitoring/README.md
+++ b/backend/charts/monitoring/README.md
@@ -549,6 +549,53 @@ Alerting is configured through Grafana unified alerting (not Prometheus AlertMan
 
 Loki ruler is configured to send alerts to AlertManager at `http://prod-kube-prometheus-stack-alertmanager:9093`.
 
+### Human-Impact Alert Contract
+
+Grafana rules are operational runbook entries, not raw metric dumps. The split files in `alerts/*.json` are the
+maintained sources; `alert-rules.json` is the canonical combined Grafana import. They must contain the same rules
+with byte-for-byte equal objects when indexed by stable Grafana UID. The deterministic monitoring contract test checks
+both exports, including duplicate UIDs, before a change can land.
+
+Every rule carries these notification fields:
+
+| Field | Purpose |
+|---|---|
+| `labels.alert_identity` | Stable Grafana rule UID for deduplication and cross-export matching. |
+| `labels.component` | Static affected Omi component. |
+| `labels.impact` | One of `infrastructure`, `product`, or `user-experience`. |
+| `annotations.summary` | A short human description of the condition. |
+| `annotations.user_impact` | What an Omi user may experience; state uncertainty when impact is only potential. |
+| `annotations.scope` | The bounded service or user path covered by the signal. |
+| `annotations.verification` | The next evidence to confirm before intervention. |
+| `annotations.safe_next_action` | The reversible, documented operator action after verification. |
+
+The tiers describe evidence, not paging severity:
+
+- `infrastructure`: capacity, readiness, resource, or scrape signals. They may warn before a user is affected.
+- `product`: evidence that an Omi service capability may fail, be delayed, or be unavailable.
+- `user-experience`: observed degradation of a real Omi user path.
+
+Product and user-experience rules must use production, real-traffic evidence. Do not treat synthetic checks, load tests,
+staging traffic, or an inferred proxy metric as proof of user impact. Infrastructure rules may use service-health metrics,
+but their `user_impact` annotation must make potential impact clear rather than claim a confirmed user outage.
+
+Never place raw provider responses, exception text, stack traces, or dynamic Grafana error output in these annotations.
+Keep the message human-readable and direct the operator to the linked dashboard for bounded verification. Do not change
+Grafana credentials, contact points, or routing configuration while adding a rule.
+
+Parakeet stream-capacity alerts use the existing `parakeet_active_streams` gauge divided by ready Parakeet replicas:
+
+```promql
+sum(parakeet_active_streams{container="parakeet", namespace="prod-omi-backend"})
+  / clamp_min(sum(kube_deployment_status_replicas_ready{
+      deployment="prod-omi-parakeet", namespace="prod-omi-backend"}), 1)
+```
+
+This avoids a cluster-total threshold that would become misleading as HPA replica count changes. The warning threshold is
+15 streams per ready replica for five minutes and the critical threshold is 20 for two minutes, both below the known
+approximately 25–30 stream per-replica capability. No-data is healthy for these capacity rules: absent metrics are not
+evidence of saturation.
+
 ## Dashboard & Metrics Lifecycle
 
 ### Approach: UI-First, Git-Backed

--- a/backend/charts/monitoring/README.md
+++ b/backend/charts/monitoring/README.md
@@ -594,7 +594,8 @@ sum(parakeet_active_streams{container="parakeet", namespace="prod-omi-backend"})
 This avoids a cluster-total threshold that would become misleading as HPA replica count changes. The warning threshold is
 15 streams per ready replica for five minutes and the critical threshold is 20 for two minutes, both below the known
 approximately 25–30 stream per-replica capability. No-data is healthy for these capacity rules: absent metrics are not
-evidence of saturation.
+evidence of saturation. Operator response is in
+[`parakeet-stream-capacity.md`](../../docs/runbooks/parakeet-stream-capacity.md).
 
 ## Dashboard & Metrics Lifecycle
 

--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -4476,7 +4476,8 @@
       "scope": "Production Parakeet streaming pods; active streams are averaged across ready replicas.",
       "verification": "Compare active streams and ready replicas in the Parakeet dashboard and confirm the condition persists for the alert duration.",
       "safe_next_action": "Allow the HPA to add healthy replicas first; investigate capacity only after checking replica readiness and the dashboard.",
-      "threshold": "15 active streams per ready replica"
+      "threshold": "15 active streams per ready replica",
+      "runbook": "backend/docs/runbooks/parakeet-stream-capacity.md"
     },
     "labels": {
       "instatus_component": "speech-processing",
@@ -4618,7 +4619,8 @@
       "scope": "Production Parakeet streaming pods; active streams are averaged across ready replicas.",
       "verification": "Compare active streams and ready replicas in the Parakeet dashboard and confirm the condition persists for the alert duration.",
       "safe_next_action": "Allow the HPA to add healthy replicas first; investigate capacity only after checking replica readiness and the dashboard.",
-      "threshold": "20 active streams per ready replica"
+      "threshold": "20 active streams per ready replica",
+      "runbook": "backend/docs/runbooks/parakeet-stream-capacity.md"
     },
     "labels": {
       "instatus_component": "speech-processing",
@@ -9047,6 +9049,145 @@
       "alert_identity": "omi-llm-gateway-no-ready-endpoints",
       "component": "ai-chat",
       "impact": "product"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-journey-live-transcription-fail",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Live transcription - terminal failure rate elevated",
+    "condition": "D",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"live_transcription\",outcome=~\"success|failure\"}[30m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"live_transcription\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"live_transcription\",outcome=~\"success|failure\"}[30m])), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A >= 20 && $B > 0.10",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "math"
+        }
+      },
+      {
+        "refId": "D",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "C",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "D",
+          "type": "reduce"
+        }
+      }
+    ],
+    "updated": "2026-07-20T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "7",
+      "summary": "Live-transcription terminal failures exceed 10% with at least 20 terminal real requests in 30m",
+      "threshold": "failure share > 0.10; terminal outcomes >= 20",
+      "user_impact": "Users may not receive live transcript text or may experience degraded results.",
+      "scope": "The Omi live-transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected live-transcription path; mitigate through the documented service runbook only after verification."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "live-transcription",
+      "alert_identity": "omi-journey-live-transcription-fail",
+      "component": "live-transcription",
+      "impact": "user-experience"
     },
     "isPaused": false,
     "notification_settings": {

--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -1,263 +1,6 @@
 [
   {
-    "uid": "dew91uem0dnggb",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Pusher",
-    "title": "Pusher RPS is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 900,
-          "to": 0
-        },
-        "datasourceUid": "prometheus",
-        "model": {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-pusher-2b11u6i0\"}[5m]))",
-          "instant": true,
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "A"
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "B"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  10
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "C"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
-    "execErrState": "Error",
-    "for": "5m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "42",
-      "threshold": "10"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
-    "uid": "few91zm7mujggb",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Pusher",
-    "title": "Pusher max concurrent requests are high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 900,
-          "to": 0
-        },
-        "datasourceUid": "prometheus",
-        "model": {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "max(pusher_active_ws_connections{pod=~\"prod-omi-pusher.*\"})",
-          "instant": true,
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "A"
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "B"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  30
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "C"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
-    "execErrState": "Error",
-    "for": "5m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "43",
-      "threshold": "30"
-    },
-    "isPaused": true,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
+    "id": 21,
     "uid": "cew923rcn3ncwb",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -371,22 +114,36 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:45Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "45",
-      "threshold": "1"
+      "__panelId__": "77",
+      "threshold": "1",
+      "summary": "Omi live transcription alert: Pusher - 4XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
+    "record": null,
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "live-transcription",
+      "alert_identity": "cew923rcn3ncwb",
+      "component": "live-transcription",
+      "impact": "product"
+    }
   },
   {
+    "id": 22,
     "uid": "aew926uoh6o00c",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -500,17 +257,27 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:45Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "3m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "45",
-      "threshold": "1"
+      "__panelId__": "77",
+      "threshold": "1",
+      "summary": "Omi live transcription alert: Pusher - 5XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "severity": "critical",
+      "alert_identity": "aew926uoh6o00c",
+      "component": "live-transcription",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -519,119 +286,12 @@
     "record": null
   },
   {
-    "uid": "dew92a2egu8sge",
+    "id": 19,
+    "uid": "dew91uem0dnggb",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
     "ruleGroup": "Pusher",
-    "title": "Pusher instance count is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "range",
-        "relativeTimeRange": {
-          "from": 600,
-          "to": 0
-        },
-        "datasourceUid": "prometheus",
-        "model": {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(kube_deployment_status_replicas{deployment=\"prod-omi-pusher\"})",
-          "instant": false,
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "A"
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  40
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "C"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
-    "execErrState": "Error",
-    "for": "5m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "69",
-      "threshold": "40"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
-    "uid": "bew9aeqgx2w3kf",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "VAD",
-    "title": "VAD RPS is high",
+    "title": "Pusher RPS is high",
     "condition": "C",
     "data": [
       {
@@ -647,7 +307,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-vad-snzro08u\"}[5m]))",
+          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-pusher-2b11u6i0\"}[5m]))",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -740,27 +400,163 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:45Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "49",
-      "threshold": "2"
+      "__panelId__": "75",
+      "threshold": "10",
+      "summary": "Omi live transcription alert: Pusher RPS is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "live-transcription",
+      "alert_identity": "dew91uem0dnggb",
+      "component": "live-transcription",
+      "impact": "infrastructure"
+    }
   },
   {
-    "uid": "eew9ai0vlsyrke",
+    "id": 23,
+    "uid": "dew92a2egu8sge",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
-    "ruleGroup": "VAD",
-    "title": "VAD request latency is high",
+    "ruleGroup": "Pusher",
+    "title": "Pusher instance count is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "range",
+        "relativeTimeRange": {
+          "from": 600,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(kube_deployment_status_replicas{deployment=\"prod-omi-pusher\"})",
+          "instant": false,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  40
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-20T02:27:46Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "79",
+      "threshold": "40",
+      "summary": "Omi live transcription alert: Pusher instance count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "live-transcription",
+      "alert_identity": "dew92a2egu8sge",
+      "component": "live-transcription",
+      "impact": "infrastructure"
+    }
+  },
+  {
+    "id": 20,
+    "uid": "few91zm7mujggb",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Pusher",
+    "title": "Pusher max concurrent requests are high",
     "condition": "C",
     "data": [
       {
@@ -776,7 +572,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.99, sum by (le)(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_bucket{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-vad-snzro08u\"}[5m])))",
+          "expr": "max(pusher_active_ws_connections{job=\"pusher-metrics\"})",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -838,7 +634,7 @@
             {
               "evaluator": {
                 "params": [
-                  2500
+                  30
                 ],
                 "type": "gt"
               },
@@ -869,22 +665,158 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T04:06:09Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "50",
-      "threshold": "2500ms (2.5s)"
+      "__panelId__": "88",
+      "threshold": "30",
+      "summary": "Omi live transcription alert: Pusher max concurrent requests are high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
-    "isPaused": true,
+    "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
+    "record": null,
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "live-transcription",
+      "alert_identity": "few91zm7mujggb",
+      "component": "live-transcription",
+      "impact": "infrastructure"
+    }
   },
   {
+    "uid": "bfobs1pusherdeg01",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Pusher",
+    "title": "Pusher - degraded session ratio high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "range",
+        "relativeTimeRange": {
+          "from": 600,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(pusher_sessions_degraded{job=\"backend-listen-metrics\"}) / clamp_min(sum(backend_listen_active_ws_connections{job=\"backend-listen-metrics\"}), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0.05
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-07-08T21:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "4",
+      "runbook": "backend/docs/runbooks/pusher-degraded.md",
+      "threshold": "0.05 (5% degraded sessions)",
+      "summary": "Omi live transcription alert: Pusher - degraded session ratio high.",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null,
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "live-transcription",
+      "alert_identity": "bfobs1pusherdeg01",
+      "component": "live-transcription",
+      "impact": "user-experience"
+    }
+  },
+  {
+    "id": 41,
     "uid": "dew9ala448r9cc",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -998,22 +930,36 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:39Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "51",
-      "threshold": "0.1"
+      "threshold": "0.1",
+      "summary": "Omi speech processing alert: VAD - 4XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
+    "record": null,
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "speech-processing",
+      "alert_identity": "dew9ala448r9cc",
+      "component": "speech-processing",
+      "impact": "product"
+    }
   },
   {
+    "id": 42,
     "uid": "few9anlyv16v4a",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -1127,6 +1073,7 @@
         }
       }
     ],
+    "updated": "2026-06-20T02:27:41Z",
     "noDataState": "Alerting",
     "execErrState": "Error",
     "for": "3m",
@@ -1134,10 +1081,19 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "51",
-      "threshold": "0.1"
+      "threshold": "0.1",
+      "summary": "Omi speech processing alert: VAD - 5XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
-      "instatus_component": "speech-processing"
+      "instatus_component": "speech-processing",
+      "severity": "critical",
+      "alert_identity": "few9anlyv16v4a",
+      "component": "speech-processing",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -1146,6 +1102,150 @@
     "record": null
   },
   {
+    "id": 39,
+    "uid": "bew9aeqgx2w3kf",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "VAD",
+    "title": "VAD RPS is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-vad-snzro08u\"}[5m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  10
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-23T01:20:17Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "49",
+      "threshold": "10",
+      "summary": "Omi speech processing alert: VAD RPS is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "speech-processing",
+      "alert_identity": "bew9aeqgx2w3kf",
+      "component": "speech-processing",
+      "impact": "infrastructure"
+    }
+  },
+  {
+    "id": 43,
     "uid": "cew9aupbed0xsd",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -1264,14 +1364,511 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:42Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "53",
-      "threshold": "3"
+      "threshold": "3",
+      "summary": "Omi speech processing alert: VAD replica count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "speech-processing",
+      "alert_identity": "cew9aupbed0xsd",
+      "component": "speech-processing",
+      "impact": "infrastructure"
+    }
+  },
+  {
+    "id": 40,
+    "uid": "eew9ai0vlsyrke",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "VAD",
+    "title": "VAD request latency is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le)(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_bucket{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-vad-snzro08u\"}[5m])))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  2500
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-20T02:27:42Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "50",
+      "threshold": "2500ms (2.5s)",
+      "summary": "Omi speech processing alert: VAD request latency is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null,
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "speech-processing",
+      "alert_identity": "eew9ai0vlsyrke",
+      "component": "speech-processing",
+      "impact": "product"
+    }
+  },
+  {
+    "id": 16,
+    "uid": "cew4j7ruiik1sd",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Backend",
+    "title": "Backend - 4XX error rate is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "timeSeriesList",
+        "relativeTimeRange": {
+          "from": 21600,
+          "to": 0
+        },
+        "datasourceUid": "beuxmaq8oxhq8e",
+        "model": {
+          "aliasBy": "4XX",
+          "datasource": {
+            "type": "stackdriver",
+            "uid": "beuxmaq8oxhq8e"
+          },
+          "instant": false,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "queryType": "timeSeriesList",
+          "range": true,
+          "refId": "A",
+          "timeSeriesList": {
+            "alignmentPeriod": "cloud-monitoring-auto",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "filters": [
+              "resource.label.backend_target_name",
+              "=",
+              "custom-domains-api-omi-me-backend-49a4-be",
+              "AND",
+              "metric.label.response_code_class",
+              "=",
+              "400",
+              "AND",
+              "metric.type",
+              "=",
+              "loadbalancing.googleapis.com/https/backend_request_count"
+            ],
+            "groupBys": [
+              "metric.label.response_code_class"
+            ],
+            "perSeriesAligner": "ALIGN_NONE",
+            "preprocessor": "rate",
+            "projectName": "based-hardware",
+            "view": "FULL"
+          }
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  5
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-23T01:27:10Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "4",
+      "threshold": "5 RPS 4xx",
+      "summary": "Omi API alert: Backend - 4XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null,
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "api",
+      "alert_identity": "cew4j7ruiik1sd",
+      "component": "api",
+      "impact": "product"
+    }
+  },
+  {
+    "id": 17,
+    "uid": "cew4jcnpa68sga",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Backend",
+    "title": "Backend - 5XX error rate is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "timeSeriesList",
+        "relativeTimeRange": {
+          "from": 21600,
+          "to": 0
+        },
+        "datasourceUid": "beuxmaq8oxhq8e",
+        "model": {
+          "aliasBy": "5XX",
+          "datasource": {
+            "type": "stackdriver",
+            "uid": "beuxmaq8oxhq8e"
+          },
+          "instant": false,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "queryType": "timeSeriesList",
+          "range": true,
+          "refId": "A",
+          "timeSeriesList": {
+            "alignmentPeriod": "cloud-monitoring-auto",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "filters": [
+              "resource.label.backend_target_name",
+              "=",
+              "custom-domains-api-omi-me-backend-49a4-be",
+              "AND",
+              "metric.label.response_code_class",
+              "=",
+              "500",
+              "AND",
+              "metric.type",
+              "=",
+              "loadbalancing.googleapis.com/https/backend_request_count"
+            ],
+            "groupBys": [
+              "metric.label.response_code_class"
+            ],
+            "perSeriesAligner": "ALIGN_NONE",
+            "preprocessor": "rate",
+            "projectName": "based-hardware",
+            "view": "FULL"
+          }
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "settings": {
+            "mode": ""
+          },
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  1
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-23T01:27:10Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "3m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "4",
+      "threshold": "1",
+      "summary": "Omi API alert: Backend - 5XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
+    },
+    "labels": {
+      "instatus_component": "api",
+      "severity": "critical",
+      "alert_identity": "cew4jcnpa68sga",
+      "component": "api",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -1280,6 +1877,156 @@
     "record": null
   },
   {
+    "id": 46,
+    "uid": "fewwk2goqfklcf",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Backend",
+    "title": "Backend - API Quota Exceeded (429)",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "range",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "aet29e27cgmwwc",
+        "model": {
+          "datasource": {
+            "type": "loki",
+            "uid": "aet29e27cgmwwc"
+          },
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "count(rate({service_name=~\"backend-listen\"} |~ `429.*(quota)` [5m])) or vector(0)",
+          "instant": true,
+          "intervalMs": 60000,
+          "maxDataPoints": 43200,
+          "queryType": "range",
+          "range": false,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "max"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "max",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  10
+                ],
+                "type": "gte"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-20T02:27:33Z",
+    "noDataState": "OK",
+    "execErrState": "OK",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "62",
+      "summary": "Omi API alert: Backend - API Quota Exceeded (429).",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
+    },
+    "labels": {
+      "instatus_component": "api",
+      "severity": "warning",
+      "alert_identity": "fewwk2goqfklcf",
+      "component": "api",
+      "impact": "product"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)",
+      "group_wait": "30s",
+      "group_interval": "5m",
+      "repeat_interval": "5m"
+    },
+    "record": null
+  },
+  {
+    "id": 14,
     "uid": "cew4a2kdopb0ga",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -1413,22 +2160,201 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-23T01:20:15Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "3",
-      "threshold": "100"
+      "threshold": "150",
+      "summary": "Omi API alert: Backend RPS is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "api",
+      "alert_identity": "cew4a2kdopb0ga",
+      "component": "api",
+      "impact": "infrastructure"
+    }
   },
   {
+    "id": 18,
+    "uid": "bew4jihxc1beob",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Backend",
+    "title": "Backend instance count is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "timeSeriesList",
+        "relativeTimeRange": {
+          "from": 21600,
+          "to": 0
+        },
+        "datasourceUid": "beuxmaq8oxhq8e",
+        "model": {
+          "aliasBy": "{{metric.label.state}}",
+          "datasource": {
+            "type": "stackdriver",
+            "uid": "beuxmaq8oxhq8e"
+          },
+          "instant": false,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "queryType": "timeSeriesList",
+          "range": true,
+          "refId": "A",
+          "timeSeriesList": {
+            "alignmentPeriod": "cloud-monitoring-auto",
+            "crossSeriesReducer": "REDUCE_MAX",
+            "filters": [
+              "resource.label.service_name",
+              "=",
+              "backend",
+              "AND",
+              "metric.type",
+              "=",
+              "run.googleapis.com/container/instance_count"
+            ],
+            "groupBys": [
+              "metric.label.state"
+            ],
+            "perSeriesAligner": "ALIGN_MEAN",
+            "preprocessor": "none",
+            "projectName": "based-hardware",
+            "view": "FULL"
+          }
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  80
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-20T02:27:34Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "5",
+      "threshold": "80 instances (80% of max)",
+      "summary": "Omi API alert: Backend instance count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "api",
+      "alert_identity": "bew4jihxc1beob",
+      "component": "api",
+      "impact": "infrastructure"
+    }
+  },
+  {
+    "id": 15,
     "uid": "bew4iwy0hzmyob",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -1572,627 +2498,36 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:34Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "6",
-      "threshold": "30"
+      "threshold": "30",
+      "summary": "Omi API alert: Backend max concurrent requests are high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
-  },
-  {
-    "uid": "cew4j7ruiik1sd",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Backend",
-    "title": "Backend - 4XX error rate is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "timeSeriesList",
-        "relativeTimeRange": {
-          "from": 21600,
-          "to": 0
-        },
-        "datasourceUid": "beuxmaq8oxhq8e",
-        "model": {
-          "aliasBy": "4XX",
-          "datasource": {
-            "type": "stackdriver",
-            "uid": "beuxmaq8oxhq8e"
-          },
-          "instant": false,
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "queryType": "timeSeriesList",
-          "range": true,
-          "refId": "A",
-          "timeSeriesList": {
-            "alignmentPeriod": "cloud-monitoring-auto",
-            "crossSeriesReducer": "REDUCE_SUM",
-            "filters": [
-              "resource.label.backend_target_name",
-              "=",
-              "custom-domains-api-omi-me-backend-49a4-be",
-              "AND",
-              "metric.label.response_code_class",
-              "=",
-              "400",
-              "AND",
-              "metric.type",
-              "=",
-              "loadbalancing.googleapis.com/https/backend_request_count"
-            ],
-            "groupBys": [
-              "metric.label.response_code_class"
-            ],
-            "perSeriesAligner": "ALIGN_NONE",
-            "preprocessor": "rate",
-            "projectName": "based-hardware",
-            "view": "FULL"
-          }
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "C"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  5
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "D"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "OK",
-    "execErrState": "Error",
-    "for": "5m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "4",
-      "threshold": "5 RPS 4xx"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
-    "uid": "cew4jcnpa68sga",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Backend",
-    "title": "Backend - 5XX error rate is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "timeSeriesList",
-        "relativeTimeRange": {
-          "from": 21600,
-          "to": 0
-        },
-        "datasourceUid": "beuxmaq8oxhq8e",
-        "model": {
-          "aliasBy": "5XX",
-          "datasource": {
-            "type": "stackdriver",
-            "uid": "beuxmaq8oxhq8e"
-          },
-          "instant": false,
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "queryType": "timeSeriesList",
-          "range": true,
-          "refId": "A",
-          "timeSeriesList": {
-            "alignmentPeriod": "cloud-monitoring-auto",
-            "crossSeriesReducer": "REDUCE_SUM",
-            "filters": [
-              "resource.label.backend_target_name",
-              "=",
-              "custom-domains-api-omi-me-backend-49a4-be",
-              "AND",
-              "metric.label.response_code_class",
-              "=",
-              "500",
-              "AND",
-              "metric.type",
-              "=",
-              "loadbalancing.googleapis.com/https/backend_request_count"
-            ],
-            "groupBys": [
-              "metric.label.response_code_class"
-            ],
-            "perSeriesAligner": "ALIGN_NONE",
-            "preprocessor": "rate",
-            "projectName": "based-hardware",
-            "view": "FULL"
-          }
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "C"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "settings": {
-            "mode": ""
-          },
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  1
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "D"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "OK",
-    "execErrState": "Error",
-    "for": "3m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "4",
-      "threshold": "1"
-    },
+    "record": null,
     "labels": {
-      "instatus_component": "api"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
+      "severity": "ticket",
+      "instatus_component": "api",
+      "alert_identity": "bew4iwy0hzmyob",
+      "component": "api",
+      "impact": "infrastructure"
+    }
   },
   {
-    "uid": "bew4jihxc1beob",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Backend",
-    "title": "Backend instance count is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "timeSeriesList",
-        "relativeTimeRange": {
-          "from": 21600,
-          "to": 0
-        },
-        "datasourceUid": "beuxmaq8oxhq8e",
-        "model": {
-          "aliasBy": "{{metric.label.state}}",
-          "datasource": {
-            "type": "stackdriver",
-            "uid": "beuxmaq8oxhq8e"
-          },
-          "instant": false,
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "queryType": "timeSeriesList",
-          "range": true,
-          "refId": "A",
-          "timeSeriesList": {
-            "alignmentPeriod": "cloud-monitoring-auto",
-            "crossSeriesReducer": "REDUCE_MAX",
-            "filters": [
-              "resource.label.service_name",
-              "=",
-              "backend",
-              "AND",
-              "metric.type",
-              "=",
-              "run.googleapis.com/container/instance_count"
-            ],
-            "groupBys": [
-              "metric.label.state"
-            ],
-            "perSeriesAligner": "ALIGN_MEAN",
-            "preprocessor": "none",
-            "projectName": "based-hardware",
-            "view": "FULL"
-          }
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "B"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  80
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "C"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
-    "execErrState": "Error",
-    "for": "5m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "5",
-      "threshold": "80 instances (80% of max)"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
-    "uid": "fewwk2goqfklcf",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Backend",
-    "title": "Backend - API Quota Exceeded (429)",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "range",
-        "relativeTimeRange": {
-          "from": 900,
-          "to": 0
-        },
-        "datasourceUid": "aet29e27cgmwwc",
-        "model": {
-          "datasource": {
-            "type": "loki",
-            "uid": "aet29e27cgmwwc"
-          },
-          "direction": "backward",
-          "editorMode": "code",
-          "expr": "count(rate({service_name=~\"backend-listen\"} |~ `429.*(quota)` [5m])) or vector(0)",
-          "instant": true,
-          "intervalMs": 60000,
-          "maxDataPoints": 43200,
-          "queryType": "range",
-          "range": false,
-          "refId": "A"
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "B"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "max"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "max",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  10
-                ],
-                "type": "gte"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "C"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
-    "execErrState": "OK",
-    "for": "5m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "62"
-    },
-    "labels": {
-      "instatus_component": "api"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)",
-      "group_wait": "30s",
-      "group_interval": "5m",
-      "repeat_interval": "5m"
-    },
-    "record": null
-  },
-  {
+    "id": 48,
     "uid": "afd0krbk1bugwf",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -2310,16 +2645,26 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:33Z",
+    "noDataState": "OK",
     "execErrState": "OK",
     "for": "5m",
     "keep_firing_for": "5m",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "62"
+      "__panelId__": "62",
+      "summary": "Omi API alert: OpenAI - Quota Exceeded.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
-      "instatus_component": "ai-chat"
+      "instatus_component": "api",
+      "severity": "ticket",
+      "alert_identity": "afd0krbk1bugwf",
+      "component": "api",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -2331,6 +2676,345 @@
     "record": null
   },
   {
+    "id": 33,
+    "uid": "cew97rzyegdtsa",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Backend-sync",
+    "title": "Backend-sync - 4XX error rate is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "timeSeriesList",
+        "relativeTimeRange": {
+          "from": 86400,
+          "to": 0
+        },
+        "datasourceUid": "beuxmaq8oxhq8e",
+        "model": {
+          "aliasBy": "4XX",
+          "datasource": {
+            "type": "stackdriver",
+            "uid": "beuxmaq8oxhq8e"
+          },
+          "instant": false,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "queryType": "timeSeriesList",
+          "range": true,
+          "refId": "A",
+          "timeSeriesList": {
+            "alignmentPeriod": "cloud-monitoring-auto",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "filters": [
+              "resource.label.backend_target_name",
+              "=",
+              "custom-domains-api-omi-me-backend-sync-49a4-be",
+              "AND",
+              "metric.label.response_code_class",
+              "=",
+              "400",
+              "AND",
+              "metric.type",
+              "=",
+              "loadbalancing.googleapis.com/https/backend_request_count"
+            ],
+            "groupBys": [
+              "metric.label.response_code_class"
+            ],
+            "perSeriesAligner": "ALIGN_NONE",
+            "preprocessor": "rate",
+            "projectName": "based-hardware",
+            "view": "FULL"
+          }
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  2
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-23T01:27:10Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "34",
+      "threshold": "2",
+      "summary": "Omi API alert: Backend-sync - 4XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "api",
+      "alert_identity": "cew97rzyegdtsa",
+      "component": "api",
+      "impact": "product"
+    }
+  },
+  {
+    "id": 34,
+    "uid": "cew97uqu791q8a",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Backend-sync",
+    "title": "Backend-sync - 5XX error rate is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "timeSeriesList",
+        "relativeTimeRange": {
+          "from": 86400,
+          "to": 0
+        },
+        "datasourceUid": "beuxmaq8oxhq8e",
+        "model": {
+          "aliasBy": "5XX",
+          "datasource": {
+            "type": "stackdriver",
+            "uid": "beuxmaq8oxhq8e"
+          },
+          "instant": false,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "queryType": "timeSeriesList",
+          "range": true,
+          "refId": "A",
+          "timeSeriesList": {
+            "alignmentPeriod": "cloud-monitoring-auto",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "filters": [
+              "resource.label.backend_target_name",
+              "=",
+              "custom-domains-api-omi-me-backend-sync-49a4-be",
+              "AND",
+              "metric.label.response_code_class",
+              "=",
+              "500",
+              "AND",
+              "metric.type",
+              "=",
+              "loadbalancing.googleapis.com/https/backend_request_count"
+            ],
+            "groupBys": [
+              "metric.label.response_code_class"
+            ],
+            "perSeriesAligner": "ALIGN_NONE",
+            "preprocessor": "rate",
+            "projectName": "based-hardware",
+            "view": "FULL"
+          }
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  2
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-23T01:27:10Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "3m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "34",
+      "threshold": "2",
+      "summary": "Omi API alert: Backend-sync - 5XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
+    },
+    "labels": {
+      "instatus_component": "api",
+      "severity": "critical",
+      "alert_identity": "cew97uqu791q8a",
+      "component": "api",
+      "impact": "product"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "id": 30,
     "uid": "cew97d5vd0ttse",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -2466,22 +3150,201 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:42Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "31",
-      "threshold": "5 RPS"
+      "threshold": "5 RPS",
+      "summary": "Omi API alert: Backend-sync RPS is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "api",
+      "alert_identity": "cew97d5vd0ttse",
+      "component": "api",
+      "impact": "infrastructure"
+    }
   },
   {
+    "id": 35,
+    "uid": "cew97x299of7kb",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Backend-sync",
+    "title": "Backend-sync instance count is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "timeSeriesList",
+        "relativeTimeRange": {
+          "from": 86400,
+          "to": 0
+        },
+        "datasourceUid": "beuxmaq8oxhq8e",
+        "model": {
+          "aliasBy": "{{metric.label.state}}",
+          "datasource": {
+            "type": "stackdriver",
+            "uid": "beuxmaq8oxhq8e"
+          },
+          "instant": false,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "queryType": "timeSeriesList",
+          "range": true,
+          "refId": "A",
+          "timeSeriesList": {
+            "alignmentPeriod": "cloud-monitoring-auto",
+            "crossSeriesReducer": "REDUCE_MAX",
+            "filters": [
+              "resource.label.service_name",
+              "=",
+              "backend-sync",
+              "AND",
+              "metric.type",
+              "=",
+              "run.googleapis.com/container/instance_count"
+            ],
+            "groupBys": [
+              "metric.label.state"
+            ],
+            "perSeriesAligner": "ALIGN_MEAN",
+            "preprocessor": "none",
+            "projectName": "based-hardware",
+            "view": "FULL"
+          }
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  20
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-20T02:27:43Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "36",
+      "threshold": "20 instances (80% of max)",
+      "summary": "Omi API alert: Backend-sync instance count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "api",
+      "alert_identity": "cew97x299of7kb",
+      "component": "api",
+      "impact": "infrastructure"
+    }
+  },
+  {
+    "id": 31,
     "uid": "dew97fqr33oxsd",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -2625,541 +3488,60 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:43Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "32",
-      "threshold": "30"
+      "threshold": "30",
+      "summary": "Omi API alert: Backend-sync max concurrent requests are high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
-  },
-  {
-    "uid": "bew97osjuu22of",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Backend-sync",
-    "title": "Backend-sync request latency is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "timeSeriesList",
-        "relativeTimeRange": {
-          "from": 86400,
-          "to": 0
-        },
-        "datasourceUid": "beuxmaq8oxhq8e",
-        "model": {
-          "aliasBy": "p99",
-          "datasource": {
-            "type": "stackdriver",
-            "uid": "beuxmaq8oxhq8e"
-          },
-          "instant": false,
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "queryType": "timeSeriesList",
-          "range": true,
-          "refId": "A",
-          "timeSeriesList": {
-            "alignmentPeriod": "cloud-monitoring-auto",
-            "crossSeriesReducer": "REDUCE_PERCENTILE_99",
-            "filters": [
-              "resource.label.location",
-              "=",
-              "us-central1",
-              "AND",
-              "resource.label.project_id",
-              "=",
-              "based-hardware",
-              "AND",
-              "resource.label.service_name",
-              "=",
-              "backend-sync",
-              "AND",
-              "metric.type",
-              "=",
-              "run.googleapis.com/request_latencies"
-            ],
-            "groupBys": [
-              "resource.label.service_name"
-            ],
-            "perSeriesAligner": "ALIGN_SUM",
-            "preprocessor": "none",
-            "projectName": "based-hardware",
-            "view": "FULL"
-          }
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "D"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  180000
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "E"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
-    "execErrState": "Error",
-    "for": "5m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "33",
-      "threshold": "180000ms (3m)"
-    },
-    "isPaused": true,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
-    "uid": "cew97rzyegdtsa",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Backend-sync",
-    "title": "Backend-sync - 4XX error rate is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "timeSeriesList",
-        "relativeTimeRange": {
-          "from": 86400,
-          "to": 0
-        },
-        "datasourceUid": "beuxmaq8oxhq8e",
-        "model": {
-          "aliasBy": "4XX",
-          "datasource": {
-            "type": "stackdriver",
-            "uid": "beuxmaq8oxhq8e"
-          },
-          "instant": false,
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "queryType": "timeSeriesList",
-          "range": true,
-          "refId": "A",
-          "timeSeriesList": {
-            "alignmentPeriod": "cloud-monitoring-auto",
-            "crossSeriesReducer": "REDUCE_SUM",
-            "filters": [
-              "resource.label.backend_target_name",
-              "=",
-              "custom-domains-api-omi-me-backend-sync-49a4-be",
-              "AND",
-              "metric.label.response_code_class",
-              "=",
-              "400",
-              "AND",
-              "metric.type",
-              "=",
-              "loadbalancing.googleapis.com/https/backend_request_count"
-            ],
-            "groupBys": [
-              "metric.label.response_code_class"
-            ],
-            "perSeriesAligner": "ALIGN_NONE",
-            "preprocessor": "rate",
-            "projectName": "based-hardware",
-            "view": "FULL"
-          }
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "C"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  2
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "D"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "OK",
-    "execErrState": "Error",
-    "for": "5m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "34",
-      "threshold": "1"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
-    "uid": "cew97uqu791q8a",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Backend-sync",
-    "title": "Backend-sync - 5XX error rate is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "timeSeriesList",
-        "relativeTimeRange": {
-          "from": 86400,
-          "to": 0
-        },
-        "datasourceUid": "beuxmaq8oxhq8e",
-        "model": {
-          "aliasBy": "5XX",
-          "datasource": {
-            "type": "stackdriver",
-            "uid": "beuxmaq8oxhq8e"
-          },
-          "instant": false,
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "queryType": "timeSeriesList",
-          "range": true,
-          "refId": "A",
-          "timeSeriesList": {
-            "alignmentPeriod": "cloud-monitoring-auto",
-            "crossSeriesReducer": "REDUCE_SUM",
-            "filters": [
-              "resource.label.backend_target_name",
-              "=",
-              "custom-domains-api-omi-me-backend-sync-49a4-be",
-              "AND",
-              "metric.label.response_code_class",
-              "=",
-              "500",
-              "AND",
-              "metric.type",
-              "=",
-              "loadbalancing.googleapis.com/https/backend_request_count"
-            ],
-            "groupBys": [
-              "metric.label.response_code_class"
-            ],
-            "perSeriesAligner": "ALIGN_SUM",
-            "preprocessor": "rate",
-            "projectName": "based-hardware",
-            "view": "FULL"
-          }
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "C"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  2
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "D"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "OK",
-    "execErrState": "Error",
-    "for": "3m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "34",
-      "threshold": "1"
-    },
+    "record": null,
     "labels": {
-      "instatus_component": "api"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
+      "severity": "ticket",
+      "instatus_component": "api",
+      "alert_identity": "dew97fqr33oxsd",
+      "component": "api",
+      "impact": "infrastructure"
+    }
   },
   {
-    "uid": "cew97x299of7kb",
+    "uid": "bfobs1syncenq01",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
     "ruleGroup": "Backend-sync",
-    "title": "Backend-sync instance count is high",
+    "title": "Backend-sync - sync enqueue uncertainty share high",
     "condition": "C",
     "data": [
       {
         "refId": "A",
-        "queryType": "timeSeriesList",
+        "queryType": "range",
         "relativeTimeRange": {
-          "from": 86400,
+          "from": 600,
           "to": 0
         },
-        "datasourceUid": "beuxmaq8oxhq8e",
+        "datasourceUid": "prometheus",
         "model": {
-          "aliasBy": "{{metric.label.state}}",
           "datasource": {
-            "type": "stackdriver",
-            "uid": "beuxmaq8oxhq8e"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
-          "instant": false,
+          "expr": "sum(rate(omi_sync_dispatch_attempts_total{mode=\"enqueue_uncertain\"}[10m])) / clamp_min(sum(rate(omi_sync_dispatch_attempts_total[10m])), 1e-9)",
+          "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
-          "queryType": "timeSeriesList",
-          "range": true,
-          "refId": "A",
-          "timeSeriesList": {
-            "alignmentPeriod": "cloud-monitoring-auto",
-            "crossSeriesReducer": "REDUCE_MAX",
-            "filters": [
-              "resource.label.service_name",
-              "=",
-              "backend-sync",
-              "AND",
-              "metric.type",
-              "=",
-              "run.googleapis.com/container/instance_count"
-            ],
-            "groupBys": [
-              "metric.label.state"
-            ],
-            "perSeriesAligner": "ALIGN_MEAN",
-            "preprocessor": "none",
-            "projectName": "based-hardware",
-            "view": "FULL"
-          }
+          "refId": "A"
         }
       },
       {
@@ -3171,27 +3553,6 @@
         },
         "datasourceUid": "__expr__",
         "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "B"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
           "datasource": {
             "type": "__expr__",
             "uid": "__expr__"
@@ -3217,7 +3578,7 @@
             {
               "evaluator": {
                 "params": [
-                  20
+                  0.2
                 ],
                 "type": "gt"
               },
@@ -3248,22 +3609,37 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-07-08T21:00:00Z",
+    "noDataState": "OK",
     "execErrState": "Error",
-    "for": "5m",
+    "for": "10m",
     "keep_firing_for": "0s",
     "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "36",
-      "threshold": "20 instances (80% of max)"
+      "runbook": "backend/docs/runbooks/sync-dispatch-fallback.md",
+      "summary": "Paused: backend-sync metrics not scraped by GKE Prometheus — use Cloud Logging",
+      "threshold": "0.2 (20% enqueue uncertainty)",
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "3",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
+    "record": null,
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "api",
+      "alert_identity": "bfobs1syncenq01",
+      "component": "api",
+      "impact": "product"
+    }
   },
   {
+    "id": 57,
     "uid": "dfpgfzd3t1m9sf",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -3284,7 +3660,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-parakeet-g38rzz69\",response_code_class=\"500\"}[5m])) or vector(0)",
+          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=~\".*prod-omi-parakeet.*\",response_code_class=\"500\"}[5m])) or vector(0)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -3377,17 +3753,27 @@
         }
       }
     ],
+    "updated": "2026-06-20T02:27:44Z",
     "noDataState": "Alerting",
     "execErrState": "Error",
     "for": "3m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
-      "__panelId__": "7",
-      "threshold": "0.1"
+      "__panelId__": "122",
+      "threshold": "0.1",
+      "summary": "Omi speech processing alert: Parakeet - 5XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
-      "instatus_component": "speech-processing"
+      "instatus_component": "speech-processing",
+      "severity": "critical",
+      "alert_identity": "dfpgfzd3t1m9sf",
+      "component": "speech-processing",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -3396,12 +3782,13 @@
     "record": null
   },
   {
-    "uid": "efpgg049laqyof",
+    "id": 61,
+    "uid": "efpossz9hmsqod",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
     "ruleGroup": "Parakeet",
-    "title": "Parakeet - request latency is high",
-    "condition": "C",
+    "title": "Parakeet - LB 5XX error ratio is critical",
+    "condition": "D",
     "data": [
       {
         "refId": "A",
@@ -3416,7 +3803,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.99, sum by (le)(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_bucket{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-parakeet-g38rzz69\"}[5m])))",
+          "expr": "(sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=~\".*prod-omi-parakeet.*\",response_code_class=\"500\"}[5m])) or vector(0)) / (sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=~\".*prod-omi-parakeet.*\"}[5m])) > 0)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -3425,118 +3812,6 @@
       },
       {
         "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "B"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  30000
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "C"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
-    "execErrState": "Error",
-    "for": "5m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
-      "__panelId__": "6",
-      "threshold": "30000ms"
-    },
-    "labels": {
-      "instatus_component": "speech-processing"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
-    "uid": "efpgg1kfjglj4d",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Parakeet",
-    "title": "Parakeet RPS is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
         "queryType": "",
         "relativeTimeRange": {
           "from": 900,
@@ -3548,53 +3823,11 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=\"k8s2-fr-heiog7uv-prod-omi-backend-prod-omi-parakeet-g38rzz69\"}[5m]))",
+          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=~\".*prod-omi-parakeet.*\"}[5m]))",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
-          "refId": "A"
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "B"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
+          "refId": "B"
         }
       },
       {
@@ -3606,12 +3839,30 @@
         },
         "datasourceUid": "__expr__",
         "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A > 0.01 && $B > 0.5",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "math"
+        }
+      },
+      {
+        "refId": "D",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
           "conditions": [
             {
               "evaluator": {
-                "params": [
-                  5
-                ],
+                "params": [],
                 "type": "gt"
               },
               "operator": {
@@ -3619,7 +3870,7 @@
               },
               "query": {
                 "params": [
-                  "C"
+                  "D"
                 ]
               },
               "reducer": {
@@ -3633,25 +3884,36 @@
             "type": "__expr__",
             "uid": "__expr__"
           },
-          "expression": "B",
+          "expression": "C",
           "intervalMs": 1000,
           "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
+          "reducer": "last",
+          "refId": "D",
+          "type": "reduce"
         }
       }
     ],
+    "updated": "2026-06-20T08:36:19Z",
     "noDataState": "Alerting",
     "execErrState": "Error",
-    "for": "5m",
+    "for": "2m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
-      "__panelId__": "5",
-      "threshold": "5 req/s"
+      "__panelId__": "122",
+      "summary": "5xx errors exceed 1% of Parakeet LB traffic (min 30 req/min gate)",
+      "threshold": "0.01",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
-      "instatus_component": "speech-processing"
+      "instatus_component": "speech-processing",
+      "severity": "critical",
+      "alert_identity": "efpossz9hmsqod",
+      "component": "speech-processing",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -3660,6 +3922,7 @@
     "record": null
   },
   {
+    "id": 60,
     "uid": "efpnx71qc88aob",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -3773,16 +4036,26 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:28:35Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "0s",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
-      "__panelId__": "113"
+      "__panelId__": "21",
+      "summary": "Omi speech processing alert: Parakeet - pod restart detected (possible OOMKill).",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "labels": {
-      "instatus_component": "speech-processing"
+      "instatus_component": "speech-processing",
+      "severity": "warning",
+      "alert_identity": "efpnx71qc88aob",
+      "component": "speech-processing",
+      "impact": "infrastructure"
     },
     "isPaused": false,
     "notification_settings": {
@@ -3791,42 +4064,887 @@
     "record": null
   },
   {
-    "uid": "cevyjulzz5pmob",
+    "id": 58,
+    "uid": "efpgg049laqyof",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Transcription Services",
-    "title": "Deepgram Engine active requests are high",
+    "ruleGroup": "Parakeet",
+    "title": "Parakeet - request latency is high",
     "condition": "C",
     "data": [
       {
         "refId": "A",
         "queryType": "",
         "relativeTimeRange": {
-          "from": 21600,
+          "from": 900,
           "to": 0
         },
         "datasourceUid": "prometheus",
         "model": {
-          "adhocFilters": [],
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum by(kind) (engine_active_requests)",
-          "format": "time_series",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
+          "expr": "histogram_quantile(0.99, sum by (le)(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_bucket{forwarding_rule_name=~\".*prod-omi-parakeet.*\"}[5m])))",
           "instant": true,
-          "interval": "",
-          "intervalMs": 30000,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  30000
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-20T02:27:44Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
+      "__panelId__": "123",
+      "threshold": "30000ms",
+      "summary": "Omi speech processing alert: Parakeet - request latency is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
+    },
+    "labels": {
+      "instatus_component": "speech-processing",
+      "severity": "warning",
+      "alert_identity": "efpgg049laqyof",
+      "component": "speech-processing",
+      "impact": "product"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "id": 59,
+    "uid": "efpgg1kfjglj4d",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Parakeet",
+    "title": "Parakeet RPS is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_count{forwarding_rule_name=~\".*prod-omi-parakeet.*\"}[5m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  5
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-20T02:27:44Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
+      "__panelId__": "122",
+      "threshold": "5 req/s",
+      "summary": "Omi speech processing alert: Parakeet RPS is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
+    },
+    "labels": {
+      "instatus_component": "speech-processing",
+      "severity": "warning",
+      "alert_identity": "efpgg1kfjglj4d",
+      "component": "speech-processing",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-parakeet-stream-capacity-warning",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Parakeet",
+    "title": "Parakeet - streaming capacity headroom reduced",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(parakeet_active_streams{container=\"parakeet\", namespace=\"prod-omi-backend\"}) / clamp_min(sum(kube_deployment_status_replicas_ready{deployment=\"prod-omi-parakeet\", namespace=\"prod-omi-backend\"}), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  15
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-07-20T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
+      "__panelId__": "3",
+      "summary": "Parakeet streaming capacity is above the warning headroom per ready replica.",
+      "user_impact": "Live transcription may slow down or reject new streams if traffic continues to rise.",
+      "scope": "Production Parakeet streaming pods; active streams are averaged across ready replicas.",
+      "verification": "Compare active streams and ready replicas in the Parakeet dashboard and confirm the condition persists for the alert duration.",
+      "safe_next_action": "Allow the HPA to add healthy replicas first; investigate capacity only after checking replica readiness and the dashboard.",
+      "threshold": "15 active streams per ready replica"
+    },
+    "labels": {
+      "instatus_component": "speech-processing",
+      "severity": "warning",
+      "alert_identity": "omi-parakeet-stream-capacity-warning",
+      "component": "speech-processing",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-parakeet-stream-capacity-critical",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Parakeet",
+    "title": "Parakeet - streaming capacity near critical limit",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(parakeet_active_streams{container=\"parakeet\", namespace=\"prod-omi-backend\"}) / clamp_min(sum(kube_deployment_status_replicas_ready{deployment=\"prod-omi-parakeet\", namespace=\"prod-omi-backend\"}), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  20
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-07-20T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "2m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
+      "__panelId__": "3",
+      "summary": "Parakeet streaming capacity is near the critical per-replica limit.",
+      "user_impact": "Live transcription may be delayed or unable to accept new streams while existing sessions are protected.",
+      "scope": "Production Parakeet streaming pods; active streams are averaged across ready replicas.",
+      "verification": "Compare active streams and ready replicas in the Parakeet dashboard and confirm the condition persists for the alert duration.",
+      "safe_next_action": "Allow the HPA to add healthy replicas first; investigate capacity only after checking replica readiness and the dashboard.",
+      "threshold": "20 active streams per ready replica"
+    },
+    "labels": {
+      "instatus_component": "speech-processing",
+      "severity": "critical",
+      "alert_identity": "omi-parakeet-stream-capacity-critical",
+      "component": "speech-processing",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "id": 8,
+    "uid": "bevzeigrns5xca",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Transcription Services",
+    "title": "Backend-listen - 4XX error rate is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{backend_target_name=\"custom-domains-api-omi-me-backend-listen-49a4-be\", response_code_class=\"400\"}[5m])) or vector(0)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  1
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-20T02:27:38Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "19",
+      "threshold": "1",
+      "summary": "Omi live transcription alert: Backend-listen - 4XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null,
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "live-transcription",
+      "alert_identity": "bevzeigrns5xca",
+      "component": "live-transcription",
+      "impact": "product"
+    }
+  },
+  {
+    "id": 9,
+    "uid": "cevzen5b94z5sb",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Transcription Services",
+    "title": "Backend-listen - 5XX error rate is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{backend_target_name=\"custom-domains-api-omi-me-backend-listen-49a4-be\", response_code_class=\"500\"}[5m])) or vector(0)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  1
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-20T02:27:37Z",
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "3m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "19",
+      "threshold": "1",
+      "summary": "Omi live transcription alert: Backend-listen - 5XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
+    },
+    "labels": {
+      "instatus_component": "live-transcription",
+      "severity": "critical",
+      "alert_identity": "cevzen5b94z5sb",
+      "component": "live-transcription",
+      "impact": "product"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "id": 45,
+    "uid": "eew9yw583gnwgd",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Transcription Services",
+    "title": "Backend-listen Memory usage is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 600,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "editorMode": "code",
+          "expr": "sum(\n    container_memory_working_set_bytes{namespace=\"prod-omi-backend\", container!=\"\", image!=\"\", service=\"prod-kube-prometheus-stack-kubelet\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace=\"prod-omi-backend\", workload=\"prod-omi-backend-listen\", workload_type=~\"deployment\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", namespace=\"prod-omi-backend\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace=\"prod-omi-backend\", workload=\"prod-omi-backend-listen\", workload_type=~\"deployment\"}\n) by (pod)\n",
+          "instant": true,
+          "intervalMs": 1000,
           "legendFormat": "__auto",
           "maxDataPoints": 43200,
           "range": false,
-          "refId": "A",
-          "useBackend": false
+          "refId": "A"
         }
       },
       {
@@ -3868,11 +4986,8 @@
           "expression": "A",
           "intervalMs": 1000,
           "maxDataPoints": 43200,
-          "reducer": "sum",
+          "reducer": "last",
           "refId": "B",
-          "settings": {
-            "mode": ""
-          },
           "type": "reduce"
         }
       },
@@ -3889,7 +5004,7 @@
             {
               "evaluator": {
                 "params": [
-                  400,
+                  0.8,
                   0
                 ],
                 "type": "gt"
@@ -3920,560 +5035,36 @@
         }
       }
     ],
-    "noDataState": "Alerting",
-    "execErrState": "Error",
-    "for": "10m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "10",
-      "threshold": "300"
-    },
-    "isPaused": true,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
-    "uid": "bevykefxxe0owd",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Transcription Services",
-    "title": "Deepgram Engine stream latency by p99 is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 21600,
-          "to": 0
-        },
-        "datasourceUid": "prometheus",
-        "model": {
-          "adhocFilters": [],
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(engine_stream_latency_bucket[5m]))) or vector(0)",
-          "instant": false,
-          "interval": "",
-          "intervalMs": 30000,
-          "legendFormat": "p99",
-          "maxDataPoints": 43200,
-          "range": true,
-          "refId": "A"
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "H"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  2
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "I"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-23T01:20:17Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "11",
-      "threshold": "2s"
+      "__dashboardUid__": "855b2e16-c098-407a-85dc-dc9ce87698a9",
+      "__panelId__": "9",
+      "threshold": "0.8 (80%)",
+      "summary": "Omi live transcription alert: Backend-listen Memory usage is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null,
     "labels": {
-      "instatus_component": "live-transcription"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
+      "severity": "warning",
+      "instatus_component": "live-transcription",
+      "alert_identity": "eew9yw583gnwgd",
+      "component": "live-transcription",
+      "impact": "infrastructure"
+    }
   },
   {
-    "uid": "devzd05c0bocgc",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Transcription Services",
-    "title": "Transcription Service Error Rate",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "range",
-        "relativeTimeRange": {
-          "from": 21600,
-          "to": 0
-        },
-        "datasourceUid": "aet29e27cgmwwc",
-        "model": {
-          "datasource": {
-            "type": "loki",
-            "uid": "aet29e27cgmwwc"
-          },
-          "direction": "backward",
-          "editorMode": "code",
-          "expr": "count(rate({service_name=\"backend-listen\"} |= `ASGI callable returned without sending` [$__auto])) or vector(0)",
-          "instant": true,
-          "intervalMs": 1000,
-          "legendFormat": "Handshake failure",
-          "maxDataPoints": 43200,
-          "queryType": "range",
-          "range": false,
-          "refId": "A"
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "C"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "settings": {
-            "mode": ""
-          },
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  2
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "D"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
-    "execErrState": "Error",
-    "for": "5m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "60",
-      "threshold": "2"
-    },
-    "labels": {
-      "instatus_component": "live-transcription"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
-    "uid": "bevzeigrns5xca",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Transcription Services",
-    "title": "Backend-listen - 4XX error rate is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 900,
-          "to": 0
-        },
-        "datasourceUid": "prometheus",
-        "model": {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(rate(stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{response_code_class=\"400\"}[5m])) or vector(0)",
-          "instant": true,
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "A"
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "B"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  1
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "C"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
-    "execErrState": "Error",
-    "for": "5m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "19",
-      "threshold": "1"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
-    "uid": "cevzen5b94z5sb",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Transcription Services",
-    "title": "Backend-listen - 5XX error rate is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 900,
-          "to": 0
-        },
-        "datasourceUid": "prometheus",
-        "model": {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(rate(stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{response_code_class=\"500\"}[5m])) or vector(0)",
-          "instant": true,
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "A"
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "B"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  1
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "C"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
-    "execErrState": "Error",
-    "for": "3m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "19",
-      "threshold": "1"
-    },
-    "labels": {
-      "instatus_component": "live-transcription"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
+    "id": 10,
     "uid": "aevzf0r8z6ayoe",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -4592,22 +5183,36 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:38Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "21",
-      "threshold": "50"
+      "threshold": "50",
+      "summary": "Omi live transcription alert: Backend-listen replica count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "live-transcription",
+      "alert_identity": "aevzf0r8z6ayoe",
+      "component": "live-transcription",
+      "impact": "infrastructure"
+    }
   },
   {
+    "id": 11,
     "uid": "bevzfbkx3fuo0c",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -4726,159 +5331,36 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:38Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "855b2e16-c098-407a-85dc-dc9ce87698a9",
       "__panelId__": "15",
-      "threshold": "8"
+      "threshold": "8",
+      "summary": "Omi live transcription alert: Backend-listen request per pod is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
-  },
-  {
-    "uid": "eevzfhdmz07b4a",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Transcription Services",
-    "title": "Backend-listen response code 500 is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 21600,
-          "to": 0
-        },
-        "datasourceUid": "prometheus",
-        "model": {
-          "adhocFilters": [],
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler=\"prod-omi-backend-listen\",metric_name=\"backend_listen_response_code_500\"}",
-          "instant": false,
-          "interval": "",
-          "intervalMs": 30000,
-          "legendFormat": "{{metric_name}} - Current",
-          "maxDataPoints": 43200,
-          "range": true,
-          "refId": "A"
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "E"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  10
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "F"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
-    "execErrState": "Error",
-    "for": "3m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "22",
-      "threshold": "10"
-    },
+    "record": null,
     "labels": {
-      "instatus_component": "live-transcription"
-    },
-    "isPaused": true,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
+      "severity": "warning",
+      "instatus_component": "live-transcription",
+      "alert_identity": "bevzfbkx3fuo0c",
+      "component": "live-transcription",
+      "impact": "infrastructure"
+    }
   },
   {
+    "id": 13,
     "uid": "fevzfwkmrjncwc",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -5004,45 +5486,65 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:39Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "10m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "13",
-      "threshold": "5"
+      "threshold": "5",
+      "summary": "Omi live transcription alert: Deepgram Engine replica count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "live-transcription",
+      "alert_identity": "fevzfwkmrjncwc",
+      "component": "live-transcription",
+      "impact": "infrastructure"
+    }
   },
   {
-    "uid": "eew9yw583gnwgd",
+    "id": 5,
+    "uid": "bevykefxxe0owd",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
     "ruleGroup": "Transcription Services",
-    "title": "Backend-listen Memory usage is high",
+    "title": "Deepgram Engine stream latency by p99 is high",
     "condition": "C",
     "data": [
       {
         "refId": "A",
         "queryType": "",
         "relativeTimeRange": {
-          "from": 600,
+          "from": 21600,
           "to": 0
         },
         "datasourceUid": "prometheus",
         "model": {
+          "adhocFilters": [],
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
-          "expr": "sum(\n    container_memory_working_set_bytes{namespace=\"prod-omi-backend\", container!=\"\", image!=\"\", service=\"prod-kube-prometheus-stack-kubelet\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace=\"prod-omi-backend\", workload=\"prod-omi-backend-listen\", workload_type=~\"deployment\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", namespace=\"prod-omi-backend\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace=\"prod-omi-backend\", workload=\"prod-omi-backend-listen\", workload_type=~\"deployment\"}\n) by (pod)\n",
-          "instant": true,
-          "intervalMs": 1000,
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(engine_stream_latency_bucket[5m]))) or vector(0)",
+          "instant": false,
+          "interval": "",
+          "intervalMs": 30000,
+          "legendFormat": "p99",
           "maxDataPoints": 43200,
-          "range": false,
+          "range": true,
           "refId": "A"
         }
       },
@@ -5058,27 +5560,25 @@
           "conditions": [
             {
               "evaluator": {
-                "params": [
-                  0,
-                  0
-                ],
+                "params": [],
                 "type": "gt"
               },
               "operator": {
                 "type": "and"
               },
               "query": {
-                "params": []
+                "params": [
+                  "H"
+                ]
               },
               "reducer": {
                 "params": [],
-                "type": "avg"
+                "type": "last"
               },
               "type": "query"
             }
           ],
           "datasource": {
-            "name": "Expression",
             "type": "__expr__",
             "uid": "__expr__"
           },
@@ -5103,8 +5603,7 @@
             {
               "evaluator": {
                 "params": [
-                  0.8,
-                  0
+                  2
                 ],
                 "type": "gt"
               },
@@ -5112,17 +5611,18 @@
                 "type": "and"
               },
               "query": {
-                "params": []
+                "params": [
+                  "I"
+                ]
               },
               "reducer": {
                 "params": [],
-                "type": "avg"
+                "type": "last"
               },
               "type": "query"
             }
           ],
           "datasource": {
-            "name": "Expression",
             "type": "__expr__",
             "uid": "__expr__"
           },
@@ -5134,14 +5634,27 @@
         }
       }
     ],
+    "updated": "2026-06-20T02:27:38Z",
     "noDataState": "Alerting",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
-      "__dashboardUid__": "855b2e16-c098-407a-85dc-dc9ce87698a9",
-      "__panelId__": "9",
-      "threshold": "0.7 (70%)"
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "11",
+      "threshold": "2s",
+      "summary": "Omi live transcription alert: Deepgram Engine stream latency by p99 is high.",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
+    },
+    "labels": {
+      "instatus_component": "live-transcription",
+      "severity": "critical",
+      "alert_identity": "bevykefxxe0owd",
+      "component": "live-transcription",
+      "impact": "user-experience"
     },
     "isPaused": false,
     "notification_settings": {
@@ -5150,6 +5663,158 @@
     "record": null
   },
   {
+    "id": 6,
+    "uid": "devzd05c0bocgc",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Transcription Services",
+    "title": "Transcription Service Error Rate",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "range",
+        "relativeTimeRange": {
+          "from": 21600,
+          "to": 0
+        },
+        "datasourceUid": "aet29e27cgmwwc",
+        "model": {
+          "datasource": {
+            "type": "loki",
+            "uid": "aet29e27cgmwwc"
+          },
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "count(rate({service_name=\"backend-listen\"} |= `ASGI callable returned without sending` [$__auto])) or vector(0)",
+          "instant": true,
+          "intervalMs": 1000,
+          "legendFormat": "Handshake failure",
+          "maxDataPoints": 43200,
+          "queryType": "range",
+          "range": false,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "settings": {
+            "mode": ""
+          },
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  2
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-20T02:27:38Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "60",
+      "threshold": "2",
+      "summary": "Omi live transcription alert: Transcription Service Error Rate.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
+    },
+    "labels": {
+      "instatus_component": "live-transcription",
+      "severity": "warning",
+      "alert_identity": "devzd05c0bocgc",
+      "component": "live-transcription",
+      "impact": "product"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "id": 47,
     "uid": "df2a40h2fbjswe",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -5268,16 +5933,26 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:37Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "63"
+      "__panelId__": "63",
+      "summary": "Omi live transcription alert: Transcription Service Error Rate: Data corrupted.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "labels": {
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "severity": "ticket",
+      "alert_identity": "df2a40h2fbjswe",
+      "component": "live-transcription",
+      "impact": "infrastructure"
     },
     "isPaused": false,
     "notification_settings": {
@@ -5286,475 +5961,7 @@
     "record": null
   },
   {
-    "uid": "bew95or0pnke8c",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Backend-integration",
-    "title": "Backend-integration RPS is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "timeSeriesList",
-        "relativeTimeRange": {
-          "from": 86400,
-          "to": 0
-        },
-        "datasourceUid": "beuxmaq8oxhq8e",
-        "model": {
-          "aliasBy": "RPS",
-          "datasource": {
-            "type": "stackdriver",
-            "uid": "beuxmaq8oxhq8e"
-          },
-          "instant": false,
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "queryType": "timeSeriesList",
-          "range": true,
-          "refId": "A",
-          "timeSeriesList": {
-            "alignmentPeriod": "cloud-monitoring-auto",
-            "crossSeriesReducer": "REDUCE_SUM",
-            "filters": [
-              "resource.label.backend_target_name",
-              "=",
-              "prod-omi-backend-integration",
-              "AND",
-              "metric.type",
-              "=",
-              "loadbalancing.googleapis.com/https/backend_request_count"
-            ],
-            "groupBys": [
-              "resource.label.backend_target_name"
-            ],
-            "perSeriesAligner": "ALIGN_NONE",
-            "preprocessor": "rate",
-            "projectName": "based-hardware",
-            "view": "FULL"
-          }
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "B"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  3
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "C"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
-    "execErrState": "Error",
-    "for": "5m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "24",
-      "threshold": "1"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
-    "uid": "bew95rob32tc0d",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Backend-integration",
-    "title": "Backend-integration max concurrent requests are high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "timeSeriesList",
-        "relativeTimeRange": {
-          "from": 86400,
-          "to": 0
-        },
-        "datasourceUid": "beuxmaq8oxhq8e",
-        "model": {
-          "aliasBy": "p99",
-          "datasource": {
-            "type": "stackdriver",
-            "uid": "beuxmaq8oxhq8e"
-          },
-          "instant": false,
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "queryType": "timeSeriesList",
-          "range": true,
-          "refId": "A",
-          "timeSeriesList": {
-            "alignmentPeriod": "cloud-monitoring-auto",
-            "crossSeriesReducer": "REDUCE_PERCENTILE_99",
-            "filters": [
-              "resource.label.location",
-              "=",
-              "us-central1",
-              "AND",
-              "resource.label.project_id",
-              "=",
-              "based-hardware",
-              "AND",
-              "resource.label.service_name",
-              "=",
-              "backend-integration",
-              "AND",
-              "metric.type",
-              "=",
-              "run.googleapis.com/container/max_request_concurrencies"
-            ],
-            "groupBys": [
-              "resource.label.service_name"
-            ],
-            "perSeriesAligner": "ALIGN_SUM",
-            "preprocessor": "none",
-            "projectName": "based-hardware",
-            "view": "FULL"
-          }
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "D"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  80
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "E"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
-    "execErrState": "Error",
-    "for": "5m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "25",
-      "threshold": "50"
-    },
-    "isPaused": false,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
-    "uid": "few9646khob9cd",
-    "orgID": 1,
-    "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Backend-integration",
-    "title": "Backend-integration request latency is high",
-    "condition": "C",
-    "data": [
-      {
-        "refId": "A",
-        "queryType": "timeSeriesList",
-        "relativeTimeRange": {
-          "from": 86400,
-          "to": 0
-        },
-        "datasourceUid": "beuxmaq8oxhq8e",
-        "model": {
-          "aliasBy": "p99",
-          "datasource": {
-            "type": "stackdriver",
-            "uid": "beuxmaq8oxhq8e"
-          },
-          "instant": false,
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "queryType": "timeSeriesList",
-          "range": true,
-          "refId": "A",
-          "timeSeriesList": {
-            "alignmentPeriod": "cloud-monitoring-auto",
-            "crossSeriesReducer": "REDUCE_PERCENTILE_99",
-            "filters": [
-              "resource.label.location",
-              "=",
-              "us-central1",
-              "AND",
-              "resource.label.project_id",
-              "=",
-              "based-hardware",
-              "AND",
-              "resource.label.service_name",
-              "=",
-              "backend-integration",
-              "AND",
-              "metric.type",
-              "=",
-              "run.googleapis.com/request_latencies"
-            ],
-            "groupBys": [
-              "resource.label.service_name"
-            ],
-            "perSeriesAligner": "ALIGN_SUM",
-            "preprocessor": "none",
-            "projectName": "based-hardware",
-            "view": "FULL"
-          }
-        }
-      },
-      {
-        "refId": "B",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "D"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "A",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "reducer": "last",
-          "refId": "B",
-          "type": "reduce"
-        }
-      },
-      {
-        "refId": "C",
-        "queryType": "",
-        "relativeTimeRange": {
-          "from": 0,
-          "to": 0
-        },
-        "datasourceUid": "__expr__",
-        "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [
-                  3600000
-                ],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "E"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
-          "datasource": {
-            "type": "__expr__",
-            "uid": "__expr__"
-          },
-          "expression": "B",
-          "intervalMs": 1000,
-          "maxDataPoints": 43200,
-          "refId": "C",
-          "type": "threshold"
-        }
-      }
-    ],
-    "noDataState": "Alerting",
-    "execErrState": "Error",
-    "for": "5m",
-    "keep_firing_for": "0s",
-    "annotations": {
-      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "26",
-      "threshold": "3600000ms (1h) - SSE/long-poll service"
-    },
-    "isPaused": true,
-    "notification_settings": {
-      "receiver": "Omi - Services Alerting (Telegram)"
-    },
-    "record": null
-  },
-  {
+    "id": 27,
     "uid": "eew96lge97gg0e",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -5898,6 +6105,7 @@
         }
       }
     ],
+    "updated": "2026-06-23T01:27:11Z",
     "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
@@ -5905,15 +6113,28 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "27",
-      "threshold": "0.1"
+      "threshold": "0.5",
+      "summary": "Omi plugin integrations alert: Backend-integration - 4XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
+    "record": null,
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "plugins",
+      "alert_identity": "eew96lge97gg0e",
+      "component": "plugins",
+      "impact": "product"
+    }
   },
   {
+    "id": 28,
     "uid": "eew96o25qztvkf",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -5960,7 +6181,7 @@
             "groupBys": [
               "metric.label.response_code_class"
             ],
-            "perSeriesAligner": "ALIGN_SUM",
+            "perSeriesAligner": "ALIGN_NONE",
             "preprocessor": "rate",
             "projectName": "based-hardware",
             "view": "FULL"
@@ -6053,6 +6274,7 @@
         }
       }
     ],
+    "updated": "2026-06-23T01:27:11Z",
     "noDataState": "OK",
     "execErrState": "Error",
     "for": "3m",
@@ -6060,10 +6282,19 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "27",
-      "threshold": "0.1"
+      "threshold": "0.5",
+      "summary": "Omi plugin integrations alert: Backend-integration - 5XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
-      "instatus_component": "plugins"
+      "instatus_component": "plugins",
+      "severity": "critical",
+      "alert_identity": "eew96o25qztvkf",
+      "component": "plugins",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -6072,6 +6303,172 @@
     "record": null
   },
   {
+    "id": 24,
+    "uid": "bew95or0pnke8c",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Backend-integration",
+    "title": "Backend-integration RPS is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "timeSeriesList",
+        "relativeTimeRange": {
+          "from": 86400,
+          "to": 0
+        },
+        "datasourceUid": "beuxmaq8oxhq8e",
+        "model": {
+          "aliasBy": "RPS",
+          "datasource": {
+            "type": "stackdriver",
+            "uid": "beuxmaq8oxhq8e"
+          },
+          "instant": false,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "queryType": "timeSeriesList",
+          "range": true,
+          "refId": "A",
+          "timeSeriesList": {
+            "alignmentPeriod": "cloud-monitoring-auto",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "filters": [
+              "resource.label.backend_target_name",
+              "=",
+              "prod-omi-backend-integration",
+              "AND",
+              "metric.type",
+              "=",
+              "loadbalancing.googleapis.com/https/backend_request_count"
+            ],
+            "groupBys": [
+              "resource.label.backend_target_name"
+            ],
+            "perSeriesAligner": "ALIGN_NONE",
+            "preprocessor": "rate",
+            "projectName": "based-hardware",
+            "view": "FULL"
+          }
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  3
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-23T01:20:15Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "24",
+      "threshold": "3",
+      "summary": "Omi plugin integrations alert: Backend-integration RPS is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "plugins",
+      "alert_identity": "bew95or0pnke8c",
+      "component": "plugins",
+      "impact": "infrastructure"
+    }
+  },
+  {
+    "id": 29,
     "uid": "cew96qrmucp34c",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -6207,22 +6604,209 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-23T01:20:16Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "29",
-      "threshold": "20 instances (80% of max)"
+      "threshold": "30 instances",
+      "summary": "Omi plugin integrations alert: Backend-integration instance count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "plugins",
+      "alert_identity": "cew96qrmucp34c",
+      "component": "plugins",
+      "impact": "infrastructure"
+    }
   },
   {
+    "id": 25,
+    "uid": "bew95rob32tc0d",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Backend-integration",
+    "title": "Backend-integration max concurrent requests are high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "timeSeriesList",
+        "relativeTimeRange": {
+          "from": 86400,
+          "to": 0
+        },
+        "datasourceUid": "beuxmaq8oxhq8e",
+        "model": {
+          "aliasBy": "p99",
+          "datasource": {
+            "type": "stackdriver",
+            "uid": "beuxmaq8oxhq8e"
+          },
+          "instant": false,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "queryType": "timeSeriesList",
+          "range": true,
+          "refId": "A",
+          "timeSeriesList": {
+            "alignmentPeriod": "cloud-monitoring-auto",
+            "crossSeriesReducer": "REDUCE_PERCENTILE_99",
+            "filters": [
+              "resource.label.location",
+              "=",
+              "us-central1",
+              "AND",
+              "resource.label.project_id",
+              "=",
+              "based-hardware",
+              "AND",
+              "resource.label.service_name",
+              "=",
+              "backend-integration",
+              "AND",
+              "metric.type",
+              "=",
+              "run.googleapis.com/container/max_request_concurrencies"
+            ],
+            "groupBys": [
+              "resource.label.service_name"
+            ],
+            "perSeriesAligner": "ALIGN_SUM",
+            "preprocessor": "none",
+            "projectName": "based-hardware",
+            "view": "FULL"
+          }
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  80
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "E"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-23T01:20:16Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "25",
+      "threshold": "80",
+      "summary": "Omi plugin integrations alert: Backend-integration max concurrent requests are high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "plugins",
+      "alert_identity": "bew95rob32tc0d",
+      "component": "plugins",
+      "impact": "infrastructure"
+    }
+  },
+  {
+    "id": 44,
     "uid": "dew9b4o7boa2oe",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -6352,22 +6936,36 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:44Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "57",
-      "threshold": "1"
+      "threshold": "1",
+      "summary": "Omi API alert: Cloud Armor denied requests per second is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
+    "record": null,
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "api",
+      "alert_identity": "dew9b4o7boa2oe",
+      "component": "api",
+      "impact": "product"
+    }
   },
   {
+    "id": 36,
     "uid": "bew99eq18r8jkf",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -6511,22 +7109,201 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-20T02:27:36Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "38",
-      "threshold": "150 RPS"
+      "threshold": "150 RPS",
+      "summary": "Omi plugin integrations alert: Plugins RPS is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
-    "record": null
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "plugins",
+      "alert_identity": "bew99eq18r8jkf",
+      "component": "plugins",
+      "impact": "infrastructure"
+    }
   },
   {
+    "id": 38,
+    "uid": "few99rmi823uof",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Plugins",
+    "title": "Plugins instance count is high",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "timeSeriesList",
+        "relativeTimeRange": {
+          "from": 86400,
+          "to": 0
+        },
+        "datasourceUid": "beuxmaq8oxhq8e",
+        "model": {
+          "aliasBy": "{{metric.label.state}}",
+          "datasource": {
+            "type": "stackdriver",
+            "uid": "beuxmaq8oxhq8e"
+          },
+          "instant": false,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "queryType": "timeSeriesList",
+          "range": true,
+          "refId": "A",
+          "timeSeriesList": {
+            "alignmentPeriod": "cloud-monitoring-auto",
+            "crossSeriesReducer": "REDUCE_MAX",
+            "filters": [
+              "resource.label.service_name",
+              "=",
+              "plugins",
+              "AND",
+              "metric.type",
+              "=",
+              "run.googleapis.com/container/instance_count"
+            ],
+            "groupBys": [
+              "metric.label.state"
+            ],
+            "perSeriesAligner": "ALIGN_MEAN",
+            "preprocessor": "none",
+            "projectName": "based-hardware",
+            "view": "FULL"
+          }
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  2
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-06-20T02:27:36Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "40",
+      "threshold": "2",
+      "summary": "Omi plugin integrations alert: Plugins instance count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null,
+    "labels": {
+      "severity": "ticket",
+      "instatus_component": "plugins",
+      "alert_identity": "few99rmi823uof",
+      "component": "plugins",
+      "impact": "infrastructure"
+    }
+  },
+  {
+    "id": 37,
     "uid": "eew99oe8y6qyod",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
@@ -6670,17 +7447,27 @@
         }
       }
     ],
-    "noDataState": "Alerting",
+    "updated": "2026-06-23T01:20:17Z",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "39",
-      "threshold": "7000ms (7s)"
+      "threshold": "14999ms (~15s)",
+      "summary": "Omi plugin integrations alert: Plugins request latency is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
-      "instatus_component": "plugins"
+      "instatus_component": "plugins",
+      "severity": "ticket",
+      "alert_identity": "eew99oe8y6qyod",
+      "component": "plugins",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -6689,53 +7476,31 @@
     "record": null
   },
   {
-    "uid": "few99rmi823uof",
+    "uid": "tz_parakeet_rps_zero",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
-    "ruleGroup": "Plugins",
-    "title": "Plugins instance count is high",
+    "ruleGroup": "Traffic Zero Detection",
+    "title": "Parakeet - traffic dropped to zero",
     "condition": "C",
     "data": [
       {
         "refId": "A",
-        "queryType": "timeSeriesList",
+        "queryType": "",
         "relativeTimeRange": {
-          "from": 86400,
+          "from": 900,
           "to": 0
         },
-        "datasourceUid": "beuxmaq8oxhq8e",
+        "datasourceUid": "prometheus",
         "model": {
-          "aliasBy": "{{metric.label.state}}",
           "datasource": {
-            "type": "stackdriver",
-            "uid": "beuxmaq8oxhq8e"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
-          "instant": false,
+          "expr": "sum(rate(parakeet_requests_total{namespace=\"prod-omi-backend\"}[10m])) or vector(0)",
+          "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
-          "queryType": "timeSeriesList",
-          "range": true,
-          "refId": "A",
-          "timeSeriesList": {
-            "alignmentPeriod": "cloud-monitoring-auto",
-            "crossSeriesReducer": "REDUCE_MAX",
-            "filters": [
-              "resource.label.service_name",
-              "=",
-              "plugins",
-              "AND",
-              "metric.type",
-              "=",
-              "run.googleapis.com/container/instance_count"
-            ],
-            "groupBys": [
-              "metric.label.state"
-            ],
-            "perSeriesAligner": "ALIGN_MEAN",
-            "preprocessor": "none",
-            "projectName": "based-hardware",
-            "view": "FULL"
-          }
+          "refId": "A"
         }
       },
       {
@@ -6747,27 +7512,6 @@
         },
         "datasourceUid": "__expr__",
         "model": {
-          "conditions": [
-            {
-              "evaluator": {
-                "params": [],
-                "type": "gt"
-              },
-              "operator": {
-                "type": "and"
-              },
-              "query": {
-                "params": [
-                  "B"
-                ]
-              },
-              "reducer": {
-                "params": [],
-                "type": "last"
-              },
-              "type": "query"
-            }
-          ],
           "datasource": {
             "type": "__expr__",
             "uid": "__expr__"
@@ -6793,9 +7537,249 @@
             {
               "evaluator": {
                 "params": [
-                  2
+                  0.001
                 ],
-                "type": "gt"
+                "type": "lt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
+      "__panelId__": "5",
+      "summary": "Parakeet receiving zero traffic for 10+ minutes — possible ILB connectivity or config issue (previous incident: https→http misconfiguration caused 8h outage)",
+      "threshold": "< 0.001 rps (effectively zero)",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "speech-processing",
+      "alert_identity": "tz_parakeet_rps_zero",
+      "component": "speech-processing",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "tz_backend_listen_lb_zero",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Traffic Zero Detection",
+    "title": "Backend-listen - LB traffic dropped to zero",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{backend_target_name=\"custom-domains-api-omi-me-backend-listen-49a4-be\"}[10m])) or vector(0)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0.001
+                ],
+                "type": "lt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "17",
+      "summary": "Backend-listen receiving zero LB traffic for 10+ minutes — transcription pipeline may be down",
+      "threshold": "< 0.001 rps (effectively zero)",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "live-transcription",
+      "alert_identity": "tz_backend_listen_lb_zero",
+      "component": "live-transcription",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "tz_backend_listen_pods_zero",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Traffic Zero Detection",
+    "title": "Backend-listen - no ready pods",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 600,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(kube_deployment_status_replicas_ready{deployment=\"prod-omi-backend-listen\", namespace=\"prod-omi-backend\"}) or vector(0)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  1
+                ],
+                "type": "lt"
               },
               "operator": {
                 "type": "and"
@@ -6830,8 +7814,523 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "40",
-      "threshold": "2"
+      "__panelId__": "21",
+      "summary": "Backend-listen has zero ready pods — all replicas are down or failing health checks",
+      "threshold": "< 1 ready pod",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "live-transcription",
+      "alert_identity": "tz_backend_listen_pods_zero",
+      "component": "live-transcription",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "tz_pusher_connections_zero",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Traffic Zero Detection",
+    "title": "Pusher - zero active WebSocket connections",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(pusher_active_ws_connections{job=\"pusher-metrics\"}) or vector(0)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  1
+                ],
+                "type": "lt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "86",
+      "summary": "Pusher has zero active WebSocket connections for 10+ minutes — live transcription pipeline broken",
+      "threshold": "< 1 active connection",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "live-transcription",
+      "alert_identity": "tz_pusher_connections_zero",
+      "component": "live-transcription",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "tz_backend_listen_ws_drop",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Traffic Zero Detection",
+    "title": "Backend-listen - active WS connections critically low",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 600,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(backend_listen_active_ws_connections{job=\"backend-listen-metrics\"}) or vector(0)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  10
+                ],
+                "type": "lt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "82",
+      "summary": "Backend-listen active WS connections dropped below 10 for 5+ minutes — clients disconnecting, likely backend-listen failure (3-day baseline: min=52, avg=218, max=365)",
+      "threshold": "< 10 active connections",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "live-transcription",
+      "alert_identity": "tz_backend_listen_ws_drop",
+      "component": "live-transcription",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "tz_backend_cloudrun_zero",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Traffic Zero Detection",
+    "title": "Backend (Cloud Run) - traffic dropped to zero",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "timeSeriesList",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "beuxmaq8oxhq8e",
+        "model": {
+          "aliasBy": "Backend RPS",
+          "datasource": {
+            "type": "stackdriver",
+            "uid": "beuxmaq8oxhq8e"
+          },
+          "instant": false,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "queryType": "timeSeriesList",
+          "range": true,
+          "refId": "A",
+          "timeSeriesList": {
+            "alignmentPeriod": "cloud-monitoring-auto",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "filters": [
+              "resource.label.backend_target_name",
+              "=",
+              "custom-domains-api-omi-me-backend-49a4-be",
+              "AND",
+              "metric.type",
+              "=",
+              "loadbalancing.googleapis.com/https/backend_request_count"
+            ],
+            "groupBys": [],
+            "perSeriesAligner": "ALIGN_NONE",
+            "preprocessor": "rate",
+            "projectName": "based-hardware",
+            "view": "FULL"
+          }
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0.001
+                ],
+                "type": "lt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
+      "__panelId__": "3",
+      "summary": "Backend Cloud Run service receiving zero LB traffic for 15+ minutes — API may be unreachable",
+      "threshold": "< 0.001 rps (effectively zero)",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "api",
+      "alert_identity": "tz_backend_cloudrun_zero",
+      "component": "api",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "bfobs1llmgfb01",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "LLM Gateway - fallback rate elevated (ticket)",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(llm_gateway_chat_extraction_requests_total{mode=\"fallback\"}[30m])) / clamp_min(sum(rate(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[30m])), 1e-9)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0.05
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-07-08T21:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "30m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "runbook": "backend/docs/runbooks/llm-gateway-fallback.md",
+      "severity": "ticket",
+      "summary": "Dependency health — elevated LLM gateway fallback rate, not a product outage by itself",
+      "threshold": "0.05 (5% fallback share over 30m)",
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "5",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi AI chat production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "ai-chat",
+      "alert_identity": "bfobs1llmgfb01",
+      "component": "ai-chat",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -6959,11 +8458,18 @@
       "__dashboardUid__": "omi-resilience-fallbacks",
       "__panelId__": "7",
       "summary": "Chat terminal failures exceed 10% with at least 20 terminal real requests in 30m",
-      "threshold": "failure share > 0.10; terminal outcomes >= 20"
+      "threshold": "failure share > 0.10; terminal outcomes >= 20",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi AI chat production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
     },
     "labels": {
       "severity": "warning",
-      "instatus_component": "ai-chat"
+      "instatus_component": "ai-chat",
+      "alert_identity": "omi-journey-chat-fail",
+      "component": "ai-chat",
+      "impact": "user-experience"
     },
     "isPaused": false,
     "notification_settings": {
@@ -7091,11 +8597,18 @@
       "__dashboardUid__": "omi-resilience-fallbacks",
       "__panelId__": "7",
       "summary": "Pusher terminal failures exceed 10% with at least 20 terminal real sessions in 30m",
-      "threshold": "failure share > 0.10; terminal outcomes >= 20"
+      "threshold": "failure share > 0.10; terminal outcomes >= 20",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
     },
     "labels": {
       "severity": "warning",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "omi-journey-pusher-fail",
+      "component": "live-transcription",
+      "impact": "user-experience"
     },
     "isPaused": false,
     "notification_settings": {
@@ -7223,11 +8736,18 @@
       "__dashboardUid__": "omi-resilience-fallbacks",
       "__panelId__": "9",
       "summary": "Capture finalization terminal failures exceed 10% with at least 20 terminal real jobs in 30m",
-      "threshold": "failure share > 0.10; terminal outcomes >= 20"
+      "threshold": "failure share > 0.10; terminal outcomes >= 20",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
     },
     "labels": {
       "severity": "warning",
-      "instatus_component": "speech-processing"
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-journey-capture-fail",
+      "component": "speech-processing",
+      "impact": "user-experience"
     },
     "isPaused": false,
     "notification_settings": {
@@ -7275,10 +8795,10 @@
           "conditions": [
             {
               "evaluator": {
-                  "params": [
-                    0
-                  ],
-                  "type": "gt"
+                "params": [
+                  0
+                ],
+                "type": "gt"
               },
               "operator": {
                 "type": "and"
@@ -7317,11 +8837,18 @@
       "__dashboardUid__": "omi-resilience-fallbacks",
       "__panelId__": "6",
       "summary": "An expected real-traffic journey metrics scrape target is absent or unhealthy",
-      "threshold": "either named scrape job absent or any target up < 1"
+      "threshold": "either named scrape job absent or any target up < 1",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi observability production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "labels": {
       "severity": "warning",
-      "instatus_component": "observability"
+      "instatus_component": "observability",
+      "alert_identity": "omi-journey-scrape-missing",
+      "component": "observability",
+      "impact": "infrastructure"
     },
     "isPaused": false,
     "notification_settings": {
@@ -7340,16 +8867,65 @@
       {
         "refId": "A",
         "queryType": "",
-        "relativeTimeRange": {"from": 900, "to": 0},
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
         "datasourceUid": "prometheus",
-        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "(sum(rate(llm_gateway_chat_extraction_requests_total{mode=\"fallback\"}[15m])) / clamp_min(sum(rate(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[15m])), 1e-9) > bool 0.05) or (max(llm_gateway_circuit_open) > bool 0) or ((sum(increase(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[15m])) >= bool 10) and (sum(increase(llm_gateway_chat_extraction_requests_total{mode=\"serving\",outcome=\"success\"}[15m])) == bool 0)) or (histogram_quantile(0.95, sum(rate(llm_gateway_client_first_byte_seconds_bucket[5m])) by (le)) > bool 5)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(sum(rate(llm_gateway_chat_extraction_requests_total{mode=\"fallback\"}[15m])) / clamp_min(sum(rate(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[15m])), 1e-9) > bool 0.05) or (max(llm_gateway_circuit_open) > bool 0) or ((sum(increase(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[15m])) >= bool 10) and (sum(increase(llm_gateway_chat_extraction_requests_total{mode=\"serving\",outcome=\"success\"}[15m])) == bool 0)) or (histogram_quantile(0.95, sum(rate(llm_gateway_client_first_byte_seconds_bucket[5m])) by (le)) > bool 5)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
       },
       {
         "refId": "B",
         "queryType": "",
-        "relativeTimeRange": {"from": 0, "to": 0},
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
         "datasourceUid": "__expr__",
-        "model": {"conditions": [{"evaluator": {"params": [0], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B", "type": "threshold"}
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
       }
     ],
     "updated": "2026-07-17T00:00:00Z",
@@ -7357,10 +8933,26 @@
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
-    "annotations": {"runbook": "backend/docs/runbooks/llm-gateway-fallback.md", "summary": "Client fallback, open circuit, zero gateway successes under traffic, or p95 first-byte latency indicates the gateway is unreachable or stalling", "threshold": "fallback >5%, circuit open, no serving success for 10 requests, or p95 first byte >5s"},
-    "labels": {"severity": "warning", "instatus_component": "ai-chat"},
+    "annotations": {
+      "runbook": "backend/docs/runbooks/llm-gateway-fallback.md",
+      "summary": "Client fallback, open circuit, zero gateway successes under traffic, or p95 first-byte latency indicates the gateway is unreachable or stalling",
+      "threshold": "fallback >5%, circuit open, no serving success for 10 requests, or p95 first byte >5s",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi AI chat production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "ai-chat",
+      "alert_identity": "omi-llm-gateway-client-reachability",
+      "component": "ai-chat",
+      "impact": "user-experience"
+    },
     "isPaused": false,
-    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
     "record": null
   },
   {
@@ -7374,16 +8966,65 @@
       {
         "refId": "A",
         "queryType": "",
-        "relativeTimeRange": {"from": 300, "to": 0},
+        "relativeTimeRange": {
+          "from": 300,
+          "to": 0
+        },
         "datasourceUid": "prometheus",
-        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(kube_endpoint_address_available{namespace=\"prod-omi-backend\",endpoint=\"prod-omi-llm-gateway\"}) < bool 1", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(kube_endpoint_address_available{namespace=\"prod-omi-backend\",endpoint=\"prod-omi-llm-gateway\"}) < bool 1",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
       },
       {
         "refId": "B",
         "queryType": "",
-        "relativeTimeRange": {"from": 0, "to": 0},
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
         "datasourceUid": "__expr__",
-        "model": {"conditions": [{"evaluator": {"params": [0], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B", "type": "threshold"}
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
       }
     ],
     "updated": "2026-07-17T00:00:00Z",
@@ -7391,10 +9032,26 @@
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
-    "annotations": {"runbook": "backend/docs/runbooks/llm-gateway-fallback.md", "summary": "The production LLM Gateway Service has no ready EndpointSlice address or kube-state-metrics is absent", "threshold": "ready endpoint count <1"},
-    "labels": {"severity": "warning", "instatus_component": "ai-chat"},
+    "annotations": {
+      "runbook": "backend/docs/runbooks/llm-gateway-fallback.md",
+      "summary": "The production LLM Gateway Service has no ready EndpointSlice address or kube-state-metrics is absent",
+      "threshold": "ready endpoint count <1",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi AI chat production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "ai-chat",
+      "alert_identity": "omi-llm-gateway-no-ready-endpoints",
+      "component": "ai-chat",
+      "impact": "product"
+    },
     "isPaused": false,
-    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
     "record": null
   }
 ]

--- a/backend/charts/monitoring/alerts/backend-integration.json
+++ b/backend/charts/monitoring/alerts/backend-integration.json
@@ -152,7 +152,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "27",
-      "threshold": "0.5"
+      "threshold": "0.5",
+      "summary": "Omi plugin integrations alert: Backend-integration - 4XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "isPaused": false,
     "notification_settings": {
@@ -161,7 +166,10 @@
     "record": null,
     "labels": {
       "severity": "warning",
-      "instatus_component": "plugins"
+      "instatus_component": "plugins",
+      "alert_identity": "eew96lge97gg0e",
+      "component": "plugins",
+      "impact": "product"
     }
   },
   {
@@ -313,11 +321,19 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "27",
-      "threshold": "0.5"
+      "threshold": "0.5",
+      "summary": "Omi plugin integrations alert: Backend-integration - 5XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
       "instatus_component": "plugins",
-      "severity": "critical"
+      "severity": "critical",
+      "alert_identity": "eew96o25qztvkf",
+      "component": "plugins",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -470,7 +486,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "24",
-      "threshold": "3"
+      "threshold": "3",
+      "summary": "Omi plugin integrations alert: Backend-integration RPS is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -479,7 +500,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "plugins"
+      "instatus_component": "plugins",
+      "alert_identity": "bew95or0pnke8c",
+      "component": "plugins",
+      "impact": "infrastructure"
     }
   },
   {
@@ -627,7 +651,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "29",
-      "threshold": "30 instances"
+      "threshold": "30 instances",
+      "summary": "Omi plugin integrations alert: Backend-integration instance count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -636,7 +665,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "plugins"
+      "instatus_component": "plugins",
+      "alert_identity": "cew96qrmucp34c",
+      "component": "plugins",
+      "impact": "infrastructure"
     }
   },
   {
@@ -792,7 +824,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "25",
-      "threshold": "80"
+      "threshold": "80",
+      "summary": "Omi plugin integrations alert: Backend-integration max concurrent requests are high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -801,7 +838,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "plugins"
+      "instatus_component": "plugins",
+      "alert_identity": "bew95rob32tc0d",
+      "component": "plugins",
+      "impact": "infrastructure"
     }
   }
 ]

--- a/backend/charts/monitoring/alerts/backend-sync.json
+++ b/backend/charts/monitoring/alerts/backend-sync.json
@@ -148,7 +148,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "34",
-      "threshold": "2"
+      "threshold": "2",
+      "summary": "Omi API alert: Backend-sync - 4XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "isPaused": false,
     "notification_settings": {
@@ -157,7 +162,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "api"
+      "instatus_component": "api",
+      "alert_identity": "cew97rzyegdtsa",
+      "component": "api",
+      "impact": "product"
     }
   },
   {
@@ -309,11 +317,19 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "34",
-      "threshold": "2"
+      "threshold": "2",
+      "summary": "Omi API alert: Backend-sync - 5XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
       "instatus_component": "api",
-      "severity": "critical"
+      "severity": "critical",
+      "alert_identity": "cew97uqu791q8a",
+      "component": "api",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -466,7 +482,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "31",
-      "threshold": "5 RPS"
+      "threshold": "5 RPS",
+      "summary": "Omi API alert: Backend-sync RPS is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -475,7 +496,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "api"
+      "instatus_component": "api",
+      "alert_identity": "cew97d5vd0ttse",
+      "component": "api",
+      "impact": "infrastructure"
     }
   },
   {
@@ -623,7 +647,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "36",
-      "threshold": "20 instances (80% of max)"
+      "threshold": "20 instances (80% of max)",
+      "summary": "Omi API alert: Backend-sync instance count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -632,7 +661,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "api"
+      "instatus_component": "api",
+      "alert_identity": "cew97x299of7kb",
+      "component": "api",
+      "impact": "infrastructure"
     }
   },
   {
@@ -788,7 +820,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "32",
-      "threshold": "30"
+      "threshold": "30",
+      "summary": "Omi API alert: Backend-sync max concurrent requests are high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -797,7 +834,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "api"
+      "instatus_component": "api",
+      "alert_identity": "dew97fqr33oxsd",
+      "component": "api",
+      "impact": "infrastructure"
     }
   },
   {
@@ -900,10 +940,14 @@
     "keep_firing_for": "0s",
     "annotations": {
       "runbook": "backend/docs/runbooks/sync-dispatch-fallback.md",
-      "summary": "Paused: backend-sync metrics not scraped by GKE Prometheus \u2014 use Cloud Logging",
+      "summary": "Paused: backend-sync metrics not scraped by GKE Prometheus — use Cloud Logging",
       "threshold": "0.2 (20% enqueue uncertainty)",
       "__dashboardUid__": "omi-resilience-fallbacks",
-      "__panelId__": "3"
+      "__panelId__": "3",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "isPaused": false,
     "notification_settings": {
@@ -912,7 +956,10 @@
     "record": null,
     "labels": {
       "severity": "warning",
-      "instatus_component": "api"
+      "instatus_component": "api",
+      "alert_identity": "bfobs1syncenq01",
+      "component": "api",
+      "impact": "product"
     }
   }
 ]

--- a/backend/charts/monitoring/alerts/backend.json
+++ b/backend/charts/monitoring/alerts/backend.json
@@ -148,7 +148,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "4",
-      "threshold": "5 RPS 4xx"
+      "threshold": "5 RPS 4xx",
+      "summary": "Omi API alert: Backend - 4XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "isPaused": false,
     "notification_settings": {
@@ -157,7 +162,10 @@
     "record": null,
     "labels": {
       "severity": "warning",
-      "instatus_component": "api"
+      "instatus_component": "api",
+      "alert_identity": "cew4j7ruiik1sd",
+      "component": "api",
+      "impact": "product"
     }
   },
   {
@@ -312,11 +320,19 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "4",
-      "threshold": "1"
+      "threshold": "1",
+      "summary": "Omi API alert: Backend - 5XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
       "instatus_component": "api",
-      "severity": "critical"
+      "severity": "critical",
+      "alert_identity": "cew4jcnpa68sga",
+      "component": "api",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -450,11 +466,19 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "62"
+      "__panelId__": "62",
+      "summary": "Omi API alert: Backend - API Quota Exceeded (429).",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
       "instatus_component": "api",
-      "severity": "warning"
+      "severity": "warning",
+      "alert_identity": "fewwk2goqfklcf",
+      "component": "api",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -608,7 +632,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "3",
-      "threshold": "150"
+      "threshold": "150",
+      "summary": "Omi API alert: Backend RPS is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -617,7 +646,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "api"
+      "instatus_component": "api",
+      "alert_identity": "cew4a2kdopb0ga",
+      "component": "api",
+      "impact": "infrastructure"
     }
   },
   {
@@ -765,7 +797,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "5",
-      "threshold": "80 instances (80% of max)"
+      "threshold": "80 instances (80% of max)",
+      "summary": "Omi API alert: Backend instance count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -774,7 +811,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "api"
+      "instatus_component": "api",
+      "alert_identity": "bew4jihxc1beob",
+      "component": "api",
+      "impact": "infrastructure"
     }
   },
   {
@@ -930,7 +970,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "6",
-      "threshold": "30"
+      "threshold": "30",
+      "summary": "Omi API alert: Backend max concurrent requests are high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -939,7 +984,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "api"
+      "instatus_component": "api",
+      "alert_identity": "bew4iwy0hzmyob",
+      "component": "api",
+      "impact": "infrastructure"
     }
   },
   {
@@ -1068,11 +1116,19 @@
     "keep_firing_for": "5m",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "62"
+      "__panelId__": "62",
+      "summary": "Omi API alert: OpenAI - Quota Exceeded.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
       "instatus_component": "api",
-      "severity": "ticket"
+      "severity": "ticket",
+      "alert_identity": "afd0krbk1bugwf",
+      "component": "api",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {

--- a/backend/charts/monitoring/alerts/cloud-armor.json
+++ b/backend/charts/monitoring/alerts/cloud-armor.json
@@ -138,7 +138,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "57",
-      "threshold": "1"
+      "threshold": "1",
+      "summary": "Omi API alert: Cloud Armor denied requests per second is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "isPaused": false,
     "notification_settings": {
@@ -147,7 +152,10 @@
     "record": null,
     "labels": {
       "severity": "warning",
-      "instatus_component": "api"
+      "instatus_component": "api",
+      "alert_identity": "dew9b4o7boa2oe",
+      "component": "api",
+      "impact": "product"
     }
   }
 ]

--- a/backend/charts/monitoring/alerts/parakeet.json
+++ b/backend/charts/monitoring/alerts/parakeet.json
@@ -122,11 +122,19 @@
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
       "__panelId__": "122",
-      "threshold": "0.1"
+      "threshold": "0.1",
+      "summary": "Omi speech processing alert: Parakeet - 5XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
       "instatus_component": "speech-processing",
-      "severity": "critical"
+      "severity": "critical",
+      "alert_identity": "dfpgfzd3t1m9sf",
+      "component": "speech-processing",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -255,11 +263,18 @@
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
       "__panelId__": "122",
       "summary": "5xx errors exceed 1% of Parakeet LB traffic (min 30 req/min gate)",
-      "threshold": "0.01"
+      "threshold": "0.01",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
       "instatus_component": "speech-processing",
-      "severity": "critical"
+      "severity": "critical",
+      "alert_identity": "efpossz9hmsqod",
+      "component": "speech-processing",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -389,11 +404,19 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
-      "__panelId__": "21"
+      "__panelId__": "21",
+      "summary": "Omi speech processing alert: Parakeet - pod restart detected (possible OOMKill).",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "labels": {
       "instatus_component": "speech-processing",
-      "severity": "warning"
+      "severity": "warning",
+      "alert_identity": "efpnx71qc88aob",
+      "component": "speech-processing",
+      "impact": "infrastructure"
     },
     "isPaused": false,
     "notification_settings": {
@@ -524,11 +547,19 @@
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
       "__panelId__": "123",
-      "threshold": "30000ms"
+      "threshold": "30000ms",
+      "summary": "Omi speech processing alert: Parakeet - request latency is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
       "instatus_component": "speech-processing",
-      "severity": "warning"
+      "severity": "warning",
+      "alert_identity": "efpgg049laqyof",
+      "component": "speech-processing",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -659,11 +690,303 @@
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
       "__panelId__": "122",
-      "threshold": "5 req/s"
+      "threshold": "5 req/s",
+      "summary": "Omi speech processing alert: Parakeet RPS is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "labels": {
       "instatus_component": "speech-processing",
-      "severity": "warning"
+      "severity": "warning",
+      "alert_identity": "efpgg1kfjglj4d",
+      "component": "speech-processing",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-parakeet-stream-capacity-warning",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Parakeet",
+    "title": "Parakeet - streaming capacity headroom reduced",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(parakeet_active_streams{container=\"parakeet\", namespace=\"prod-omi-backend\"}) / clamp_min(sum(kube_deployment_status_replicas_ready{deployment=\"prod-omi-parakeet\", namespace=\"prod-omi-backend\"}), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  15
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-07-20T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
+      "__panelId__": "3",
+      "summary": "Parakeet streaming capacity is above the warning headroom per ready replica.",
+      "user_impact": "Live transcription may slow down or reject new streams if traffic continues to rise.",
+      "scope": "Production Parakeet streaming pods; active streams are averaged across ready replicas.",
+      "verification": "Compare active streams and ready replicas in the Parakeet dashboard and confirm the condition persists for the alert duration.",
+      "safe_next_action": "Allow the HPA to add healthy replicas first; investigate capacity only after checking replica readiness and the dashboard.",
+      "threshold": "15 active streams per ready replica"
+    },
+    "labels": {
+      "instatus_component": "speech-processing",
+      "severity": "warning",
+      "alert_identity": "omi-parakeet-stream-capacity-warning",
+      "component": "speech-processing",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-parakeet-stream-capacity-critical",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Parakeet",
+    "title": "Parakeet - streaming capacity near critical limit",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(parakeet_active_streams{container=\"parakeet\", namespace=\"prod-omi-backend\"}) / clamp_min(sum(kube_deployment_status_replicas_ready{deployment=\"prod-omi-parakeet\", namespace=\"prod-omi-backend\"}), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  20
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-07-20T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "2m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
+      "__panelId__": "3",
+      "summary": "Parakeet streaming capacity is near the critical per-replica limit.",
+      "user_impact": "Live transcription may be delayed or unable to accept new streams while existing sessions are protected.",
+      "scope": "Production Parakeet streaming pods; active streams are averaged across ready replicas.",
+      "verification": "Compare active streams and ready replicas in the Parakeet dashboard and confirm the condition persists for the alert duration.",
+      "safe_next_action": "Allow the HPA to add healthy replicas first; investigate capacity only after checking replica readiness and the dashboard.",
+      "threshold": "20 active streams per ready replica"
+    },
+    "labels": {
+      "instatus_component": "speech-processing",
+      "severity": "critical",
+      "alert_identity": "omi-parakeet-stream-capacity-critical",
+      "component": "speech-processing",
+      "impact": "infrastructure"
     },
     "isPaused": false,
     "notification_settings": {

--- a/backend/charts/monitoring/alerts/parakeet.json
+++ b/backend/charts/monitoring/alerts/parakeet.json
@@ -837,7 +837,8 @@
       "scope": "Production Parakeet streaming pods; active streams are averaged across ready replicas.",
       "verification": "Compare active streams and ready replicas in the Parakeet dashboard and confirm the condition persists for the alert duration.",
       "safe_next_action": "Allow the HPA to add healthy replicas first; investigate capacity only after checking replica readiness and the dashboard.",
-      "threshold": "15 active streams per ready replica"
+      "threshold": "15 active streams per ready replica",
+      "runbook": "backend/docs/runbooks/parakeet-stream-capacity.md"
     },
     "labels": {
       "instatus_component": "speech-processing",
@@ -979,7 +980,8 @@
       "scope": "Production Parakeet streaming pods; active streams are averaged across ready replicas.",
       "verification": "Compare active streams and ready replicas in the Parakeet dashboard and confirm the condition persists for the alert duration.",
       "safe_next_action": "Allow the HPA to add healthy replicas first; investigate capacity only after checking replica readiness and the dashboard.",
-      "threshold": "20 active streams per ready replica"
+      "threshold": "20 active streams per ready replica",
+      "runbook": "backend/docs/runbooks/parakeet-stream-capacity.md"
     },
     "labels": {
       "instatus_component": "speech-processing",

--- a/backend/charts/monitoring/alerts/plugins.json
+++ b/backend/charts/monitoring/alerts/plugins.json
@@ -152,7 +152,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "38",
-      "threshold": "150 RPS"
+      "threshold": "150 RPS",
+      "summary": "Omi plugin integrations alert: Plugins RPS is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -161,7 +166,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "plugins"
+      "instatus_component": "plugins",
+      "alert_identity": "bew99eq18r8jkf",
+      "component": "plugins",
+      "impact": "infrastructure"
     }
   },
   {
@@ -309,7 +317,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "40",
-      "threshold": "2"
+      "threshold": "2",
+      "summary": "Omi plugin integrations alert: Plugins instance count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -318,7 +331,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "plugins"
+      "instatus_component": "plugins",
+      "alert_identity": "few99rmi823uof",
+      "component": "plugins",
+      "impact": "infrastructure"
     }
   },
   {
@@ -474,11 +490,19 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "39",
-      "threshold": "14999ms (~15s)"
+      "threshold": "14999ms (~15s)",
+      "summary": "Omi plugin integrations alert: Plugins request latency is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi plugin integrations production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
       "instatus_component": "plugins",
-      "severity": "ticket"
+      "severity": "ticket",
+      "alert_identity": "eew99oe8y6qyod",
+      "component": "plugins",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {

--- a/backend/charts/monitoring/alerts/pusher.json
+++ b/backend/charts/monitoring/alerts/pusher.json
@@ -122,7 +122,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "77",
-      "threshold": "1"
+      "threshold": "1",
+      "summary": "Omi live transcription alert: Pusher - 4XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "isPaused": false,
     "notification_settings": {
@@ -131,7 +136,10 @@
     "record": null,
     "labels": {
       "severity": "warning",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "cew923rcn3ncwb",
+      "component": "live-transcription",
+      "impact": "product"
     }
   },
   {
@@ -250,18 +258,26 @@
       }
     ],
     "updated": "2026-06-20T02:27:45Z",
-    "noDataState": "Alerting",
+    "noDataState": "OK",
     "execErrState": "Error",
     "for": "3m",
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "77",
-      "threshold": "1"
+      "threshold": "1",
+      "summary": "Omi live transcription alert: Pusher - 5XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
       "instatus_component": "live-transcription",
-      "severity": "critical"
+      "severity": "critical",
+      "alert_identity": "aew926uoh6o00c",
+      "component": "live-transcription",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -392,7 +408,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "75",
-      "threshold": "10"
+      "threshold": "10",
+      "summary": "Omi live transcription alert: Pusher RPS is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -401,7 +422,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "dew91uem0dnggb",
+      "component": "live-transcription",
+      "impact": "infrastructure"
     }
   },
   {
@@ -506,7 +530,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "79",
-      "threshold": "40"
+      "threshold": "40",
+      "summary": "Omi live transcription alert: Pusher instance count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -515,7 +544,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "dew92a2egu8sge",
+      "component": "live-transcription",
+      "impact": "infrastructure"
     }
   },
   {
@@ -641,7 +673,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "88",
-      "threshold": "30"
+      "threshold": "30",
+      "summary": "Omi live transcription alert: Pusher max concurrent requests are high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -650,7 +687,10 @@
     "record": null,
     "labels": {
       "severity": "warning",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "few91zm7mujggb",
+      "component": "live-transcription",
+      "impact": "infrastructure"
     }
   },
   {
@@ -674,7 +714,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(pusher_sessions_degraded{job=\"pusher-metrics\"}) / clamp_min(sum(pusher_active_ws_connections{job=\"pusher-metrics\"}), 1)",
+          "expr": "sum(pusher_sessions_degraded{job=\"backend-listen-metrics\"}) / clamp_min(sum(backend_listen_active_ws_connections{job=\"backend-listen-metrics\"}), 1)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -755,7 +795,12 @@
       "__dashboardUid__": "omi-resilience-fallbacks",
       "__panelId__": "4",
       "runbook": "backend/docs/runbooks/pusher-degraded.md",
-      "threshold": "0.05 (5% degraded sessions)"
+      "threshold": "0.05 (5% degraded sessions)",
+      "summary": "Omi live transcription alert: Pusher - degraded session ratio high.",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
     },
     "isPaused": false,
     "notification_settings": {
@@ -764,7 +809,10 @@
     "record": null,
     "labels": {
       "severity": "warning",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "bfobs1pusherdeg01",
+      "component": "live-transcription",
+      "impact": "user-experience"
     }
   }
 ]

--- a/backend/charts/monitoring/alerts/resilience.json
+++ b/backend/charts/monitoring/alerts/resilience.json
@@ -540,6 +540,145 @@
     "record": null
   },
   {
+    "uid": "omi-journey-live-transcription-fail",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Live transcription - terminal failure rate elevated",
+    "condition": "D",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"live_transcription\",outcome=~\"success|failure\"}[30m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"live_transcription\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"live_transcription\",outcome=~\"success|failure\"}[30m])), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A >= 20 && $B > 0.10",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "math"
+        }
+      },
+      {
+        "refId": "D",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "C",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "D",
+          "type": "reduce"
+        }
+      }
+    ],
+    "updated": "2026-07-20T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "7",
+      "summary": "Live-transcription terminal failures exceed 10% with at least 20 terminal real requests in 30m",
+      "threshold": "failure share > 0.10; terminal outcomes >= 20",
+      "user_impact": "Users may not receive live transcript text or may experience degraded results.",
+      "scope": "The Omi live-transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected live-transcription path; mitigate through the documented service runbook only after verification."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "live-transcription",
+      "alert_identity": "omi-journey-live-transcription-fail",
+      "component": "live-transcription",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
     "uid": "omi-journey-scrape-missing",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",

--- a/backend/charts/monitoring/alerts/resilience.json
+++ b/backend/charts/monitoring/alerts/resilience.json
@@ -100,14 +100,21 @@
     "annotations": {
       "runbook": "backend/docs/runbooks/llm-gateway-fallback.md",
       "severity": "ticket",
-      "summary": "Dependency health \u2014 elevated LLM gateway fallback rate, not a product outage by itself",
+      "summary": "Dependency health — elevated LLM gateway fallback rate, not a product outage by itself",
       "threshold": "0.05 (5% fallback share over 30m)",
       "__dashboardUid__": "omi-resilience-fallbacks",
-      "__panelId__": "5"
+      "__panelId__": "5",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi AI chat production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
       "severity": "warning",
-      "instatus_component": "ai-chat"
+      "instatus_component": "ai-chat",
+      "alert_identity": "bfobs1llmgfb01",
+      "component": "ai-chat",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -126,30 +133,104 @@
       {
         "refId": "A",
         "queryType": "",
-        "relativeTimeRange": {"from": 1800, "to": 0},
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
         "datasourceUid": "prometheus",
-        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=~\"success|failure\"}[30m]))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=~\"success|failure\"}[30m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
       },
       {
         "refId": "B",
         "queryType": "",
-        "relativeTimeRange": {"from": 1800, "to": 0},
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
         "datasourceUid": "prometheus",
-        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=~\"success|failure\"}[30m])), 1)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B"}
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=~\"success|failure\"}[30m])), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B"
+        }
       },
       {
         "refId": "C",
         "queryType": "",
-        "relativeTimeRange": {"from": 0, "to": 0},
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
         "datasourceUid": "__expr__",
-        "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "$A >= 20 && $B > 0.10", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "math"}
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A >= 20 && $B > 0.10",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "math"
+        }
       },
       {
         "refId": "D",
         "queryType": "",
-        "relativeTimeRange": {"from": 0, "to": 0},
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
         "datasourceUid": "__expr__",
-        "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["D"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "C", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "D", "type": "reduce"}
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "C",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "D",
+          "type": "reduce"
+        }
       }
     ],
     "updated": "2026-07-15T00:00:00Z",
@@ -157,10 +238,27 @@
     "execErrState": "Error",
     "for": "10m",
     "keep_firing_for": "0s",
-    "annotations": {"__dashboardUid__": "omi-resilience-fallbacks", "__panelId__": "7", "summary": "Chat terminal failures exceed 10% with at least 20 terminal real requests in 30m", "threshold": "failure share > 0.10; terminal outcomes >= 20"},
-    "labels": {"severity": "warning", "instatus_component": "ai-chat"},
+    "annotations": {
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "7",
+      "summary": "Chat terminal failures exceed 10% with at least 20 terminal real requests in 30m",
+      "threshold": "failure share > 0.10; terminal outcomes >= 20",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi AI chat production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "ai-chat",
+      "alert_identity": "omi-journey-chat-fail",
+      "component": "ai-chat",
+      "impact": "user-experience"
+    },
     "isPaused": false,
-    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
     "record": null
   },
   {
@@ -174,30 +272,104 @@
       {
         "refId": "A",
         "queryType": "",
-        "relativeTimeRange": {"from": 1800, "to": 0},
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
         "datasourceUid": "prometheus",
-        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=~\"success|failure\"}[30m]))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=~\"success|failure\"}[30m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
       },
       {
         "refId": "B",
         "queryType": "",
-        "relativeTimeRange": {"from": 1800, "to": 0},
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
         "datasourceUid": "prometheus",
-        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=~\"success|failure\"}[30m])), 1)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B"}
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=~\"success|failure\"}[30m])), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B"
+        }
       },
       {
         "refId": "C",
         "queryType": "",
-        "relativeTimeRange": {"from": 0, "to": 0},
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
         "datasourceUid": "__expr__",
-        "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "$A >= 20 && $B > 0.10", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "math"}
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A >= 20 && $B > 0.10",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "math"
+        }
       },
       {
         "refId": "D",
         "queryType": "",
-        "relativeTimeRange": {"from": 0, "to": 0},
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
         "datasourceUid": "__expr__",
-        "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["D"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "C", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "D", "type": "reduce"}
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "C",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "D",
+          "type": "reduce"
+        }
       }
     ],
     "updated": "2026-07-15T00:00:00Z",
@@ -205,10 +377,27 @@
     "execErrState": "Error",
     "for": "10m",
     "keep_firing_for": "0s",
-    "annotations": {"__dashboardUid__": "omi-resilience-fallbacks", "__panelId__": "7", "summary": "Pusher terminal failures exceed 10% with at least 20 terminal real sessions in 30m", "threshold": "failure share > 0.10; terminal outcomes >= 20"},
-    "labels": {"severity": "warning", "instatus_component": "live-transcription"},
+    "annotations": {
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "7",
+      "summary": "Pusher terminal failures exceed 10% with at least 20 terminal real sessions in 30m",
+      "threshold": "failure share > 0.10; terminal outcomes >= 20",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "live-transcription",
+      "alert_identity": "omi-journey-pusher-fail",
+      "component": "live-transcription",
+      "impact": "user-experience"
+    },
     "isPaused": false,
-    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
     "record": null
   },
   {
@@ -222,30 +411,104 @@
       {
         "refId": "A",
         "queryType": "",
-        "relativeTimeRange": {"from": 1800, "to": 0},
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
         "datasourceUid": "prometheus",
-        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[30m]))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[30m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
       },
       {
         "refId": "B",
         "queryType": "",
-        "relativeTimeRange": {"from": 1800, "to": 0},
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
         "datasourceUid": "prometheus",
-        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[30m])), 1)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B"}
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[30m])), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B"
+        }
       },
       {
         "refId": "C",
         "queryType": "",
-        "relativeTimeRange": {"from": 0, "to": 0},
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
         "datasourceUid": "__expr__",
-        "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "$A >= 20 && $B > 0.10", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "math"}
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A >= 20 && $B > 0.10",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "math"
+        }
       },
       {
         "refId": "D",
         "queryType": "",
-        "relativeTimeRange": {"from": 0, "to": 0},
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
         "datasourceUid": "__expr__",
-        "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["D"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "C", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "D", "type": "reduce"}
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "C",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "D",
+          "type": "reduce"
+        }
       }
     ],
     "updated": "2026-07-15T00:00:00Z",
@@ -253,10 +516,27 @@
     "execErrState": "Error",
     "for": "10m",
     "keep_firing_for": "0s",
-    "annotations": {"__dashboardUid__": "omi-resilience-fallbacks", "__panelId__": "9", "summary": "Capture finalization terminal failures exceed 10% with at least 20 terminal real jobs in 30m", "threshold": "failure share > 0.10; terminal outcomes >= 20"},
-    "labels": {"severity": "warning", "instatus_component": "speech-processing"},
+    "annotations": {
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "9",
+      "summary": "Capture finalization terminal failures exceed 10% with at least 20 terminal real jobs in 30m",
+      "threshold": "failure share > 0.10; terminal outcomes >= 20",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-journey-capture-fail",
+      "component": "speech-processing",
+      "impact": "user-experience"
+    },
     "isPaused": false,
-    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
     "record": null
   },
   {
@@ -270,16 +550,66 @@
       {
         "refId": "A",
         "queryType": "",
-        "relativeTimeRange": {"from": 300, "to": 0},
+        "relativeTimeRange": {
+          "from": 300,
+          "to": 0
+        },
         "datasourceUid": "prometheus",
-        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "(count(count by (job) (up{job=~\"backend-listen-metrics|pusher-metrics\"})) < bool 2) or (min(up{job=~\"backend-listen-metrics|pusher-metrics\"}) < bool 1)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(count(count by (job) (up{job=~\"backend-listen-metrics|pusher-metrics\"})) < bool 2) or (min(up{job=~\"backend-listen-metrics|pusher-metrics\"}) < bool 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
       },
       {
         "refId": "B",
         "queryType": "",
-        "relativeTimeRange": {"from": 0, "to": 0},
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
         "datasourceUid": "__expr__",
-        "model": {"conditions": [{"evaluator": {"params": [0], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "B", "type": "reduce"}
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
       }
     ],
     "updated": "2026-07-15T00:00:00Z",
@@ -287,10 +617,27 @@
     "execErrState": "Error",
     "for": "10m",
     "keep_firing_for": "0s",
-    "annotations": {"__dashboardUid__": "omi-resilience-fallbacks", "__panelId__": "6", "summary": "An expected real-traffic journey metrics scrape target is absent or unhealthy", "threshold": "either named scrape job absent or any target up < 1"},
-    "labels": {"severity": "warning", "instatus_component": "observability"},
+    "annotations": {
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "6",
+      "summary": "An expected real-traffic journey metrics scrape target is absent or unhealthy",
+      "threshold": "either named scrape job absent or any target up < 1",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi observability production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "observability",
+      "alert_identity": "omi-journey-scrape-missing",
+      "component": "observability",
+      "impact": "infrastructure"
+    },
     "isPaused": false,
-    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
     "record": null
   },
   {
@@ -304,16 +651,65 @@
       {
         "refId": "A",
         "queryType": "",
-        "relativeTimeRange": {"from": 900, "to": 0},
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
         "datasourceUid": "prometheus",
-        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "(sum(rate(llm_gateway_chat_extraction_requests_total{mode=\"fallback\"}[15m])) / clamp_min(sum(rate(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[15m])), 1e-9) > bool 0.05) or (max(llm_gateway_circuit_open) > bool 0) or ((sum(increase(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[15m])) >= bool 10) and (sum(increase(llm_gateway_chat_extraction_requests_total{mode=\"serving\",outcome=\"success\"}[15m])) == bool 0)) or (histogram_quantile(0.95, sum(rate(llm_gateway_client_first_byte_seconds_bucket[5m])) by (le)) > bool 5)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(sum(rate(llm_gateway_chat_extraction_requests_total{mode=\"fallback\"}[15m])) / clamp_min(sum(rate(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[15m])), 1e-9) > bool 0.05) or (max(llm_gateway_circuit_open) > bool 0) or ((sum(increase(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[15m])) >= bool 10) and (sum(increase(llm_gateway_chat_extraction_requests_total{mode=\"serving\",outcome=\"success\"}[15m])) == bool 0)) or (histogram_quantile(0.95, sum(rate(llm_gateway_client_first_byte_seconds_bucket[5m])) by (le)) > bool 5)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
       },
       {
         "refId": "B",
         "queryType": "",
-        "relativeTimeRange": {"from": 0, "to": 0},
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
         "datasourceUid": "__expr__",
-        "model": {"conditions": [{"evaluator": {"params": [0], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B", "type": "threshold"}
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
       }
     ],
     "updated": "2026-07-17T00:00:00Z",
@@ -321,10 +717,26 @@
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
-    "annotations": {"runbook": "backend/docs/runbooks/llm-gateway-fallback.md", "summary": "Client fallback, open circuit, zero gateway successes under traffic, or p95 first-byte latency indicates the gateway is unreachable or stalling", "threshold": "fallback >5%, circuit open, no serving success for 10 requests, or p95 first byte >5s"},
-    "labels": {"severity": "warning", "instatus_component": "ai-chat"},
+    "annotations": {
+      "runbook": "backend/docs/runbooks/llm-gateway-fallback.md",
+      "summary": "Client fallback, open circuit, zero gateway successes under traffic, or p95 first-byte latency indicates the gateway is unreachable or stalling",
+      "threshold": "fallback >5%, circuit open, no serving success for 10 requests, or p95 first byte >5s",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi AI chat production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "ai-chat",
+      "alert_identity": "omi-llm-gateway-client-reachability",
+      "component": "ai-chat",
+      "impact": "user-experience"
+    },
     "isPaused": false,
-    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
     "record": null
   },
   {
@@ -338,16 +750,65 @@
       {
         "refId": "A",
         "queryType": "",
-        "relativeTimeRange": {"from": 300, "to": 0},
+        "relativeTimeRange": {
+          "from": 300,
+          "to": 0
+        },
         "datasourceUid": "prometheus",
-        "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(kube_endpoint_address_available{namespace=\"prod-omi-backend\",endpoint=\"prod-omi-llm-gateway\"}) < bool 1", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(kube_endpoint_address_available{namespace=\"prod-omi-backend\",endpoint=\"prod-omi-llm-gateway\"}) < bool 1",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
       },
       {
         "refId": "B",
         "queryType": "",
-        "relativeTimeRange": {"from": 0, "to": 0},
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
         "datasourceUid": "__expr__",
-        "model": {"conditions": [{"evaluator": {"params": [0], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B", "type": "threshold"}
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
       }
     ],
     "updated": "2026-07-17T00:00:00Z",
@@ -355,10 +816,26 @@
     "execErrState": "Error",
     "for": "5m",
     "keep_firing_for": "0s",
-    "annotations": {"runbook": "backend/docs/runbooks/llm-gateway-fallback.md", "summary": "The production LLM Gateway Service has no ready EndpointSlice address or kube-state-metrics is absent", "threshold": "ready endpoint count <1"},
-    "labels": {"severity": "warning", "instatus_component": "ai-chat"},
+    "annotations": {
+      "runbook": "backend/docs/runbooks/llm-gateway-fallback.md",
+      "summary": "The production LLM Gateway Service has no ready EndpointSlice address or kube-state-metrics is absent",
+      "threshold": "ready endpoint count <1",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi AI chat production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "ai-chat",
+      "alert_identity": "omi-llm-gateway-no-ready-endpoints",
+      "component": "ai-chat",
+      "impact": "product"
+    },
     "isPaused": false,
-    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
     "record": null
   }
 ]

--- a/backend/charts/monitoring/alerts/traffic-zero.json
+++ b/backend/charts/monitoring/alerts/traffic-zero.json
@@ -99,12 +99,19 @@
     "annotations": {
       "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
       "__panelId__": "5",
-      "summary": "Parakeet receiving zero traffic for 10+ minutes \u2014 possible ILB connectivity or config issue (previous incident: https\u2192http misconfiguration caused 8h outage)",
-      "threshold": "< 0.001 rps (effectively zero)"
+      "summary": "Parakeet receiving zero traffic for 10+ minutes — possible ILB connectivity or config issue (previous incident: https→http misconfiguration caused 8h outage)",
+      "threshold": "< 0.001 rps (effectively zero)",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
     },
     "labels": {
       "severity": "critical",
-      "instatus_component": "speech-processing"
+      "instatus_component": "speech-processing",
+      "alert_identity": "tz_parakeet_rps_zero",
+      "component": "speech-processing",
+      "impact": "user-experience"
     },
     "isPaused": false,
     "notification_settings": {
@@ -212,12 +219,19 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "17",
-      "summary": "Backend-listen receiving zero LB traffic for 10+ minutes \u2014 transcription pipeline may be down",
-      "threshold": "< 0.001 rps (effectively zero)"
+      "summary": "Backend-listen receiving zero LB traffic for 10+ minutes — transcription pipeline may be down",
+      "threshold": "< 0.001 rps (effectively zero)",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
     },
     "labels": {
       "severity": "critical",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "tz_backend_listen_lb_zero",
+      "component": "live-transcription",
+      "impact": "user-experience"
     },
     "isPaused": false,
     "notification_settings": {
@@ -325,12 +339,19 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "21",
-      "summary": "Backend-listen has zero ready pods \u2014 all replicas are down or failing health checks",
-      "threshold": "< 1 ready pod"
+      "summary": "Backend-listen has zero ready pods — all replicas are down or failing health checks",
+      "threshold": "< 1 ready pod",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
     },
     "labels": {
       "severity": "critical",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "tz_backend_listen_pods_zero",
+      "component": "live-transcription",
+      "impact": "user-experience"
     },
     "isPaused": false,
     "notification_settings": {
@@ -438,12 +459,19 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "86",
-      "summary": "Pusher has zero active WebSocket connections for 10+ minutes \u2014 live transcription pipeline broken",
-      "threshold": "< 1 active connection"
+      "summary": "Pusher has zero active WebSocket connections for 10+ minutes — live transcription pipeline broken",
+      "threshold": "< 1 active connection",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
     },
     "labels": {
       "severity": "critical",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "tz_pusher_connections_zero",
+      "component": "live-transcription",
+      "impact": "user-experience"
     },
     "isPaused": false,
     "notification_settings": {
@@ -552,11 +580,18 @@
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "82",
       "summary": "Backend-listen active WS connections dropped below 10 for 5+ minutes — clients disconnecting, likely backend-listen failure (3-day baseline: min=52, avg=218, max=365)",
-      "threshold": "< 10 active connections"
+      "threshold": "< 10 active connections",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
     },
     "labels": {
       "severity": "critical",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "tz_backend_listen_ws_drop",
+      "component": "live-transcription",
+      "impact": "user-experience"
     },
     "isPaused": false,
     "notification_settings": {
@@ -684,12 +719,19 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "3",
-      "summary": "Backend Cloud Run service receiving zero LB traffic for 15+ minutes \u2014 API may be unreachable",
-      "threshold": "< 0.001 rps (effectively zero)"
+      "summary": "Backend Cloud Run service receiving zero LB traffic for 15+ minutes — API may be unreachable",
+      "threshold": "< 0.001 rps (effectively zero)",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi API production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
     },
     "labels": {
       "severity": "critical",
-      "instatus_component": "api"
+      "instatus_component": "api",
+      "alert_identity": "tz_backend_cloudrun_zero",
+      "component": "api",
+      "impact": "user-experience"
     },
     "isPaused": false,
     "notification_settings": {

--- a/backend/charts/monitoring/alerts/transcription-services.json
+++ b/backend/charts/monitoring/alerts/transcription-services.json
@@ -122,7 +122,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "19",
-      "threshold": "1"
+      "threshold": "1",
+      "summary": "Omi live transcription alert: Backend-listen - 4XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "isPaused": false,
     "notification_settings": {
@@ -131,7 +136,10 @@
     "record": null,
     "labels": {
       "severity": "warning",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "bevzeigrns5xca",
+      "component": "live-transcription",
+      "impact": "product"
     }
   },
   {
@@ -257,11 +265,19 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "19",
-      "threshold": "1"
+      "threshold": "1",
+      "summary": "Omi live transcription alert: Backend-listen - 5XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
       "instatus_component": "live-transcription",
-      "severity": "critical"
+      "severity": "critical",
+      "alert_identity": "cevzen5b94z5sb",
+      "component": "live-transcription",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -393,7 +409,12 @@
     "annotations": {
       "__dashboardUid__": "855b2e16-c098-407a-85dc-dc9ce87698a9",
       "__panelId__": "9",
-      "threshold": "0.8 (80%)"
+      "threshold": "0.8 (80%)",
+      "summary": "Omi live transcription alert: Backend-listen Memory usage is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -402,7 +423,10 @@
     "record": null,
     "labels": {
       "severity": "warning",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "eew9yw583gnwgd",
+      "component": "live-transcription",
+      "impact": "infrastructure"
     }
   },
   {
@@ -533,7 +557,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "21",
-      "threshold": "50"
+      "threshold": "50",
+      "summary": "Omi live transcription alert: Backend-listen replica count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -542,7 +571,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "aevzf0r8z6ayoe",
+      "component": "live-transcription",
+      "impact": "infrastructure"
     }
   },
   {
@@ -673,7 +705,12 @@
     "annotations": {
       "__dashboardUid__": "855b2e16-c098-407a-85dc-dc9ce87698a9",
       "__panelId__": "15",
-      "threshold": "8"
+      "threshold": "8",
+      "summary": "Omi live transcription alert: Backend-listen request per pod is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -682,7 +719,10 @@
     "record": null,
     "labels": {
       "severity": "warning",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "bevzfbkx3fuo0c",
+      "component": "live-transcription",
+      "impact": "infrastructure"
     }
   },
   {
@@ -820,7 +860,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "13",
-      "threshold": "5"
+      "threshold": "5",
+      "summary": "Omi live transcription alert: Deepgram Engine replica count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -829,7 +874,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "live-transcription"
+      "instatus_component": "live-transcription",
+      "alert_identity": "fevzfwkmrjncwc",
+      "component": "live-transcription",
+      "impact": "infrastructure"
     }
   },
   {
@@ -960,11 +1008,19 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "11",
-      "threshold": "2s"
+      "threshold": "2s",
+      "summary": "Omi live transcription alert: Deepgram Engine stream latency by p99 is high.",
+      "user_impact": "Users may be unable to complete this Omi interaction or may experience degraded results.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and the affected user path; mitigate through the documented service runbook only after verification."
     },
     "labels": {
       "instatus_component": "live-transcription",
-      "severity": "critical"
+      "severity": "critical",
+      "alert_identity": "bevykefxxe0owd",
+      "component": "live-transcription",
+      "impact": "user-experience"
     },
     "isPaused": false,
     "notification_settings": {
@@ -1103,11 +1159,19 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "60",
-      "threshold": "2"
+      "threshold": "2",
+      "summary": "Omi live transcription alert: Transcription Service Error Rate.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
       "instatus_component": "live-transcription",
-      "severity": "warning"
+      "severity": "warning",
+      "alert_identity": "devzd05c0bocgc",
+      "component": "live-transcription",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -1242,11 +1306,19 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
-      "__panelId__": "63"
+      "__panelId__": "63",
+      "summary": "Omi live transcription alert: Transcription Service Error Rate: Data corrupted.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi live transcription production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "labels": {
       "instatus_component": "live-transcription",
-      "severity": "ticket"
+      "severity": "ticket",
+      "alert_identity": "df2a40h2fbjswe",
+      "component": "live-transcription",
+      "impact": "infrastructure"
     },
     "isPaused": false,
     "notification_settings": {

--- a/backend/charts/monitoring/alerts/vad.json
+++ b/backend/charts/monitoring/alerts/vad.json
@@ -122,7 +122,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "51",
-      "threshold": "0.1"
+      "threshold": "0.1",
+      "summary": "Omi speech processing alert: VAD - 4XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "isPaused": false,
     "notification_settings": {
@@ -131,7 +136,10 @@
     "record": null,
     "labels": {
       "severity": "warning",
-      "instatus_component": "speech-processing"
+      "instatus_component": "speech-processing",
+      "alert_identity": "dew9ala448r9cc",
+      "component": "speech-processing",
+      "impact": "product"
     }
   },
   {
@@ -257,11 +265,19 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "51",
-      "threshold": "0.1"
+      "threshold": "0.1",
+      "summary": "Omi speech processing alert: VAD - 5XX error rate is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "labels": {
       "instatus_component": "speech-processing",
-      "severity": "critical"
+      "severity": "critical",
+      "alert_identity": "few9anlyv16v4a",
+      "component": "speech-processing",
+      "impact": "product"
     },
     "isPaused": false,
     "notification_settings": {
@@ -392,7 +408,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "49",
-      "threshold": "10"
+      "threshold": "10",
+      "summary": "Omi speech processing alert: VAD RPS is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -401,7 +422,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "speech-processing"
+      "instatus_component": "speech-processing",
+      "alert_identity": "bew9aeqgx2w3kf",
+      "component": "speech-processing",
+      "impact": "infrastructure"
     }
   },
   {
@@ -532,7 +556,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "53",
-      "threshold": "3"
+      "threshold": "3",
+      "summary": "Omi speech processing alert: VAD replica count is high.",
+      "user_impact": "No confirmed user impact yet; Omi capacity or reliability headroom is reduced.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and check service readiness before intervention.",
+      "safe_next_action": "Inspect readiness and capacity first; use the documented scaling or rollback path only if the condition persists."
     },
     "isPaused": false,
     "notification_settings": {
@@ -541,7 +570,10 @@
     "record": null,
     "labels": {
       "severity": "ticket",
-      "instatus_component": "speech-processing"
+      "instatus_component": "speech-processing",
+      "alert_identity": "cew9aupbed0xsd",
+      "component": "speech-processing",
+      "impact": "infrastructure"
     }
   },
   {
@@ -667,7 +699,12 @@
     "annotations": {
       "__dashboardUid__": "6d3d0897-c5a8-4f7b-b034-a3718c52a63b",
       "__panelId__": "50",
-      "threshold": "2500ms (2.5s)"
+      "threshold": "2500ms (2.5s)",
+      "summary": "Omi speech processing alert: VAD request latency is high.",
+      "user_impact": "Users may see this Omi capability fail, slow down, or become unavailable.",
+      "scope": "The Omi speech processing production service path.",
+      "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",
+      "safe_next_action": "Inspect the linked dashboard and service readiness; use the documented rollback or capacity path only after verification."
     },
     "isPaused": false,
     "notification_settings": {
@@ -676,7 +713,10 @@
     "record": null,
     "labels": {
       "severity": "warning",
-      "instatus_component": "speech-processing"
+      "instatus_component": "speech-processing",
+      "alert_identity": "eew9ai0vlsyrke",
+      "component": "speech-processing",
+      "impact": "product"
     }
   }
 ]

--- a/backend/charts/monitoring/dashboards/gke/parakeet-asr-monitoring.json
+++ b/backend/charts/monitoring/dashboards/gke/parakeet-asr-monitoring.json
@@ -212,7 +212,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Number of active WebSocket streaming connections to the ASR service.",
+      "description": "Average active WebSocket streams per ready Parakeet replica. Warning at 15; critical at 20. Check that HPA replicas are ready before changing capacity.",
       "fieldConfig": {
         "defaults": {
           "decimals": 0,
@@ -226,11 +226,11 @@
               },
               {
                 "color": "yellow",
-                "value": 50
+                "value": 15
               },
               {
                 "color": "red",
-                "value": 100
+                "value": 20
               }
             ]
           },
@@ -269,13 +269,13 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(parakeet_active_streams{container=\"parakeet\", namespace=\"prod-omi-backend\"})",
+          "expr": "sum(parakeet_active_streams{container=\"parakeet\", namespace=\"prod-omi-backend\"}) / clamp_min(sum(kube_deployment_status_replicas_ready{deployment=\"prod-omi-parakeet\", namespace=\"prod-omi-backend\"}), 1)",
           "instant": true,
-          "legendFormat": "Active Streams",
+          "legendFormat": "Active streams / ready replica",
           "refId": "A"
         }
       ],
-      "title": "Active Streams",
+      "title": "Streaming capacity per ready replica",
       "type": "stat"
     },
     {

--- a/backend/charts/monitoring/dashboards/omi-services/resilience-fallbacks.json
+++ b/backend/charts/monitoring/dashboards/omi-services/resilience-fallbacks.json
@@ -503,7 +503,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "**Real-traffic journeys:** chat, pusher, and capture-finalization measure accepted work through a server-observable terminal boundary. Product-failure alerts require real traffic; cancelled client/transport endings and fenced stale work remain visible without counting as product failures. An absent source is scrape health, not zero traffic. Semantics: `backend/docs/runbooks/real-traffic-journeys.md`.",
+        "content": "**Real-traffic journeys:** chat, pusher, live transcription, and capture-finalization measure accepted work through a server-observable terminal boundary. Product-failure alerts require real traffic; cancelled client/transport endings and fenced stale work remain visible without counting as product failures. An absent source is scrape health, not zero traffic. Semantics: `backend/docs/runbooks/real-traffic-journeys.md`.",
         "mode": "markdown"
       },
       "pluginVersion": "12.1.0",

--- a/backend/docs/runbooks/parakeet-stream-capacity.md
+++ b/backend/docs/runbooks/parakeet-stream-capacity.md
@@ -1,0 +1,50 @@
+# Parakeet — streaming capacity per ready replica
+
+**What it means:** Production Parakeet has less streaming headroom per ready
+replica than intended. This is an infrastructure signal: it can precede live
+transcription delay or rejected streams, but does not by itself prove a user
+outage.
+
+**Owner:** speech-processing / platform team.
+
+**Dashboard:** Grafana → Parakeet ASR Monitoring → **Streaming capacity per
+ready replica**. Compare it with **HPA Replicas (Ready / Total / Desired)**,
+GPU utilization, queue duration, request latency, and request errors.
+
+**PromQL:**
+
+```promql
+sum(parakeet_active_streams{container="parakeet", namespace="prod-omi-backend"}) / clamp_min(sum(kube_deployment_status_replicas_ready{deployment="prod-omi-parakeet", namespace="prod-omi-backend"}), 1)
+```
+
+The metric is the sum of active WebSocket streams divided by ready deployment
+replicas. It deliberately follows the currently serving replica count, so a
+cluster-total stream count cannot hide a per-pod capacity problem while the HPA
+is catching up.
+
+| Alert | Threshold | Duration | Meaning |
+| --- | --- | --- | --- |
+| Warning | 15 active streams per ready replica | 5 minutes | Headroom is reduced; confirm HPA progress and pod readiness. |
+| Critical | 20 active streams per ready replica | 2 minutes | Near the known 25–30 stream per-replica limit; act after corroborating the dashboard. |
+
+No data is healthy for these capacity alerts. Missing metrics are not proof of
+saturation; investigate scrape, deployment, or readiness separately if the
+dashboard is unexpectedly empty.
+
+## First checks
+
+1. Confirm the capacity panel remains above the alert threshold for its full
+   duration and that the displayed ready-replica value is current.
+2. Compare HPA desired, total, and ready replicas. A desired-versus-ready gap
+   points to scheduling, image startup, readiness, or node-capacity delay—not a
+   reason to change the capacity threshold.
+3. Inspect Parakeet pod readiness, restarts, GPU utilization, GPU OOM events,
+   queue duration, latency, and request error rate. Correlate with production
+   traffic before declaring user impact.
+4. Allow the HPA to add healthy replicas first. If it has reached its configured
+   maximum with sustained demand, use the documented capacity-change path after
+   confirming node and GPU availability.
+
+Do not force-scale, change alert thresholds, or state that users are affected
+from this metric alone. The alert measures serving headroom; request errors,
+latency, and queueing provide the user-path corroboration.

--- a/backend/docs/runbooks/pusher-degraded.md
+++ b/backend/docs/runbooks/pusher-degraded.md
@@ -1,8 +1,10 @@
 # Pusher — degraded session ratio high
 
-**What it means:** More than 5% of active pusher WebSocket sessions are in degraded mode (pusher unavailable, audio routed elsewhere).
+**What it means:** More than 5% of active listener WebSocket sessions are in degraded mode because the listener cannot use Pusher and routes audio elsewhere. This is a likely user-impact signal, not proof that every listener lost data.
 
-**PromQL:** `sum(pusher_sessions_degraded) / clamp_min(sum(pusher_active_ws_connections), 1)`
+**PromQL:** `sum(pusher_sessions_degraded{job="backend-listen-metrics"}) / clamp_min(sum(backend_listen_active_ws_connections{job="backend-listen-metrics"}), 1)`
+
+The degraded-session gauge is emitted by the backend-listen reconnect loop. Do not query the similarly named Pusher-process connection metric: it does not own this outcome.
 
 **Owner:** listen/pusher team.
 

--- a/backend/docs/runbooks/real-traffic-journeys.md
+++ b/backend/docs/runbooks/real-traffic-journeys.md
@@ -15,8 +15,8 @@ traffic it scrapes, with no cross-environment comparison or labels.
 | `omi_capture_finalization_reconciliations_total` | `outcome` | A stale durable capture job was requeued, or its requeue handoff failed. |
 | `listen_finalization_oldest_nonterminal_age_seconds` | none | Age of the oldest queued, leased, or BYOK-blocked capture finalization job. |
 
-`journey` is exactly `chat_response`, `pusher_session`, or
-`capture_finalization`. `outcome` is exactly `success`, `failure`,
+`journey` is exactly `chat_response`, `pusher_session`, `live_transcription`,
+or `capture_finalization`. `outcome` is exactly `success`, `failure`,
 `cancelled`, or `stale`; reconciliation `outcome` is exactly `requeued` or
 `enqueue_failed`. There are no user, conversation, request, error-text,
 provider, or content labels.
@@ -34,6 +34,12 @@ provider, or content labels.
   server has already identified an application failure. A `1011` or stronger
   application failure is `failure`; other transport/client endings are
   `cancelled`, not product failures.
+- `live_transcription` is accepted when `/v4/listen` receives its first
+  nontrivial audio frame. `success` is recorded only after the server has sent
+  the first nonempty transcript payload to that WebSocket. This cannot prove
+  the client rendered the payload. An upstream/live-session failure or an
+  unexpected listen worker failure is `failure`; all other endings before a
+  transcript send are `cancelled`.
 - `capture_finalization` is accepted only once, when the Firestore finalization
   outbox creates a new durable job. Successful completion is `success`, a
   dead-letter is `failure`, and a lifecycle-fenced durable job is `stale`.
@@ -43,7 +49,7 @@ provider, or content labels.
 
 ## Dashboard, alerts, and scrape health
 
-The **Resilience / Fallbacks** dashboard includes all three journey success
+The **Resilience / Fallbacks** dashboard includes all four journey success
 rates and p95 latencies. Success rate intentionally uses only terminal
 `success` and `failure` outcomes: cancelled client/transport endings and
 stale fenced capture jobs stay visible but do not masquerade as application
@@ -66,6 +72,9 @@ worker) and `pusher-metrics` (pusher sessions plus inline capture finalization).
 The metric children are initialized at process startup, so a scraped idle
 target exports zeros; an absent series should be investigated as scrape or
 deployment health, not read as zero traffic.
+
+The live-transcription failure alert uses Grafana `noDataState: OK`: an empty
+result is expected before that traffic exists and is not an outage.
 
 Known blind spots: a server can only observe the SSE/WS boundary it controls,
 not client rendering; process restarts may defer a terminal metric until the

--- a/backend/routers/listen/contracts.py
+++ b/backend/routers/listen/contracts.py
@@ -53,6 +53,8 @@ class ListenSessionState:
     speaker_id_done: asyncio.Event = field(default_factory=asyncio.Event)
     speaker_map_dirty: bool = False
     first_audio_byte_timestamp: Optional[float] = None
+    live_transcription_attempt: Any = None
+    live_transcription_failed: bool = False
     last_usage_record_timestamp: Optional[float] = None
     words_transcribed_since_last_record: int = 0
     last_transcript_time: Optional[float] = None

--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -417,6 +417,7 @@ class ListenReceiver:
                     if self.host.state.first_audio_byte_timestamp is None:
                         self.host.state.first_audio_byte_timestamp = now
                         self.host.state.last_usage_record_timestamp = now
+                        self.host.start_live_transcription()
                     if self.host.is_multi_channel:
                         await self._handle_multi_channel_audio(data)
                         continue

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -45,6 +45,7 @@ from utils.listen_session_bootstrap import finalize_listen_connect_context, load
 from utils.metrics import BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS
 from utils.notifications import send_credit_limit_notification, send_silent_user_notification
 from utils.onboarding import OnboardingHandler
+from utils.observability.journeys import JourneyAttempt, JourneyOutcome
 from utils.pusher import PusherCircuitBreakerOpen
 from utils.stt.streaming import STTService, get_stt_service_for_language
 from config.stt_provider_policy import PARAKEET_PROVIDER, STTServingSurface, provider_is_enabled
@@ -182,6 +183,28 @@ class ListenSessionRuntime:
                 segment_id=segment_id,
             )
         )
+
+    def start_live_transcription(self) -> None:
+        """Accept the journey once the listen socket has received real audio."""
+        if self.state.live_transcription_attempt is None:
+            self.state.live_transcription_attempt = JourneyAttempt('live_transcription')
+
+    def complete_live_transcription(self) -> None:
+        """Record the first nonempty transcript successfully delivered to the client."""
+        if self.state.live_transcription_attempt is not None:
+            self.state.live_transcription_attempt.finish('success')
+
+    def _finish_live_transcription(self) -> None:
+        """Terminalize an accepted attempt that never delivered a transcript."""
+        attempt = self.state.live_transcription_attempt
+        if attempt is None:
+            return
+        outcome: JourneyOutcome = (
+            'failure'
+            if self.state.live_transcription_failed or self.state.stt_terminal_failure or self.state.close_code == 1011
+            else 'cancelled'
+        )
+        attempt.finish(outcome)
 
     async def _admit(self) -> bool:
         if not self.request.uid:
@@ -539,6 +562,8 @@ class ListenSessionRuntime:
             self.send_event(MessageServiceStatusEvent(status='ready'))
             result = await self.task_supervisor.supervise(receive_task=receive_task)
             logger.info('Listen supervisor exited reason=%s task=%s', result.reason, result.task_name)
+            if result.reason in {'crash', 'lifetime_done'}:
+                self.state.live_transcription_failed = True
             if receive_task.done() and not receive_task.cancelled():
                 receive_error = receive_task.exception()
                 if receive_error is not None:
@@ -554,12 +579,14 @@ class ListenSessionRuntime:
             await self.task_supervisor.drain_monitored(timeout=self.limits.bg_drain_timeout, cancel=False)
         except Exception as error:
             logger.error('Listen WebSocket operation failed type=%s', type(error).__name__)
+            self.state.live_transcription_failed = True
         finally:
             await self._teardown()
 
     async def _teardown(self) -> None:
         self.state.shutdown_event.set()
         self.task_supervisor.end_session()
+        self._finish_live_transcription()
         try:
             await self.transcripts.flush_translations()
         except Exception as error:

--- a/backend/routers/listen/transcripts.py
+++ b/backend/routers/listen/transcripts.py
@@ -311,7 +311,10 @@ class TranscriptProcessor:
                 self.host.send_event(SegmentsDeletedEvent(segment_ids=removed))
             if not transcript_segments:
                 continue
-            await self.host.request.websocket.send_json([segment.model_dump() for segment in updated])
+            client_segments = [segment.model_dump() for segment in updated]
+            await self.host.request.websocket.send_json(client_segments)
+            if client_segments:
+                self.host.complete_live_transcription()
             if self.host.transcript_send is not None and self.host.user_has_credits:
                 self.host.transcript_send([segment.model_dump() for segment in transcript_segments])
             elif not self.host.pusher_enabled and self.host.user_has_credits:

--- a/backend/tests/unit/test_journey_observability.py
+++ b/backend/tests/unit/test_journey_observability.py
@@ -31,11 +31,11 @@ def _install_journey_metrics(monkeypatch):
 def test_journey_contract_uses_only_closed_privacy_safe_labels(monkeypatch):
     accepted, terminal, latency, reconciliations = _install_journey_metrics(monkeypatch)
 
-    journeys.record_journey_accepted('chat_response')
+    journeys.record_journey_accepted('live_transcription')
     journeys.record_journey_terminal('pusher_session', 'cancelled', 1.5)
     journeys.record_capture_finalization_reconciliation('requeued')
 
-    accepted.labels.assert_called_once_with(journey='chat_response')
+    accepted.labels.assert_called_once_with(journey='live_transcription')
     terminal.labels.assert_called_once_with(journey='pusher_session', outcome='cancelled')
     latency.labels.assert_called_once_with(journey='pusher_session', outcome='cancelled')
     reconciliations.labels.assert_called_once_with(outcome='requeued')
@@ -79,6 +79,7 @@ def test_terminal_finalization_failure_records_once_after_dead_letter(monkeypatc
 def test_idle_metrics_and_monitoring_contract_distinguish_traffic_from_a_missing_scrape_source():
     exported = metrics.generate_latest().decode()
     assert 'omi_journey_accepted_total{journey="chat_response"}' in exported
+    assert 'omi_journey_accepted_total{journey="live_transcription"}' in exported
     assert 'omi_journey_terminal_total{journey="pusher_session",outcome="success"}' in exported
     assert 'omi_capture_finalization_reconciliations_total{outcome="requeued"}' in exported
 
@@ -88,17 +89,28 @@ def test_idle_metrics_and_monitoring_contract_distinguish_traffic_from_a_missing
     expected_ids = {
         'omi-journey-chat-fail',
         'omi-journey-pusher-fail',
+        'omi-journey-live-transcription-fail',
         'omi-journey-capture-fail',
         'omi-journey-scrape-missing',
     }
     assert expected_ids <= {rule['uid'] for rule in split_alerts}
     assert expected_ids <= {rule['uid'] for rule in combined_alerts}
 
-    product_rules = [rule for rule in split_alerts if rule['uid'] in expected_ids - {'omi-journey-scrape-missing'}]
-    assert {rule['noDataState'] for rule in product_rules} == {'NoData'}
+    product_rule_ids = expected_ids - {'omi-journey-scrape-missing'}
+    product_rules = [rule for rule in split_alerts if rule['uid'] in product_rule_ids]
     for rule in product_rules:
         assert 'outcome=~"success|failure"' in rule['data'][0]['model']['expr']
         assert '$A >= 20 && $B > 0.10' in rule['data'][2]['model']['expression']
+    live_transcription_rule = next(
+        rule for rule in product_rules if rule['uid'] == 'omi-journey-live-transcription-fail'
+    )
+    assert live_transcription_rule['noDataState'] == 'OK'
+    assert live_transcription_rule['annotations']['__panelId__'] == '7'
+    assert all(
+        rule['noDataState'] == 'NoData'
+        for rule in product_rules
+        if rule['uid'] != 'omi-journey-live-transcription-fail'
+    )
     scrape_rule = next(rule for rule in split_alerts if rule['uid'] == 'omi-journey-scrape-missing')
     assert scrape_rule['noDataState'] == 'Alerting'
     assert 'count by (job)' in scrape_rule['data'][0]['model']['expr']

--- a/backend/tests/unit/test_listen_receiver_frame_recovery.py
+++ b/backend/tests/unit/test_listen_receiver_frame_recovery.py
@@ -37,6 +37,7 @@ class _BrokenDecoder:
 )
 async def test_receiver_drops_malformed_codec_frame_and_continues_to_custom_transcript(codec, decoder_attribute):
     received_segments = []
+    live_transcription_starts = []
     websocket = _FramesWebSocket(
         [
             {'text': '{not valid json'},
@@ -70,6 +71,7 @@ async def test_receiver_drops_malformed_codec_frame_and_continues_to_custom_tran
         use_custom_stt=True,
         audio_bytes_send=None,
         transcripts=SimpleNamespace(enqueue=received_segments.extend),
+        start_live_transcription=lambda: live_transcription_starts.append(True),
     )
     receiver = ListenReceiver(host, [], {})
     setattr(receiver, decoder_attribute, _BrokenDecoder())
@@ -77,6 +79,7 @@ async def test_receiver_drops_malformed_codec_frame_and_continues_to_custom_tran
     await receiver.receive_data()
 
     assert received_segments == [{'id': 'recovered', 'text': 'Recovered transcript', 'stt_provider': 'test-provider'}]
+    assert live_transcription_starts == [True]
     assert host.state.close_code == 1000
 
 

--- a/backend/tests/unit/test_listen_runtime_regressions.py
+++ b/backend/tests/unit/test_listen_runtime_regressions.py
@@ -1,11 +1,14 @@
 """Behavioral regression coverage for the extracted listen runtime."""
 
+import asyncio
+from collections import deque
 from types import SimpleNamespace
 
 import pytest
 
 from routers.listen.contracts import ListenRequest
 from routers.listen.runtime import ListenSessionRuntime
+from routers.listen.transcripts import TranscriptProcessor
 from utils.listen_session_bootstrap import ListenConnectBase
 
 
@@ -152,6 +155,163 @@ def test_runtime_emits_speaker_suggestion_event():
     assert emitted_events[0].event_type == 'speaker_label_suggestion'
     assert emitted_events[0].speaker_id == 4
     assert emitted_events[0].person_name == 'Avery'
+
+
+class _JourneyAttempt:
+    instances = []
+
+    def __init__(self, journey):
+        self.journey = journey
+        self.finished = False
+        self.outcomes = []
+        self.__class__.instances.append(self)
+
+    def finish(self, outcome):
+        if self.finished:
+            return
+        self.finished = True
+        self.outcomes.append(outcome)
+
+
+def _live_transcription_runtime(*, close_code=1001, stt_terminal_failure=False, live_transcription_failed=False):
+    runtime = object.__new__(ListenSessionRuntime)
+    runtime.state = SimpleNamespace(
+        close_code=close_code,
+        stt_terminal_failure=stt_terminal_failure,
+        live_transcription_failed=live_transcription_failed,
+        live_transcription_attempt=None,
+    )
+    return runtime
+
+
+def test_live_transcription_journey_starts_once_and_success_wins_over_teardown(monkeypatch):
+    import routers.listen.runtime as runtime_module
+
+    _JourneyAttempt.instances = []
+    monkeypatch.setattr(runtime_module, 'JourneyAttempt', _JourneyAttempt)
+    runtime = _live_transcription_runtime(close_code=1011, stt_terminal_failure=True)
+
+    runtime.start_live_transcription()
+    runtime.start_live_transcription()
+    runtime.complete_live_transcription()
+    runtime._finish_live_transcription()
+
+    assert len(_JourneyAttempt.instances) == 1
+    assert _JourneyAttempt.instances[0].journey == 'live_transcription'
+    assert _JourneyAttempt.instances[0].outcomes == ['success']
+
+
+@pytest.mark.parametrize(
+    ('close_code', 'stt_terminal_failure', 'live_transcription_failed', 'expected'),
+    [
+        (1000, False, False, 'cancelled'),
+        (1011, False, False, 'failure'),
+        (1001, True, False, 'failure'),
+        (1001, False, True, 'failure'),
+    ],
+)
+def test_live_transcription_teardown_classifies_unsent_attempts_once(
+    monkeypatch, close_code, stt_terminal_failure, live_transcription_failed, expected
+):
+    import routers.listen.runtime as runtime_module
+
+    _JourneyAttempt.instances = []
+    monkeypatch.setattr(runtime_module, 'JourneyAttempt', _JourneyAttempt)
+    runtime = _live_transcription_runtime(
+        close_code=close_code,
+        stt_terminal_failure=stt_terminal_failure,
+        live_transcription_failed=live_transcription_failed,
+    )
+
+    runtime.start_live_transcription()
+    runtime._finish_live_transcription()
+    runtime._finish_live_transcription()
+
+    assert _JourneyAttempt.instances[0].outcomes == [expected]
+
+
+@pytest.mark.anyio
+async def test_transcript_delivery_marks_live_transcription_success_only_after_a_nonempty_client_send(monkeypatch):
+    import routers.listen.transcripts as transcripts_module
+
+    class Segment:
+        def __init__(self, **data):
+            self.id = data['id']
+            self.text = data['text']
+            self.start = data['start']
+            self.end = data['end']
+            self.speech_profile_processed = data['speech_profile_processed']
+            self.is_user = False
+
+        def model_dump(self):
+            return {'id': self.id, 'text': self.text}
+
+        @staticmethod
+        def combine_segments(_existing, new_segments):
+            return new_segments, [], []
+
+    class WebSocket:
+        def __init__(self):
+            self.sent = []
+
+        async def send_json(self, payload):
+            self.sent.append(payload)
+
+    state = SimpleNamespace(
+        active=True,
+        first_audio_byte_timestamp=100.0,
+        last_transcript_time=None,
+        words_transcribed_since_last_record=0,
+        current_conversation_id='conversation-1',
+        speaker_id_done=asyncio.Event(),
+    )
+    state.speaker_id_done.set()
+    websocket = WebSocket()
+    delivered = []
+
+    async def wait(_seconds):
+        state.active = False
+        return False
+
+    async def cache_get(_conversation_id):
+        return {'transcript_segments': []}
+
+    async def update(_conversation, segments, _photos, _finished_at, _started_at):
+        return SimpleNamespace(id='conversation-1'), segments, []
+
+    async def no_op(*_args, **_kwargs):
+        return None
+
+    host = SimpleNamespace(
+        state=state,
+        wait=wait,
+        request=SimpleNamespace(uid='user-1', onboarding_mode=False, websocket=websocket),
+        transcript_send=None,
+        user_has_credits=True,
+        pusher_enabled=True,
+        onboarding_handler=None,
+        send_event=lambda _event: None,
+        speakers=SimpleNamespace(drain=no_op),
+        complete_live_transcription=lambda: delivered.append(True),
+    )
+    processor = object.__new__(TranscriptProcessor)
+    processor.host = host
+    processor.segment_buffer = deque([{'id': 'segment-1', 'text': 'Hello', 'start': 0.0, 'end': 0.5}])
+    processor.photo_buffer = deque()
+    processor.cache = SimpleNamespace(get=cache_get)
+    processor.current_session_segments = {}
+    processor._update_live_conversation = update
+    processor._translate = no_op
+    processor._speaker_detection = no_op
+    processor.flush_speaker_assignments = no_op
+
+    monkeypatch.setattr(transcripts_module, 'TranscriptSegment', Segment)
+    monkeypatch.setattr(transcripts_module, 'deserialize_conversation', lambda _data: SimpleNamespace())
+
+    await processor.process_loop()
+
+    assert websocket.sent == [[{'id': 'segment-1', 'text': 'Hello'}]]
+    assert delivered == [True]
 
 
 async def _async_result(value):

--- a/backend/tests/unit/test_monitoring_alert_rule_contract.py
+++ b/backend/tests/unit/test_monitoring_alert_rule_contract.py
@@ -33,6 +33,12 @@ PARAKEET_STREAMS_PER_READY_REPLICA = (
     '/ clamp_min(sum(kube_deployment_status_replicas_ready{deployment="prod-omi-parakeet", '
     'namespace="prod-omi-backend"}), 1)'
 )
+PARAKEET_STREAM_CAPACITY_RUNBOOK = "backend/docs/runbooks/parakeet-stream-capacity.md"
+PARAKEET_CAPACITY_DASHBOARD = MONITORING / "dashboards/gke/parakeet-asr-monitoring.json"
+LIVE_TRANSCRIPTION_FAILURE_RULE = "omi-journey-live-transcription-fail"
+LIVE_TRANSCRIPTION_FAILURE_EXPR = (
+    'sum(increase(omi_journey_terminal_total{journey="live_transcription",outcome=~"success|failure"}[30m]))'
+)
 
 
 def _rules(path: Path) -> dict[str, dict]:
@@ -126,6 +132,32 @@ def test_parakeet_stream_capacity_alerts_preserve_per_ready_replica_headroom():
         assert rule["data"][2]["model"]["conditions"][0]["evaluator"]["params"] == [threshold]
 
 
+def test_parakeet_stream_capacity_alerts_link_the_matching_dashboard_and_runbook():
+    """The alert, dashboard, and operator response use the same per-replica signal."""
+    rules = _rules(ALERT_SOURCES / "parakeet.json")
+    dashboard = json.loads(PARAKEET_CAPACITY_DASHBOARD.read_text(encoding="utf-8"))
+    panel = next(panel for panel in dashboard["panels"] if panel["id"] == 3)
+    runbook = (REPO / PARAKEET_STREAM_CAPACITY_RUNBOOK).read_text(encoding="utf-8")
+
+    assert panel["title"] == "Streaming capacity per ready replica"
+    assert panel["targets"][0]["expr"] == PARAKEET_STREAMS_PER_READY_REPLICA
+    assert panel["fieldConfig"]["defaults"]["thresholds"]["steps"] == [
+        {"color": "green", "value": 0},
+        {"color": "yellow", "value": 15},
+        {"color": "red", "value": 20},
+    ]
+
+    for uid, (severity, threshold) in PARAKEET_STREAM_CAPACITY_RULES.items():
+        rule = rules[uid]
+        assert rule["labels"]["severity"] == severity
+        assert rule["annotations"]["__dashboardUid__"] == dashboard["uid"]
+        assert rule["annotations"]["__panelId__"] == str(panel["id"])
+        assert rule["annotations"]["runbook"] == PARAKEET_STREAM_CAPACITY_RUNBOOK
+        assert f"{threshold} active streams per ready replica" in runbook
+
+    assert PARAKEET_STREAMS_PER_READY_REPLICA in runbook
+
+
 def test_pusher_degradation_uses_listener_emitter_metrics():
     """The reconnect degradation gauge is emitted by backend-listen, not Pusher."""
     rule = _rules(ALERT_SOURCES / "pusher.json")["bfobs1pusherdeg01"]
@@ -155,3 +187,14 @@ def test_llm_gateway_alerts_cover_client_black_holes_and_ready_endpoints():
     endpoint_rule = split["omi-llm-gateway-no-ready-endpoints"]
     assert endpoint_rule["noDataState"] == "Alerting"
     assert "kube_endpoint_address_available" in endpoint_rule["data"][0]["model"]["expr"]
+
+
+def test_live_transcription_alert_is_traffic_gated_and_ignores_idle_no_data():
+    """The real-traffic alert must not page before any live sessions exist."""
+    for rules in _all_rule_exports().values():
+        rule = rules[LIVE_TRANSCRIPTION_FAILURE_RULE]
+        assert rule["noDataState"] == "OK"
+        assert rule["data"][0]["model"]["expr"] == LIVE_TRANSCRIPTION_FAILURE_EXPR
+        assert rule["data"][2]["model"]["expression"] == "$A >= 20 && $B > 0.10"
+        assert rule["annotations"]["__dashboardUid__"] == "omi-resilience-fallbacks"
+        assert rule["annotations"]["__panelId__"] == "7"

--- a/backend/tests/unit/test_monitoring_alert_rule_contract.py
+++ b/backend/tests/unit/test_monitoring_alert_rule_contract.py
@@ -1,10 +1,11 @@
-"""Static contract for Grafana rules where an empty error-count series is healthy."""
+"""Static contracts for Grafana alert rules."""
 
 import json
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[3]
 MONITORING = REPO / "backend/charts/monitoring"
+ALERT_SOURCES = MONITORING / "alerts"
 ERROR_COUNT_RULES = {
     "cew4j7ruiik1sd",  # Backend 4XX
     "cew4jcnpa68sga",  # Backend 5XX
@@ -13,10 +14,48 @@ ERROR_COUNT_RULES = {
     "eew96lge97gg0e",  # Backend-integration 4XX
     "eew96o25qztvkf",  # Backend-integration 5XX
 }
+REQUIRED_HUMAN_ANNOTATIONS = {
+    "summary",
+    "user_impact",
+    "scope",
+    "verification",
+    "safe_next_action",
+}
+REQUIRED_IDENTITY_LABELS = {"alert_identity", "component", "impact"}
+IMPACT_TIERS = {"infrastructure", "product", "user-experience"}
+UNSAFE_ANNOTATION_MARKERS = ("{{", "}}", "$values", "traceback", "stack trace")
+PARAKEET_STREAM_CAPACITY_RULES = {
+    "omi-parakeet-stream-capacity-warning": ("warning", 15),
+    "omi-parakeet-stream-capacity-critical": ("critical", 20),
+}
+PARAKEET_STREAMS_PER_READY_REPLICA = (
+    'sum(parakeet_active_streams{container="parakeet", namespace="prod-omi-backend"}) '
+    '/ clamp_min(sum(kube_deployment_status_replicas_ready{deployment="prod-omi-parakeet", '
+    'namespace="prod-omi-backend"}), 1)'
+)
 
 
 def _rules(path: Path) -> dict[str, dict]:
-    return {rule["uid"]: rule for rule in json.loads(path.read_text(encoding="utf-8"))}
+    rules = json.loads(path.read_text(encoding="utf-8"))
+    by_uid = {rule["uid"]: rule for rule in rules}
+    assert len(by_uid) == len(rules), f"duplicate Grafana alert UID in {path}"
+    return by_uid
+
+
+def _split_rules() -> dict[str, dict]:
+    rules = {}
+    for path in sorted(ALERT_SOURCES.glob("*.json")):
+        for uid, rule in _rules(path).items():
+            assert uid not in rules, f"duplicate Grafana alert UID across split exports: {uid}"
+            rules[uid] = rule
+    return rules
+
+
+def _all_rule_exports() -> dict[str, dict[str, dict]]:
+    return {
+        "combined": _rules(MONITORING / "alert-rules.json"),
+        "split": _split_rules(),
+    }
 
 
 def test_stackdriver_error_count_rules_treat_no_data_as_zero_errors():
@@ -35,13 +74,70 @@ def test_stackdriver_error_count_rules_treat_no_data_as_zero_errors():
 def test_split_alert_exports_preserve_error_count_no_data_contract():
     """The deployable combined export and group exports must not drift."""
     combined = _rules(MONITORING / "alert-rules.json")
-    split = {}
-    for name in ("backend.json", "backend-sync.json", "backend-integration.json"):
-        split.update(_rules(MONITORING / "alerts" / name))
+    split = _split_rules()
 
     assert ERROR_COUNT_RULES <= split.keys()
     for uid in ERROR_COUNT_RULES:
         assert combined[uid]["noDataState"] == split[uid]["noDataState"] == "OK"
+
+
+def test_combined_alert_export_matches_every_split_source_rule():
+    """The combined Grafana import is an exact UID-indexed copy of split sources."""
+    combined, split = _all_rule_exports().values()
+
+    assert combined.keys() == split.keys()
+    for uid in combined:
+        assert combined[uid] == split[uid], uid
+
+
+def test_grafana_alert_rules_have_safe_human_impact_metadata():
+    """Every operator notification explains human impact without raw error output."""
+    for export_name, rules in _all_rule_exports().items():
+        for uid, rule in rules.items():
+            annotations = rule["annotations"]
+            labels = rule["labels"]
+
+            assert REQUIRED_HUMAN_ANNOTATIONS <= annotations.keys(), f"{export_name}:{uid}"
+            assert REQUIRED_IDENTITY_LABELS <= labels.keys(), f"{export_name}:{uid}"
+            assert labels["alert_identity"] == uid, f"{export_name}:{uid}"
+            assert labels["impact"] in IMPACT_TIERS, f"{export_name}:{uid}"
+
+            for key in REQUIRED_HUMAN_ANNOTATIONS:
+                value = annotations[key]
+                assert isinstance(value, str) and value.strip(), f"{export_name}:{uid}:{key}"
+                value_lower = value.lower()
+                assert not any(
+                    marker in value_lower for marker in UNSAFE_ANNOTATION_MARKERS
+                ), f"{export_name}:{uid}:{key} exposes raw alert output"
+
+            assert isinstance(labels["component"], str) and labels["component"].strip(), f"{export_name}:{uid}"
+
+
+def test_parakeet_stream_capacity_alerts_preserve_per_ready_replica_headroom():
+    """Capacity alerts use the active-stream gauge, normalized by ready replicas."""
+    rules = _rules(ALERT_SOURCES / "parakeet.json")
+
+    assert PARAKEET_STREAM_CAPACITY_RULES.keys() <= rules.keys()
+    for uid, (severity, threshold) in PARAKEET_STREAM_CAPACITY_RULES.items():
+        rule = rules[uid]
+        assert rule["labels"]["severity"] == severity
+        assert rule["noDataState"] == "OK"
+        assert rule["data"][0]["model"]["expr"] == PARAKEET_STREAMS_PER_READY_REPLICA
+        assert rule["data"][2]["model"]["conditions"][0]["evaluator"]["params"] == [threshold]
+
+
+def test_pusher_degradation_uses_listener_emitter_metrics():
+    """The reconnect degradation gauge is emitted by backend-listen, not Pusher."""
+    rule = _rules(ALERT_SOURCES / "pusher.json")["bfobs1pusherdeg01"]
+    expr = rule["data"][0]["model"]["expr"]
+
+    assert 'pusher_sessions_degraded{job="backend-listen-metrics"}' in expr
+    assert 'backend_listen_active_ws_connections{job="backend-listen-metrics"}' in expr
+    assert 'job="pusher-metrics"' not in expr
+
+    pusher_5xx = _rules(ALERT_SOURCES / "pusher.json")["aew926uoh6o00c"]
+    assert pusher_5xx["noDataState"] == "OK"
+    assert "or vector(0)" in pusher_5xx["data"][0]["model"]["expr"]
 
 
 def test_llm_gateway_alerts_cover_client_black_holes_and_ready_endpoints():

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -53,7 +53,7 @@ OMI_CAPTURE_FINALIZATION_RECONCILIATIONS_TOTAL = Counter(
 
 # Export zero-valued children from a healthy but idle process. This lets
 # Prometheus/Grafana distinguish no user traffic from an absent scrape target.
-for _journey in ('chat_response', 'pusher_session', 'capture_finalization'):
+for _journey in ('chat_response', 'pusher_session', 'live_transcription', 'capture_finalization'):
     OMI_JOURNEY_ACCEPTED_TOTAL.labels(journey=_journey)
     for _outcome in ('success', 'failure', 'cancelled', 'stale'):
         OMI_JOURNEY_TERMINAL_TOTAL.labels(journey=_journey, outcome=_outcome)

--- a/backend/utils/observability/journeys.py
+++ b/backend/utils/observability/journeys.py
@@ -13,11 +13,11 @@ from utils.metrics import (
     OMI_JOURNEY_TERMINAL_TOTAL,
 )
 
-JourneyName = Literal['chat_response', 'pusher_session', 'capture_finalization']
+JourneyName = Literal['chat_response', 'pusher_session', 'live_transcription', 'capture_finalization']
 JourneyOutcome = Literal['success', 'failure', 'cancelled', 'stale']
 ReconciliationOutcome = Literal['requeued', 'enqueue_failed']
 
-_JOURNEYS = frozenset({'chat_response', 'pusher_session', 'capture_finalization'})
+_JOURNEYS = frozenset({'chat_response', 'pusher_session', 'live_transcription', 'capture_finalization'})
 _OUTCOMES = frozenset({'success', 'failure', 'cancelled', 'stale'})
 _RECONCILIATION_OUTCOMES = frozenset({'requeued', 'enqueue_failed'})
 


### PR DESCRIPTION
## Summary

Closes the detection gap exposed by the Parakeet live-transcription incident without changing routing, capacity admission, release workflows, or deployed contact-point configuration.

- Adds per-ready-replica Parakeet active-stream warnings (15) and critical alerts (20), plus a matching dashboard panel and operator runbook.
- Adds a privacy-safe `live_transcription` real-traffic journey: first valid audio accepted → first non-empty transcript successfully sent to the WebSocket client → one terminal outcome.
- Adds a traffic-gated warning when live-transcription terminal failures exceed 10% with at least 20 real terminal outcomes in 30 minutes. Empty/idle data is explicitly inconclusive (`noDataState: OK`).
- Corrects Pusher degraded-session alerting and runbook guidance to query the listener-side metric owner.
- Establishes human-impact metadata and exact combined/split Grafana export consistency for all alert rules.

## Failure class

The incident was a capacity/routing failure that stayed invisible because monitoring observed infrastructure symptoms rather than user-facing live-transcription outcome. This PR adds detection and a reusable alert contract; routing admission and release rollback are intentionally owned by separate follow-up work.

Failure-Class: none

## Verification

- `make preflight` — passed: 19 checks.
- Python 3.11 compilation for changed runtime/observability modules — passed.
- Exact combined/split Grafana export verification — passed: 63 rules.
- `git diff --check` — passed.
- Independent review approved the live-transcription journey’s acceptance, success, teardown, double-counting, PromQL, no-data, and export-sync semantics.

## Limitations

The worktree has no project-local backend Python environment, and the ambient Python installation lacks `google.cloud.firestore`; the full focused pytest collection could not run locally. The deterministic repository preflight passed. This PR does not claim that a server-side WebSocket send proves client rendering; it deliberately measures the strongest server-observable boundary.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

