### PR TITLE
fix(desktop): clear all onboarding state on sign-out via one shared key list

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/AuthService.swift": 3303,
+    "desktop/macos/Desktop/Sources/AuthService.swift": 3298,
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4179,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1578,

--- a/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
@@ -153,23 +153,14 @@ extension AppState {
       DispatchQueue.main.sync(execute: postResetNotification)
     }
 
-    // Clear onboarding-related UserDefaults keys (thread-safe, after live state)
-    let onboardingKeys = [
-      "hasCompletedOnboarding",
-      "onboardingStep",
-      "hasSeenRewindIntro",
-      "hasTriggeredNotification",
-      "hasTriggeredAutomation",
-      "hasTriggeredScreenRecording",
-      "hasTriggeredMicrophone",
-      "hasTriggeredSystemAudio",
-      "hasTriggeredAccessibility",
-      "hasTriggeredBluetooth",
-      "onboardingJustCompleted",
-    ]
-    for key in onboardingKeys {
-      UserDefaults.standard.removeObject(forKey: key)
-    }
+    // Clear onboarding-related UserDefaults keys (thread-safe, after live state).
+    // Shared list with AuthService.signOut so a new onboarding key can't be
+    // forgotten at one site.
+    OnboardingFlow.clearPersistedState()
+    // hasCompletedOnboarding lives on AppState (@AppStorage on an
+    // ObservableObject); the .resetOnboardingRequested handler above set it to
+    // false, this drops the persisted key before the restart.
+    UserDefaults.standard.removeObject(forKey: DefaultsKey.hasCompletedOnboarding)
     UserDefaults.standard.synchronize()
     log("Cleared onboarding UserDefaults keys")
 

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -3000,15 +3000,10 @@ class AuthService {
     NotificationCenter.default.post(name: .userDidSignOut, object: nil)
 
     // Clear non-@AppStorage onboarding keys via UserDefaults (these work fine).
-    UserDefaults.standard.removeObject(forKey: "onboardingStep")
-    UserDefaults.standard.removeObject(forKey: "hasTriggeredNotification")
-    UserDefaults.standard.removeObject(forKey: "hasTriggeredAutomation")
-    UserDefaults.standard.removeObject(forKey: "hasTriggeredScreenRecording")
-    UserDefaults.standard.removeObject(forKey: "hasTriggeredMicrophone")
-    UserDefaults.standard.removeObject(forKey: "hasTriggeredSystemAudio")
-    UserDefaults.standard.removeObject(forKey: "onboardingChatMessages")
-    UserDefaults.standard.removeObject(forKey: "onboardingACPSessionId")
-    UserDefaults.standard.removeObject(forKey: "onboardingJustCompleted")
+    // Shared list with resetOnboardingAndRestart so a new onboarding key
+    // can't be forgotten at one site and leak to the next account.
+    OnboardingFlow.clearPersistedState()
+    OnboardingChatPersistence.clear()
 
     // screenAnalysisEnabled: Don't removeObject here — SettingsSyncManager overwrites
     // it from the server within ~200ms of sign-in. Instead, onboarding force-starts

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingFlow.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingFlow.swift
@@ -141,4 +141,45 @@ enum OnboardingFlow {
   ) -> Bool {
     observedShortcutPress && (voiceTurnPhase == nil || voiceTurnPhase?.isTerminal == true)
   }
+
+  /// Account-scoped onboarding UserDefaults keys, cleared on both sign-out
+  /// (`AuthService.signOut`) and onboarding reset
+  /// (`AppState.resetOnboardingAndRestart`) via `clearPersistedState`. Any new
+  /// persisted onboarding key MUST be added here so it can't be forgotten at
+  /// one clearing site and leak across accounts on the same Mac.
+  ///
+  /// Deliberately excluded:
+  /// - "hasCompletedOnboarding": @AppStorage on AppState (an ObservableObject)
+  ///   caches internally and writes back after removeObject(); it is reset via
+  ///   the `.userDidSignOut` / `.resetOnboardingRequested` handlers in
+  ///   DesktopHomeView (plus a belt-and-suspenders removeObject at the reset
+  ///   site, which restarts the app anyway).
+  /// - "screenAnalysisEnabled": SettingsSyncManager overwrites it from the
+  ///   server within ~200ms of sign-in; onboarding force-starts monitoring
+  ///   regardless of this setting.
+  /// - onboarding chat keys (mid-onboarding/exploration state, legacy
+  ///   "onboardingChatMessages"/"onboardingACPSessionId"): owned by
+  ///   `OnboardingChatPersistence.clear()`, which both sites call.
+  static let persistedStateKeys: [String] = [
+    "onboardingStep",
+    "onboardingJustCompleted",
+    "hasSeenRewindIntro",
+    "hasTriggeredNotification",
+    "hasTriggeredAutomation",
+    "hasTriggeredScreenRecording",
+    "hasTriggeredMicrophone",
+    "hasTriggeredSystemAudio",
+    "hasTriggeredAccessibility",
+    "hasTriggeredBluetooth",
+  ]
+
+  /// Remove every account-scoped onboarding key. Mounted-@AppStorage values
+  /// that need a live reset (e.g. `onboardingStep` while OnboardingView is
+  /// showing) are handled by the notification handlers; this clears the
+  /// persisted backing store.
+  static func clearPersistedState(in defaults: UserDefaults = .standard) {
+    for key in persistedStateKeys {
+      defaults.removeObject(forKey: key)
+    }
+  }
 }

