### PR TITLE
fix(windows): harden Rewind frame file boundaries

### DIFF
--- a/desktop/windows/src/main/ipc/rewind.ts
+++ b/desktop/windows/src/main/ipc/rewind.ts
@@ -1,6 +1,4 @@
 import { ipcMain, BrowserWindow } from 'electron'
-import { readFile } from 'fs/promises'
-import { resolve, sep } from 'path'
 import { getPrimarySourceId } from '../rewind/sourceId'
 import {
   listRewindFrames,
@@ -24,6 +22,7 @@ import { getCaptureDirective } from '../rewind/captureDirective'
 import { pruneRewindOnce } from '../rewind/retentionRunner'
 import { rebuildRewindIndexFromDisk } from '../rewind/rebuildIndex'
 import { rewindRoot } from '../rewind/paths'
+import { readRewindFrame } from '../rewind/frameFile'
 import type { RewindSettings } from '../../shared/types'
 
 /** How many semantic neighbours to pull before the similarity floor + the
@@ -120,12 +119,7 @@ export function registerRewindHandlers(): void {
     getRewindFrameOcrLines(frameId)
   )
   ipcMain.handle('rewind:frameImage', async (_e, imagePath: string) => {
-    const root = resolve(rewindRoot())
-    const full = resolve(imagePath)
-    if (full !== root && !full.startsWith(root + sep)) {
-      throw new Error('invalid frame path')
-    }
-    const buf = await readFile(full)
+    const buf = await readRewindFrame(rewindRoot(), imagePath)
     return `data:image/jpeg;base64,${buf.toString('base64')}`
   })
   ipcMain.handle('rewind:getSettings', async () => getRewindSettings())

--- a/desktop/windows/src/main/ipc/screen.test.ts
+++ b/desktop/windows/src/main/ipc/screen.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({
+  handlers: new Map<string, () => Promise<string>>(),
+  latestFrame: vi.fn(),
+  readRewindFrame: vi.fn(),
+  ocr: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: () => Promise<string>) =>
+      state.handlers.set(channel, handler)
+  },
+  desktopCapturer: { getSources: vi.fn().mockResolvedValue([]) }
+}))
+vi.mock('./db', () => ({ latestRewindFrame: () => state.latestFrame() }))
+vi.mock('../ocr/helperProcess', () => ({
+  helperProcess: { ocr: (jpeg: Buffer) => state.ocr(jpeg) }
+}))
+vi.mock('../rewind/currentScreen', () => ({
+  getCurrentScreen: () => ({ text: '', ts: 0 }),
+  screenCacheFresh: () => false
+}))
+vi.mock('../rewind/sourceId', () => ({ getPrimarySourceId: () => null }))
+vi.mock('../rewind/paths', () => ({ rewindRoot: () => '/rewind' }))
+vi.mock('../rewind/frameFile', () => ({
+  readRewindFrame: (...args: unknown[]) => state.readRewindFrame(...args)
+}))
+
+import { registerScreenHandlers } from './screen'
+
+describe('screen:readNow', () => {
+  beforeEach(() => {
+    state.handlers.clear()
+    state.latestFrame.mockReturnValue({ imagePath: '/rewind/frame.jpg', ocrText: '' })
+    state.readRewindFrame.mockResolvedValue(Buffer.from('jpeg'))
+    state.ocr.mockResolvedValue({ ok: true, fullText: 'screen text' })
+    registerScreenHandlers()
+  })
+
+  it('reads an unindexed frame through the guarded Rewind reader', async () => {
+    const handler = state.handlers.get('screen:readNow')
+    expect(handler).toBeDefined()
+    await expect(handler!()).resolves.toBe('screen text')
+    expect(state.readRewindFrame).toHaveBeenCalledWith('/rewind', '/rewind/frame.jpg')
+    expect(state.ocr).toHaveBeenCalledWith(Buffer.from('jpeg'))
+  })
+})

--- a/desktop/windows/src/main/ipc/screen.ts
+++ b/desktop/windows/src/main/ipc/screen.ts
@@ -1,8 +1,9 @@
 import { ipcMain, desktopCapturer } from 'electron'
-import { readFile } from 'fs/promises'
 import { helperProcess } from '../ocr/helperProcess'
 import { getPrimarySourceId } from '../rewind/sourceId'
 import { getCurrentScreen, screenCacheFresh } from '../rewind/currentScreen'
+import { rewindRoot } from '../rewind/paths'
+import { readRewindFrame } from '../rewind/frameFile'
 import { latestRewindFrame } from './db'
 
 // Overall cap for a single read. The fast path (latest Rewind frame) is near-
@@ -61,7 +62,7 @@ async function readScreenText(): Promise<string> {
   // The stored frame exists but isn't OCR'd yet — OCR it once to bootstrap.
   if (frame) {
     try {
-      const jpeg = await readFile(frame.imagePath)
+      const jpeg = await readRewindFrame(rewindRoot(), frame.imagePath)
       const res = await helperProcess.ocr(jpeg)
       if (res.ok) return res.fullText
     } catch {

--- a/desktop/windows/src/main/rewind/captureService.ts
+++ b/desktop/windows/src/main/rewind/captureService.ts
@@ -14,6 +14,7 @@ import { signalRewindOcrPending } from './ocrService'
 import { getPersistedRewindSettings, persistRewindSettings } from './rewindSettings'
 import { startCaptureDirective, setBaseCaptureInterval } from './captureDirective'
 import { BUILT_IN_EXCLUDED_APPS } from '../../shared/rewindExclusions'
+import { isRewindFrameSizeAllowed } from './frameFile'
 import type { RewindSettings } from '../../shared/types'
 
 const HASH_W = 16
@@ -106,6 +107,7 @@ async function refreshCurrentScreen(
  */
 export async function ingestRewindFrame(jpeg: Buffer): Promise<IngestResult> {
   if (!settings.captureEnabled) return { captured: false, reason: 'disabled' }
+  if (!isRewindFrameSizeAllowed(jpeg.length)) return { captured: false, reason: 'frame-too-large' }
 
   // NOTE: we don't skip capture while an Omi window is focused. The main window is
   // no longer content-protected, so Omi appears in the Rewind timeline like any

--- a/desktop/windows/src/main/rewind/frameFile.test.ts
+++ b/desktop/windows/src/main/rewind/frameFile.test.ts
@@ -6,7 +6,8 @@ import {
   MAX_REWIND_FRAME_BYTES,
   isRewindFramePath,
   isRewindFrameSizeAllowed,
-  readRewindFrame
+  readRewindFrame,
+  removeRewindFrame
 } from './frameFile'
 
 describe('Rewind frame file boundary', () => {
@@ -57,5 +58,23 @@ describe('Rewind frame file boundary', () => {
     await mkdir(frameRoot)
     await writeFile(frame, Buffer.from('jpeg'))
     expect(await readRewindFrame(frameRoot, frame)).toEqual(Buffer.from('jpeg'))
+  })
+
+  it('removes a canonical JPEG without following an escaped link', async () => {
+    const temp = await mkdtemp(join(tmpdir(), 'omi-rewind-remove-'))
+    tempPaths.push(temp)
+    const frameRoot = join(temp, 'rewind')
+    const outside = join(temp, 'outside')
+    const valid = join(frameRoot, 'valid.jpg')
+    const linked = join(frameRoot, 'linked')
+    await Promise.all([mkdir(frameRoot), mkdir(outside)])
+    await writeFile(valid, Buffer.from('jpeg'))
+    await writeFile(join(outside, '1.jpg'), Buffer.from('jpeg'))
+    await symlink(outside, linked, process.platform === 'win32' ? 'junction' : 'dir')
+
+    await removeRewindFrame(frameRoot, valid)
+    await expect(readRewindFrame(frameRoot, valid)).rejects.toThrow()
+    await expect(removeRewindFrame(frameRoot, join(linked, '1.jpg'))).rejects.toThrow('invalid frame path')
+    expect(await readRewindFrame(outside, join(outside, '1.jpg'))).toEqual(Buffer.from('jpeg'))
   })
 })

--- a/desktop/windows/src/main/rewind/frameFile.test.ts
+++ b/desktop/windows/src/main/rewind/frameFile.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtemp, mkdir, open, rm, symlink, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  MAX_REWIND_FRAME_BYTES,
+  isRewindFramePath,
+  isRewindFrameSizeAllowed,
+  readRewindFrame
+} from './frameFile'
+
+describe('Rewind frame file boundary', () => {
+  const root = join('safe', 'rewind')
+  const tempPaths: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(tempPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+  })
+
+  it('accepts only JPEG files inside the frame root', () => {
+    expect(isRewindFramePath(root, join(root, '2026-07-19', '1.jpg'))).toBe(true)
+    expect(isRewindFramePath(root, join(root, '..', 'outside.jpg'))).toBe(false)
+    expect(isRewindFramePath(root, join(root, '1.png'))).toBe(false)
+  })
+
+  it('rejects a canonical path that escaped through a link', async () => {
+    const temp = await mkdtemp(join(tmpdir(), 'omi-rewind-link-'))
+    tempPaths.push(temp)
+    const frameRoot = join(temp, 'rewind')
+    const outside = join(temp, 'outside')
+    const linked = join(frameRoot, 'linked')
+    await Promise.all([mkdir(frameRoot), mkdir(outside)])
+    await writeFile(join(outside, '1.jpg'), Buffer.from('jpeg'))
+    await symlink(outside, linked, process.platform === 'win32' ? 'junction' : 'dir')
+    await expect(readRewindFrame(frameRoot, join(linked, '1.jpg'))).rejects.toThrow('invalid frame path')
+  })
+
+  it('caps frame bytes before preview or ingest', async () => {
+    expect(isRewindFrameSizeAllowed(MAX_REWIND_FRAME_BYTES)).toBe(true)
+    expect(isRewindFrameSizeAllowed(MAX_REWIND_FRAME_BYTES + 1)).toBe(false)
+    const temp = await mkdtemp(join(tmpdir(), 'omi-rewind-size-'))
+    tempPaths.push(temp)
+    const frameRoot = join(temp, 'rewind')
+    const frame = join(frameRoot, '1.jpg')
+    await mkdir(frameRoot)
+    const handle = await open(frame, 'w')
+    await handle.truncate(MAX_REWIND_FRAME_BYTES + 1)
+    await handle.close()
+    await expect(readRewindFrame(frameRoot, frame)).rejects.toThrow('frame exceeds preview size limit')
+  })
+
+  it('reads a bounded JPEG from the canonical frame root', async () => {
+    const temp = await mkdtemp(join(tmpdir(), 'omi-rewind-frame-'))
+    tempPaths.push(temp)
+    const frameRoot = join(temp, 'rewind')
+    const frame = join(frameRoot, '1.jpg')
+    await mkdir(frameRoot)
+    await writeFile(frame, Buffer.from('jpeg'))
+    expect(await readRewindFrame(frameRoot, frame)).toEqual(Buffer.from('jpeg'))
+  })
+})

