### PR TITLE
fix(desktop): surface silent client failures

### DIFF
--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Apps.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Apps.swift
@@ -422,7 +422,10 @@ extension APIClient {
       if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
         return json["is_setup_completed"] as? Bool ?? false
       }
-    } catch {}
+      log("APIClient: app setup status response was not JSON")
+    } catch {
+      logError("APIClient: failed to check app setup status", error: error)
+    }
     return false
   }
 

--- a/desktop/macos/changelog/unreleased/20260724-silent-failure-logging.json
+++ b/desktop/macos/changelog/unreleased/20260724-silent-failure-logging.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved desktop diagnostics when app setup, connected accounts, screen capture, or retention cleanup fail"
+}

--- a/desktop/macos/e2e/flows/apps.yaml
+++ b/desktop/macos/e2e/flows/apps.yaml
@@ -4,6 +4,7 @@ tier: manual
 description: Apps/Integrations marketplace flow — browse apps, filter by category, search, view app details
 app: com.omi.computer-macos
 covers:
+  - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Apps.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
   # S5b is the only place either of these is exercised where it can actually fail. `AppsPage`
   # presents its connector sheet with `.dismissableSheet`, which mounts a `ShellModalScrim`; Apps

--- a/desktop/macos/e2e/flows/apps.yaml
+++ b/desktop/macos/e2e/flows/apps.yaml
@@ -4,6 +4,7 @@ tier: manual
 description: Apps/Integrations marketplace flow — browse apps, filter by category, search, view app details
 app: com.omi.computer-macos
 covers:
+  - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Apps.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPageHeaderControls.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SearchableDropdown.swift

--- a/desktop/windows/src/main/integrations/tokenStore.ts
+++ b/desktop/windows/src/main/integrations/tokenStore.ts
@@ -26,7 +26,9 @@ export function loadRefreshToken(): { refreshToken: string; email?: string } | n
     if (!raw.refreshToken) return null
     const dec = safeStorage.decryptString(Buffer.from(raw.refreshToken, 'base64'))
     return { refreshToken: dec, email: raw.email }
-  } catch {
+  } catch (error) {
+    // Corrupt/unreadable secure storage must not look like "never connected".
+    console.warn('[google] failed to load refresh token from secure storage:', error)
     return null
   }
 }

--- a/desktop/windows/src/main/ipc/screen.ts
+++ b/desktop/windows/src/main/ipc/screen.ts
@@ -16,7 +16,10 @@ const READ_TIMEOUT_MS = 4500
 // used when Rewind has no frame yet (capture just enabled / disabled).
 async function desktopCapturerOcr(): Promise<string> {
   try {
-    const primaryId = await getPrimarySourceId().catch(() => null)
+    const primaryId = await getPrimarySourceId().catch((error: unknown) => {
+      console.warn('[screen:readNow] primary source lookup failed; falling back to first screen:', error)
+      return null
+    })
     const sources = await desktopCapturer.getSources({
       types: ['screen'],
       thumbnailSize: { width: 1920, height: 1080 }

--- a/desktop/windows/src/main/rewind/retentionRunner.ts
+++ b/desktop/windows/src/main/rewind/retentionRunner.ts
@@ -11,7 +11,15 @@ export async function pruneRewindOnce(): Promise<number> {
   const cutoff = retentionCutoff(Date.now(), retentionDays)
   const removed = deleteRewindFramesOlderThan(cutoff)
   await Promise.all(
-    removed.map((f) => removeRewindFrame(rewindRoot(), f.imagePath).catch(() => undefined)) // file may already be gone
+    removed.map((f) =>
+      removeRewindFrame(rewindRoot(), f.imagePath).catch((error: NodeJS.ErrnoException) => {
+        // ENOENT is idempotent (frame already gone). Other failures need a log
+        // so retention cannot silently leave disk growth undiagnosed.
+        if (error?.code !== 'ENOENT') {
+          console.warn('[rewind] failed to delete pruned frame:', f.imagePath, error)
+        }
+      })
+    )
   )
   return removed.length
 }


### PR DESCRIPTION
## Summary

Surface previously swallowed desktop client failures in macOS app setup checks and Windows connected-account, screen-capture, and retention cleanup paths.

## Product invariants affected

- INV-VOICE-1
- INV-CHAT-1

## Verification

- `xcrun swift test -c debug --package-path Desktop --filter APIClientSetupCompletedTests` compiled successfully. The local XCTest runner could not load Sparkle under host Xcode Beta 27; the authoritative rerun uses CI’s pinned Xcode 16.4.
- Windows dependencies are not installed in this isolated worktree; the fresh Windows CI run is authoritative for TypeScript checks.

Failure-Class: none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes with no altered success paths; failures remain handled as before but are easier to diagnose in support and CI logs.
> 
> **Overview**
> Replaces swallowed errors with **diagnostic logging** on macOS and Windows desktop paths where failures were previously invisible. Runtime behavior on failure stays the same (e.g. setup still reports not completed, token load still returns null).
> 
> **macOS:** `isAppSetupCompleted` now logs when the setup-status response is not JSON and when the network request fails, instead of an empty `catch`.
> 
> **Windows:** Google refresh token load warns on corrupt secure storage (still returns null so UI does not treat corruption as “never connected”). Screen capture fallback warns when primary display lookup fails before using the first screen. Rewind retention logs non-`ENOENT` frame delete failures during prune; launch and hourly prune already had top-level failure warnings.
> 
> Also adds an unreleased changelog entry and extends the macOS apps e2e flow **covers** to include `APIClient+Apps.swift`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c71a0a667e563f19d022b5db100b564da845accf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->