### PR TITLE
fix(macos): share qualification profile setup

### DIFF
--- a/desktop/macos/changelog/unreleased/20260720-qualification-profile-setup.json
+++ b/desktop/macos/changelog/unreleased/20260720-qualification-profile-setup.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved reliability of macOS beta qualification retries by starting each run with a clean synthetic profile"
+}

--- a/desktop/macos/scripts/prepare-qualification-profile.sh
+++ b/desktop/macos/scripts/prepare-qualification-profile.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Prepare the isolated local state used by a named desktop qualification bundle.
+#
+# This is intentionally reusable: release qualification and direct local retry
+# lanes must start from the same signed-in, onboarded synthetic-profile defaults.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUNDLE_NAME="${1:-}"
+
+if [[ ! "$BUNDLE_NAME" =~ ^omi-qualification-[A-Za-z0-9.+-]+$ ]]; then
+  echo "refusing to prepare non-qualification profile: ${BUNDLE_NAME:-<empty>}" >&2
+  exit 2
+fi
+
+# shellcheck source=app-config.sh
+source "$SCRIPT_DIR/app-config.sh"
+derive_omi_app_config "$BUNDLE_NAME"
+
+# Qualification profiles never inherit onboarding, capture, shortcut, or UI
+# state from a previous attempt or from Omi Dev.
+rm -rf "$HOME/Library/Application Support/$BUNDLE_NAME" "$HOME/Library/Caches/$BUNDLE_NAME"
+defaults delete "$BUNDLE_ID" >/dev/null 2>&1 || true
+defaults write "$BUNDLE_ID" hasCompletedOnboarding -bool true
+defaults write "$BUNDLE_ID" devLazyPermissionsEnabled -bool true
+defaults write "$BUNDLE_ID" screenAnalysisEnabled -bool false
+defaults write "$BUNDLE_ID" transcriptionEnabled -bool false
+defaults write "$BUNDLE_ID" systemAudioCaptureMode -string never
+defaults write "$BUNDLE_ID" screenAnalysisAutoStartFixed_v2 -bool true
+defaults write "$BUNDLE_ID" shortcut_floatingBarTypedQuestionVoiceAnswersEnabled -bool false
+
+echo "prepared qualification profile: $BUNDLE_NAME ($BUNDLE_ID)"

--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -234,25 +234,6 @@ PY
   return 1
 }
 
