### PR TITLE
fix(conversations): honor a preferred summarization app the setter admitted

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "backend/utils/apps.py": 1641,
+    "backend/utils/apps.py": 1652,
     "backend/utils/memory/legacy_backfill.py": 1816,
     "backend/utils/memory_ingestion/pipeline.py": 1711,
     "backend/utils/other/storage.py": 1584,
@@ -8,6 +8,7 @@
     "backend/utils/sync/pipeline.py": 2299
   },
   "raise_justifications": {
+    "backend/utils/apps.py": "get_available_app_model_by_id: the set-preferred-app availability authority as a validated App model, so the summary path honors what the setter admitted instead of re-deciding with the installed slice (#10074).",
     "backend/utils/other/storage.py": "delete_app_logo now requires an exact app-logo bucket prefix (startswith) so a foreign URL embedding the prefix later cannot delete an unrelated object on this deletion path (David review on #9873).",
     "backend/utils/sync/pipeline.py": "Durable-ledger convergence remains beside the Sync pipeline's run-lock ownership and terminal-result transitions instead of splitting one recovery invariant across modules."
   },

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -916,8 +916,14 @@ def _make_trigger_conversation(suggested_apps=None):
     return conv
 
 
-def _trigger_apps_context(default_apps=None):
-    """Context manager that patches all external dependencies of _trigger_apps."""
+def _trigger_apps_context(default_apps=None, availability_app=None):
+    """Context manager that patches all external dependencies of _trigger_apps.
+
+    `availability_app` stands in for `get_available_app_model_by_id` — the
+    set-preferred route's availability authority (#10074): None models a
+    deleted/inaccessible app; an app object models one the setter admitted even
+    though it is outside the enabled-installed slice.
+    """
     suggestion_mock = MagicMock(return_value=(["suggested-app"], "reasoning"))
     app_result_mock = MagicMock(return_value="App result content")
     record_mock = MagicMock()
@@ -929,6 +935,7 @@ def _trigger_apps_context(default_apps=None):
         patch.object(process_conversation, "get_suggested_apps_for_conversation", suggestion_mock),
         patch.object(process_conversation, "get_app_result", app_result_mock),
         patch.object(process_conversation, "record_app_usage", record_mock),
+        patch.object(process_conversation, "get_available_app_model_by_id", return_value=availability_app),
     )
 
 
@@ -938,11 +945,11 @@ def test_trigger_apps_uses_preferred_app_skips_llm_suggestion():
     _setup_trigger_apps_mocks(preferred_app_id="preferred-app-1", available_apps=[preferred])
     conv = _make_trigger_conversation()
 
-    suggestion_mock, app_result_mock, p1, p2, p3, p4, p5 = _trigger_apps_context()
+    suggestion_mock, app_result_mock, p1, p2, p3, p4, p5, p6 = _trigger_apps_context()
     # Override get_available_apps to return the preferred app
     p2 = patch.object(process_conversation, "get_available_apps", return_value=[preferred])
 
-    with p1, p2, p3, p4, p5:
+    with p1, p2, p3, p4, p5, p6:
         process_conversation._trigger_apps("user-preferred", conv)
 
     # The suggestion LLM call must NOT have been invoked
@@ -959,9 +966,9 @@ def test_trigger_apps_stale_preferred_app_falls_through_to_suggestion():
     _setup_trigger_apps_mocks(preferred_app_id="deleted-app-999")
     conv = _make_trigger_conversation()
 
-    suggestion_mock, app_result_mock, p1, p2, p3, p4, p5 = _trigger_apps_context(default_apps=[suggestion_app])
+    suggestion_mock, app_result_mock, p1, p2, p3, p4, p5, p6 = _trigger_apps_context(default_apps=[suggestion_app])
 
-    with p1, p2, p3, p4, p5:
+    with p1, p2, p3, p4, p5, p6:
         process_conversation._trigger_apps("user-stale", conv)
 
     # The suggestion LLM call SHOULD have been invoked since preferred app was invalid
@@ -974,10 +981,47 @@ def test_trigger_apps_no_preferred_app_runs_suggestion():
     _setup_trigger_apps_mocks(preferred_app_id=None)
     conv = _make_trigger_conversation()
 
-    suggestion_mock, app_result_mock, p1, p2, p3, p4, p5 = _trigger_apps_context(default_apps=[suggestion_app])
+    suggestion_mock, app_result_mock, p1, p2, p3, p4, p5, p6 = _trigger_apps_context(default_apps=[suggestion_app])
 
