### PR TITLE
fix(listen): meter custom-STT speech in an isolated fair-use lane

### DIFF
--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -419,7 +419,16 @@ class ListenSessionRuntime:
         if self.state.fair_use_track_dg_usage and self.state.dg_usage_ms_pending:
             await self.persistence.call(record_dg_usage_ms, self.request.uid, self.state.dg_usage_ms_pending)
             self.state.dg_usage_ms_pending = 0
-        if self.use_custom_stt or not self.state.last_usage_record_timestamp:
+        if self.use_custom_stt:
+            # Exempt from transcription billing and live caps, but the speech
+            # still drives Omi-paid LLM post-processing — meter it in its own
+            # isolated fair-use lane so the spend is visible (#7690).
+            if FAIR_USE_ENABLED and self.receiver.vad_gate is not None:
+                custom_speech_ms = self.receiver.vad_gate.consume_speech_ms_delta()
+                if custom_speech_ms:
+                    await self.persistence.call(record_speech_ms, self.request.uid, custom_speech_ms, 'custom_stt')
+            return 0
+        if not self.state.last_usage_record_timestamp:
             return 0
         speech_seconds = 0
         if self.receiver.vad_gate is not None:

--- a/backend/tests/unit/test_dg_usage_batch.py
+++ b/backend/tests/unit/test_dg_usage_batch.py
@@ -106,13 +106,17 @@ class TestDgUsageBatchingStructure:
         assert len(resets) == 1, f'Expected one shared reset point, found {len(resets)}'
 
     def test_flush_before_custom_stt_guard(self):
-        """DG flush must happen before use_custom_stt:continue guard."""
+        """DG flush must happen before use_custom_stt early-return guard."""
         source = _read_listen_source('runtime')
         flush_start = source.find('async def _flush_usage(')
         flush_end = source.find('    async def _start_pusher', flush_start)
         flush_body = source[flush_start:flush_end]
         flush_pos = flush_body.find('record_dg_usage_ms, self.request.uid, self.state.dg_usage_ms_pending')
-        guard_pos = flush_body.find('if self.use_custom_stt or not self.state.last_usage_record_timestamp:')
+        # PR #7690 split the compound guard into a standalone custom-STT
+        # early-return (with its own isolated fair-use lane) followed by the
+        # last_usage_record_timestamp check.  The invariant is unchanged: the
+        # DG accumulator flush must precede the custom-STT exit path.
+        guard_pos = flush_body.find('if self.use_custom_stt:')
         assert flush_pos != -1, 'DG flush call not found'
         assert guard_pos != -1, 'use_custom_stt guard not found'
         assert flush_pos < guard_pos, 'DG flush must be before use_custom_stt guard'

--- a/backend/tests/unit/test_fair_use_engine.py
+++ b/backend/tests/unit/test_fair_use_engine.py
@@ -78,6 +78,25 @@ class TestRecordSpeechMs:
             )
 
     @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    def test_custom_stt_lane_records_under_its_own_keys(self):
+        """#7690: custom-STT speech is metered in an isolated lane, never
+        coerced into the live-enforced realtime lane."""
+        pipe = MagicMock()
+        _mock_redis.pipeline.return_value = pipe
+        fair_use_mod.record_speech_ms('user1', 5000, source='custom_stt')
+        bucket_key = pipe.hincrby.call_args.args[0]
+        zset_key = pipe.zadd.call_args.args[0]
+        assert bucket_key == 'fair_use:v2:bucket:custom_stt:user1'
+        assert zset_key == 'fair_use:v2:speech:custom_stt:user1'
+
+    def test_custom_stt_source_is_valid_and_outside_live_enforcement(self):
+        """#7690: the lane must exist (unknown sources coerce to realtime,
+        which would gate exempt users) and must stay out of the live meter."""
+        assert fair_use_mod._normalize_speech_source('custom_stt') == 'custom_stt'
+        assert fair_use_mod._normalize_speech_source('not-a-lane') == 'realtime'
+        assert 'custom_stt' not in fair_use_mod.LIVE_SPEECH_SOURCES
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
     def test_ignores_zero_speech(self):
         pipe = MagicMock()
         _mock_redis.pipeline.return_value = pipe

--- a/backend/tests/unit/test_listen_runtime_regressions.py
+++ b/backend/tests/unit/test_listen_runtime_regressions.py
@@ -368,3 +368,41 @@ async def test_transcript_delivery_marks_live_transcription_success_only_after_a
 
 async def _async_result(value):
     return value
