### PR TITLE
fix: expose apps_results in MCP SimpleConversation model

### DIFF
--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -24,6 +24,7 @@ from database.vector_db import upsert_memory_vector, delete_memory_vector
 import database.vector_db as vector_db
 from models.memories import MemoryDB, Memory, MemoryCategory
 from models.conversation_enums import CategoryEnum
+from models.conversation import AppResult
 from utils.conversations.render import populate_speaker_names, redact_conversations_for_list
 from utils.apps import update_personas_async
 from utils.llm.memories import identify_category_for_memory
@@ -461,6 +462,7 @@ class SimpleConversation(BaseModel):
     finished_at: Optional[datetime]
     structured: SimpleStructured
     language: Optional[str] = None
+    apps_results: List[AppResult] = []
 
 
 class FullConversation(SimpleConversation):

--- a/backend/tests/unit/test_mcp_apps_results.py
+++ b/backend/tests/unit/test_mcp_apps_results.py
@@ -1,0 +1,42 @@
+"""Tests that SimpleConversation includes apps_results field."""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from datetime import datetime
+from routers.mcp import SimpleConversation, SimpleStructured
+from models.conversation_enums import CategoryEnum
+from models.conversation import AppResult
+
+
+def test_simple_conversation_includes_apps_results():
+    """SimpleConversation should include apps_results field."""
+    conv = SimpleConversation(
+        id="test-id",
+        started_at=datetime.now(),
+        finished_at=datetime.now(),
+        structured=SimpleStructured(
+            title="Test",
+            overview="Test overview",
+            category=CategoryEnum.personal,
+        ),
+        apps_results=[AppResult(app_id="app-1", content="Custom summary")],
+    )
+    assert len(conv.apps_results) == 1
+    assert conv.apps_results[0].content == "Custom summary"
+    assert conv.apps_results[0].app_id == "app-1"
+
+
+def test_simple_conversation_apps_results_defaults_to_empty():
+    """apps_results should default to empty list."""
+    conv = SimpleConversation(
+        id="test-id",
+        started_at=datetime.now(),
+        finished_at=datetime.now(),
+        structured=SimpleStructured(
+            title="Test",
+            overview="Test overview",
+            category=CategoryEnum.personal,
+        ),
+    )
+    assert conv.apps_results == []


### PR DESCRIPTION
Custom summaries generated by apps were silently dropped from MCP 
responses because SimpleConversation did not include the apps_results 
field. This adds the field so custom summaries are returned alongside 
the default structured overview.

Fixes #7478

## What changed and why
Added `apps_results: List[AppResult] = []` to `SimpleConversation` in 
`backend/routers/mcp.py` and imported `AppResult` from 
`models.conversation`. The REST API already returns apps_results 
correctly via model_dump() on the full Conversation model. This fix 
brings the MCP endpoints in line with the REST API.

## Product invariants affected
none

## How it was verified
Ran unit tests locally using `uv run pytest tests/unit/test_mcp_apps_results.py -v`. Both tests passed. Could not verify against a live MCP server as that requires Firebase credentials.

## Tests
Added `backend/tests/unit/test_mcp_apps_results.py` with two tests:
- test_simple_conversation_includes_apps_results
- test_simple_conversation_apps_results_defaults_to_empty

## Failure class (fixes)
Failure-Class: none

## Failure-class transition narrative (only when needed)
N/A

## New guards (only when adding a check or ratchet)
N/A

## Scoped cleanups (optional)
N/A

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

