### PR TITLE
Reject an oversized status or source filter before it reaches Firestore

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -336,6 +336,18 @@ def _ensure_aware(value: datetime) -> datetime:
     return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
 
 
+# Firestore 'in' filters accept at most 30 values (see database/apps.py, database/chat.py). Reject
+# an oversized status/source filter before it reaches the query so a caller cannot turn a
+# comma-separated filter into an unhandled 500. ConversationStatus and the source set are both
+# tiny, so a cap of 20 can never reject a request a real client would send.
+MAX_IN_FILTER_VALUES = 20
+
+
+def _reject_oversized_filter(values: List[str], field_name: str) -> None:
+    if len(values) > MAX_IN_FILTER_VALUES:
+        raise HTTPException(status_code=400, detail=f"{field_name} accepts at most {MAX_IN_FILTER_VALUES} values")
+
+
 @router.get(
     '/v1/conversations',
     response_model=List[Conversation],
@@ -363,12 +375,15 @@ def get_conversations(
     if len(statuses) == 0:
         statuses = "processing,completed"
 
+    status_filter = statuses.split(",") if len(statuses) > 0 else []
+    _reject_oversized_filter(status_filter, "statuses")
+
     conversations = conversations_db.get_conversations_without_photos(
         uid,
         limit,
         offset,
         include_discarded=include_discarded,
-        statuses=statuses.split(",") if len(statuses) > 0 else [],
+        statuses=status_filter,
         start_date=start_date,
         end_date=end_date,
         folder_id=folder_id,
@@ -394,6 +409,8 @@ def get_conversations_count(
         raise HTTPException(status_code=400, detail="start_date must be earlier than or equal to end_date")
     status_list = [s.strip() for s in statuses.split(',') if s.strip()] if statuses else []
     source_list = [s.strip() for s in sources.split(',') if s.strip()] if sources else []
+    _reject_oversized_filter(status_list, "statuses")
+    _reject_oversized_filter(source_list, "sources")
     if status_list and source_list:
         # Combining status+source `in` filters would need a composite index; keep them exclusive.
         raise HTTPException(status_code=400, detail="statuses and sources filters cannot be combined")

--- a/backend/tests/unit/test_conversations_status_filter_cap.py
+++ b/backend/tests/unit/test_conversations_status_filter_cap.py
@@ -1,0 +1,109 @@
+"""GET /v1/conversations and /v1/conversations/count must bound their comma-separated filters.
+
+Both endpoints split a comma-separated `statuses` (and the count route also `sources`) into a
+list that reaches an unchunked Firestore `in` filter in database/conversations.py:
+
+    conversations_ref.where(filter=FieldFilter('status', 'in', statuses))
+
+Firestore rejects an `in` filter with more than 30 values, and nothing wraps the query, so a
+request repeating the query key past thirty raises out of the client and surfaces as an unhandled
+HTTP 500 on the core conversation-list route the app hits constantly. ConversationStatus has five
+legitimate values, so this is malformed-input surface, not a real client shape.
+
+The fakes here mirror Firestore by raising above thirty values, so the tests prove the guard
+rejects with 400 before the query is built, rather than only checking the HTTP status.
+"""
+
+import os
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+import pytest
+from fastapi import HTTPException
+
+import routers.conversations as conv
+
+_FIRESTORE_IN_LIMIT = 30
+
+
+class _FirestoreLikeDB:
+    """Records the filter it was asked for and raises past the real Firestore `in` limit."""
+
+    def __init__(self):
+        self.last_statuses = None
+        self.last_sources = None
+
+    def get_conversations_without_photos(self, uid, limit, offset, *, statuses=(), **kwargs):
+        self.last_statuses = list(statuses)
+        if len(statuses) > _FIRESTORE_IN_LIMIT:
+            raise Exception("'in' filters support a maximum of 30 elements.")
+        return []
+
+    def get_conversations_count(self, uid, *, statuses=(), sources=(), **kwargs):
+        self.last_statuses = list(statuses)
+        self.last_sources = list(sources)
+        if len(statuses) > _FIRESTORE_IN_LIMIT or len(sources) > _FIRESTORE_IN_LIMIT:
+            raise Exception("'in' filters support a maximum of 30 elements.")
+        return 0
+
+
+@pytest.fixture
+def db(monkeypatch):
+    fake = _FirestoreLikeDB()
+    monkeypatch.setattr(conv, "conversations_db", fake)
+    monkeypatch.setattr(conv, "redact_conversations_for_list", lambda conversations: None)
+    return fake
+
+
+# --- list endpoint -----------------------------------------------------------------------
+
+
+def test_list_oversized_statuses_rejected_before_db(db):
+    oversized = ",".join(["completed"] * 40)
+
+    with pytest.raises(HTTPException) as ei:
+        conv.get_conversations(statuses=oversized, start_date=None, end_date=None, uid="u1")
+
+    assert ei.value.status_code == 400
+    # The guard fires before the query is built: the Firestore-like fake never saw the filter.
+    assert db.last_statuses is None
+
+
+def test_list_normal_statuses_reach_db(db):
+    result = conv.get_conversations(statuses="processing,completed", start_date=None, end_date=None, uid="u1")
+
+    assert result == []
+    assert db.last_statuses == ["processing", "completed"]
+
+
+# --- count endpoint ----------------------------------------------------------------------
+
+
+def test_count_oversized_statuses_rejected_before_db(db):
+    oversized = ",".join(["completed"] * 40)
+
+    with pytest.raises(HTTPException) as ei:
+        conv.get_conversations_count(statuses=oversized, sources=None, start_date=None, end_date=None, uid="u1")
+
+    assert ei.value.status_code == 400
+    assert db.last_statuses is None
+
+
+def test_count_oversized_sources_rejected_before_db(db):
+    oversized = ",".join(["omi"] * 40)
+
+    with pytest.raises(HTTPException) as ei:
+        conv.get_conversations_count(statuses=None, sources=oversized, start_date=None, end_date=None, uid="u1")
+
+    assert ei.value.status_code == 400
+    assert db.last_sources is None
+
+
+def test_count_normal_filters_reach_db(db):
+    result = conv.get_conversations_count(
+        statuses="processing,completed", sources=None, start_date=None, end_date=None, uid="u1"
+    )
+
+    assert result == {"count": 0}
+    assert db.last_statuses == ["processing", "completed"]


### PR DESCRIPTION
`GET /v1/conversations` and `GET /v1/conversations/count` both split a comma-separated `statuses`
filter (and the count route also a `sources` filter) into a list that reaches an unchunked
Firestore `in` filter in `database/conversations.py`:

```python
conversations_ref.where(filter=FieldFilter('status', 'in', statuses))
```

Firestore rejects an `in` filter with more than 30 values. The repo already knows this and guards
it elsewhere:

- `database/apps.py`: `# Firestore 'in' limited to 30 items`
- `database/chat.py`: `# Firestore IN operator supports max 30 values, so chunk the queries`

These two list/count endpoints do not, and nothing wraps the `stream()` call, so a request
repeating the query key past thirty (`?statuses=a,a,...`) raises out of the Firestore client and
surfaces as an unhandled **HTTP 500 on the core conversation-list route the app hits constantly**.

`ConversationStatus` has five legitimate values and the source set is small, so this is
malformed-input surface, not a shape any real client sends.

## The fix

A shared helper rejects an oversized filter with 400 before the query is built, applied to
`statuses` on both endpoints and to `sources` on the count endpoint. It rejects rather than clamps,
matching this file's own idiom (it already raises 400 for `start_date > end_date` and for combining
`statuses`+`sources`). With at most a handful of valid values, a cap of 20 cannot reject a request
any real client would send.

The check is in the handler body, not `Query(..., max_length=20)` on the parameter, so the
generated OpenAPI does not move (`docs/api-reference` is a compatibility boundary): the parameter
declarations are byte-identical to origin/main. That also keeps the bound testable, since a
`Query`-level constraint is enforced by FastAPI request parsing that a direct handler call bypasses.

## Tests

`tests/unit/test_conversations_status_filter_cap.py`:

- an oversized `statuses` filter on the list endpoint is rejected with 400 before the query
- an oversized `statuses` filter on the count endpoint is rejected with 400 before the query
- an oversized `sources` filter on the count endpoint is rejected with 400 before the query
- normal `statuses` filters reach the database unchanged on both endpoints

The fake standing in for the database seam mirrors Firestore by raising above thirty values, so the
tests assert the guard fires before the query is built rather than only checking the response.

## Verification

Run in `backend/`:

- `pytest tests/unit/test_conversations_status_filter_cap.py`: 5 passed
- prove-fail: with `routers/conversations.py` reverted to origin/main and confirmed byte-identical
  (`git diff origin/main` empty), the three oversized tests fail with
  `Exception: 'in' filters support a maximum of 30 elements.` while the two normal-path tests pass
  both ways. Re-applied: 5 passed
- pytest with `test_conversation_events_bounds.py` and `test_conversation_action_items_count.py`:
  14 passed
- the test imports `routers.conversations` at module scope, so the heavy router import is collection
  cost rather than per-test CPU; the file passes under the strict duration guard
  (`BACKEND_FAST_UNIT_FAIL_SECONDS=0.12`, exit 0)
- the diff changes no route signature or `response_model`, so no OpenAPI/generated-client
  regeneration is needed
- `black --line-length 120 --skip-string-normalization --check`: clean
- `pyright routers/conversations.py`: 0 errors
- `scripts/check_module_stub_pollution.py`: 0 violations
- `scripts/scan_async_blockers.py --dirs routers utils`: clean
- `routers/conversations.py` is not in the product file line-count ratchet baseline

## Related

This is the first-party counterpart of the same Firestore `in`-overflow class fixed on the
integration route in a separate PR (`GET /v2/integrations/{app_id}/conversations`). Same cause,
different route and parameter shape (comma-separated string here vs `List[str]` Query there).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

