### PR TITLE
Skip external task sync when an action item is already exported

### DIFF
--- a/backend/tests/unit/test_task_sync_cloud_export_dedup.py
+++ b/backend/tests/unit/test_task_sync_cloud_export_dedup.py
@@ -1,0 +1,120 @@
+import asyncio
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from testing.import_isolation import load_module_fresh, stub_modules
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _module(name: str, **attributes: Any) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    return module
+
+
+def _stubs(store: dict[str, dict[str, Any]], create_calls: list[dict[str, Any]], *, default_app: str = 'todoist'):
+    """Stub the database + integration ops so utils.task_sync loads without google.cloud.firestore.
+
+    ``store`` maps action-item id to its persisted Firestore document. The stubbed
+    ``get_action_item`` reads from it and ``update_action_item`` writes the export fields back,
+    so a second auto-sync sees ``exported=True`` exactly like a retry against real Firestore.
+    """
+
+    def get_action_item(_uid: str, item_id: str):
+        return store.get(item_id)
+
+    def update_action_item(_uid: str, item_id: str, updates: dict[str, Any]) -> None:
+        store.setdefault(item_id, {}).update(updates)
+
+    async def create_task_internal(**kwargs: Any) -> dict[str, Any]:
+        create_calls.append(kwargs)
+        return {'success': True, 'external_task_id': f'ext-{len(create_calls)}'}
+
+    return {
+        'database.users': _module(
+            'database.users',
+            get_default_task_integration=lambda _uid: default_app,
+            get_task_integration=lambda _uid, _app: {'connected': True},
+        ),
+        'database.action_items': _module(
+            'database.action_items',
+            get_action_item=get_action_item,
+            update_action_item=update_action_item,
+            batch_set_sync_requested=lambda *_a, **_k: None,
+        ),
+        'utils.notifications': _module(
+            'utils.notifications',
+            send_apple_reminders_sync_push_async=lambda **_k: None,
+        ),
+        'utils.task_integrations_ops': _module(
+            'utils.task_integrations_ops',
+            create_task_internal=create_task_internal,
+        ),
+    }
+
+
+def test_retried_cloud_sync_does_not_create_a_second_external_task() -> None:
+    store = {'task-1': {'id': 'task-1', 'description': 'Plan launch'}}
+    create_calls: list[dict[str, Any]] = []
+
+    with stub_modules(_stubs(store, create_calls)):
+        task_sync = load_module_fresh('utils.task_sync', str(BACKEND_DIR / 'utils' / 'task_sync.py'))
+
+        async def exercise():
+            item = {'id': 'task-1', 'description': 'Plan launch'}
+            first = await task_sync.auto_sync_action_item('user-1', item)
+            # The client retried the create. The router deduped the Firestore document to the same
+            # id and submitted auto-sync a second time with the same payload.
+            second = await task_sync.auto_sync_action_item('user-1', item)
+            return first, second
+
+        first, second = asyncio.run(exercise())
+
+    assert first['synced'] is True
+    assert first['platform'] == 'todoist'
+    # The external task is created exactly once across the retry.
+    assert len(create_calls) == 1
+    assert second['synced'] is True
+    assert second.get('reason') == 'already_exported'
+    assert store['task-1'].get('exported') is True
+
+
+def test_batch_cloud_sync_skips_items_already_exported() -> None:
+    store = {
+        'task-a': {'id': 'task-a', 'description': 'Already done', 'exported': True},
+        'task-b': {'id': 'task-b', 'description': 'Fresh'},
+    }
+    create_calls: list[dict[str, Any]] = []
+
+    with stub_modules(_stubs(store, create_calls)):
+        task_sync = load_module_fresh('utils.task_sync', str(BACKEND_DIR / 'utils' / 'task_sync.py'))
+
+        items = [
+            {'id': 'task-a', 'description': 'Already done'},
+            {'id': 'task-b', 'description': 'Fresh'},
+        ]
+        results = asyncio.run(task_sync.auto_sync_action_items_batch('user-1', items))
+
+    # Only the not-yet-exported item hits the external service.
+    assert len(create_calls) == 1
+    assert create_calls[0]['title'] == 'Fresh'
+    assert results[0].get('reason') == 'already_exported'
+    assert results[1]['synced'] is True
+
+
+def test_first_cloud_sync_creates_the_external_task() -> None:
+    store = {'task-9': {'id': 'task-9', 'description': 'Write notes'}}
+    create_calls: list[dict[str, Any]] = []
+
+    with stub_modules(_stubs(store, create_calls)):
+        task_sync = load_module_fresh('utils.task_sync', str(BACKEND_DIR / 'utils' / 'task_sync.py'))
+
+        item = {'id': 'task-9', 'description': 'Write notes'}
+        result = asyncio.run(task_sync.auto_sync_action_item('user-1', item))
+
+    assert result['synced'] is True
+    assert len(create_calls) == 1
+    assert store['task-9'].get('exported') is True

