### PR TITLE
Preserve a legitimate zero start timestamp on mentor segments

### DIFF
--- a/backend/tests/unit/test_mentor_notification_segment_start_zero.py
+++ b/backend/tests/unit/test_mentor_notification_segment_start_zero.py
@@ -1,0 +1,80 @@
+"""Regression: a mentor segment whose ``start`` is a legitimate 0.0 (the first utterance of a
+capture) must keep that timestamp, not be stamped with wall-clock time and sorted to the end of the
+chronologically ordered mentor context handed to the proactive-notification LLM.
+
+``utils.mentor_notifications`` imports ``database.notifications`` (Firestore) at import time, so it
+is loaded through the sanctioned ``stub_modules`` / ``load_module_fresh`` seam rather than imported
+directly. Each load gets a fresh module-global ``message_buffer``, so no state leaks between tests.
+"""
+
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Iterator
+
+from testing.import_isolation import load_module_fresh, stub_modules
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _module(name: str, **attributes: Any) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    return module
+
+
+@contextmanager
+def _loaded_mentor(frequency: int = 3) -> Iterator[ModuleType]:
+    stubs = {
+        'database.notifications': _module(
+            'database.notifications',
+            get_mentor_notification_frequency=lambda _uid: frequency,
+        ),
+    }
+    with stub_modules(stubs):
+        mentor = load_module_fresh(
+            'utils.mentor_notifications',
+            str(BACKEND_DIR / 'utils' / 'mentor_notifications.py'),
+        )
+        yield mentor
+
+
+def _spaced_segments(first_start: float) -> list[dict[str, Any]]:
+    """Ten segments (== MIN_NEW_SEGMENTS_FOR_ANALYSIS) whose first starts at ``first_start``.
+
+    Starts are 10s apart and ``is_user`` alternates so none coalesce (the buffer only merges
+    consecutive same-speaker segments within 2s), yielding ten distinct messages that trigger a
+    return.
+    """
+    segments = [{'text': 'opening line', 'start': first_start, 'is_user': True}]
+    for i in range(1, 10):
+        segments.append({'text': f'line {i}', 'start': float(i * 10), 'is_user': i % 2 == 0})
+    return segments
+
+
+def test_first_segment_start_zero_stays_first_in_sorted_context() -> None:
+    with _loaded_mentor() as mentor:
+        result = mentor.process_mentor_notification('user-zero-start', _spaced_segments(0.0))
+
+        assert result is not None
+        # Direct bug assertion: the opening line keeps its real capture start of 0.0. On the unfixed
+        # ``... or current_time`` code this is wall-clock time (~1.78e9).
+        opening = next(m for m in result if m['text'] == 'opening line')
+        assert opening['timestamp'] == 0.0
+        # And therefore stays first in the timestamp-sorted context handed to the mentor LLM.
+        assert result[0]['text'] == 'opening line'
+
+
+def test_missing_segment_start_still_falls_back_to_wall_clock() -> None:
+    """The fix must preserve the original fallback: a segment with no ``start`` still gets a
+    wall-clock timestamp (not 0.0, not a crash)."""
+    with _loaded_mentor() as mentor:
+        # No 'start' key at all; alternate is_user so the ten messages stay distinct.
+        segments = [{'text': f'line {i}', 'is_user': i % 2 == 0} for i in range(10)]
+
+        result = mentor.process_mentor_notification('user-missing-start', segments)
+
+        assert result is not None
+        # 1e9 seconds is ~year 2001; every real wall-clock stamp is well above it.
+        assert all(m['timestamp'] > 1_000_000_000 for m in result)

--- a/backend/utils/mentor_notifications.py
+++ b/backend/utils/mentor_notifications.py
@@ -115,7 +115,14 @@ def process_mentor_notification(uid: str, segments: List[Dict[str, Any]]) -> Lis
 
         text = segment['text'].strip()
         if text:
