### PR TITLE
feat(desktop): add Monologur always-listening background agent to des…

### DIFF
--- a/desktop/windows/src/main/ipc/integrations.ts
+++ b/desktop/windows/src/main/ipc/integrations.ts
@@ -14,7 +14,13 @@ import type {
   GoogleSource,
   FetchNewResult,
   GmailItem,
+<<<<<<< Updated upstream
   CalendarItem
+=======
+  CalendarItem,
+  TranslationResult,
+  DeepgramTtsResult
+>>>>>>> Stashed changes
 } from '../../shared/types'
 
 // All integrations IPC lives here (3e Sticky Notes + 3d Gmail/Calendar) so
@@ -76,4 +82,29 @@ export function registerIntegrationsHandlers(): void {
       markProcessed(source, ids)
     }
   )
+<<<<<<< Updated upstream
+=======
+
+  ipcMain.handle(
+    'integrations:signLanguage:translate',
+    async (_e, payload: unknown): Promise<TranslationResult> => {
+      const text = typeof payload === 'string' ? payload : (payload as { text?: string })?.text
+      const spokenLanguage =
+        typeof payload === 'object' && payload ? (payload as { spokenLanguage?: string }).spokenLanguage : 'en'
+      const signedLanguage =
+        typeof payload === 'object' && payload ? (payload as { signedLanguage?: string }).signedLanguage : 'ase'
+      if (!text) throw new Error('No text provided for translation')
+      return translateToGlosses(text, spokenLanguage ?? 'en', signedLanguage ?? 'ase', defaultSignOpts())
+    }
+  )
+
+  // Deepgram TTS synthesis. The renderer's Monologur engine calls this only when
+  // the user selects the Deepgram provider; it currently returns not-implemented
+  // so the engine falls back to the Web Speech API. Wire a real Deepgram Aura
+  // call here in a follow-up when the desktop backend exposes TTS credentials.
+  ipcMain.handle('deepgram:ttsSynthesize', async (): Promise<DeepgramTtsResult> => {
+    console.warn('[deepgram] ttsSynthesize not implemented; falling back to Web Speech TTS')
+    return { ok: false, error: 'not_implemented' }
+  })
+>>>>>>> Stashed changes
 }

--- a/desktop/windows/src/main/ipc/integrations.ts
+++ b/desktop/windows/src/main/ipc/integrations.ts
@@ -14,13 +14,8 @@ import type {
   GoogleSource,
   FetchNewResult,
   GmailItem,
-<<<<<<< Updated upstream
-  CalendarItem
-=======
   CalendarItem,
-  TranslationResult,
   DeepgramTtsResult
->>>>>>> Stashed changes
 } from '../../shared/types'
 
 // All integrations IPC lives here (3e Sticky Notes + 3d Gmail/Calendar) so
@@ -82,22 +77,6 @@ export function registerIntegrationsHandlers(): void {
       markProcessed(source, ids)
     }
   )
-<<<<<<< Updated upstream
-=======
-
-  ipcMain.handle(
-    'integrations:signLanguage:translate',
-    async (_e, payload: unknown): Promise<TranslationResult> => {
-      const text = typeof payload === 'string' ? payload : (payload as { text?: string })?.text
-      const spokenLanguage =
-        typeof payload === 'object' && payload ? (payload as { spokenLanguage?: string }).spokenLanguage : 'en'
-      const signedLanguage =
-        typeof payload === 'object' && payload ? (payload as { signedLanguage?: string }).signedLanguage : 'ase'
-      if (!text) throw new Error('No text provided for translation')
-      return translateToGlosses(text, spokenLanguage ?? 'en', signedLanguage ?? 'ase', defaultSignOpts())
-    }
-  )
-
   // Deepgram TTS synthesis. The renderer's Monologur engine calls this only when
   // the user selects the Deepgram provider; it currently returns not-implemented
   // so the engine falls back to the Web Speech API. Wire a real Deepgram Aura
@@ -106,5 +85,4 @@ export function registerIntegrationsHandlers(): void {
     console.warn('[deepgram] ttsSynthesize not implemented; falling back to Web Speech TTS')
     return { ok: false, error: 'not_implemented' }
   })
