### PR TITLE
test(app): add regression test for toggleApp failed-install branch

### DIFF
--- a/app/lib/providers/app_provider.dart
+++ b/app/lib/providers/app_provider.dart
@@ -17,6 +17,9 @@ class AppProvider extends BaseProvider {
   /// Test seam — overrides [enableAppServer] in [toggleApp].
   Future<bool> Function(String appId)? enableAppOverride;
 
+  /// Test seam — overrides [disableAppServer] in [toggleApp].
+  Future<void> Function(String appId)? disableAppOverride;
+
   List<App> apps = [];
   List<App> popularApps = [];
   // v2 grouped apps: [{ category: {id,title}, data: List<App>, pagination: {...} }]
@@ -815,7 +818,7 @@ class AppProvider extends BaseProvider {
           PlatformManager.instance.analytics.appEnabled(appId);
         }
       } else {
-        await disableAppServer(appId);
+        await (disableAppOverride ?? disableAppServer)(appId);
         success = true;
         PlatformManager.instance.analytics.appDisabled(appId);
       }

--- a/app/lib/providers/app_provider.dart
+++ b/app/lib/providers/app_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:collection/collection.dart';
 
@@ -15,9 +16,11 @@ import 'package:omi/utils/logger.dart';
 
 class AppProvider extends BaseProvider {
   /// Test seam — overrides [enableAppServer] in [toggleApp].
+  @visibleForTesting
   Future<bool> Function(String appId)? enableAppOverride;
 
   /// Test seam — overrides [disableAppServer] in [toggleApp].
+  @visibleForTesting
   Future<void> Function(String appId)? disableAppOverride;
 
   List<App> apps = [];

--- a/app/lib/providers/app_provider.dart
+++ b/app/lib/providers/app_provider.dart
@@ -14,6 +14,9 @@ import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
 
 class AppProvider extends BaseProvider {
+  /// Test seam — overrides [enableAppServer] in [toggleApp].
+  Future<bool> Function(String appId)? enableAppOverride;
+
   List<App> apps = [];
   List<App> popularApps = [];
   // v2 grouped apps: [{ category: {id,title}, data: List<App>, pagination: {...} }]
@@ -802,7 +805,7 @@ class AppProvider extends BaseProvider {
 
     try {
       if (isEnabled) {
-        success = await enableAppServer(appId);
+        success = await (enableAppOverride ?? enableAppServer)(appId);
         if (!success) {
           final context = globalNavigatorKey.currentState?.context;
           errorMessage = context != null && context.mounted

--- a/app/lib/utils/alerts/app_dialog.dart
+++ b/app/lib/utils/alerts/app_dialog.dart
@@ -48,8 +48,10 @@ class AppDialog {
     bool singleButton = false,
     String? okButtonText,
   }) {
+    final state = globalNavigatorKey.currentState;
+    if (state == null || state.overlay == null) return;
     showDialog(
-      context: globalNavigatorKey.currentState!.overlay!.context,
+      context: state.overlay!.context,
       builder: (c) => _getDialog(
         context: globalNavigatorKey.currentState!.context,
         onConfirm: onConfirm,

--- a/app/test/providers/app_provider_toggle_test.dart
+++ b/app/test/providers/app_provider_toggle_test.dart
@@ -1,15 +1,13 @@
-import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:omi/app_globals.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/app.dart';
-import 'package:omi/l10n/app_localizations.dart';
 import 'package:omi/providers/app_provider.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('AppProvider.toggleApp', () {
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
@@ -22,28 +20,7 @@ void main() {
       provider.dispose();
     });
 
-    /// Creates a minimal MaterialApp so [AppDialog.show] (called inside
-    /// [toggleApp] on failure) has a navigator context and does not crash.
-    Future<void> pumpNavigator(WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          navigatorKey: globalNavigatorKey,
-          localizationsDelegates: const [
-            AppLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-          ],
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: const Scaffold(body: Text('test')),
-        ),
-      );
-      await tester.pump();
-    }
-
-    testWidgets('returns false when enableAppServer fails (regression guard)', (tester) async {
-      await pumpNavigator(tester);
-
+    test('returns false when enableAppServer fails (regression guard)', () async {
       provider = AppProvider();
       provider.enableAppOverride = (String id) async {
         expect(id, equals('app_123'));
@@ -57,9 +34,7 @@ void main() {
       expect(result, isFalse);
     });
 
-    testWidgets('returns true when enableAppServer succeeds', (tester) async {
-      await pumpNavigator(tester);
-
+    test('returns true when enableAppServer succeeds', () async {
       provider = AppProvider();
       // Set up local app so the success path can find and update it.
       provider.apps = [
@@ -87,12 +62,26 @@ void main() {
       };
 
       final result = await provider.toggleApp('app_123', true, null);
-      // Flush both debounced timers (updatePrefApps 500ms + _scheduleAppsRefresh 2s)
-      await tester.pump(const Duration(seconds: 3));
-      await tester.pump();
 
       expect(result, isTrue);
       expect(enableCalled, isTrue);
+    });
+
+    test('does not call enableAppOverride when disabling', () async {
+      provider = AppProvider();
+      var enableCalled = false;
+      provider.enableAppOverride = (String id) async {
+        enableCalled = true;
+        return true;
+      };
+      provider.disableAppOverride = (String id) async {
+        expect(id, equals('app_456'));
+      };
+
+      final result = await provider.toggleApp('app_456', false, null);
+
+      expect(result, isTrue); // disable always reports success
+      expect(enableCalled, isFalse); // only disableAppOverride was used
     });
   });
 }

--- a/app/test/providers/app_provider_toggle_test.dart
+++ b/app/test/providers/app_provider_toggle_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/app_globals.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/app.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/providers/app_provider.dart';
+
+void main() {
+  group('AppProvider.toggleApp', () {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      await SharedPreferencesUtil.init();
+    });
+
+    late AppProvider provider;
+
+    tearDown(() {
+      provider.dispose();
+    });
+
+    /// Creates a minimal MaterialApp so [AppDialog.show] (called inside
+    /// [toggleApp] on failure) has a navigator context and does not crash.
+    Future<void> pumpNavigator(WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: globalNavigatorKey,
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const Scaffold(body: Text('test')),
+        ),
+      );
+      await tester.pump();
+    }
+
+    testWidgets('returns false when enableAppServer fails (regression guard)', (tester) async {
+      await pumpNavigator(tester);
+
+      provider = AppProvider();
+      provider.enableAppOverride = (String id) async {
+        expect(id, equals('app_123'));
+        return false;
+      };
+
+      final result = await provider.toggleApp('app_123', true, null);
+
+      // The entire purpose of the #10100 fix: the caller can now
+      // distinguish failure from success instead of assuming success.
+      expect(result, isFalse);
+    });
+
+    testWidgets('returns true when enableAppServer succeeds', (tester) async {
+      await pumpNavigator(tester);
+
+      provider = AppProvider();
+      // Set up local app so the success path can find and update it.
+      provider.apps = [
+        App(
+            id: 'app_123',
+            name: 'Test',
+            author: 'tester',
+            description: 'test',
+            image: '',
+            capabilities: {'memories'},
+            status: 'approved',
+            category: 'test',
+            approved: true,
+            ratingCount: 0,
+            enabled: true,
+            deleted: false,
+            isPaid: false,
+            isUserPaid: false),
+      ];
+      var enableCalled = false;
+      provider.enableAppOverride = (String id) async {
+        enableCalled = true;
+        expect(id, equals('app_123'));
+        return true;
+      };
+
+      final result = await provider.toggleApp('app_123', true, null);
+      // Flush both debounced timers (updatePrefApps 500ms + _scheduleAppsRefresh 2s)
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pump();
+
+      expect(result, isTrue);
+      expect(enableCalled, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
# Summary

Adds a regression test for the failed-install branch that PR #10100 fixed. The PR changed `toggleApp` from `Future<void>` → `Future<bool>` and routed the create-template sheet through it. The reviewer [requested](https://github.com/BasedHardware/omi/pull/10100#issuecomment-5021611256) a test covering the failure path so the false-success regression cannot silently return.

# Changes

## `app/lib/providers/app_provider.dart` (+10/-3)

Adds two minimal test seams:

| Seam | Purpose |
|------|---------|
| `enableAppOverride` | Mocks `enableAppServer` in tests for the failed-install branch |
| `disableAppOverride` | Mocks `disableAppServer` for the disable path |

Both fall through to the real functions when null — existing callers unaffected.

## `app/lib/utils/alerts/app_dialog.dart` (+3/-1)

Makes `AppDialog.show()` null-safe: returns early when no navigator is mounted. Prevents a hard crash on the failure path in edge-case production scenarios and in tests without a widget tree.

## `app/test/providers/app_provider_toggle_test.dart` (new, ~85 lines)

Three tests, all pure `test()` (no widget tree needed):

| Test | What it covers |
|------|---------------|
| `returns false when enableAppServer fails (regression guard)` | The exact regression #10100 fixed — `toggleApp` must surface failure to its caller |
| `returns true when enableAppServer succeeds` | Happy path — the override is plumbed correctly and success propagates |
| `does not call enableAppOverride when disabling` | Disable path uses its own override, not the enable one |

# Verification

```
$ flutter test test/providers/app_provider_toggle_test.dart
00:00 +3: All tests passed!
```

Existing provider tests also pass (no regressions):

```
$ flutter test test/widget_test.dart test/providers/add_app_provider_test.dart
00:00 +20: All tests passed!
```

pre-push checks: 10/10 passed.

Failure-Class: none
