### PR TITLE
harden(desktop-backend): give the bare Client::new() call sites a bounded deadline

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/crisp.rs
+++ b/desktop/macos/Backend-Rust/src/routes/crisp.rs
@@ -239,7 +239,7 @@ async fn get_unread_messages(
     };
 
     let auth = BASE64.encode(format!("{}:{}", identifier, key));
-    let client = reqwest::Client::new();
+    let client = crate::services::http::bounded_client(std::time::Duration::from_secs(15));
     let email_lower = email.to_lowercase();
 
     // Try cache first, then fall back to conversation list search

--- a/desktop/macos/Backend-Rust/src/routes/realtime.rs
+++ b/desktop/macos/Backend-Rust/src/routes/realtime.rs
@@ -229,11 +229,7 @@ fn value_as_numeric_code(value: Option<&serde_json::Value>) -> Option<String> {
 }
 
 fn http_client() -> reqwest::Client {
-    reqwest::Client::builder()
-        .connect_timeout(Duration::from_secs(10))
-        .timeout(Duration::from_secs(15))
-        .build()
-        .unwrap_or_default()
+    crate::services::http::bounded_client(Duration::from_secs(15))
 }
 
 async fn mint_session(

--- a/desktop/macos/Backend-Rust/src/routes/screen_activity.rs
+++ b/desktop/macos/Backend-Rust/src/routes/screen_activity.rs
@@ -162,7 +162,7 @@ async fn upsert_pinecone_vectors(
         return Ok(());
     }
 
-    let client = reqwest::Client::new();
+    let client = crate::services::http::bounded_client(std::time::Duration::from_secs(30));
     let url = format!("{}/vectors/upsert", host);
 
     // Pinecone limit: 100 vectors per upsert

--- a/desktop/macos/Backend-Rust/src/routes/tts.rs
+++ b/desktop/macos/Backend-Rust/src/routes/tts.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 use crate::auth::{AuthUser, PaywalledAuthUser};
 use crate::byok;
+use crate::services::http::bounded_client;
 use crate::AppState;
 
 use super::rate_limit::requires_server_metering;
@@ -142,11 +143,7 @@ async fn tts_synthesize(
         response_format: "mp3",
     };
 
-    let client = reqwest::Client::builder()
-        .connect_timeout(Duration::from_secs(10))
-        .timeout(Duration::from_secs(30))
-        .build()
-        .unwrap_or_default();
+    let client = bounded_client(Duration::from_secs(30));
 
     // Retry the request on transient OpenAI failures (network/429/5xx) so a brief blip
     // doesn't drop the voice reply. The client additionally falls back to the macOS

--- a/desktop/macos/Backend-Rust/src/routes/webhooks.rs
+++ b/desktop/macos/Backend-Rust/src/routes/webhooks.rs
@@ -315,7 +315,7 @@ async fn fetch_sentry_event_details(
 
     let url = format!("https://sentry.io/api/0/issues/{}/events/latest/", issue_id);
 
-    let client = reqwest::Client::new();
+    let client = crate::services::http::bounded_client(std::time::Duration::from_secs(15));
     let response = match client
         .get(&url)
         .header("Authorization", format!("Bearer {}", auth_token))
@@ -554,7 +554,7 @@ async fn poll_sentry_feedback(State(state): State<AppState>) -> Result<Json<Valu
     // failure, unparseable body) are transient and outside this service's control, so
     // they return a typed 2xx "skipped" response instead of a 500 — a 500 here wrongly
     // implies desktop-backend broke and spams the prod error logs. See issue #9139.
-    let client = reqwest::Client::new();
+    let client = crate::services::http::bounded_client(std::time::Duration::from_secs(15));
     let sentry_url = "https://sentry.io/api/0/organizations/mediar-n5/issues/?query=issue.category:feedback&limit=25&sort=date";
 
     let response = match client

--- a/desktop/macos/Backend-Rust/src/services/http.rs
+++ b/desktop/macos/Backend-Rust/src/services/http.rs
@@ -19,11 +19,12 @@ pub(crate) fn bounded_client(total_timeout: Duration) -> reqwest::Client {
         .connect_timeout(CONNECT_TIMEOUT)
         .timeout(total_timeout)
         .build()
-        .unwrap_or_default()
+        .expect("bounded_client: reqwest builder misconfigured")
 }
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
     use std::time::Instant;
     use tokio::io::AsyncReadExt;

--- a/desktop/macos/Backend-Rust/src/services/http.rs
+++ b/desktop/macos/Backend-Rust/src/services/http.rs
@@ -1,0 +1,65 @@
+#![deny(dead_code, unreachable_pub)]
+//! Shared bounded HTTP client construction.
+//!
+//! Every outbound HTTP call must carry a connect timeout and a total-request
+//! deadline: a bare `reqwest::Client::new()` has neither, so one hung upstream
+//! (Pinecone, Sentry, Crisp, ...) pins its handler or background task until the
+//! platform kills it. Related failure class: FC-per-hop-timeout — bounded
+//! per-request budgets instead of per-call-site retail timeouts.
+
+use std::time::Duration;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Build a client whose every request fails after `total_timeout` end to end
+/// (connect included, capped separately at 10s). Callers pick the budget that
+/// fits their upstream; none may opt out of having one.
+pub(crate) fn bounded_client(total_timeout: Duration) -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(total_timeout)
+        .build()
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+    use tokio::io::AsyncReadExt;
+    use tokio::net::TcpListener;
+
+    #[tokio::test]
+    async fn bounded_client_fails_a_stalled_upstream_within_its_budget() {
+        // A listener that accepts the connection and then never responds —
+        // the exact upstream shape a bare Client::new() hangs on forever.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 1024];
+            // Read the request, then stall without ever writing a response.
+            let _ = socket.read(&mut buf).await;
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        });
+
+        let client = bounded_client(Duration::from_millis(300));
+        let started = Instant::now();
+        let result = client.get(format!("http://{}", addr)).send().await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            result.is_err(),
+            "stalled upstream must not yield a response"
+        );
+        assert!(
+            result.unwrap_err().is_timeout(),
+            "failure must be the client-side deadline, not a transport error"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "deadline must fire near its budget, elapsed={elapsed:?}"
+        );
+        server.abort();
+    }
+}

