### PR TITLE
fix(macos): prevent notification settings startup crash

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-proactiveassistants.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-proactiveassistants.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift": 1742,
-    "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": 1669
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": 1655
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift": "Task candidate context now carries only backend action-item IDs, while local SQLite/staged evidence remains id-less so the model cannot target it for a backend mutation.",

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+NotificationSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+NotificationSettings.swift
@@ -1,0 +1,33 @@
+import Foundation
+import UserNotifications
+
+extension ProactiveAssistantsPlugin {
+  /// Registers the system callback outside MainActor, then hands only its
+  /// authorization status to a MainActor handler. `query` is injected so the
+  /// off-main callback contract is exercised without a system permission prompt.
+  nonisolated static func queryStartupNotificationSettings(
+    query: @escaping @Sendable (@escaping @Sendable (UNAuthorizationStatus) -> Void) -> Void,
+    handler: @escaping @MainActor @Sendable (UNAuthorizationStatus) -> Void,
+    dispatchToMain: @escaping @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void =
+      dispatchNotificationCallbackToMain
+  ) {
+    query { authorizationStatus in
+      dispatchToMain {
+        handler(authorizationStatus)
+      }
+    }
+  }
+
+  /// UserNotifications invokes its callback on a private XPC queue. Dispatching
+  /// explicitly to the main queue avoids inheriting that queue's executor into a
+  /// Swift task before the MainActor handler runs.
+  nonisolated private static func dispatchNotificationCallbackToMain(
+    _ work: @escaping @MainActor @Sendable () -> Void
+  ) {
+    DispatchQueue.main.async {
+      MainActor.assumeIsolated {
+        work()
+      }
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -298,20 +298,6 @@ public class ProactiveAssistantsPlugin: NSObject {
     }
   }
 
-  /// Registers the system callback outside MainActor, then hands only its
-  /// authorization status to a MainActor handler. `query` is injected so the
-  /// off-main callback contract is exercised without a system permission prompt.
-  nonisolated static func queryStartupNotificationSettings(
-    query: @escaping @Sendable (@escaping @Sendable (UNAuthorizationStatus) -> Void) -> Void,
-    handler: @escaping @MainActor @Sendable (UNAuthorizationStatus) -> Void
-  ) {
-    query { authorizationStatus in
-      Task { @MainActor in
-        handler(authorizationStatus)
-      }
-    }
-  }
-
   @MainActor
   private static func handleStartupNotificationAuthorizationStatus(_ authorizationStatus: UNAuthorizationStatus) {
     guard authorizationStatus == .notDetermined else {

--- a/desktop/macos/Desktop/Tests/ProactiveAssistantsNotificationSettingsTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveAssistantsNotificationSettingsTests.swift
@@ -3,7 +3,8 @@ import XCTest
 @testable import Omi_Computer
 
 final class ProactiveAssistantsNotificationSettingsTests: XCTestCase {
-  func testNotificationSettingsCallbackDeliveredOffMainHopsToMainActor() async {
+  func testNotificationSettingsCallbackDeliveredOffMainUsesMainDispatcherBeforeHandler() async {
+    let dispatcherCalled = expectation(description: "main dispatcher called")
     let result = await withCheckedContinuation { continuation in
       ProactiveAssistantsPlugin.queryStartupNotificationSettings(
         query: { completion in
@@ -13,10 +14,17 @@ final class ProactiveAssistantsNotificationSettingsTests: XCTestCase {
         },
         handler: { status in
           continuation.resume(returning: (Thread.isMainThread, status))
+        },
+        dispatchToMain: { work in
+          dispatcherCalled.fulfill()
+          DispatchQueue.main.async {
+            work()
+          }
         }
       )
     }
 
+    await fulfillment(of: [dispatcherCalled])
     XCTAssertTrue(result.0)
     XCTAssertEqual(result.1, .notDetermined)
   }

--- a/desktop/macos/changelog/unreleased/20260719-notification-startup-crash.json
+++ b/desktop/macos/changelog/unreleased/20260719-notification-startup-crash.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a startup crash that could occur while checking notification permissions"
+}

--- a/desktop/macos/e2e/flows/screen-recording-permission.yaml
+++ b/desktop/macos/e2e/flows/screen-recording-permission.yaml
@@ -19,6 +19,7 @@ covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ScreenCaptureTargetPolicy.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+NotificationSettings.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+ScreenCaptureHealth.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
 preconditions:


### PR DESCRIPTION
## Summary

- dispatch the startup UserNotifications callback to the main queue before invoking the MainActor handler
- add a regression test that proves an off-main callback uses the explicit dispatcher
- extract the callback bridge to a focused Proactive Assistants extension and ratchet the oversized plugin baseline down

## Root cause

`UNUserNotificationCenter.getNotificationSettings` invoked its completion on a private XPC queue. Creating `Task { @MainActor ... }` from that queue tripped Swift executor isolation validation before the actor hop and crashed the app at launch.

## Verification

- `xcrun swift test --package-path Desktop --filter ProactiveAssistantsNotificationSettingsTests`
- `./scripts/agent-logic-harness.sh --cross-surface-smoke`
- `OMI_APP_NAME=omi-fix-notification-callback NO_WAIT=1 ./run.sh --yolo --full`
- strict code-sign verification and local automation health/ready checks on the named bundle

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

