### PR TITLE
fix(sync): time out WALs wedged in the uploaded state (offline recordings stuck forever)

### DIFF
--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -26,6 +26,14 @@ import 'package:omi/utils/wal_file_manager.dart';
 const _kBackendBusyErrorHint = 'background worker likely died';
 const _freshSyncCutoffSeconds = 6 * 60 * 60;
 
+/// How long a WAL may sit in [WalStatus.uploaded] under one job before the
+/// reconciler abandons that job and re-uploads. A job the backend keeps
+/// reporting non-terminal — notably one wedged `queued`, which the backend
+/// stale guard never fails — would otherwise be polled forever, leaving the
+/// recording stuck on "Uploaded · processing on Omi" and never becoming a
+/// conversation. See issue #10033.
+const _uploadedStaleTimeoutSeconds = 6 * 60 * 60;
+
 enum SyncJobTerminalPolicy { wait, acknowledge, retry }
 
 /// The shared WAL acknowledgement boundary for async sync jobs.
@@ -39,6 +47,20 @@ SyncJobTerminalPolicy syncJobTerminalPolicy({required String status, required bo
   return status == 'completed' ? SyncJobTerminalPolicy.acknowledge : SyncJobTerminalPolicy.retry;
 }
 
+/// Whether an uploaded WAL has waited on its job past the stale cutoff. Used to
+/// break out of an otherwise unbounded poll on a job the backend never resolves.
+/// A WAL uploaded before this field existed carries `uploadedAt == 0`; those
+/// keep polling as before rather than being force-reverted.
+@visibleForTesting
+bool syncJobUploadIsStale({
+  required int uploadedAt,
+  required int nowSecs,
+  int timeoutSeconds = _uploadedStaleTimeoutSeconds,
+}) {
+  if (uploadedAt <= 0) return false;
+  return nowSecs - uploadedAt >= timeoutSeconds;
+}
+
 @visibleForTesting
 bool syncJobIsBackendBusy(SyncJobStatusResponse status) {
   if ((status.error ?? '').contains(_kBackendBusyErrorHint)) return true;
@@ -50,8 +72,8 @@ bool syncJobIsBackendBusy(SyncJobStatusResponse status) {
 
 SyncUploadLane syncUploadLaneForTimestamp(int captureSeconds, int nowSeconds, {required bool hasServerCaptureProof}) =>
     hasServerCaptureProof && nowSeconds - captureSeconds <= _freshSyncCutoffSeconds
-        ? SyncUploadLane.fresh
-        : SyncUploadLane.backfill;
+    ? SyncUploadLane.fresh
+    : SyncUploadLane.backfill;
 
 SyncUploadLane _syncLaneForWal(Wal wal, int nowSeconds) =>
     syncUploadLaneForTimestamp(wal.timerStart, nowSeconds, hasServerCaptureProof: wal.conversationId != null);
@@ -75,8 +97,8 @@ List<Wal> nextSyncUploadBatch(
 }) {
   SyncUploadLane effectiveLane(Wal wal) =>
       wal.conversationId != null && forcedBackfillConversationIds.contains(wal.conversationId)
-          ? SyncUploadLane.backfill
-          : _syncLaneForWal(wal, nowSeconds);
+      ? SyncUploadLane.backfill
+      : _syncLaneForWal(wal, nowSeconds);
 
   final ordered = List<Wal>.from(pending)
     ..sort((a, b) {
@@ -662,8 +684,8 @@ class LocalWalSyncImpl implements LocalWalSync {
       forcedBackfillConversationIds.addAll(oversizedFreshConversationIds(candidates, batchNowSeconds));
       SyncUploadLane effectiveLane(Wal wal) =>
           wal.conversationId != null && forcedBackfillConversationIds.contains(wal.conversationId)
-              ? SyncUploadLane.backfill
-              : _syncLaneForWal(wal, batchNowSeconds);
+          ? SyncUploadLane.backfill
+          : _syncLaneForWal(wal, batchNowSeconds);
       final pending = candidates
           .where(
             (wal) =>
@@ -681,8 +703,8 @@ class LocalWalSyncImpl implements LocalWalSync {
       attemptedWalIds.addAll(batch.map((wal) => wal.id));
       final batchLane =
           batch.first.conversationId != null && forcedBackfillConversationIds.contains(batch.first.conversationId)
-              ? SyncUploadLane.backfill
-              : _syncLaneForWal(batch.first, batchNowSeconds);
+          ? SyncUploadLane.backfill
+          : _syncLaneForWal(batch.first, batchNowSeconds);
       if (_isCancelled) {
         Logger.debug("LocalWalSync: Upload cancelled");
         DebugLogManager.logWarning('Local upload cancelled', {
@@ -1062,7 +1084,36 @@ class LocalWalSyncImpl implements LocalWalSync {
                 'processedSegments': s.processedSegments,
                 'totalSegments': s.totalSegments,
               });
-              break; // still queued/processing — check later
+              // Escape hatch for a job the backend never resolves (e.g. wedged
+              // `queued`): past the stale cutoff, abandon it and recover from the
+              // retained local file so the recording isn't stuck forever. Mirrors
+              // the `notFound` recovery below. See issue #10033.
+              for (final w in members) {
+                if (!syncJobUploadIsStale(uploadedAt: w.uploadedAt, nowSecs: nowSecs)) continue;
+                changed = true;
+                final hadJob = w.jobId;
+                final ageSeconds = nowSecs - w.uploadedAt;
+                w.jobId = null;
+                final fileExists = await _localFileExists(w);
+                if (fileExists) {
+                  w.status = WalStatus.miss; // re-upload under a fresh job (dedup-safe)
+                  w.retryCount += 1;
+                  w.lastRetryAt = nowSecs;
+                } else {
+                  w.markCorrupted(); // nothing left to recover
+                }
+                DebugLogManager.logEvent('reconcile_revert', {
+                  'walId': w.id,
+                  'jobId': hadJob,
+                  'outcome': 'stale_timeout',
+                  'serverStatus': s.status,
+                  'ageSeconds': ageSeconds,
+                  'fileExists': fileExists,
+                  'newStatus': w.status.name,
+                  'retryCount': w.retryCount,
+                });
+              }
+              break; // remaining members still queued/processing — check later
             }
             if (s.result != null) {
               resp.newConversationIds.addAll(

--- a/app/test/unit/sync_job_terminal_policy_test.dart
+++ b/app/test/unit/sync_job_terminal_policy_test.dart
@@ -6,10 +6,7 @@ import 'package:omi/services/wals/local_wal_sync.dart';
 void main() {
   group('syncJobTerminalPolicy', () {
     test('acknowledges only a truthful completed terminal job', () {
-      expect(
-        syncJobTerminalPolicy(status: 'completed', isTerminal: true),
-        SyncJobTerminalPolicy.acknowledge,
-      );
+      expect(syncJobTerminalPolicy(status: 'completed', isTerminal: true), SyncJobTerminalPolicy.acknowledge);
     });
 
     test('retains retry material for partial and full failures', () {
@@ -23,14 +20,27 @@ void main() {
     });
 
     test('waits for nonterminal jobs regardless of their status text', () {
-      expect(
-        syncJobTerminalPolicy(status: 'processing', isTerminal: false),
-        SyncJobTerminalPolicy.wait,
-      );
-      expect(
-        syncJobTerminalPolicy(status: 'completed', isTerminal: false),
-        SyncJobTerminalPolicy.wait,
-      );
+      expect(syncJobTerminalPolicy(status: 'processing', isTerminal: false), SyncJobTerminalPolicy.wait);
+      expect(syncJobTerminalPolicy(status: 'completed', isTerminal: false), SyncJobTerminalPolicy.wait);
+    });
+  });
+
+  group('syncJobUploadIsStale', () {
+    const timeout = 6 * 60 * 60;
+
+    test('flags a WAL wedged past the cutoff so it stops polling forever', () {
+      // A job the backend keeps reporting non-terminal (e.g. stuck `queued`)
+      // must eventually be abandoned and re-uploaded. Regression for #10033.
+      expect(syncJobUploadIsStale(uploadedAt: 1000, nowSecs: 1000 + timeout, timeoutSeconds: timeout), isTrue);
+      expect(syncJobUploadIsStale(uploadedAt: 1000, nowSecs: 1000 + timeout + 1, timeoutSeconds: timeout), isTrue);
+    });
+
+    test('keeps polling a job still within the cutoff', () {
+      expect(syncJobUploadIsStale(uploadedAt: 1000, nowSecs: 1000 + timeout - 1, timeoutSeconds: timeout), isFalse);
+    });
+
+    test('never force-reverts a legacy WAL with no recorded upload time', () {
+      expect(syncJobUploadIsStale(uploadedAt: 0, nowSecs: 9999999, timeoutSeconds: timeout), isFalse);
     });
   });
 
@@ -45,13 +55,7 @@ void main() {
 
       expect(
         () => requireCompleteSyncUpload(response),
-        throwsA(
-          isA<SyncUploadIncompleteException>().having(
-            (error) => error.failedSegments,
-            'failedSegments',
-            1,
-          ),
-        ),
+        throwsA(isA<SyncUploadIncompleteException>().having((error) => error.failedSegments, 'failedSegments', 1)),
       );
     });
   });
@@ -72,10 +76,7 @@ void main() {
 
     test('recognizes the legacy stale-worker shape', () {
       expect(syncJobIsBackendBusy(status()), isTrue);
-      expect(
-        syncJobIsBackendBusy(status(error: 'Job timed out (background worker likely died)')),
-        isTrue,
-      );
+      expect(syncJobIsBackendBusy(status(error: 'Job timed out (background worker likely died)')), isTrue);
     });
 
     test('does not hide typed zero-segment failures from retry accounting', () {


### PR DESCRIPTION
## What

Adds a client-side staleness timeout to the WAL sync reconciler so an offline recording can't be polled in the `uploaded`/"processing" state indefinitely. Past a 6h cutoff the reconciler abandons the stale job and recovers from the retained local file.

## Why — issue #10033

> Audio recorded while offline may upload, but then remain stuck in the queue with `Uploaded · processing on Omi` for many hours without completing. […] Multiple queued items remain stuck for 12+ hours. No transcription is produced for those recordings.

Root cause: an offline recording uploads (HTTP 202), gets a `jobId`, and `reconcileUploadedWals()` polls its sync-job status until terminal. The `wait` branch just `break`s while the status is non-terminal — with **no timeout**. A job the backend keeps reporting non-terminal (notably one wedged `queued`, which the backend stale guard in `sync_jobs.py` explicitly never fails) is therefore polled forever, and the WAL stays in `WalStatus.uploaded` showing "Uploaded · processing on Omi" — exactly the reported symptom.

`Wal.uploadedAt` was already persisted (`wal.dart:132`) but had **zero readers** — the intended escape hatch was never wired.

## The fix

- New pure, `@visibleForTesting` helper `syncJobUploadIsStale(uploadedAt, nowSecs)` — a WAL uploaded past the 6h cutoff is stale. Legacy WALs with `uploadedAt == 0` return `false` (keep polling as before — no behavior change for them).
- In `reconcileUploadedWals()`'s non-terminal (`wait`) branch, stale members abandon the job and recover from the retained local file — re-upload under a fresh job when the file still exists (dedup-safe, same as the backend already handles on the `notFound` path), else `markCorrupted()`. This mirrors the existing `notFound` recovery path exactly.

## What I verified

- Added regression tests in `app/test/unit/sync_job_terminal_policy_test.dart` for the new decision boundary (wedged-past-cutoff → stale, within-cutoff → keep polling, legacy `uploadedAt==0` → never force-revert).
- `bash test.sh test/unit/sync_job_terminal_policy_test.dart` → **All 9 tests passed** (3 new).
- `dart analyze` on both changed files → clean. (The analyzer ratchet reports one `deprecated_member_use_from_same_package` finding, but I confirmed it pre-exists on a clean `main` checkout and is unrelated to this change.)
- **UNVERIFIED end-to-end:** I did not reproduce a real 6h-wedged backend job in a running app (requires a backend job genuinely stuck `queued` for hours). The fix is covered by the regression test on the decision function plus reconciler wiring that mirrors the already-exercised `notFound` recovery path.

Auto-generated from issue feedback by the mini issues-improver. Review before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