--- a/desktop/macos/Backend-Rust/src/services/http.rs
+++ b/desktop/macos/Backend-Rust/src/services/http.rs
@@ -1,11 +1,17 @@
 #![deny(dead_code, unreachable_pub)]
 //! Shared bounded HTTP client construction.
 //!
-//! Every outbound HTTP call must carry a connect timeout and a total-request
-//! deadline: a bare `reqwest::Client::new()` has neither, so one hung upstream
-//! (Pinecone, Sentry, Crisp, ...) pins its handler or background task until the
-//! platform kills it. Related failure class: FC-per-hop-timeout — bounded
-//! per-request budgets instead of per-call-site retail timeouts.
+//! A bare `reqwest::Client::new()` carries neither a connect timeout nor a
+//! total-request deadline, so one hung upstream (Pinecone, Sentry, Crisp, ...)
+//! pins its handler or background task until the platform kills it. This helper
+//! is the covered replacement for those call sites.
+//!
+//! New non-streaming outbound integrations should build their client here
+//! unless they have a documented streaming or route/request-level deadline —
+//! streaming paths (e.g. the Anthropic/Gemini chat transports) deliberately
+//! omit a client-level total timeout and bound their budget elsewhere. Related
+//! failure class: FC-per-hop-timeout — bounded per-request budgets instead of
+//! per-call-site retail timeouts.
 
 use std::time::Duration;
 
