### PR TITLE
fix(release): verify atomic recovery across GKE and Cloud Run

### DIFF
--- a/.github/scripts/check_release_rings.py
+++ b/.github/scripts/check_release_rings.py
@@ -6,12 +6,13 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 
 
 def require(text: str, path: Path, fragments: tuple[str, ...]) -> list[str]:
-    return [f"{path}: missing required release-ring guard {fragment!r}" for fragment in fragments if fragment not in text]
+    return [
+        f"{path}: missing required release-ring guard {fragment!r}" for fragment in fragments if fragment not in text
+    ]
 
 
 def check() -> list[str]:
@@ -56,19 +57,32 @@ def check() -> list[str]:
                 "group: deploy-release-ring-${{ inputs.ring }}",
                 "environment: ${{ inputs.ring }}",
                 "github.ref == 'refs/heads/main'",
-                "test \"${{ inputs.confirm }}\" = \"deploy-prod\"",
+                "RELEASE_ID: ${{ inputs.release_id }}",
+                "PROD_CONFIRM: ${{ inputs.confirm }}",
+                'test "$PROD_CONFIRM" = "deploy-prod"',
+                "ref: ${{ github.sha }}",
                 "backend/scripts/release_rings.py validate-record",
                 "Require a non-held beta-soaked record before prod promotion",
-                "Checkout the immutable record source for deployment rendering",
+                "Checkout immutable release source inputs",
                 "ref: ${{ steps.record.outputs.git_sha }}",
+                "path: artifacts/release-ring/source",
                 "render_backend_runtime_env.py",
+                "Preflight all recorded GKE configuration before mutation",
+                "--dry-run=server",
+                "DRY_RUN=true",
                 "--update-secrets",
                 "backend/scripts/deploy-backend-secrets.sh",
                 "Verify beta endpoint prerequisites before mutation",
                 "cloud_run_traffic_snapshot.py capture",
+                "release_ring_gke_snapshot.py capture",
                 "--no-traffic",
                 "cloud_run_traffic_snapshot.py restore",
-                "gcloud run services delete",
+                "--remove-tag \"ring-${GITHUB_RUN_ID}\"",
+                "--delete-missing",
+                "release_ring_gke_snapshot.py restore",
+                "wait_external_secret_refresh.py",
+                "active-before.json",
+                "steps.snapshot.outputs.active_generation",
                 "state=partial_mutation",
                 "--hold",
                 "--if-generation-match=\"$generation\"",
@@ -85,6 +99,9 @@ def check() -> list[str]:
             errors.append(f"{path}: release-ring workflows must use ring-bound OIDC, not JSON credentials")
     if "release_sha:" in deploy or "branch:" in deploy or "image:" in deploy:
         errors.append(f"{deploy_path}: deploy accepts free-form source or image input")
+    for expression in ("${{ inputs.release_id }}", "${{ inputs.confirm }}"):
+        if deploy.count(expression) != 1:
+            errors.append(f"{deploy_path}: dispatch input {expression} must enter shell only through the job env")
     topology_path = ROOT / "backend/deploy/release_rings.yaml"
     if not topology_path.exists() or "backend: backend-beta" not in topology_path.read_text(encoding="utf-8"):
         errors.append("backend/deploy/release_rings.yaml: beta must use distinct Cloud Run service identities")

--- a/.github/scripts/test_check_release_rings.py
+++ b/.github/scripts/test_check_release_rings.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import importlib.util
+import shutil
 import sys
 from pathlib import Path
-
 
 MODULE_PATH = Path(__file__).with_name("check_release_rings.py")
 SPEC = importlib.util.spec_from_file_location("check_release_rings", MODULE_PATH)