-    with p1, p2, p3, p4, p5:
+    with p1, p2, p3, p4, p5, p6:
         process_conversation._trigger_apps("user-no-pref", conv)
 
     # The suggestion LLM call SHOULD have been invoked
+    suggestion_mock.assert_called_once()
+
+
+def test_trigger_apps_preferred_app_outside_installed_slice_is_still_used():
+    """#10074: the set-preferred route admits apps the enabled-installed slice
+    does not contain (e.g. a template whose enable call failed). The reader must
+    honor the setter's availability authority instead of silently ignoring it."""
+    preferred = _make_mock_app("template-app-1", "MyTemplate")
+    _setup_trigger_apps_mocks(preferred_app_id="template-app-1")
+    conv = _make_trigger_conversation()
+
+    suggestion_mock, app_result_mock, p1, p2, p3, p4, p5, p6 = _trigger_apps_context(availability_app=preferred)
+
+    with p1, p2, p3, p4, p5, p6:
+        process_conversation._trigger_apps("user-template", conv)
+
+    suggestion_mock.assert_not_called()
+    app_result_mock.assert_called_once()
+    assert len(conv.apps_results) == 1
+
+
+def test_trigger_apps_preferred_app_without_memories_capability_falls_through():
+    """A resolvable preferred app that cannot summarize (no memories capability)
+    falls back to suggestions rather than running as a summarizer."""
+    persona = _make_mock_app("persona-app-1", "ChatPersona")
+    persona.works_with_memories.return_value = False
+    suggestion_app = _make_mock_app("suggested-app", "SuggestedApp")
+    _setup_trigger_apps_mocks(preferred_app_id="persona-app-1")
+    conv = _make_trigger_conversation()
+
+    suggestion_mock, app_result_mock, p1, p2, p3, p4, p5, p6 = _trigger_apps_context(
+        default_apps=[suggestion_app], availability_app=persona
+    )
+
+    with p1, p2, p3, p4, p5, p6:
+        process_conversation._trigger_apps("user-persona", conv)
+
     suggestion_mock.assert_called_once()

--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -395,6 +395,17 @@ def get_available_apps(uid: str, include_reviews: bool = False) -> List[App]:
     return apps
 
 
+def get_available_app_model_by_id(app_id: str, uid: str | None) -> Optional[App]:
+    """`get_available_app_by_id` as a validated App model.
+
+    This is the same availability authority the set-preferred-app route uses
+    (routers/users.py), for readers that must honor what that route admitted
+    rather than re-deciding availability with a different check (#10074).
+    """
+    raw_app = get_available_app_by_id(app_id, uid)
+    return _safe_build_app(dict(raw_app)) if raw_app else None
+
+
 def get_available_app_by_id(app_id: str, uid: str | None) -> Dict[str, Any] | None:
     cached_app = get_app_cache_by_id(app_id)
     if cached_app:

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -61,7 +61,7 @@ from models.structured import Structured
 from utils.notifications import send_important_conversation_message
 from models.task import Task, TaskStatus, TaskAction, TaskActionProvider
 from models.notification_message import NotificationMessage
