### PR TITLE
fix(dev): serve legacy memories when a legacy-cohort account has no rollout state

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -2,12 +2,13 @@
   "files": {
     "backend/routers/apps.py": 2335,
     "backend/routers/chat.py": 1577,
-    "backend/routers/developer.py": 2184,
+    "backend/routers/developer.py": 2195,
     "backend/routers/mcp_sse.py": 1857,
     "backend/routers/sync.py": 2024,
     "backend/routers/users.py": 2046
   },
   "raise_justifications": {
+    "backend/routers/developer.py": "GET /v1/dev/user/memories serves the authoritative legacy memories collection for legacy-cohort accounts with no rollout state (#9892), keeping the narrow deny/fallback decision in the route that owns the read contract.",
     "backend/routers/chat.py": "PTT stereo rejection keeps the serving STT provider boundary explicit in the established chat admission owner.",
     "backend/routers/sync.py": "Fresh Sync admission and final Cloud Tasks ledger recovery retain their coupled task, lock, ledger, and staged-blob lifecycle in the existing ingestion owner rather than a new module.",
     "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first."

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -80,6 +80,7 @@ from utils.memory.default_read_rollout import (
     guard_legacy_memory_write,
     read_default_read_rollout,
 )
+from utils.observability import record_fallback
 import logging
 
 logger = logging.getLogger(__name__)
@@ -393,11 +394,21 @@ def get_memories(
     if memory_result.read_decision == MemoryReadDecision.USE_MEMORY:
         return [CleanerMemory.model_validate(memory) for memory in memory_result.memories]
     if memory_result.read_decision in {MemoryReadDecision.DENY_MEMORY, MemoryReadDecision.SHADOW_ONLY}:
-        raise HTTPException(
-            status_code=403, detail=_developer_memory_access_not_ready_detail(memory_result.fallback_reason)
+        if memory_result.fallback_reason != 'missing_rollout_state':
+            raise HTTPException(
+                status_code=403, detail=_developer_memory_access_not_ready_detail(memory_result.fallback_reason)
+            )
+        # pin_memory_system above already resolved this account to LEGACY, so an absent
+        # memory_control/state doc is the expected un-enrolled state and the legacy
+        # `memories` collection is the authoritative read surface — not a fail-closed
+        # migration condition (#9892).
+        record_fallback(
+            component='other',
+            from_mode='memory_default_read',
+            to_mode='legacy_memories',
+            reason='policy',
+            outcome='recovered',
         )
-    if memory_result.should_use_legacy_fallback:
-        pass
 
     memories = memories_db.get_memories(uid, limit, offset, [c.value for c in category_list])
     # Validate each record individually so a single malformed/legacy doc (e.g. missing a required

--- a/backend/tests/unit/test_dev_api_canonical_grant_ordering.py
+++ b/backend/tests/unit/test_dev_api_canonical_grant_ordering.py
@@ -375,21 +375,60 @@ def test_get_memories_allowed_grant_canonical_lists():
     assert resp.json()[0]['id'] == 'canon-1'
 
 
-def test_get_memories_missing_rollout_state_has_actionable_contract():
-    """A valid memory-read key must not look invalid when account rollout is absent."""
+def _denied_memory_result(fallback_reason):
+    return type(
+        'DeniedMemoryResult',
+        (),
+        {
+            'read_decision': developer_module.MemoryReadDecision.DENY_MEMORY,
+            'memories': [],
+            'fallback_reason': fallback_reason,
+            'should_use_legacy_fallback': False,
+        },
+    )()
+
+
+def test_get_memories_missing_rollout_state_falls_back_to_legacy():
+    """A legacy-cohort account with no rollout doc reads legacy memories, not 403 (#9892).
+
+    pin_memory_system already resolved the account to LEGACY, so an absent
+    memory_control/state doc is the expected un-enrolled state — the route must
+    serve the authoritative legacy `memories` collection instead of failing closed.
+    """
     client = _build()
 
     developer_module.search_memory_default_developer_memories = MagicMock(
-        return_value=type(
-            'DeniedMemoryResult',
-            (),
-            {
-                'read_decision': developer_module.MemoryReadDecision.DENY_MEMORY,
-                'memories': [],
-                'fallback_reason': 'missing_rollout_state',
-                'should_use_legacy_fallback': False,
-            },
-        )()
+        return_value=_denied_memory_result('missing_rollout_state')
+    )
+
+    legacy_memory = {
+        'id': 'legacy-1',
+        'content': 'a legacy memory',
+        'category': _VALID_CATEGORY,
+        'visibility': 'private',
+        'tags': [],
+        'manually_added': False,
+        'reviewed': False,
+        'edited': False,
+    }
+    with __import__('unittest.mock', fromlist=['patch']).patch.object(
+        developer_module.memories_db, 'get_memories', return_value=[legacy_memory]
+    ):
+        resp = client.get('/v1/dev/user/memories')
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]['id'] == 'legacy-1'
+    assert developer_module.authorize_memory_external_default_memory_read.called
+
+
+def test_get_memories_other_deny_reason_still_403():
+    """Deny reasons other than missing_rollout_state keep the fail-closed contract."""
+    client = _build()
+
+    developer_module.search_memory_default_developer_memories = MagicMock(
+        return_value=_denied_memory_result('missing_developer_default_memory_grant')
     )
 
     resp = client.get('/v1/dev/user/memories')
@@ -397,9 +436,8 @@ def test_get_memories_missing_rollout_state_has_actionable_contract():
     assert resp.status_code == 403
     detail = resp.json()['detail']
     assert detail['code'] == 'developer_memory_access_not_ready'
-    assert detail['reason'] == 'missing_rollout_state'
+    assert detail['reason'] == 'missing_developer_default_memory_grant'
     assert 'key can be valid and correctly scoped' in detail['message']
-    assert developer_module.authorize_memory_external_default_memory_read.called
 
 
 def test_search_memories_vector_missing_rollout_state_has_actionable_contract():

--- a/backend/tests/unit/test_developer_memory_adapter.py
+++ b/backend/tests/unit/test_developer_memory_adapter.py
@@ -185,16 +185,22 @@ def test_developer_update_route_checks_split_brain_guard_before_reads_and_legacy
 
 
 def test_developer_routes_only_reach_legacy_after_explicit_legacy_safe_decision():
+    # Static tripwire (source order, not behavior): the list route may reach the
+    # legacy read only through the deny branch's narrow un-enrolled guard (#9892);
+    # the vector route still requires an explicit legacy-safe decision.
     developer_py = Path(__file__).resolve().parents[2] / 'routers' / 'developer.py'
     contents = developer_py.read_text(encoding='utf-8')
     denied_check = 'if memory_result.read_decision in {MemoryReadDecision.DENY_MEMORY, MemoryReadDecision.SHADOW_ONLY}:'
-    legacy_safe_check = 'if memory_result.should_use_legacy_fallback:'
+    unenrolled_guard = "if memory_result.fallback_reason != 'missing_rollout_state':"
     legacy_call = 'memories_db.get_memories(uid, limit, offset, [c.value for c in category_list])'
     assert denied_check in contents
-    assert legacy_safe_check in contents
+    assert unenrolled_guard in contents
     assert legacy_call in contents
-    assert contents.index(denied_check) < contents.index(legacy_safe_check) < contents.index(legacy_call)
+    assert contents.index(denied_check) < contents.index(unenrolled_guard) < contents.index(legacy_call)
     vector_route_source = _function_source_for_route('/v1/dev/user/memories/vector/search', 'get')
+    legacy_safe_check = 'if memory_result.should_use_legacy_fallback:'
+    assert denied_check in vector_route_source
+    assert legacy_safe_check in vector_route_source
     assert vector_route_source.index(denied_check) < vector_route_source.index(legacy_safe_check)
 
 


### PR DESCRIPTION
# Summary

- `GET /v1/dev/user/memories` no longer returns `403 missing_rollout_state` for accounts that were never enrolled in the canonical-memory rollout: the route now serves the authoritative legacy `memories` collection for them.
- Every other deny reason (missing grant, malformed state, unsupported schema, uid mismatch) keeps the fail-closed 403 contract, as does `/v1/dev/user/memories/vector/search`, which has no legacy read surface.
- The mode change is recorded through the shared `record_fallback` helper (`component=other`, `reason=policy`, `outcome=recovered`) — no new one-off counter.

Fixes #9892.

# Root cause

Two authorities disagreed about the same account, and the fail-closed one won:

- **Cohort selector (authoritative):** `pin_memory_system` → `resolve_memory_system` resolves everyone outside the code-reviewed `CANONICAL_MEMORY_USERS` whitelist to `MemorySystem.LEGACY` — "the documented default — not an implicit None fallback" (its own words). For these accounts, `users/{uid}/memory_control/state` is *expected* to be absent.
- **Rollout gate:** `read_default_read_rollout` treats an absent doc as `DENY_MEMORY` / `missing_rollout_state` — correct fail-closed behavior for an account that might be mid-migration, wrong for one the cohort selector already pinned LEGACY in the same request.

The route's legacy read path (`memories_db.get_memories` + per-doc validation) already existed but was unreachable: only `USE_LEGACY_SAFE` reaches it, and rollout normalization never produces `USE_LEGACY_SAFE` from Firestore state — only the explicit opt-in constructor does. So every un-enrolled account lost Developer API memory reads entirely, while `/v1/dev/user/conversations` and `/v1/dev/user/action-items` (no such gate) kept working — exactly the reported symptom, breaking e.g. the Obsidian omi-sync memories feed.

# Failure class

Failure-Class: none

No registered class covers a reader failing closed on state whose absence the authoritative cohort selector defines as normal. It rhymes with FC-split-mutation-authority (competing authorities over one decision) but that class is scoped to mutable-state transition ownership, not read-side policy divergence; flagging rather than stretching — same call as #10078.

# Durable guard

- The fallback is *narrow and explicit*: only `missing_rollout_state` (doc absent = never enrolled) on the already-LEGACY branch falls back. `malformed_rollout_state`, `rollout_read_failed`, grant and schema denials all stay fail-closed, because there a doc exists (or its state is unknown) and the account may be mid-migration.
- The previously silent-dead `should_use_legacy_fallback: pass` branch is gone; the decision structure now states every outcome.
- Mode change is observable via the shared `omi_fallback_total` metric instead of being invisible.

# Product invariants affected

none (verified with `scripts/pr-preflight --suggest`)

# Validation

- Old-code regression check (route change stashed): `test_get_memories_missing_rollout_state_falls_back_to_legacy` → **fails** (403); with the fix → **passes**. Full file: 7 passed.
- New tests extend the existing grant-ordering suite through its established seams: an un-enrolled legacy-cohort account lists legacy memories with 200 (grant check still runs first); a non-missing deny reason still 403s with the actionable `developer_memory_access_not_ready` contract; the vector-search missing-rollout 403 test keeps its contract untouched.
- Repo runner (file-isolated, as CI executes): `tests/unit/test_dev_api_canonical_grant_ordering.py` → 7 passed, `tests/unit/test_developer_memory_adapter.py` → 24 passed, `tests/unit/test_memories_validation.py` → 12 passed, `tests/unit/test_dev_api_folder_filters.py` → included in sweep, passed.
- The pre-push bounded gate ran the wider backend selection and passed; it caught (and I updated) the static source-order tripwire in `test_developer_memory_adapter.py` that encoded the old "no legacy after deny" ordering — it now asserts the narrow un-enrolled guard precedes the legacy read, and is labeled as a static tripwire per the repo's testing guidance.
- `make preflight` (local lane, this PR body) → all selected checks pass.
- `black --line-length 120 --skip-string-normalization` clean on both changed files.

Not exercised live: a production Developer API key against a real un-enrolled account (no such credentials here). The fix point is server-side branch selection driven directly by the regression tests; the issue reporter's account can verify live after deploy.

# Out of scope, named

- MCP list/search (`routers/mcp.py`, `mcp_sse.py`) degrade differently for the same accounts (silent empty list instead of 403). Same underlying divergence, different surface and files — follow-up rather than scope creep here.
- The issue's alternative ask (enrolling individual accounts) is an ops action, not a code fix; this makes it unnecessary for reads.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