@@ -13,7 +19,7 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Build a client whose every request fails after `total_timeout` end to end
 /// (connect included, capped separately at 10s). Callers pick the budget that
-/// fits their upstream; none may opt out of having one.
+/// fits their upstream.
 pub(crate) fn bounded_client(total_timeout: Duration) -> reqwest::Client {
     reqwest::Client::builder()
         .connect_timeout(CONNECT_TIMEOUT)

--- a/desktop/macos/Backend-Rust/src/services/mod.rs
+++ b/desktop/macos/Backend-Rust/src/services/mod.rs
@@ -1,6 +1,7 @@
 // Services module
 
 pub(crate) mod firestore;
+pub(crate) mod http;
 pub(crate) mod redis;
 
 pub(crate) use firestore::FirestoreService;


### PR DESCRIPTION
# Summary

- Four desktop-backend call sites built reqwest clients with **no connect timeout and no total-request deadline** — screen-activity Pinecone upserts, both Sentry fetches (webhook enrichment + feedback poll), and the Crisp session lookup. One hung upstream pinned its handler or background task until the platform killed it, holding the connection slot the whole time.
- `services::http::bounded_client(total_timeout)` is now the one owner of outbound client construction: connect capped at 10s, every request failing after the caller's total budget (Pinecone 30s; Sentry/Crisp 15s). No caller can opt out of having a deadline.
- `realtime.rs`'s private duplicate helper (identical 10s/15s values) folds onto the primitive; `tts.rs` keeps its deliberate retry-shaped 30s client unchanged — it already had both bounds.


**Scope:** this establishes bounded connect + total timeouts for the bare `reqwest::Client::new()` call sites the helper replaces, and steers new *non-streaming* integrations to `bounded_client(total_timeout)`. It is **not** a repo-wide 'every client' invariant — streaming transports (Anthropic/Gemini chat) deliberately omit a client-level total timeout and bound their budget at the route/request level.
# Why a primitive, not four timeouts

The repo's own FC-per-hop-timeout class (evidence: #9835) names the pattern: per-call-site retail timeouts drift and new call sites ship bare. After this PR the bare `reqwest::Client::new()` call sites this helper covers carry bounded connect + total deadlines, and the next non-streaming outbound integration reaches for the bounded constructor because it is the one that exists. Cited, not declared — this is a `harden:` commit with no triggering incident, per the contribution guide's fix/harden distinction.

# Product invariants affected

none (verified with `scripts/pr-preflight --suggest`)

Failure-Class: none

# Validation

- New hermetic regression test drives the primitive against a **stalled local upstream** (TCP listener that accepts, reads the request, and never responds — the exact shape a bare client hangs on forever) and asserts the client-side deadline fires, as a timeout error, within budget. No network, no sleeps on the assert path.
- `cargo test` → **377 passed** (full crate, includes the new test).
- `cargo clippy` clean on the crate; the `--all-targets` `unwrap()` lints in `src/routes/chat/tests/all.rs` are pre-existing on main (from the #9851 module split), untouched here.
- `rustfmt --edition 2021` applied to all changed files.
- Behavior at the four migrated sites is unchanged on the success path; the only new behavior is that a hung upstream now errors at its budget instead of hanging forever — exercised directly by the test above.

# Out of scope, named

- **Three bare `reqwest::Client::new()` sites remain in the crate** — `services/firestore.rs:81`, `auth.rs:120`, `routes/auth.rs:847` (verified against the current head). They sit on auth/Firestore surfaces rather than the non-streaming outbound-integration surface this helper covers, and migrating them changes behavior on credential/data paths that deserve their own review — so they are named follow-up, not bundled into an already-approved hardening PR.

- The pre-existing `--all-targets` clippy lints in `routes/chat/tests/all.rs` — separate cleanup, not this PR's surface.
- Per-request deadline propagation (deadline budgets flowing across hops, FC-per-hop-timeout's full shape) — #10054/#10056 own that for the chat/proxy paths.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