-            timestamp = segment.get('start', 0) or current_time
+            # A segment's ``start`` is relative capture seconds, so a legitimate 0.0 (the first
+            # utterance beginning at capture start) is a real timestamp, not a missing value.
+            # ``segment.get('start', 0) or current_time`` treated 0.0 as falsy and replaced it with
+            # wall-clock time, which sorted that opening line to the END of the timestamp-ordered
+            # context built below. Preserve a real numeric start; fall back to wall-clock only when
+            # ``start`` is genuinely absent or non-numeric.
+            raw_start = segment.get('start')
+            timestamp = raw_start if isinstance(raw_start, (int, float)) else current_time
             is_user = segment.get('is_user', False)
 
             # Count words after silence


### PR DESCRIPTION
## Problem

`process_mentor_notification` in `utils/mentor_notifications.py` buffers realtime transcript
segments and, when enough accumulate, returns them sorted by timestamp as the conversation context
for the proactive mentor-notification LLM (`evaluate_relevance` / `generate_notification` /
`validate_notification`).

Each segment's timestamp came from:

```python
timestamp = segment.get('start', 0) or current_time
```

A transcript segment's `start` is relative capture seconds. The first utterance of a capture
legitimately begins at `start == 0.0`, and `0.0` is falsy, so `... or current_time` replaced that
real timestamp with wall-clock time (`time.time()`, about 1.78e9). The opening line was then sorted
to the END of the timestamp-ordered context handed to the mentor LLM, and it stays pinned last
across later analysis windows because every later relative start is far below wall-clock time.

The segments reaching this function come from the live realtime path
(`app_integrations._async_trigger_realtime_integrations`, fed by `routers/listen/transcripts.py`
and `routers/pusher.py`), where `start` is relative to session start. The pipeline itself treats
`raw_segments[0]['start']` as a small relative offset (`routers/listen/transcripts.py`), so a first
segment at exactly `0.0` is a normal STT output.

## Scope

This is a correctness bug with modest impact: it only bites when the first buffered segment's
`start` is exactly `0.0`, and the consequence is a mis-ordered conversation context for the mentor
notification (the opening line placed last), which can subtly affect what proactive notification is
generated. It does not crash, lose data, or touch any auth boundary.

## Fix

Preserve a real numeric `start` (including `0.0`) and fall back to wall-clock time only when `start`
is genuinely absent or non-numeric:

```python
raw_start = segment.get('start')
timestamp = raw_start if isinstance(raw_start, (int, float)) else current_time
```

This keeps the original missing-start fallback intent and additionally avoids a latent sort crash
if a non-numeric `start` ever arrived (mixed str/float keys would raise in `sorted`). It is the
same "a valid falsy or edge numeric must not be treated as missing" class as the recent
AudioRingBuffer non-positive `sample_rate` guard.

## Tests

`tests/unit/test_mentor_notification_segment_start_zero.py` (new), using the sanctioned
`stub_modules`/`load_module_fresh` seam so it does not import the real `google.cloud.firestore`
chain:

- a first segment at `start == 0.0` keeps timestamp `0.0` and stays first in the sorted context
- a segment with no `start` still falls back to a wall-clock timestamp

## Verification

Run in `backend/`:

- `pytest tests/unit/test_mentor_notification_segment_start_zero.py`: 2 passed
- prove-fail: with `utils/mentor_notifications.py` reverted to origin/main and confirmed
  byte-identical (`git diff origin/main` empty), the start-zero test fails with
  `assert 1784551851.3 == 0.0` (the opening line stamped with wall-clock time), while the
  missing-start fallback test passes. Reapplied: 2 passed
- `pytest tests/unit/test_mentor_notifications.py tests/unit/test_mentor_notification_segment_start_zero.py`: 47 passed (the full existing mentor suite plus the new file)
- `black --line-length 120 --skip-string-normalization --check`: clean
- `pyright -p pyrightconfig.json utils/mentor_notifications.py`: 0 errors, 0 warnings
- `scripts/check_module_stub_pollution.py`: 0 violations
- `scripts/scan_async_blockers.py --dirs routers utils`: 0 findings
- `scripts/scan_import_time_side_effects.py`: 0 violations
- `scripts/pr-preflight --suggest`: product invariants affected none, no failure-class declaration required


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