->>>>>>> Stashed changes
 }

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -16,7 +16,14 @@ import type {
   RewindSettings,
   InsightPayload,
   AutomationPlan,
+<<<<<<< Updated upstream
   StepResult
+=======
+  StepResult,
+  TranslationResult,
+  DeepgramTtsOptions,
+  DeepgramTtsResult
+>>>>>>> Stashed changes
 } from '../shared/types'
 
 const omi: OmiBridgeApi = {
@@ -150,7 +157,18 @@ const omi: OmiBridgeApi = {
     const listener = (): void => cb()
     ipcRenderer.on('conversations:changed', listener)
     return () => ipcRenderer.removeListener('conversations:changed', listener)
+<<<<<<< Updated upstream
   }
+=======
+  },
+  onDeepgramSignUpdate: (cb: (result: TranslationResult) => void) => {
+    const listener = (_e: Electron.IpcRendererEvent, result: TranslationResult): void => cb(result)
+    ipcRenderer.on('omi-sign-update', listener)
+    return () => ipcRenderer.removeListener('omi-sign-update', listener)
+  },
+  deepgramTtsSynthesize: (options: DeepgramTtsOptions): Promise<DeepgramTtsResult> =>
+    ipcRenderer.invoke('deepgram:ttsSynthesize', options)
+>>>>>>> Stashed changes
 }
 
 const omiOverlay: OmiOverlayApi = {

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -16,14 +16,9 @@ import type {
   RewindSettings,
   InsightPayload,
   AutomationPlan,
-<<<<<<< Updated upstream
-  StepResult
-=======
   StepResult,
-  TranslationResult,
   DeepgramTtsOptions,
   DeepgramTtsResult
->>>>>>> Stashed changes
 } from '../shared/types'
 
 const omi: OmiBridgeApi = {
@@ -157,18 +152,9 @@ const omi: OmiBridgeApi = {
     const listener = (): void => cb()
     ipcRenderer.on('conversations:changed', listener)
     return () => ipcRenderer.removeListener('conversations:changed', listener)
-<<<<<<< Updated upstream
-  }
-=======
-  },
-  onDeepgramSignUpdate: (cb: (result: TranslationResult) => void) => {
-    const listener = (_e: Electron.IpcRendererEvent, result: TranslationResult): void => cb(result)
-    ipcRenderer.on('omi-sign-update', listener)
-    return () => ipcRenderer.removeListener('omi-sign-update', listener)
   },
   deepgramTtsSynthesize: (options: DeepgramTtsOptions): Promise<DeepgramTtsResult> =>
     ipcRenderer.invoke('deepgram:ttsSynthesize', options)
->>>>>>> Stashed changes
 }
 
 const omiOverlay: OmiOverlayApi = {

--- a/desktop/windows/src/renderer/src/App.tsx
+++ b/desktop/windows/src/renderer/src/App.tsx
@@ -24,6 +24,7 @@ import { ContinuousRecordingHost } from './components/recording/ContinuousRecord
 import { invalidateConversationsCache } from './lib/pageCache'
 import { runAnimBench } from './lib/animBench'
 import { InsightToast } from './components/insight/InsightToast'
+import { MonologurHost } from './components/monologur/MonologurHost'
 
 function AppShellInner(): React.JSX.Element {
   const { recorder, pickerOpen, setPickerOpen } = useAppState()
@@ -85,6 +86,8 @@ function AppShellInner(): React.JSX.Element {
       <RewindCaptureHost />
       {/* Always-on mic capture for continuous recording mode. */}
       <ContinuousRecordingHost />
+      {/* Monologur: always-listening background agent (proactive TTS interruptions). */}
+      <MonologurHost />
     </div>
   )
 }

--- a/desktop/windows/src/renderer/src/components/monologur/MonologurHost.tsx
+++ b/desktop/windows/src/renderer/src/components/monologur/MonologurHost.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState, useCallback } from 'react'
+import {
+  startMonologur,
+  stopMonologur,
+  setOnProactiveMessage,
+  setOnMonologurStatusChange,
+  getMonologurSettings
+} from '../../lib/monologurEngine'
+import { resumeAfterInteraction } from '../../lib/ttsService'
+
+type MonologurStatus = 'idle' | 'listening' | 'thinking' | 'speaking'
+
+export function MonologurHost(): React.JSX.Element | null {
+  const [status, setStatus] = useState<MonologurStatus>('idle')
+  const [lastMessage, setLastMessage] = useState<string | null>(null)
+  const [showMessage, setShowMessage] = useState(false)
+  const [ttsProvider, setTtsProvider] = useState<'web' | 'deepgram'>('web')
+
+  const handleMessage = useCallback((text: string) => {
+    setLastMessage(text)
+    setShowMessage(true)
+    setTimeout(() => setShowMessage(false), 10000)
+  }, [])
+
+  useEffect(() => {
+    const handleInteraction = (): void => {
+      resumeAfterInteraction()
+    }
+    document.addEventListener('click', handleInteraction, { once: true })
+
+    setOnProactiveMessage(handleMessage)
+    setOnMonologurStatusChange(setStatus)
+
+    const settings = getMonologurSettings()
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- derives provider label from persisted settings
+    setTtsProvider(settings.ttsProvider)
+
+    if (settings.enabled) {
+      startMonologur()
+    }
+
+    return () => {
+      document.removeEventListener('click', handleInteraction)
+      setOnProactiveMessage(null)
+      setOnMonologurStatusChange(null)
+      stopMonologur()
+    }
+  }, [handleMessage])
+
+  if (status === 'idle') return null
+
+  const isDeepgram = ttsProvider === 'deepgram'
+
+  return (
+    <>
+      {/* Status indicator */}
+      <div
+        className="fixed bottom-4 left-4 z-50 flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium shadow-lg"
+        style={{
+          backgroundColor: 'rgba(0, 0, 0, 0.7)',
+          color: 'white'
+        }}
+      >
+        <div
+          className="h-2 w-2 rounded-full"
+          style={{
+            backgroundColor:
+              status === 'speaking'
+                ? '#22c55e'
+                : status === 'thinking'
+                  ? '#eab308'
+                  : status === 'listening'
+                    ? '#3b82f6'
+                    : '#6b7280',
+            animation: status === 'thinking' ? 'pulse 1s infinite' : undefined
+          }}
+        />
+        <span>
+          {status === 'speaking'
+            ? `Monologur speaking${isDeepgram ? ' (Deepgram)' : ''}...`
+            : status === 'thinking'
+              ? 'Monologur thinking...'
+              : status === 'listening'
+                ? `Monologur listening${isDeepgram ? ' (Deepgram)' : ''}`
+                : 'Monologur'}
+        </span>
+      </div>
+
+      {/* Proactive message toast */}
+      {showMessage && lastMessage && (
+        <div
+          className="fixed bottom-16 left-4 z-50 max-w-sm rounded-lg p-4 shadow-xl transition-all duration-300"
+          style={{
+            backgroundColor: 'rgba(59, 130, 246, 0.9)',
+            color: 'white',
+            transform: showMessage ? 'translateY(0)' : 'translateY(20px)',
+            opacity: showMessage ? 1 : 0
+          }}
+        >
+          <div className="flex items-start gap-3">
+            <div className="flex-shrink-0 text-lg">💬</div>
+            <div>
+              <div className="mb-1 text-xs font-semibold opacity-80">
+                Monologur {isDeepgram ? '(Deepgram TTS)' : ''}
+              </div>
+              <div className="text-sm">{lastMessage}</div>
+            </div>
+            <button
+              onClick={() => setShowMessage(false)}
+              className="ml-2 flex-shrink-0 opacity-70 hover:opacity-100"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      )}
+
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.5; }
+        }
+      `}</style>
+    </>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/settings/tabs/GeneralTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/GeneralTab.tsx
@@ -1,35 +1,91 @@
 import { useState } from 'react'
-import { MessagesSquare } from 'lucide-react'
+import { MessagesSquare, Mic } from 'lucide-react'
 import { getPreferences, setPreferences } from '../../../lib/preferences'
 import { SettingRow } from '../SettingRow'
+import {
+  getMonologurSettings,
+  saveMonologurSettings,
+  startMonologur,
+  stopMonologur
+} from '../../../lib/monologurEngine'
 
 export function GeneralTab(): React.JSX.Element {
   const [chatHistoryMode, setChatHistoryMode] = useState(getPreferences().chatHistoryMode)
+  const [monologurEnabled, setMonologurEnabled] = useState(() => getMonologurSettings().enabled)
+  const [ttsProvider, setTtsProvider] = useState<'web' | 'deepgram'>(() => getMonologurSettings().ttsProvider)
 
   return (
-    <SettingRow
-      icon={MessagesSquare}
-      title="Chat history"
-      subtitle="By default, one ongoing conversation (shared with the floating bar) that persists across launches — scroll up in chat to load older messages. Or start a fresh conversation each launch."
-      keywords="conversation thread floating bar history infinite"
-      control={
-        <select
-          value={chatHistoryMode}
-          onChange={(e) => {
-            const v = e.target.value as 'per-launch' | 'infinite'
-            setChatHistoryMode(v)
-            setPreferences({ chatHistoryMode: v })
-          }}
-          className="rounded-md bg-white/10 px-2 py-1.5 text-sm text-white focus:outline-none"
-        >
-          <option value="infinite" className="bg-neutral-900">
-            One ongoing conversation (default)
-          </option>
-          <option value="per-launch" className="bg-neutral-900">
-            New conversation each launch
-          </option>
-        </select>
-      }
-    />
+    <>
+      <SettingRow
+        icon={MessagesSquare}
+        title="Chat history"
+        subtitle="By default, one ongoing conversation (shared with the floating bar) that persists across launches — scroll up in chat to load older messages. Or start a fresh conversation each launch."
+        keywords="conversation thread floating bar history infinite"
+        control={
+          <select
+            value={chatHistoryMode}
+            onChange={(e) => {
+              const v = e.target.value as 'per-launch' | 'infinite'
+              setChatHistoryMode(v)
+              setPreferences({ chatHistoryMode: v })
+            }}
+            className="rounded-md bg-white/10 px-2 py-1.5 text-sm text-white focus:outline-none"
+          >
+            <option value="infinite" className="bg-neutral-900">
+              One ongoing conversation (default)
+            </option>
+            <option value="per-launch" className="bg-neutral-900">
+              New conversation each launch
+            </option>
+          </select>
+        }
+      />
+
+      <SettingRow
+        icon={Mic}
+        title="Monologur"
+        subtitle="Always-listening AI assistant that provides real-time guidance and suggestions via text-to-speech based on your ongoing conversations."
+        keywords="monologur always listening tts speech proactive"
+        control={
+          <div className="flex items-center gap-2">
+            <select
+              value={ttsProvider}
+              onChange={(e) => {
+                const v = e.target.value as 'web' | 'deepgram'
+                setTtsProvider(v)
+                saveMonologurSettings({ ttsProvider: v })
+              }}
+              className="rounded-md bg-white/10 px-2 py-1.5 text-sm text-white focus:outline-none"
+            >
+              <option value="web" className="bg-neutral-900">
+                Web TTS
+              </option>
+              <option value="deepgram" className="bg-neutral-900">
+                Deepgram Aura
+              </option>
+            </select>
+            <button
+              onClick={() => {
+                const newValue = !monologurEnabled
+                setMonologurEnabled(newValue)
+                saveMonologurSettings({ enabled: newValue })
+                if (newValue) {
+                  startMonologur()
+                } else {
+                  stopMonologur()
+                }
+              }}
+              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                monologurEnabled
+                  ? 'bg-green-500/20 text-green-400 hover:bg-green-500/30'
+                  : 'bg-white/10 text-white/60 hover:bg-white/20'
+              }`}
+            >
+              {monologurEnabled ? 'Enabled' : 'Disabled'}
+            </button>
+          </div>
+        }
+      />
+    </>
   )
 }

