### PR TITLE
fix(macos): parse notification smoke marker

### DIFF
--- a/desktop/macos/changelog/unreleased/20260720-signed-artifact-smoke-marker.json
+++ b/desktop/macos/changelog/unreleased/20260720-signed-artifact-smoke-marker.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved the reliability of macOS beta release verification"
+}

--- a/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
+++ b/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
@@ -613,7 +613,7 @@ try:
     marker = Path(marker_path).read_text(encoding="utf-8").strip()
 except OSError as error:
     raise SystemExit(f"invalid UserNotifications callback marker: {error}")
-match = re.fullmatch(r"main_actor=true authorization_status=(\\d+)", marker)
+match = re.fullmatch(r"main_actor=true authorization_status=(\d+)", marker)
 if match is None:
     raise SystemExit("UserNotifications callback marker must prove main_actor=true and an authorization status")
 

--- a/desktop/macos/tests/test-signed-artifact-smoke.sh
+++ b/desktop/macos/tests/test-signed-artifact-smoke.sh
@@ -12,7 +12,7 @@ fail() {
 
 TMP_ROOTS=()
 cleanup() {
-  for path in "${TMP_ROOTS[@]}"; do
+  for path in "${TMP_ROOTS[@]:-}"; do
     [[ -n "$path" ]] && rm -rf "$path"
   done
 }
@@ -23,6 +23,21 @@ trap cleanup EXIT
 if ! "$SMOKE" --help >/tmp/omi-smoke-help.out; then
   fail "--help should succeed"
 fi
+
+python3 - "$SMOKE" <<'PY'
+import ast
+import re
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+match = re.search(r're\.fullmatch\((r"[^"]+")\s*, marker\)', source)
+if match is None:
+    raise SystemExit("notification callback marker parser is missing")
+pattern = ast.literal_eval(match.group(1))
+if re.fullmatch(pattern, "main_actor=true authorization_status=0") is None:
+    raise SystemExit("notification callback marker parser must accept a numeric authorization status")
+PY
 
 for required in \
   "Launch + identity" \


### PR DESCRIPTION
## Summary

Fix the signed macOS artifact smoke parser so it accepts the numeric UserNotifications authorization status emitted by the callback canary.

The prior raw regular expression used `\\d` and therefore matched a literal backslash-plus-`d`, causing the signed `.88` artifact smoke gate to reject a valid marker such as `main_actor=true authorization_status=0`.

## Product invariants affected

- INV-AUTH-1

## Verification

- `bash desktop/macos/tests/test-signed-artifact-smoke.sh`
- `bash -n desktop/macos/scripts/smoke-signed-desktop-artifact.sh`
- `make preflight`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

