### PR TITLE
fix(mcp): serve legacy memories when a legacy-cohort account has no rollout state

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -3,7 +3,7 @@
     "backend/routers/apps.py": 2335,
     "backend/routers/chat.py": 1577,
     "backend/routers/developer.py": 2195,
-    "backend/routers/mcp_sse.py": 1857,
+    "backend/routers/mcp_sse.py": 1858,
     "backend/routers/sync.py": 2024,
     "backend/routers/users.py": 2046
   },
@@ -11,7 +11,8 @@
     "backend/routers/developer.py": "GET /v1/dev/user/memories serves the authoritative legacy memories collection for legacy-cohort accounts with no rollout state (#9892), keeping the narrow deny/fallback decision in the route that owns the read contract.",
     "backend/routers/chat.py": "PTT stereo rejection keeps the serving STT provider boundary explicit in the established chat admission owner.",
     "backend/routers/sync.py": "Fresh Sync admission and final Cloud Tasks ledger recovery retain their coupled task, lock, ledger, and staged-blob lifecycle in the existing ingestion owner rather than a new module.",
-    "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first."
+    "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first.",
+    "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line."
   },
   "threshold": 1500
 }

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -54,6 +54,7 @@ import utils.mcp_action_items as mcp_action_items
 from utils.mcp_memories import (
     collect_filtered_memories,
     list_default_mcp_memories,
+    mcp_legacy_read_authorized,
     parse_mcp_bool,
     parse_mcp_datetime,
     parse_mcp_int,
@@ -298,7 +299,7 @@ def search_memories(
     )
     if vector_search_results.read_decision == MemoryReadDecision.USE_MEMORY:
         return vector_search_results.memories
-    if vector_search_results.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:
+    if not mcp_legacy_read_authorized(vector_search_results):
         return []
 
     return memory_service.search_mcp(uid, query, limit=limit)
@@ -394,7 +395,7 @@ def get_memories(
     )
     if memory_list_results.read_decision == MemoryReadDecision.USE_MEMORY:
         return memory_list_results.memories
-    if memory_list_results.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:
+    if not mcp_legacy_read_authorized(memory_list_results):
         return []
 
     result = collect_filtered_memories(

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -67,6 +67,7 @@ from utils.mcp_memories import (
     build_mcp_default_memory_read_context,
     collect_filtered_memories,
     list_default_mcp_memories,
+    mcp_legacy_read_authorized,
     parse_mcp_bool,
     parse_mcp_datetime,
     parse_mcp_int,
@@ -862,7 +863,7 @@ def execute_tool(
         )
         if memory_list_results.read_decision == MemoryReadDecision.USE_MEMORY:
             return {"memories": memory_list_results.memories}
-        if memory_list_results.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:
+        if not mcp_legacy_read_authorized(memory_list_results):
             return {"memories": []}
 
         result = collect_filtered_memories(
@@ -1090,7 +1091,7 @@ def execute_tool(
         )
         if vector_search_results.read_decision == MemoryReadDecision.USE_MEMORY:
             return {"memories": vector_search_results.memories}
-        if vector_search_results.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:
+        if not mcp_legacy_read_authorized(vector_search_results):
             return {"memories": []}
 
         matches = vector_db.find_similar_memories(user_id, query, threshold=0.0, limit=fetch_limit)

--- a/backend/tests/unit/test_mcp_memory_adapter.py
+++ b/backend/tests/unit/test_mcp_memory_adapter.py
@@ -22,9 +22,36 @@ from utils.mcp_memories import (
     McpMemoryListResult,
     McpMemorySearchResult,
     list_default_mcp_memories,
+    mcp_legacy_read_authorized,
     search_default_mcp_memories,
     search_default_mcp_memories_vector,
 )
+
+
+def test_mcp_legacy_read_authorized_only_for_explicit_or_unenrolled():
+    """#9892: only an explicit legacy-safe decision or a never-enrolled account
+    (absent memory_control/state doc) may reach the legacy read; every other
+    deny reason stays fail-closed."""
+
+    def result(read_decision, fallback_reason=None):
+        return McpMemorySearchResult(memories=[], read_decision=read_decision, fallback_reason=fallback_reason)
+
+    assert mcp_legacy_read_authorized(result(MemoryReadDecision.USE_LEGACY_SAFE)) is True
+    assert mcp_legacy_read_authorized(result(MemoryReadDecision.DENY_MEMORY, 'missing_rollout_state')) is True
+    assert mcp_legacy_read_authorized(result(MemoryReadDecision.DENY_MEMORY, 'malformed_rollout_state')) is False
+    assert mcp_legacy_read_authorized(result(MemoryReadDecision.DENY_MEMORY, 'rollout_read_failed')) is False
+    assert (
+        mcp_legacy_read_authorized(result(MemoryReadDecision.DENY_MEMORY, 'missing_mcp_default_memory_grant')) is False
+    )
+    assert mcp_legacy_read_authorized(result(MemoryReadDecision.SHADOW_ONLY, 'shadow_only')) is False
+    assert (
+        mcp_legacy_read_authorized(
+            McpMemoryListResult(
+                memories=[], read_decision=MemoryReadDecision.DENY_MEMORY, fallback_reason='missing_rollout_state'
+            )
+        )
+        is True
+    )
 
 
 def _legacy_branch_after_canonical(route_contents: str, *, marker: str | None = None) -> str:
@@ -145,49 +172,49 @@ def test_mcp_sse_transport_authenticates_full_mcp_api_key_context_without_inferr
     )
 
 
-def test_mcp_rest_search_route_only_reaches_legacy_after_explicit_legacy_safe_decision():
+def test_mcp_rest_search_route_only_reaches_legacy_through_authorized_decision():
     mcp_py = Path(__file__).resolve().parents[2] / 'routers' / 'mcp.py'
     contents = mcp_py.read_text(encoding='utf-8')
     search_route = contents[
         contents.index('@router.get("/v1/mcp/memories/search"') : contents.index('@router.get("/v1/mcp/memories"')
     ]
     assert 'MemoryReadDecision.USE_MEMORY' in search_route
-    assert 'MemoryReadDecision.USE_LEGACY_SAFE' in search_route
+    assert 'mcp_legacy_read_authorized' in search_route
     assert 'if vector_search_results.read_decision == MemoryReadDecision.USE_MEMORY:' in search_route
-    assert 'if vector_search_results.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:' in search_route
-    assert search_route.index(
-        'if vector_search_results.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:'
-    ) < search_route.rindex('return memory_service.search_mcp(uid, query, limit=limit)')
+    assert 'if not mcp_legacy_read_authorized(vector_search_results):' in search_route
+    assert search_route.index('if not mcp_legacy_read_authorized(vector_search_results):') < search_route.rindex(
+        'return memory_service.search_mcp(uid, query, limit=limit)'
+    )
 
 
-def test_mcp_rest_get_route_only_reaches_legacy_after_explicit_legacy_safe_decision():
+def test_mcp_rest_get_route_only_reaches_legacy_through_authorized_decision():
     mcp_py = Path(__file__).resolve().parents[2] / 'routers' / 'mcp.py'
     contents = mcp_py.read_text(encoding='utf-8')
     get_route = contents[contents.index('@router.get("/v1/mcp/memories"') : contents.index('class SimpleStructured')]
     assert 'list_default_mcp_memories(' in get_route
     assert 'if memory_list_results.read_decision == MemoryReadDecision.USE_MEMORY:' in get_route
-    assert 'if memory_list_results.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:' in get_route
+    assert 'if not mcp_legacy_read_authorized(memory_list_results):' in get_route
     assert get_route.index("read_default_read_rollout(uid=uid, db_client=db, consumer='mcp')") < get_route.index(
         'list_default_mcp_memories('
     )
-    assert get_route.index(
-        'if memory_list_results.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:'
-    ) < get_route.index('memories_db.get_memories(')
+    assert get_route.index('if not mcp_legacy_read_authorized(memory_list_results):') < get_route.index(
+        'memories_db.get_memories('
+    )
 
 
-def test_mcp_sse_search_tool_only_reaches_legacy_after_explicit_legacy_safe_decision():
+def test_mcp_sse_search_tool_only_reaches_legacy_through_authorized_decision():
     mcp_sse_py = Path(__file__).resolve().parents[2] / 'routers' / 'mcp_sse.py'
     contents = mcp_sse_py.read_text(encoding='utf-8')
     assert 'MemoryReadDecision.USE_MEMORY' in contents
-    assert 'MemoryReadDecision.USE_LEGACY_SAFE' in contents
+    assert 'mcp_legacy_read_authorized' in contents
     assert 'if vector_search_results.read_decision == MemoryReadDecision.USE_MEMORY:' in contents
-    assert 'if vector_search_results.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:' in contents
-    assert contents.index(
-        'if vector_search_results.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:'
-    ) < contents.index('vector_db.find_similar_memories(user_id, query, threshold=0.0, limit=fetch_limit)')
+    assert 'if not mcp_legacy_read_authorized(vector_search_results):' in contents
+    assert contents.index('if not mcp_legacy_read_authorized(vector_search_results):') < contents.index(
+        'vector_db.find_similar_memories(user_id, query, threshold=0.0, limit=fetch_limit)'
+    )
 
 
-def test_mcp_sse_get_tool_only_reaches_legacy_after_explicit_legacy_safe_decision():
+def test_mcp_sse_get_tool_only_reaches_legacy_through_authorized_decision():
     mcp_sse_py = Path(__file__).resolve().parents[2] / 'routers' / 'mcp_sse.py'
     contents = mcp_sse_py.read_text(encoding='utf-8')
     get_tool = contents[
@@ -195,13 +222,13 @@ def test_mcp_sse_get_tool_only_reaches_legacy_after_explicit_legacy_safe_decisio
     ]
     assert 'list_default_mcp_memories(' in get_tool
     assert 'if memory_list_results.read_decision == MemoryReadDecision.USE_MEMORY:' in get_tool
-    assert 'if memory_list_results.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:' in get_tool
+    assert 'if not mcp_legacy_read_authorized(memory_list_results):' in get_tool
     assert get_tool.index("read_default_read_rollout(uid=user_id, db_client=db, consumer='mcp')") < get_tool.index(
         'list_default_mcp_memories('
     )
-    assert get_tool.index(
-        'if memory_list_results.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:'
-    ) < get_tool.index('memories_db.get_memories(')
+    assert get_tool.index('if not mcp_legacy_read_authorized(memory_list_results):') < get_tool.index(
+        'memories_db.get_memories('
+    )
 
 
 def test_mcp_rest_write_routes_guard_legacy_mutation_before_side_effects():

--- a/backend/utils/mcp_memories.py
+++ b/backend/utils/mcp_memories.py
@@ -17,6 +17,7 @@ from utils.memory.default_read_surface import (
     rollout_decision_from_legacy_args,
 )
 from utils.memory.product_memory_read_service import fetch_default_product_memory_search
+from utils.observability import record_fallback
 
 ACTIVITY_TAGS = {
     'activity',
@@ -113,6 +114,29 @@ class McpMemoryListResult:
     @property
     def should_use_legacy_fallback(self) -> bool:
         return self.read_decision == MemoryReadDecision.USE_LEGACY_SAFE
+
+
+def mcp_legacy_read_authorized(result: 'McpMemorySearchResult | McpMemoryListResult') -> bool:
+    """Whether an MCP memory read may serve the legacy `memories` surface.
+
+    True for an explicit legacy-safe decision, and for a legacy-cohort account
+    whose `memory_control/state` doc was never created (#9892): callers reach
+    this only on the non-canonical branch after `pin_memory_system`, where the
+    absent doc is the expected un-enrolled state and legacy reads are
+    authoritative. Every other deny reason stays fail-closed.
+    """
+    if result.read_decision == MemoryReadDecision.USE_LEGACY_SAFE:
+        return True
+    if result.read_decision == MemoryReadDecision.DENY_MEMORY and result.fallback_reason == 'missing_rollout_state':
+        record_fallback(
+            component='other',
+            from_mode='memory_default_read',
+            to_mode='legacy_memories',
+            reason='policy',
+            outcome='recovered',
+        )
+        return True
+    return False
 
 
 def _mcp_search_result(result: DefaultReadSearchResult) -> McpMemorySearchResult:


### PR DESCRIPTION
# Summary

- MCP memory reads (`GET /v1/mcp/memories`, `GET /v1/mcp/memories/search`, and the SSE `get_memories` / `search_memories` tools) no longer return a silent empty result for accounts that were never enrolled in the canonical-memory rollout: they now serve the authoritative legacy `memories` surface.
- All four sites route the decision through one shared helper, `mcp_legacy_read_authorized`, instead of four copies of the `!= USE_LEGACY_SAFE` comparison. Every other deny reason (malformed state, read failure, missing grant, shadow-only) stays fail-closed.
- The mode change is recorded through the shared `record_fallback` helper — no new one-off counter.

MCP-surface counterpart of #10094 (Developer API), same root cause. Fixes #9892 for the MCP surface.

# Root cause

Same divergence as #10094: `pin_memory_system` resolves every account outside the code-reviewed canonical whitelist to `MemorySystem.LEGACY`, where `users/{uid}/memory_control/state` is *expected* to be absent — but `read_default_read_rollout` treats the absent doc as `DENY_MEMORY` / `missing_rollout_state`. The MCP sites reach that branch only after the cohort pin already said LEGACY, then returned `[]` instead of reading the legacy collection the selector had just declared authoritative. The Developer API surfaced this as a 403; MCP hid it as an empty memories list.

# Failure class

Failure-Class: none

Same call as #10094: no registered class covers a reader failing closed on state whose absence the authoritative cohort selector defines as normal, and FC-split-mutation-authority is scoped to mutable-state transition ownership, not read-side policy.

# Durable guard

- One shared decision owner: the four call sites can no longer drift apart — the narrow un-enrolled exception and its telemetry live in `mcp_legacy_read_authorized`, whose docstring names the contract.
- The fallback is narrow: only `missing_rollout_state` (doc absent = never enrolled) qualifies; `malformed_rollout_state` and `rollout_read_failed` stay fail-closed because there the doc exists or its state is unknown.
- The existing source-order tripwires (labeled as such) now assert all four routes gate legacy reads through the helper.

# Product invariants affected

- INV-MEM-1 (path-matched via `utils/mcp_memories.py`): no tier vocabulary change — the helper only decides legacy-vs-deny routing; tier semantics and the guard test are untouched.
- INV-MEM-3 note: the new fallback runs only on the non-canonical branch (cohort pin already resolved LEGACY); canonical selection still never falls back to legacy.

# Validation

- Behavioral regression test of the helper's full decision table (`test_mcp_legacy_read_authorized_only_for_explicit_or_unenrolled`): explicit legacy-safe and never-enrolled pass; malformed/read-failed/no-grant/shadow-only fail closed — this test cannot pass on pre-fix code (the helper did not exist, and the old inline comparisons denied the un-enrolled case).
- Repo runner (file-isolated, as CI executes): `tests/unit/test_mcp_memory_adapter.py` + `tests/unit/test_mcp_data_endpoints.py` → 27 passed.
- `make preflight` (local lane, this PR body) → all selected checks pass.
- `black` clean on all changed files.
- `backend/routers/mcp_sse.py` frozen-size baseline raised 1857 → 1858 (one import line) with justification, per the ratchet's documented raise path.

Not exercised live: a production MCP key against a real un-enrolled account (no credentials here). The fix point is the shared server-side decision helper driven directly by the tests.

# Out of scope, named

- `should_use_legacy_fallback` properties on the two result dataclasses remain for API compatibility; the routes now use the shared helper instead.
- Chat/omi_chat consumer surfaces keep their existing rollout semantics — different consumer contract, untouched.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