--- a/desktop/windows/src/renderer/src/lib/monologurEngine.ts
+++ b/desktop/windows/src/renderer/src/lib/monologurEngine.ts
@@ -1,0 +1,321 @@
+// src/renderer/src/lib/monologurEngine.ts
+import { generate } from './geminiClient'
+import { liveConversation } from './liveConversation'
+import { speak, stop as stopTTS, setOnSpeakingChange, isTTSSpeaking } from './ttsService'
+import { getMonologurMemoryContext, saveMonologurInsight } from './monologurMemory'
+import type { TTSSettings } from './ttsService'
+import type { TranscriptLine } from '../../../shared/types'
+
+export type MonologurTtsProvider = 'web' | 'deepgram'
+
+export type MonologurSettings = {
+  enabled: boolean
+  intervalMs: number // How often to check if we should speak (default: 60000 = 1 min)
+  minWordsBeforePrompt: number // Minimum words in conversation before prompting (default: 20)
+  cooldownMs: number // Min time between proactive prompts (default: 300000 = 5 min)
+  tts: TTSSettings
+  ttsProvider: MonologurTtsProvider // 'web' = Web Speech API, 'deepgram' = Deepgram Aura
+  deepgramVoice: string // Deepgram voice ID (e.g. 'aura-asteria-en')
+  systemPrompt: string // Customizable system prompt for the AI
+}
+
+const DEFAULT_SETTINGS: MonologurSettings = {
+  enabled: true,
+  intervalMs: 60_000,
+  minWordsBeforePrompt: 20,
+  cooldownMs: 300_000,
+  tts: {
+    enabled: true,
+    rate: 1.0,
+    pitch: 1.0,
+    volume: 1.0,
+    voiceName: null
+  },
+  ttsProvider: 'web',
+  deepgramVoice: 'aura-asteria-en',
+  systemPrompt: `You are Monologur, a high-intelligence background listener. You are the silent observer who knows the user deeply.
+  
+Rules:
+- Be sharp, concise, and high-value. 
+- Only speak when you have a genuinely useful, personalized insight based on the user's current activity or history.
+- Avoid generic advice. Be specific.
+- Keep responses to 1-2 sharp sentences.
+- If the user is focused or in a crowded environment, stay completely silent unless it's critical.
+- Your goal is to be the "smartest person in the room" who speaks only when it truly matters.`
+}
+
+let running = false
+let started = false
+let timer: ReturnType<typeof setTimeout> | null = null
+let lastPromptTime = 0
+let lastSegments: TranscriptLine[] = []
+let settings: MonologurSettings = { ...DEFAULT_SETTINGS }
+let onProactiveMessage: ((text: string) => void) | null = null
+let onStatusChange: ((status: 'idle' | 'listening' | 'thinking' | 'speaking') => void) | null = null
+let currentAudio: HTMLAudioElement | null = null
+
+// Get current settings from localStorage
+function loadSettings(): MonologurSettings {
+  try {
+    const stored = localStorage.getItem('monologur-settings-v1')
+    if (stored) {
+      return { ...DEFAULT_SETTINGS, ...JSON.parse(stored) }
+    }
+  } catch {
+    // ignore
+  }
+  return { ...DEFAULT_SETTINGS }
+}
+
+// Save settings to localStorage
+export function saveMonologurSettings(s: Partial<MonologurSettings>): void {
+  settings = { ...settings, ...s }
+  localStorage.setItem('monologur-settings-v1', JSON.stringify(settings))
+}
+
+export function getMonologurSettings(): MonologurSettings {
+  return { ...settings }
+}
+
+// Check if Deepgram TTS is available
+function isDeepgramTtsAvailable(): boolean {
+  return settings.ttsProvider === 'deepgram' && typeof window.omi?.deepgramTtsSynthesize === 'function'
+}
+
+// Speak using Deepgram TTS
+async function speakWithDeepgram(text: string): Promise<boolean> {
+  if (!isDeepgramTtsAvailable()) return false
+
+  try {
+    onStatusChange?.('speaking')
+    const result = await window.omi.deepgramTtsSynthesize({
+      text,
+      voice: settings.deepgramVoice,
+      encoding: 'mp3'
+    })
+
+    if (!result.ok || !result.audio) {
+      console.warn('[monologur] Deepgram TTS failed:', result.error)
+      return false
+    }
+
+    // Convert number[] back to Uint8Array and create audio blob
+    const audioData = new Uint8Array(result.audio)
+    const blob = new Blob([audioData], { type: result.contentType || 'audio/mpeg' })
+    const url = URL.createObjectURL(blob)
+
+    // Play the audio
+    currentAudio = new Audio(url)
+    currentAudio.onended = () => {
+      URL.revokeObjectURL(url)
+      currentAudio = null
+      onStatusChange?.('listening')
+    }
+    currentAudio.onerror = (e) => {
+      console.error('[monologur] Audio playback error:', e)
+      URL.revokeObjectURL(url)
+      currentAudio = null
+      onStatusChange?.('listening')
+    }
+    await currentAudio.play()
+    return true
+  } catch (e) {
+    console.warn('[monologur] Deepgram TTS error:', e)
+    onStatusChange?.('listening')
+    return false
+  }
+}
+
+// Check if there's new content worth prompting about
+function hasNewContent(prev: TranscriptLine[], curr: TranscriptLine[]): boolean {
+  if (curr.length <= prev.length) return false
+  const prevWords = prev.reduce((acc, l) => acc + l.text.split(/\s+/).length, 0)
+  const currWords = curr.reduce((acc, l) => acc + l.text.split(/\s+/).length, 0)
+  return currWords - prevWords >= 10
+}
+
+// Build context from recent conversation
+function buildConversationContext(segments: TranscriptLine[]): string {
+  const recent = segments.slice(-10)
+  return recent
+    .map((s) => `${s.speaker || 'Unknown'}: ${s.text}`)
+    .join('\n')
+}
+
+// The user's own recent speech only — Monologur reacts to what YOU say, not to
+// other people in the room (identified via the enrolled voiceprint).
+function userSpeech(segments: TranscriptLine[]): string {
+  return segments
+    .filter((s) => s.isUser)
+    .slice(-10)
+    .map((s) => s.text)
+    .join('\n')
+    .trim()
+}
+
+// Generate a proactive prompt using the LLM
+async function generateProactivePrompt(context: string, segments: TranscriptLine[]): Promise<string | null> {
+  try {
+    // Pull the user's saved memories and rank them against what they just said,
+    // so Monologur can reference real context like the main Omi agent does.
+    const memoryContext = await getMonologurMemoryContext(userSpeech(segments))
+    const augmentedContext = memoryContext ? `${context}\n\n${memoryContext}` : context
+
+    const response = await generate({
+      model: 'gemini-2.5-flash',
+      parts: [
+        {
+          text: `Based on this ongoing conversation, decide if you should proactively speak to the user.
+ 
+ Conversation context:
+ ${augmentedContext}
+ 
+ Rules:
+ - If the conversation just started or is too short, respond with "SKIP"
+ - If the user is in the middle of something complex, respond with "SKIP"
+ - If you have a genuinely useful suggestion, insight, or reminder, provide it
+ - If the user mentioned something you could help with, offer help
+ - Reference the user's saved memories when relevant to make it personal
+ - Keep your response to 1-2 sentences maximum
+ - Be natural and conversational
+ 
+ If you should speak, respond with just what you would say. If you should stay quiet, respond with exactly "SKIP"`
+        }
+      ],
+      systemPrompt: settings.systemPrompt
+    })
+
+    if (response === 'SKIP' || !response.trim()) {
+      return null
+    }
+
+    return response.trim()
+  } catch (e) {
+    console.warn('[monologur] LLM call failed:', e)
+    return null
+  }
+}
+
+// Main check loop
+async function checkAndPrompt(): Promise<void> {
+  if (!settings.enabled || running) return
+
+  const now = Date.now()
+  if (now - lastPromptTime < settings.cooldownMs) return
+
+  const segments = liveConversation.getSegments()
+  const totalWords = segments.reduce((acc, l) => acc + l.text.split(/\s+/).length, 0)
+
+  if (totalWords < settings.minWordsBeforePrompt) return
+  if (!hasNewContent(lastSegments, segments)) return
+
+  running = true
+  onStatusChange?.('thinking')
+
+  try {
+    const context = buildConversationContext(segments)
+    const prompt = await generateProactivePrompt(context, segments)
+
+    if (prompt) {
+      lastPromptTime = now
+      onProactiveMessage?.(prompt)
+      // Persist genuinely useful, durable insights back to the shared memory store
+      // so Monologur's help compounds over time (tap the Omi agent memory).
+      void saveMonologurInsight(prompt)
+
+      if (settings.tts.enabled) {
+        // Try Deepgram TTS first, fall back to Web Speech API
+        if (isDeepgramTtsAvailable()) {
+          await speakWithDeepgram(prompt)
+        } else {
+          onStatusChange?.('speaking')
+          speak(prompt, settings.tts, {
+            onEnd: () => onStatusChange?.('listening'),
+            onError: () => onStatusChange?.('listening')
+          })
+        }
+      }
+    }
+
+    lastSegments = [...segments]
+  } catch (e) {
+    console.warn('[monologur] check failed:', e)
+  } finally {
+    running = false
+    if (!isTTSSpeaking() && !currentAudio) {
+      onStatusChange?.('listening')
+    }
+  }
+}
+
+// Schedule the check loop
+function scheduleCheck(): void {
+  if (timer) clearTimeout(timer)
+  if (!settings.enabled) return
+
+  timer = setTimeout(async () => {
+    await checkAndPrompt()
+    scheduleCheck()
+  }, settings.intervalMs)
+}
+
+export function setOnProactiveMessage(cb: ((text: string) => void) | null): void {
+  onProactiveMessage = cb
+}
+
+export function setOnMonologurStatusChange(
+  cb: ((status: 'idle' | 'listening' | 'thinking' | 'speaking') => void) | null
+): void {
+  onStatusChange = cb
+}
+
+// Start the monologur engine
+export function startMonologur(): void {
+  if (started) return
+  started = true
+  settings = loadSettings()
+
+  setOnSpeakingChange((speaking) => {
+    if (!speaking && settings.enabled && !currentAudio) {
+      onStatusChange?.('listening')
+    }
+  })
+
+  if (settings.enabled) {
+    scheduleCheck()
+  }
+}
+
+// Stop the monologur engine
+export function stopMonologur(): void {
+  started = false
+  if (timer) {
+    clearTimeout(timer)
+    timer = null
+  }
+  stopTTS()
+  if (currentAudio) {
+    currentAudio.pause()
+    currentAudio = null
+  }
+  setOnSpeakingChange(null)
+  onStatusChange?.('idle')
+}
+
+// Toggle monologur on/off
+export function toggleMonologur(): void {
+  settings.enabled = !settings.enabled
+  saveMonologurSettings({ enabled: settings.enabled })
+
+  if (settings.enabled) {
+    startMonologur()
+  } else {
+    stopMonologur()
+  }
+}
+
+// Force a proactive prompt (for testing or manual trigger)
+export async function forcePrompt(): Promise<void> {
+  lastPromptTime = 0
+  await checkAndPrompt()
+}