--- a/backend/utils/task_sync.py
+++ b/backend/utils/task_sync.py
@@ -56,6 +56,16 @@ async def _sync_to_cloud_service(
     uid: str, app_key: str, integration: Dict[str, Any], action_item: Dict[str, Any]
 ) -> Dict[str, Any]:
     """Create task in external service using shared task integration ops."""
+    # A retried POST /v1/action-items dedups the Firestore document by idempotency key but still
+    # submits auto-sync, and create_task_internal has no idempotency key of its own. Re-read the
+    # persisted export state and skip the external call when the item was already exported, so a
+    # retry does not create a second task in the user's Todoist/Asana/ClickUp/Google Tasks.
+    item_id = action_item.get("id")
+    if item_id:
+        existing = await run_blocking(db_executor, action_items_db.get_action_item, uid, item_id)
+        if existing and existing.get("exported"):
+            return {"synced": True, "platform": app_key, "reason": "already_exported"}
+
     async with httpx.AsyncClient(timeout=10.0) as client:
         result = await create_task_internal(
             uid=uid,


### PR DESCRIPTION
## Problem

`POST /v1/action-items` is content-idempotent on the Firestore document: a retried request with
the same (uid, description) resolves to the same action-item id via
`create_action_item(..., idempotency_key=...)`, so it does not create a duplicate document. The
router documents this.

But regardless of whether that call created a new document or returned a pre-existing one, the
router unconditionally submits `_run_auto_sync`, which calls `auto_sync_action_item` then
`_sync_to_cloud_service` then `create_task_internal`. `create_task_internal` does a real POST to the
user's connected Todoist, Asana, ClickUp, or Google Tasks account, and it has no idempotency key of
its own.

So a retried create (network timeout, client retry, duplicate delivery) correctly dedups the
Firestore document but creates a second duplicate task in the user's external task app. That is a
persistent, user-visible artifact they have to find and delete by hand.

`_sync_to_cloud_service` sets `exported: True` on the action item only after the external call
succeeds, and nothing reads that flag before the call, so the mark never prevents a repeat.

## Fix

Re-read the persisted `exported` flag at the top of `_sync_to_cloud_service` and skip the external
call when the item was already exported.

The re-read is required rather than trusting the passed dict, because the router passes the request
payload (which never carries `exported`), and the flag is only set on the persisted document by a
prior successful sync.

`_sync_to_cloud_service` is the single shared helper used by both `auto_sync_action_item` (the
router-create path and the candidate-dispatch path) and `auto_sync_action_items_batch`
(conversation extraction). The router-create path has no dedup guard today, so this closes it. The
candidate-dispatch path already holds a `claim_candidate_integration_dispatch` lease, so there this
is defense-in-depth.

The result is reported as `synced: True` on the skip, not `False`, because the candidate-dispatch
path treats a `synced: False` result with an unrecognized reason as a dispatch failure and would
requeue it. Already-exported means the sync goal is already satisfied, so success is the honest and
safe report.

This does not add a cross-connection lease, so it does not by itself close a truly concurrent
duplicate delivery (two overlapping requests that both read `exported` as false before either
writes it). It closes the dominant sequential-retry case, where the first request has completed and
set the flag before the retry's sync runs. A lease on this path, matching the candidate-dispatch
pattern, is the larger follow-up for the concurrent window.

## Tests

`tests/unit/test_task_sync_cloud_export_dedup.py` (new), using the sanctioned
`stub_modules`/`load_module_fresh` seam so it does not import the real `google.cloud.firestore`
chain:

- a retried cloud sync creates the external task exactly once and reports already_exported on the retry
- a batch sync skips the item already marked exported and syncs only the fresh one
- a first-time cloud sync still creates the external task and marks the item exported

## Verification

Run in `backend/`:

- `pytest tests/unit/test_task_sync_cloud_export_dedup.py`: 3 passed
- prove-fail: with `utils/task_sync.py` reverted to origin/main and confirmed byte-identical
  (`git diff origin/main` empty), the retry and batch tests fail with `create_task_internal` called
  twice (the duplicate external task), while the first-sync test passes. Reapplied: 3 passed
- `pytest test_task_sync_async.py test_task_sync_apple_async_boundary.py test_action_item_idempotency.py test_task_sync_cloud_export_dedup.py`: 21 passed
- `pytest test_workstream_core.py test_workstream_router_contract.py test_candidate_lifecycle.py test_candidates_router.py`: 111 passed (the workflow-contract and candidate-dispatch suites that consume this path)
- `black --line-length 120 --skip-string-normalization --check`: clean
- `pyright -p pyrightconfig.json utils/task_sync.py`: 0 errors, unchanged from the origin/main baseline
- `scripts/check_module_stub_pollution.py`: 0 violations
- `scripts/scan_async_blockers.py --dirs routers utils`: 0 findings
- `scripts/scan_import_time_side_effects.py`: 0 violations
- `scripts/pr-preflight --suggest`: product invariants affected none, no failure-class declaration required


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

