### PR TITLE
fix(desktop): make app category menu scrollable with SearchableDropdown

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1854,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3598,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3621,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4467,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3298,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5706,
@@ -9,7 +9,7 @@
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": "SB redesign: Omi-mark avatar on replies that spins while thinking (typing-dots suppressed for Omi's own replies) and tool-call chips gated to the streaming turn, merged with main's metadata-row reveal honoring keyboard focus (shared FocusState + testable ChatBubbleMetadataReveal); a component split is tracked follow-up.",
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "Category filter Menu replaced with SearchableDropdown; scrollable category list so long lists stay reachable.",
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "SearchableDropdown category filter plus extracted filter helpers for regression coverage.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": "Home ask bar now auto-grows as a multi-line TextField so long messages wrap instead of scrolling off-screen (+14 lines over the prior SB-redesign home/chat layout); a component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": "Bridge memory search now awaits the active initial or pagination projection before refreshing, preventing an immediate post-navigation marker search from using stale lifecycle capability state.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": "SB redesign: adds the Notion-style status board (time-bucket columns, task cards with priority/due chips) and Board/List toggle alongside the existing list; a component split is tracked follow-up.",

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1854,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3643,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3598,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4467,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3298,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5706,
@@ -9,7 +9,7 @@
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": "SB redesign: Omi-mark avatar on replies that spins while thinking (typing-dots suppressed for Omi's own replies) and tool-call chips gated to the streaming turn, merged with main's metadata-row reveal honoring keyboard focus (shared FocusState + testable ChatBubbleMetadataReveal); a component split is tracked follow-up.",
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "Rebase reconciliation applies the pinned swift-format to the main-branch app-detail safety fixes; runtime behavior is unchanged.",
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "Category filter Menu replaced with SearchableDropdown; scrollable category list so long lists stay reachable.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": "Home ask bar now auto-grows as a multi-line TextField so long messages wrap instead of scrolling off-screen (+14 lines over the prior SB-redesign home/chat layout); a component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": "Bridge memory search now awaits the active initial or pagination projection before refreshing, preventing an immediate post-navigation marker search from using stale lifecycle capability state.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": "SB redesign: adds the Notion-style status board (time-bucket columns, task cards with priority/due chips) and Board/List toggle alongside the existing list; a component split is tracked follow-up.",

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -114,6 +114,29 @@ enum AppsCatalogInitialSection {
   case exports
 }
 
+enum AppsPageCategoryFilter {
+  static let allCategoriesOptionId = ""
+  static let allCategoriesTitle = "All Categories"
+
+  enum Selection: Equatable {
+    case allCategories
+    case category(String)
+  }
+
+  static func categoryDropdownOptions(categories: [OmiAppCategory]) -> [SearchableDropdownOption] {
+    [SearchableDropdownOption(id: allCategoriesOptionId, title: allCategoriesTitle)]
+      + categories.map { SearchableDropdownOption(id: $0.id, title: $0.title) }
+  }
+
+  static func selectedCategoryDropdownId(_ selectedCategory: String?) -> String {
+    selectedCategory ?? allCategoriesOptionId
+  }
+
+  static func categorySelection(forOptionId optionId: String) -> Selection {
+    optionId.isEmpty ? .allCategories : .category(optionId)
+  }
+}
+
 struct AppsPage: View {
   @ObservedObject var appProvider: AppProvider
   var appState: AppState? = nil
@@ -538,16 +561,16 @@ struct AppsPage: View {
     SearchableDropdown(
       title: "Category",
       label: "Category",
-      options: [SearchableDropdownOption(id: "", title: "All Categories")]
-        + appProvider.categories.map { SearchableDropdownOption(id: $0.id, title: $0.title) },
-      selectedId: appProvider.selectedCategory ?? "",
+      options: AppsPageCategoryFilter.categoryDropdownOptions(categories: appProvider.categories),
+      selectedId: AppsPageCategoryFilter.selectedCategoryDropdownId(appProvider.selectedCategory),
       minWidth: 180
     ) { option in
       viewAllSection = nil
-      if option.id.isEmpty {
+      switch AppsPageCategoryFilter.categorySelection(forOptionId: option.id) {
+      case .allCategories:
         appProvider.clearCategoryFilter()
-      } else {
-        appProvider.selectedCategory = option.id
+      case .category(let categoryId):
+        appProvider.selectedCategory = categoryId
       }
       Task { await appProvider.searchApps() }
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -535,58 +535,22 @@ struct AppsPage: View {
   }
 
   private var categoryMenu: some View {
-    Menu {
-      Button(action: {
-        viewAllSection = nil
+    SearchableDropdown(
+      title: "Category",
+      label: "Category",
+      options: [SearchableDropdownOption(id: "", title: "All Categories")]
+        + appProvider.categories.map { SearchableDropdownOption(id: $0.id, title: $0.title) },
+      selectedId: appProvider.selectedCategory ?? "",
+      minWidth: 180
+    ) { option in
+      viewAllSection = nil
+      if option.id.isEmpty {
         appProvider.clearCategoryFilter()
-        Task { await appProvider.searchApps() }
-      }) {
-        HStack {
-          Text("All Categories")
-          if appProvider.selectedCategory == nil {
-            Image(systemName: "checkmark")
-          }
-        }
+      } else {
+        appProvider.selectedCategory = option.id
       }
-
-      Divider()
-
-      ForEach(appProvider.categories) { category in
-        Button(action: {
-          viewAllSection = nil
-          appProvider.selectedCategory = category.id
-          Task { await appProvider.searchApps() }
-        }) {
-          HStack {
-            Text(category.title)
-            if appProvider.selectedCategory == category.id {
-              Image(systemName: "checkmark")
-            }
-          }
-        }
-      }
-    } label: {
-      HStack(spacing: OmiSpacing.xs) {
-        Image(systemName: "line.3.horizontal.decrease.circle")
-          .scaledFont(size: OmiType.caption)
-        Text(selectedCategoryLabel)
-          .scaledFont(size: OmiType.body)
-          .lineLimit(1)
-        Image(systemName: "chevron.down")
-          .scaledFont(size: OmiType.micro, weight: .medium)
-      }
-      .padding(.horizontal, OmiSpacing.md)
-      .padding(.vertical, OmiSpacing.sm)
-      .background(OmiColors.backgroundSecondary)
-      .foregroundColor(OmiColors.textPrimary)
-      .cornerRadius(OmiChrome.elementRadius)
-      .overlay(
-        RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
-          .stroke(appProvider.selectedCategory != nil ? OmiColors.border : Color.clear, lineWidth: 1)
-      )
+      Task { await appProvider.searchApps() }
     }
-    .menuStyle(.borderlessButton)
-    .tint(OmiColors.textPrimary)
     .fixedSize()
   }
 
@@ -611,15 +575,6 @@ struct AppsPage: View {
 
   private var hasActiveFilters: Bool {
     appProvider.hasActiveFilters || viewAllSection != nil
-  }
-
-  private var selectedCategoryLabel: String {
-    if let categoryId = appProvider.selectedCategory,
-      let category = appProvider.categories.first(where: { $0.id == categoryId })
-    {
-      return category.title
-    }
-    return "Category"
   }
 
   /// Apps for the selected filter/search result set or "See more" section.

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SearchableDropdown.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SearchableDropdown.swift
@@ -14,6 +14,26 @@ struct SearchableDropdownOption: Identifiable, Hashable {
   }
 }
 
+enum SearchableDropdownFiltering {
+  static func filteredOptions(
+    _ options: [SearchableDropdownOption],
+    query: String
+  ) -> [SearchableDropdownOption] {
+    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return options }
+
+    return options.filter { option in
+      option.title.localizedCaseInsensitiveContains(trimmed)
+        || option.id.localizedCaseInsensitiveContains(trimmed)
+        || (option.subtitle?.localizedCaseInsensitiveContains(trimmed) ?? false)
+    }
+  }
+
+  static func usesSearchablePopover(optionCount: Int, threshold: Int = 8) -> Bool {
+    optionCount > threshold
+  }
+}
+
 struct SearchableDropdown: View {
   let title: String
   var label: String? = nil
@@ -135,14 +155,7 @@ private struct SearchableDropdownPopover: View {
   @FocusState private var searchIsFocused: Bool
 
   private var filteredOptions: [SearchableDropdownOption] {
-    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else { return options }
-
-    return options.filter { option in
-      option.title.localizedCaseInsensitiveContains(trimmed)
-        || option.id.localizedCaseInsensitiveContains(trimmed)
-        || (option.subtitle?.localizedCaseInsensitiveContains(trimmed) ?? false)
-    }
+    SearchableDropdownFiltering.filteredOptions(options, query: query)
   }
 
   private var listHeight: CGFloat {

--- a/desktop/macos/Desktop/Tests/AppsPageCategoryFilterTests.swift
+++ b/desktop/macos/Desktop/Tests/AppsPageCategoryFilterTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class AppsPageCategoryFilterTests: XCTestCase {
+  private func sampleCategories(count: Int) -> [OmiAppCategory] {
+    (1...count).map { index in
+      OmiAppCategory(id: "category-\(index)", title: "Category \(index)")
+    }
+  }
+
+  func testCategoryDropdownOptionsPrependsAllCategories() {
+    let options = AppsPageCategoryFilter.categoryDropdownOptions(
+      categories: [
+        OmiAppCategory(id: "productivity", title: "Productivity"),
+        OmiAppCategory(id: "chat", title: "Chat"),
+      ]
+    )
+
+    XCTAssertEqual(options.count, 3)
+    XCTAssertEqual(options.first?.id, AppsPageCategoryFilter.allCategoriesOptionId)
+    XCTAssertEqual(options.first?.title, AppsPageCategoryFilter.allCategoriesTitle)
+    XCTAssertEqual(options.map(\.id), ["", "productivity", "chat"])
+  }
+
+  func testLongCategoryListUsesSearchablePopoverPath() {
+    let options = AppsPageCategoryFilter.categoryDropdownOptions(categories: sampleCategories(count: 10))
+
+    XCTAssertTrue(SearchableDropdownFiltering.usesSearchablePopover(optionCount: options.count))
+  }
+
+  func testShortCategoryListUsesCompactMenuPath() {
+    let options = AppsPageCategoryFilter.categoryDropdownOptions(categories: sampleCategories(count: 5))
+
+    XCTAssertFalse(SearchableDropdownFiltering.usesSearchablePopover(optionCount: options.count))
+  }
+
+  func testFilterCategoriesByTitle() {
+    let options = AppsPageCategoryFilter.categoryDropdownOptions(
+      categories: [
+        OmiAppCategory(id: "productivity", title: "Productivity"),
+        OmiAppCategory(id: "personality-clone", title: "Personality Clone"),
+        OmiAppCategory(id: "chat", title: "Chat"),
+      ]
+    )
+
+    let filtered = SearchableDropdownFiltering.filteredOptions(options, query: "clone")
+
+    XCTAssertEqual(filtered.map(\.id), ["personality-clone"])
+  }
+
+  func testFilterCategoriesById() {
+    let options = AppsPageCategoryFilter.categoryDropdownOptions(
+      categories: [
+        OmiAppCategory(id: "productivity", title: "Productivity"),
+        OmiAppCategory(id: "personality-clone", title: "Personality Clone"),
+      ]
+    )
+
+    let filtered = SearchableDropdownFiltering.filteredOptions(options, query: "productivity")
+
+    XCTAssertEqual(filtered.map(\.id), ["productivity"])
+  }
+
+  func testSelectingSpecificCategoryUpdatesProviderState() {
+    let provider = AppProvider()
+
+    switch AppsPageCategoryFilter.categorySelection(forOptionId: "productivity") {
+    case .allCategories:
+      provider.clearCategoryFilter()
+    case .category(let categoryId):
+      provider.selectedCategory = categoryId
+    }
+
+    XCTAssertEqual(provider.selectedCategory, "productivity")
+    XCTAssertEqual(
+      AppsPageCategoryFilter.selectedCategoryDropdownId(provider.selectedCategory), "productivity")
+  }
+
+  func testResetToAllCategoriesClearsProviderState() {
+    let provider = AppProvider()
+    provider.selectedCategory = "productivity"
+    provider.filteredApps = []
+    provider.hasMoreFilteredApps = true
+
+    switch AppsPageCategoryFilter.categorySelection(forOptionId: AppsPageCategoryFilter.allCategoriesOptionId) {
+    case .allCategories:
+      provider.clearCategoryFilter()
+    case .category(let categoryId):
+      provider.selectedCategory = categoryId
+    }
+
+    XCTAssertNil(provider.selectedCategory)
+    XCTAssertNil(provider.filteredApps)
+    XCTAssertFalse(provider.hasMoreFilteredApps)
+    XCTAssertEqual(
+      AppsPageCategoryFilter.selectedCategoryDropdownId(provider.selectedCategory),
+      AppsPageCategoryFilter.allCategoriesOptionId)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260720-apps-page-category-scroll.json
+++ b/desktop/macos/changelog/unreleased/20260720-apps-page-category-scroll.json
@@ -1,0 +1,3 @@
+{
+  "change": "Made the app category filter scrollable by using SearchableDropdown for long category lists"
+}

--- a/desktop/macos/e2e/flows/apps-marketplace.yaml
+++ b/desktop/macos/e2e/flows/apps-marketplace.yaml
@@ -5,6 +5,7 @@ description: Apps tab — Imports, Exports, search, filters, Create App (v0.12.1
 app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SearchableDropdown.swift
   - desktop/macos/Desktop/Sources/Providers/AppProvider.swift
 preconditions:
   - auth_ready

--- a/desktop/macos/e2e/flows/apps.yaml
+++ b/desktop/macos/e2e/flows/apps.yaml
@@ -5,6 +5,7 @@ description: Apps/Integrations marketplace flow — browse apps, filter by categ
 app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SearchableDropdown.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ManualInstallationDisclosure.swift
   - desktop/macos/Desktop/Sources/ConferencingApps.swift
   - desktop/macos/Desktop/Sources/ConnectorBrandIcon.swift


### PR DESCRIPTION
## Summary
Makes the app category filter in `AppsPage` scrollable by replacing the native `Menu` with the existing `SearchableDropdown` component. This addresses overflow when the category list is long in the Apps/Connect popup.

- `desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift`: `categoryMenu` now uses `SearchableDropdown` with `title`, `label`, `options`, `selectedId`, and `minWidth`.

## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1

Failure-Class: none

#### Test plan
- [x] `xcrun swiftc -parse desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift` passes.
- [x] CI desktop Swift build (Xcode 16.4) passes.
- [ ] UI smoke test: open the app "More" menu and confirm the category dropdown scrolls and selecting a category updates the list.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


