### PR TITLE
fix(desktop): route onboarding arrow-key navigation through the mounted view

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -787,6 +787,12 @@ class AppState: ObservableObject {
 
 extension Notification.Name {
   static let resetOnboardingRequested = Notification.Name("resetOnboardingRequested")
+  /// Posted by the onboarding arrow-key monitor with a "targetStep" Int in
+  /// userInfo. The mounted OnboardingView applies it to its live @AppStorage —
+  /// the monitor closure must not mutate its own captured copy (writes there
+  /// never reach UserDefaults or the UI on all macOS versions).
+  static let onboardingStepNavigationRequested = Notification.Name(
+    "onboardingStepNavigationRequested")
   /// Posted when the system wakes from sleep
   static let systemDidWake = Notification.Name("systemDidWake")
   /// Posted when the screen is locked

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -38,6 +38,7 @@ enum DefaultsKey: String {
   case aiChatWorkingDirectory = "aiChatWorkingDirectory"
   case hasCompletedOnboarding = "hasCompletedOnboarding"
   case onboardingStep = "onboardingStep"
+  case onboardingFurthestStep = "onboardingFurthestStep"
   case onboardingMemoryImportOwnerUserId = "onboardingMemoryImportOwnerUserID"
   case homeOmiDeviceAccountHistory = "home-omi-device-account-history"
   case chatScreenshotSharingEnabled = "chatScreenshotSharingEnabled"

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingFlow.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingFlow.swift
@@ -59,6 +59,36 @@ enum OnboardingFlow {
     return !(frontier..<target).contains { unskippableSteps.contains($0) }
   }
 
+  /// What a bare arrow key does at `step`. Left/up go back one step; right/down
+  /// jump forward when the next step is cleared or skippable, and otherwise
+  /// defer to the step's own Continue gating (the caller re-issues the default
+  /// action). Non-arrow key codes navigate nothing.
+  enum ArrowNavigation: Equatable {
+    case jump(to: Int)
+    case forwardDefaultAction
+  }
+
+  static func arrowNavigation(keyCode: UInt16, step: Int, furthestStep: Int) -> ArrowNavigation? {
+    switch keyCode {
+    case 123, 126:  // left, up
+      return step > 0 ? .jump(to: step - 1) : nil
+    case 124, 125:  // right, down
+      let next = step + 1
+      return canJump(to: next, furthestStep: furthestStep) ? .jump(to: next) : .forwardDefaultAction
+    default:
+      return nil
+    }
+  }
+
+  /// Validates a requested arrow-navigation target against live state before
+  /// the mounted view applies it: backward is always allowed, forward only
+  /// through cleared/skippable steps (same policy as the progress dots).
+  static func validatedNavigationTarget(_ target: Int, currentStep: Int, furthestStep: Int) -> Int? {
+    guard target >= 0, target <= lastStepIndex else { return nil }
+    if target > currentStep, !canJump(to: target, furthestStep: furthestStep) { return nil }
+    return target
+  }
+
   static func migratedStep(
     currentStep: Int,
     hasMigratedVideoStep: Bool,

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
@@ -38,7 +38,11 @@ struct OnboardingView: View {
   @StateObject private var introCoordinator = OnboardingPagedIntroCoordinator()
   @StateObject private var graphViewModel = MemoryGraphViewModel()
   @FocusState private var contentFocused: Bool
-  @State private var keyNavMonitor: Any?
+  /// Static, not @State: SwiftUI can recreate this view mid-flow (parent tree
+  /// identity changes), and a per-identity handle would leak the old monitor —
+  /// which keeps consuming arrow keys — while installing a second one. One
+  /// shared handle means re-install replaces instead of stacking.
+  private static var keyNavMonitor: Any?
 
   let steps = OnboardingFlow.steps
 
@@ -113,7 +117,13 @@ struct OnboardingView: View {
       installKeyNavigationMonitor()
     }
     .onDisappear {
-      removeKeyNavigationMonitor()
+      // Identity churn re-creates this view mid-flow, and the new identity's
+      // onAppear may run before this onDisappear — removing here would tear
+      // down the monitor it just installed. Only remove once onboarding is
+      // actually over; the handler also no-ops after completion.
+      if !isExportPreview, appState.hasCompletedOnboarding {
+        removeKeyNavigationMonitor()
+      }
     }
     .task {
       guard !isExportPreview else { return }
@@ -128,6 +138,16 @@ struct OnboardingView: View {
       log("OnboardingView: resetOnboardingRequested — returning to the first onboarding step")
       currentStep = 0
       furthestStep = 0
+    }
+    .onReceive(
+      NotificationCenter.default.publisher(for: .onboardingStepNavigationRequested)
+    ) { note in
+      guard !isExportPreview, let requested = note.userInfo?["targetStep"] as? Int else { return }
+      guard
+        let target = OnboardingFlow.validatedNavigationTarget(
+          requested, currentStep: currentStep, furthestStep: furthestStep)
+      else { return }
+      currentStep = target
     }
   }
 
@@ -513,43 +533,42 @@ struct OnboardingView: View {
     currentStep = index
   }
 
-  /// Forward navigation. Cleared and skippable steps advance automatically
-  /// (answers/permissions are already fixed, or the step could be skipped
-  /// anyway). At an unanswered required step it defers to the step's own
-  /// Continue gating by re-issuing the default action.
-  private func handleForwardNavigation() -> Bool {
-    let next = currentStep + 1
-    if OnboardingFlow.canJump(to: next, furthestStep: furthestStep) {
-      currentStep = next
-      return true
-    }
-    return handleForwardKey() == .handled
-  }
-
   /// Arrow-key navigation runs off a local `NSEvent` monitor rather than SwiftUI
   /// `.onKeyPress`, because the "Ask a question" steps take key focus away from the
   /// onboarding window (shortcut steps null the app menu + install their own key
   /// monitor; demo steps hand focus to the floating Ask Omi panel). A monitor sees
   /// the keystroke regardless of which of the app's windows is key.
   private func installKeyNavigationMonitor() {
-    guard keyNavMonitor == nil, !isExportPreview else { return }
-    keyNavMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+    // The outer onAppear also runs on the already-completed branch — don't
+    // install an arrow monitor for a flow that isn't showing.
+    guard !isExportPreview, !appState.hasCompletedOnboarding else { return }
+    removeKeyNavigationMonitor()
+    Self.keyNavMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
       handleArrowNavigation(event) ? nil : event
     }
   }
 
   private func removeKeyNavigationMonitor() {
-    if let monitor = keyNavMonitor {
+    if let monitor = Self.keyNavMonitor {
       NSEvent.removeMonitor(monitor)
-      keyNavMonitor = nil
+      Self.keyNavMonitor = nil
     }
   }
 
   /// Returns true when the event was consumed as a back/forward navigation.
   /// Skips plain arrows while the user is typing (any text field, including the
   /// floating Ask Omi bar) so the caret keeps moving instead of navigating.
+  ///
+  /// Runs inside the NSEvent monitor closure, which holds a detached copy of
+  /// this view. Mutating @AppStorage through that copy silently drops the write
+  /// on some macOS versions (it never reaches UserDefaults or the mounted
+  /// view), so this reads the persisted step state directly and posts the
+  /// target step for the mounted view's `.onReceive` to apply.
   private func handleArrowNavigation(_ event: NSEvent) -> Bool {
     guard !isExportPreview else { return false }
+    // The monitor may briefly outlive the flow (removal is deferred across
+    // identity churn); never swallow arrows once onboarding is done.
+    guard !UserDefaults.standard.bool(forKey: .hasCompletedOnboarding) else { return false }
     // Only bare arrows navigate — leave shortcut chords (⌘/⌥/⌃/⇧) to their owners.
     let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
     guard mods.subtracting([.function, .numericPad]).isEmpty else { return false }
@@ -557,16 +576,25 @@ struct OnboardingView: View {
     if NSApp.keyWindow is FloatingControlBarWindow { return false }
     if NSApp.keyWindow?.firstResponder is NSText { return false }
 
-    switch event.keyCode {
-    case 123, 126:  // left, up
-      guard canGoBack else { return false }
-      goBack()
+    let defaults = UserDefaults.standard
+    let step = defaults.integer(forKey: .onboardingStep)
+    let frontier = defaults.integer(forKey: .onboardingFurthestStep)
+
+    switch OnboardingFlow.arrowNavigation(keyCode: event.keyCode, step: step, furthestStep: frontier)
+    {
+    case .jump(let target):
+      postStepNavigation(target)
       return true
-    case 124, 125:  // right, down
-      return handleForwardNavigation()
-    default:
+    case .forwardDefaultAction:
+      return handleForwardKey() == .handled
+    case nil:
       return false
     }
+  }
+
+  private func postStepNavigation(_ target: Int) {
+    NotificationCenter.default.post(
+      name: .onboardingStepNavigationRequested, object: nil, userInfo: ["targetStep": target])
   }
 
   /// Forward arrow == pressing the step's visible Continue button. Re-issuing the

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -387,6 +387,43 @@ final class OnboardingFlowTests: XCTestCase {
     }
   }
 
+  // Regression: arrow navigation must be computed from persisted step state and
+  // applied by the mounted view — the NSEvent monitor's captured view copy drops
+  // @AppStorage writes on some macOS versions. These cover the extracted
+  // decision + validation seam the monitor and .onReceive now route through.
+  func testArrowNavigationDecisions() {
+    // Left/up go back one step; blocked at the first step.
+    XCTAssertEqual(
+      OnboardingFlow.arrowNavigation(keyCode: 123, step: 10, furthestStep: 15), .jump(to: 9))
+    XCTAssertEqual(
+      OnboardingFlow.arrowNavigation(keyCode: 126, step: 1, furthestStep: 1), .jump(to: 0))
+    XCTAssertNil(OnboardingFlow.arrowNavigation(keyCode: 123, step: 0, furthestStep: 5))
+    // Right/down jump when the next step is cleared or skippable.
+    XCTAssertEqual(
+      OnboardingFlow.arrowNavigation(keyCode: 124, step: 10, furthestStep: 15), .jump(to: 11))
+    XCTAssertEqual(
+      OnboardingFlow.arrowNavigation(keyCode: 125, step: 5, furthestStep: 5), .jump(to: 6))
+    // At an uncleared required step, defer to the step's own Continue gating.
+    XCTAssertEqual(
+      OnboardingFlow.arrowNavigation(keyCode: 124, step: 1, furthestStep: 1),
+      .forwardDefaultAction)
+    // Non-arrow keys navigate nothing.
+    XCTAssertNil(OnboardingFlow.arrowNavigation(keyCode: 36, step: 5, furthestStep: 10))
+  }
+
+  func testValidatedNavigationTargetPolicy() {
+    // Backward always allowed, forward gated by canJump, range clamped.
+    XCTAssertEqual(
+      OnboardingFlow.validatedNavigationTarget(9, currentStep: 10, furthestStep: 15), 9)
+    XCTAssertEqual(
+      OnboardingFlow.validatedNavigationTarget(11, currentStep: 10, furthestStep: 15), 11)
+    XCTAssertNil(OnboardingFlow.validatedNavigationTarget(2, currentStep: 1, furthestStep: 1))
+    XCTAssertNil(OnboardingFlow.validatedNavigationTarget(-1, currentStep: 0, furthestStep: 0))
+    XCTAssertNil(
+      OnboardingFlow.validatedNavigationTarget(
+        OnboardingFlow.lastStepIndex + 1, currentStep: 5, furthestStep: 17))
+  }
+
   @MainActor
   func testHowDidYouHearKeepsOtherLast() {
     XCTAssertEqual(OnboardingHowDidYouHearStepView.sources.last?.name, "Other")

--- a/desktop/macos/changelog/unreleased/20260720-onboarding-arrow-keys.json
+++ b/desktop/macos/changelog/unreleased/20260720-onboarding-arrow-keys.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed onboarding arrow-key navigation dying partway through the flow (from the Ask a question shortcut step onward)"
+}


### PR DESCRIPTION
## Problem

Arrow-key navigation in desktop onboarding dies partway through the flow — reported as "stopped working at the *Let's set 'Ask a question' shortcut* step". Left/right/up/down presses are consumed but the step never changes, and navigation never comes back for the rest of the flow.

## Root cause

`OnboardingView` installs an `NSEvent` local key monitor whose closure captures the view struct once at install time. Navigation mutated `currentStep`/`furthestStep` through that captured copy's `@AppStorage`. That works only while the captured storage boxes are still the mounted view's live ones: when SwiftUI re-creates `OnboardingView` mid-flow (parent identity churn around the shortcut/demo steps), the stale monitor keeps consuming arrow events while its writes land in orphaned storage — the UI freezes on the current step. Two competing writers of the same state (the mounted view and the detached closure copy) with no single authority — `FC-split-mutation-authority`.

## Fix

The monitor now only decides; the mounted view mutates:

- `handleArrowNavigation` reads persisted step state directly from `UserDefaults`, resolves the action via a new pure seam `OnboardingFlow.arrowNavigation(keyCode:step:furthestStep:)`, and posts `.onboardingStepNavigationRequested`.
- The mounted view's `.onReceive` re-validates with `OnboardingFlow.validatedNavigationTarget` (backward always allowed, forward gated by the same `canJump` policy as the progress dots) and applies the step through its live `@AppStorage`.
- The monitor handle is static — re-install replaces instead of stacking across identity churn — teardown waits for actual flow completion, and the handler no-ops once onboarding is complete so a lingering monitor can never swallow arrow keys in the main app.

## Verification

- Reproduced pre-fix on a live named test bundle seeded to the shortcut step (step 10, frontier 15): 12 arrow presses via the new `post_key` automation-bridge action, step pinned at 10 while debug logs showed the monitor "navigating" into the orphaned copy.
- Post-fix on the same harness with a real key window: rights walk 10 → 11 → 12 → 13 (across the floating-bar demo and voice shortcut steps), lefts walk 13 → 12 → 11 → 10 → 9.
- `xcrun swift build -c debug --package-path Desktop` clean; `swift test --filter OnboardingFlowTests`: 22 tests, 0 failures — including new regression coverage `testArrowNavigationDecisions` and `testValidatedNavigationTargetPolicy` for the extracted decision/validation seam.

## Invariants

Path-matched per `scripts/pr-preflight --suggest`: INV-AUTH-1, INV-CHAT-1, INV-INT-1 — no behavior change to any of the three; the diff touches `AppState.swift` only to declare the new `Notification.Name`, and onboarding chat/session flows are untouched.

Failure-Class: FC-split-mutation-authority


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

