### PR TITLE
fix(desktop): Xcode Beta / Swift 6.4 build compatibility

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-onboarding.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-onboarding.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift": 2179,
+    "desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift": 2180,
     "desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift": 1714
   },
   "raise_justifications": {

--- a/desktop/macos/Desktop/Sources/Chat/ChatDraftStore.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatDraftStore.swift
@@ -175,7 +175,7 @@ final class ChatDraftStore {
     // `@Sendable` closure — an inferred `@MainActor` block dispatched off the main
     // queue would trap (`dispatch_assert_queue_fail`). `persist` is a static call;
     // the in-memory bookkeeping hops back to the main actor via a `Task`.
-    let block: @Sendable () -> Void = {
+    let block: @Sendable () -> Void = { [weak self] in
       Self.persist(text: text, id: id, rootURL: rootURL)
       Task { @MainActor [weak self] in
         guard let self, self.writeGenerations[id] == generation else { return }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -1018,7 +1018,7 @@ extension RealtimeHubController {
             sessionID: voiceSessionID,
             responseID: identity.responseID))
       }
-      source.resumeAfterToolOnlyCycle(identity: identity) { resumed in
+      source.resumeAfterToolOnlyCycle(identity: identity) { [self, source] resumed in
         DispatchQueue.main.async { [weak self, weak source] in
           guard let self, let source else { return }
           self.handlePostToolContinuationStart(

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -44,7 +44,6 @@ struct DesktopHomeView: View {
     DesktopAutomationPresentationCoordinator.shared
   @State private var selectedIndex: Int = {
     if OMIApp.launchMode == .rewind { return SidebarNavItem.rewind.rawValue }
-    let tier = UserDefaults.standard.integer(forKey: "currentTierLevel")
     return SidebarNavItem.dashboard.rawValue
   }()
   @State private var isSidebarCollapsed: Bool = true

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import OmiTheme
 import SwiftUI
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/FocusPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/FocusPage.swift
@@ -1,3 +1,4 @@
+import Combine
 import OmiTheme
 import SwiftUI
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import OmiTheme
 import SwiftUI
 

--- a/desktop/macos/Desktop/Sources/MemoryExportExecutor.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportExecutor.swift
@@ -315,7 +315,7 @@ enum MemoryExportExecutor {
 
   private static func requestAccessibilityApprovalForCloudSetup() {
     let options =
-      [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+      ["AXTrustedCheckOptionPrompt": true] as CFDictionary
     let trusted = AXIsProcessTrustedWithOptions(options)
     guard !trusted,
       let url = URL(

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -1,3 +1,4 @@
+import Combine
 @preconcurrency import GRDB
 import OmiTheme
 import SwiftUI

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarDemoView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarDemoView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import OmiTheme
 import SwiftUI
 

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingPermissionStepView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingPermissionStepView.swift
@@ -1,3 +1,4 @@
+import Combine
 import OmiTheme
 import SwiftUI
 

--- a/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
@@ -64,185 +64,187 @@ private actor AgentSyncDelayedTokenGate {
   }
 }
 
-private final class AgentSyncManualClock: @unchecked Sendable {
-  private let lock = NSLock()
-  private var value: Date
+#if DEBUG
+  private final class AgentSyncManualClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
 
-  init(_ value: Date = Date(timeIntervalSince1970: 1_700_000_000)) {
-    self.value = value
+    init(_ value: Date = Date(timeIntervalSince1970: 1_700_000_000)) {
+      self.value = value
+    }
+
+    func now() -> Date {
+      lock.withLock { value }
+    }
+
+    func advance(_ interval: TimeInterval) {
+      lock.withLock { value.addTimeInterval(interval) }
+    }
   }
 
-  func now() -> Date {
-    lock.withLock { value }
-  }
+  private actor AgentSyncReplacementCallbackGate {
+    enum Endpoint: Hashable {
+      case sync
+      case health
+      case upload
+    }
 
-  func advance(_ interval: TimeInterval) {
-    lock.withLock { value.addTimeInterval(interval) }
-  }
-}
+    private let suspended: Set<Endpoint>
+    private var started: Set<Endpoint> = []
+    private var startWaiters: [Endpoint: [CheckedContinuation<Void, Never>]] = [:]
+    private var releaseContinuations: [Endpoint: CheckedContinuation<Void, Never>] = [:]
+    private var reuploadVMs: [String] = []
 
-private actor AgentSyncReplacementCallbackGate {
-  enum Endpoint: Hashable {
-    case sync
-    case health
-    case upload
-  }
+    init(suspending endpoint: Endpoint) {
+      suspended = [endpoint]
+    }
 
-  private let suspended: Set<Endpoint>
-  private var started: Set<Endpoint> = []
-  private var startWaiters: [Endpoint: [CheckedContinuation<Void, Never>]] = [:]
-  private var releaseContinuations: [Endpoint: CheckedContinuation<Void, Never>] = [:]
-  private var reuploadVMs: [String] = []
+    func respond(to request: URLRequest) async throws -> (Data, URLResponse) {
+      let url = try XCTUnwrap(request.url)
+      let endpoint: Endpoint? =
+        switch url.path {
+        case "/sync": .sync
+        case "/health": .health
+        default: nil
+        }
+      if url.host == "old-vm", let endpoint, suspended.contains(endpoint) {
+        await suspend(endpoint)
+      }
 
-  init(suspending endpoint: Endpoint) {
-    suspended = [endpoint]
-  }
-
-  func respond(to request: URLRequest) async throws -> (Data, URLResponse) {
-    let url = try XCTUnwrap(request.url)
-    let endpoint: Endpoint? =
       switch url.path {
-      case "/sync": .sync
-      case "/health": .health
-      default: nil
-      }
-    if url.host == "old-vm", let endpoint, suspended.contains(endpoint) {
-      await suspend(endpoint)
-    }
-
-    switch url.path {
-    case "/auth":
-      return (Data(), response(url, status: 200))
-    case "/sync":
-      let payload = try XCTUnwrap(request.httpBody)
-      let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: payload) as? [String: Any])
-      let table = try XCTUnwrap(json["table"] as? String)
-      if table == "transcription_sessions" {
-        return (Data("SQLite error: no such table: \(table)".utf8), response(url, status: 500))
-      }
-      return (Data(), response(url, status: 200))
-    case "/health":
-      return (try JSONSerialization.data(withJSONObject: ["databaseReady": true]), response(url, status: 200))
-    default:
-      return (Data(), response(url, status: 404))
-    }
-  }
-
-  func reupload(vmIP: String) async -> Bool {
-    reuploadVMs.append(vmIP)
-    if vmIP == "old-vm", suspended.contains(.upload) {
-      await suspend(.upload)
-    }
-    return true
-  }
-
-  func waitUntilStarted(_ endpoint: Endpoint) async {
-    guard !started.contains(endpoint) else { return }
-    await withCheckedContinuation { continuation in
-      startWaiters[endpoint, default: []].append(continuation)
-    }
-  }
-
-  func release(_ endpoint: Endpoint) {
-    releaseContinuations.removeValue(forKey: endpoint)?.resume()
-  }
-
-  func uploadVMs() -> [String] {
-    reuploadVMs
-  }
-
-  private func suspend(_ endpoint: Endpoint) async {
-    started.insert(endpoint)
-    let waiters = startWaiters.removeValue(forKey: endpoint) ?? []
-    waiters.forEach { $0.resume() }
-    await withCheckedContinuation { continuation in
-      releaseContinuations[endpoint] = continuation
-    }
-  }
-
-  private func response(_ url: URL, status: Int) -> URLResponse {
-    HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)
-      ?? URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
-  }
-}
-
-private actor AgentSyncRecoveryProbe {
-  enum HealthResponse {
-    case ready
-    case malformed
-    case status(Int)
-  }
-
-  private var missingTables: Set<String>
-  private var healthResponse: HealthResponse = .ready
-  private var uploadResults: [Bool] = [true]
-  private var healthChecks = 0
-  private var uploads = 0
-  private var syncedTables: [String] = []
-
-  init(missingTable: String? = "transcription_sessions") {
-    missingTables = missingTable.map { [$0] } ?? []
-  }
-
-  func respond(to request: URLRequest) throws -> (Data, URLResponse) {
-    let url = try XCTUnwrap(request.url)
-    switch url.path {
-    case "/auth":
-      return (Data(), response(url, status: 200))
-    case "/sync":
-      let payload = try XCTUnwrap(request.httpBody)
-      let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: payload) as? [String: Any])
-      let table = try XCTUnwrap(json["table"] as? String)
-      syncedTables.append(table)
-      if missingTables.contains(table) {
-        return (Data("SQLite error: no such table: \(table)".utf8), response(url, status: 500))
-      }
-      return (Data(), response(url, status: 200))
-    case "/health":
-      healthChecks += 1
-      switch healthResponse {
-      case .ready:
+      case "/auth":
+        return (Data(), response(url, status: 200))
+      case "/sync":
+        let payload = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: payload) as? [String: Any])
+        let table = try XCTUnwrap(json["table"] as? String)
+        if table == "transcription_sessions" {
+          return (Data("SQLite error: no such table: \(table)".utf8), response(url, status: 500))
+        }
+        return (Data(), response(url, status: 200))
+      case "/health":
         return (try JSONSerialization.data(withJSONObject: ["databaseReady": true]), response(url, status: 200))
-      case .malformed:
-        return (Data("not-json".utf8), response(url, status: 200))
-      case .status(let status):
-        return (Data(), response(url, status: status))
+      default:
+        return (Data(), response(url, status: 404))
       }
-    default:
-      return (Data(), response(url, status: 404))
+    }
+
+    func reupload(vmIP: String) async -> Bool {
+      reuploadVMs.append(vmIP)
+      if vmIP == "old-vm", suspended.contains(.upload) {
+        await suspend(.upload)
+      }
+      return true
+    }
+
+    func waitUntilStarted(_ endpoint: Endpoint) async {
+      guard !started.contains(endpoint) else { return }
+      await withCheckedContinuation { continuation in
+        startWaiters[endpoint, default: []].append(continuation)
+      }
+    }
+
+    func release(_ endpoint: Endpoint) {
+      releaseContinuations.removeValue(forKey: endpoint)?.resume()
+    }
+
+    func uploadVMs() -> [String] {
+      reuploadVMs
+    }
+
+    private func suspend(_ endpoint: Endpoint) async {
+      started.insert(endpoint)
+      let waiters = startWaiters.removeValue(forKey: endpoint) ?? []
+      waiters.forEach { $0.resume() }
+      await withCheckedContinuation { continuation in
+        releaseContinuations[endpoint] = continuation
+      }
+    }
+
+    private func response(_ url: URL, status: Int) -> URLResponse {
+      HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)
+        ?? URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
     }
   }
 
-  func reupload() -> Bool {
-    uploads += 1
-    return uploadResults.isEmpty ? false : uploadResults.removeFirst()
-  }
+  private actor AgentSyncRecoveryProbe {
+    enum HealthResponse {
+      case ready
+      case malformed
+      case status(Int)
+    }
 
-  func setMissingTable(_ table: String?) {
-    missingTables = table.map { [$0] } ?? []
-  }
+    private var missingTables: Set<String>
+    private var healthResponse: HealthResponse = .ready
+    private var uploadResults: [Bool] = [true]
+    private var healthChecks = 0
+    private var uploads = 0
+    private var syncedTables: [String] = []
 
-  func setMissingTables(_ tables: Set<String>) {
-    missingTables = tables
-  }
+    init(missingTable: String? = "transcription_sessions") {
+      missingTables = missingTable.map { [$0] } ?? []
+    }
 
-  func setHealthResponse(_ response: HealthResponse) {
-    healthResponse = response
-  }
+    func respond(to request: URLRequest) throws -> (Data, URLResponse) {
+      let url = try XCTUnwrap(request.url)
+      switch url.path {
+      case "/auth":
+        return (Data(), response(url, status: 200))
+      case "/sync":
+        let payload = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: payload) as? [String: Any])
+        let table = try XCTUnwrap(json["table"] as? String)
+        syncedTables.append(table)
+        if missingTables.contains(table) {
+          return (Data("SQLite error: no such table: \(table)".utf8), response(url, status: 500))
+        }
+        return (Data(), response(url, status: 200))
+      case "/health":
+        healthChecks += 1
+        switch healthResponse {
+        case .ready:
+          return (try JSONSerialization.data(withJSONObject: ["databaseReady": true]), response(url, status: 200))
+        case .malformed:
+          return (Data("not-json".utf8), response(url, status: 200))
+        case .status(let status):
+          return (Data(), response(url, status: status))
+        }
+      default:
+        return (Data(), response(url, status: 404))
+      }
+    }
 
-  func setUploadResults(_ results: [Bool]) {
-    uploadResults = results
-  }
+    func reupload() -> Bool {
+      uploads += 1
+      return uploadResults.isEmpty ? false : uploadResults.removeFirst()
+    }
 
-  func counts() -> (healthChecks: Int, uploads: Int, syncedTables: [String]) {
-    (healthChecks, uploads, syncedTables)
-  }
+    func setMissingTable(_ table: String?) {
+      missingTables = table.map { [$0] } ?? []
+    }
 
-  private func response(_ url: URL, status: Int) -> URLResponse {
-    HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)
-      ?? URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+    func setMissingTables(_ tables: Set<String>) {
+      missingTables = tables
+    }
+
+    func setHealthResponse(_ response: HealthResponse) {
+      healthResponse = response
+    }
+
+    func setUploadResults(_ results: [Bool]) {
+      uploadResults = results
+    }
+
+    func counts() -> (healthChecks: Int, uploads: Int, syncedTables: [String]) {
+      (healthChecks, uploads, syncedTables)
+    }
+
+    private func response(_ url: URL, status: Int) -> URLResponse {
+      HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)
+        ?? URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+    }
   }
-}
+#endif
 
 /// Regression test for the AgentSync mutable-table pagination skip: paging with a
 /// strict `updatedAt > ?` cursor drops every row past the first batch when more
@@ -348,267 +350,272 @@ final class AgentSyncBatchQueryTests: XCTestCase {
   }
 }
 
-/// These tests drive `syncTick` through the same table reads and HTTP paths as
-/// the loop. The DEBUG-only clock/hook seam avoids a scheduler or bridge fault
-/// protocol while preserving production ownership and recovery behavior.
-final class AgentSyncRecoveryTests: XCTestCase {
-  private var storageFixture: RewindStorageTestIsolation.Fixture?
-  private var authSnapshot: RewindStorageTestIsolation.AuthSnapshot?
+#if DEBUG
+  /// These tests drive `syncTick` through the same table reads and HTTP paths as
+  /// the loop. The DEBUG-only clock/hook seam avoids a scheduler or bridge fault
+  /// protocol while preserving production ownership and recovery behavior.
+  /// Release CI (`swift test -c release`) must skip this suite because
+  /// `startForTesting` / `syncOnceForTesting` are DEBUG-only.
+  final class AgentSyncRecoveryTests: XCTestCase {
+    private var storageFixture: RewindStorageTestIsolation.Fixture?
+    private var authSnapshot: RewindStorageTestIsolation.AuthSnapshot?
 
-  override func setUp() async throws {
-    try await super.setUp()
-    let fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "agent-sync-recovery")
-    storageFixture = fixture
-    authSnapshot = await MainActor.run { RewindStorageTestIsolation.captureAuthSnapshot() }
-    await MainActor.run { RewindStorageTestIsolation.signInForTests(userId: fixture.testUserId) }
-    try await insertSyncRows()
-  }
-
-  override func tearDown() async throws {
-    if let authSnapshot {
-      await MainActor.run { RewindStorageTestIsolation.restoreAuthSnapshot(authSnapshot) }
+    override func setUp() async throws {
+      try await super.setUp()
+      let fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "agent-sync-recovery")
+      storageFixture = fixture
+      authSnapshot = await MainActor.run { RewindStorageTestIsolation.captureAuthSnapshot() }
+      await MainActor.run { RewindStorageTestIsolation.signInForTests(userId: fixture.testUserId) }
+      try await insertSyncRows()
     }
-    await RewindStorageTestIsolation.tearDown(userDir: storageFixture?.userDir)
-    try await super.tearDown()
-  }
 
-  func testMixedSuccessStillRecoversTheRepeatedRequiredTableFailure() async {
-    let probe = AgentSyncRecoveryProbe()
-    let service = makeService(probe: probe)
-    await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
-
-    await service.syncOnceForTesting()
-    await service.syncOnceForTesting()
-    await service.syncOnceForTesting()
-
-    let counts = await probe.counts()
-    XCTAssertTrue(
-      counts.syncedTables.contains("action_items"), "The control table must take the real /sync success path")
-    XCTAssertEqual(counts.syncedTables.filter { $0 == "transcription_sessions" }.count, 3)
-    XCTAssertEqual(counts.healthChecks, 1, "Three causal failures trigger one fail-closed /health check")
-    XCTAssertEqual(counts.uploads, 1, "The existing database-upload owner repairs the missing table exactly once")
-  }
-
-  func testTwoMissingRequiredTablesDoNotAlternateAwayTheSelectedRecovery() async {
-    let probe = AgentSyncRecoveryProbe()
-    await probe.setMissingTables(["transcription_sessions", "action_items"])
-    let service = makeService(probe: probe)
-    await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
-
-    for _ in 0..<3 { await service.syncOnceForTesting() }
-
-    let counts = await probe.counts()
-    XCTAssertEqual(counts.syncedTables.filter { $0 == "transcription_sessions" }.count, 3)
-    XCTAssertEqual(counts.syncedTables.filter { $0 == "action_items" }.count, 3)
-    XCTAssertTrue(
-      counts.syncedTables.contains("memories"),
-      "A successful required table must not suppress recovery for the selected missing table"
-    )
-    XCTAssertEqual(counts.healthChecks, 1, "Alternating missing tables must still reach the causal recovery threshold")
-    XCTAssertEqual(counts.uploads, 1, "One selected causal table produces one bounded repair")
-  }
-
-  func testMatchingTableSuccessClearsRecoveryButUnrelatedSuccessDoesNot() async throws {
-    let probe = AgentSyncRecoveryProbe()
-    let service = makeService(probe: probe)
-    await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
-
-    await service.syncOnceForTesting()
-    await service.syncOnceForTesting()
-    await probe.setMissingTable(nil)  // The previously failing table now succeeds.
-    await service.syncOnceForTesting()
-    await probe.setMissingTable("transcription_sessions")
-    try await touchTranscriptionSession()
-    await service.syncOnceForTesting()
-    await service.syncOnceForTesting()
-
-    var counts = await probe.counts()
-    XCTAssertEqual(counts.uploads, 0, "A matching success clears the earlier table's causal evidence")
-    await service.syncOnceForTesting()
-    counts = await probe.counts()
-    XCTAssertEqual(counts.uploads, 1, "Only three new failures of the same required table recover it")
-  }
-
-  func testMalformedAndNonSuccessHealthNeverUpload() async {
-    let probe = AgentSyncRecoveryProbe()
-    await probe.setHealthResponse(.malformed)
-    let service = makeService(probe: probe)
-    await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
-
-    for _ in 0..<3 { await service.syncOnceForTesting() }
-    var counts = await probe.counts()
-    XCTAssertEqual(counts.healthChecks, 1)
-    XCTAssertEqual(counts.uploads, 0)
-
-    await probe.setHealthResponse(.status(503))
-    await service.syncOnceForTesting()
-    counts = await probe.counts()
-    XCTAssertEqual(counts.uploads, 0, "Non-2xx health responses fail closed before upload")
-  }
-
-  func testSameOwnerRestartPreservesCooldownAndFailedUploadsStayBounded() async {
-    let probe = AgentSyncRecoveryProbe()
-    await probe.setUploadResults([false, false, false])
-    let clock = AgentSyncManualClock()
-    let service = makeService(probe: probe, clock: clock)
-    await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
-
-    for _ in 0..<3 { await service.syncOnceForTesting() }
-    var counts = await probe.counts()
-    XCTAssertEqual(counts.uploads, 1)
-
-    await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
-    await service.syncOnceForTesting()
-    counts = await probe.counts()
-    XCTAssertEqual(counts.uploads, 1, "Same-owner restart cannot mint a new cooldown allowance")
-
-    clock.advance(30 * 60 + 1)
-    await service.syncOnceForTesting()
-    counts = await probe.counts()
-    XCTAssertEqual(counts.uploads, 2)
-
-    clock.advance(30 * 60 + 1)
-    await service.syncOnceForTesting()
-    counts = await probe.counts()
-    XCTAssertEqual(counts.uploads, 2, "Failed recovery uploads stop at the existing bounded policy")
-  }
-
-  func testSameOwnerReplacementVMResetsOldRecoveryEvidenceCooldownAndBudget() async {
-    let probe = AgentSyncRecoveryProbe()
-    await probe.setUploadResults([false, false, false])
-    let clock = AgentSyncManualClock()
-    let service = makeService(probe: probe, clock: clock)
-    await service.startForTesting(vmIP: "old-vm", authToken: "test-token")
-
-    for _ in 0..<3 { await service.syncOnceForTesting() }
-    clock.advance(30 * 60 + 1)
-    await service.syncOnceForTesting()
-    var counts = await probe.counts()
-    XCTAssertEqual(counts.uploads, 2, "The old VM exhausts its bounded retry budget")
-
-    await service.startForTesting(vmIP: "replacement-vm", authToken: "test-token")
-    await service.syncOnceForTesting()
-    await service.syncOnceForTesting()
-    counts = await probe.counts()
-    XCTAssertEqual(counts.uploads, 2, "Replacement must not upload from stale old-VM evidence")
-
-    await service.syncOnceForTesting()
-    counts = await probe.counts()
-    XCTAssertEqual(counts.uploads, 3, "Replacement gets a fresh causal threshold and bounded retry budget")
-  }
-
-  func testDelayedOldVMSyncResponseCannotCreateReplacementRecoveryEvidence() async {
-    let gate = AgentSyncReplacementCallbackGate(suspending: .sync)
-    let service = makeService(gate: gate)
-    await service.startForTesting(vmIP: "old-vm", authToken: "test-token")
-    let oldTick = Task { await service.syncOnceForTesting() }
-    await gate.waitUntilStarted(.sync)
-
-    await service.startForTesting(vmIP: "replacement-vm", authToken: "test-token")
-    await gate.release(.sync)
-    await oldTick.value
-    for _ in 0..<3 { await service.syncOnceForTesting() }
-
-    let uploadVMs = await gate.uploadVMs()
-    XCTAssertEqual(uploadVMs, ["replacement-vm"])
-  }
-
-  func testDelayedOldVMHealthResponseCannotSpendReplacementRecoveryBudget() async {
-    let gate = AgentSyncReplacementCallbackGate(suspending: .health)
-    let service = makeService(gate: gate)
-    await service.startForTesting(vmIP: "old-vm", authToken: "test-token")
-    await service.syncOnceForTesting()
-    await service.syncOnceForTesting()
-    let oldTick = Task { await service.syncOnceForTesting() }
-    await gate.waitUntilStarted(.health)
-
-    await service.startForTesting(vmIP: "replacement-vm", authToken: "test-token")
-    await gate.release(.health)
-    await oldTick.value
-    for _ in 0..<3 { await service.syncOnceForTesting() }
-
-    let uploadVMs = await gate.uploadVMs()
-    XCTAssertEqual(uploadVMs, ["replacement-vm"])
-  }
-
-  func testDelayedOldVMUploadResponseCannotClearReplacementRecoveryEvidence() async {
-    let gate = AgentSyncReplacementCallbackGate(suspending: .upload)
-    let service = makeService(gate: gate)
-    await service.startForTesting(vmIP: "old-vm", authToken: "test-token")
-    await service.syncOnceForTesting()
-    await service.syncOnceForTesting()
-    let oldTick = Task { await service.syncOnceForTesting() }
-    await gate.waitUntilStarted(.upload)
-
-    await service.startForTesting(vmIP: "replacement-vm", authToken: "test-token")
-    await service.syncOnceForTesting()
-    await service.syncOnceForTesting()
-    await gate.release(.upload)
-    await oldTick.value
-    await service.syncOnceForTesting()
-
-    let uploadVMs = await gate.uploadVMs()
-    XCTAssertEqual(uploadVMs, ["old-vm", "replacement-vm"])
-  }
-
-  private func makeService(
-    probe: AgentSyncRecoveryProbe,
-    clock: AgentSyncManualClock = AgentSyncManualClock()
-  ) -> AgentSyncService {
-    AgentSyncService(
-      networkHooks: AgentSyncService.NetworkHooks(
-        fetchIDToken: { "test-firebase-token" },
-        dataForRequest: { request in try await probe.respond(to: request) },
-        reuploadDatabase: { _, _ in await probe.reupload() },
-        now: { clock.now() },
-        tableSyncEnabled: true))
-  }
-
-  private func makeService(gate: AgentSyncReplacementCallbackGate) -> AgentSyncService {
-    AgentSyncService(
-      networkHooks: AgentSyncService.NetworkHooks(
-        fetchIDToken: { "test-firebase-token" },
-        dataForRequest: { request in try await gate.respond(to: request) },
-        reuploadDatabase: { vmIP, _ in await gate.reupload(vmIP: vmIP) },
-        now: Date.init,
-        tableSyncEnabled: true))
-  }
-
-  private func insertSyncRows() async throws {
-    guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
-      return XCTFail("Rewind database should be initialized")
+    override func tearDown() async throws {
+      if let authSnapshot {
+        await MainActor.run { RewindStorageTestIsolation.restoreAuthSnapshot(authSnapshot) }
+      }
+      await RewindStorageTestIsolation.tearDown(userDir: storageFixture?.userDir)
+      try await super.tearDown()
     }
-    let now = Date(timeIntervalSince1970: 1_700_000_000)
-    try await dbQueue.write { db in
-      try db.execute(
-        sql: """
-          INSERT INTO transcription_sessions (startedAt, source, createdAt, updatedAt)
-          VALUES (?, ?, ?, ?)
-          """,
-        arguments: [now, "desktop", now, now])
-      try db.execute(
-        sql: """
-            INSERT INTO action_items (description, createdAt, updatedAt)
-            VALUES (?, ?, ?)
-          """,
-        arguments: ["mixed-success control", now, now])
-      try db.execute(
-        sql: """
-          INSERT INTO memories (content, category, createdAt, updatedAt)
-          VALUES (?, ?, ?, ?)
-          """,
-        arguments: ["mixed-success recovery control", "system", now, now])
-    }
-  }
 
-  private func touchTranscriptionSession() async throws {
-    guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
-      return XCTFail("Rewind database should be initialized")
+    func testMixedSuccessStillRecoversTheRepeatedRequiredTableFailure() async {
+      let probe = AgentSyncRecoveryProbe()
+      let service = makeService(probe: probe)
+      await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
+
+      await service.syncOnceForTesting()
+      await service.syncOnceForTesting()
+      await service.syncOnceForTesting()
+
+      let counts = await probe.counts()
+      XCTAssertTrue(
+        counts.syncedTables.contains("action_items"), "The control table must take the real /sync success path")
+      XCTAssertEqual(counts.syncedTables.filter { $0 == "transcription_sessions" }.count, 3)
+      XCTAssertEqual(counts.healthChecks, 1, "Three causal failures trigger one fail-closed /health check")
+      XCTAssertEqual(counts.uploads, 1, "The existing database-upload owner repairs the missing table exactly once")
     }
-    try await dbQueue.write { db in
-      try db.execute(
-        sql: "UPDATE transcription_sessions SET updatedAt = ? WHERE id = 1",
-        arguments: [Date(timeIntervalSince1970: 1_700_000_001)])
+
+    func testTwoMissingRequiredTablesDoNotAlternateAwayTheSelectedRecovery() async {
+      let probe = AgentSyncRecoveryProbe()
+      await probe.setMissingTables(["transcription_sessions", "action_items"])
+      let service = makeService(probe: probe)
+      await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
+
+      for _ in 0..<3 { await service.syncOnceForTesting() }
+
+      let counts = await probe.counts()
+      XCTAssertEqual(counts.syncedTables.filter { $0 == "transcription_sessions" }.count, 3)
+      XCTAssertEqual(counts.syncedTables.filter { $0 == "action_items" }.count, 3)
+      XCTAssertTrue(
+        counts.syncedTables.contains("memories"),
+        "A successful required table must not suppress recovery for the selected missing table"
+      )
+      XCTAssertEqual(
+        counts.healthChecks, 1, "Alternating missing tables must still reach the causal recovery threshold")
+      XCTAssertEqual(counts.uploads, 1, "One selected causal table produces one bounded repair")
+    }
+
+    func testMatchingTableSuccessClearsRecoveryButUnrelatedSuccessDoesNot() async throws {
+      let probe = AgentSyncRecoveryProbe()
+      let service = makeService(probe: probe)
+      await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
+
+      await service.syncOnceForTesting()
+      await service.syncOnceForTesting()
+      await probe.setMissingTable(nil)  // The previously failing table now succeeds.
+      await service.syncOnceForTesting()
+      await probe.setMissingTable("transcription_sessions")
+      try await touchTranscriptionSession()
+      await service.syncOnceForTesting()
+      await service.syncOnceForTesting()
+
+      var counts = await probe.counts()
+      XCTAssertEqual(counts.uploads, 0, "A matching success clears the earlier table's causal evidence")
+      await service.syncOnceForTesting()
+      counts = await probe.counts()
+      XCTAssertEqual(counts.uploads, 1, "Only three new failures of the same required table recover it")
+    }
+
+    func testMalformedAndNonSuccessHealthNeverUpload() async {
+      let probe = AgentSyncRecoveryProbe()
+      await probe.setHealthResponse(.malformed)
+      let service = makeService(probe: probe)
+      await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
+
+      for _ in 0..<3 { await service.syncOnceForTesting() }
+      var counts = await probe.counts()
+      XCTAssertEqual(counts.healthChecks, 1)
+      XCTAssertEqual(counts.uploads, 0)
+
+      await probe.setHealthResponse(.status(503))
+      await service.syncOnceForTesting()
+      counts = await probe.counts()
+      XCTAssertEqual(counts.uploads, 0, "Non-2xx health responses fail closed before upload")
+    }
+
+    func testSameOwnerRestartPreservesCooldownAndFailedUploadsStayBounded() async {
+      let probe = AgentSyncRecoveryProbe()
+      await probe.setUploadResults([false, false, false])
+      let clock = AgentSyncManualClock()
+      let service = makeService(probe: probe, clock: clock)
+      await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
+
+      for _ in 0..<3 { await service.syncOnceForTesting() }
+      var counts = await probe.counts()
+      XCTAssertEqual(counts.uploads, 1)
+
+      await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
+      await service.syncOnceForTesting()
+      counts = await probe.counts()
+      XCTAssertEqual(counts.uploads, 1, "Same-owner restart cannot mint a new cooldown allowance")
+
+      clock.advance(30 * 60 + 1)
+      await service.syncOnceForTesting()
+      counts = await probe.counts()
+      XCTAssertEqual(counts.uploads, 2)
+
+      clock.advance(30 * 60 + 1)
+      await service.syncOnceForTesting()
+      counts = await probe.counts()
+      XCTAssertEqual(counts.uploads, 2, "Failed recovery uploads stop at the existing bounded policy")
+    }
+
+    func testSameOwnerReplacementVMResetsOldRecoveryEvidenceCooldownAndBudget() async {
+      let probe = AgentSyncRecoveryProbe()
+      await probe.setUploadResults([false, false, false])
+      let clock = AgentSyncManualClock()
+      let service = makeService(probe: probe, clock: clock)
+      await service.startForTesting(vmIP: "old-vm", authToken: "test-token")
+
+      for _ in 0..<3 { await service.syncOnceForTesting() }
+      clock.advance(30 * 60 + 1)
+      await service.syncOnceForTesting()
+      var counts = await probe.counts()
+      XCTAssertEqual(counts.uploads, 2, "The old VM exhausts its bounded retry budget")
+
+      await service.startForTesting(vmIP: "replacement-vm", authToken: "test-token")
+      await service.syncOnceForTesting()
+      await service.syncOnceForTesting()
+      counts = await probe.counts()
+      XCTAssertEqual(counts.uploads, 2, "Replacement must not upload from stale old-VM evidence")
+
+      await service.syncOnceForTesting()
+      counts = await probe.counts()
+      XCTAssertEqual(counts.uploads, 3, "Replacement gets a fresh causal threshold and bounded retry budget")
+    }
+
+    func testDelayedOldVMSyncResponseCannotCreateReplacementRecoveryEvidence() async {
+      let gate = AgentSyncReplacementCallbackGate(suspending: .sync)
+      let service = makeService(gate: gate)
+      await service.startForTesting(vmIP: "old-vm", authToken: "test-token")
+      let oldTick = Task { await service.syncOnceForTesting() }
+      await gate.waitUntilStarted(.sync)
+
+      await service.startForTesting(vmIP: "replacement-vm", authToken: "test-token")
+      await gate.release(.sync)
+      await oldTick.value
+      for _ in 0..<3 { await service.syncOnceForTesting() }
+
+      let uploadVMs = await gate.uploadVMs()
+      XCTAssertEqual(uploadVMs, ["replacement-vm"])
+    }
+
+    func testDelayedOldVMHealthResponseCannotSpendReplacementRecoveryBudget() async {
+      let gate = AgentSyncReplacementCallbackGate(suspending: .health)
+      let service = makeService(gate: gate)
+      await service.startForTesting(vmIP: "old-vm", authToken: "test-token")
+      await service.syncOnceForTesting()
+      await service.syncOnceForTesting()
+      let oldTick = Task { await service.syncOnceForTesting() }
+      await gate.waitUntilStarted(.health)
+
+      await service.startForTesting(vmIP: "replacement-vm", authToken: "test-token")
+      await gate.release(.health)
+      await oldTick.value
+      for _ in 0..<3 { await service.syncOnceForTesting() }
+
+      let uploadVMs = await gate.uploadVMs()
+      XCTAssertEqual(uploadVMs, ["replacement-vm"])
+    }
+
+    func testDelayedOldVMUploadResponseCannotClearReplacementRecoveryEvidence() async {
+      let gate = AgentSyncReplacementCallbackGate(suspending: .upload)
+      let service = makeService(gate: gate)
+      await service.startForTesting(vmIP: "old-vm", authToken: "test-token")
+      await service.syncOnceForTesting()
+      await service.syncOnceForTesting()
+      let oldTick = Task { await service.syncOnceForTesting() }
+      await gate.waitUntilStarted(.upload)
+
+      await service.startForTesting(vmIP: "replacement-vm", authToken: "test-token")
+      await service.syncOnceForTesting()
+      await service.syncOnceForTesting()
+      await gate.release(.upload)
+      await oldTick.value
+      await service.syncOnceForTesting()
+
+      let uploadVMs = await gate.uploadVMs()
+      XCTAssertEqual(uploadVMs, ["old-vm", "replacement-vm"])
+    }
+
+    private func makeService(
+      probe: AgentSyncRecoveryProbe,
+      clock: AgentSyncManualClock = AgentSyncManualClock()
+    ) -> AgentSyncService {
+      AgentSyncService(
+        networkHooks: AgentSyncService.NetworkHooks(
+          fetchIDToken: { "test-firebase-token" },
+          dataForRequest: { request in try await probe.respond(to: request) },
+          reuploadDatabase: { _, _ in await probe.reupload() },
+          now: { clock.now() },
+          tableSyncEnabled: true))
+    }
+
+    private func makeService(gate: AgentSyncReplacementCallbackGate) -> AgentSyncService {
+      AgentSyncService(
+        networkHooks: AgentSyncService.NetworkHooks(
+          fetchIDToken: { "test-firebase-token" },
+          dataForRequest: { request in try await gate.respond(to: request) },
+          reuploadDatabase: { vmIP, _ in await gate.reupload(vmIP: vmIP) },
+          now: Date.init,
+          tableSyncEnabled: true))
+    }
+
+    private func insertSyncRows() async throws {
+      guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+        return XCTFail("Rewind database should be initialized")
+      }
+      let now = Date(timeIntervalSince1970: 1_700_000_000)
+      try await dbQueue.write { db in
+        try db.execute(
+          sql: """
+            INSERT INTO transcription_sessions (startedAt, source, createdAt, updatedAt)
+            VALUES (?, ?, ?, ?)
+            """,
+          arguments: [now, "desktop", now, now])
+        try db.execute(
+          sql: """
+              INSERT INTO action_items (description, createdAt, updatedAt)
+              VALUES (?, ?, ?)
+            """,
+          arguments: ["mixed-success control", now, now])
+        try db.execute(
+          sql: """
+            INSERT INTO memories (content, category, createdAt, updatedAt)
+            VALUES (?, ?, ?, ?)
+            """,
+          arguments: ["mixed-success recovery control", "system", now, now])
+      }
+    }
+
+    private func touchTranscriptionSession() async throws {
+      guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+        return XCTFail("Rewind database should be initialized")
+      }
+      try await dbQueue.write { db in
+        try db.execute(
+          sql: "UPDATE transcription_sessions SET updatedAt = ? WHERE id = 1",
+          arguments: [Date(timeIntervalSince1970: 1_700_000_001)])
+      }
     }
   }
-}
+#endif