--- a/desktop/macos/Desktop/Tests/AuthSessionCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthSessionCoordinatorTests.swift
@@ -82,12 +82,15 @@ final class AuthSessionCoordinatorTests: XCTestCase {
     let signOutTail = authSource[signOutRange!.lowerBound...]
     let signOutEnd = signOutTail.range(of: "// MARK: - Helper Methods")?.lowerBound ?? signOutTail.endIndex
     let signOutSnippet = String(signOutTail[..<signOutEnd])
-    XCTAssertTrue(signOutSnippet.contains("onboardingStep"))
+    // Onboarding wipe now routes through the shared clearing helpers
+    // (OnboardingFlow.persistedStateKeys), not a hand-rolled key list.
+    XCTAssertTrue(signOutSnippet.contains("OnboardingFlow.clearPersistedState()"))
     XCTAssertTrue(signOutSnippet.contains("userDidSignOut"))
 
     let invalidateRange = authSource.range(of: "func performLightSessionInvalidation()")
     XCTAssertNotNil(invalidateRange)
     let invalidateSnippet = String(authSource[invalidateRange!.lowerBound...]).prefix(500)
+    XCTAssertFalse(invalidateSnippet.contains("clearPersistedState"))
     XCTAssertFalse(invalidateSnippet.contains("onboardingStep"))
     XCTAssertFalse(invalidateSnippet.contains("userDidSignOut"))
     XCTAssertFalse(invalidateSnippet.contains("stopTranscription"))

--- a/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for onboarding state leaking across accounts on the
+/// same Mac: sign-out and onboarding-reset each kept a hand-maintained key
+/// list, so keys present at only one site (e.g. hasSeenRewindIntro,
+/// hasTriggeredAccessibility, the onboarding-chat exploration state) were
+/// cleared at neither on the other path. A user who deleted their account and
+/// re-onboarded saw the previous run's answers still filled in. Both sites now
+/// iterate the shared `OnboardingFlow.persistedStateKeys` via
+/// `clearPersistedState` and call `OnboardingChatPersistence.clear()`.
+final class OnboardingPersistenceClearingTests: XCTestCase {
+  func testClearPersistedStateRemovesEverySharedKey() throws {
+    let suiteName = "OnboardingPersistenceClearingTests-\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    for key in OnboardingFlow.persistedStateKeys {
+      defaults.set("leaked-from-previous-account", forKey: key)
+    }
+
+    OnboardingFlow.clearPersistedState(in: defaults)
+
+    for key in OnboardingFlow.persistedStateKeys {
+      XCTAssertNil(defaults.object(forKey: key), "\(key) must be cleared by clearPersistedState")
+    }
+  }
+
+  func testSharedListCoversAccountScopedOnboardingKeys() {
+    // The keys sign-out historically missed, plus onboardingStep as the
+    // canonical member.
+    let required = [
+      "onboardingStep",
+      "hasSeenRewindIntro",
+      "hasTriggeredAccessibility",
+      "hasTriggeredBluetooth",
+    ]
+    for key in required {
+      XCTAssertTrue(
+        OnboardingFlow.persistedStateKeys.contains(key),
+        "\(key) is account-scoped and must be in the shared clearing list")
+    }
+  }
+
+  /// An earlier version of this fix was silently reverted when a merge
+  /// resolved AuthService.swift toward a wholesale reformat that still carried
+  /// the old hand-rolled key list — and the suite stayed green because it only
+  /// tested clearPersistedState in isolation. Behavioral coverage of signOut()
+  /// would need a live Firebase session, so pin the call sites statically.
+  func testSignOutClearsOnboardingStateViaSharedList() throws {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // -> Tests/
+      .deletingLastPathComponent()  // -> Desktop/
+      .appendingPathComponent("Sources/AuthService.swift")
+    // A merge reintroducing a hand-rolled removeObject list regresses silently.
+    // omi-test-quality: source-inspection -- static contract: signOut() must use the shared clearing helpers
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+    let signOutStart = try XCTUnwrap(source.range(of: "func signOut() async throws {"))
+    let tail = source[signOutStart.lowerBound...]
+    XCTAssertNotNil(
+      tail.range(of: "OnboardingFlow.clearPersistedState()"),
+      "signOut() must clear onboarding keys via the shared OnboardingFlow.persistedStateKeys list")
+    XCTAssertNotNil(
+      tail.range(of: "OnboardingChatPersistence.clear()"),
+      "signOut() must clear onboarding chat/exploration state via OnboardingChatPersistence.clear()")
+    XCTAssertNil(
+      tail.range(of: "removeObject(forKey: \"onboardingStep\")"),
+      "signOut() must not keep a hand-rolled onboarding key list alongside the shared helper")
+  }
+
+  /// Same static contract for the onboarding-reset site.
+  func testResetOnboardingClearsStateViaSharedList() throws {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // -> Tests/
+      .deletingLastPathComponent()  // -> Desktop/
+      .appendingPathComponent("Sources/AppState/AppState+SystemActions.swift")
+    // omi-test-quality: source-inspection -- static contract: reset must use the shared clearing helpers
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+    let resetStart = try XCTUnwrap(source.range(of: "func resetOnboardingAndRestart() {"))
+    let tail = source[resetStart.lowerBound...]
+    XCTAssertNotNil(
+      tail.range(of: "OnboardingFlow.clearPersistedState()"),
+      "resetOnboardingAndRestart() must clear onboarding keys via the shared list")
+    XCTAssertNotNil(
+      tail.range(of: "OnboardingChatPersistence.clear()"),
+      "resetOnboardingAndRestart() must clear onboarding chat/exploration state")
+    XCTAssertNil(
+      tail.range(of: "removeObject(forKey: \"onboardingStep\")"),
+      "resetOnboardingAndRestart() must not keep a hand-rolled onboarding key list")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260720-clear-onboarding-state-on-sign-out.json
+++ b/desktop/macos/changelog/unreleased/20260720-clear-onboarding-state-on-sign-out.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed onboarding pages showing the previous account's answers after deleting an account or signing out on the same Mac"
+}


### PR DESCRIPTION
# fix(desktop): clear all onboarding state on sign-out via one shared key list

Deleting an account (or signing out) and re-onboarding on the same Mac showed the previous run's onboarding answers still filled in. `AuthService.signOut()` and `AppState.resetOnboardingAndRestart()` each kept a hand-maintained onboarding-key list, so keys present at only one site — `hasSeenRewindIntro`, `hasTriggeredAccessibility`, `hasTriggeredBluetooth`, and the onboarding-chat exploration state (`onboardingExplorationText`/`Completed`, `onboardingMidOnboarding`, `onboardingToolCompleted`, `onboardingGoalCompleted`) — leaked across accounts.

Root cause: two divergent hand-maintained lists (split authority over the same cleanup contract). Durable guard: `OnboardingFlow.persistedStateKeys` + `clearPersistedState(in:)` is the single list both sites iterate; both sites also call `OnboardingChatPersistence.clear()`. Deliberate exclusions (`hasCompletedOnboarding`, `screenAnalysisEnabled`, chat keys) are documented at the list. Static call-site tripwires pin both sites to the shared helpers — an earlier version of this fix was silently reverted by a merge resolving toward a wholesale reformat while an isolation-only test stayed green.

## Product invariants affected

- INV-AUTH-1 — `AuthService.signOut()` is touched only to route onboarding-key cleanup through the shared helpers; session-death ownership (`AuthSessionCoordinator`, `invalidateSession` vs nuclear `signOut()`) is unchanged.

## Failure class (fixes)

Failure-Class: FC-split-mutation-authority

## Verification

- `./scripts/dev-feedback.py --once swift 'OnboardingPersistenceClearingTests'` — 4/4 pass locally and on the qualification Mac (67s).
- `make preflight` (full deterministic check manifest, same as CI Hygiene) green on the qualification Mac.
- Line-count ratchet: `AuthService.swift` shrank; owning baseline shard ratcheted down in the same PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