+
+
+@pytest.mark.anyio
+async def test_custom_stt_flush_meters_speech_in_isolated_lane(monkeypatch):
+    """#7690: a custom-STT session's speech reaches the fair-use meter under
+    the custom_stt lane — and nothing else: no transcription usage recording,
+    no realtime-lane write that live enforcement would read."""
+    import routers.listen.runtime as runtime_module
+
+    recorded = []
+    monkeypatch.setattr(runtime_module, 'FAIR_USE_ENABLED', True)
+    monkeypatch.setattr(
+        runtime_module, 'record_speech_ms', lambda uid, ms, source='realtime': recorded.append((uid, ms, source))
+    )
+    monkeypatch.setattr(
+        runtime_module, 'record_usage', lambda *a, **k: (_ for _ in ()).throw(AssertionError('billed custom STT'))
+    )
+
+    runtime = object.__new__(ListenSessionRuntime)
+    runtime.request = SimpleNamespace(uid='custom-stt-user')
+    runtime.use_custom_stt = True
+    runtime.persistence = _Persistence()
+    runtime.state = SimpleNamespace(
+        fair_use_track_dg_usage=False,
+        dg_usage_ms_pending=0,
+        last_usage_record_timestamp=123.0,
+        words_transcribed_since_last_record=7,
+        last_audio_received_time=124.0,
+    )
+    runtime.receiver = SimpleNamespace(vad_gate=SimpleNamespace(consume_speech_ms_delta=lambda: 4200))
+
+    assert await runtime._flush_usage(final=False) == 0
+    assert recorded == [('custom-stt-user', 4200, 'custom_stt')]
+
+    # No speech delta → no meter write either.
+    runtime.receiver = SimpleNamespace(vad_gate=SimpleNamespace(consume_speech_ms_delta=lambda: 0))
+    assert await runtime._flush_usage(final=True) == 0
+    assert recorded == [('custom-stt-user', 4200, 'custom_stt')]

--- a/backend/utils/fair_use.py
+++ b/backend/utils/fair_use.py
@@ -88,7 +88,12 @@ MAX_DAILY_AUDIO_MS = MAX_DAILY_AUDIO_HOURS * 3600 * 1000
 
 
 LIVE_SPEECH_SOURCES = ('realtime', 'sync_fresh')
-_VALID_SPEECH_SOURCES = frozenset((*LIVE_SPEECH_SOURCES, 'sync_backfill'))
+# custom_stt is metered but never live-enforced: those users transcribe on
+# their own provider and are exempt from transcription caps, yet their speech
+# drives the same downstream LLM post-processing spend — the lane makes that
+# spend visible without gating anyone (#7690). Any cap is a separate policy
+# decision reading this lane.
+_VALID_SPEECH_SOURCES = frozenset((*LIVE_SPEECH_SOURCES, 'sync_backfill', 'custom_stt'))
 
 
 def _normalize_speech_source(source: str) -> str:


### PR DESCRIPTION
# Summary

- Custom-STT sessions' speech now reaches the fair-use meter — in a new **isolated `custom_stt` lane** that live enforcement never reads. Previously `_flush_usage` returned early for these sessions before any recording, so the speech driving Omi-paid LLM post-processing (structuring, memory extraction) was invisible to every meter (#7690).
- Nothing is gated and no billing semantics change: transcription usage recording stays skipped for these users, and the lane is excluded from `LIVE_SPEECH_SOURCES` — the same isolation contract `sync_backfill` already uses ("metered, never live-enforced").
- This is the **accounting half** of #7690. Quantifying the spend reads this lane (`get_rolling_speech_ms(uid, sources=('custom_stt',))` — the reader already takes a sources tuple); whether to cap is the issue's open policy question and deliberately not decided here.

Addresses #7690 (accounting); capping policy remains open there.

# Root cause

`use_custom_stt` short-circuits `_flush_usage` before both `record_speech_ms` (fair-use meter) and `record_usage` (usage stats). The exemption was designed for transcription billing but silently swallowed all speech accounting with it — so the existing fair-use machinery never sees these users at all, exactly as #7690 describes.

# Why a lane, not a flag

The fair-use engine already models this: sources are lane-isolated by key (`fair_use:v2:*:{source}:{uid}`), live enforcement reads only `LIVE_SPEECH_SOURCES`, and `sync_backfill` is the precedent for "metered but never live-enforced". One frozenset entry gives custom-STT the same contract. Critically, an *unregistered* source coerces to `'realtime'` in `_normalize_speech_source` — which would have put exempt users into the live-enforced lane and gated them; the tests pin that trap.

# Failure class

Failure-Class: none

No registered class covers an exemption swallowing adjacent accounting; single instance, decision extracted to the existing lane model rather than a new mechanism.

# Product invariants affected

none (verified with `scripts/pr-preflight --suggest`)

# Validation

- Old-code check (production files stashed, tests kept): **3 failed** — the lane coerces to `realtime`, and the custom-STT flush records nothing; with the fix all pass.
- New coverage: the lane records under its own Redis keys (`fair_use:v2:bucket:custom_stt:*`); `custom_stt` is a valid source and absent from `LIVE_SPEECH_SOURCES` (with the unknown-source-coerces-to-realtime trap pinned); a runtime-level test drives the real `_flush_usage` for a custom-STT session and asserts speech reaches the lane and **only** the lane — any `record_usage` call raises.
- Repo runner (file-isolated, as CI executes): `tests/unit/test_fair_use_engine.py` → **61 passed**, `tests/unit/test_listen_runtime_regressions.py` → **12 passed**.
- `make preflight` (local lane, this PR body) → all selected checks pass.
- `black` clean on all changed files.

Not exercised live: a real custom-STT device session (no BYOK credentials here). The flush seam is driven directly by the runtime test; the engine's lane isolation is driven by the key-shape tests.

# Out of scope, named

- Spend quantification dashboards/alerts over the new lane, and any cap policy — #7690's open decisions, now unblocked by the data existing.
- Sync-path custom-STT accounting (offline sync for custom-STT users transcribes on-device; no server speech signal exists there today).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