--- a/desktop/macos/changelog/unreleased/20260720-desktop-xcode-beta-build-fixes.json
+++ b/desktop/macos/changelog/unreleased/20260720-desktop-xcode-beta-build-fixes.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed macOS desktop build compatibility with Xcode Beta / Swift 6.4"
+}

--- a/desktop/macos/e2e/flows/connector-import-progress.yaml
+++ b/desktop/macos/e2e/flows/connector-import-progress.yaml
@@ -7,7 +7,9 @@ covers:
   - desktop/macos/Desktop/Sources/Automation/DesktopAutomationPresentationCoordinator.swift
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/MemoryExportExecutor.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/APIClient+XConnector.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportOperations.swift

--- a/desktop/macos/e2e/flows/home.yaml
+++ b/desktop/macos/e2e/flows/home.yaml
@@ -6,6 +6,7 @@ app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/FocusPage.swift
 preconditions:
   - auth_ready
 

--- a/desktop/windows/src/renderer/src/pages/Tasks.test.tsx
+++ b/desktop/windows/src/renderer/src/pages/Tasks.test.tsx
@@ -520,19 +520,23 @@ describe('Tasks — keyboard navigation (mac parity, flat list)', () => {
     expect(evt.defaultPrevented).toBe(false)
   })
 
