### PR TITLE
Abort the merge instead of destroying a source's audio when its chunks fail to copy

### DIFF
--- a/backend/tests/unit/test_merge_audio_chunk_copy_failure.py
+++ b/backend/tests/unit/test_merge_audio_chunk_copy_failure.py
@@ -1,0 +1,100 @@
+"""A failed audio-chunk copy during merge must abort, not silently drop a source's audio.
+
+perform_merge_async copies every source conversation's audio chunks to the merged conversation
+(_copy_audio_chunks_for_merge), then in step 9 unconditionally deletes every source's original
+chunks. The copy helper used to wrap each conversation's copy in a try/except that only logged the
+error. Because `has_chunks` could already be True from an earlier source that copied fine, a later
+source whose copy threw (a transient GCS error, no adversarial input) left the helper returning a
+normal non-empty result. The merge then completed and deleted that source's original audio, which
+was never copied anywhere: the user's raw recording is destroyed with a merge-completed
+notification and only a log line as the record.
+
+The fix lets the failure propagate so perform_merge_async aborts into _handle_merge_failure before
+any source is deleted. These tests assert the propagation happens even after an earlier source
+copied successfully, which is the case the swallowing except masked.
+"""
+
+import os
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import utils.conversations.merge_conversations as merge
+
+
+class _FakeBucket:
+    """copy_blob raises when the source path belongs to a conversation in fail_for."""
+
+    def __init__(self, fail_for=()):
+        self._fail_for = set(fail_for)
+
+    def blob(self, path):
+        b = MagicMock()
+        b.path = path
+        return b
+
+    def copy_blob(self, source_blob, _bucket, _new_path):
+        for conv_id in self._fail_for:
+            if f'/{conv_id}/' in getattr(source_blob, 'path', ''):
+                raise Exception(f"simulated transient GCS copy error for {conv_id}")
+
+
+def _install(monkeypatch, *, chunks_by_conv, bucket, list_raises_for=()):
+    storage_client = MagicMock()
+    storage_client.bucket.return_value = bucket
+    monkeypatch.setattr(merge, "_get_storage_client", lambda: storage_client)
+
+    def _list_audio_chunks(uid, conv_id):
+        if conv_id in list_raises_for:
+            raise Exception(f"simulated transient GCS listing error for {conv_id}")
+        return chunks_by_conv.get(conv_id, [])
+
+    monkeypatch.setattr(merge, "list_audio_chunks", _list_audio_chunks)
+    monkeypatch.setattr(
+        merge.conversations_db,
+        "create_audio_files_from_chunks",
+        lambda uid, new_id: ["audio-file-record"],
+    )
+
+
+_CONVS = [{'id': 'conv_a'}, {'id': 'conv_b'}]
+_CHUNKS = {
+    'conv_a': [{'path': 'chunks/u1/conv_a/100.bin'}],
+    'conv_b': [{'path': 'chunks/u1/conv_b/200.bin'}],
+}
+
+
+def test_later_conversation_list_failure_propagates(monkeypatch):
+    # conv_a lists+copies fine (has_chunks becomes True), conv_b's listing throws.
+    _install(monkeypatch, chunks_by_conv=_CHUNKS, bucket=_FakeBucket(), list_raises_for={'conv_b'})
+
+    with pytest.raises(Exception):
+        merge._copy_audio_chunks_for_merge('u1', _CONVS, 'merged_1')
+
+
+def test_later_conversation_copy_failure_propagates(monkeypatch):
+    # conv_a copies fine, conv_b's copy_blob throws.
+    _install(monkeypatch, chunks_by_conv=_CHUNKS, bucket=_FakeBucket(fail_for={'conv_b'}))
+
+    with pytest.raises(Exception):
+        merge._copy_audio_chunks_for_merge('u1', _CONVS, 'merged_1')
+
+
+def test_all_conversations_copy_successfully_returns_audio_files(monkeypatch):
+    # No failure anywhere: the helper still returns the created audio-file records unchanged.
+    _install(monkeypatch, chunks_by_conv=_CHUNKS, bucket=_FakeBucket())
+
+    result = merge._copy_audio_chunks_for_merge('u1', _CONVS, 'merged_1')
+
+    assert result == ["audio-file-record"]
+
+
+def test_no_chunks_anywhere_returns_empty(monkeypatch):
+    # A source with genuinely no chunks is not a failure and must not abort the merge.
+    _install(monkeypatch, chunks_by_conv={}, bucket=_FakeBucket())
+
+    assert merge._copy_audio_chunks_for_merge('u1', _CONVS, 'merged_1') == []

