### PR TITLE
Guard the audio ring buffer against a non-positive client sample_rate

### DIFF
--- a/backend/tests/unit/test_audio_ring_buffer_nonpositive_rate.py
+++ b/backend/tests/unit/test_audio_ring_buffer_nonpositive_rate.py
@@ -1,0 +1,65 @@
+"""AudioRingBuffer must not crash on a non-positive sample_rate or duration.
+
+sample_rate reaches AudioRingBuffer straight from the /v4/listen WebSocket query parameter
+(routers/transcribe.py: `sample_rate: int = 8000`, no gt=0). validate_audio_format only
+range-checks sample_rate for the opus codecs, so for the default pcm codec a client can send 0 or
+a negative value. When speaker identification is enabled (a normal state for a user with an
+enrolled speech profile or private-cloud sync), routers/listen/runtime.py builds
+AudioRingBuffer(duration, request.sample_rate), and receiver.py writes to it on the first audio
+frame.
+
+Before the guard:
+- sample_rate=0 -> capacity 0 -> bytearray(0); the first write() did buffer[0] = byte, raising
+  IndexError (and % capacity would raise ZeroDivisionError), which was uncaught in the WS receive
+  loop and killed the live-transcription session on its first audio frame.
+- a negative sample_rate -> negative capacity -> bytearray(negative) raised ValueError during
+  session bootstrap.
+
+The guard mirrors resample_pcm, which already treats a non-positive rate as a no-op.
+"""
+
+from utils.audio import AudioRingBuffer
+
+
+def test_zero_sample_rate_write_does_not_raise():
+    buf = AudioRingBuffer(duration_seconds=30.0, sample_rate=0)
+
+    # The first audio frame must not crash the session.
+    buf.write(b"\x01\x02\x03\x04", timestamp=100.0)
+
+    # Nothing is buffered, which the extraction/speaker path already treats as "no audio".
+    assert buf.get_time_range() is None
+    assert buf.extract(0.0, 1000.0) is None
+
+
+def test_negative_sample_rate_construction_does_not_raise():
+    buf = AudioRingBuffer(duration_seconds=30.0, sample_rate=-16000)
+
+    buf.write(b"\x01\x02", timestamp=100.0)
+    assert buf.get_time_range() is None
+
+
+def test_zero_duration_does_not_raise():
+    buf = AudioRingBuffer(duration_seconds=0.0, sample_rate=16000)
+
+    buf.write(b"\x01\x02", timestamp=100.0)
+    assert buf.get_time_range() is None
+
+
+def test_normal_positive_rate_still_buffers_and_extracts():
+    rate = 16000
+    buf = AudioRingBuffer(duration_seconds=30.0, sample_rate=rate)
+
+    # One second of PCM16 mono at 16 kHz is 32000 bytes.
+    one_second = bytes(rate * 2)
+    buf.write(one_second, timestamp=100.0)
+
+    time_range = buf.get_time_range()
+    assert time_range is not None
+    start_ts, end_ts = time_range
+    assert end_ts == 100.0
+    assert abs((end_ts - start_ts) - 1.0) < 1e-6
+
+    extracted = buf.extract(99.5, 100.0)
+    assert extracted is not None
+    assert len(extracted) > 0

--- a/backend/utils/audio.py
+++ b/backend/utils/audio.py
@@ -7,7 +7,12 @@ class AudioRingBuffer:
     def __init__(self, duration_seconds: float, sample_rate: int):
         self.sample_rate = sample_rate
         self.bytes_per_second = sample_rate * 2  # PCM16 mono
-        self.capacity = int(duration_seconds * self.bytes_per_second)
+        # A non-positive sample_rate or duration yields a zero (or, unclamped, negative) capacity.
+        # sample_rate reaches here straight from the /v4/listen query param, which is only range
+        # checked for opus codecs, so a pcm client can send 0 or a negative value. Clamp so
+        # bytearray() cannot raise "negative count" at construction. Mirrors resample_pcm, which
+        # guards the same non-positive rate.
+        self.capacity = max(0, int(duration_seconds * self.bytes_per_second))
         self.buffer = bytearray(self.capacity)
         self.write_pos = 0
         self.total_bytes_written = 0
