### PR TITLE
fix(app): stop reporting a failed template install as success

### DIFF
--- a/app/lib/pages/conversation_detail/widgets/create_template_bottom_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/create_template_bottom_sheet.dart
@@ -162,10 +162,11 @@ class _CreateTemplateBottomSheetState extends State<CreateTemplateBottomSheet> {
             _statusMessage = context.l10n.installingApp;
           });
 
-          // Enable/install the app for the user
-          final success = await enableAppServer(createdApp.id);
+          // Enable/install through the provider: it owns prefs, app-list
+          // state, and the failure dialog, so a failed install can no longer
+          // be reported as success (#10074 follow-up).
+          final success = await context.read<AppProvider>().toggleApp(createdApp.id, true, null);
           if (success) {
-            SharedPreferencesUtil().enableApp(createdApp.id);
             createdApp.enabled = true;
 
             // Update the conversation detail provider's cached apps
@@ -178,15 +179,21 @@ class _CreateTemplateBottomSheetState extends State<CreateTemplateBottomSheet> {
           if (mounted) {
             // Close the create template bottom sheet
             Navigator.pop(context);
-            AppSnackbar.showSnackbarSuccess(context.l10n.appCreatedAndInstalled);
+            if (success) {
+              AppSnackbar.showSnackbarSuccess(context.l10n.appCreatedAndInstalled);
 
-            // Show the summarized apps sheet so user can use the new app
-            showModalBottomSheet(
-              context: context,
-              isScrollControlled: true,
-              backgroundColor: Colors.transparent,
-              builder: (context) => const SummarizedAppsBottomSheet(),
-            );
+              // Show the summarized apps sheet so user can use the new app
+              showModalBottomSheet(
+                context: context,
+                isScrollControlled: true,
+                backgroundColor: Colors.transparent,
+                builder: (context) => const SummarizedAppsBottomSheet(),
+              );
+            } else {
+              // The provider already showed the failure dialog; tell the user
+              // what state they are actually in.
+              AppSnackbar.showSnackbarError(context.l10n.failedToInstallApp(createdApp.name));
+            }
           }
         } else if (mounted) {
           Navigator.pop(context);

--- a/app/lib/providers/app_provider.dart
+++ b/app/lib/providers/app_provider.dart
@@ -783,11 +783,13 @@ class AppProvider extends BaseProvider {
     }
   }
 
-  Future<void> toggleApp(String appId, bool isEnabled, int? idx) async {
+  /// Enable/disable [appId] server-side, keeping prefs, local app state, and
+  /// failure UX (error dialog) in one owner. Returns whether the toggle stuck.
+  Future<bool> toggleApp(String appId, bool isEnabled, int? idx) async {
     int loadingIndex = -1;
     if (idx != null && idx >= 0 && idx < appLoading.length) {
       loadingIndex = idx;
-      if (appLoading[loadingIndex]) return;
+      if (appLoading[loadingIndex]) return false;
       appLoading[loadingIndex] = true;
       notifyListeners();
     } else if (idx != null) {
@@ -866,6 +868,7 @@ class AppProvider extends BaseProvider {
     }
 
     notifyListeners();
+    return success;
   }
 
   // Performance optimization: Dispose method to clean up resources


### PR DESCRIPTION
# Summary

- Creating a summary template from a conversation no longer reports **"App created and installed!"** when the install actually failed. The sheet now installs through `AppProvider.toggleApp` — the existing owner of enable/disable — and reports the real outcome: on failure the user sees `Failed to install {app}. Please try again.` (existing l10n string) plus the provider's standard error dialog, instead of a false success and the summarized-apps picker.
- `AppProvider.toggleApp` now returns `Future<bool>` (whether the toggle stuck). All existing callers ignore the return value and are source-compatible unchanged.

App-side half of #10074; the server-side honor fix landed in #10078's scope (preferred app admitted by the setter is now honored at generation time). This closes the flow that *created* the never-enabled default in the first place.

# Root cause

`create_template_bottom_sheet.dart` called the raw `enableAppServer` API and ignored its result (`if (success)` with no else): a failed enable still showed the success snackbar, opened the picker, and let the user set the never-enabled template as default. Meanwhile `AppProvider.toggleApp` — used by every other enable surface — already handles the failure path (error dialog, no false local state). Classic sibling-caller divergence; the fix routes the sheet through the shared owner instead of patching the raw call site.

# Failure class

Failure-Class: none

No registered class covers a UI flow reporting success for a failed side effect; the nearest theme (one authoritative owner per decision) is the shape of the fix, not a registered class.

# Validation

- **Not run locally — this machine has no Flutter SDK** (same constraint stated in #10097). The change is confined to the sheet's install branch and a `Future<void>` → `Future<bool>` signature widening; the app CI lane compiles, analyzes, and runs the app test suite over it.
- No hermetic regression test is included, stated plainly: the sheet's flow calls five top-level API functions (`getGeneratedDescriptionAndEmoji`, `submitAppServer`, `getAppDetailsServer`, plus enable) with no injection seams, and the repo's app tests have no network-mocking harness for them. Introducing that seam is a refactor beyond this fix's scope; the change instead *reduces* untested surface by deleting a raw API call site in favor of the provider path that every other enable surface already exercises.
- Reviewed against all `toggleApp` call sites (`chat/page.dart`, `apps/list_item.dart`) — all ignore the return value; `app_detail.dart` uses its own wrapper, untouched.

# Out of scope, named

- An injectable API seam for app-flow widget tests (would unlock hermetic coverage for this and several sibling sheets) — refactor with its own review.
- The store/detail surfaces already surface enable failures via the provider dialog; no change needed there.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

