### PR TITLE
fix(ci): keep signed desktop candidates retryable

### DIFF
--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -102,6 +102,10 @@ def check_desktop_codemagic_release() -> list[str]:
         errors.append("desktop release must dispatch trusted macOS qualification after GitHub candidate publication")
     if "desktop_qualify_beta.yml" not in desktop_workflow_body:
         errors.append("desktop release must dispatch the trusted macOS qualification workflow")
+    if "if ! gh workflow run desktop_qualify_beta.yml" not in desktop_workflow_body:
+        errors.append("desktop qualification handoff must not fail a published candidate on a transient dispatch error")
+    if "candidate remains non-live" not in desktop_workflow_body:
+        errors.append("desktop qualification handoff must state that a failed dispatch cannot publish beta")
     if "docker info" in desktop_workflow_body:
         errors.append("Codemagic desktop release must not run Docker-backed beta qualification")
     if "scripts/smoke-signed-desktop-artifact.sh" not in desktop_workflow_body:

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2885,8 +2885,11 @@ workflows:
             echo "Automatic desktop beta qualification paused by DESKTOP_AUTO_BETA_ENABLED=false; candidate remains non-live."
             exit 0
           fi
-          gh workflow run desktop_qualify_beta.yml --repo "$GITHUB_REPO" \
-            -f release_tag="$CM_TAG"
+          if ! gh workflow run desktop_qualify_beta.yml --repo "$GITHUB_REPO" \
+            -f release_tag="$CM_TAG"; then
+            echo "WARNING: qualification dispatch failed; candidate remains non-live."
+            echo "Retry desktop_qualify_beta.yml for $CM_TAG after GitHub Actions recovers."
+          fi
 
     artifacts:
       - build/*.app


### PR DESCRIPTION
## Summary

- keep a signed, smoke-verified macOS candidate successful when only the GitHub qualification workflow dispatch hits a transient error
- preserve mandatory trusted qualification and beta promotion: a dispatch failure leaves the candidate non-live
- add a release-process guard that prevents the dispatch from becoming a candidate-build failure again

## Root cause

Codemagic build `6a5d6b9839957861f1e7ae2f` completed signing, notarization, artifact smoke, and GitHub candidate publication, then failed solely because `gh workflow run desktop_qualify_beta.yml` received a GitHub HTTP 503.

## Verification

- `python3 .github/scripts/check-release-process-guards.py`
- `make preflight` with this PR body

## Product invariants affected

- INV-AUTH-1

## Failure class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