-from utils.apps import get_available_apps, update_persona_prompt
+from utils.apps import get_available_app_model_by_id, get_available_apps, update_persona_prompt
 from utils.executors import db_executor, llm_executor, postprocess_executor, submit_with_context
 from utils.llm.conversation_processing import (
     get_transcript_structure,
@@ -418,8 +418,26 @@ def _trigger_apps(
         if preferred_app_id and preferred_app_id in all_apps_dict:
             app_to_run = cast(App, all_apps_dict.get(preferred_app_id))
             logger.info(f"Using user's preferred app: {app_to_run.name} (id: {preferred_app_id})")
-        else:
-            # Only run suggestion LLM call when no preferred app is set
+        elif preferred_app_id:
+            # The set-preferred route admits any app `get_available_app_by_id`
+            # can see (routers/users.py); it never requires the enabled-installed
+            # slice this dict is built from. A default whose enablement never
+            # landed (e.g. the template create flow's enable call failed) was
+            # therefore accepted by the setter and silently ignored here (#10074).
+            # Resolve through the setter's own authority instead of re-deciding.
+            candidate = get_available_app_model_by_id(preferred_app_id, uid)
+            if candidate and candidate.works_with_memories():
+                app_to_run = candidate
+                logger.info(
+                    f"Using user's preferred app outside the installed slice: {candidate.name} (id: {preferred_app_id})"
+                )
+            else:
+                logger.warning(
+                    f"Preferred app {preferred_app_id} is set but unusable "
+                    f"(missing={candidate is None}); falling back to suggestions {uid}"
+                )
+        if app_to_run is None:
+            # Only run suggestion LLM call when no usable preferred app is set
             if not conversation.suggested_summarization_apps:
                 with track_usage(uid, Features.CONVERSATION_APPS):
                     suggested_apps, _reasoning = get_suggested_apps_for_conversation(conversation, all_suggestion_apps)


### PR DESCRIPTION
## Summary

- A summary template set as the standard/default via `PUT /v1/users/preferences/app` is now actually applied at generation time, even when the app never landed in the user's enabled-installed slice.
- The reader resolves a preferred app missing from that slice through the **setter's own availability authority** (`get_available_app_model_by_id`, the new shared App-model form of `get_available_app_by_id`) and uses it when it can summarize.
- The previously **silent** drop now always logs: a deleted/inaccessible preferred app falls through to suggestions with a warning; a resolvable app without the `memories` capability falls through with a warning.

Fixes #10074.

## Root cause

Split availability authority between admission and use:

- **Setter** (`routers/users.py`): `get_available_app_by_id` — existence + private-ownership only. Accepts the template and stores it in Redis.
- **Reader** (`_trigger_apps` in `utils/conversations/process_conversation.py`): honored the preferred id only if present in the `works_with_memories() AND enabled` installed slice.

Any app passing the first check but not the second was accepted as the default and silently ignored at generation, falling through to the LLM suggestion path — exactly the reported behavior ("the template can be set as standard/default, but it is not applied"). Two concrete ways to get there without any user error:

1. The template create flow calls `enableAppServer` and **ignores failure** (`create_template_bottom_sheet.dart` — `if (success)` with no else), then lets the user set the never-enabled app as default.
2. The per-user app-slice and enabled-set caches (30s TTLs) mean a template created/enabled on one device can be set as default before another surface's slice converges.

## Failure class

Failure-Class: none

No registered class covers split availability authority between an admission route and its consumer. It rhymes with `FC-split-mutation-authority` (one authoritative owner per decision) but that class is scoped to mutable-state transitions, not read-side policy; declaring it here would stretch its definition. Flagging rather than stretching.

## Durable guard

- One authority: the reader now consults the exact check the setter used, via a shared function whose docstring names the contract — future preference readers have a primitive to reuse instead of re-deciding availability locally.
- The remaining legitimate fallthroughs (deleted app, capability mismatch) are logged with reasons, so this failure mode can never be silent again.
- The capability guard stays: a chat-only persona set as preferred cannot run as a summarizer.

## Product invariants affected

none (verified with `scripts/pr-preflight --suggest`)

## Validation

- Old-code regression check (reader change stashed): the two new tests → **2 failed** (template ignored, suggestion LLM invoked); new code → **20 passed** in `tests/unit/test_process_conversation_usage_context.py`.
- New tests extend the existing `_trigger_apps` preferred-app suite through its established seams: an admitted-but-not-installed template runs with **no suggestion LLM call**; a capability-less preferred app falls back to suggestions; the existing deleted-app fallthrough test keeps its contract (resolver returns None).
- Repo runner (file-isolated, as CI executes): `tests/unit/test_process_conversation_usage_context.py` → 20 passed, `tests/unit/test_lock_bypass_fixes.py` → 61 passed, `tests/unit/test_listen_process_pending_shutdown.py` → 3 passed.
- Note for reviewers: running `test_process_conversation_usage_context.py` and `test_lock_bypass_fixes.py` in one shared pytest process shows 19 cross-file failures **on clean main as well** — pre-existing module-isolation interaction, which is exactly why `test.sh` runs file-isolated; not introduced or worsened here.
- `make preflight` (local lane, this PR body) → all selected checks pass.
- `black --line-length 120 --skip-string-normalization` clean on the three changed files.

Not exercised live: the full app→backend template flow against production (no device/credentials here). The fix point is server-side selection logic driven directly by the regression tests; the app-side create flow is unchanged.

## Out of scope, named

- The app-side silent `enableAppServer` failure (`create_template_bottom_sheet.dart:167`) still deserves a user-visible error; with this fix it no longer breaks the default template, so it's a polish follow-up.
- The reprocess path (`app_id` parameter) keeps its existing installed-slice lookup — different admission route, untouched.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

