### PR TITLE
fix(ci): avoid automatic beta tag SIGPIPE

### DIFF
--- a/.github/workflows/desktop_promote_beta.yml
+++ b/.github/workflows/desktop_promote_beta.yml
@@ -48,7 +48,11 @@ jobs:
             echo "Automatic desktop beta promotion is paused by DESKTOP_AUTO_BETA_ENABLED=false." >&2
             exit 1
           fi
-          LATEST_TAG=$(git tag -l 'v*-macos' --sort=-v:refname | head -1)
+          LATEST_TAG=$(git for-each-ref --count=1 --sort=-v:refname --format='%(refname:strip=2)' 'refs/tags/v*-macos')
+          if [[ -z "$LATEST_TAG" ]]; then
+            echo "Automatic beta promotion requires at least one macOS candidate tag." >&2
+            exit 1
+          fi
           if [[ "$RELEASE_TAG" != "$LATEST_TAG" ]]; then
             echo "Automatic beta promotion refuses stale tag $RELEASE_TAG; newest is $LATEST_TAG." >&2
             exit 1

--- a/backend/tests/unit/test_desktop_release_scripts.py
+++ b/backend/tests/unit/test_desktop_release_scripts.py
@@ -265,6 +265,8 @@ def test_automatic_beta_is_pauseable_and_rejects_stale_tags():
     assert "automatic:" in workflow
     assert "DESKTOP_AUTO_BETA_ENABLED" in workflow
     assert "newest is $LATEST_TAG" in workflow
+    assert "git for-each-ref --count=1 --sort=-v:refname" in workflow
+    assert "git tag -l 'v*-macos' --sort=-v:refname | head -1" not in workflow
     assert automatic_gate < candidate_download
 
 


### PR DESCRIPTION
## Summary
- Use Git's bounded ref lookup for the automatic newest macOS candidate checks in qualification and promotion.
- Avoid the `head` + `pipefail` SIGPIPE that prevented qualified automatic beta release progression.
- Cover both workflow contracts against reintroducing the unsafe pipeline.

## Test plan
- `/Users/dazheng/workspace/omi/backend/.venv/bin/python -m pytest backend/tests/unit/test_desktop_release_scripts.py -q`
- `bash -o errexit -o nounset -o pipefail -c 'tag=$(git for-each-ref --count=1 --sort=-v:refname --format="%(refname:strip=2)" "refs/tags/v*-macos"); test "$tag" = "v0.12.87+12087-macos"'`

## Failure-Class
Failure-Class: none
