### PR TITLE
Only buffer multi-channel audio when an audio-bytes consumer is attached

### DIFF
--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -362,18 +362,24 @@ class ListenReceiver:
                 )
                 if sent:
                     self.host.state.dg_usage_ms_pending += dg_usage_ms
-        self.channel_mix_buffers[channel_index].extend(pcm)
-        decision = decide_multi_channel_mix(
-            self.channel_mix_buffers, audio_bytes_enabled=self.host.audio_bytes_send is not None
-        )
-        if decision.should_mix:
-            mixed = mix_n_channel_buffers(
-                [bytearray(buffer[: decision.min_len]) for buffer in self.channel_mix_buffers]
+        # Only accumulate channel audio for the pusher mix when an audio-bytes consumer is attached.
+        # decide_multi_channel_mix and the teardown flush both gate on this same condition, so
+        # without a consumer nothing ever drains these per-channel buffers. Appending regardless (the
+        # old behavior) left them growing for the whole session (~64 KB/s for stereo) until the
+        # worker ran out of memory, taking every co-located live session down with it.
+        if self.host.audio_bytes_send is not None:
+            self.channel_mix_buffers[channel_index].extend(pcm)
+            decision = decide_multi_channel_mix(
+                self.channel_mix_buffers, audio_bytes_enabled=self.host.audio_bytes_send is not None
             )
-            if mixed and self.host.audio_bytes_send is not None:
-                self.host.audio_bytes_send(mixed, self.host.state.last_audio_received_time or time.time())
-            for buffer in self.channel_mix_buffers:
-                del buffer[: decision.min_len]
+            if decision.should_mix:
+                mixed = mix_n_channel_buffers(
+                    [bytearray(buffer[: decision.min_len]) for buffer in self.channel_mix_buffers]
+                )
+                if mixed and self.host.audio_bytes_send is not None:
+                    self.host.audio_bytes_send(mixed, self.host.state.last_audio_received_time or time.time())
+                for buffer in self.channel_mix_buffers:
+                    del buffer[: decision.min_len]
 
     async def _handle_text(self, message: str) -> None:
         try:

--- a/backend/tests/unit/test_listen_multichannel_mix_buffer_leak.py
+++ b/backend/tests/unit/test_listen_multichannel_mix_buffer_leak.py
@@ -1,0 +1,66 @@
+"""Regression: a multi-channel listen session must not accumulate ``channel_mix_buffers`` when
+there is no audio-bytes consumer.
+
+``decide_multi_channel_mix`` and the teardown flush both return should_mix/flush=False when
+``audio_bytes_send`` is None, so appending every inbound frame unconditionally (the old behavior)
+left the per-channel buffers growing for the whole session (~64 KB/s for stereo) until the worker
+ran out of memory, taking every co-located live session down with it. The append must obey the same
+condition the drain and flush already use.
+
+Exercises the real ``ListenReceiver._handle_multi_channel_audio`` with the real
+``decide_multi_channel_mix``/``mix_n_channel_buffers``/``resample_pcm``; the receiver is a minimal
+stand-in supplying only the attributes the method reads (``use_custom_stt=True`` skips the STT
+branch, which is the realistic custom-STT multi-channel desktop case, and captured audio still
+flows to the mix path).
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import routers.listen.receiver as receiver
+
+TARGET_SAMPLE_RATE = receiver.TARGET_SAMPLE_RATE
+
+
+def _make_receiver(audio_bytes_send):
+    return SimpleNamespace(
+        host=SimpleNamespace(
+            request=SimpleNamespace(codec='pcm', sample_rate=TARGET_SAMPLE_RATE, websocket=None),
+            use_custom_stt=True,
+            audio_bytes_send=audio_bytes_send,
+            state=SimpleNamespace(last_audio_received_time=0.0),
+        ),
+        channel_id_to_index={0: 0, 1: 1},
+        multi_opus_decoders=[None, None],
+        stt_sockets_multi=[None, None],
+        channel_mix_buffers=[bytearray(), bytearray()],
+    )
+
+
+def _frame(channel_id, payload):
+    return bytes([channel_id]) + payload
+
+
+async def _feed(recv, frames):
+    for channel_id, payload in frames:
+        await receiver.ListenReceiver._handle_multi_channel_audio(recv, _frame(channel_id, payload))
+
+
+def test_multichannel_buffers_do_not_leak_without_audio_bytes_consumer():
+    recv = _make_receiver(audio_bytes_send=None)
+    pcm = b'\x01\x02' * 160  # 320 bytes
+    asyncio.run(_feed(recv, [(0, pcm)] * 50))
+    buffered = sum(len(b) for b in recv.channel_mix_buffers)
+    # With no consumer nothing ever drains these buffers, so nothing may accumulate. The old code
+    # held all 50 frames (~16000 bytes) and would keep growing for the whole session.
+    assert buffered == 0
+
+
+def test_multichannel_mix_still_drains_with_audio_bytes_consumer():
+    sent = []
+    recv = _make_receiver(audio_bytes_send=lambda mixed, ts: sent.append(mixed))
+    pcm = b'\x01\x02' * 160
+    # Feed both channels so decide_multi_channel_mix sees all buffers non-empty and mixes.
+    asyncio.run(_feed(recv, [(0, pcm), (1, pcm)]))
+    assert sent, "expected a mixed frame delivered to the audio-bytes consumer"
+    assert sum(len(b) for b in recv.channel_mix_buffers) == 0


### PR DESCRIPTION
## Problem

`ListenReceiver._handle_multi_channel_audio` (`routers/listen/receiver.py`) resamples each inbound
channel frame and appends it to a per-channel `channel_mix_buffers[channel_index]` on every frame.
That append is unconditional. The only in-session drain is inside `if decision.should_mix:`, and the
teardown drain is in `flush_multi_channel_tail`.

Both the drain decision and the teardown flush gate on whether an audio-bytes consumer is attached:

- `decide_multi_channel_mix(buffers, audio_bytes_enabled=self.host.audio_bytes_send is not None)`
  returns `should_mix=False` immediately when `audio_bytes_enabled` is False
  (`utils/transcribe_decisions.py`).
- `should_flush_final_multi_channel_mix(..., audio_bytes_enabled=...)` returns False when it is False.

`self.host.audio_bytes_send` is None unless `_start_pusher` sets it, which requires
`HOSTED_PUSHER_API_URL` to be set and the user to have an audio-bytes webhook, an audio-bytes app,
or private cloud sync enabled (`routers/listen/runtime.py`). For a normal multi-channel session (Omi
desktop mic plus system_audio, or a phone_call) without any of those, `audio_bytes_send` stays None,
so:

- every frame appends to `channel_mix_buffers` (~64 KB/s for two 16 kHz 16-bit channels),
- `decide_multi_channel_mix` returns `should_mix=False`, so the buffers never drain,
- `flush_multi_channel_tail` returns early, so teardown never drains them,
- `clear()` does not touch these buffers, and there is no size cap.

So the per-channel buffers grow for the entire session (about 230 MB/hour) with nobody reading them.
A long session, or several concurrent multi-channel sessions on a worker, drives it to OOM. When the
worker is killed it takes down every co-located live session and loses their in-progress
conversations. This matches the hazard `backend/AGENTS.md` gotcha #11 caps `private_cloud_queue`
against (unbounded audio buffers causing pod OOM that loses data for all users).

## Why this is reliability, not security

Same user, same session, own audio. No auth, scope, or tenant boundary is involved. It is resource
exhaustion leading to data loss.

## The fix

Only accumulate channel audio for the mix when an audio-bytes consumer is attached, gating the
append on the same `self.host.audio_bytes_send is not None` condition that `decide_multi_channel_mix`
and the teardown flush already use. `channel_mix_buffers` is consumed only by this mix path (the STT
path uses the resampled `pcm` directly), so when there is no consumer the buffers are never read and
there is nothing to accumulate.

The consumer path is byte-for-byte equivalent: inside the guard `audio_bytes_send is not None` is
always True, so the decision, mix, send, and drain run exactly as before.

## Tests

`tests/unit/test_listen_multichannel_mix_buffer_leak.py` (new) drives the real
`_handle_multi_channel_audio` with the real `decide_multi_channel_mix`, `mix_n_channel_buffers`, and
`resample_pcm`:

- 50 multi-channel frames with no audio-bytes consumer leave `channel_mix_buffers` empty (they must not accumulate)
- with an audio-bytes consumer attached, feeding both channels still mixes, delivers the mixed frame to the consumer, and drains the buffers

## Verification

Run in `backend/`:

- `pytest tests/unit/test_listen_multichannel_mix_buffer_leak.py`: 2 passed
- prove-fail: with `routers/listen/receiver.py` reverted to origin/main and confirmed byte-identical
  (`git diff origin/main` empty), the leak test fails with `assert 16000 == 0` (50 frames times 320
  bytes held and never drained, and it would keep growing), while the consumer test passes.
  Reapplied: 2 passed
- fake fidelity: the test exercises the real decision and mix functions; only the receiver object is
  a stand-in supplying the attributes the method reads, in production shapes. The leak is inherent to
  the unconditional append plus the gated drain, verified against clean origin/main.
- `pytest test_listen_receiver_frame_recovery test_transcribe_decisions test_transcribe_teardown_flush test_listen_multichannel_mix_buffer_leak`: 34 passed
- `black --line-length 120 --skip-string-normalization --check`: clean
- `pyright -p pyrightconfig.json routers/listen/receiver.py`: 0 errors
- `scripts/check_module_stub_pollution.py`: 0 violations
- `scripts/scan_async_blockers.py --dirs routers utils`: 0 findings
- `scripts/scan_import_time_side_effects.py`: 0 violations
- `scripts/check_conversation_lifecycle_writes.py`: passed
- `scripts/pr-preflight --suggest`: product invariants affected none, no failure-class declaration required

## Impact

Affected: every multi-channel listen session (Omi desktop mic plus system_audio, or phone_call)
without an audio-bytes consumer, which is the default for most desktop and phone users since
audio-bytes webhooks/apps and private cloud sync are opt-in. The leak is continuous (~64 KB/s per
session) whenever it applies. A single short session will not OOM by itself; the risk is a long
session or normal production concurrency of long multi-channel sessions exhausting worker memory, at
which point the OOM kill loses in-progress conversations for every session on that worker.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