--- a/backend/utils/conversations/merge_conversations.py
+++ b/backend/utils/conversations/merge_conversations.py
@@ -446,20 +446,20 @@ def _copy_audio_chunks_for_merge(
     for conv in conversations:
         conv_id = conv['id']
 
-        # List and copy chunks for this conversation
-        try:
-            chunks = list_audio_chunks(uid, conv_id)
-            for chunk in chunks:
-                has_chunks = True
+        # A copy failure here must propagate, not be swallowed. perform_merge_async deletes every
+        # source conversation's original audio chunks (step 9) after this returns, so a swallowed
+        # failure — while has_chunks may already be True from an earlier source — would let that
+        # deletion destroy audio that was never copied anywhere. Raising instead aborts the merge
+        # into _handle_merge_failure, which runs before any source is deleted.
+        chunks = list_audio_chunks(uid, conv_id)
+        for chunk in chunks:
+            has_chunks = True
 
-                # Preserve original filename (handles both single and batch blob naming)
-                original_filename = chunk['path'].split('/')[-1]
-                new_path = f'chunks/{uid}/{new_conversation_id}/{original_filename}'
-                source_blob = bucket.blob(chunk['path'])
-                bucket.copy_blob(source_blob, bucket, new_path)
-
-        except Exception as e:
-            logger.error(f"Error copying chunks for {conv_id}: {e}")
+            # Preserve original filename (handles both single and batch blob naming)
+            original_filename = chunk['path'].split('/')[-1]
+            new_path = f'chunks/{uid}/{new_conversation_id}/{original_filename}'
+            source_blob = bucket.blob(chunk['path'])
+            bucket.copy_blob(source_blob, bucket, new_path)
 
     # Create AudioFile records from copied chunks
     if has_chunks:


### PR DESCRIPTION
When two conversations are merged, a transient failure copying one source's audio silently
destroys that source's raw recording.

`perform_merge_async` copies every source conversation's audio chunks to the merged conversation
via `_copy_audio_chunks_for_merge`, then in step 9 unconditionally deletes every source's original
chunks (`_delete_conversation_and_related_data` -> `delete_conversation_audio_files`). The outer
handler that would abort into `_handle_merge_failure` only runs if an exception propagates out of
the copy.

The copy helper wrapped each conversation's copy in a per-conversation try/except that only logged
the error:

```python
try:
    chunks = list_audio_chunks(uid, conv_id)
    for chunk in chunks:
        has_chunks = True
        ...
        bucket.copy_blob(source_blob, bucket, new_path)
except Exception as e:
    logger.error(f"Error copying chunks for {conv_id}: {e}")
```

Because `has_chunks` can already be `True` from an earlier source that copied fine, a later source
whose `list_audio_chunks` or `copy_blob` throws (a transient GCS error, no adversarial input) leaves
the helper returning a normal non-empty result, indistinguishable from full success. The merge then
runs to completion and deletes that source's original audio, which was never copied anywhere.

**The user's raw recording is permanently destroyed**, with a merge-completed FCM notification and
only a log line as the record. Unlike derived data (action items, memories), raw audio cannot be
regenerated.

## The fix

Remove the swallowing try/except so a copy failure propagates. That makes `perform_merge_async`
abort into `_handle_merge_failure` before any source is deleted. That handler is the same recovery
path the merge already uses for every other mid-merge failure, so preserving all sources on a copy
failure is the existing contract, not new behavior. A source that genuinely has no chunks is an
empty list, not an exception, so it still does not abort.

This is a data-safety change in the conversation-merge path. It makes deletion strictly safer (it
never deletes audio that was not successfully copied); it does not add or change any deletion.

## Tests

`tests/unit/test_merge_audio_chunk_copy_failure.py`:

- a later source whose chunk listing throws propagates even after an earlier source copied fine
- a later source whose `copy_blob` throws propagates the same way
- an all-success merge still returns the created audio-file records unchanged
- a merge where no source has chunks returns empty without aborting

The fakes mirror Firestore/GCS by raising, so the tests assert the failure reaches the caller
rather than only checking a return value.

## Verification

Run in `backend/`:

- `pytest tests/unit/test_merge_audio_chunk_copy_failure.py`: 4 passed
- prove-fail: with `utils/conversations/merge_conversations.py` reverted to origin/main and
  confirmed byte-identical (`git diff origin/main` empty), the two propagation tests fail with
  `Failed: DID NOT RAISE <class 'Exception'>` while the two normal-path tests pass both ways.
  Re-applied: 4 passed
- this file is a `conversation_lifecycle` workflow-contract source, so the required contract tests
  were run: `test_conversation_lifecycle_contract.py` and
  `test_check_conversation_lifecycle_writes.py` 20 passed, and
  `scripts/check_conversation_lifecycle_writes.py` passes
- pytest with all `tests/unit/test_merge*.py`: 49 passed
- `black --line-length 120 --skip-string-normalization --check`: clean
- `pyright utils/conversations/merge_conversations.py`: 0 errors
- `scripts/check_module_stub_pollution.py`: 0 violations


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

