### PR TITLE
fix(desktop): clear no-require-imports ESLint errors blocking #10096

### DIFF
--- a/desktop/windows/src/main/usage/nativeForeground.ts
+++ b/desktop/windows/src/main/usage/nativeForeground.ts
@@ -42,6 +42,7 @@ function load(): Win32 | null {
   if (cached) return cached
   if (loadFailed) return null
   try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const koffi = require('koffi') as typeof import('koffi')
     const user32 = koffi.load('user32.dll')
     const kernel32 = koffi.load('kernel32.dll')

--- a/desktop/windows/src/main/usage/userAssistRegistry.ts
+++ b/desktop/windows/src/main/usage/userAssistRegistry.ts
@@ -43,6 +43,7 @@ function load(): Advapi | null {
   if (advapi) return advapi
   if (loadFailed) return null
   try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const koffi = require('koffi') as typeof import('koffi')
     const lib = koffi.load('advapi32.dll')
     advapi = {


### PR DESCRIPTION
## Summary
Adds a scoped `// eslint-disable-next-line @typescript-eslint/no-require-imports` above the two lazy `require('koffi')` calls (nativeForeground.ts:45, userAssistRegistry.ts:46) so the **Desktop Windows CI / Typecheck · Lint · Test** check goes green on #10096.

The lazy require is the right idea (keeps `nativeForeground` importable off-Windows); it just trips the `no-require-imports` rule. This is the exact fix the maintainer requested in the #10096 review.

## Test plan
- `cd desktop/windows && npx eslint src/main/usage/nativeForeground.ts src/main/usage/userAssistRegistry.ts` → no `no-require-imports` errors.
- Part of the consolidated Linux PR #10096 (supersedes #9503/#9963/#8415).

## Notes
Pushed from the `consolidation/linux-electron` HEAD. Intended to be merged into that branch (or squashed into its feat commit) so #10096 can land.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