-prepare_qualification_defaults() {
-  local bundle_id="$1" bundle_name="$2"
-  case "$bundle_name" in
-    omi-qualification-*) ;;
-    *) echo "refusing to reset non-qualification profile: $bundle_name" >&2; return 1 ;;
-  esac
-  # Qualification is a fresh, synthetic profile. Never inherit stale onboarding,
-  # capture, or shortcut state from this bundle's previous run or from Omi Dev.
-  rm -rf "$HOME/Library/Application Support/$bundle_name" "$HOME/Library/Caches/$bundle_name"
-  defaults delete "$bundle_id" >/dev/null 2>&1 || true
-  defaults write "$bundle_id" hasCompletedOnboarding -bool true
-  defaults write "$bundle_id" devLazyPermissionsEnabled -bool true
-  defaults write "$bundle_id" screenAnalysisEnabled -bool false
-  defaults write "$bundle_id" transcriptionEnabled -bool false
-  defaults write "$bundle_id" systemAudioCaptureMode -string never
-  defaults write "$bundle_id" screenAnalysisAutoStartFixed_v2 -bool true
-  defaults write "$bundle_id" shortcut_floatingBarTypedQuestionVoiceAnswersEnabled -bool false
-}
-
 cleanup() {
   local exit_code=$?
   if [[ -n "$BUNDLE" ]]; then
@@ -271,9 +252,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-QUALIFICATION_BUNDLE_ID="$(derive_bundle_id "$BUNDLE")"
 terminate_qualification_desktop "$BUNDLE"
-prepare_qualification_defaults "$QUALIFICATION_BUNDLE_ID" "$BUNDLE"
+"$SCRIPT_DIR/prepare-qualification-profile.sh" "$BUNDLE"
 
 (
   cd "$WORKTREE"

--- a/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
+++ b/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 QUALIFIER="$SCRIPT_DIR/../scripts/qualify-desktop-beta.sh"
 CORE_HARNESS="$SCRIPT_DIR/../scripts/desktop-core-harness.sh"
+PROFILE_PREP="$SCRIPT_DIR/../scripts/prepare-qualification-profile.sh"
 APP_CONFIG="$SCRIPT_DIR/../scripts/app-config.sh"
 
 require_text() {
@@ -15,17 +16,45 @@ require_text() {
   }
 }
 
-require_text 'defaults delete "$bundle_id"'
-require_text 'omi-qualification-*'
-require_text 'Application Support/$bundle_name'
-require_text 'defaults write "$bundle_id" hasCompletedOnboarding -bool true'
-require_text 'defaults write "$bundle_id" devLazyPermissionsEnabled -bool true'
-require_text 'defaults write "$bundle_id" screenAnalysisEnabled -bool false'
-require_text 'defaults write "$bundle_id" transcriptionEnabled -bool false'
+require_text 'defaults delete "$BUNDLE_ID"' "$PROFILE_PREP"
+require_text '^omi-qualification-' "$PROFILE_PREP"
+require_text 'Application Support/$BUNDLE_NAME' "$PROFILE_PREP"
+require_text 'defaults write "$BUNDLE_ID" hasCompletedOnboarding -bool true' "$PROFILE_PREP"
+require_text 'defaults write "$BUNDLE_ID" devLazyPermissionsEnabled -bool true' "$PROFILE_PREP"
+require_text 'defaults write "$BUNDLE_ID" screenAnalysisEnabled -bool false' "$PROFILE_PREP"
+require_text 'defaults write "$BUNDLE_ID" transcriptionEnabled -bool false' "$PROFILE_PREP"
+require_text '"$SCRIPT_DIR/prepare-qualification-profile.sh" "$BUNDLE"' "$QUALIFIER"
 require_text 'OMI_SKIP_SETTINGS_SEED=1 make desktop-run-local'
 require_text 'terminate_qualification_desktop "$BUNDLE"'
 require_text 'derive_omi_app_config "$BUNDLE"' "$CORE_HARNESS"
 require_text 'wrong bundle on port' "$CORE_HARNESS"
+
+if [[ ! -x "$PROFILE_PREP" ]]; then
+  echo "FAIL: missing executable qualification profile preparation helper" >&2
+  exit 1
+fi
+
+# Profile preparation is shared by release qualification and direct local retries.
+# Exercise it with an isolated preferences home so this contract never reads or
+# changes a developer's real qualification profile.
+prefs_home="$(mktemp -d "${TMPDIR:-/tmp}/omi-qualification-profile.XXXXXX")"
+trap 'rm -rf "$prefs_home"' EXIT
+bundle_name="omi-qualification-contract-$$"
+source "$APP_CONFIG"
+derive_omi_app_config "$bundle_name"
+HOME="$prefs_home" "$PROFILE_PREP" "$bundle_name"
+if [[ "$(HOME="$prefs_home" defaults read "$BUNDLE_ID" hasCompletedOnboarding)" != "1" ]]; then
+  echo "FAIL: prepared qualification profile must complete onboarding" >&2
+  exit 1
+fi
+if [[ "$(HOME="$prefs_home" defaults read "$BUNDLE_ID" devLazyPermissionsEnabled)" != "1" ]]; then
+  echo "FAIL: prepared qualification profile must enable lazy dev permissions" >&2
+  exit 1
+fi
+if HOME="$prefs_home" "$PROFILE_PREP" 'omi-not-a-qualification' >/dev/null 2>&1; then
+  echo "FAIL: profile preparation accepted a non-qualification bundle" >&2
+  exit 1
+fi
 
 # Release qualification names contain SemVer punctuation; the preflight must
 # compare against the same slugged identity run.sh installs.


### PR DESCRIPTION
## Summary
- Extract named qualification-profile reset/defaults into a reusable, executable helper.
- Make macOS beta qualification invoke the shared helper before launching its synthetic local profile.
- Add an isolated-preferences contract test for onboarding and lazy-permission defaults, including rejection of non-qualification bundle names.

## Root cause
Direct local Tier-2 retries that bypassed the release qualifier did not apply the required qualification defaults. The named local profile launched into onboarding, so conversation-detail, floating-bar, Home, and shortcut flows failed deterministically even though focused Swift tests passed. Applying the shared profile setup made the full Tier-2 harness pass.

## Verification
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh`
- `bash -n desktop/macos/scripts/qualify-desktop-beta.sh desktop/macos/scripts/prepare-qualification-profile.sh`
- `make preflight`
- Fresh named local bundle with the helper: `desktop-core-harness.sh --tier 2 --bundle omi-qualification-pr-proof --port 47989` — passed.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