-  it('Esc with a selection deselects and preventDefault (consumes it)', async () => {
-    incomplete = twoRows()
-    await renderTasks()
-    await waitFor(() => expect(screen.queryByText('first')).not.toBeNull())
+  it(
+    'Esc with a selection deselects and preventDefault (consumes it)',
+    async () => {
+      incomplete = twoRows()
+      await renderTasks()
+      await waitFor(() => expect(screen.queryByText('first')).not.toBeNull())
 
-    fireEvent.keyDown(document.body, { key: 'ArrowDown' })
-    await waitFor(() => expect(selectedText()).toContain('first'))
+      fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+      await waitFor(() => expect(selectedText()).toContain('first'))
 
-    const evt = createEvent.keyDown(document.body, { key: 'Escape' })
-    fireEvent(document.body, evt)
-    expect(evt.defaultPrevented).toBe(true)
-    await waitFor(() => expect(selectedText()).toBeNull())
-  })
+      const evt = createEvent.keyDown(document.body, { key: 'Escape' })
+      fireEvent(document.body, evt)
+      expect(evt.defaultPrevented).toBe(true)
+      await waitFor(() => expect(selectedText()).toBeNull())
+    },
+    15_000
+  )
 
   it('Ctrl+D on the last row moves selection to the previous row', async () => {
     incomplete = twoRows()


### PR DESCRIPTION
## Summary
Resolves strict-concurrency diagnostics and missing imports that prevent the macOS desktop package from compiling on the Xcode Beta / Swift 6.4 toolchain.

- Replace `kAXTrustedCheckOptionPrompt` C global with the string literal `"AXTrustedCheckOptionPrompt"` in accessibility option dictionaries.
- Add explicit capture lists to nested closures in `ChatDraftStore` and `RealtimeHubController+SessionDelegate` to satisfy Swift 6.4 implicit-strong-capture checks.
- Add missing `import Combine` to six views using `Timer.publish(...).autoconnect()`.
- Remove the unused `tier` binding in `DesktopHomeView`.

Merged `origin/main` to pick up OmiMarkdown onboarding refactor and CI reliability fixes. PR Swift 6.4 hygiene changes are preserved.

This PR touches paths governed by `INV-CHAT-1`, `INV-INT-1`, and `INV-MEM-1` (via merged main changes) but does not change product behavior in the desktop fixes; only compiler/runtime hygiene.

## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1
- INV-INT-1
- INV-MEM-1

Failure-Class: none

#### Test plan
- [x] `xcrun swift build -c debug --package-path desktop/macos/Desktop` passes on Xcode Beta.
- [ ] CI desktop Swift build (Xcode 16.4) passes.
- [ ] Manual smoke test of accessibility permission prompt, chat persistence, and timer-driven UI.