@@ -15,6 +20,12 @@ class AudioRingBuffer:
 
     def write(self, data: bytes, timestamp: float):
         """Append audio data with timestamp."""
+        if self.capacity <= 0:
+            # Zero-capacity buffer (non-positive sample_rate/duration): skip rather than IndexError
+            # on buffer[0] or ZeroDivisionError on % capacity when the first audio frame arrives.
+            # last_write_timestamp stays None, so get_time_range()/extract() report nothing buffered
+            # and speaker matching handles that, keeping the live session alive.
+            return
         for byte in data:
             self.buffer[self.write_pos] = byte
             self.write_pos = (self.write_pos + 1) % self.capacity


### PR DESCRIPTION
`AudioRingBuffer` receives `sample_rate` straight from the `/v4/listen` WebSocket query parameter
(`routers/transcribe.py`: `sample_rate: int = 8000`, with no `gt=0` constraint).
`validate_audio_format` only range-checks `sample_rate` for the opus codecs, so for the default
pcm codec a client can send 0 or a negative value. When speaker identification is enabled (a normal
state for a user with an enrolled speech profile or private-cloud sync),
`routers/listen/runtime.py` builds `AudioRingBuffer(duration, request.sample_rate)`, and
`routers/listen/receiver.py` writes to it on the first audio frame.

```python
self.capacity = int(duration_seconds * self.bytes_per_second)   # bytes_per_second = rate * 2
self.buffer = bytearray(self.capacity)
...
def write(self, data, timestamp):
    for byte in data:
        self.buffer[self.write_pos] = byte
        self.write_pos = (self.write_pos + 1) % self.capacity
```

- `sample_rate=0` makes capacity 0, so `bytearray(0)` succeeds but the first `write()` does
  `buffer[0] = byte` (IndexError) or `% capacity` (ZeroDivisionError). That exception is uncaught in
  the WS receive loop, so it ends that lifetime task and **kills the live-transcription session on
  its very first audio frame**.
- a negative `sample_rate` makes capacity negative, so `bytearray(negative)` raises ValueError
  during session bootstrap.

## The fix

Clamp capacity non-negative and make `write()` a no-op when capacity is not positive.
`last_write_timestamp` then stays `None`, which `get_time_range()` and `extract()` already treat as
"nothing buffered", and `routers/listen/speakers.py` handles that `None`. So the session stays
alive and transcription continues; only the speaker-id buffer is empty.

This mirrors `resample_pcm` in `utils/listen_audio.py`, which already guards the same non-positive
rate from the same request field. A cleaner boundary-level rejection (`validate_audio_format`
refusing `sample_rate <= 0` for pcm) is a larger change to connection-acceptance behavior; guarding
the buffer matches the established sibling pattern and keeps the change surgical.

## Tests

`tests/unit/test_audio_ring_buffer_nonpositive_rate.py`:

- a zero `sample_rate` does not raise on write and reports nothing buffered
- a negative `sample_rate` does not raise at construction
- a zero duration does not raise on write
- a normal positive `sample_rate` still buffers and extracts audio correctly

## Verification

Run in `backend/`:

- `pytest tests/unit/test_audio_ring_buffer_nonpositive_rate.py`: 4 passed
- prove-fail: with `utils/audio.py` reverted to origin/main and confirmed byte-identical
  (`git diff origin/main` empty), the three edge tests fail with
  `IndexError: bytearray index out of range`, `ValueError: negative count`, and another IndexError
  respectively, while the normal-path test passes both ways. Re-applied: 4 passed
- pytest with the existing `test_audio_ring_buffer_*.py`: 10 passed
- pytest `test_speaker_id_pipeline.py -k RingBuffer` (the buffer's real consumer): 20 passed
- `black --line-length 120 --skip-string-normalization --check`: clean
- `pyright utils/audio.py`: 0 errors
- `scripts/check_module_stub_pollution.py`: 0 violations
- `utils/audio.py` is not in the product file line-count ratchet baseline, and no route signature
  or Pydantic model changed, so no OpenAPI regeneration is needed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