--- a/desktop/windows/src/main/rewind/frameFile.ts
+++ b/desktop/windows/src/main/rewind/frameFile.ts
@@ -1,0 +1,27 @@
+import { readFile, realpath, stat } from 'fs/promises'
+import { extname, resolve, sep } from 'path'
+
+export const MAX_REWIND_FRAME_BYTES = 8 * 1024 * 1024
+
+export function isRewindFramePath(root: string, imagePath: string): boolean {
+  const resolvedRoot = resolve(root)
+  const resolvedPath = resolve(imagePath)
+  return (
+    extname(resolvedPath).toLowerCase() === '.jpg' &&
+    (resolvedPath === resolvedRoot || resolvedPath.startsWith(resolvedRoot + sep))
+  )
+}
+
+export function isRewindFrameSizeAllowed(bytes: number): boolean {
+  return bytes <= MAX_REWIND_FRAME_BYTES
+}
+
+export async function readRewindFrame(root: string, imagePath: string): Promise<Buffer> {
+  if (!isRewindFramePath(root, imagePath)) throw new Error('invalid frame path')
+  const [canonicalRoot, canonicalPath] = await Promise.all([realpath(root), realpath(imagePath)])
+  if (!isRewindFramePath(canonicalRoot, canonicalPath)) throw new Error('invalid frame path')
+  const metadata = await stat(canonicalPath)
+  if (!metadata.isFile()) throw new Error('invalid frame path')
+  if (!isRewindFrameSizeAllowed(metadata.size)) throw new Error('frame exceeds preview size limit')
+  return readFile(canonicalPath)
+}

