### PR TITLE
Persist bulk segment assignment transactionally by segment id

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-database.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-database.json
@@ -1,10 +1,10 @@
 {
   "files": {
-    "backend/database/conversations.py": 1580,
+    "backend/database/conversations.py": 1643,
     "backend/database/users.py": 1943
   },
   "raise_justifications": {
-    "backend/database/conversations.py": "Public shared-chat uses the existing conversation storage format for bounded, safe transcript decoding; extraction would duplicate crypto/storage invariants."
+    "backend/database/conversations.py": "Public shared-chat uses the existing conversation storage format for bounded, safe transcript decoding; extraction would duplicate crypto/storage invariants. The transactional bulk_assign_segment_speakers helper must sit beside update_conversation_segment_text because it reuses this module's private _prepare_conversation_for_read/_prepare_conversation_for_write encryption boundary and conversations collection handle; extracting it would export those internals."
   },
   "threshold": 1500
 }

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -905,6 +905,69 @@ def update_conversation_segment_text(uid: str, conversation_id: str, segment_id:
     return _update_segment_text(transaction)
 
 
+def bulk_assign_segment_speakers(
+    uid: str,
+    conversation_id: str,
+    segment_ids: List[str],
+    assign_type: str,
+    value: Optional[str],
+    *,
+    firestore_client: Any = None,
+) -> str:
+    """
+    Assign is_user / person_id to multiple segments by id in a single transaction.
+
+    Mirrors update_conversation_segment_text: the read-modify-write runs inside a Firestore
+    transaction and applies each change by segment id. The bulk-assign endpoint previously read the
+    whole transcript_segments array outside any transaction, mutated it in memory, and overwrote the
+    array wholesale via update_conversation_segments — so a concurrent segment edit that committed in
+    between was silently dropped (the lose-update hazard update_conversation_segment_text's docstring
+    describes). Lock enforcement stays with the caller (_get_valid_conversation_by_id), so it is not
+    re-checked here.
+
+    Returns 'ok' on success, 'not_found' if the conversation is missing, or 'segment_not_found' if
+    none of segment_ids were present.
+    """
+    target_ids = set(segment_ids)
+    client = firestore_client if firestore_client is not None else get_firestore_client()
+    doc_ref = client.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
+    transaction = client.transaction()
+
+    @firestore.transactional
+    def _assign(transaction) -> str:
+        doc_snapshot = doc_ref.get(transaction=transaction)
+        if not getattr(doc_snapshot, 'exists', False):
+            return 'not_found'
+
+        conversation_data = _prepare_conversation_for_read(doc_snapshot.to_dict(), uid)
+        if not conversation_data:
+            return 'not_found'
+
+        segments = conversation_data.get('transcript_segments', [])
+        found = False
+        for segment in segments:
+            if not isinstance(segment, dict) or segment.get('id') not in target_ids:
+                continue
+            if assign_type == 'is_user':
+                segment['is_user'] = bool(value) if value is not None else False
+                segment['person_id'] = None
+                found = True
+            elif assign_type == 'person_id':
+                segment['is_user'] = False
+                segment['person_id'] = value
+                found = True
+
+        if not found:
+            return 'segment_not_found'
+
+        doc_level = conversation_data.get('data_protection_level', 'standard')
+        prepared_payload = _prepare_conversation_for_write({'transcript_segments': segments}, uid, doc_level)
+        transaction.update(doc_ref, prepared_payload)
+        return 'ok'
+
+    return _assign(transaction)
+
+
 def delete_conversation_photos(uid: str, conversation_id: str) -> int:
     """
     Delete all photos in a conversation's photos subcollection.

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -1035,9 +1035,16 @@ def assign_segments_bulk(
             else:
                 raise HTTPException(status_code=400, detail="Invalid assign type")
 
-    conversations_db.update_conversation_segments(
-        uid, conversation_id, [segment.model_dump() for segment in conversation.transcript_segments]
+    # Persist the assignment as a transactional read-modify-write by segment id, not a whole-array
+    # overwrite of the snapshot read above. update_conversation_segments replaces transcript_segments
+    # wholesale, so a concurrent segment edit (e.g. update_conversation_segment_text from another
+    # tab, or a retried request after a later edit landed) that commits between the read above and
+    # this write would be silently lost. Mirrors that sibling's transactional-by-id fix.
+    result = conversations_db.bulk_assign_segment_speakers(
+        uid, conversation_id, data.segment_ids, data.assign_type, value
     )
+    if result == 'not_found':
+        raise HTTPException(status_code=404, detail="Conversation not found")
 
     # Trigger speaker sample extraction when assigning to a person
     if data.assign_type == 'person_id' and value:

--- a/backend/tests/unit/test_conversation_bulk_assign_lost_update.py
+++ b/backend/tests/unit/test_conversation_bulk_assign_lost_update.py
@@ -1,0 +1,105 @@
+"""Regression: PATCH /v1/conversations/{id}/segments/assign-bulk must persist the assignment as a
+transactional read-modify-write by segment id, not a whole-array overwrite of a snapshot read
+outside the transaction. Otherwise a concurrent segment edit that commits between the handler's read
+and its write is silently lost.
+
+The real ``assign_segments_bulk`` handler is exercised; only the database seam
+(``conversations_db``) and the snapshot deserialization are faked. The stateful fake models the two
+persistence primitives' real semantics — ``update_conversation_segments`` overwrites
+``transcript_segments`` wholesale, ``bulk_assign_segment_speakers`` re-reads current state and
+applies by id — plus a concurrent edit that lands right after the handler's read.
+"""
+
+import copy
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi import BackgroundTasks
+
+import routers.conversations as convo_router
+from models.conversation import BulkAssignSegmentsRequest
+
+
+class _Seg:
+    """Minimal transcript-segment stand-in with the attributes the handler touches."""
+
+    def __init__(self, sid, text, is_user=False, person_id=None):
+        self.id = sid
+        self.text = text
+        self.is_user = is_user
+        self.person_id = person_id
+
+    def model_dump(self):
+        return {'id': self.id, 'text': self.text, 'is_user': self.is_user, 'person_id': self.person_id}
+
+
+def _run(assign_type, value):
+    # Authoritative DB state, keyed by segment id.
+    db_state = {
+        'transcript_segments': [
+            {'id': 's1', 'text': 'original one', 'is_user': False, 'person_id': None},
+            {'id': 's2', 'text': 'second', 'is_user': False, 'person_id': None},
+        ]
+    }
+
+    def fake_get_valid(_uid, cid):
+        return {'id': cid}  # opaque; deserialize is faked below
+
+    def fake_deserialize(_conv):
+        # The handler reads its working snapshot here.
+        snapshot = [_Seg(s['id'], s['text'], s['is_user'], s['person_id']) for s in db_state['transcript_segments']]
+        # A concurrent writer commits an edit to s1 right after the handler's read, before it persists.
+        for s in db_state['transcript_segments']:
+            if s['id'] == 's1':
+                s['text'] = 'edited by other writer'
+        return SimpleNamespace(transcript_segments=snapshot)
+
+    # OLD path: whole-array overwrite with the caller's (now stale) array.
+    def fake_update_conversation_segments(_uid, _cid, segments, *a, **k):
+        db_state['transcript_segments'] = copy.deepcopy(segments)
+        return True
+
+    # NEW path: transactional read-modify-write by id against CURRENT state.
+    def fake_bulk_assign(_uid, _cid, segment_ids, atype, val):
+        target = set(segment_ids)
+        found = False
+        for seg in db_state['transcript_segments']:
+            if seg['id'] not in target:
+                continue
+            if atype == 'is_user':
+                seg['is_user'] = bool(val) if val is not None else False
+                seg['person_id'] = None
+                found = True
+            elif atype == 'person_id':
+                seg['is_user'] = False
+                seg['person_id'] = val
+                found = True
+        return 'ok' if found else 'segment_not_found'
+
+    with patch.object(convo_router, '_get_valid_conversation_by_id', fake_get_valid), patch.object(
+        convo_router, 'deserialize_conversation', fake_deserialize
+    ), patch.object(
+        convo_router.conversations_db, 'update_conversation_segments', fake_update_conversation_segments
+    ), patch.object(
+        convo_router.conversations_db, 'bulk_assign_segment_speakers', fake_bulk_assign, create=True
+    ):
+        req = BulkAssignSegmentsRequest(segment_ids=['s2'], assign_type=assign_type, value=value)
+        convo_router.assign_segments_bulk(conversation_id='c1', data=req, background_tasks=BackgroundTasks(), uid='u1')
+
+    return {s['id']: s for s in db_state['transcript_segments']}
+
+
+def test_bulk_assign_does_not_clobber_concurrent_segment_edit():
+    by_id = _run(assign_type='person_id', value='person-42')
+    # The requested assignment landed on s2.
+    assert by_id['s2']['person_id'] == 'person-42'
+    assert by_id['s2']['is_user'] is False
+    # And the concurrent edit to s1 survived (was not overwritten by the stale snapshot array).
+    assert by_id['s1']['text'] == 'edited by other writer'
+
+
+def test_bulk_assign_is_user_also_survives_concurrent_edit():
+    by_id = _run(assign_type='is_user', value='true')
+    assert by_id['s2']['is_user'] is True
+    assert by_id['s2']['person_id'] is None
+    assert by_id['s1']['text'] == 'edited by other writer'


### PR DESCRIPTION
## Problem

`PATCH /v1/conversations/{conversation_id}/segments/assign-bulk` (`assign_segments_bulk`) reads the
conversation outside any transaction, mutates the in-memory `transcript_segments` array, then
persists by overwriting the entire array via `update_conversation_segments`.
`update_conversation_segments` re-reads the document inside its transaction only to recompute
`has_content` and the protection level, then writes `transcript_segments` wholesale from the
caller's array. So the transaction does not protect the segments from a stale-array overwrite.

If another write to the same conversation's `transcript_segments` commits between the router's read
and this overwrite, it is silently and permanently lost.

Failure scenario (same user, same conversation, two overlapping writes):

1. The conversation is open in two places (two tabs or two devices), or a request is retried.
2. A segment text edit commits via the transactional `update_conversation_segment_text` (edits s1).
3. The bulk-assign request, holding a snapshot read before that edit, assigns a speaker to s2 and
   writes the whole stale array back. s1's edit is gone.

This is same-tenant data loss, so it is a reliability bug, not an authorization issue.

## Why this pattern is already known here

`database.conversations.update_conversation_segment_text` was deliberately made a transactional
read-modify-write by segment id for exactly this class. Its docstring:

> The read-modify-write runs in a Firestore transaction so concurrent edits (e.g. the same
> conversation open in two tabs) can't lose-update each other. Without it, two edits that both read
> the pre-edit transcript_segments array and each rewrite the whole array clobber one another, the
> later write wins and silently drops the earlier edit.

The bulk-assign endpoint reintroduced the whole-array overwrite the sibling was written to avoid.

## Fix

Add `bulk_assign_segment_speakers` in `database/conversations.py`, a transactional read-modify-write
that applies is_user/person_id by segment id inside the transaction, mirroring
`update_conversation_segment_text` (including the `_prepare_conversation_for_read` /
`_prepare_conversation_for_write` encryption boundary). The router calls it instead of the
whole-array overwrite.

The router keeps its in-memory loop for assign-type validation and for the returned `Conversation`
snapshot; only the persistence call changes. Lock enforcement stays where it already is
(`_get_valid_conversation_by_id` raises 402 on a locked conversation before this point), so the
helper does not re-check it. The change is scoped to the cleanest instance; the same
non-transactional overwrite also exists in the two `set_assignee_conversation_segment` endpoints and
is a reasonable follow-up, not folded in here to keep this a small, reviewable fix.

## Tests

`tests/unit/test_conversation_bulk_assign_lost_update.py` (new) drives the real `assign_segments_bulk`
handler and fakes only the database seam, with a stateful fake that models both persistence
primitives' real semantics (whole-array overwrite vs by-id transactional re-read) plus a concurrent
edit that lands right after the handler's read:

- a person_id bulk-assign lands on the target segment and a concurrent edit to a different segment survives
- an is_user bulk-assign behaves the same

## Verification

Run in `backend/`:

- `pytest tests/unit/test_conversation_bulk_assign_lost_update.py`: 2 passed
- prove-fail: with `routers/conversations.py` reverted to origin/main and confirmed byte-identical
  (`git diff origin/main` empty), both tests fail with
  `AssertionError: assert 'original one' == 'edited by other writer'` (the assignment lands but the
  concurrent edit is clobbered). Reapplied: 2 passed
- fake fidelity: the fake `update_conversation_segments` overwrites `transcript_segments` wholesale,
  matching the real function which sets `'transcript_segments': segments` from the caller inside its
  transaction, so the lost update is real production behavior, not a fake artifact
- the conversation_lifecycle workflow contract set (test_conversation_lifecycle_contract,
  test_finalization_decision, test_check_conversation_lifecycle_writes,
  test_conversation_finalization_jobs, test_recording_sessions, test_listen_finalization_cloud_tasks)
  plus test_conversation_revision_contract and the new file: 137 passed
- `python scripts/check_conversation_lifecycle_writes.py`: passed
- `black --line-length 120 --skip-string-normalization --check`: clean
- `scripts/check_module_stub_pollution.py`: 0 violations
- `scripts/scan_async_blockers.py --dirs routers utils`: 0 findings (the handler is sync)
- `scripts/scan_import_time_side_effects.py`: 0 violations
- `scripts/pr-preflight --suggest`: product invariants affected none, no failure-class declaration required

## Impact

Users bulk-assigning a person or speaker to segments while a concurrent write to the same
conversation is in flight (two tabs or devices, or a retried assign after a later edit landed). The
window is the read-to-write span, so it is not the dominant case, but it is exactly the two-tab race
the codebase already treats as real for `update_conversation_segment_text`. When it hits, a user's
segment edit is silently and permanently lost with no error.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