@@ -27,3 +27,24 @@ def test_missing_guard_is_reported(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(checker, "ROOT", tmp_path)
 
     assert any("missing required release-ring guard" in error for error in checker.check())
+
+
+def test_dispatch_release_id_cannot_be_interpolated_into_shell(tmp_path: Path, monkeypatch) -> None:
+    for relative in (
+        Path(".github/workflows/release-record.yml"),
+        Path(".github/workflows/deploy-release-ring.yml"),
+        Path("backend/deploy/release_rings.yaml"),
+    ):
+        destination = tmp_path / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(checker.ROOT / relative, destination)
+    deploy_path = tmp_path / ".github/workflows/deploy-release-ring.yml"
+    deploy_path.write_text(
+        deploy_path.read_text(encoding="utf-8").replace(
+            'records/${RELEASE_ID}.json', 'records/${{ inputs.release_id }}.json'
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(checker, "ROOT", tmp_path)
+
+    assert any("must enter shell only through the job env" in error for error in checker.check())

--- a/.github/workflows/deploy-release-ring.yml
+++ b/.github/workflows/deploy-release-ring.yml
@@ -38,6 +38,9 @@ jobs:
       RELEASE_BUCKET: ${{ vars.RELEASE_RECORDS_BUCKET }}
       RELEASE_RUNTIME_PROJECT: ${{ vars.RELEASE_RUNTIME_PROJECT_ID }}
       RELEASE_GKE_CLUSTER: ${{ vars.RELEASE_GKE_CLUSTER }}
+      RELEASE_RING: ${{ inputs.ring }}
+      RELEASE_ID: ${{ inputs.release_id }}
+      PROD_CONFIRM: ${{ inputs.confirm }}
     steps:
       - name: Refuse free-form or ungated prod deploys
         run: |
@@ -45,14 +48,16 @@ jobs:
           test -n "$RELEASE_BUCKET"
           test -n "$RELEASE_RUNTIME_PROJECT"
           test -n "$RELEASE_GKE_CLUSTER"
-          if [[ "${{ inputs.ring }}" == "prod" ]]; then
-            test "${{ inputs.confirm }}" = "deploy-prod"
+          [[ "$RELEASE_RING" == "beta" || "$RELEASE_RING" == "prod" ]]
+          [[ "$RELEASE_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$ ]]
+          if [[ "$RELEASE_RING" == "prod" ]]; then
+            test "$PROD_CONFIRM" = "deploy-prod"
           fi
 
-      - name: Checkout reviewed deployment code from main
+      - name: Checkout immutable reviewed deployment controller
         uses: actions/checkout@v7
         with:
-          ref: main
+          ref: ${{ github.sha }}
 
       - name: Authenticate with ring-bound OIDC identity
         uses: google-github-actions/auth@v3
@@ -76,9 +81,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts/release-ring/config
-          gcloud storage cp "gs://${RELEASE_BUCKET}/records/${{ inputs.release_id }}.json" artifacts/release-ring/record.json
+          gcloud storage cp "gs://${RELEASE_BUCKET}/records/${RELEASE_ID}.json" artifacts/release-ring/record.json
           python3 backend/scripts/release_rings.py validate-record --record artifacts/release-ring/record.json
-          test "$(jq -r .release_id artifacts/release-ring/record.json)" = "${{ inputs.release_id }}"
+          test "$(jq -r .release_id artifacts/release-ring/record.json)" = "$RELEASE_ID"
           while IFS=$'\t' read -r name reference; do
             object="${reference%%#sha256:*}"
             destination="artifacts/release-ring/config/${name//\//-}.yaml"
@@ -99,30 +104,71 @@ jobs:
           set -euo pipefail
           test "$MIN_SOAK_SECONDS" -ge 1
           gcloud storage cp "gs://${RELEASE_BUCKET}/rings/beta/active.json" artifacts/release-ring/beta-active.json
-          if jq -e --arg id "${{ inputs.release_id }}" '.held_release_ids | index($id)' artifacts/release-ring/beta-active.json; then
-            echo "Refusing held beta release ${{ inputs.release_id }}." >&2
+          if jq -e --arg id "$RELEASE_ID" '.held_release_ids | index($id)' artifacts/release-ring/beta-active.json; then
+            echo "Refusing held beta release ${RELEASE_ID}." >&2
             exit 1
           fi
-          verified="$(gcloud storage ls --recursive "gs://${RELEASE_BUCKET}/receipts/beta/${{ inputs.release_id }}/" | grep '/verified.json$' | sort | tail -1)"
+          verified="$(gcloud storage ls --recursive "gs://${RELEASE_BUCKET}/receipts/beta/${RELEASE_ID}/" | grep '/verified.json$' | sort | tail -1)"
           test -n "$verified"
           gcloud storage cp "$verified" artifacts/release-ring/beta-verified.json
           test "$(jq -r .state artifacts/release-ring/beta-verified.json)" = verified
           verified_at="$(jq -r .created_at artifacts/release-ring/beta-verified.json)"
           test $(( $(date -u +%s) - $(date -u -d "$verified_at" +%s) )) -ge "$MIN_SOAK_SECONDS"
 
-      - name: Checkout the immutable record source for deployment rendering
+      - name: Checkout immutable release source inputs
         uses: actions/checkout@v7
         with:
           ref: ${{ steps.record.outputs.git_sha }}
-          clean: false
+          path: artifacts/release-ring/source
+
+      - name: Verify immutable release source checkout
+        run: |
+          set -euo pipefail
+          test "$(git -C artifacts/release-ring/source rev-parse HEAD)" = "${{ steps.record.outputs.git_sha }}"
 
       - name: Render recorded Cloud Run runtime configuration
         id: runtime
         run: |
           python3 backend/scripts/render_backend_runtime_env.py \
-            --env "${{ inputs.ring }}" \
-            --manifest "artifacts/release-ring/config/${{ inputs.ring }}-backend.yaml" \
+            --env "$RELEASE_RING" \
+            --manifest "artifacts/release-ring/config/${RELEASE_RING}-backend.yaml" \
             | tee artifacts/release-ring/runtime-outputs.txt >> "$GITHUB_OUTPUT"
+
+      - name: Preflight all recorded GKE configuration before mutation
+        run: |
+          set -euo pipefail
+          namespace="$(jq -r --arg ring "$RELEASE_RING" '.topology[$ring].namespace' artifacts/release-ring/record.json)"
+          source_root="artifacts/release-ring/source"
+          kubectl -n "$namespace" apply --dry-run=server \
+            -f "artifacts/release-ring/config/${RELEASE_RING}-backend-config.yaml" >/dev/null
+          ENVIRONMENT="$RELEASE_RING" \
+          NAMESPACE="$namespace" \
+          RELEASE_NAME="${RELEASE_RING}-omi-backend-secrets" \
+          VALUES_FILE="artifacts/release-ring/config/${RELEASE_RING}-backend-secrets.yaml" \
+          CHART_DIR="${source_root}/backend/charts/backend-secrets" \
+          GCP_PROJECT_ID="$RELEASE_RUNTIME_PROJECT" \
+          GKE_CLUSTER="$RELEASE_GKE_CLUSTER" \
+          REGION="$REGION" \
+          BACKEND_SECRETS_GSA="${{ vars.BACKEND_SECRETS_GSA }}" \
+          DRY_RUN=true \
+          backend/scripts/deploy-backend-secrets.sh
+          preflight_component() {
+            component="$1"
+            release="$2"
+            image="$(jq -r --arg component "$component" '.images[$component]' artifacts/release-ring/record.json)"
+            repository="${image%@sha256:*}"
+            digest="sha256:${image##*@sha256:}"
+            helm template "$release" "${source_root}/backend/charts/${component}" \
+              --namespace "$namespace" \
+              -f "artifacts/release-ring/config/${RELEASE_RING}-${component}.yaml" \
+              --set-string image.repository="$repository" \
+              --set-string image.digest="$digest" \
+              | kubectl -n "$namespace" apply --dry-run=server -f - >/dev/null
+          }
+          preflight_component backend-listen "${RELEASE_RING}-omi-backend-listen"
+          preflight_component pusher "${RELEASE_RING}-omi-pusher"
+          preflight_component llm-gateway "${RELEASE_RING}-omi-llm-gateway"
+          preflight_component agent-proxy "${RELEASE_RING}-omi-agent-proxy"
 
       - name: Verify beta endpoint prerequisites before mutation
         if: inputs.ring == 'beta'
@@ -142,10 +188,10 @@ jobs:
         id: snapshot
         run: |
           set -euo pipefail
-          namespace="$(jq -r --arg ring "${{ inputs.ring }}" '.topology[$ring].namespace' artifacts/release-ring/record.json)"
+          namespace="$(jq -r --arg ring "$RELEASE_RING" '.topology[$ring].namespace' artifacts/release-ring/record.json)"
           services=()
           for logical in backend backend-sync backend-sync-backfill backend-integration; do
-            services+=(--service "$(jq -r --arg ring "${{ inputs.ring }}" --arg logical "$logical" '.topology[$ring].cloud_run_services[$logical]' artifacts/release-ring/record.json)")
+            services+=(--service "$(jq -r --arg ring "$RELEASE_RING" --arg logical "$logical" '.topology[$ring].cloud_run_services[$logical]' artifacts/release-ring/record.json)")
           done
           mkdir -p artifacts/release-ring
           python3 backend/scripts/cloud_run_traffic_snapshot.py capture \
@@ -154,36 +200,54 @@ jobs:
             "${services[@]}" \
             --allow-missing \
             --output artifacts/release-ring/cloud-run-snapshot.json
-          helm_revision() {
-            helm -n "$namespace" history "$1" --output json 2>/dev/null \
-              | jq -r 'map(select(.status == "deployed")) | last.revision // empty' || true
-          }
+          python3 backend/scripts/release_ring_gke_snapshot.py capture \
+            --namespace "$namespace" \
+            --config-map "${RELEASE_RING}-omi-backend-config" \
+            --release "backend-secrets=${RELEASE_RING}-omi-backend-secrets" \
+            --release "backend-listen=${RELEASE_RING}-omi-backend-listen" \
+            --release "pusher=${RELEASE_RING}-omi-pusher" \
+            --release "llm-gateway=${RELEASE_RING}-omi-llm-gateway" \
+            --release "agent-proxy=${RELEASE_RING}-omi-agent-proxy" \
+            --output artifacts/release-ring/gke-snapshot.json
+          active_object="gs://${RELEASE_BUCKET}/rings/${RELEASE_RING}/active.json"
+          active_generation=0
+          if gcloud storage cp "$active_object" artifacts/release-ring/active-before.json \
+            2>artifacts/release-ring/active-before-error.txt; then
+            active_generation="$(gcloud storage objects describe "$active_object" --format='value(generation)')"
+            rm artifacts/release-ring/active-before-error.txt
+            active_pointer="$(jq -c . artifacts/release-ring/active-before.json)"
+          elif grep -Eiq 'not.?found|404' artifacts/release-ring/active-before-error.txt; then
+            active_pointer=null
+          else
+            sed 's/^/active pointer read failed: /' artifacts/release-ring/active-before-error.txt >&2
+            exit 1
+          fi
           jq -n \
             --arg namespace "$namespace" \
             --argjson cloud_run "$(jq -c . artifacts/release-ring/cloud-run-snapshot.json)" \
-            --arg backend_listen "$(helm_revision "${{ inputs.ring }}-omi-backend-listen")" \
-            --arg pusher "$(helm_revision "${{ inputs.ring }}-omi-pusher")" \
-            --arg llm_gateway "$(helm_revision "${{ inputs.ring }}-omi-llm-gateway")" \
-            --arg agent_proxy "$(helm_revision "${{ inputs.ring }}-omi-agent-proxy")" \
-            '{schema_version: 1, namespace: $namespace, cloud_run: $cloud_run, helm_revisions: {"backend-listen": $backend_listen, pusher: $pusher, "llm-gateway": $llm_gateway, "agent-proxy": $agent_proxy}}' \
+            --argjson gke "$(jq -c . artifacts/release-ring/gke-snapshot.json)" \
+            --argjson active_pointer "$active_pointer" \
+            --argjson active_generation "$active_generation" \
+            '{schema_version: 1, namespace: $namespace, cloud_run: $cloud_run, gke: $gke, active_pointer: $active_pointer, active_generation: $active_generation}' \
             > artifacts/release-ring/snapshot.json
           snapshot_sha="$(sha256sum artifacts/release-ring/snapshot.json | awk '{print $1}')"
-          snapshot_object="gs://${RELEASE_BUCKET}/receipts/${{ inputs.ring }}/${{ inputs.release_id }}/${GITHUB_RUN_ID}/snapshot.json"
+          snapshot_object="gs://${RELEASE_BUCKET}/receipts/${RELEASE_RING}/${RELEASE_ID}/${GITHUB_RUN_ID}/snapshot.json"
           gcloud storage cp --if-generation-match=0 artifacts/release-ring/snapshot.json "$snapshot_object"
           printf 'reference=%s#sha256:%s\n' "$snapshot_object" "$snapshot_sha" >> "$GITHUB_OUTPUT"
+          printf 'active_generation=%s\n' "$active_generation" >> "$GITHUB_OUTPUT"
 
       - name: Write pre-mutation receipt
         run: |
           python3 backend/scripts/release_rings.py receipt \
-            --ring "${{ inputs.ring }}" \
-            --release-id "${{ inputs.release_id }}" \
+            --ring "$RELEASE_RING" \
+            --release-id "$RELEASE_ID" \
             --run-id "$GITHUB_RUN_ID" \
             --state started \
             --snapshot-reference "${{ steps.snapshot.outputs.reference }}" \
             --component cloud-run=pending \
             --component gke=pending \
             --output artifacts/release-ring/receipt-started.json
-          gcloud storage cp --if-generation-match=0 artifacts/release-ring/receipt-started.json "gs://${RELEASE_BUCKET}/receipts/${{ inputs.ring }}/${{ inputs.release_id }}/${GITHUB_RUN_ID}/started.json"
+          gcloud storage cp --if-generation-match=0 artifacts/release-ring/receipt-started.json "gs://${RELEASE_BUCKET}/receipts/${RELEASE_RING}/${RELEASE_ID}/${GITHUB_RUN_ID}/started.json"
 
       - name: Create no-traffic Cloud Run revisions from recorded digest
         id: cloud_run_candidate
@@ -204,7 +268,7 @@ jobs:
           PY
           }
           for logical in backend backend-sync backend-sync-backfill backend-integration; do
-            service="$(jq -r --arg ring "${{ inputs.ring }}" --arg logical "$logical" '.topology[$ring].cloud_run_services[$logical]' artifacts/release-ring/record.json)"
+            service="$(jq -r --arg ring "$RELEASE_RING" --arg logical "$logical" '.topology[$ring].cloud_run_services[$logical]' artifacts/release-ring/record.json)"
             case "$logical" in
               backend)
                 env_vars="$(recorded_output backend_env_vars)"
@@ -243,7 +307,7 @@ jobs:
         id: backend_candidate
         run: |
           set -euo pipefail
-          service="$(jq -r --arg ring "${{ inputs.ring }}" '.topology[$ring].cloud_run_services.backend' artifacts/release-ring/record.json)"
+          service="$(jq -r --arg ring "$RELEASE_RING" '.topology[$ring].cloud_run_services.backend' artifacts/release-ring/record.json)"
           revision="$(gcloud run services describe "$service" --project "$RELEASE_RUNTIME_PROJECT" --region "$REGION" --format='value(status.latestReadyRevisionName)')"
           url="$(python3 backend/scripts/resolve_cloud_run_tagged_url.py --project "$RELEASE_RUNTIME_PROJECT" --region "$REGION" --service "$service" --revision "$revision" --tag "ring-${GITHUB_RUN_ID}")"
           CLOUD_RUN_IDENTITY_TOKEN="$(gcloud auth print-identity-token --audiences="$url")"
@@ -276,20 +340,22 @@ jobs:
         id: gke_candidate
         run: |
           set -euo pipefail
-          namespace="$(jq -r --arg ring "${{ inputs.ring }}" '.topology[$ring].namespace' artifacts/release-ring/record.json)"
-          kubectl -n "$namespace" apply -f "artifacts/release-ring/config/${{ inputs.ring }}-backend-config.yaml"
-          ENVIRONMENT="${{ inputs.ring }}" \
+          namespace="$(jq -r --arg ring "$RELEASE_RING" '.topology[$ring].namespace' artifacts/release-ring/record.json)"
+          source_root="artifacts/release-ring/source"
+          kubectl -n "$namespace" apply -f "artifacts/release-ring/config/${RELEASE_RING}-backend-config.yaml"
+          ENVIRONMENT="$RELEASE_RING" \
           NAMESPACE="$namespace" \
-          RELEASE_NAME="${{ inputs.ring }}-omi-backend-secrets" \
-          VALUES_FILE="artifacts/release-ring/config/${{ inputs.ring }}-backend-secrets.yaml" \
+          RELEASE_NAME="${RELEASE_RING}-omi-backend-secrets" \
+          VALUES_FILE="artifacts/release-ring/config/${RELEASE_RING}-backend-secrets.yaml" \
+          CHART_DIR="${source_root}/backend/charts/backend-secrets" \
           GCP_PROJECT_ID="$RELEASE_RUNTIME_PROJECT" \
           GKE_CLUSTER="$RELEASE_GKE_CLUSTER" \
           REGION="$REGION" \
           BACKEND_SECRETS_GSA="${{ vars.BACKEND_SECRETS_GSA }}" \
           backend/scripts/deploy-backend-secrets.sh
           python3 backend/scripts/verify_pusher_config_references.py \
-            --environment "${{ inputs.ring }}" --namespace "$namespace" \
-            --values-file "artifacts/release-ring/config/${{ inputs.ring }}-pusher.yaml"
+            --environment "$RELEASE_RING" --namespace "$namespace" \
+            --values-file "artifacts/release-ring/config/${RELEASE_RING}-pusher.yaml"
           deploy_component() {
             component="$1"
             release="$2"
@@ -298,22 +364,22 @@ jobs:
             repository="${image%@sha256:*}"
             digest="sha256:${image##*@sha256:}"
             helm -n "$namespace" upgrade --install "$release" "$chart" \
-              -f "artifacts/release-ring/config/${{ inputs.ring }}-${component}.yaml" \
+              -f "artifacts/release-ring/config/${RELEASE_RING}-${component}.yaml" \
               --set-string image.repository="$repository" \
               --set-string image.digest="$digest"
             kubectl -n "$namespace" rollout status "deployment/$release" --timeout=1800s
           }
-          deploy_component backend-listen "${{ inputs.ring }}-omi-backend-listen" backend/charts/backend-listen
-          deploy_component pusher "${{ inputs.ring }}-omi-pusher" backend/charts/pusher
-          deploy_component llm-gateway "${{ inputs.ring }}-omi-llm-gateway" backend/charts/llm-gateway
-          deploy_component agent-proxy "${{ inputs.ring }}-omi-agent-proxy" backend/charts/agent-proxy
+          deploy_component backend-listen "${RELEASE_RING}-omi-backend-listen" "${source_root}/backend/charts/backend-listen"
+          deploy_component pusher "${RELEASE_RING}-omi-pusher" "${source_root}/backend/charts/pusher"
+          deploy_component llm-gateway "${RELEASE_RING}-omi-llm-gateway" "${source_root}/backend/charts/llm-gateway"
+          deploy_component agent-proxy "${RELEASE_RING}-omi-agent-proxy" "${source_root}/backend/charts/agent-proxy"
 
       - name: Shift validated Cloud Run revisions to serving traffic
         id: promote_traffic
         run: |
           set -euo pipefail
           for logical in backend backend-sync backend-sync-backfill backend-integration; do
-            service="$(jq -r --arg ring "${{ inputs.ring }}" --arg logical "$logical" '.topology[$ring].cloud_run_services[$logical]' artifacts/release-ring/record.json)"
+            service="$(jq -r --arg ring "$RELEASE_RING" --arg logical "$logical" '.topology[$ring].cloud_run_services[$logical]' artifacts/release-ring/record.json)"
             revision="$(gcloud run services describe "$service" --project "$RELEASE_RUNTIME_PROJECT" --region "$REGION" --format='value(status.latestReadyRevisionName)')"
             gcloud run services update-traffic "$service" --project "$RELEASE_RUNTIME_PROJECT" --region "$REGION" --to-revisions="${revision}=100" --quiet
           done
@@ -324,12 +390,12 @@ jobs:
           set -euo pipefail
           expected="${{ steps.record.outputs.backend_image }}"
           for logical in backend backend-sync backend-sync-backfill backend-integration; do
-            service="$(jq -r --arg ring "${{ inputs.ring }}" --arg logical "$logical" '.topology[$ring].cloud_run_services[$logical]' artifacts/release-ring/record.json)"
+            service="$(jq -r --arg ring "$RELEASE_RING" --arg logical "$logical" '.topology[$ring].cloud_run_services[$logical]' artifacts/release-ring/record.json)"
             actual="$(gcloud run services describe "$service" --project "$RELEASE_RUNTIME_PROJECT" --region "$REGION" --format='value(spec.template.spec.containers[0].image)')"
             test "$actual" = "$expected"
           done
-          namespace="$(jq -r --arg ring "${{ inputs.ring }}" '.topology[$ring].namespace' artifacts/release-ring/record.json)"
-          for deployment in "${{ inputs.ring }}-omi-backend-listen" "${{ inputs.ring }}-omi-pusher" "${{ inputs.ring }}-omi-llm-gateway" "${{ inputs.ring }}-omi-agent-proxy"; do
+          namespace="$(jq -r --arg ring "$RELEASE_RING" '.topology[$ring].namespace' artifacts/release-ring/record.json)"
+          for deployment in "${RELEASE_RING}-omi-backend-listen" "${RELEASE_RING}-omi-pusher" "${RELEASE_RING}-omi-llm-gateway" "${RELEASE_RING}-omi-agent-proxy"; do
             kubectl -n "$namespace" rollout status "deployment/$deployment" --timeout=300s
           done
 
@@ -337,28 +403,27 @@ jobs:
         if: success()
         run: |
           set -euo pipefail
-          object="gs://${RELEASE_BUCKET}/rings/${{ inputs.ring }}/active.json"
-          generation=0
-          if gcloud storage cp "$object" artifacts/release-ring/active.json; then
-            generation="$(gcloud storage objects describe "$object" --format='value(generation)')"
-            existing=(--existing artifacts/release-ring/active.json)
+          object="gs://${RELEASE_BUCKET}/rings/${RELEASE_RING}/active.json"
+          if [[ -f artifacts/release-ring/active-before.json ]]; then
+            existing=(--existing artifacts/release-ring/active-before.json)
           else
             existing=()
           fi
           python3 backend/scripts/release_rings.py active-pointer \
-            --ring "${{ inputs.ring }}" --release-id "${{ inputs.release_id }}" \
+            --ring "$RELEASE_RING" --release-id "$RELEASE_ID" \
             "${existing[@]}" --output artifacts/release-ring/active-next.json
-          gcloud storage cp --if-generation-match="$generation" artifacts/release-ring/active-next.json "$object"
+          gcloud storage cp --if-generation-match="${{ steps.snapshot.outputs.active_generation }}" \
+            artifacts/release-ring/active-next.json "$object"
 
       - name: Write verified receipt
         if: success()
         run: |
           python3 backend/scripts/release_rings.py receipt \
-            --ring "${{ inputs.ring }}" --release-id "${{ inputs.release_id }}" --run-id "$GITHUB_RUN_ID" \
+            --ring "$RELEASE_RING" --release-id "$RELEASE_ID" --run-id "$GITHUB_RUN_ID" \
             --state verified --snapshot-reference "${{ steps.snapshot.outputs.reference }}" \
             --component cloud-run=verified --component gke=verified \
             --output artifacts/release-ring/receipt-verified.json
-          gcloud storage cp --if-generation-match=0 artifacts/release-ring/receipt-verified.json "gs://${RELEASE_BUCKET}/receipts/${{ inputs.ring }}/${{ inputs.release_id }}/${GITHUB_RUN_ID}/verified.json"
+          gcloud storage cp --if-generation-match=0 artifacts/release-ring/receipt-verified.json "gs://${RELEASE_BUCKET}/receipts/${RELEASE_RING}/${RELEASE_ID}/${GITHUB_RUN_ID}/verified.json"
 
       - name: Restore pre-mutation state once after a deterministic failure
         id: restore
@@ -367,21 +432,28 @@ jobs:
           set +e
           python3 backend/scripts/cloud_run_traffic_snapshot.py restore \
             --snapshot artifacts/release-ring/cloud-run-snapshot.json \
+            --remove-tag "ring-${GITHUB_RUN_ID}" \
+            --delete-missing \
             --evidence-path artifacts/release-ring/cloud-run-restore.json
           result=$?
-          while IFS= read -r service; do
-            [[ -z "$service" ]] && continue
-            gcloud run services delete "$service" --project "$RELEASE_RUNTIME_PROJECT" --region "$REGION" --quiet
+          python3 backend/scripts/release_ring_gke_snapshot.py restore \
+            --snapshot artifacts/release-ring/gke-snapshot.json \
+            --evidence-path artifacts/release-ring/gke-restore.json
+          result=$((result || $?))
+          if jq -e '.helm_releases["backend-secrets"].present == true' artifacts/release-ring/gke-snapshot.json >/dev/null; then
+            namespace="$(jq -r .namespace artifacts/release-ring/gke-snapshot.json)"
+            force_sync_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            kubectl -n "$namespace" annotate externalsecret \
+              "${RELEASE_RING}-omi-backend-external-secret" \
+              force-sync="$force_sync_at" --overwrite
             result=$((result || $?))
-          done < <(jq -r '.missing_services[]?' artifacts/release-ring/cloud-run-snapshot.json)
-          namespace="$(jq -r --arg ring "${{ inputs.ring }}" '.topology[$ring].namespace' artifacts/release-ring/record.json)"
-          for component in backend-listen pusher llm-gateway agent-proxy; do
-            revision="$(jq -r --arg component "$component" '.helm_revisions[$component]' artifacts/release-ring/snapshot.json)"
-            if [[ -n "$revision" && "$revision" != "null" ]]; then
-              helm -n "$namespace" rollback "${{ inputs.ring }}-omi-${component}" "$revision" --wait --timeout 1800s
-              result=$((result || $?))
-            fi
-          done
+            python3 backend/scripts/wait_external_secret_refresh.py \
+              --namespace "$namespace" \
+              --name "${RELEASE_RING}-omi-backend-external-secret" \
+              --min-refresh-time "$force_sync_at" \
+              --timeout-seconds 120
+            result=$((result || $?))
+          fi
           test "$result" -eq 0
 
       - name: Hold failed record and write recovery receipt
@@ -390,31 +462,45 @@ jobs:
           PAGER_WEBHOOK: ${{ secrets.RELEASE_PAGER_WEBHOOK }}
         run: |
           set -euo pipefail
-          object="gs://${RELEASE_BUCKET}/rings/${{ inputs.ring }}/active.json"
+          object="gs://${RELEASE_BUCKET}/rings/${RELEASE_RING}/active.json"
           generation=0
-          if gcloud storage cp "$object" artifacts/release-ring/active.json; then
+          if gcloud storage cp "$object" artifacts/release-ring/active-current.json \
+            2>artifacts/release-ring/active-current-error.txt; then
             generation="$(gcloud storage objects describe "$object" --format='value(generation)')"
-            existing=(--existing artifacts/release-ring/active.json)
-          else
+            rm artifacts/release-ring/active-current-error.txt
+            if jq -e --arg id "$RELEASE_ID" '.current_release_id == $id' \
+              artifacts/release-ring/active-current.json >/dev/null \
+              && [[ -f artifacts/release-ring/active-before.json ]]; then
+              existing=(--existing artifacts/release-ring/active-before.json)
+            elif jq -e --arg id "$RELEASE_ID" '.current_release_id == $id' \
+              artifacts/release-ring/active-current.json >/dev/null; then
+              existing=()
+            else
+              existing=(--existing artifacts/release-ring/active-current.json)
+            fi
+          elif grep -Eiq 'not.?found|404' artifacts/release-ring/active-current-error.txt; then
             existing=()
+          else
+            sed 's/^/active pointer read failed: /' artifacts/release-ring/active-current-error.txt >&2
+            exit 1
           fi
           state=partial_mutation
           if [[ "${{ steps.restore.outcome }}" == "success" ]]; then state=restored; fi
           python3 backend/scripts/release_rings.py active-pointer \
-            --ring "${{ inputs.ring }}" --release-id "${{ inputs.release_id }}" --hold \
+            --ring "$RELEASE_RING" --release-id "$RELEASE_ID" --hold \
             "${existing[@]}" --output artifacts/release-ring/active-held.json
           gcloud storage cp --if-generation-match="$generation" artifacts/release-ring/active-held.json "$object"
           python3 backend/scripts/release_rings.py receipt \
-            --ring "${{ inputs.ring }}" --release-id "${{ inputs.release_id }}" --run-id "$GITHUB_RUN_ID" \
+            --ring "$RELEASE_RING" --release-id "$RELEASE_ID" --run-id "$GITHUB_RUN_ID" \
             --state "$state" --snapshot-reference "${{ steps.snapshot.outputs.reference }}" \
             --component cloud-run="${{ steps.restore.outcome }}" --component gke="${{ steps.restore.outcome }}" \
             --output artifacts/release-ring/receipt-recovery.json
-          gcloud storage cp --if-generation-match=0 artifacts/release-ring/receipt-recovery.json "gs://${RELEASE_BUCKET}/receipts/${{ inputs.ring }}/${{ inputs.release_id }}/${GITHUB_RUN_ID}/recovery.json"
+          gcloud storage cp --if-generation-match=0 artifacts/release-ring/receipt-recovery.json "gs://${RELEASE_BUCKET}/receipts/${RELEASE_RING}/${RELEASE_ID}/${GITHUB_RUN_ID}/recovery.json"
           if [[ "$state" == partial_mutation ]]; then
-            echo "::error title=Release partial mutation::${{ inputs.ring }} release ${{ inputs.release_id }} could not be restored."
+            echo "::error title=Release partial mutation::${RELEASE_RING} release ${RELEASE_ID} could not be restored."
             test -n "$PAGER_WEBHOOK"
             curl --fail --silent --show-error -X POST -H 'content-type: application/json' \
-              --data "{\"ring\":\"${{ inputs.ring }}\",\"release_id\":\"${{ inputs.release_id }}\",\"state\":\"partial_mutation\"}" \
+              --data "{\"ring\":\"${RELEASE_RING}\",\"release_id\":\"${RELEASE_ID}\",\"state\":\"partial_mutation\"}" \
               "$PAGER_WEBHOOK"
           fi
           exit 1
@@ -423,7 +509,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: release-ring-${{ inputs.ring }}-${{ inputs.release_id }}-${{ github.run_id }}
-          path: artifacts/release-ring
+          name: release-ring-${{ env.RELEASE_RING }}-${{ env.RELEASE_ID }}-${{ github.run_id }}
+          path: |
+            artifacts/release-ring/*.json
+            artifacts/release-ring/*.txt
+            artifacts/release-ring/config
           if-no-files-found: warn
           retention-days: 30

--- a/backend/scripts/cloud_run_traffic_snapshot.py
+++ b/backend/scripts/cloud_run_traffic_snapshot.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import subprocess
 import sys
 from datetime import UTC, datetime
@@ -22,6 +23,9 @@ DEFAULT_SERVICES = ('backend', 'backend-sync', 'backend-sync-backfill', 'backend
 SNAPSHOT_SCHEMA_VERSION = 1
 
 RunCommand = Callable[[Sequence[str]], None]
+FetchService = Callable[..., Mapping[str, Any]]
+
+_TRAFFIC_TAG_RE = re.compile(r'^[a-z][a-z0-9-]{0,62}$')
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:
@@ -49,6 +53,23 @@ def _traffic_entries(value: Any) -> list[dict[str, Any]]:
             sanitized['latestRevision'] = True
         entries.append(sanitized)
     return entries
+
+
+def _traffic_tags(value: Any) -> set[str]:
+    if not isinstance(value, list):
+        return set()
+    return {
+        tag
+        for raw_entry in value
+        if isinstance(raw_entry, Mapping)
+        for tag in (raw_entry.get('tag'),)
+        if isinstance(tag, str) and tag
+    }
+
+
+def _is_not_found(exc: subprocess.CalledProcessError) -> bool:
+    evidence = f"{getattr(exc, 'stderr', '')} {getattr(exc, 'output', '')}".lower()
+    return 'not found' in evidence or 'notfound' in evidence
 
 
 def sanitize_service_document(service: str, document: Mapping[str, Any]) -> dict[str, Any]:
@@ -105,8 +126,7 @@ def capture_snapshot(
         try:
             document = fetcher(project=project, region=region, service=service)
         except subprocess.CalledProcessError as exc:
-            evidence = f"{getattr(exc, 'stderr', '')} {getattr(exc, 'output', '')}".lower()
-            if allow_missing and ('not found' in evidence or 'notfound' in evidence):
+            if allow_missing and _is_not_found(exc):
                 missing.append(service)
                 continue
             raise
@@ -147,14 +167,25 @@ def _load_snapshot(path: Path) -> dict[str, Any]:
     return cast(dict[str, Any], loaded)
 
 
-def restore_targets(service_snapshot: Mapping[str, Any]) -> list[tuple[str, int]]:
-    """Resolve a recorded spec.traffic entry to immutable revision percentages."""
-    spec = _mapping(service_snapshot.get('spec'))
+def restore_targets(
+    service_snapshot: Mapping[str, Any],
+    *,
+    traffic_source: str = 'spec',
+) -> list[tuple[str, int]]:
+    """Resolve recorded traffic entries to immutable revision percentages.
+
+    ``traffic_source`` selects which sanitized section holds the entries to
+    resolve. The recorded snapshot (what we restore *to*) lives under ``spec``;
+    the live read-back after a restore must resolve ``status`` so a wedged Cloud
+    Run service whose ``status.traffic`` still serves a different revision than
+    its just-updated ``spec.traffic`` cannot be falsely reported as restored.
+    """
+    source = _mapping(service_snapshot.get(traffic_source))
     status = _mapping(service_snapshot.get('status'))
     fallback = status.get('latestReadyRevisionName')
     targets: list[tuple[str, int]] = []
     seen: set[str] = set()
-    for entry in _traffic_entries(spec.get('traffic')):
+    for entry in _traffic_entries(source.get('traffic')):
         percent = cast(int, entry['percent'])
         if percent == 0:
             continue
@@ -173,9 +204,16 @@ def restore_targets(service_snapshot: Mapping[str, Any]) -> list[tuple[str, int]
     return targets
 
 
-def restore_command(*, project: str, region: str, service: str, targets: Sequence[tuple[str, int]]) -> list[str]:
+def restore_command(
+    *,
+    project: str,
+    region: str,
+    service: str,
+    targets: Sequence[tuple[str, int]],
+    remove_tag: str | None = None,
+) -> list[str]:
     rendered_targets = ','.join(f'{revision}={percent}' for revision, percent in targets)
-    return [
+    command = [
         'gcloud',
         'run',
         'services',
@@ -184,20 +222,51 @@ def restore_command(*, project: str, region: str, service: str, targets: Sequenc
         f'--project={project}',
         f'--region={region}',
         f'--to-revisions={rendered_targets}',
+    ]
+    if remove_tag:
+        if not _TRAFFIC_TAG_RE.fullmatch(remove_tag):
+            raise ValueError(f'invalid Cloud Run traffic tag {remove_tag!r}')
+        command.append(f'--remove-tags={remove_tag}')
+    command.append('--quiet')
+    return command
+
+
+def delete_service_command(*, project: str, region: str, service: str) -> list[str]:
+    return [
+        'gcloud',
+        'run',
+        'services',
+        'delete',
+        service,
+        f'--project={project}',
+        f'--region={region}',
         '--quiet',
     ]
+
+
+def _observed_targets(document: Mapping[str, Any]) -> list[tuple[str, int]]:
+    sanitized = sanitize_service_document('observed', document)
+    return restore_targets(sanitized, traffic_source='status')
 
 
 def restore_snapshot(
     snapshot: Mapping[str, Any],
     *,
     runner: RunCommand | None = None,
+    fetcher: FetchService = _fetch_service,
+    remove_tag: str | None = None,
+    delete_missing: bool = False,
 ) -> dict[str, Any]:
-    """Restore every recorded traffic spec, retaining bounded per-service evidence."""
+    """Restore and observe every recorded route, retaining bounded evidence."""
     project = cast(str, snapshot['project'])
     region = cast(str, snapshot['region'])
     services = cast(Mapping[str, Any], snapshot['services'])
-    if not services:
+    missing_services = snapshot.get('missing_services', [])
+    if not isinstance(missing_services, list) or any(
+        not isinstance(item, str) or not item for item in missing_services
+    ):
+        raise ValueError('traffic snapshot contains invalid missing_services')
+    if not services and not delete_missing:
         return {
             'schema_version': SNAPSHOT_SCHEMA_VERSION,
             'scope': 'backend Cloud Run traffic restoration',
@@ -205,7 +274,7 @@ def restore_snapshot(
             'result': 'pass',
             'failed_services': [],
             'services': {},
-            'note': 'no prior Cloud Run services existed; candidate remains non-serving',
+            'note': 'no prior Cloud Run services existed',
         }
     execute = runner or (lambda command: subprocess.run(command, check=True, capture_output=True, text=True))
     results: dict[str, dict[str, Any]] = {}
@@ -215,7 +284,13 @@ def restore_snapshot(
         if not isinstance(raw_service_snapshot, Mapping):
             raise ValueError(f'{service}: traffic snapshot service entry is invalid')
         targets = restore_targets(raw_service_snapshot)
-        command = restore_command(project=project, region=region, service=service, targets=targets)
+        command = restore_command(
+            project=project,
+            region=region,
+            service=service,
+            targets=targets,
+            remove_tag=remove_tag,
+        )
         result: dict[str, Any] = {
             'targets': [{'revision': revision, 'percent': percent} for revision, percent in targets],
             'command': ' '.join(command),
@@ -225,9 +300,47 @@ def restore_snapshot(
         except subprocess.CalledProcessError as exc:
             result.update({'result': 'failed', 'error': f'gcloud exited with code {exc.returncode}'})
         else:
-            result['result'] = 'restored'
+            try:
+                observed = fetcher(project=project, region=region, service=service)
+                observed_targets = _observed_targets(observed)
+                observed_tags = _traffic_tags(_mapping(observed.get('spec')).get('traffic'))
+            except (ValueError, subprocess.CalledProcessError):
+                result.update({'result': 'failed', 'error': 'could not observe restored traffic'})
+            else:
+                result['observed_targets'] = [
+                    {'revision': revision, 'percent': percent} for revision, percent in observed_targets
+                ]
+                if sorted(observed_targets) != sorted(targets):
+                    result.update({'result': 'failed', 'error': 'observed traffic does not match snapshot'})
+                elif remove_tag and remove_tag in observed_tags:
+                    result.update({'result': 'failed', 'error': 'candidate traffic tag remains after restore'})
+                else:
+                    result['result'] = 'restored'
         results[service] = result
+
+    deleted: dict[str, dict[str, Any]] = {}
+    if delete_missing:
+        for service in missing_services:
+            command = delete_service_command(project=project, region=region, service=service)
+            result = {'command': ' '.join(command)}
+            try:
+                execute(command)
+            except subprocess.CalledProcessError as exc:
+                if not _is_not_found(exc):
+                    result.update({'result': 'failed', 'error': f'gcloud exited with code {exc.returncode}'})
+            if 'result' not in result:
+                try:
+                    fetcher(project=project, region=region, service=service)
+                except subprocess.CalledProcessError as exc:
+                    if _is_not_found(exc):
+                        result['result'] = 'deleted'
+                    else:
+                        result.update({'result': 'failed', 'error': 'could not verify service deletion'})
+                else:
+                    result.update({'result': 'failed', 'error': 'service still exists after delete'})
+            deleted[service] = result
     failures = [service for service, result in results.items() if result['result'] != 'restored']
+    failures.extend(service for service, result in deleted.items() if result['result'] != 'deleted')
     return {
         'schema_version': SNAPSHOT_SCHEMA_VERSION,
         'scope': 'backend Cloud Run traffic restoration',
@@ -235,6 +348,7 @@ def restore_snapshot(
         'result': 'pass' if not failures else 'fail',
         'failed_services': failures,
         'services': results,
+        'deleted_services': deleted,
     }
 
 
@@ -260,6 +374,8 @@ def main() -> int:
     restore = commands.add_parser('restore', help='restore Cloud Run traffic from a recorded snapshot')
     restore.add_argument('--snapshot', type=Path, required=True)
     restore.add_argument('--evidence-path', type=Path, required=True)
+    restore.add_argument('--remove-tag')
+    restore.add_argument('--delete-missing', action='store_true')
     args = parser.parse_args()
     try:
         if args.command == 'capture':
@@ -273,7 +389,11 @@ def main() -> int:
             print(f'captured sanitized Cloud Run traffic snapshot at {args.output}')
             return 0
         snapshot = _load_snapshot(args.snapshot)
-        evidence = restore_snapshot(snapshot)
+        evidence = restore_snapshot(
+            snapshot,
+            remove_tag=args.remove_tag,
+            delete_missing=args.delete_missing,
+        )
         _write_json(args.evidence_path, evidence)
         print(json.dumps(evidence, indent=2, sort_keys=True))
         return 0 if evidence['result'] == 'pass' else 1

--- a/backend/scripts/release_ring_gke_snapshot.py
+++ b/backend/scripts/release_ring_gke_snapshot.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Capture, restore, and verify the release ring's pre-mutation GKE state."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence, cast
+
+SCHEMA_VERSION = 1
+
+CommandRunner = Callable[[Sequence[str], str | None], str]
+
+
+def _run(command: Sequence[str], input_text: str | None = None) -> str:
+    completed = subprocess.run(command, check=True, capture_output=True, text=True, input=input_text)
+    return completed.stdout
+
+
+def _is_not_found(exc: subprocess.CalledProcessError) -> bool:
+    evidence = f"{getattr(exc, 'stderr', '')} {getattr(exc, 'output', '')}".lower()
+    return 'not found' in evidence or 'notfound' in evidence or 'release: not found' in evidence
+
+
+def _load_json(text: str, *, label: str) -> Any:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f'{label} returned invalid JSON') from exc
+
+
+def _canonical_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(',', ':'))
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode('utf-8')).hexdigest()
+
+
+def _sanitize_config_map(value: object, *, namespace: str, name: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f'{name}: ConfigMap is not an object')
+    metadata = value.get('metadata')
+    if not isinstance(metadata, Mapping) or metadata.get('name') != name:
+        raise ValueError(f'{name}: ConfigMap identity does not match the requested object')
+    observed_namespace = metadata.get('namespace')
+    if observed_namespace not in (None, namespace):
+        raise ValueError(f'{name}: ConfigMap namespace does not match {namespace}')
+    sanitized: dict[str, Any] = {
+        'apiVersion': 'v1',
+        'kind': 'ConfigMap',
+        'metadata': {'name': name, 'namespace': namespace},
+        'data': {},
+        'binaryData': {},
+    }
+    for field in ('data', 'binaryData'):
+        raw = value.get(field)
+        if raw is None:
+            continue
+        if not isinstance(raw, Mapping) or any(
+            not isinstance(key, str) or not isinstance(item, str) for key, item in raw.items()
+        ):
+            raise ValueError(f'{name}: ConfigMap {field} must contain string values')
+        sanitized[field] = dict(sorted(cast(Mapping[str, str], raw).items()))
+    return sanitized
+
+
+def _capture_config_map(*, namespace: str, name: str, runner: CommandRunner) -> dict[str, Any]:
+    command = ['kubectl', '-n', namespace, 'get', 'configmap', name, '-o', 'json']
+    try:
+        raw = runner(command, None)
+    except subprocess.CalledProcessError as exc:
+        if _is_not_found(exc):
+            return {'name': name, 'present': False}
+        raise
+    config_map = _sanitize_config_map(_load_json(raw, label=f'{name} ConfigMap'), namespace=namespace, name=name)
+    return {
+        'name': name,
+        'present': True,
+        'sha256': _sha256_text(_canonical_json(config_map)),
+        'object': config_map,
+    }
+
+
+def _capture_helm_release(*, namespace: str, name: str, runner: CommandRunner) -> dict[str, Any]:
+    try:
+        history_text = runner(['helm', '-n', namespace, 'history', name, '--output', 'json'], None)
+    except subprocess.CalledProcessError as exc:
+        if _is_not_found(exc):
+            return {'name': name, 'present': False}
+        raise
+    history = _load_json(history_text, label=f'{name} Helm history')
+    if not isinstance(history, list):
+        raise ValueError(f'{name}: Helm history is not a list')
+    deployed_revisions: list[int] = []
+    for entry in history:
+        if not isinstance(entry, Mapping) or entry.get('status') != 'deployed':
+            continue
+        raw_revision = entry.get('revision')
+        try:
+            revision = int(raw_revision)
+        except (TypeError, ValueError):
+            raise ValueError(f'{name}: deployed Helm revision is invalid') from None
+        if revision <= 0:
+            raise ValueError(f'{name}: deployed Helm revision is invalid')
+        deployed_revisions.append(revision)
+    if not deployed_revisions:
+        raise ValueError(f'{name}: Helm release exists without a deployed revision')
+    revision = max(deployed_revisions)
+    manifest = runner(['helm', '-n', namespace, 'get', 'manifest', name, '--revision', str(revision)], None)
+    if not manifest.strip():
+        raise ValueError(f'{name}: deployed Helm manifest is empty')
+    return {
+        'name': name,
+        'present': True,
+        'revision': revision,
+        'manifest_sha256': _sha256_text(manifest),
+    }
+
+
+def capture_snapshot(
+    *,
+    namespace: str,
+    config_map_name: str,
+    releases: Mapping[str, str],
+    runner: CommandRunner = _run,
+) -> dict[str, Any]:
+    if not namespace or not config_map_name:
+        raise ValueError('namespace and ConfigMap name are required')
+    if not releases or any(not component or not name for component, name in releases.items()):
+        raise ValueError('at least one named Helm release is required')
+    return {
+        'schema_version': SCHEMA_VERSION,
+        'scope': 'release ring GKE pre-mutation state',
+        'captured_at': datetime.now(UTC).isoformat(),
+        'namespace': namespace,
+        'config_map': _capture_config_map(namespace=namespace, name=config_map_name, runner=runner),
+        'helm_releases': {
+            component: _capture_helm_release(namespace=namespace, name=name, runner=runner)
+            for component, name in releases.items()
+        },
+    }
+
+
+def _restore_config_map(snapshot: Mapping[str, Any], *, namespace: str, runner: CommandRunner) -> dict[str, Any]:
+    name = snapshot.get('name')
+    if not isinstance(name, str) or not name:
+        raise ValueError('GKE snapshot contains an invalid ConfigMap name')
+    if snapshot.get('present') is True:
+        raw_object = snapshot.get('object')
+        config_map = _sanitize_config_map(raw_object, namespace=namespace, name=name)
+        expected_sha = snapshot.get('sha256')
+        if expected_sha != _sha256_text(_canonical_json(config_map)):
+            raise ValueError(f'{name}: ConfigMap snapshot digest does not match its object')
+        runner(['kubectl', '-n', namespace, 'apply', '-f', '-'], _canonical_json(config_map))
+        observed = runner(['kubectl', '-n', namespace, 'get', 'configmap', name, '-o', 'json'], None)
+        observed_map = _sanitize_config_map(
+            _load_json(observed, label=f'{name} restored ConfigMap'), namespace=namespace, name=name
+        )
+        if _sha256_text(_canonical_json(observed_map)) != expected_sha:
+            raise ValueError(f'{name}: observed ConfigMap does not match the snapshot')
+        return {'result': 'restored', 'sha256': expected_sha}
+
+    runner(['kubectl', '-n', namespace, 'delete', 'configmap', name, '--ignore-not-found=true'], None)
+    try:
+        runner(['kubectl', '-n', namespace, 'get', 'configmap', name, '-o', 'json'], None)
+    except subprocess.CalledProcessError as exc:
+        if _is_not_found(exc):
+            return {'result': 'deleted'}
+        raise
+    raise ValueError(f'{name}: ConfigMap still exists after delete')
+
+
+def _restore_helm_release(snapshot: Mapping[str, Any], *, namespace: str, runner: CommandRunner) -> dict[str, Any]:
+    name = snapshot.get('name')
+    if not isinstance(name, str) or not name:
+        raise ValueError('GKE snapshot contains an invalid Helm release name')
+    if snapshot.get('present') is True:
+        revision = snapshot.get('revision')
+        digest = snapshot.get('manifest_sha256')
+        if not isinstance(revision, int) or revision <= 0 or not isinstance(digest, str) or len(digest) != 64:
+            raise ValueError(f'{name}: Helm snapshot is incomplete')
+        runner(
+            ['helm', '-n', namespace, 'rollback', name, str(revision), '--wait', '--timeout', '1800s'],
+            None,
+        )
+        observed_manifest = runner(['helm', '-n', namespace, 'get', 'manifest', name], None)
+        if _sha256_text(observed_manifest) != digest:
+            raise ValueError(f'{name}: observed Helm manifest does not match the snapshot')
+        return {'result': 'restored', 'revision': revision, 'manifest_sha256': digest}
+
+    try:
+        runner(['helm', '-n', namespace, 'status', name, '--output', 'json'], None)
+    except subprocess.CalledProcessError as exc:
+        if _is_not_found(exc):
+            return {'result': 'absent'}
+        raise
+    runner(['helm', '-n', namespace, 'uninstall', name, '--wait', '--timeout', '1800s'], None)
+    try:
+        runner(['helm', '-n', namespace, 'status', name, '--output', 'json'], None)
+    except subprocess.CalledProcessError as exc:
+        if _is_not_found(exc):
+            return {'result': 'deleted'}
+        raise
+    raise ValueError(f'{name}: Helm release still exists after uninstall')
+
+
+def restore_snapshot(snapshot: Mapping[str, Any], *, runner: CommandRunner = _run) -> dict[str, Any]:
+    if snapshot.get('schema_version') != SCHEMA_VERSION:
+        raise ValueError('GKE snapshot has an unsupported schema version')
+    namespace = snapshot.get('namespace')
+    config_map = snapshot.get('config_map')
+    releases = snapshot.get('helm_releases')
+    if not isinstance(namespace, str) or not namespace:
+        raise ValueError('GKE snapshot is missing namespace')
+    if not isinstance(config_map, Mapping) or not isinstance(releases, Mapping):
+        raise ValueError('GKE snapshot is incomplete')
+
+    results: dict[str, dict[str, Any]] = {}
+
+    def attempt(component: str, operation: Callable[[], dict[str, Any]]) -> None:
+        try:
+            results[component] = operation()
+        except (OSError, ValueError, subprocess.CalledProcessError) as exc:
+            if isinstance(exc, subprocess.CalledProcessError):
+                error = f'command exited with code {exc.returncode}'
+            else:
+                error = str(exc)
+            results[component] = {'result': 'failed', 'error': error}
+
+    secret_snapshot = releases.get('backend-secrets')
+    if isinstance(secret_snapshot, Mapping):
+        attempt(
+            'backend-secrets',
+            lambda: _restore_helm_release(secret_snapshot, namespace=namespace, runner=runner),
+        )
+    attempt('backend-config', lambda: _restore_config_map(config_map, namespace=namespace, runner=runner))
+    for component, raw_release in releases.items():
+        if component == 'backend-secrets':
+            continue
+        if not isinstance(component, str) or not isinstance(raw_release, Mapping):
+            results[str(component)] = {'result': 'failed', 'error': 'invalid Helm release snapshot'}
+            continue
+        attempt(
+            component,
+            lambda raw_release=raw_release: _restore_helm_release(raw_release, namespace=namespace, runner=runner),
+        )
+
+    failures = sorted(component for component, result in results.items() if result.get('result') == 'failed')
+    return {
+        'schema_version': SCHEMA_VERSION,
+        'scope': 'release ring GKE restoration',
+        'result': 'pass' if not failures else 'fail',
+        'failed_components': failures,
+        'components': results,
+    }
+
+
+def _parse_releases(values: Sequence[str]) -> dict[str, str]:
+    releases: dict[str, str] = {}
+    for value in values:
+        component, separator, name = value.partition('=')
+        if not separator or not component or not name or component in releases:
+            raise ValueError(f'--release must be unique COMPONENT=NAME: {value!r}')
+        releases[component] = name
+    return releases
+
+
+def _read_snapshot(path: Path) -> dict[str, Any]:
+    loaded = _load_json(path.read_text(encoding='utf-8'), label=str(path))
+    if not isinstance(loaded, dict):
+        raise ValueError('GKE snapshot must be an object')
+    return cast(dict[str, Any], loaded)
+
+
+def _write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f'{json.dumps(value, indent=2, sort_keys=True)}\n', encoding='utf-8')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest='command', required=True)
+    capture = commands.add_parser('capture')
+    capture.add_argument('--namespace', required=True)
+    capture.add_argument('--config-map', required=True)
+    capture.add_argument('--release', action='append', default=[])
+    capture.add_argument('--output', type=Path, required=True)
+    restore = commands.add_parser('restore')
+    restore.add_argument('--snapshot', type=Path, required=True)
+    restore.add_argument('--evidence-path', type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        if args.command == 'capture':
+            releases = _parse_releases(args.release)
+            snapshot = capture_snapshot(
+                namespace=args.namespace,
+                config_map_name=args.config_map,
+                releases=releases,
+            )
+            _write_json(args.output, snapshot)
+            return 0
+        evidence = restore_snapshot(_read_snapshot(args.snapshot))
+        _write_json(args.evidence_path, evidence)
+        print(json.dumps(evidence, indent=2, sort_keys=True))
+        return 0 if evidence['result'] == 'pass' else 1
+    except (OSError, ValueError, subprocess.CalledProcessError) as exc:
+        print(f'ERROR: {exc}', file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/tests/unit/test_cloud_run_traffic_snapshot.py
+++ b/backend/tests/unit/test_cloud_run_traffic_snapshot.py
@@ -62,7 +62,15 @@ def test_restore_snapshot_resolves_latest_revision_before_the_new_candidate_exis
     }
     calls: list[list[str]] = []
 
-    evidence = snapshots.restore_snapshot(snapshot, runner=lambda command: calls.append(list(command)))
+    revisions = {
+        'backend': 'backend-pre-promotion',
+        'backend-sync': 'backend-sync-pre-promotion',
+    }
+    evidence = snapshots.restore_snapshot(
+        snapshot,
+        runner=lambda command: calls.append(list(command)),
+        fetcher=lambda **kwargs: _service_document(revision=revisions[kwargs['service']]),
+    )
 
     assert evidence['result'] == 'pass'
     assert evidence['failed_services'] == []
@@ -132,7 +140,11 @@ def test_restore_snapshot_attempts_every_service_and_sanitizes_a_failed_command(
         if command[4] == 'backend':
             raise subprocess.CalledProcessError(17, command, stderr='sensitive remote response')
 
-    evidence = snapshots.restore_snapshot(snapshot, runner=runner)
+    evidence = snapshots.restore_snapshot(
+        snapshot,
+        runner=runner,
+        fetcher=lambda **kwargs: _service_document(revision=f"{kwargs['service']}-pre-promotion"),
+    )
 
     assert calls == ['backend', 'backend-sync']
     assert evidence['result'] == 'fail'
@@ -147,3 +159,108 @@ def test_restore_snapshot_attempts_every_service_and_sanitizes_a_failed_command(
         'error': 'gcloud exited with code 17',
     }
     assert 'sensitive remote response' not in str(evidence)
+
+
+def test_restore_removes_candidate_tag_and_rejects_unconverged_observation() -> None:
+    snapshot = {
+        'schema_version': 1,
+        'project': 'based-hardware',
+        'region': 'us-central1',
+        'services': {
+            'backend': {
+                'spec': {'traffic': [{'revisionName': 'backend-stable', 'percent': 100}]},
+                'status': {'latestReadyRevisionName': 'backend-stable'},
+            }
+        },
+        'missing_services': [],
+    }
+    calls: list[list[str]] = []
+    observed = _service_document(revision='backend-stable')
+    observed['spec']['traffic'][0]['tag'] = 'ring-12345'
+
+    evidence = snapshots.restore_snapshot(
+        snapshot,
+        runner=lambda command: calls.append(list(command)),
+        fetcher=lambda **_kwargs: observed,
+        remove_tag='ring-12345',
+    )
+
+    assert '--remove-tags=ring-12345' in calls[0]
+    assert evidence['result'] == 'fail'
+    assert evidence['services']['backend']['error'] == 'candidate traffic tag remains after restore'
+
+
+def test_restore_detects_wedged_status_traffic_after_update() -> None:
+    """A wedged Cloud Run service: spec.traffic reflects our restore request but
+    status.traffic still serves the candidate. The read-back must resolve
+    status.traffic, not spec.traffic, so convergence is not falsely claimed."""
+    snapshot = {
+        'schema_version': 1,
+        'project': 'based-hardware',
+        'region': 'us-central1',
+        'services': {
+            'backend': {
+                'spec': {'traffic': [{'revisionName': 'backend-stable', 'percent': 100}]},
+                'status': {'latestReadyRevisionName': 'backend-stable'},
+            }
+        },
+        'missing_services': [],
+    }
+
+    # After restore, spec.traffic matches our target (gcloud accepted the
+    # update), but status.traffic still serves the candidate revision.
+    wedged = {
+        'spec': {'traffic': [{'revisionName': 'backend-stable', 'percent': 100}]},
+        'status': {
+            'traffic': [{'revisionName': 'backend-candidate', 'percent': 100}],
+            'latestReadyRevisionName': 'backend-stable',
+            'latestCreatedRevisionName': 'backend-candidate',
+        },
+    }
+
+    evidence = snapshots.restore_snapshot(
+        snapshot,
+        runner=lambda command: None,
+        fetcher=lambda **_kwargs: wedged,
+    )
+
+    assert evidence['result'] == 'fail'
+    assert evidence['failed_services'] == ['backend']
+    assert evidence['services']['backend']['error'] == 'observed traffic does not match snapshot'
+    assert evidence['services']['backend']['observed_targets'] == [{'revision': 'backend-candidate', 'percent': 100}]
+
+
+def test_restore_deletes_and_observes_services_missing_before_bootstrap() -> None:
+    snapshot = {
+        'schema_version': 1,
+        'project': 'based-hardware',
+        'region': 'us-central1',
+        'services': {},
+        'missing_services': ['backend-beta'],
+    }
+    calls: list[list[str]] = []
+
+    def missing(**_kwargs):
+        raise subprocess.CalledProcessError(1, ['gcloud'], stderr='NOT_FOUND: service was not found')
+
+    evidence = snapshots.restore_snapshot(
+        snapshot,
+        runner=lambda command: calls.append(list(command)),
+        fetcher=missing,
+        delete_missing=True,
+    )
+
+    assert calls == [
+        [
+            'gcloud',
+            'run',
+            'services',
+            'delete',
+            'backend-beta',
+            '--project=based-hardware',
+            '--region=us-central1',
+            '--quiet',
+        ]
+    ]
+    assert evidence['result'] == 'pass'
+    assert evidence['deleted_services']['backend-beta']['result'] == 'deleted'

--- a/backend/tests/unit/test_release_ring_gke_snapshot.py
+++ b/backend/tests/unit/test_release_ring_gke_snapshot.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+from scripts import release_ring_gke_snapshot as snapshots
+
+NAMESPACE = 'prod-omi-backend'
+CONFIG_NAME = 'prod-omi-backend-config'
+
+
+def _config_map(value: str) -> dict:
+    return {
+        'apiVersion': 'v1',
+        'kind': 'ConfigMap',
+        'metadata': {'name': CONFIG_NAME, 'namespace': NAMESPACE},
+        'data': {'PUBLIC_VALUE': value},
+    }
+
+
+def _config_snapshot(value: str) -> dict:
+    sanitized = snapshots._sanitize_config_map(_config_map(value), namespace=NAMESPACE, name=CONFIG_NAME)
+    return {
+        'name': CONFIG_NAME,
+        'present': True,
+        'sha256': snapshots._sha256_text(snapshots._canonical_json(sanitized)),
+        'object': sanitized,
+    }
+
+
+def test_capture_records_exact_config_and_helm_restore_targets() -> None:
+    calls: list[list[str]] = []
+
+    def runner(command, _input):
+        command = list(command)
+        calls.append(command)
+        if command[:6] == ['kubectl', '-n', NAMESPACE, 'get', 'configmap', CONFIG_NAME]:
+            return json.dumps(_config_map('before'))
+        if command[:5] == ['helm', '-n', NAMESPACE, 'history', 'prod-omi-backend-secrets']:
+            return json.dumps([{'revision': 3, 'status': 'superseded'}, {'revision': 4, 'status': 'deployed'}])
+        if command[:6] == ['helm', '-n', NAMESPACE, 'get', 'manifest', 'prod-omi-backend-secrets']:
+            return 'old-secret-manifest\n'
+        if command[:5] == ['helm', '-n', NAMESPACE, 'history', 'prod-omi-pusher']:
+            raise subprocess.CalledProcessError(1, command, stderr='release: not found')
+        raise AssertionError(command)
+
+    snapshot = snapshots.capture_snapshot(
+        namespace=NAMESPACE,
+        config_map_name=CONFIG_NAME,
+        releases={
+            'backend-secrets': 'prod-omi-backend-secrets',
+            'pusher': 'prod-omi-pusher',
+        },
+        runner=runner,
+    )
+
+    assert snapshot['config_map']['object']['data'] == {'PUBLIC_VALUE': 'before'}
+    assert snapshot['helm_releases']['backend-secrets'] == {
+        'name': 'prod-omi-backend-secrets',
+        'present': True,
+        'revision': 4,
+        'manifest_sha256': snapshots._sha256_text('old-secret-manifest\n'),
+    }
+    assert snapshot['helm_releases']['pusher'] == {'name': 'prod-omi-pusher', 'present': False}
+    assert calls[-1] == ['helm', '-n', NAMESPACE, 'history', 'prod-omi-pusher', '--output', 'json']
+
+
+def test_restore_reverts_config_and_secrets_then_removes_bootstrap_release() -> None:
+    old_secret_manifest = 'old-secret-manifest\n'
+    snapshot = {
+        'schema_version': 1,
+        'namespace': NAMESPACE,
+        'config_map': _config_snapshot('before'),
+        'helm_releases': {
+            'backend-secrets': {
+                'name': 'prod-omi-backend-secrets',
+                'present': True,
+                'revision': 4,
+                'manifest_sha256': snapshots._sha256_text(old_secret_manifest),
+            },
+            'pusher': {'name': 'prod-omi-pusher', 'present': False},
+        },
+    }
+    calls: list[list[str]] = []
+    current_config = _config_map('candidate')
+    current_secret_manifest = 'candidate-secret-manifest\n'
+    pusher_exists = True
+
+    def runner(command, input_text):
+        nonlocal current_config, current_secret_manifest, pusher_exists
+        command = list(command)
+        calls.append(command)
+        if command[:5] == ['helm', '-n', NAMESPACE, 'rollback', 'prod-omi-backend-secrets']:
+            current_secret_manifest = old_secret_manifest
+            return ''
+        if command[:6] == ['helm', '-n', NAMESPACE, 'get', 'manifest', 'prod-omi-backend-secrets']:
+            return current_secret_manifest
+        if command[:6] == ['kubectl', '-n', NAMESPACE, 'apply', '-f', '-']:
+            current_config = json.loads(input_text)
+            return ''
+        if command[:6] == ['kubectl', '-n', NAMESPACE, 'get', 'configmap', CONFIG_NAME]:
+            return json.dumps(current_config)
+        if command[:5] == ['helm', '-n', NAMESPACE, 'status', 'prod-omi-pusher']:
+            if pusher_exists:
+                return json.dumps({'info': {'status': 'deployed'}})
+            raise subprocess.CalledProcessError(1, command, stderr='release: not found')
+        if command[:5] == ['helm', '-n', NAMESPACE, 'uninstall', 'prod-omi-pusher']:
+            pusher_exists = False
+            return ''
+        raise AssertionError(command)
+
+    evidence = snapshots.restore_snapshot(snapshot, runner=runner)
+
+    assert evidence['result'] == 'pass'
+    assert evidence['components']['backend-secrets']['result'] == 'restored'
+    assert evidence['components']['backend-config']['result'] == 'restored'
+    assert evidence['components']['pusher']['result'] == 'deleted'
+    assert calls.index(
+        ['helm', '-n', NAMESPACE, 'rollback', 'prod-omi-backend-secrets', '4', '--wait', '--timeout', '1800s']
+    ) < calls.index(['kubectl', '-n', NAMESPACE, 'apply', '-f', '-'])
+
+
+def test_restore_fails_when_helm_reports_success_without_manifest_convergence() -> None:
+    snapshot = {
+        'schema_version': 1,
+        'namespace': NAMESPACE,
+        'config_map': {'name': CONFIG_NAME, 'present': False},
+        'helm_releases': {
+            'pusher': {
+                'name': 'prod-omi-pusher',
+                'present': True,
+                'revision': 7,
+                'manifest_sha256': snapshots._sha256_text('old-manifest\n'),
+            }
+        },
+    }
+
+    def runner(command, _input):
+        command = list(command)
+        if command[:6] == ['kubectl', '-n', NAMESPACE, 'delete', 'configmap', CONFIG_NAME]:
+            return ''
+        if command[:6] == ['kubectl', '-n', NAMESPACE, 'get', 'configmap', CONFIG_NAME]:
+            raise subprocess.CalledProcessError(1, command, stderr='NotFound')
+        if command[:5] == ['helm', '-n', NAMESPACE, 'rollback', 'prod-omi-pusher']:
+            return ''
+        if command[:6] == ['helm', '-n', NAMESPACE, 'get', 'manifest', 'prod-omi-pusher']:
+            return 'still-candidate\n'
+        raise AssertionError(command)
+
+    evidence = snapshots.restore_snapshot(snapshot, runner=runner)
+
+    assert evidence['result'] == 'fail'
+    assert evidence['failed_components'] == ['pusher']
+    assert (
+        evidence['components']['pusher']['error']
+        == 'prod-omi-pusher: observed Helm manifest does not match the snapshot'
+    )

--- a/backend/tests/unit/test_release_rings.py
+++ b/backend/tests/unit/test_release_rings.py
@@ -100,6 +100,30 @@ def test_active_pointer_promote_and_hold_are_monotonic() -> None:
         release_rings.build_active_pointer(ring="beta", release_id="2026-07-20.2", existing=held)
 
 
+def test_recovery_pointer_uses_pre_mutation_state_after_a_late_failure() -> None:
+    before = {
+        "current_release_id": "2026-07-19.1",
+        "previous_verified_release_id": "2026-07-18.1",
+        "held_release_ids": [],
+    }
+    promoted = release_rings.build_active_pointer(
+        ring="prod", release_id="2026-07-20.1", existing=before, updated_at="2026-07-20T00:00:00+00:00"
+    )
+    assert promoted["current_release_id"] == "2026-07-20.1"
+
+    recovered = release_rings.build_active_pointer(
+        ring="prod",
+        release_id="2026-07-20.1",
+        existing=before,
+        hold=True,
+        updated_at="2026-07-20T00:01:00+00:00",
+    )
+
+    assert recovered["current_release_id"] == "2026-07-19.1"
+    assert recovered["previous_verified_release_id"] == "2026-07-18.1"
+    assert recovered["held_release_ids"] == ["2026-07-20.1"]
+
+
 def test_receipt_keeps_partial_mutation_distinct_from_restoration() -> None:
     receipt = release_rings.build_receipt(
         ring="prod",

--- a/docs/runbooks/release-process.md
+++ b/docs/runbooks/release-process.md
@@ -132,17 +132,25 @@ which is the explicit #10057 boundary.
 - `deploy-release-ring.yml` accepts only `ring` and `release_id`. It uses the
   selected GitHub environment and that environment's OIDC identity; it has no
   SHA, tag, branch, Helm-revision, or image input. `prod` additionally requires
-  the literal `confirm=deploy-prod` after the GitHub environment approval.
-- A ring deploy captures Cloud Run traffic and Helm revisions before mutation,
-  writes a `started` receipt, creates no-traffic Cloud Run revisions using the
+  the literal `confirm=deploy-prod` after the GitHub environment approval. The
+  workflow controller stays pinned to the dispatch commit; only immutable chart
+  source inputs are checked out from the record's full Git SHA.
+- Before mutation, a ring deploy server-dry-runs the recorded ConfigMap and all
+  rendered Helm resources. It then captures Cloud Run traffic, the public
+  ConfigMap, deployed Helm revisions plus manifest digests, and the active
+  pointer generation. It writes a `started` receipt, creates no-traffic Cloud Run revisions using the
   recorded public config and numeric secret versions, performs an authenticated
   health smoke, and for beta proves an authenticated known-audio transcription
   through the tagged candidate before applying the recorded
   ConfigMap/ExternalSecret/Helm values by digest and switching traffic. Prod
   depends on that verified beta evidence plus the soak, because prod has no
-  public candidate URL. A deterministic failure restores the snapshot once;
-  any failure to restore writes `partial_mutation`, holds the record, and
-  invokes the configured pager webhook.
+  public candidate URL. A deterministic failure restores the snapshot once,
+  removes the failed candidate's tagged route, deletes resources that did not
+  exist before a bootstrap attempt, refreshes restored ExternalSecrets, and
+  verifies observed Cloud Run traffic, ConfigMap content, and Helm manifests.
+  It also restores the pre-mutation active pointer if a later evidence write
+  failed after pointer advancement. Any failure to converge writes
+  `partial_mutation`, holds the record, and invokes the configured pager webhook.
 - `prod` additionally requires a verified beta receipt older than the configured
   soak window (12 hours by default) and refuses a beta-held record. The prod
   environment approval is where the operator records the initial Sentry,
@@ -176,15 +184,17 @@ this repository.
 `deploy <ring> <release_id>`:
 
 1. Resolve the record from the bucket; refuse anything else.
-2. Snapshot the ring's active serving state (a receipt) before any mutation.
+2. Dry-run every recorded GKE render, then snapshot the ring's active serving
+   state and active-pointer generation before any mutation.
 3. Cloud Run: create no-traffic revisions from recorded digests → smoke check
    the revision URL → shift traffic.
-4. GKE: apply charts with recorded digests and values, wait for rollout,
-   verify with `backend/scripts/deploy_status_report.py`.
+4. GKE: apply charts with recorded digests and values and wait for rollout.
 5. On deterministic failure before or immediately after the traffic switch:
    restore the pre-mutation snapshot automatically (Cloud Run: shift traffic
-   back; a first-time beta service is deleted because it had no prior serving
-   state; GKE: one `helm rollback` attempt). If restoration also fails, write
+   back, remove the candidate tag, and delete a first-time service; GKE:
+   restore the ConfigMap and backend-secrets, roll back existing Helm releases,
+   and uninstall first-time releases). Every restore target is read back and
+   compared with the snapshot before recovery is accepted. If restoration also fails, write
    `partial_mutation` with the exact component diff, leave state visible, and
    page — no recursive recovery attempts.
 6. A failed record is marked held in `rings/<ring>/active.json` so auto-deploy


### PR DESCRIPTION
## Summary

Follow-up to #10068. Restores the complete pre-mutation serving vector after a failed release ring and verifies convergence rather than trusting command success.

- Snapshot and restore GKE ConfigMaps plus Helm release revisions/manifests, with read-back checks.
- Verify restored Cloud Run traffic, remove candidate tags, and delete first-time services during recovery.
- Fail closed on recovery divergence and preserve the pre-mutation active release pointer using generation-aware updates.
- Prevent manual-dispatch values from being interpolated directly into shell commands.

## Verification

- `rtk proxy backend/.venv/bin/python -m pytest -q .github/scripts/test_check_release_rings.py backend/tests/unit/test_release_rings.py backend/tests/unit/test_render_release_ring_config.py backend/tests/unit/test_cloud_run_traffic_snapshot.py backend/tests/unit/test_release_ring_gke_snapshot.py` — 25 passed
- `rtk python3 .github/scripts/check_release_rings.py` — passed
- `rtk python3 .github/scripts/check-deployment-concurrency.py` — passed
- Independent review: approved; no blockers found.

## Product invariants affected

- INV-AUTH-1

## Failure class

Failure-Class: FC-nonrecoverable-promotion

The release must preserve and restore the pre-promotion serving vector until the complete candidate is verified.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