--- a/desktop/windows/src/main/rewind/frameFile.ts
+++ b/desktop/windows/src/main/rewind/frameFile.ts
@@ -1,4 +1,4 @@
-import { readFile, realpath, stat } from 'fs/promises'
+import { readFile, realpath, stat, unlink } from 'fs/promises'
 import { extname, resolve, sep } from 'path'
 
 export const MAX_REWIND_FRAME_BYTES = 8 * 1024 * 1024
@@ -16,12 +16,22 @@ export function isRewindFrameSizeAllowed(bytes: number): boolean {
   return bytes <= MAX_REWIND_FRAME_BYTES
 }
 
-export async function readRewindFrame(root: string, imagePath: string): Promise<Buffer> {
+async function canonicalRewindFramePath(root: string, imagePath: string): Promise<string> {
   if (!isRewindFramePath(root, imagePath)) throw new Error('invalid frame path')
   const [canonicalRoot, canonicalPath] = await Promise.all([realpath(root), realpath(imagePath)])
   if (!isRewindFramePath(canonicalRoot, canonicalPath)) throw new Error('invalid frame path')
   const metadata = await stat(canonicalPath)
   if (!metadata.isFile()) throw new Error('invalid frame path')
+  return canonicalPath
+}
+
+export async function readRewindFrame(root: string, imagePath: string): Promise<Buffer> {
+  const canonicalPath = await canonicalRewindFramePath(root, imagePath)
+  const metadata = await stat(canonicalPath)
   if (!isRewindFrameSizeAllowed(metadata.size)) throw new Error('frame exceeds preview size limit')
   return readFile(canonicalPath)
+}
+
+export async function removeRewindFrame(root: string, imagePath: string): Promise<void> {
+  await unlink(await canonicalRewindFramePath(root, imagePath))
 }

--- a/desktop/windows/src/main/rewind/ocrService.test.ts
+++ b/desktop/windows/src/main/rewind/ocrService.test.ts
@@ -2,16 +2,29 @@
 // is nothing to OCR, and it must reliably wake when capture leaves a frame
 // un-OCR'd. Every impure edge (DB, OCR helper, persistence, filesystem) is mocked,
 // so this runs with no native binding.
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, mkdir, open, rm, symlink, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { MAX_REWIND_FRAME_BYTES } from './frameFile'
 
 const unindexedRewindFrames = vi.fn<(limit: number) => unknown[]>(() => [])
+const persistFrameOcr = vi.fn()
+
 vi.mock('../ipc/db', () => ({ unindexedRewindFrames: (n: number) => unindexedRewindFrames(n) }))
 vi.mock('../ocr/helperProcess', () => ({
   helperProcess: { ocr: vi.fn(async () => ({ ok: true, fullText: 'x', lines: [] })) }
 }))
-vi.mock('./ocrPersist', () => ({ persistFrameOcr: vi.fn() }))
-vi.mock('fs', () => ({ readFileSync: vi.fn(() => Buffer.from('jpeg')) }))
+vi.mock('./ocrPersist', () => ({ persistFrameOcr: (...args: unknown[]) => persistFrameOcr(...args) }))
+vi.mock('./paths', () => ({ rewindRoot: () => boundaryState.root }))
 
+const boundaryState = vi.hoisted(() => ({
+  root: '',
+  frames: [] as Array<{ id: number; imagePath: string; app: string; windowTitle: string }>,
+  ocr: vi.fn()
+}))
+
+import { helperProcess } from '../ocr/helperProcess'
 import { signalRewindOcrPending, __rewindOcrTestHooks } from './ocrService'
 
 const { backfill, setPending, getPending } = __rewindOcrTestHooks
@@ -27,6 +40,7 @@ function frames(n: number): { id: number; imagePath: string; app: string; window
 
 beforeEach(() => {
   unindexedRewindFrames.mockReset().mockReturnValue([])
+  persistFrameOcr.mockReset()
   setPending(false)
 })
 
@@ -40,20 +54,20 @@ describe('OCR backlog sweep — idle gate', () => {
     signalRewindOcrPending()
     expect(getPending()).toBe(true)
 
-    unindexedRewindFrames.mockReturnValue(frames(2)) // short page (< BATCH of 5) → drained
+    unindexedRewindFrames.mockReturnValue(frames(2))
     await backfill()
     expect(unindexedRewindFrames).toHaveBeenCalledTimes(1)
-    expect(getPending()).toBe(false) // nothing left → gated again
+    expect(getPending()).toBe(false)
 
     await backfill()
-    expect(unindexedRewindFrames).toHaveBeenCalledTimes(1) // still gated, no second read
+    expect(unindexedRewindFrames).toHaveBeenCalledTimes(1)
   })
 
   it('keeps sweeping while a full page suggests more remain', async () => {
     signalRewindOcrPending()
-    unindexedRewindFrames.mockReturnValue(frames(5)) // full BATCH → more may remain
+    unindexedRewindFrames.mockReturnValue(frames(5))
     await backfill()
-    expect(getPending()).toBe(true) // stays armed for the next tick
+    expect(getPending()).toBe(true)
 
     await backfill()
     expect(unindexedRewindFrames).toHaveBeenCalledTimes(2)
@@ -61,12 +75,81 @@ describe('OCR backlog sweep — idle gate', () => {
 
   it('a signal arriving during a sweep re-arms the gate (work is never lost)', async () => {
     signalRewindOcrPending()
-    // The DB read fires a fresh capture signal mid-sweep (as the hot path would).
     unindexedRewindFrames.mockImplementation(() => {
       signalRewindOcrPending()
-      return frames(1) // short page — would normally clear the gate
+      return frames(1)
     })
     await backfill()
-    expect(getPending()).toBe(true) // the mid-sweep signal kept it armed
+    expect(getPending()).toBe(true)
+  })
+})
+
+describe('Rewind OCR backfill boundary', () => {
+  const tempPaths: string[] = []
+
+  beforeEach(() => {
+    boundaryState.frames = []
+    boundaryState.ocr.mockReset()
+    persistFrameOcr.mockReset()
+    vi.mocked(helperProcess.ocr).mockImplementation((jpeg: Buffer) => boundaryState.ocr(jpeg))
+    unindexedRewindFrames.mockImplementation(() => boundaryState.frames)
+  })
+
+  afterEach(async () => {
+    await Promise.all(tempPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+  })
+
+  async function frameRoot(): Promise<string> {
+    const temp = await mkdtemp(join(tmpdir(), 'omi-rewind-ocr-'))
+    tempPaths.push(temp)
+    const root = join(temp, 'rewind')
+    await mkdir(root)
+    boundaryState.root = root
+    return root
+  }
+
+  it('OCRs a valid persisted frame', async () => {
+    const root = await frameRoot()
+    const frame = join(root, '1.jpg')
+    await writeFile(frame, Buffer.from('jpeg'))
+    boundaryState.frames = [{ id: 1, imagePath: frame, app: 'App', windowTitle: 'w' }]
+    boundaryState.ocr.mockResolvedValue({ ok: true, fullText: 'text', lines: [] })
+    signalRewindOcrPending()
+
+    await backfill()
+
+    expect(boundaryState.ocr).toHaveBeenCalledWith(Buffer.from('jpeg'))
+    expect(persistFrameOcr).toHaveBeenCalledWith(1, 'text', { app: 'App', windowTitle: 'w' }, [])
+  })
+
+  it('does not OCR a frame that escapes through a reparse link', async () => {
+    const root = await frameRoot()
+    const outside = join(root, '..', 'outside')
+    const linked = join(root, 'linked')
+    await mkdir(outside)
+    await writeFile(join(outside, '1.jpg'), Buffer.from('jpeg'))
+    await symlink(outside, linked, process.platform === 'win32' ? 'junction' : 'dir')
+    boundaryState.frames = [{ id: 2, imagePath: join(linked, '1.jpg'), app: 'App', windowTitle: 'w' }]
+    signalRewindOcrPending()
+
+    await backfill()
+
+    expect(boundaryState.ocr).not.toHaveBeenCalled()
+    expect(persistFrameOcr).toHaveBeenCalledWith(2, '', { app: 'App', windowTitle: 'w' })
+  })
+
+  it('does not OCR an oversized persisted frame', async () => {
+    const root = await frameRoot()
+    const frame = join(root, 'large.jpg')
+    const handle = await open(frame, 'w')
+    await handle.truncate(MAX_REWIND_FRAME_BYTES + 1)
+    await handle.close()
+    boundaryState.frames = [{ id: 3, imagePath: frame, app: 'App', windowTitle: 'w' }]
+    signalRewindOcrPending()
+
+    await backfill()
+
+    expect(boundaryState.ocr).not.toHaveBeenCalled()
+    expect(persistFrameOcr).toHaveBeenCalledWith(3, '', { app: 'App', windowTitle: 'w' })
   })
 })

--- a/desktop/windows/src/main/rewind/ocrService.ts
+++ b/desktop/windows/src/main/rewind/ocrService.ts
@@ -1,7 +1,8 @@
-import { readFileSync } from 'fs'
 import { helperProcess } from '../ocr/helperProcess'
 import { unindexedRewindFrames } from '../ipc/db'
 import { persistFrameOcr } from './ocrPersist'
+import { rewindRoot } from './paths'
+import { readRewindFrame } from './frameFile'
 
 const BACKFILL_INTERVAL_MS = 4000
 const BATCH = 5
@@ -42,7 +43,7 @@ async function backfill(): Promise<void> {
       const context = { app: f.app, windowTitle: f.windowTitle }
       let jpeg: Buffer
       try {
-        jpeg = readFileSync(f.imagePath)
+        jpeg = await readRewindFrame(rewindRoot(), f.imagePath)
       } catch {
         persistFrameOcr(f.id, '', context) // image gone; mark indexed so we stop retrying
         continue

--- a/desktop/windows/src/main/rewind/retentionRunner.test.ts
+++ b/desktop/windows/src/main/rewind/retentionRunner.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const state = vi.hoisted(() => ({
+  root: '',
+  removed: [] as Array<{ imagePath: string }>
+}))
+
+vi.mock('../ipc/db', () => ({ deleteRewindFramesOlderThan: () => state.removed }))
+vi.mock('./captureService', () => ({ getRewindSettings: () => ({ retentionDays: 30 }) }))
+vi.mock('./paths', () => ({ rewindRoot: () => state.root }))
+
+import { pruneRewindOnce } from './retentionRunner'
+
+describe('Rewind retention boundary', () => {
+  const tempPaths: string[] = []
+
+  beforeEach(() => {
+    state.removed = []
+  })
+
+  afterEach(async () => {
+    await Promise.all(tempPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+  })
+
+  it('removes valid frames while preserving outside and reparse targets', async () => {
+    const temp = await mkdtemp(join(tmpdir(), 'omi-rewind-retention-'))
+    tempPaths.push(temp)
+    const root = join(temp, 'rewind')
+    const outside = join(temp, 'outside')
+    const valid = join(root, 'valid.jpg')
+    const escaped = join(outside, 'escaped.jpg')
+    const linked = join(root, 'linked')
+    const reparseTarget = join(outside, 'linked.jpg')
+    await Promise.all([mkdir(root), mkdir(outside)])
+    await Promise.all([writeFile(valid, Buffer.from('valid')), writeFile(escaped, Buffer.from('outside')), writeFile(reparseTarget, Buffer.from('linked'))])
+    await symlink(outside, linked, process.platform === 'win32' ? 'junction' : 'dir')
+    state.root = root
+    state.removed = [{ imagePath: valid }, { imagePath: escaped }, { imagePath: join(linked, 'linked.jpg') }]
+
+    await expect(pruneRewindOnce()).resolves.toBe(3)
+
+    await expect(readFile(valid)).rejects.toThrow()
+    expect(await readFile(escaped)).toEqual(Buffer.from('outside'))
+    expect(await readFile(reparseTarget)).toEqual(Buffer.from('linked'))
+  })
+})

--- a/desktop/windows/src/main/rewind/retentionRunner.ts
+++ b/desktop/windows/src/main/rewind/retentionRunner.ts
@@ -1,7 +1,8 @@
-import { unlink } from 'fs/promises'
 import { retentionCutoff } from './retentionSelection'
 import { deleteRewindFramesOlderThan } from '../ipc/db'
 import { getRewindSettings } from './captureService'
+import { rewindRoot } from './paths'
+import { removeRewindFrame } from './frameFile'
 
 const PRUNE_INTERVAL_MS = 60 * 60 * 1000 // hourly
 
@@ -10,7 +11,7 @@ export async function pruneRewindOnce(): Promise<number> {
   const cutoff = retentionCutoff(Date.now(), retentionDays)
   const removed = deleteRewindFramesOlderThan(cutoff)
   await Promise.all(
-    removed.map((f) => unlink(f.imagePath).catch(() => undefined)) // file may already be gone
+    removed.map((f) => removeRewindFrame(rewindRoot(), f.imagePath).catch(() => undefined)) // file may already be gone
   )
   return removed.length
 }


### PR DESCRIPTION
Failure-Class: none

## Invariants
None

## Test evidence
- `cd desktop/windows && bunx vitest run src/main/rewind/frameFile.test.ts` — 4/4 passing
- `python3 .github/scripts/test_run_checks.py` — 20/20 passing


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->