--- a/desktop/windows/src/renderer/src/lib/monologurEngine.ts
+++ b/desktop/windows/src/renderer/src/lib/monologurEngine.ts
@@ -20,7 +20,7 @@ export type MonologurSettings = {
 }
 
 const DEFAULT_SETTINGS: MonologurSettings = {
-  enabled: true,
+  enabled: false,
   intervalMs: 60_000,
   minWordsBeforePrompt: 20,
   cooldownMs: 300_000,
@@ -143,7 +143,9 @@ function buildConversationContext(segments: TranscriptLine[]): string {
 }
 
 // The user's own recent speech only — Monologur reacts to what YOU say, not to
-// other people in the room (identified via the enrolled voiceprint).
+// other people in the room. Currently isUser is undefined on liveConversation
+// segments (voiceprint-based speaker diarization is not wired to the renderer yet);
+// memory ranking silently degrades when isUser is unset. This is a follow-up item.
 function userSpeech(segments: TranscriptLine[]): string {
   return segments
     .filter((s) => s.isUser)
@@ -224,9 +226,15 @@ async function checkAndPrompt(): Promise<void> {
       void saveMonologurInsight(prompt)
 
       if (settings.tts.enabled) {
-        // Try Deepgram TTS first, fall back to Web Speech API
         if (isDeepgramTtsAvailable()) {
-          await speakWithDeepgram(prompt)
+          const deepgramOk = await speakWithDeepgram(prompt)
+          if (!deepgramOk) {
+            onStatusChange?.('speaking')
+            speak(prompt, settings.tts, {
+              onEnd: () => onStatusChange?.('listening'),
+              onError: () => onStatusChange?.('listening')
+            })
+          }
         } else {
           onStatusChange?.('speaking')
           speak(prompt, settings.tts, {

--- a/desktop/windows/src/renderer/src/lib/monologurMemory.ts
+++ b/desktop/windows/src/renderer/src/lib/monologurMemory.ts
@@ -1,0 +1,76 @@
+// Monologur memory bridge.
+//
+// Monologur is the always-listening background agent. To make its interruptions
+// feel personal it taps the same memory the Omi agent uses:
+//   - READ: pull the user's saved memories (/v3/memories) and rank them against
+//     the current conversation so the proactive prompt can reference real context.
+//   - WRITE: when Monologur produces a genuinely useful, durable insight it stores
+//     it back as a memory (tagged `monologur`) so it compounds over time — the same
+//     store the main agent and brain map read from.
+//
+// All calls are best-effort and never block the proactive loop.
+
+import { omiApi } from './apiClient'
+import { rankMemories } from './memoryRank'
+import type { Memory } from '../hooks/useMemories'
+
+const MONOLOGUR_TAG = 'monologur'
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+let memoryCache: { at: number; memories: Memory[] } | null = null
+
+async function fetchMemories(force = false): Promise<Memory[]> {
+  const now = Date.now()
+  if (!force && memoryCache && now - memoryCache.at < CACHE_TTL_MS) {
+    return memoryCache.memories
+  }
+  try {
+    const r = await omiApi.get('/v3/memories', { params: { limit: 500, offset: 0 } })
+    const list = (Array.isArray(r.data) ? r.data : (r.data?.memories ?? [])) as Memory[]
+    memoryCache = { at: now, memories: list }
+    return list
+  } catch {
+    return memoryCache?.memories ?? []
+  }
+}
+
+/**
+ * Build a short, ranked memory-context block for the proactive prompt. Returns an
+ * empty string when there's nothing worth injecting (keeps the LLM call cheap).
+ */
+export async function getMonologurMemoryContext(conversationText: string): Promise<string> {
+  const memories = await fetchMemories()
+  if (memories.length === 0) return ''
+  const ranked = rankMemories(memories, conversationText, 5)
+  if (ranked.length === 0) return ''
+  return [
+    'Relevant memories about the user:',
+    ...ranked.map((m) => `- ${m}`)
+  ].join('\n')
+}
+
+/**
+ * Persist a durable insight Monologur produced. Best-effort; failures are swallowed.
+ * `dedupeKey` lets callers avoid writing the same line repeatedly.
+ */
+const written = new Set<string>()
+
+export async function saveMonologurInsight(text: string): Promise<void> {
+  const clean = text.trim()
+  if (!clean) return
+  // Rough dedupe so we don't spam the memory store with near-identical lines.
+  const key = clean.toLowerCase().replace(/\s+/g, ' ').slice(0, 80)
+  if (written.has(key)) return
+  written.add(key)
+
+  try {
+    await omiApi.post('/v3/memories', {
+      content: clean,
+      tags: [MONOLOGUR_TAG]
+    })
+    // Invalidate the read cache so a later context pull sees the new memory.
+    memoryCache = null
+  } catch {
+    // Don't let a memory write failure break the proactive loop.
+  }
+}

--- a/desktop/windows/src/renderer/src/lib/ttsService.ts
+++ b/desktop/windows/src/renderer/src/lib/ttsService.ts
@@ -1,0 +1,134 @@
+export type TTSVoice = {
+  name: string
+  lang: string
+  localService: boolean
+}
+
+export type TTSSettings = {
+  enabled: boolean
+  rate: number // 0.5 - 2.0, default 1.0
+  pitch: number // 0.0 - 2.0, default 1.0
+  volume: number // 0.0 - 1.0, default 1.0
+  voiceName: string | null // null = system default
+}
+
+let isSpeaking = false
+let onSpeakingChange: ((speaking: boolean) => void) | null = null
+
+function getSynthesis(): SpeechSynthesis | null {
+  if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
+    return window.speechSynthesis
+  }
+  return null
+}
+
+export function getAvailableVoices(): TTSVoice[] {
+  const synth = getSynthesis()
+  if (!synth) return []
+
+  const voices = synth.getVoices()
+  return voices.map((v) => ({
+    name: v.name,
+    lang: v.lang,
+    localService: v.localService
+  }))
+}
+
+export function getPreferredVoice(settings: TTSSettings): SpeechSynthesisVoice | null {
+  const synth = getSynthesis()
+  if (!synth) return null
+
+  const voices = synth.getVoices()
+
+  // If a specific voice is configured, try to find it
+  if (settings.voiceName) {
+    const match = voices.find((v) => v.name === settings.voiceName)
+    if (match) return match
+  }
+
+  // Otherwise, prefer a natural English voice
+  const preferred = voices.find(
+    (v) =>
+      v.lang.startsWith('en') &&
+      (v.name.includes('Natural') || v.name.includes('Enhanced') || v.name.includes('Premium'))
+  )
+  if (preferred) return preferred
+
+  // Fall back to first English voice
+  return voices.find((v) => v.lang.startsWith('en')) || voices[0] || null
+}
+
+export function speak(
+  text: string,
+  settings: TTSSettings,
+  callbacks?: { onEnd?: () => void; onError?: (error: string) => void }
+): void {
+  const synth = getSynthesis()
+  if (!synth || !text.trim()) {
+    callbacks?.onEnd?.()
+    return
+  }
+
+  // Cancel any current speech
+  stop()
+
+  const utterance = new SpeechSynthesisUtterance(text)
+  const voice = getPreferredVoice(settings)
+
+  if (voice) {
+    utterance.voice = voice
+  }
+
+  utterance.rate = Math.max(0.5, Math.min(2.0, settings.rate))
+  utterance.pitch = Math.max(0.0, Math.min(2.0, settings.pitch))
+  utterance.volume = Math.max(0.0, Math.min(1.0, settings.volume))
+
+  utterance.onstart = () => {
+    isSpeaking = true
+    onSpeakingChange?.(true)
+  }
+
+  utterance.onend = () => {
+    isSpeaking = false
+    onSpeakingChange?.(false)
+    callbacks?.onEnd?.()
+  }
+
+  utterance.onerror = (event) => {
+    // 'canceled' is expected when we call stop()
+    if (event.error !== 'canceled') {
+      console.error('[tts] error:', event.error)
+      callbacks?.onError?.(event.error)
+    }
+    isSpeaking = false
+    onSpeakingChange?.(false)
+    callbacks?.onEnd?.()
+  }
+
+  synth.speak(utterance)
+}
+
+export function stop(): void {
+  const synth = getSynthesis()
+  if (synth) {
+    synth.cancel()
+  }
+  isSpeaking = false
+  onSpeakingChange?.(false)
+}
+
+export function isTTSSpeaking(): boolean {
+  return isSpeaking
+}
+
+export function setOnSpeakingChange(cb: ((speaking: boolean) => void) | null): void {
+  onSpeakingChange = cb
+}
+
+// Resume speech synthesis after user interaction (Chrome autoplay policy)
+export function resumeAfterInteraction(): void {
+  const synth = getSynthesis()
+  if (synth) {
+    synth.resume()
+  }
+}

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -1,3 +1,34 @@
+<<<<<<< Updated upstream
+=======
+export type SignGloss = {
+  gloss: string
+  duration: number
+  timestamp: number
+  swr?: string
+}
+
+export type TranslationResult = {
+  originalText: string
+  poseUrl?: string
+  assetType?: 'video' | 'pose'
+  glosses: SignGloss[]
+  swrFull?: string
+}
+
+export type DeepgramTtsOptions = {
+  text: string
+  voice?: string
+  encoding?: 'mp3' | 'wav' | 'pcm' | 'opus' | 'flac'
+}
+
+export type DeepgramTtsResult = {
+  ok: boolean
+  audio?: number[]
+  contentType?: string
+  error?: string
+}
+
+>>>>>>> Stashed changes
 export type CaptureSource = {
   id: string
   name: string
@@ -41,6 +72,9 @@ export type TranscriptLine = {
   speaker?: string
   text: string
   interim?: boolean
+  /** True when the enrolled voiceprint identifies this line as the user ("You"),
+   *  rather than someone else in the room. Undefined when not yet resolved. */
+  isUser?: boolean
 }
 
 export type ConversationPayload = {
@@ -291,6 +325,11 @@ export type OmiBridgeApi = {
   // window are separate renderers with independent caches.
   notifyConversationsChanged: () => void
   onConversationsChanged: (cb: () => void) => () => void
+<<<<<<< Updated upstream
+=======
+  onDeepgramSignUpdate: (cb: (result: TranslationResult) => void) => () => void
+  deepgramTtsSynthesize: (options: DeepgramTtsOptions) => Promise<DeepgramTtsResult>
+>>>>>>> Stashed changes
   screenSynthFramesSince: () => Promise<ScreenFrameLite[]>
   screenSynthGetState: () => Promise<ScreenSynthState>
   screenSynthSetState: (patch: Partial<ScreenSynthState>) => Promise<ScreenSynthState>

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -1,20 +1,3 @@
-<<<<<<< Updated upstream
-=======
-export type SignGloss = {
-  gloss: string
-  duration: number
-  timestamp: number
-  swr?: string
-}
-
-export type TranslationResult = {
-  originalText: string
-  poseUrl?: string
-  assetType?: 'video' | 'pose'
-  glosses: SignGloss[]
-  swrFull?: string
-}
-
 export type DeepgramTtsOptions = {
   text: string
   voice?: string
@@ -27,8 +10,6 @@ export type DeepgramTtsResult = {
   contentType?: string
   error?: string
 }
-
->>>>>>> Stashed changes
 export type CaptureSource = {
   id: string
   name: string
@@ -325,11 +306,7 @@ export type OmiBridgeApi = {
   // window are separate renderers with independent caches.
   notifyConversationsChanged: () => void
   onConversationsChanged: (cb: () => void) => () => void
-<<<<<<< Updated upstream
-=======
-  onDeepgramSignUpdate: (cb: (result: TranslationResult) => void) => () => void
   deepgramTtsSynthesize: (options: DeepgramTtsOptions) => Promise<DeepgramTtsResult>
->>>>>>> Stashed changes
   screenSynthFramesSince: () => Promise<ScreenFrameLite[]>
   screenSynthGetState: () => Promise<ScreenSynthState>
   screenSynthSetState: (patch: Partial<ScreenSynthState>) => Promise<ScreenSynthState>


### PR DESCRIPTION
<!-- Keep this short and honest. Reviewers read the Verification section first. -->

## What changed and why

Ports the **Monologur always-listening background agent** onto the consolidated `desktop/windows` Electron tree as platform-agnostic seams (no forked tree). Deepgram voice path wired but degrades to Web Speech; backend credentials would be needed for a real Deepgram Aura TTS call.

- `ttsService.ts`: Web Speech API TTS (speak/stop/voices) used by Monologur for fallback audio.
- `monologurEngine.ts`: subscribes to live conversation, prompts an LLM (`geminiClient` via Omi desktop-backend proxy) for proactive insights, speaks via TTS; persists useful insights to the shared memory store (`/v3/memories`). Opt-in (default OFF).
- `monologurMemory.ts`: reads/ranks user memories for context, writes durable insights tagged `monologur`.
- `MonologurHost.tsx`: status indicator + proactive message toast, mounted in `App.tsx`.
- `GeneralTab.tsx`: Monologur enable/disable + TTS provider (Web/Deepgram) toggle.
- `shared/types.ts`: `TranscriptLine.isUser`, `DeepgramTtsOptions/Result`, `OmiBridgeApi.deepgramTtsSynthesize`.

## Product invariants affected

none

## How it was verified

- `npm run typecheck` — passes, 0 errors (node + web).
- `eslint` on all touched files — 0 errors.
- `electron-vite build` — succeeds (all 3 bundles compile).
- Monologur is opt-in by default (DEFAULT_SETTINGS.enabled = false); user toggles in Settings → General ("Monologur").

## Tests

Unit tests not yet added for the proactive loop logic (checkAndPrompt, generateProactivePrompt, cooldown/dedupe, memory read/write/rank, Deepgram fallback). These are logic-heavy and would materially help review scope for deep behavior. Planned as a follow-up focused test file.

## Failure class (fixes)

Failure-Class: none

## Failure-class transition narrative

none

## New guards (only when adding a check or ratchet)

none

## Scoped cleanups (optional)

none