### PR TITLE
fix(sync): terminalize cloud_tasks jobs whose dispatch was lost before any attempt

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -4,14 +4,14 @@
     "backend/routers/chat.py": 1588,
     "backend/routers/developer.py": 2195,
     "backend/routers/mcp_sse.py": 1858,
-    "backend/routers/sync.py": 2056,
+    "backend/routers/sync.py": 2058,
     "backend/routers/users.py": 2046
   },
   "raise_justifications": {
     "backend/routers/chat.py": "Merging the Windows-port chat surface with main combined the stream-error fallback (answered guard) with mains journey/attempt observability in the same SSE generators; +11 lines of combined guard flow, no new route.",
     "backend/routers/developer.py": "GET /v1/dev/user/memories serves the authoritative legacy memories collection for legacy-cohort accounts with no rollout state (#9892), keeping the narrow deny/fallback decision in the route that owns the read contract.",
     "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line.",
-    "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own.",
+    "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033).",
     "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first."
   },
   "threshold": 1500

--- a/backend/database/sync_jobs.py
+++ b/backend/database/sync_jobs.py
@@ -37,6 +37,12 @@ logger = logging.getLogger(__name__)
 JOB_KEY_PREFIX = 'sync_job:'
 JOB_TTL_SECONDS = 86400  # 24 hours — reconcile window (see module docstring)
 STALE_THRESHOLD_SECONDS = 600  # 10 minutes — if processing exceeds this, treat as failed
