### PR TITLE
fix conversation detail crash when startedAt and createdAt differ by day

### DIFF
--- a/app/lib/pages/conversation_detail/conversation_detail_provider.dart
+++ b/app/lib/pages/conversation_detail/conversation_detail_provider.dart
@@ -76,11 +76,18 @@ class ConversationDetailProvider extends ChangeNotifier with MessageNotifierMixi
     }
 
     result ??= _cachedConversation;
-    if (result != null &&
-        result.createdAt.year == selectedDate.year &&
-        result.createdAt.month == selectedDate.month &&
-        result.createdAt.day == selectedDate.day) {
-      return _cachedConversation = result;
+    if (result != null) {
+      // Validate against the same effective date used to group conversations
+      // (startedAt ?? createdAt). Using createdAt alone breaks for
+      // conversations whose startedAt lands on a different calendar day, which
+      // would otherwise make this getter return null for a conversation that is
+      // actually present in the selected day-group.
+      final effectiveDate = result.startedAt ?? result.createdAt;
+      if (effectiveDate.year == selectedDate.year &&
+          effectiveDate.month == selectedDate.month &&
+          effectiveDate.day == selectedDate.day) {
+        return _cachedConversation = result;
+      }
     }
 
     return null;

--- a/app/test/providers/conversation_detail_provider_selection_test.dart
+++ b/app/test/providers/conversation_detail_provider_selection_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
+import 'package:omi/providers/conversation_provider.dart';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('conversation getter resolves when startedAt and createdAt fall on different days', () {
+    // Regression for "Bad state: No conversation available": conversations are
+    // grouped by their effective date (startedAt ?? createdAt), and tapping a
+    // list item selects that group's date. When startedAt lands on an earlier
+    // calendar day than createdAt (session spanning midnight / timezone edge),
+    // the detail provider must still resolve the conversation instead of
+    // throwing from the non-null `conversation` getter.
+    final convo = ServerConversation(
+      id: 'c1',
+      startedAt: DateTime.utc(2026, 7, 18, 23, 30),
+      createdAt: DateTime.utc(2026, 7, 19, 0, 15),
+      structured: Structured('Title', 'Overview'),
+      status: ConversationStatus.completed,
+    );
+
+    final conversationProvider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      isSignedIn: () => true,
+    );
+    addTearDown(conversationProvider.dispose);
+    conversationProvider.conversations = [convo];
+    conversationProvider.groupConversationsByDate();
+
+    // The date key the list item passes on tap is the group key.
+    final groupDate = conversationProvider.groupedConversations.keys.single;
+
+    final detailProvider = ConversationDetailProvider();
+    addTearDown(detailProvider.dispose);
+    detailProvider.conversationProvider = conversationProvider;
+
+    detailProvider.updateConversation(convo.id, groupDate);
+
+    expect(detailProvider.conversationOrNull, isNotNull);
+    expect(detailProvider.conversation.id, 'c1');
+    expect(detailProvider.conversation.structured.title, 'Title');
+  });
+}


### PR DESCRIPTION
## Crash

`ConversationDetailProvider.conversation` — `FlutterError - Bad state: No conversation available`

`package:omi/pages/conversation_detail/conversation_detail_provider.dart:47`

[Crashlytics issue](https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/8da74a612952e8ce7b9e07447166a3ca?time=7d&types=crash&sessionEventKey=a83d21e3e6464727a4943d8451a50bd8_2242364011895244017)

```
Fatal Exception: FlutterError
0  ???  ConversationDetailProvider.conversation + 93 (conversation_detail_provider.dart:93)
1  ???  _ConversationListItemState.build.<fn>.<fn> + 128 (conversation_list_item.dart:128)
2  ???  GestureRecognizer.invokeCallback + 345 (recognizer.dart:345)
3  ???  TapGestureRecognizer.handleTapUp + 758 (tap.dart:758)
...
```

Crashes on the main thread when a user taps a conversation in the list.

## Root cause

Conversations are grouped by their **effective date** — `startedAt ?? createdAt` — in `ConversationProvider._buildGroupedByDate`, and tapping a list item selects that group's date (`updateConversation` sets `selectedDate` to the group key).

But `conversationOrNull` validated the resolved conversation against `createdAt` **only**:

```dart
if (result != null &&
    result.createdAt.year == selectedDate.year &&
    result.createdAt.month == selectedDate.month &&
    result.createdAt.day == selectedDate.day) { ... }
```

When a conversation's `startedAt` lands on an earlier calendar day than its `createdAt` (a session spanning midnight, or a timezone boundary), the item is grouped under the `startedAt` day but this check compares `createdAt`'s day and fails — so `conversationOrNull` returns `null` for a conversation that is actually present in the selected group. The non-null `conversation` getter then throws `Bad state: No conversation available`, crashing the tap handler.

## Fix

Validate against the same effective date (`startedAt ?? createdAt`) used for grouping, so selection and validation agree.

## Test

Added `app/test/providers/conversation_detail_provider_selection_test.dart` — builds a conversation whose `startedAt` and `createdAt` fall on different days, groups it, taps it via `updateConversation`, and asserts `conversation` resolves instead of throwing. Fails without the fix, passes with it.

```
00:00 +1: All tests passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