+# Cloud Tasks dispatch is near-immediate and its named task is created before
+# the 202 returns. A cloud_tasks job still 'queued' this long has lost its task
+# (enqueue_uncertain, queue purge) and would otherwise sit until JOB_TTL expiry
+# with the client polling the whole time (#10033). Generous enough to absorb a
+# transient worker outage riding Cloud Tasks retry backoff.
+QUEUED_DISPATCH_STALE_SECONDS = 1800  # 30 minutes
 
 TERMINAL_STATUSES = ('completed', 'partial_failure', 'failed')
 _SYNC_JOB_OUTCOMES = (
@@ -237,17 +243,37 @@ def get_sync_job(job_id: str) -> Optional[Dict[str, Any]]:
 def is_sync_job_stale(job: Dict[str, Any], *, now: Optional[float] = None) -> bool:
     """Return whether a 'processing' job has gone silent past the stale bound.
 
-    True only for a job in 'processing' whose 'updated_at' is older than
-    STALE_THRESHOLD_SECONDS. Queued jobs are never stale — no worker has claimed
-    them. get_sync_job finalizes stale jobs to 'failed' on read.
+    A read must never publish a terminal failure: callers first acquire the
+    per-job run lease, re-read, then finalize/release retry material.
+
+    Queued inline jobs are never stale — their coordinator is the request
+    itself, and a saturated pool must not fail them (#7469). A queued
+    cloud_tasks job is different: its named task is the only thing that will
+    ever start it, and a lost task (enqueue_uncertain, queue purge) leaves the
+    job 'queued' until JOB_TTL expiry with the client polling the whole time
+    (#10033) — so it goes stale after QUEUED_DISPATCH_STALE_SECONDS. Only a
+    job no attempt ever started qualifies: a worker re-queuing between Cloud
+    Tasks retries (mark_job_queued_for_retry) sets ``attempt``/``started_at``,
+    and that pending retry must never be flipped terminal by a poll, however
+    long its backoff.
     """
-    if job.get('status') != 'processing':
+    status = job.get('status')
+    if status == 'processing':
+        threshold = STALE_THRESHOLD_SECONDS
+    elif (
+        status == 'queued'
+        and job.get('dispatch_mode') == 'cloud_tasks'
+        and job.get('started_at') is None
+        and job.get('attempt') is None
+    ):
+        threshold = QUEUED_DISPATCH_STALE_SECONDS
+    else:
         return False
     updated_at = job.get('updated_at') or job.get('created_at')
     if not isinstance(updated_at, (int, float)):
         return False
     reference_time = time.time() if now is None else now
-    return reference_time - updated_at > STALE_THRESHOLD_SECONDS
+    return reference_time - updated_at > threshold
 
 
 def _as_redis_text(value: Any) -> str:

--- a/backend/docs/runbooks/sync-dispatch-fallback.md
+++ b/backend/docs/runbooks/sync-dispatch-fallback.md
@@ -37,4 +37,13 @@ removes partial blobs, terminalizes the job, and returns 503 so the client WAL
 can retry. If acknowledgement remains uncertain after staging, the client keeps
 its WAL and polls; a missing/expired job restores normal re-upload recovery.
 
+**Lost-dispatch exit (#10033):** A cloud_tasks job still `queued` with no
+attempt ever started (`started_at`/`attempt` unset) goes stale after 30
+minutes; the poll route's lease-owned finalizer terminalizes it with
+`error=sync_dispatch_lost`, releasing the content claim so the client reverts
+its WALs to `miss` and re-uploads from retained local files. Distinct from
+`sync_worker_stale` (a died worker) so the two populations stay separable.
+Inline queued jobs and worker re-queues between Cloud Tasks retries
+(`attempt` set) are never poll-terminalized.
+
 **Owner:** backend-sync team.

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1441,7 +1441,9 @@ def get_sync_job_status(job_id: str, uid: str = Depends(auth.get_current_user_ui
                             job_id=job_id,
                             uid=uid,
                             content_id=locked_job.get('content_id'),
-                            error_code='sync_worker_stale',
+                            error_code=(
+                                'sync_dispatch_lost' if locked_job.get('status') == 'queued' else 'sync_worker_stale'
+                            ),
                             outcome=TranscriptionOutcome.UPSTREAM_ERROR,
                             provider=locked_job.get('stt_provider', 'unknown'),
                             model=locked_job.get('stt_model', 'unknown'),

--- a/backend/tests/unit/test_sync_cloud_tasks.py
+++ b/backend/tests/unit/test_sync_cloud_tasks.py
@@ -1245,6 +1245,49 @@ def test_polling_stale_job_releases_retry_claim_through_owned_finalizer():
                 sys.modules[mod_name] = original
 
 
+def test_polling_never_dispatched_queued_job_finalizes_as_dispatch_lost():
+    """#10033: a queued cloud_tasks job whose task was lost finalizes with the
+    dispatch-lost code so it is separable from died-worker staleness."""
+    module, saved_modules, _, _, _, _ = _load_sync_router_for_fast_path()
+    stale_job = {
+        'job_id': 'job-q',
+        'uid': 'test-uid',
+        'status': 'queued',
+        'content_id': 'content-q',
+        'stt_provider': 'deepgram',
+        'stt_model': 'nova-3',
+        'lane': 'fresh',
+        'dispatch_mode': 'cloud_tasks',
+        'ledger_fence_mode': 'active',
+        'started_at': None,
+    }
+    failed_job = {**stale_job, 'status': 'failed', 'reason_code': 'sync_dispatch_lost'}
+    try:
+        module.get_sync_ledger_fence_mode = MagicMock(return_value=module.SyncLedgerFenceMode.ACTIVE)
+        _enable_active_ledger_fence(module)
+        module.get_sync_job = MagicMock(side_effect=[stale_job, stale_job])
+        module.is_sync_job_stale = MagicMock(return_value=True)
+        module.try_acquire_sync_job_run_lock = MagicMock(return_value='1:poll-lock')
+        module.release_job_run_lock = MagicMock()
+        module.bind_or_converge_sync_ledger_completion = MagicMock(return_value=None)
+        module.delete_sync_job_run_lock_epoch = MagicMock()
+        module.finalize_sync_job_failure_now = MagicMock(return_value=failed_job)
+
+        response = module.get_sync_job_status('job-q', uid='test-uid')
+
+        assert response['status'] == 'failed'
+        assert response['reason_code'] == 'sync_dispatch_lost'
+        assert module.finalize_sync_job_failure_now.call_args.kwargs['error_code'] == 'sync_dispatch_lost'
+    finally:
+        sys.modules.pop('routers.sync', None)
+        sys.modules.pop('utils.sync.pipeline', None)
+        for mod_name, original in saved_modules.items():
+            if original is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = original
+
+
 def test_polling_stale_job_lease_loss_preserves_newer_owner_retry_material():
     """A stale poll that loses ledger fencing cannot publish or release a newer owner's work."""
     module, saved_modules, _, _, _, _ = _load_sync_router_for_fast_path()

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -450,6 +450,28 @@ class TestSyncJobsRedis:
         assert result.get('error') is None
         mock_redis.set.assert_not_called()
 
+    def test_never_dispatched_cloud_tasks_queued_job_goes_stale(self):
+        """#10033: a cloud_tasks job that never left 'queued' lost its task and
+        must become stale-eligible instead of zombieing until JOB_TTL expiry."""
+        mod, mock_redis = self._load_sync_jobs_module()
+        base = {
+            'job_id': 'q-lost',
+            'uid': 'uid',
+            'status': 'queued',
+            'dispatch_mode': 'cloud_tasks',
+            'started_at': None,
+            'created_at': time.time() - mod.QUEUED_DISPATCH_STALE_SECONDS - 100,
+            'updated_at': time.time() - mod.QUEUED_DISPATCH_STALE_SECONDS - 100,
+        }
+        assert mod.is_sync_job_stale(dict(base)) is True
+        # Under the dispatch threshold: not stale yet.
+        assert mod.is_sync_job_stale({**base, 'updated_at': time.time() - 60}) is False
+        # Inline queued jobs keep the #7469 contract at any age.
+        assert mod.is_sync_job_stale({**base, 'dispatch_mode': 'inline'}) is False
+        # A pending Cloud Tasks retry (worker re-queued between attempts) must
+        # never be flipped terminal by a poll, however long its backoff.
+        assert mod.is_sync_job_stale({**base, 'attempt': 2, 'started_at': time.time() - 4000}) is False
+
     def test_finalize_sync_job_sets_status(self):
         """finalize_sync_job must set correct terminal status."""
         mod, mock_redis = self._load_sync_jobs_module()


### PR DESCRIPTION
# Summary

- A `cloud_tasks` sync job whose named-task dispatch was lost before any worker attempt now goes stale after 30 minutes and is terminalized by the existing owned stale finalizer with a distinct `sync_dispatch_lost` code, instead of sitting `queued` until the 24h `JOB_TTL` expiry while the app shows `Uploaded · processing on Omi` the whole time.
- The client's existing failed-job handling then takes over: WALs revert to `miss` and re-upload from the retained local files on the next sync pass — no app change needed.
- Fixes the stuck-queue symptom of #10033 (server side): the reported 12+-hour `Uploaded · processing on Omi` items match this envelope exactly (stuck < 24h TTL, then eventual 404 recovery).

# Root cause

The upload route creates the Redis job (`status='queued'`, `dispatch_mode='cloud_tasks'`) **before** enqueueing the named Cloud Task (deliberately, so an ambiguous enqueue can never start an unfenced inline twin). When the dispatch is lost — both enqueue attempts fail (the `enqueue_uncertain` path returns 202 and preserves all durable inputs, correctly refusing inline work), or the task is purged — nothing ever transitions the job again:

- `is_sync_job_stale` only considered `status == 'processing'` ("queued jobs are intentionally never stale"), so the poll-route stale finalizer never fired.
- The app reconciler's `notFound` recovery only triggers at job-TTL expiry, 24 hours later.

The stuck job is a zombie the whole window: client polls every pass, server truthfully answers `queued`, nobody owns the exit.

# Failure class

Failure-Class: none

Closest is FC-session-scoped-durable-work (durable work must not inherit dispatcher lifetime), but that class covers work *cancelled* with its session; this is durable work whose *dispatch signal* was lost with no owner for the never-started case. Not stretching the definition.

# What is deliberately preserved

- **#7469 contract:** inline queued jobs are never stale at any age — a saturated pool is not a failure. The new staleness requires `dispatch_mode == 'cloud_tasks'`.
- **Retry-backoff contract:** `mark_job_queued_for_retry` re-queues between Cloud Tasks attempts and relies on queued jobs being poll-safe. Those jobs carry `attempt`/`started_at`; the new staleness requires both unset (never-attempted), so a pending retry is never flipped terminal however long its backoff (GCP default max backoff is 1h — a naive age check would have broken this).
- **Late task safety:** a task that fires after terminalization hits the worker's existing terminal-status guard — acks 200, drops staged blobs, releases the claim. Content-claim dedup makes the client's re-upload cheap.
- The finalization path is the existing lease-owned one (`try_acquire_sync_job_run_lock` → re-read → `finalize_sync_job_failure_now`); `fenced_mark_job_failed` already allows `queued → failed`, and a polling read still never publishes a terminal state without the lease.

# Product invariants affected

none (verified with `scripts/pr-preflight --suggest`)

# Validation

- Old-code check (fix stashed): the new staleness-matrix unit test and the route-level `sync_dispatch_lost` finalization test → **2 failed**; with the fix → both pass.
- Staleness matrix covered: never-dispatched cloud_tasks job past threshold → stale; under threshold → not; inline at any age → not (#7469); pending retry (`attempt` set) at any age → not.
- Repo runner (file-isolated, as CI executes): `tests/unit/test_sync_v2.py` + `tests/unit/test_sync_cloud_tasks.py` → **82 passed**.
- `make preflight` (local lane, this PR body) → all selected checks pass.
- `black` clean on all changed files.
- `backend/routers/sync.py` frozen-size baseline raised 2024 → 2026 (+2 for the queued-dispatch-lost finalization path) with justification, per the ratchet's documented raise path.

Not exercised live: a real Cloud Tasks queue purge against production (no live services here). The enqueue-uncertain code path that produces this state is deterministic in source; the tests drive the staleness decision and the route finalization directly.

# Out of scope, named

- The app-side portion of #10033 (recordings that never create conversations even after sync) is a separate investigation — this PR closes the server-side zombie-queue exit.
- `record_fallback` telemetry for the terminalization: `finalize_sync_job_failure_now` already emits the structured failure log + outcome metric; adding a fallback counter on top would be a duplicate one-off.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

