### PR TITLE
feat(desktop): Home redesign — Today hub + first-win surface (data-driven)

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -2,14 +2,14 @@
   "files": {
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2375,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2928,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4846,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4848,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2423,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1621
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": "Agent completion presentation now follows the canonical terminal lifecycle used by PTT and chat.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": "Onboarding bar glow, the reach-error card (Retry/Skip), and the notch hover/voice surface-state boundary render on the shared bar surface.",
-    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": "Reach-error state lives with the owning manager; savePreChatCenterIfNeeded snaps to the full stored restore frame so the pill no longer drifts per re-open cycle.",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": "Two one-line product-side activation marks adjacent to the existing query-submit telemetry sites (marks must not live inside AnalyticsManager).",
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior."
   },

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1939,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3643,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4448,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4483,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3298,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5518,
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1570
@@ -10,7 +10,7 @@
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": "Syncs the local rating shadow to external message.rating changes so an un-rate tap is no longer swallowed after a server refresh.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "Rebase reconciliation applies the pinned swift-format to the main-branch app-detail safety fixes; runtime behavior is unchanged.",
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": "Home redesign wires the new Today/first-win Dashboard section views; net +35 after removing the stat ribbon \u2014 all substantial new logic lives in MainWindow/Dashboard/ files.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": "Bridge memory search now awaits the active initial or pagination projection before refreshing, preventing an immediate post-navigation marker search from using stale lifecycle capability state.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": "The Load-more-tasks action reads displayTasks.last at execution time via loadMoreTapped() instead of force-unwrapping (an emptied list no longer crashes); merged with main binding first-load/loading/error/retry state to the selected To Do or Done view.",
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": "Strict concurrency imports annotate legacy AppKit image usage without changing runtime behavior."

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
@@ -1,13 +1,13 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1621,
-    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3510,
-    "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": 1856
+    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3522,
+    "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": 1882
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": "Surfaced task ids (backend id or local_<rowid>) resolve through one shared identity helper, so mutating an unsynced task no longer no-ops or throws recordNotFound.",
-    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": "Nullable screenshot capture provenance preserves the canonical-memory device identity and prevents multi-Mac screen activity from overwriting local row IDs.",
-    "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": "Search-result rows load a downsampled ImageIO thumbnail instead of the full-resolution screenshot, so a long results list no longer retains full-size images behind a 120x80 view."
+    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": "Adds the today-scoped screenshot count used by the Home proof line.",
+    "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": "Consumes the one-shot Home filmstrip seek handoff (nearest-frame jump on load and on appear)."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -799,6 +799,8 @@ extension Notification.Name {
   static let screenCaptureKitBroken = Notification.Name("screenCaptureKitBroken")
   /// Posted to show the "Try asking" popup centered over the full window
   static let showTryAskingPopup = Notification.Name("showTryAskingPopup")
+  /// Posted to hide that popup without dismissing it (first-win owns the moment)
+  static let hideTryAskingPopup = Notification.Name("hideTryAskingPopup")
   /// Posted (automation bridge) to open the inline chat on the redesigned Home
   static let homeStageOpenChat = Notification.Name("homeStageOpenChat")
   /// Posted (automation bridge) to toggle the Connect tray on the redesigned Home

--- a/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
@@ -329,6 +329,7 @@ extension AppState {
       // Track conversation creation — use captured start time for accurate duration after session rotation
       if didBindLocalSession, let startTime = targetStartTime {
         let durationSeconds = Int(Date().timeIntervalSince(startTime))
+        ActivationProgressStore.shared.markConversationCaptured(title: nil)
         AnalyticsManager.shared.conversationCreated(
           conversationId: memoryId,
           source: currentConversationSource.rawValue,

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -59,6 +59,10 @@ struct ScopedDefaultsKey {
   static func trialNudge(_ kind: String, ownerHash: String) -> Self {
     Self(rawValue: "trial_nudge.v1.\(kind).\(ownerHash)")
   }
+
+  static func homeActivationProgress(ownerID: String) -> Self {
+    Self(rawValue: "homeActivationProgress.v1.\(ownerID)")
+  }
 }
 
 /// Typed accessors that take a `DefaultsKey` instead of a `String`.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -4360,6 +4360,7 @@ class FloatingControlBarManager {
     }
     barWindow.orderFrontRegardless()
 
+    ActivationProgressStore.shared.markAskedOmi()
     AnalyticsManager.shared.floatingBarQuerySent(messageLength: message.count, hasScreenshot: screenshotData != nil)
 
     let shouldPlayVoice = ShortcutSettings.shared.shouldSpeakFloatingBarResponse(
@@ -4598,6 +4599,7 @@ class FloatingControlBarManager {
       currentTracer?.mark("screenshot_capture")
     }
 
+    ActivationProgressStore.shared.markAskedOmi()
     AnalyticsManager.shared.floatingBarQuerySent(messageLength: message.count, hasScreenshot: screenshotData != nil)
 
     let clientTurnId = UUID().uuidString

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ActivationProgressStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ActivationProgressStore.swift
@@ -83,16 +83,21 @@ final class ActivationProgressStore: ObservableObject {
   }
 
   /// Lifetime counts arrived — a history of captured conversations means this
-  /// account activated long ago (possibly on another machine).
+  /// account activated long ago (possibly on another machine). Only accounts
+  /// whose history predates first-win graduate silently; once first-win has
+  /// shown, a rising count is this user's FIRST conversation landing and must
+  /// complete that step normally (keeping the ask step and celebration).
   func applyLifetimeCounts(conversations: Int?, memories: Int?) {
     guard !automationForcedFirstWin else { return }
     guard !isActivated else { return }
     if let conversations, conversations > 0 {
-      mutate {
-        $0.conversationCaptured = true
-        // An account with real conversation history is past first-win even if
-        // this machine never saw a query.
-        $0.graduated = true
+      if progress.firstWinFirstShownAt == nil {
+        mutate {
+          $0.conversationCaptured = true
+          $0.graduated = true
+        }
+      } else {
+        markConversationCaptured(title: nil)
       }
     }
     _ = memories  // memory counts alone don't graduate: onboarding import seeds them

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ActivationProgressStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ActivationProgressStore.swift
@@ -215,6 +215,9 @@ final class ActivationProgressStore: ObservableObject {
   private func reloadForCurrentOwner() {
     let ownerID = normalizedOwnerID()
     activeOwnerID = ownerID
+    // Transient session UI state must never survive an owner change — the
+    // next account must not inherit the previous account's celebration.
+    celebrationPending = false
     guard let ownerID,
       let data = defaults.data(forKey: ScopedDefaultsKey.homeActivationProgress(ownerID: ownerID)),
       let stored = try? JSONDecoder().decode(Progress.self, from: data)

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ActivationProgressStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ActivationProgressStore.swift
@@ -1,0 +1,212 @@
+import Combine
+import Foundation
+
+/// Tracks whether the signed-in user has reached desktop activation.
+///
+/// The July 2026 usage study found retention is decided in the first 48 hours
+/// by proof-of-delivery: a real conversation captured (8.9× retained-vs-churned
+/// lift) and a first question asked (the median churned user never sends one).
+/// Home renders the first-win surface until both happen, then permanently
+/// switches to the Today hub.
+///
+/// Marks are product-side signals written adjacent to (never inside) the
+/// telemetry call sites — product authority stays independent from analytics.
+/// State is persisted per owner so an account switch never shows another
+/// user's progress, and lifetime counts auto-complete the flow so a veteran
+/// on a fresh Mac never sees the checklist.
+@MainActor
+final class ActivationProgressStore: ObservableObject {
+  static let shared = ActivationProgressStore()
+
+  struct Progress: Codable, Equatable {
+    var askedOmi = false
+    var conversationCaptured = false
+    var firstConversationTitle: String?
+    var firstWinFirstShownAt: Date?
+    var firstWinVisits = 0
+    /// Set once the user leaves first-win for good (completed or timed out).
+    var graduated = false
+  }
+
+  /// First-win stops insisting after this window or visit count — a user who
+  /// skipped microphone/screen permissions must not live on a stale checklist.
+  static let firstWinMaxAge: TimeInterval = 48 * 60 * 60
+  static let firstWinMaxVisits = 5
+
+  @Published private(set) var progress = Progress()
+
+  /// One-time transient flag: both activation marks just completed in this
+  /// session, so Home may show its quiet "second brain is live" greeting
+  /// once. Never persisted.
+  @Published private(set) var celebrationPending = false
+
+  private let defaults: UserDefaults
+  private let ownerIDProvider: () -> String?
+  private let now: () -> Date
+  private var activeOwnerID: String?
+  private nonisolated(unsafe) var ownerObserver: NSObjectProtocol?
+
+  init(
+    defaults: UserDefaults = .standard,
+    ownerIDProvider: (() -> String?)? = nil,
+    now: @escaping () -> Date = Date.init
+  ) {
+    self.defaults = defaults
+    self.ownerIDProvider = ownerIDProvider ?? { RuntimeOwnerIdentity.currentOwnerId() }
+    self.now = now
+    reloadForCurrentOwner()
+    ownerObserver = NotificationCenter.default.addObserver(
+      forName: .runtimeOwnerDidChange, object: nil, queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor in
+        self?.reloadForCurrentOwner()
+      }
+    }
+  }
+
+  deinit {
+    if let ownerObserver { NotificationCenter.default.removeObserver(ownerObserver) }
+  }
+
+  var isActivated: Bool {
+    progress.graduated || (progress.askedOmi && progress.conversationCaptured)
+  }
+
+  /// Whether Home should render the first-win surface. Requires the lifetime
+  /// counts to be loaded (`countsKnown`) — while they are still nil the Today
+  /// hub renders, so a veteran signing in on a new machine never flashes the
+  /// checklist before their data arrives.
+  func shouldShowFirstWin(countsKnown: Bool) -> Bool {
+    if automationForcedFirstWin { return true }
+    guard countsKnown else { return false }
+    return !isActivated
+  }
+
+  /// Lifetime counts arrived — a history of captured conversations means this
+  /// account activated long ago (possibly on another machine).
+  func applyLifetimeCounts(conversations: Int?, memories: Int?) {
+    guard !automationForcedFirstWin else { return }
+    guard !isActivated else { return }
+    if let conversations, conversations > 0 {
+      mutate {
+        $0.conversationCaptured = true
+        // An account with real conversation history is past first-win even if
+        // this machine never saw a query.
+        $0.graduated = true
+      }
+    }
+    _ = memories  // memory counts alone don't graduate: onboarding import seeds them
+  }
+
+  func markAskedOmi() {
+    guard !progress.askedOmi else { return }
+    mutate { $0.askedOmi = true }
+  }
+
+  func markConversationCaptured(title: String?) {
+    guard !progress.conversationCaptured else { return }
+    mutate {
+      $0.conversationCaptured = true
+      $0.firstConversationTitle = title
+    }
+  }
+
+  /// Called when the first-win surface renders; applies the time-box so
+  /// permission-skippers eventually land on the Today hub anyway.
+  func noteFirstWinShown() {
+    let currentTime = now()
+    mutate {
+      if $0.firstWinFirstShownAt == nil {
+        $0.firstWinFirstShownAt = currentTime
+      }
+      $0.firstWinVisits += 1
+      if let firstShown = $0.firstWinFirstShownAt,
+        currentTime.timeIntervalSince(firstShown) > Self.firstWinMaxAge
+          || $0.firstWinVisits > Self.firstWinMaxVisits
+      {
+        $0.graduated = true
+      }
+    }
+  }
+
+  // MARK: - Persistence
+
+  func consumeCelebration() {
+    celebrationPending = false
+  }
+
+  // MARK: - Automation bridge (non-prod QA only)
+
+  /// QA override so a seeded account with history can render the first-win
+  /// surface. Transient, bridge-gated; never affects production behavior.
+  @Published private(set) var automationForcedFirstWin = false
+
+  func registerAutomationActions() {
+    guard DesktopAutomationLaunchOptions.isEnabled, !didRegisterAutomationActions else { return }
+    didRegisterAutomationActions = true
+    DesktopAutomationActionRegistry.shared.register(
+      name: "activation_force_first_win",
+      summary: "Force or release the Home first-win surface for QA",
+      params: ["enabled"]
+    ) { [weak self] params in
+      guard let self else { return ["error": "activation store deallocated"] }
+      self.automationForcedFirstWin = (params["enabled"] ?? "true") != "false"
+      return ["forced": String(self.automationForcedFirstWin)]
+    }
+    DesktopAutomationActionRegistry.shared.register(
+      name: "activation_state",
+      summary: "Dump activation progress for the current owner",
+      params: []
+    ) { [weak self] _ in
+      guard let self else { return ["error": "activation store deallocated"] }
+      return [
+        "asked_omi": String(self.progress.askedOmi),
+        "conversation_captured": String(self.progress.conversationCaptured),
+        "graduated": String(self.progress.graduated),
+        "activated": String(self.isActivated),
+        "forced_first_win": String(self.automationForcedFirstWin),
+      ]
+    }
+  }
+
+  private var didRegisterAutomationActions = false
+
+  private func mutate(_ change: (inout Progress) -> Void) {
+    var updated = progress
+    change(&updated)
+    guard updated != progress else { return }
+    let wasActivated = progress.askedOmi && progress.conversationCaptured
+    let becomesActivated = updated.askedOmi && updated.conversationCaptured
+    if !wasActivated, becomesActivated, !updated.graduated {
+      celebrationPending = true
+    }
+    progress = updated
+    persist()
+  }
+
+  private func persist() {
+    guard let ownerID = normalizedOwnerID() else { return }
+    defaults.set(
+      try? JSONEncoder().encode(progress),
+      forKey: ScopedDefaultsKey.homeActivationProgress(ownerID: ownerID)
+    )
+  }
+
+  private func reloadForCurrentOwner() {
+    let ownerID = normalizedOwnerID()
+    activeOwnerID = ownerID
+    guard let ownerID,
+      let data = defaults.data(forKey: ScopedDefaultsKey.homeActivationProgress(ownerID: ownerID)),
+      let stored = try? JSONDecoder().decode(Progress.self, from: data)
+    else {
+      progress = Progress()
+      return
+    }
+    progress = stored
+  }
+
+  private func normalizedOwnerID() -> String? {
+    let trimmed = ownerIDProvider()?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return trimmed.isEmpty ? nil : trimmed
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ActivationProgressStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ActivationProgressStore.swift
@@ -23,15 +23,17 @@ final class ActivationProgressStore: ObservableObject {
     var conversationCaptured = false
     var firstConversationTitle: String?
     var firstWinFirstShownAt: Date?
+    /// Distinct calendar days the first-win surface was seen (same-day tab
+    /// switches must not burn the window down).
     var firstWinVisits = 0
+    var lastFirstWinDayStamp: String?
     /// Set once the user leaves first-win for good (completed or timed out).
     var graduated = false
   }
 
-  /// First-win stops insisting after this window or visit count — a user who
-  /// skipped microphone/screen permissions must not live on a stale checklist.
+  /// First-win stops insisting after this window — a user who skipped
+  /// microphone/screen permissions must not live on a stale checklist.
   static let firstWinMaxAge: TimeInterval = 48 * 60 * 60
-  static let firstWinMaxVisits = 5
 
   @Published private(set) var progress = Progress()
 
@@ -117,22 +119,35 @@ final class ActivationProgressStore: ObservableObject {
   }
 
   /// Called when the first-win surface renders; applies the time-box so
-  /// permission-skippers eventually land on the Today hub anyway.
+  /// permission-skippers eventually land on the Today hub anyway. Visits are
+  /// counted per distinct calendar day — navigating to Home six times in one
+  /// session is one visit, not a graduation.
   func noteFirstWinShown() {
     let currentTime = now()
+    let dayStamp = Self.dayStampFormatter.string(from: currentTime)
     mutate {
       if $0.firstWinFirstShownAt == nil {
         $0.firstWinFirstShownAt = currentTime
       }
-      $0.firstWinVisits += 1
+      if $0.lastFirstWinDayStamp != dayStamp {
+        $0.lastFirstWinDayStamp = dayStamp
+        $0.firstWinVisits += 1
+      }
       if let firstShown = $0.firstWinFirstShownAt,
         currentTime.timeIntervalSince(firstShown) > Self.firstWinMaxAge
-          || $0.firstWinVisits > Self.firstWinMaxVisits
       {
         $0.graduated = true
       }
     }
   }
+
+  private static let dayStampFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter
+  }()
 
   // MARK: - Persistence
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeFirstWinSection.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeFirstWinSection.swift
@@ -1,0 +1,257 @@
+import OmiTheme
+import SwiftUI
+
+/// The new-user Home surface, shown until activation (first conversation
+/// captured + first question asked — the two first-48h behaviors that
+/// separate retained users from churned ones in the July 2026 usage study).
+///
+/// Leads with proof Omi already delivered: real memories ingested during
+/// onboarding. Below, two ambient pipeline pills show capture working (or the
+/// honest fix when a permission was skipped — never a fake checkmark). The
+/// ask bar rendered underneath by `DashboardPage` is the single ask
+/// affordance; the keycap row teaches the floating-bar shortcut.
+struct HomeFirstWinSection: View {
+  let memories: [String]
+  let memoryCount: Int
+  let shortcutTokens: [String]
+  let conversationCaptured: Bool
+  let firstConversationTitle: String?
+  let hasMicrophonePermission: Bool
+  let hasScreenRecordingPermission: Bool
+  let isTranscribing: Bool
+  let screenshotsToday: Int?
+  let onOpenMemories: () -> Void
+  let onFixPermissions: () -> Void
+  let onOpenConversations: () -> Void
+
+  var body: some View {
+    VStack(spacing: OmiSpacing.lg) {
+      VStack(spacing: OmiSpacing.xs) {
+        Text("Omi already knows you.")
+          .font(.system(size: 34, weight: .medium, design: .serif))
+          .foregroundStyle(HomeStagePalette.ink)
+          .lineLimit(1)
+          .minimumScaleFactor(0.7)
+
+        Text("Learned during setup — before your first conversation.")
+          .scaledFont(size: OmiType.caption, weight: .medium)
+          .foregroundStyle(HomeStagePalette.muted)
+      }
+
+      if !memories.isEmpty {
+        VStack(spacing: OmiSpacing.xs) {
+          ForEach(Array(memories.enumerated()), id: \.offset) { _, memory in
+            HomeFirstWinMemoryRow(text: memory, onTap: onOpenMemories)
+          }
+
+          if memoryCount > memories.count {
+            Button(action: onOpenMemories) {
+              Text("…and \(memoryCount - memories.count) more — see everything Omi learned")
+                .scaledFont(size: OmiType.caption, weight: .medium)
+                .foregroundStyle(HomeStagePalette.muted)
+                .underline(false)
+            }
+            .buttonStyle(.plain)
+            .padding(.top, OmiSpacing.xxs)
+          }
+        }
+      } else {
+        Text("Omi starts learning the moment you do anything.")
+          .scaledFont(size: OmiType.body, weight: .medium)
+          .foregroundStyle(HomeStagePalette.secondary)
+      }
+
+      HStack(spacing: OmiSpacing.sm) {
+        conversationPill
+        screenPill
+      }
+
+      if !shortcutTokens.isEmpty {
+        HStack(spacing: OmiSpacing.xs) {
+          Text("Ask from anywhere")
+            .scaledFont(size: OmiType.micro, weight: .medium)
+            .foregroundStyle(HomeStagePalette.faint)
+          ForEach(Array(shortcutTokens.enumerated()), id: \.offset) { _, token in
+            HomeFirstWinKeycap(token: token)
+          }
+        }
+      }
+    }
+    .frame(maxWidth: .infinity)
+    .accessibilityIdentifier("home-first-win")
+  }
+
+  // MARK: Pipeline pills
+
+  @ViewBuilder
+  private var conversationPill: some View {
+    if conversationCaptured {
+      HomeFirstWinPill(
+        state: .done,
+        text: firstConversationTitle.map { "First conversation: \($0)" }
+          ?? "First conversation captured",
+        actionLabel: nil,
+        action: onOpenConversations
+      )
+    } else if !hasMicrophonePermission {
+      HomeFirstWinPill(
+        state: .blocked,
+        text: "First conversation",
+        actionLabel: "Enable microphone →",
+        action: onFixPermissions
+      )
+    } else {
+      HomeFirstWinPill(
+        state: .active(pulsing: isTranscribing),
+        text: isTranscribing
+          ? "Listening — your first conversation lands here"
+          : "First conversation — start talking or join a meeting",
+        actionLabel: nil,
+        action: nil
+      )
+    }
+  }
+
+  @ViewBuilder
+  private var screenPill: some View {
+    if !hasScreenRecordingPermission {
+      HomeFirstWinPill(
+        state: .blocked,
+        text: "Screen memory",
+        actionLabel: "Turn on →",
+        action: onFixPermissions
+      )
+    } else {
+      HomeFirstWinPill(
+        state: .active(pulsing: true),
+        text: screenshotsToday.map { $0 > 0 ? "Screen memory — \($0) screens so far" : "Screen memory — capturing" }
+          ?? "Screen memory — capturing",
+        actionLabel: nil,
+        action: nil
+      )
+    }
+  }
+}
+
+// MARK: - Pieces
+
+private struct HomeFirstWinMemoryRow: View {
+  let text: String
+  let onTap: () -> Void
+
+  @State private var isHovering = false
+
+  var body: some View {
+    Button(action: onTap) {
+      HStack(alignment: .firstTextBaseline, spacing: OmiSpacing.sm) {
+        Image(systemName: "brain")
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .foregroundStyle(HomeStagePalette.secondary)
+          .frame(width: 18)
+
+        Text(text)
+          .scaledFont(size: OmiType.body, weight: .medium)
+          .foregroundStyle(HomeStagePalette.ink)
+          .lineLimit(2)
+          .multilineTextAlignment(.leading)
+
+        Spacer(minLength: 0)
+      }
+      .padding(.horizontal, OmiSpacing.md)
+      .padding(.vertical, OmiSpacing.sm)
+      .background(
+        RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
+          .fill(isHovering ? HomeStagePalette.tileHover : HomeStagePalette.tile.opacity(0.85))
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
+          .stroke(HomeStagePalette.hairline.opacity(0.8), lineWidth: 1)
+      )
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .onHover { isHovering = $0 }
+  }
+}
+
+private struct HomeFirstWinKeycap: View {
+  let token: String
+
+  var body: some View {
+    Text(token)
+      .scaledFont(size: OmiType.caption, weight: .semibold)
+      .foregroundStyle(HomeStagePalette.secondary)
+      .padding(.horizontal, 7)
+      .padding(.vertical, 3)
+      .background(
+        RoundedRectangle(cornerRadius: 5, style: .continuous)
+          .fill(HomeStagePalette.tile)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 5, style: .continuous)
+          .stroke(HomeStagePalette.hairline, lineWidth: 1)
+      )
+  }
+}
+
+private struct HomeFirstWinPill: View {
+  enum PillState {
+    case active(pulsing: Bool)
+    case blocked
+    case done
+  }
+
+  let state: PillState
+  let text: String
+  let actionLabel: String?
+  let action: (() -> Void)?
+
+  @State private var isHovering = false
+
+  var body: some View {
+    Button {
+      action?()
+    } label: {
+      HStack(spacing: OmiSpacing.xs) {
+        indicator
+
+        Text(text)
+          .scaledFont(size: OmiType.micro, weight: .medium)
+          .foregroundStyle(HomeStagePalette.secondary)
+          .lineLimit(1)
+
+        if let actionLabel {
+          Text(actionLabel)
+            .scaledFont(size: OmiType.micro, weight: .semibold)
+            .foregroundStyle(isHovering ? HomeStagePalette.ink : HomeStagePalette.secondary)
+        }
+      }
+      .padding(.horizontal, OmiSpacing.sm)
+      .padding(.vertical, 5)
+      .background(Capsule().fill(HomeStagePalette.tile.opacity(0.9)))
+      .overlay(Capsule().stroke(HomeStagePalette.hairline, lineWidth: 1))
+      .contentShape(Capsule())
+    }
+    .buttonStyle(.plain)
+    .disabled(action == nil)
+    .onHover { isHovering = $0 }
+  }
+
+  @ViewBuilder
+  private var indicator: some View {
+    switch state {
+    case .active:
+      Circle()
+        .fill(HomeStagePalette.green)
+        .frame(width: 6, height: 6)
+    case .blocked:
+      Circle()
+        .stroke(HomeStagePalette.muted, lineWidth: 1.2)
+        .frame(width: 6, height: 6)
+    case .done:
+      Image(systemName: "checkmark.circle.fill")
+        .scaledFont(size: OmiType.micro, weight: .semibold)
+        .foregroundStyle(HomeStagePalette.green)
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeFirstWinSection.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeFirstWinSection.swift
@@ -11,17 +11,28 @@ import SwiftUI
 /// ask bar rendered underneath by `DashboardPage` is the single ask
 /// affordance; the keycap row teaches the floating-bar shortcut.
 struct HomeFirstWinSection: View {
+  /// Honest pipeline state per capture lane. Permission granted is NOT the
+  /// same as capture running — `paused` renders the truthful resume
+  /// affordance instead of a fake pulsing dot.
+  enum PipelineState: Equatable {
+    case blocked
+    case paused
+    case waiting
+    case live
+    case done
+  }
+
   let memories: [String]
   let memoryCount: Int
   let shortcutTokens: [String]
-  let conversationCaptured: Bool
+  let conversationState: PipelineState
   let firstConversationTitle: String?
-  let hasMicrophonePermission: Bool
-  let hasScreenRecordingPermission: Bool
-  let isTranscribing: Bool
+  let screenState: PipelineState
   let screenshotsToday: Int?
   let onOpenMemories: () -> Void
   let onFixPermissions: () -> Void
+  let onResumeListening: () -> Void
+  let onResumeCapture: () -> Void
   let onOpenConversations: () -> Void
 
   var body: some View {
@@ -85,7 +96,8 @@ struct HomeFirstWinSection: View {
 
   @ViewBuilder
   private var conversationPill: some View {
-    if conversationCaptured {
+    switch conversationState {
+    case .done:
       HomeFirstWinPill(
         state: .done,
         text: firstConversationTitle.map { "First conversation: \($0)" }
@@ -93,19 +105,31 @@ struct HomeFirstWinSection: View {
         actionLabel: nil,
         action: onOpenConversations
       )
-    } else if !hasMicrophonePermission {
+    case .blocked:
       HomeFirstWinPill(
         state: .blocked,
         text: "First conversation",
         actionLabel: "Enable microphone →",
         action: onFixPermissions
       )
-    } else {
+    case .paused:
       HomeFirstWinPill(
-        state: .active(pulsing: isTranscribing),
-        text: isTranscribing
-          ? "Listening — your first conversation lands here"
-          : "First conversation — start talking or join a meeting",
+        state: .blocked,
+        text: "Listening is off",
+        actionLabel: "Turn on →",
+        action: onResumeListening
+      )
+    case .live:
+      HomeFirstWinPill(
+        state: .active(pulsing: true),
+        text: "Listening — your first conversation lands here",
+        actionLabel: nil,
+        action: nil
+      )
+    case .waiting:
+      HomeFirstWinPill(
+        state: .active(pulsing: false),
+        text: "First conversation — start talking or join a meeting",
         actionLabel: nil,
         action: nil
       )
@@ -114,14 +138,22 @@ struct HomeFirstWinSection: View {
 
   @ViewBuilder
   private var screenPill: some View {
-    if !hasScreenRecordingPermission {
+    switch screenState {
+    case .blocked:
       HomeFirstWinPill(
         state: .blocked,
         text: "Screen memory",
         actionLabel: "Turn on →",
         action: onFixPermissions
       )
-    } else {
+    case .paused:
+      HomeFirstWinPill(
+        state: .blocked,
+        text: "Screen memory is paused",
+        actionLabel: "Resume →",
+        action: onResumeCapture
+      )
+    case .live, .waiting, .done:
       HomeFirstWinPill(
         state: .active(pulsing: true),
         text: screenshotsToday.map { $0 > 0 ? "Screen memory — \($0) screens so far" : "Screen memory — capturing" }

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeGreetingView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeGreetingView.swift
@@ -1,0 +1,75 @@
+import OmiTheme
+import SwiftUI
+
+/// The greeting block at the top of the Home stage: a serif salutation and a
+/// single ambient proof sub-line summarizing what Omi delivered today.
+/// Capture/listening status intentionally lives only in the header chips —
+/// this line is content, not status.
+struct HomeGreetingView: View {
+  let greeting: String
+  let segments: [HomeGreetingComposer.Segment]
+  let onOpen: (HomeGreetingComposer.SegmentDestination) -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+      Text(greeting)
+        .font(.system(size: 30, weight: .medium, design: .serif))
+        .foregroundStyle(HomeStagePalette.ink)
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
+
+      if !segments.isEmpty {
+        proofLine
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("home-greeting")
+  }
+
+  private var proofLine: some View {
+    HStack(spacing: 0) {
+      ForEach(Array(segments.enumerated()), id: \.offset) { index, segment in
+        if index > 0 {
+          Text(separator(before: segment))
+            .scaledFont(size: OmiType.caption, weight: .medium)
+            .foregroundStyle(HomeStagePalette.faint)
+        }
+        HomeGreetingSegmentView(segment: segment, onOpen: onOpen)
+      }
+    }
+    .lineLimit(1)
+  }
+
+  /// Countable segments join with a middle dot; plain-text segments (e.g.
+  /// "today", "Quiet so far today —") join with a space.
+  private func separator(before segment: HomeGreetingComposer.Segment) -> String {
+    segment.destination == nil ? " " : "  ·  "
+  }
+}
+
+private struct HomeGreetingSegmentView: View {
+  let segment: HomeGreetingComposer.Segment
+  let onOpen: (HomeGreetingComposer.SegmentDestination) -> Void
+
+  @State private var isHovering = false
+
+  var body: some View {
+    if let destination = segment.destination {
+      Button {
+        onOpen(destination)
+      } label: {
+        Text(segment.text)
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .foregroundStyle(isHovering ? HomeStagePalette.ink : HomeStagePalette.secondary)
+          .underline(isHovering, color: HomeStagePalette.muted)
+      }
+      .buttonStyle(.plain)
+      .onHover { isHovering = $0 }
+    } else {
+      Text(segment.text)
+        .scaledFont(size: OmiType.caption, weight: .medium)
+        .foregroundStyle(HomeStagePalette.muted)
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeNoticedSection.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeNoticedSection.swift
@@ -1,0 +1,206 @@
+import OmiTheme
+import SwiftUI
+
+/// "What Omi noticed" — the hero of the redesigned Home hub.
+///
+/// Merges the two proactive-intelligence streams into one quiet feed:
+/// canonical What-Matters-Now recommendations (task intelligence, with its
+/// feedback contract intact) and today's local proactive insights — the
+/// advice stream that previously only surfaced as floating-bar notifications
+/// (99.4% dismissed there; the content earns its keep on Home instead).
+///
+/// Rows are ambient: icon + text + caption, actions appear on hover. No
+/// bordered card container — borders and strong color stay reserved for
+/// real errors per the design language.
+struct HomeNoticedSection: View {
+  @ObservedObject var intelligenceStore: DashboardIntelligenceStore
+  @ObservedObject var todayStore: HomeTodayStore
+  let onOpenRecommendation: (DashboardRecommendation) async -> Bool
+  let onOpenInsights: () -> Void
+
+  private static let maxRows = 5
+
+  private var visibleInsights: [HomeTodayStore.InsightItem] {
+    let remaining = Self.maxRows - intelligenceStore.recommendations.count
+    guard remaining > 0 else { return [] }
+    return Array(todayStore.content.insights.prefix(remaining))
+  }
+
+  private var isEmpty: Bool {
+    intelligenceStore.recommendations.isEmpty && todayStore.content.insights.isEmpty
+  }
+
+  var body: some View {
+    if !isEmpty {
+      VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+        Text("What Omi noticed")
+          .scaledFont(size: OmiType.micro, weight: .semibold)
+          .kerning(1.1)
+          .textCase(.uppercase)
+          .foregroundStyle(HomeStagePalette.muted)
+          .padding(.bottom, OmiSpacing.xxs)
+
+        ForEach(intelligenceStore.recommendations) { recommendation in
+          HomeNoticedRecommendationRow(
+            recommendation: recommendation,
+            onOpen: {
+              if await onOpenRecommendation(recommendation) {
+                await intelligenceStore.recordPrimaryAction(recommendation)
+              }
+            },
+            onLater: { await intelligenceStore.later(recommendation) },
+            onDismiss: { reason in await intelligenceStore.dismiss(recommendation, reason: reason) }
+          )
+        }
+
+        ForEach(visibleInsights) { insight in
+          HomeNoticedInsightRow(
+            insight: insight,
+            onOpen: onOpenInsights,
+            onDismiss: { await todayStore.dismissInsight(insight) }
+          )
+        }
+      }
+      .accessibilityIdentifier("what-matters-now")
+    }
+  }
+}
+
+// MARK: - Rows
+
+private struct HomeNoticedRecommendationRow: View {
+  let recommendation: DashboardRecommendation
+  let onOpen: () async -> Void
+  let onLater: () async -> Void
+  let onDismiss: (OmiAPI.TaskIntelligenceFeedbackReason?) async -> Void
+
+  @State private var isHovering = false
+
+  var body: some View {
+    HomeNoticedRowChrome(isHovering: $isHovering, onTap: { Task { await onOpen() } }) {
+      Image(systemName: "sparkle")
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+        .foregroundStyle(HomeStagePalette.secondary)
+        .frame(width: 18)
+    } content: {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(recommendation.headline)
+          .scaledFont(size: OmiType.body, weight: .medium)
+          .foregroundStyle(HomeStagePalette.ink)
+          .lineLimit(2)
+        Text(captionText)
+          .scaledFont(size: OmiType.micro, weight: .medium)
+          .foregroundStyle(HomeStagePalette.muted)
+          .lineLimit(1)
+      }
+    } actions: {
+      Button(recommendation.recommendedAction) { Task { await onOpen() } }
+        .buttonStyle(.borderedProminent)
+        .tint(HomeStagePalette.ink)
+        .foregroundColor(.black)
+        .controlSize(.small)
+        .lineLimit(1)
+        .accessibilityIdentifier("wmn-primary-\(recommendation.interventionID)")
+
+      Menu {
+        Button("Later") { Task { await onLater() } }
+        Menu("Dismiss") {
+          Button("Already handled") { Task { await onDismiss(.already_handled) } }
+          Button("Not mine") { Task { await onDismiss(.not_mine) } }
+          Button("Not useful") { Task { await onDismiss(.not_useful) } }
+          Button("No reason") { Task { await onDismiss(nil) } }
+        }
+      } label: {
+        Image(systemName: "ellipsis")
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .foregroundStyle(HomeStagePalette.secondary)
+      }
+      .menuStyle(.borderlessButton)
+      .menuIndicator(.hidden)
+      .frame(width: 26)
+      .accessibilityIdentifier("wmn-dismiss-\(recommendation.interventionID)")
+    }
+  }
+
+  private var captionText: String {
+    var parts: [String] = []
+    if !recommendation.whyNow.isEmpty { parts.append(recommendation.whyNow) }
+    if let context = recommendation.contextLabel, !context.isEmpty { parts.append(context) }
+    return parts.joined(separator: " · ")
+  }
+}
+
+private struct HomeNoticedInsightRow: View {
+  let insight: HomeTodayStore.InsightItem
+  let onOpen: () -> Void
+  let onDismiss: () async -> Void
+
+  @State private var isHovering = false
+
+  var body: some View {
+    HomeNoticedRowChrome(isHovering: $isHovering, onTap: onOpen) {
+      Image(systemName: "lightbulb")
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+        .foregroundStyle(HomeStagePalette.secondary)
+        .frame(width: 18)
+    } content: {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(insight.text)
+          .scaledFont(size: OmiType.body, weight: .medium)
+          .foregroundStyle(HomeStagePalette.ink)
+          .lineLimit(2)
+        Text("\(insight.sourceApp) · \(insight.createdAt.formatted(date: .omitted, time: .shortened))")
+          .scaledFont(size: OmiType.micro, weight: .medium)
+          .foregroundStyle(HomeStagePalette.muted)
+          .lineLimit(1)
+      }
+    } actions: {
+      Button {
+        Task { await onDismiss() }
+      } label: {
+        Image(systemName: "xmark")
+          .scaledFont(size: OmiType.micro, weight: .semibold)
+          .foregroundStyle(HomeStagePalette.secondary)
+      }
+      .buttonStyle(.plain)
+      .frame(width: 26)
+      .help("Dismiss")
+    }
+  }
+}
+
+/// Shared row chrome: full-width tap target, hover tint, actions revealed on
+/// hover (reserved space so rows don't jump).
+private struct HomeNoticedRowChrome<Icon: View, Content: View, Actions: View>: View {
+  @Binding var isHovering: Bool
+  let onTap: () -> Void
+  @ViewBuilder let icon: () -> Icon
+  @ViewBuilder let content: () -> Content
+  @ViewBuilder let actions: () -> Actions
+
+  var body: some View {
+    HStack(alignment: .center, spacing: OmiSpacing.sm) {
+      Button(action: onTap) {
+        HStack(alignment: .firstTextBaseline, spacing: OmiSpacing.sm) {
+          icon()
+          content()
+          Spacer(minLength: 0)
+        }
+        .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+
+      HStack(spacing: OmiSpacing.xs) {
+        actions()
+      }
+      .opacity(isHovering ? 1 : 0)
+    }
+    .padding(.horizontal, OmiSpacing.sm)
+    .padding(.vertical, OmiSpacing.xs)
+    .background(
+      RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius, style: .continuous)
+        .fill(isHovering ? HomeStagePalette.tileHover.opacity(0.7) : Color.clear)
+    )
+    .onHover { isHovering = $0 }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeNoticedSection.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeNoticedSection.swift
@@ -77,49 +77,55 @@ private struct HomeNoticedRecommendationRow: View {
   @State private var isHovering = false
 
   var body: some View {
-    HomeNoticedRowChrome(isHovering: $isHovering, onTap: { Task { await onOpen() } }) {
-      Image(systemName: "sparkle")
-        .scaledFont(size: OmiType.caption, weight: .semibold)
-        .foregroundStyle(HomeStagePalette.secondary)
-        .frame(width: 18)
-    } content: {
-      VStack(alignment: .leading, spacing: 2) {
-        Text(recommendation.headline)
-          .scaledFont(size: OmiType.body, weight: .medium)
-          .foregroundStyle(HomeStagePalette.ink)
-          .lineLimit(2)
-        Text(captionText)
-          .scaledFont(size: OmiType.micro, weight: .medium)
-          .foregroundStyle(HomeStagePalette.muted)
-          .lineLimit(1)
-      }
-    } actions: {
-      Button(recommendation.recommendedAction) { Task { await onOpen() } }
-        .buttonStyle(.borderedProminent)
-        .tint(HomeStagePalette.ink)
-        .foregroundColor(.black)
-        .controlSize(.small)
-        .lineLimit(1)
-        .accessibilityIdentifier("wmn-primary-\(recommendation.interventionID)")
-
-      Menu {
-        Button("Later") { Task { await onLater() } }
-        Menu("Dismiss") {
-          Button("Already handled") { Task { await onDismiss(.already_handled) } }
-          Button("Not mine") { Task { await onDismiss(.not_mine) } }
-          Button("Not useful") { Task { await onDismiss(.not_useful) } }
-          Button("No reason") { Task { await onDismiss(nil) } }
-        }
-      } label: {
-        Image(systemName: "ellipsis")
+    HomeNoticedRowChrome(
+      isHovering: $isHovering,
+      onTap: { Task { await onOpen() } },
+      icon: {
+        Image(systemName: "sparkle")
           .scaledFont(size: OmiType.caption, weight: .semibold)
           .foregroundStyle(HomeStagePalette.secondary)
+          .frame(width: 18)
+      },
+      content: {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(recommendation.headline)
+            .scaledFont(size: OmiType.body, weight: .medium)
+            .foregroundStyle(HomeStagePalette.ink)
+            .lineLimit(2)
+          Text(captionText)
+            .scaledFont(size: OmiType.micro, weight: .medium)
+            .foregroundStyle(HomeStagePalette.muted)
+            .lineLimit(1)
+        }
+      },
+      actions: {
+        Button(recommendation.recommendedAction) { Task { await onOpen() } }
+          .buttonStyle(.borderedProminent)
+          .tint(HomeStagePalette.ink)
+          .foregroundColor(.black)
+          .controlSize(.small)
+          .lineLimit(1)
+          .accessibilityIdentifier("wmn-primary-\(recommendation.interventionID)")
+
+        Menu {
+          Button("Later") { Task { await onLater() } }
+          Menu("Dismiss") {
+            Button("Already handled") { Task { await onDismiss(.already_handled) } }
+            Button("Not mine") { Task { await onDismiss(.not_mine) } }
+            Button("Not useful") { Task { await onDismiss(.not_useful) } }
+            Button("No reason") { Task { await onDismiss(nil) } }
+          }
+        } label: {
+          Image(systemName: "ellipsis")
+            .scaledFont(size: OmiType.caption, weight: .semibold)
+            .foregroundStyle(HomeStagePalette.secondary)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .frame(width: 26)
+        .accessibilityIdentifier("wmn-dismiss-\(recommendation.interventionID)")
       }
-      .menuStyle(.borderlessButton)
-      .menuIndicator(.hidden)
-      .frame(width: 26)
-      .accessibilityIdentifier("wmn-dismiss-\(recommendation.interventionID)")
-    }
+    )
   }
 
   private var captionText: String {
@@ -138,34 +144,40 @@ private struct HomeNoticedInsightRow: View {
   @State private var isHovering = false
 
   var body: some View {
-    HomeNoticedRowChrome(isHovering: $isHovering, onTap: onOpen) {
-      Image(systemName: "lightbulb")
-        .scaledFont(size: OmiType.caption, weight: .semibold)
-        .foregroundStyle(HomeStagePalette.secondary)
-        .frame(width: 18)
-    } content: {
-      VStack(alignment: .leading, spacing: 2) {
-        Text(insight.text)
-          .scaledFont(size: OmiType.body, weight: .medium)
-          .foregroundStyle(HomeStagePalette.ink)
-          .lineLimit(2)
-        Text("\(insight.sourceApp) · \(insight.createdAt.formatted(date: .omitted, time: .shortened))")
-          .scaledFont(size: OmiType.micro, weight: .medium)
-          .foregroundStyle(HomeStagePalette.muted)
-          .lineLimit(1)
-      }
-    } actions: {
-      Button {
-        Task { await onDismiss() }
-      } label: {
-        Image(systemName: "xmark")
-          .scaledFont(size: OmiType.micro, weight: .semibold)
+    HomeNoticedRowChrome(
+      isHovering: $isHovering,
+      onTap: onOpen,
+      icon: {
+        Image(systemName: "lightbulb")
+          .scaledFont(size: OmiType.caption, weight: .semibold)
           .foregroundStyle(HomeStagePalette.secondary)
+          .frame(width: 18)
+      },
+      content: {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(insight.text)
+            .scaledFont(size: OmiType.body, weight: .medium)
+            .foregroundStyle(HomeStagePalette.ink)
+            .lineLimit(2)
+          Text("\(insight.sourceApp) · \(insight.createdAt.formatted(date: .omitted, time: .shortened))")
+            .scaledFont(size: OmiType.micro, weight: .medium)
+            .foregroundStyle(HomeStagePalette.muted)
+            .lineLimit(1)
+        }
+      },
+      actions: {
+        Button {
+          Task { await onDismiss() }
+        } label: {
+          Image(systemName: "xmark")
+            .scaledFont(size: OmiType.micro, weight: .semibold)
+            .foregroundStyle(HomeStagePalette.secondary)
+        }
+        .buttonStyle(.plain)
+        .frame(width: 26)
+        .help("Dismiss")
       }
-      .buttonStyle(.plain)
-      .frame(width: 26)
-      .help("Dismiss")
-    }
+    )
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeRewindFilmstrip.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeRewindFilmstrip.swift
@@ -108,7 +108,14 @@ private struct HomeFilmstripFrame: View {
     do {
       let image = try await RewindStorage.shared.loadScreenshotImage(for: screenshot)
       guard !Task.isCancelled else { return }
-      thumbnail = Self.downscale(image, maxHeight: HomeRewindFilmstrip.frameHeight * 2)
+      // Force the full-resolution decode + draw off the main thread — ten
+      // frames decode at once when Home appears.
+      let targetHeight = HomeRewindFilmstrip.frameHeight * 2
+      let scaled = await Task.detached(priority: .utility) {
+        Self.downscale(image, maxHeight: targetHeight)
+      }.value
+      guard !Task.isCancelled else { return }
+      thumbnail = scaled
     } catch {
       // Pruned frames are expected occasionally; keep the neutral tile but
       // leave a trace for diagnosis.
@@ -116,7 +123,7 @@ private struct HomeFilmstripFrame: View {
     }
   }
 
-  private static func downscale(_ image: NSImage, maxHeight: CGFloat) -> NSImage {
+  private nonisolated static func downscale(_ image: NSImage, maxHeight: CGFloat) -> NSImage {
     let size = image.size
     guard size.height > maxHeight, size.height > 0 else { return image }
     let scale = maxHeight / size.height

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeRewindFilmstrip.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeRewindFilmstrip.swift
@@ -1,0 +1,135 @@
+import AppKit
+import OmiTheme
+import SwiftUI
+
+/// "Today in Rewind" — a slim filmstrip of sampled frames from today's screen
+/// capture. The deepest hands-on desktop feature gets a presence on Home;
+/// clicking a frame opens Rewind at that moment. Hidden entirely when today
+/// has no frames (no empty shell).
+struct HomeRewindFilmstrip: View {
+  let screenshots: [Screenshot]
+  let onOpen: (Screenshot?) -> Void
+
+  var body: some View {
+    if !screenshots.isEmpty {
+      VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+        HStack {
+          Text("Today in Rewind")
+            .scaledFont(size: OmiType.micro, weight: .semibold)
+            .kerning(1.1)
+            .textCase(.uppercase)
+            .foregroundStyle(HomeStagePalette.muted)
+
+          Spacer()
+
+          Button {
+            onOpen(nil)
+          } label: {
+            Text("Open Rewind →")
+              .scaledFont(size: OmiType.micro, weight: .semibold)
+              .foregroundStyle(HomeStagePalette.secondary)
+          }
+          .buttonStyle(.plain)
+        }
+
+        HStack(spacing: OmiSpacing.xs) {
+          ForEach(screenshots, id: \.id) { screenshot in
+            HomeFilmstripFrame(screenshot: screenshot) {
+              onOpen(screenshot)
+            }
+          }
+        }
+        .frame(height: Self.frameHeight)
+      }
+      .accessibilityIdentifier("home-rewind-filmstrip")
+    }
+  }
+
+  static let frameHeight: CGFloat = 58
+}
+
+private struct HomeFilmstripFrame: View {
+  let screenshot: Screenshot
+  let onTap: () -> Void
+
+  @State private var thumbnail: NSImage?
+  @State private var isHovering = false
+
+  private static let timeFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "H:mm"
+    return formatter
+  }()
+
+  var body: some View {
+    Button(action: onTap) {
+      ZStack(alignment: .bottomLeading) {
+        Group {
+          if let thumbnail {
+            Image(nsImage: thumbnail)
+              .resizable()
+              .aspectRatio(contentMode: .fill)
+          } else {
+            HomeStagePalette.tile
+          }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: HomeRewindFilmstrip.frameHeight)
+        .clipped()
+
+        Text(Self.timeFormatter.string(from: screenshot.timestamp))
+          .scaledFont(size: 9, weight: .semibold)
+          .foregroundStyle(Color.white.opacity(0.85))
+          .padding(.horizontal, 4)
+          .padding(.vertical, 2)
+          .background(Color.black.opacity(0.45))
+          .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
+          .padding(4)
+      }
+      .clipShape(RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius, style: .continuous))
+      .overlay(
+        RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius, style: .continuous)
+          .stroke(
+            isHovering ? HomeStagePalette.secondary.opacity(0.5) : HomeStagePalette.hairline,
+            lineWidth: 1
+          )
+      )
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .onHover { isHovering = $0 }
+    .task(id: screenshot.id) {
+      await loadThumbnail()
+    }
+  }
+
+  private func loadThumbnail() async {
+    guard thumbnail == nil else { return }
+    do {
+      let image = try await RewindStorage.shared.loadScreenshotImage(for: screenshot)
+      guard !Task.isCancelled else { return }
+      thumbnail = Self.downscale(image, maxHeight: HomeRewindFilmstrip.frameHeight * 2)
+    } catch {
+      // Pruned frames are expected occasionally; keep the neutral tile but
+      // leave a trace for diagnosis.
+      log("HomeFilmstrip: thumbnail load failed for frame \(screenshot.id ?? -1): \(error)")
+    }
+  }
+
+  private static func downscale(_ image: NSImage, maxHeight: CGFloat) -> NSImage {
+    let size = image.size
+    guard size.height > maxHeight, size.height > 0 else { return image }
+    let scale = maxHeight / size.height
+    let target = NSSize(width: size.width * scale, height: maxHeight)
+    let resized = NSImage(size: target)
+    resized.lockFocus()
+    image.draw(
+      in: NSRect(origin: .zero, size: target),
+      from: NSRect(origin: .zero, size: size),
+      operation: .copy,
+      fraction: 1.0
+    )
+    resized.unlockFocus()
+    return resized
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeStagePalette.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeStagePalette.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+/// Warm neutral palette for the redesigned Home stage, shared by
+/// `DashboardPage` and the Dashboard section views.
+///
+/// `stageGlow` is deliberately neutral (INV-UI-1: accents stay white/neutral);
+/// it was previously a violet literal that predated the brand ratchet.
+enum HomeStagePalette {
+  static let paper = Color(red: 0.018, green: 0.019, blue: 0.021)
+  static let panel = Color(red: 0.045, green: 0.046, blue: 0.052)
+  static let tile = Color(red: 0.078, green: 0.078, blue: 0.088)
+  static let tileHover = Color(red: 0.11, green: 0.11, blue: 0.122)
+  static let ink = Color(red: 0.94, green: 0.925, blue: 0.89)
+  static let secondary = Color(red: 0.78, green: 0.765, blue: 0.725)
+  static let muted = Color(red: 0.49, green: 0.47, blue: 0.43)
+  static let faint = Color(red: 0.36, green: 0.35, blue: 0.33)
+  static let hairline = Color(red: 0.155, green: 0.155, blue: 0.172)
+  static let green = Color(red: 0.17, green: 0.78, blue: 0.38)
+  static let stageGlow = Color(red: 0.92, green: 0.9, blue: 0.86)
+  static let glow = stageGlow
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeTodayModel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeTodayModel.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Pure composition logic for the Home greeting line and its proof sub-line.
+///
+/// The sub-line is the single on-canvas summary of what Omi delivered today
+/// (capture status itself lives only in the header chips). Kept free of UI
+/// and stores so every branch is hermetically testable.
+enum HomeGreetingComposer {
+
+  struct TodayCounts: Equatable {
+    var conversations: Int?
+    var memories: Int?
+    var tasks: Int?
+    var screens: Int?
+
+    /// True once every source has reported (no nil left).
+    var isComplete: Bool {
+      conversations != nil && memories != nil && tasks != nil && screens != nil
+    }
+
+    var total: Int {
+      (conversations ?? 0) + (memories ?? 0) + (tasks ?? 0) + (screens ?? 0)
+    }
+  }
+
+  enum SegmentDestination: Equatable {
+    case conversations
+    case memories
+    case tasks
+    case rewind
+  }
+
+  struct Segment: Equatable {
+    let text: String
+    let destination: SegmentDestination?
+  }
+
+  static func greeting(name: String?, hour: Int) -> String {
+    let daypart: String
+    switch hour {
+    case 5..<12: daypart = "Good morning"
+    case 12..<18: daypart = "Good afternoon"
+    default: daypart = "Good evening"
+    }
+    let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    // "there" is the legacy signed-in-without-a-name placeholder; a bare
+    // greeting reads intentional, a placeholder does not.
+    guard !trimmed.isEmpty, trimmed.lowercased() != "there" else { return "\(daypart)." }
+    return "\(daypart), \(trimmed)."
+  }
+
+  /// The proof sub-line. Only non-zero counts render; the morning case
+  /// (nothing today yet, real history) leads with the lifetime memory instead
+  /// of a row of zeros.
+  static func proofSegments(
+    today: TodayCounts,
+    lifetimeConversations: Int?
+  ) -> [Segment] {
+    var segments: [Segment] = []
+    if let conversations = today.conversations, conversations > 0 {
+      segments.append(
+        Segment(
+          text: "\(conversations) conversation\(conversations == 1 ? "" : "s")",
+          destination: .conversations
+        ))
+    }
+    if let memories = today.memories, memories > 0 {
+      segments.append(
+        Segment(text: "\(memories) memor\(memories == 1 ? "y" : "ies")", destination: .memories))
+    }
+    if let tasks = today.tasks, tasks > 0 {
+      segments.append(Segment(text: "\(tasks) task\(tasks == 1 ? "" : "s")", destination: .tasks))
+    }
+    if let screens = today.screens, screens > 0 {
+      segments.append(Segment(text: "\(formattedCount(screens)) screens", destination: .rewind))
+    }
+
+    if !segments.isEmpty {
+      segments.append(Segment(text: "today", destination: nil))
+      return segments
+    }
+
+    if let lifetime = lifetimeConversations, lifetime > 0 {
+      return [
+        Segment(text: "Quiet so far today —", destination: nil),
+        Segment(
+          text: "\(formattedCount(lifetime)) conversation\(lifetime == 1 ? "" : "s") remembered",
+          destination: .conversations
+        ),
+      ]
+    }
+
+    return [Segment(text: "Omi learns as you work — nothing captured yet today.", destination: nil)]
+  }
+
+  static func formattedCount(_ count: Int) -> String {
+    if count >= 10_000 {
+      let thousands = Double(count) / 1000.0
+      return String(format: "%.0fk", thousands)
+    }
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    return formatter.string(from: NSNumber(value: count)) ?? String(count)
+  }
+}
+
+/// Quality gate for memory texts surfaced on the first-win hero.
+///
+/// The legacy onboarding batch import writes one memory per scanned file, so
+/// "newest first" can surface a bare filename as the introduction to Omi.
+/// Filter to human-readable sentences about the user.
+enum FirstWinMemoryFilter {
+
+  static func isDisplayable(_ text: String) -> Bool {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.count >= 12, trimmed.count <= 240 else { return false }
+    // File-path-shaped: multiple path separators or a tilde-rooted path.
+    if trimmed.hasPrefix("~/") || trimmed.hasPrefix("/") { return false }
+    if trimmed.components(separatedBy: "/").count > 2 { return false }
+    if trimmed.components(separatedBy: "\\").count > 2 { return false }
+    // A lone filename with an extension and no sentence structure.
+    let wordCount = trimmed.split(whereSeparator: { $0.isWhitespace }).count
+    if wordCount < 3 { return false }
+    return true
+  }
+
+  static func displayable(_ texts: [String], limit: Int) -> [String] {
+    var seen = Set<String>()
+    var result: [String] = []
+    for text in texts {
+      let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard isDisplayable(trimmed), seen.insert(trimmed.lowercased()).inserted else { continue }
+      result.append(trimmed)
+      if result.count >= limit { break }
+    }
+    return result
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeTodayStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeTodayStore.swift
@@ -1,0 +1,148 @@
+import Combine
+import Foundation
+
+/// Loads the content pieces of the redesigned Home surface that are not plain
+/// counts: today's proactive insights (the advice stream that previously only
+/// reached the floating-bar notification surface), today's Rewind filmstrip
+/// frames, and the quality-gated memories shown on the first-win hero.
+///
+/// All sources are local (GRDB stores + Rewind database); a loader seam keeps
+/// every branch hermetically testable.
+@MainActor
+final class HomeTodayStore: ObservableObject {
+
+  struct InsightItem: Identifiable, Equatable {
+    let id: Int64
+    let text: String
+    let sourceApp: String
+    let createdAt: Date
+  }
+
+  struct Content: Equatable {
+    var insights: [InsightItem] = []
+    var filmstrip: [Screenshot] = []
+    var firstWinMemories: [String] = []
+    var firstWinMemoryCount = 0
+  }
+
+  struct Loader {
+    let loadTodayInsights: @MainActor @Sendable (_ startOfDay: Date) async -> [InsightItem]
+    let loadFilmstrip: @MainActor @Sendable (_ startOfDay: Date) async -> [Screenshot]
+    let loadFirstWinMemories: @MainActor @Sendable () async -> (memories: [String], total: Int)
+    let dismissInsight: @MainActor @Sendable (_ id: Int64) async -> Void
+
+    static let live = Loader(
+      loadTodayInsights: { startOfDay in
+        do {
+          let records = try await ProactiveStorage.shared.getExtractions(
+            type: .insight, limit: 40, includeDismissed: false)
+          return
+            records
+            .filter { $0.createdAt >= startOfDay }
+            .sorted { $0.createdAt > $1.createdAt }
+            .prefix(HomeTodayStore.maxInsights)
+            .compactMap { record in
+              guard let id = record.id else { return nil }
+              let text = record.content.trimmingCharacters(in: .whitespacesAndNewlines)
+              guard !text.isEmpty else { return nil }
+              return InsightItem(
+                id: id, text: text, sourceApp: record.sourceApp, createdAt: record.createdAt)
+            }
+        } catch {
+          logError("HomeTodayStore: Failed to load today's insights", error: error)
+          return []
+        }
+      },
+      loadFilmstrip: { startOfDay in
+        do {
+          // Thumbnails decode from video chunks; storage must be initialized
+          // before Home renders frames (Rewind page normally does this).
+          try await RewindStorage.shared.initialize()
+          return try await RewindDatabase.shared.getScreenshotsSampled(
+            from: startOfDay, to: Date(), targetCount: HomeTodayStore.filmstripTargetCount)
+        } catch {
+          // Common and expected before the Rewind database opens or when
+          // screen capture never ran today.
+          return []
+        }
+      },
+      loadFirstWinMemories: {
+        do {
+          let memories = try await MemoryStorage.shared.getLocalMemories(limit: 80)
+          let total = try await MemoryStorage.shared.getLocalMemoriesCount()
+          let texts = FirstWinMemoryFilter.displayable(
+            memories.map { $0.content }, limit: HomeTodayStore.maxFirstWinMemories)
+          return (texts, total)
+        } catch {
+          logError("HomeTodayStore: Failed to load first-win memories", error: error)
+          return ([], 0)
+        }
+      },
+      dismissInsight: { id in
+        do {
+          try await ProactiveStorage.shared.dismissExtraction(id: id)
+        } catch {
+          logError("HomeTodayStore: Failed to dismiss insight", error: error)
+        }
+      }
+    )
+  }
+
+  static let maxInsights = 3
+  static let maxFirstWinMemories = 3
+  static let filmstripTargetCount = 10
+
+  @Published private(set) var content = Content()
+
+  private let loader: Loader
+  private let now: () -> Date
+  private var refreshTask: Task<Void, Never>?
+
+  init(loader: Loader = .live, now: @escaping () -> Date = Date.init) {
+    self.loader = loader
+    self.now = now
+  }
+
+  func refresh(includeFirstWin: Bool) async {
+    if let refreshTask {
+      await refreshTask.value
+      return
+    }
+    let task = Task { [weak self] in
+      guard let self else { return }
+      await self.performRefresh(includeFirstWin: includeFirstWin)
+    }
+    refreshTask = task
+    await task.value
+    refreshTask = nil
+  }
+
+  func dismissInsight(_ item: InsightItem) async {
+    content.insights.removeAll { $0.id == item.id }
+    await loader.dismissInsight(item.id)
+  }
+
+  func resetSessionState() {
+    refreshTask?.cancel()
+    refreshTask = nil
+    content = Content()
+  }
+
+  private func performRefresh(includeFirstWin: Bool) async {
+    let startOfDay = Calendar.current.startOfDay(for: now())
+    async let insights = loader.loadTodayInsights(startOfDay)
+    async let filmstrip = loader.loadFilmstrip(startOfDay)
+    let (loadedInsights, loadedFilmstrip) = await (insights, filmstrip)
+
+    var updated = content
+    updated.insights = loadedInsights
+    updated.filmstrip = loadedFilmstrip
+    if includeFirstWin {
+      let (memories, total) = await loader.loadFirstWinMemories()
+      updated.firstWinMemories = memories
+      updated.firstWinMemoryCount = total
+    }
+    guard !Task.isCancelled else { return }
+    content = updated
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeTodayStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeTodayStore.swift
@@ -98,6 +98,11 @@ final class HomeTodayStore: ObservableObject {
   private let now: () -> Date
   private var refreshTask: Task<Void, Never>?
   private var refreshTaskID: UUID?
+  /// Bumped on session reset; an in-flight refresh spawned before the bump
+  /// may finish but must never publish into the next owner's content.
+  private var refreshGeneration = 0
+  private var lastRefreshAt = Date.distantPast
+  private var lastRefreshIncludedFirstWin = false
 
   init(loader: Loader = .live, now: @escaping () -> Date = Date.init) {
     self.loader = loader
@@ -105,16 +110,29 @@ final class HomeTodayStore: ObservableObject {
   }
 
   func refresh(includeFirstWin: Bool) async {
-    // Wait out an in-flight refresh but still run our own pass — the caller's
-    // includeFirstWin may differ (e.g. the first-win surface appearing right
-    // after a plain refresh started), and its data must not be skipped.
+    // Wait out an in-flight refresh but still evaluate our own pass — the
+    // caller's includeFirstWin may differ (e.g. the first-win surface
+    // appearing right after a plain refresh started).
     if let refreshTask {
       await refreshTask.value
     }
+    // Cooldown: app-activation spam must not resample the filmstrip (up to
+    // ten video-chunk decodes per pass). A pass that upgrades to first-win
+    // data always runs.
+    let currentTime = now()
+    let upgradesToFirstWin = includeFirstWin && !lastRefreshIncludedFirstWin
+    guard
+      upgradesToFirstWin
+        || PollingConfig.shouldAllowActivationRefresh(now: currentTime, lastRefresh: lastRefreshAt)
+    else { return }
+    lastRefreshAt = currentTime
+    lastRefreshIncludedFirstWin = includeFirstWin
+
     let taskID = UUID()
+    let generation = refreshGeneration
     let task = Task { [weak self] in
       guard let self else { return }
-      await self.performRefresh(includeFirstWin: includeFirstWin)
+      await self.performRefresh(includeFirstWin: includeFirstWin, generation: generation)
     }
     refreshTask = task
     refreshTaskID = taskID
@@ -131,13 +149,16 @@ final class HomeTodayStore: ObservableObject {
   }
 
   func resetSessionState() {
+    refreshGeneration += 1
     refreshTask?.cancel()
     refreshTask = nil
     refreshTaskID = nil
+    lastRefreshAt = .distantPast
+    lastRefreshIncludedFirstWin = false
     content = Content()
   }
 
-  private func performRefresh(includeFirstWin: Bool) async {
+  private func performRefresh(includeFirstWin: Bool, generation: Int) async {
     let startOfDay = Calendar.current.startOfDay(for: now())
     async let insights = loader.loadTodayInsights(startOfDay)
     async let filmstrip = loader.loadFilmstrip(startOfDay)
@@ -151,7 +172,9 @@ final class HomeTodayStore: ObservableObject {
       updated.firstWinMemories = memories
       updated.firstWinMemoryCount = total
     }
-    guard !Task.isCancelled else { return }
+    // Owner fencing: a reset (account switch) invalidates this pass even if
+    // the task was not cancelled in time.
+    guard !Task.isCancelled, generation == refreshGeneration else { return }
     content = updated
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeTodayStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeTodayStore.swift
@@ -97,6 +97,7 @@ final class HomeTodayStore: ObservableObject {
   private let loader: Loader
   private let now: () -> Date
   private var refreshTask: Task<Void, Never>?
+  private var refreshTaskID: UUID?
 
   init(loader: Loader = .live, now: @escaping () -> Date = Date.init) {
     self.loader = loader
@@ -104,17 +105,24 @@ final class HomeTodayStore: ObservableObject {
   }
 
   func refresh(includeFirstWin: Bool) async {
+    // Wait out an in-flight refresh but still run our own pass — the caller's
+    // includeFirstWin may differ (e.g. the first-win surface appearing right
+    // after a plain refresh started), and its data must not be skipped.
     if let refreshTask {
       await refreshTask.value
-      return
     }
+    let taskID = UUID()
     let task = Task { [weak self] in
       guard let self else { return }
       await self.performRefresh(includeFirstWin: includeFirstWin)
     }
     refreshTask = task
+    refreshTaskID = taskID
     await task.value
-    refreshTask = nil
+    if refreshTaskID == taskID {
+      refreshTask = nil
+      refreshTaskID = nil
+    }
   }
 
   func dismissInsight(_ item: InsightItem) async {
@@ -125,6 +133,7 @@ final class HomeTodayStore: ObservableObject {
   func resetSessionState() {
     refreshTask?.cancel()
     refreshTask = nil
+    refreshTaskID = nil
     content = Content()
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/RewindSeekRequestStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/RewindSeekRequestStore.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// One-shot handoff from the Home filmstrip to the Rewind page: Home stores
+/// the tapped frame's timestamp, navigates, and Rewind consumes the request
+/// after its screenshots load, seeking to the nearest frame.
+@MainActor
+final class RewindSeekRequestStore {
+  static let shared = RewindSeekRequestStore()
+
+  private(set) var pendingDate: Date?
+
+  func request(_ date: Date) {
+    pendingDate = date
+  }
+
+  func consume() -> Date? {
+    defer { pendingDate = nil }
+    return pendingDate
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1020,6 +1020,11 @@ struct DesktopHomeView: View {
     .onReceive(NotificationCenter.default.publisher(for: .showTryAskingPopup)) { _ in
       showTryAskingPopup = true
     }
+    .onReceive(NotificationCenter.default.publisher(for: .hideTryAskingPopup)) { _ in
+      // First-win won the fresh-user moment — hide without marking dismissed
+      // so the suggestions can still surface after activation.
+      showTryAskingPopup = false
+    }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToRewindSettings)) { _ in
       // Set the section directly and navigate to settings
       selectedSettingsSection = .rewind

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1174,6 +1174,7 @@ private struct PageContentView: View {
           chatProvider: viewModelContainer.chatProvider,
           memoriesViewModel: viewModelContainer.memoriesViewModel,
           taskChatCoordinator: viewModelContainer.taskChatCoordinator,
+          homeTodayStore: viewModelContainer.homeTodayStore,
           selectedIndex: $selectedTabIndex)
       case 1:
         ConversationsPageHost(appState: appState)
@@ -1222,6 +1223,7 @@ private struct PageContentView: View {
           chatProvider: viewModelContainer.chatProvider,
           memoriesViewModel: viewModelContainer.memoriesViewModel,
           taskChatCoordinator: viewModelContainer.taskChatCoordinator,
+          homeTodayStore: viewModelContainer.homeTodayStore,
           selectedIndex: $selectedTabIndex)
       }
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
@@ -455,6 +455,7 @@ struct ChatPage: View {
   private var inputArea: some View {
     ChatInputView(
       onSend: { text in
+        ActivationProgressStore.shared.markAskedOmi()
         AnalyticsManager.shared.chatMessageSent(
           messageLength: text.count, hasSelectedAppContext: selectedApp != nil, source: "main_chat")
         Task { await chatProvider.sendMainDraft(text) }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -220,8 +220,11 @@ struct DashboardPage: View {
   @ObservedObject var chatProvider: ChatProvider
   @ObservedObject var memoriesViewModel: MemoriesViewModel
   var taskChatCoordinator: TaskChatCoordinator? = nil
+  @ObservedObject var homeTodayStore: HomeTodayStore = HomeTodayStore()
   @ObservedObject private var deviceProvider = DeviceProvider.shared
   @ObservedObject private var homeSuggestionsStore = HomeSuggestionsStore.shared
+  @ObservedObject private var activationStore = ActivationProgressStore.shared
+  @ObservedObject private var shortcutSettings = ShortcutSettings.shared
   @StateObject private var intelligenceStore = DashboardIntelligenceStore()
   @Binding var selectedIndex: Int
   @State private var citedConversation: ServerConversation? = nil
@@ -461,8 +464,15 @@ struct DashboardPage: View {
   private func applyHomeLifecycle<Content: View>(to content: Content) -> some View {
     content
       .onAppear {
-        if PostOnboardingPromptSuggestions.shouldShowPopup && !postOnboardingSuggestions.isEmpty {
+        // First-win owns the fresh-user moment; the Try-Asking popup would
+        // fight it for the same screen and duplicates its ask affordance.
+        if PostOnboardingPromptSuggestions.shouldShowPopup && !postOnboardingSuggestions.isEmpty
+          && !showFirstWinSurface
+        {
           NotificationCenter.default.post(name: .showTryAskingPopup, object: nil)
+        }
+        if showFirstWinSurface {
+          activationStore.noteFirstWinShown()
         }
         syncCaptureState()
         reportHomeAutomationMode()
@@ -470,6 +480,7 @@ struct DashboardPage: View {
           await openRecommendation(recommendation)
         }
         intelligenceStore.registerAutomationActions()
+        activationStore.registerAutomationActions()
         Task { await intelligenceStore.load() }
         Task {
           if let recommendationID = ContextualTaskNavigationRouter.shared.consume() {
@@ -478,9 +489,15 @@ struct DashboardPage: View {
         }
         Task { await homeStatusStore.refreshIfNeeded() }
         Task { await homeSuggestionsStore.refreshIfNeeded() }
+        Task { await homeTodayStore.refresh(includeFirstWin: showFirstWinSurface) }
       }
       .onDisappear {
         intelligenceStore.setRecommendationActionHandler(nil)
+        activationStore.consumeCelebration()
+      }
+      .onReceive(homeStatusStore.$conversationCount) { conversations in
+        activationStore.applyLifetimeCounts(
+          conversations: conversations, memories: homeStatusStore.memoryCount)
       }
       .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
         viewModel.refreshGoals()
@@ -489,6 +506,7 @@ struct DashboardPage: View {
         syncCaptureState()
         Task { await homeStatusStore.refreshIfNeeded() }
         Task { await homeSuggestionsStore.refreshIfNeeded() }
+        Task { await homeTodayStore.refresh(includeFirstWin: showFirstWinSurface) }
       }
       .onReceive(NotificationCenter.default.publisher(for: .assistantMonitoringStateDidChange)) { _ in
         syncCaptureState()
@@ -699,15 +717,17 @@ struct DashboardPage: View {
     }
   }
 
-  /// Vertical stage: mode content on top (hub metrics, inline chat, or the
+  /// Vertical stage: mode content on top (hub content, inline chat, or the
   /// connect tray), the persistent ask bar anchored beneath it, and the
   /// suggested questions under the bar while the hub is showing.
   private func homeStage(stageWidth: CGFloat, stageHeight: CGFloat) -> some View {
     let askBarWidth = homeAskBarWidth(for: stageWidth)
+    let sectionWidth = homeSectionWidth(for: stageWidth)
 
     return Group {
       if homeMode == .hub {
-        homeHubStage(askBarWidth: askBarWidth, stageHeight: stageHeight)
+        homeHubStage(
+          askBarWidth: askBarWidth, sectionWidth: sectionWidth, stageHeight: stageHeight)
       } else {
         homePanelStage(stageWidth: stageWidth, askBarWidth: askBarWidth)
       }
@@ -716,76 +736,181 @@ struct DashboardPage: View {
     .padding(.bottom, Self.homeStageBottomPadding)
   }
 
-  /// Hub layout: the omi wordmark centered in the full screen, with the stats
-  /// ribbon, ask bar, and suggestions docked as one column at the bottom.
+  /// Width for the hub content sections (greeting, noticed feed, filmstrip):
+  /// wider than the collapsed ask bar so content breathes, still capped for
+  /// readability on large windows.
+  private func homeSectionWidth(for stageWidth: CGFloat) -> CGFloat {
+    min(880, homeStageContentWidth(for: stageWidth))
+  }
+
+  /// Hub layout. Two states share the frame:
   ///
-  /// Built as a plain VStack (wordmark, flexible gap, cluster) so the two can
-  /// never overlap. The wordmark's top inset is computed so it lands on the
-  /// true stage center when the window is tall enough, and lifts to sit just
-  /// above the cluster (with a minimum gap) when it isn't.
-  private func homeHubStage(askBarWidth: CGFloat, stageHeight: CGFloat) -> some View {
-    // Wordmark height and a deliberately generous estimate of the docked
-    // cluster height (ribbon + gap + ask bar + gap + three suggestion rows).
-    // Overestimating only lifts the wordmark slightly early; it never lets
-    // the cluster clip.
-    let wordmarkHeight: CGFloat = 76
-    let clusterHeight: CGFloat = intelligenceStore.recommendations.isEmpty ? 390 : 570
-    let minGap: CGFloat = 24
-    let contentHeight = stageHeight - Self.homeStageTopPadding - Self.homeStageBottomPadding
+  /// - **Today hub** (activated users): greeting + one ambient proof line at
+  ///   the top, "What Omi noticed" as the single hero, today's Rewind
+  ///   filmstrip, then goals + ask bar + suggestion chips docked at the
+  ///   bottom. The wordmark appears only in the true-empty state.
+  /// - **First win** (until the first conversation + first question): "Omi
+  ///   already knows you" hero with onboarding-derived memories and the two
+  ///   capture pipeline pills, ask bar beneath.
+  private func homeHubStage(
+    askBarWidth: CGFloat, sectionWidth: CGFloat, stageHeight: CGFloat
+  ) -> some View {
+    VStack(spacing: 0) {
+      if showFirstWinSurface {
+        Spacer(minLength: OmiSpacing.xl)
 
-    let trueCenterInset = (contentHeight - wordmarkHeight) / 2
-    let maxInset = contentHeight - wordmarkHeight - clusterHeight - minGap
-    let topInset = max(0, min(trueCenterInset, maxInset))
+        HomeFirstWinSection(
+          memories: homeTodayStore.content.firstWinMemories,
+          memoryCount: homeTodayStore.content.firstWinMemoryCount,
+          shortcutTokens: shortcutSettings.askOmiShortcut.displayTokens,
+          conversationCaptured: activationStore.progress.conversationCaptured,
+          firstConversationTitle: activationStore.progress.firstConversationTitle,
+          hasMicrophonePermission: appState.hasMicrophonePermission,
+          hasScreenRecordingPermission: appState.hasScreenRecordingPermission,
+          isTranscribing: appState.isTranscribing,
+          screenshotsToday: homeStatusStore.screenshotCountToday,
+          onOpenMemories: { navigate(to: .memories) },
+          onFixPermissions: { navigate(to: .permissions) },
+          onOpenConversations: { navigate(to: .conversations) }
+        )
+        .frame(width: min(sectionWidth, 640))
+        .transition(.homeHubFade)
 
-    return VStack(spacing: 0) {
-      Spacer(minLength: 0)
-        .frame(height: topInset)
+        homeHubBottomCluster(askBarWidth: askBarWidth)
+          .padding(.top, OmiSpacing.xl)
 
-      if intelligenceStore.recommendations.isEmpty {
+        Spacer(minLength: OmiSpacing.xl)
+      } else if hasNoticedContent {
+        // Content-rich hub reads top-down: greeting, the noticed feed,
+        // today's filmstrip, then the ask cluster directly beneath.
+        HomeGreetingView(
+          greeting: greetingHeadline,
+          segments: greetingProofSegments,
+          onOpen: { destination in openGreetingDestination(destination) }
+        )
+        .frame(width: sectionWidth)
+
+        VStack(alignment: .leading, spacing: OmiSpacing.lg) {
+          HomeNoticedSection(
+            intelligenceStore: intelligenceStore,
+            todayStore: homeTodayStore,
+            onOpenRecommendation: { recommendation in await openRecommendation(recommendation) },
+            onOpenInsights: { navigate(to: .insight) }
+          )
+
+          HomeRewindFilmstrip(
+            screenshots: homeTodayStore.content.filmstrip,
+            onOpen: { screenshot in openRewind(at: screenshot) }
+          )
+        }
+        .frame(width: sectionWidth)
+        .padding(.top, OmiSpacing.xl)
+
+        homeHubBottomCluster(askBarWidth: askBarWidth)
+          .padding(.top, OmiSpacing.xl)
+
+        Spacer(minLength: 0)
+      } else {
+        // True-empty stage: the wordmark keeps the room warm until Omi has
+        // something real to show; the ask cluster stays docked at the bottom.
+        HomeGreetingView(
+          greeting: greetingHeadline,
+          segments: greetingProofSegments,
+          onOpen: { destination in openGreetingDestination(destination) }
+        )
+        .frame(width: sectionWidth)
+
+        Spacer(minLength: OmiSpacing.lg)
         homeHubWordmark
           .transition(.homeHubFade)
+        Spacer(minLength: OmiSpacing.lg)
 
-        // Flexible gap absorbs the remaining height, docking the cluster at
-        // the bottom while keeping at least `minGap` below the wordmark.
-        Spacer(minLength: minGap)
-      } else {
-        Spacer(minLength: 0)
-      }
-
-      VStack(spacing: 0) {
-        WhatMattersNowSection(
-          store: intelligenceStore,
-          onOpen: { recommendation in await openRecommendation(recommendation) }
-        )
-        .frame(width: askBarWidth)
-        .padding(.bottom, intelligenceStore.recommendations.isEmpty ? 0 : OmiSpacing.sm)
-
-        dashboardIntelligenceError
-          .frame(width: askBarWidth)
-          .padding(.bottom, intelligenceStore.error == nil ? 0 : OmiSpacing.sm)
-
-        FocusedGoalsSection(
-          store: intelligenceStore,
-          onOpenGoal: { goalID in await openGoal(goalID) },
-          onShowAll: { showingAllGoals = true }
-        )
-        .frame(width: askBarWidth)
-        .padding(.bottom, intelligenceStore.goals.isEmpty ? 0 : OmiSpacing.sm)
-
-        homeStatRibbon
-          .frame(width: askBarWidth)
-          .padding(.bottom, OmiSpacing.md)
-
-        homeAskBar
-          .frame(width: askBarWidth)
-
-        homeSuggestionList
-          .frame(width: askBarWidth)
-          .padding(.top, OmiSpacing.md)
-          .transition(.homeSuggestionsFade)
+        homeHubBottomCluster(askBarWidth: askBarWidth)
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private func homeHubBottomCluster(askBarWidth: CGFloat) -> some View {
+    VStack(spacing: 0) {
+      dashboardIntelligenceError
+        .frame(width: askBarWidth)
+        .padding(.bottom, intelligenceStore.error == nil ? 0 : OmiSpacing.sm)
+
+      FocusedGoalsSection(
+        store: intelligenceStore,
+        onOpenGoal: { goalID in await openGoal(goalID) },
+        onShowAll: { showingAllGoals = true }
+      )
+      .frame(width: askBarWidth)
+      .padding(.bottom, intelligenceStore.goals.isEmpty ? 0 : OmiSpacing.sm)
+
+      homeAskBar
+        .frame(width: askBarWidth)
+
+      homeSuggestionList
+        .frame(width: askBarWidth)
+        .padding(.top, OmiSpacing.md)
+        .transition(.homeSuggestionsFade)
+    }
+  }
+
+  /// The greeting is content-first: the sub-line summarizes what Omi
+  /// delivered today, never duplicates the header status chips.
+  private var greetingHeadline: String {
+    if activationStore.celebrationPending {
+      return "Your second brain is live."
+    }
+    return HomeGreetingComposer.greeting(
+      name: greetingName,
+      hour: Calendar.current.component(.hour, from: Date())
+    )
+  }
+
+  private var greetingName: String? {
+    let givenName = AuthService.shared.givenName.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !givenName.isEmpty { return givenName }
+    let displayName = AuthService.shared.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+    return displayName.isEmpty ? nil : displayName
+  }
+
+  private var greetingProofSegments: [HomeGreetingComposer.Segment] {
+    HomeGreetingComposer.proofSegments(
+      today: HomeGreetingComposer.TodayCounts(
+        conversations: homeStatusStore.conversationCountToday,
+        memories: homeStatusStore.memoryCountToday,
+        tasks: homeStatusStore.taskCountToday,
+        screens: homeStatusStore.screenshotCountToday
+      ),
+      lifetimeConversations: homeStatusStore.conversationCount ?? appState.totalConversationsCount
+    )
+  }
+
+  private var hasNoticedContent: Bool {
+    !intelligenceStore.recommendations.isEmpty
+      || !homeTodayStore.content.insights.isEmpty
+      || !homeTodayStore.content.filmstrip.isEmpty
+  }
+
+  private var showFirstWinSurface: Bool {
+    !useLegacyHomeDesign
+      && activationStore.shouldShowFirstWin(countsKnown: homeStatusStore.knowledgeCountsKnown)
+  }
+
+  private func openGreetingDestination(_ destination: HomeGreetingComposer.SegmentDestination) {
+    switch destination {
+    case .conversations: navigate(to: .conversations)
+    case .memories: navigate(to: .memories)
+    case .tasks: navigate(to: .tasks)
+    case .rewind: navigate(to: .rewind)
+    }
+  }
+
+  private func openRewind(at screenshot: Screenshot?) {
+    if let timestamp = screenshot?.timestamp {
+      RewindSeekRequestStore.shared.request(timestamp)
+    }
+    navigate(to: .rewind)
   }
 
   /// Panel layout (chat / connect): the surface fills the height with the ask
@@ -823,38 +948,7 @@ struct DashboardPage: View {
       .font(.system(size: 58, weight: .bold, design: .rounded))
       .foregroundStyle(HomePalette.ink)
       .lineLimit(1)
-      .shadow(color: HomePalette.stageGlow.opacity(0.46), radius: 26)
       .frame(maxWidth: .infinity, alignment: .center)
-  }
-
-  /// Stat summary strip that docks directly above the ask bar.
-  private var homeStatRibbon: some View {
-    HomeStatRibbon(items: [
-      HomeStatItem(
-        title: "Conversations",
-        value: conversationMetricValue,
-        systemImage: "text.bubble.fill",
-        action: { navigate(to: .conversations) }
-      ),
-      HomeStatItem(
-        title: "Tasks",
-        value: taskMetricValue,
-        systemImage: "checklist",
-        action: { navigate(to: .tasks) }
-      ),
-      HomeStatItem(
-        title: "Memories",
-        value: memoryMetricValue,
-        systemImage: "brain",
-        action: { navigate(to: .memories) }
-      ),
-      HomeStatItem(
-        title: "Screenshots",
-        value: screenshotMetricValue,
-        systemImage: "photo.on.rectangle.angled",
-        action: { navigate(to: .rewind) }
-      ),
-    ])
   }
 
   // MARK: Inline chat panel
@@ -1032,18 +1126,38 @@ struct DashboardPage: View {
   }
 
   private var homeSuggestedQuestions: [String] {
-    HomeSuggestionComposer.compose(
+    if showFirstWinSurface {
+      // Guaranteed-answerable first questions: what onboarding actually
+      // ingested, led by the one query every fresh account can answer.
+      let onboarding = HomeSuggestionComposer.sanitize(PostOnboardingPromptSuggestions.suggestions())
+      return ["What do you already know about me?"] + onboarding.prefix(2)
+    }
+    return HomeSuggestionComposer.compose(
       personalized: homeSuggestionsStore.personalizedQuestions,
       onboarding: PostOnboardingPromptSuggestions.suggestions()
     )
   }
 
+  /// One compact row of chips (not three full-width rows) — suggestions stay
+  /// present without competing with the hero content above. Chips never
+  /// truncate mid-sentence: when the row is tight, fewer chips render.
   private var homeSuggestionList: some View {
-    VStack(spacing: OmiSpacing.sm) {
-      ForEach(homeSuggestedQuestions, id: \.self) { question in
-        HomeSuggestionRow(text: question) {
+    let questions = homeSuggestedQuestions
+    return ViewThatFits(in: .horizontal) {
+      homeSuggestionChipRow(Array(questions.prefix(3)))
+      homeSuggestionChipRow(Array(questions.prefix(2)))
+      homeSuggestionChipRow(Array(questions.prefix(1)))
+    }
+    .frame(maxWidth: .infinity)
+  }
+
+  private func homeSuggestionChipRow(_ questions: [String]) -> some View {
+    HStack(spacing: OmiSpacing.xs) {
+      ForEach(questions, id: \.self) { question in
+        HomeSuggestionChip(text: question) {
           askHomeSuggestion(question)
         }
+        .fixedSize()
       }
     }
   }
@@ -1136,6 +1250,7 @@ struct DashboardPage: View {
     // an attachment-only "send" would silently drop the turn.
     guard !text.isEmpty else { return }
     openHomeChat(focusInput: false)
+    ActivationProgressStore.shared.markAskedOmi()
     AnalyticsManager.shared.chatMessageSent(
       messageLength: text.count,
       hasSelectedAppContext: selectedApp != nil,
@@ -1150,6 +1265,7 @@ struct DashboardPage: View {
 
   private func askHomeSuggestion(_ suggestion: String) {
     openHomeChat(focusInput: false)
+    ActivationProgressStore.shared.markAskedOmi()
     AnalyticsManager.shared.chatMessageSent(
       messageLength: suggestion.count,
       hasSelectedAppContext: selectedApp != nil,
@@ -1440,29 +1556,6 @@ struct DashboardPage: View {
         openAppsPopup(initialSection: .exports)
       }
     }
-  }
-
-  private var conversationMetricValue: String {
-    formattedCount(
-      homeStatusStore.conversationCount ?? appState.totalConversationsCount ?? appState.conversations.count
-    )
-  }
-
-  private var taskMetricValue: String {
-    formattedCount(homeStatusStore.taskCount ?? incompleteTaskCount)
-  }
-
-  private var memoryMetricValue: String {
-    let count =
-      homeStatusStore.memoryCount
-      ?? (memoriesViewModel.totalMemoriesCount > 0
-        ? memoriesViewModel.totalMemoriesCount
-        : memoriesViewModel.memories.count)
-    return formattedCount(count)
-  }
-
-  private var screenshotMetricValue: String {
-    homeStatusStore.screenshotCount.map(formattedCount) ?? "—"
   }
 
   private func navigate(to item: SidebarNavItem) {
@@ -2041,20 +2134,10 @@ struct DashboardPage: View {
 
 // MARK: - Home Components
 
-private enum HomePalette {
-  static let paper = Color(red: 0.018, green: 0.019, blue: 0.021)
-  static let panel = Color(red: 0.045, green: 0.046, blue: 0.052)
-  static let tile = Color(red: 0.078, green: 0.078, blue: 0.088)
-  static let tileHover = Color(red: 0.115, green: 0.103, blue: 0.142)
-  static let ink = Color(red: 0.94, green: 0.925, blue: 0.89)
-  static let secondary = Color(red: 0.78, green: 0.765, blue: 0.725)
-  static let muted = Color(red: 0.49, green: 0.47, blue: 0.43)
-  static let faint = Color(red: 0.36, green: 0.35, blue: 0.33)
-  static let hairline = Color(red: 0.155, green: 0.155, blue: 0.172)
-  static let green = Color(red: 0.17, green: 0.78, blue: 0.38)
-  static let stageGlow = Color(red: 0.48, green: 0.30, blue: 0.95)
-  static let glow = stageGlow
-}
+/// Palette moved to `HomeStagePalette` (MainWindow/Dashboard/) so the
+/// Dashboard section views share the exact tokens; the alias keeps the
+/// page-local call sites unchanged.
+private typealias HomePalette = HomeStagePalette
 
 private enum HomeRowStatus {
   case connect
@@ -2369,7 +2452,7 @@ private struct HomeAskBarConnectButton: View {
   }
 }
 
-private struct HomeSuggestionRow: View {
+private struct HomeSuggestionChip: View {
   let text: String
   let action: () -> Void
 
@@ -2377,34 +2460,27 @@ private struct HomeSuggestionRow: View {
 
   var body: some View {
     Button(action: action) {
-      HStack(spacing: OmiSpacing.sm) {
+      HStack(spacing: OmiSpacing.xs) {
         Image(systemName: "sparkles")
-          .scaledFont(size: OmiType.caption, weight: .semibold)
-          .foregroundStyle(isHovering ? Color(hex: 0xE3BF63) : HomePalette.muted)
+          .scaledFont(size: OmiType.micro, weight: .semibold)
+          .foregroundStyle(HomePalette.muted)
 
         Text(text)
-          .scaledFont(size: OmiType.body, weight: .medium)
+          .scaledFont(size: OmiType.caption, weight: .medium)
           .foregroundStyle(isHovering ? HomePalette.ink : HomePalette.secondary)
           .lineLimit(1)
-
-        Spacer(minLength: 8)
-
-        Image(systemName: "arrow.up.right")
-          .scaledFont(size: OmiType.micro, weight: .bold)
-          .foregroundStyle(isHovering ? HomePalette.ink : HomePalette.faint)
       }
-      .padding(.horizontal, OmiSpacing.lg)
-      .frame(height: 42)
-      .frame(maxWidth: .infinity)
+      .padding(.horizontal, OmiSpacing.md)
+      .frame(height: 30)
       .background(
-        RoundedRectangle(cornerRadius: 21, style: .continuous)
+        Capsule()
           .fill(isHovering ? HomePalette.tileHover : HomePalette.tile.opacity(0.55))
       )
       .overlay(
-        RoundedRectangle(cornerRadius: 21, style: .continuous)
+        Capsule()
           .stroke(HomePalette.hairline.opacity(isHovering ? 1 : 0.55), lineWidth: 1)
       )
-      .contentShape(.rect(cornerRadius: 21))
+      .contentShape(Capsule())
     }
     .buttonStyle(.plain)
     .onHover { isHovering = $0 }
@@ -3276,83 +3352,6 @@ private struct HomeSourceTile: View {
         .scaledFont(size: OmiType.caption, weight: .bold)
         .foregroundStyle(HomePalette.secondary)
     }
-  }
-}
-
-private struct HomeStatItem: Identifiable {
-  let id = UUID()
-  let title: String
-  let value: String
-  let systemImage: String
-  let action: () -> Void
-}
-
-/// Slim summary strip: the four Home metrics fused into a single
-/// hairline-divided bar so they read as one glanceable object instead of
-/// four heavy widgets. Each cell still hovers and navigates.
-private struct HomeStatRibbon: View {
-  let items: [HomeStatItem]
-
-  var body: some View {
-    HStack(spacing: 0) {
-      ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
-        if index > 0 {
-          Rectangle()
-            .fill(HomePalette.hairline.opacity(0.7))
-            .frame(width: 1)
-            .padding(.vertical, OmiSpacing.lg)
-        }
-        HomeStatRibbonCell(item: item)
-      }
-    }
-    // Pin the height so the hairline dividers (greedy Rectangles) size to the
-    // content instead of stretching the whole strip in taller windows.
-    .frame(height: 76)
-    .background(HomePalette.tile.opacity(0.88))
-    .clipShape(RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous))
-    .overlay(
-      RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
-        .stroke(HomePalette.hairline.opacity(0.8), lineWidth: 1)
-    )
-    .shadow(color: .black.opacity(0.16), radius: 10, y: 8)
-  }
-}
-
-private struct HomeStatRibbonCell: View {
-  let item: HomeStatItem
-
-  @State private var isHovering = false
-
-  var body: some View {
-    Button(action: item.action) {
-      VStack(spacing: OmiSpacing.xxs) {
-        HStack(alignment: .firstTextBaseline, spacing: OmiSpacing.xs) {
-          Image(systemName: item.systemImage)
-            .scaledFont(size: OmiType.caption, weight: .semibold)
-            .foregroundStyle(isHovering ? HomePalette.ink : HomePalette.secondary)
-
-          Text(item.value)
-            .font(.system(size: 22, weight: .medium, design: .serif))
-            .foregroundStyle(HomePalette.ink)
-            .lineLimit(1)
-            .minimumScaleFactor(0.6)
-        }
-
-        Text(item.title)
-          .scaledFont(size: OmiType.caption, weight: .medium)
-          .foregroundStyle(isHovering ? HomePalette.secondary : HomePalette.muted)
-          .lineLimit(1)
-          .minimumScaleFactor(0.78)
-      }
-      .frame(maxWidth: .infinity)
-      .padding(.vertical, OmiSpacing.md)
-      .padding(.horizontal, OmiSpacing.sm)
-      .background(isHovering ? HomePalette.tileHover : Color.clear)
-      .contentShape(Rectangle())
-    }
-    .buttonStyle(.plain)
-    .onHover { isHovering = $0 }
-    .accessibilityLabel("\(item.title), \(item.value)")
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -499,6 +499,14 @@ struct DashboardPage: View {
         activationStore.applyLifetimeCounts(
           conversations: conversations, memories: homeStatusStore.memoryCount)
       }
+      // The first-win surface can appear only after counts finish loading —
+      // load its hero data and start its time-box at that moment, not just on
+      // the (earlier) page appear.
+      .onChange(of: showFirstWinSurface) { wasShowing, isShowing in
+        guard !wasShowing, isShowing else { return }
+        activationStore.noteFirstWinShown()
+        Task { await homeTodayStore.refresh(includeFirstWin: true) }
+      }
       .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
         viewModel.refreshGoals()
         Task { await intelligenceStore.load() }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -464,13 +464,7 @@ struct DashboardPage: View {
   private func applyHomeLifecycle<Content: View>(to content: Content) -> some View {
     content
       .onAppear {
-        // First-win owns the fresh-user moment; the Try-Asking popup would
-        // fight it for the same screen and duplicates its ask affordance.
-        if PostOnboardingPromptSuggestions.shouldShowPopup && !postOnboardingSuggestions.isEmpty
-          && !showFirstWinSurface
-        {
-          NotificationCenter.default.post(name: .showTryAskingPopup, object: nil)
-        }
+        maybeShowTryAskingPopup()
         if showFirstWinSurface {
           activationStore.noteFirstWinShown()
         }
@@ -498,13 +492,18 @@ struct DashboardPage: View {
       .onReceive(homeStatusStore.$conversationCount) { conversations in
         activationStore.applyLifetimeCounts(
           conversations: conversations, memories: homeStatusStore.memoryCount)
+        // Counts just became known — this is the earliest moment the
+        // popup-vs-first-win decision can be made correctly.
+        maybeShowTryAskingPopup()
       }
       // The first-win surface can appear only after counts finish loading —
       // load its hero data and start its time-box at that moment, not just on
-      // the (earlier) page appear.
+      // the (earlier) page appear. It also owns the fresh-user moment: a
+      // Try-Asking popup that raced ahead of the counts must yield.
       .onChange(of: showFirstWinSurface) { wasShowing, isShowing in
         guard !wasShowing, isShowing else { return }
         activationStore.noteFirstWinShown()
+        NotificationCenter.default.post(name: .hideTryAskingPopup, object: nil)
         Task { await homeTodayStore.refresh(includeFirstWin: true) }
       }
       .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
@@ -771,14 +770,14 @@ struct DashboardPage: View {
           memories: homeTodayStore.content.firstWinMemories,
           memoryCount: homeTodayStore.content.firstWinMemoryCount,
           shortcutTokens: shortcutSettings.askOmiShortcut.displayTokens,
-          conversationCaptured: activationStore.progress.conversationCaptured,
+          conversationState: firstWinConversationState,
           firstConversationTitle: activationStore.progress.firstConversationTitle,
-          hasMicrophonePermission: appState.hasMicrophonePermission,
-          hasScreenRecordingPermission: appState.hasScreenRecordingPermission,
-          isTranscribing: appState.isTranscribing,
+          screenState: firstWinScreenState,
           screenshotsToday: homeStatusStore.screenshotCountToday,
           onOpenMemories: { navigate(to: .memories) },
           onFixPermissions: { navigate(to: .permissions) },
+          onResumeListening: { toggleListening() },
+          onResumeCapture: { toggleCapture() },
           onOpenConversations: { navigate(to: .conversations) }
         )
         .frame(width: min(sectionWidth, 640))
@@ -905,6 +904,23 @@ struct DashboardPage: View {
       && activationStore.shouldShowFirstWin(countsKnown: homeStatusStore.knowledgeCountsKnown)
   }
 
+  /// Honest first-win pipeline states — permission granted is not the same
+  /// as capture running (paused capture renders a truthful resume action).
+  private var firstWinConversationState: HomeFirstWinSection.PipelineState {
+    if activationStore.progress.conversationCaptured { return .done }
+    if !appState.hasMicrophonePermission { return .blocked }
+    if !transcriptionEnabled || appState.transcriptionServiceError != nil { return .paused }
+    return appState.isTranscribing ? .live : .waiting
+  }
+
+  private var firstWinScreenState: HomeFirstWinSection.PipelineState {
+    switch captureStatus {
+    case .blocked: return .blocked
+    case .inactive: return .paused
+    case .active: return .live
+    }
+  }
+
   private func openGreetingDestination(_ destination: HomeGreetingComposer.SegmentDestination) {
     switch destination {
     case .conversations: navigate(to: .conversations)
@@ -919,6 +935,18 @@ struct DashboardPage: View {
       RewindSeekRequestStore.shared.request(timestamp)
     }
     navigate(to: .rewind)
+  }
+
+  /// Posts the Try-Asking popup only once the popup-vs-first-win decision can
+  /// be made correctly: never while lifetime counts are still unknown (the
+  /// first post-onboarding appearance — exactly when first-win must win).
+  private func maybeShowTryAskingPopup() {
+    guard PostOnboardingPromptSuggestions.shouldShowPopup,
+      !postOnboardingSuggestions.isEmpty,
+      homeStatusStore.knowledgeCountsKnown,
+      !showFirstWinSurface
+    else { return }
+    NotificationCenter.default.post(name: .showTryAskingPopup, object: nil)
   }
 
   /// Panel layout (chat / connect): the surface fills the height with the ask

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/HomeStatusStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/HomeStatusStore.swift
@@ -6,14 +6,36 @@ struct HomeKnowledgeCounts: Equatable, Sendable {
   let memories: Int?
   let tasks: Int?
   let hasOmiDeviceConversations: Bool?
+  var conversationsToday: Int?
+  var memoriesToday: Int?
+  var tasksToday: Int?
 }
 
 @MainActor
 struct HomeStatusLoader {
   let refreshConnectorStatuses: @MainActor @Sendable () async -> Void
   let loadScreenshotCount: @MainActor @Sendable () async -> Int?
+  let loadScreenshotCountToday: @MainActor @Sendable () async -> Int?
   let loadKnowledgeCounts: @MainActor @Sendable (_ includeOmiDeviceHistory: Bool) async -> HomeKnowledgeCounts
   let loadMemoryExportStatuses: @MainActor @Sendable () async -> [MemoryExportDestination: MemoryExportStatus]
+
+  init(
+    refreshConnectorStatuses: @escaping @MainActor @Sendable () async -> Void,
+    loadScreenshotCount: @escaping @MainActor @Sendable () async -> Int?,
+    loadScreenshotCountToday: @escaping @MainActor @Sendable () async -> Int? = { nil },
+    loadKnowledgeCounts:
+      @escaping @MainActor @Sendable (_ includeOmiDeviceHistory: Bool) async ->
+      HomeKnowledgeCounts,
+    loadMemoryExportStatuses:
+      @escaping @MainActor @Sendable () async -> [MemoryExportDestination:
+      MemoryExportStatus]
+  ) {
+    self.refreshConnectorStatuses = refreshConnectorStatuses
+    self.loadScreenshotCount = loadScreenshotCount
+    self.loadScreenshotCountToday = loadScreenshotCountToday
+    self.loadKnowledgeCounts = loadKnowledgeCounts
+    self.loadMemoryExportStatuses = loadMemoryExportStatuses
+  }
 
   static func live(connectorStatusStore: ImportConnectorStatusStore) -> HomeStatusLoader {
     HomeStatusLoader(
@@ -28,10 +50,26 @@ struct HomeStatusLoader {
           return nil
         }
       },
+      loadScreenshotCountToday: {
+        do {
+          let startOfDay = Calendar.current.startOfDay(for: Date())
+          return try await RewindDatabase.shared.getScreenshotCount(since: startOfDay)
+        } catch {
+          logError("HomeStatusLoader: Failed to load today's screenshot count", error: error)
+          return nil
+        }
+      },
       loadKnowledgeCounts: { includeOmiDeviceHistory in
+        let startOfDay = Calendar.current.startOfDay(for: Date())
         async let conversations = try? APIClient.shared.getConversationsCount(includeDiscarded: false)
         async let memories = try? MemoryStorage.shared.getLocalMemoriesCount()
         async let tasks = try? ActionItemStorage.shared.getLocalActionItemsCount(completed: false)
+        async let conversationsToday = try? APIClient.shared.getConversationsCount(
+          includeDiscarded: false, startDate: startOfDay)
+        async let memoriesToday = try? MemoryStorage.shared.getLocalMemoriesCount(
+          createdAfter: startOfDay)
+        async let tasksToday = try? ActionItemStorage.shared.getLocalActionItemsCount(
+          startDate: startOfDay)
         async let deviceHistory =
           includeOmiDeviceHistory
           ? (try? APIClient.shared.hasOmiDeviceConversations())
@@ -41,7 +79,10 @@ struct HomeStatusLoader {
           conversations: conversations,
           memories: memories,
           tasks: tasks,
-          hasOmiDeviceConversations: deviceHistory
+          hasOmiDeviceConversations: deviceHistory,
+          conversationsToday: conversationsToday,
+          memoriesToday: memoriesToday,
+          tasksToday: tasksToday
         )
       },
       loadMemoryExportStatuses: {
@@ -64,8 +105,19 @@ final class HomeStatusStore: ObservableObject {
   @Published private(set) var conversationCount: Int?
   @Published private(set) var memoryCount: Int?
   @Published private(set) var taskCount: Int?
+  @Published private(set) var screenshotCountToday: Int?
+  @Published private(set) var conversationCountToday: Int?
+  @Published private(set) var memoryCountToday: Int?
+  @Published private(set) var taskCountToday: Int?
   @Published private(set) var accountHasOmiDeviceConversations: Bool
   @Published var memoryExportStatuses: [MemoryExportDestination: MemoryExportStatus] = [:]
+
+  /// Lifetime counts have loaded — the first-win gate must never fire on
+  /// still-unknown (nil) counts or a veteran on a fresh machine would flash
+  /// the new-user surface.
+  var knowledgeCountsKnown: Bool {
+    conversationCount != nil && memoryCount != nil
+  }
 
   private let defaults: UserDefaults
   private let loader: HomeStatusLoader
@@ -163,11 +215,13 @@ final class HomeStatusStore: ObservableObject {
 
     let generation = refreshGeneration
     let loadedScreenshotCount = await loader.loadScreenshotCount()
+    let loadedScreenshotCountToday = await loader.loadScreenshotCountToday()
     guard !Task.isCancelled,
       generation == refreshGeneration,
       localDatabaseReady
     else { return }
     apply(screenshotCount: loadedScreenshotCount)
+    apply(screenshotCountToday: loadedScreenshotCountToday)
   }
 
   private func resetTransientState() {
@@ -182,6 +236,10 @@ final class HomeStatusStore: ObservableObject {
     conversationCount = nil
     memoryCount = nil
     taskCount = nil
+    screenshotCountToday = nil
+    conversationCountToday = nil
+    memoryCountToday = nil
+    taskCountToday = nil
     memoryExportStatuses = [:]
   }
 
@@ -204,17 +262,22 @@ final class HomeStatusStore: ObservableObject {
     let knowledgeRefreshID = beginKnowledgeRefresh()
     async let connectorStatuses: Void = loader.refreshConnectorStatuses()
     async let screenshots: Int? = shouldLoadScreenshotCount ? loader.loadScreenshotCount() : nil
+    async let screenshotsToday: Int? =
+      shouldLoadScreenshotCount ? loader.loadScreenshotCountToday() : nil
     async let knowledgeCounts = loader.loadKnowledgeCounts(includeDeviceHistory)
     async let exportStatuses = loader.loadMemoryExportStatuses()
-    let (_, loadedScreenshots, loadedKnowledgeCounts, loadedExportStatuses) = await (
-      connectorStatuses,
-      screenshots,
-      knowledgeCounts,
-      exportStatuses
-    )
+    let (_, loadedScreenshots, loadedScreenshotsToday, loadedKnowledgeCounts, loadedExportStatuses) =
+      await (
+        connectorStatuses,
+        screenshots,
+        screenshotsToday,
+        knowledgeCounts,
+        exportStatuses
+      )
 
     guard !Task.isCancelled, generation == refreshGeneration else { return }
     apply(screenshotCount: loadedScreenshots)
+    apply(screenshotCountToday: loadedScreenshotsToday)
     if knowledgeRefreshID == latestKnowledgeRefreshID {
       apply(knowledgeCounts: loadedKnowledgeCounts)
     }
@@ -247,6 +310,12 @@ final class HomeStatusStore: ObservableObject {
     }
   }
 
+  private func apply(screenshotCountToday: Int?) {
+    if let screenshotCountToday {
+      self.screenshotCountToday = screenshotCountToday
+    }
+  }
+
   private func apply(knowledgeCounts: HomeKnowledgeCounts) {
     if let conversations = knowledgeCounts.conversations {
       conversationCount = conversations
@@ -256,6 +325,15 @@ final class HomeStatusStore: ObservableObject {
     }
     if let tasks = knowledgeCounts.tasks {
       taskCount = tasks
+    }
+    if let conversationsToday = knowledgeCounts.conversationsToday {
+      conversationCountToday = conversationsToday
+    }
+    if let memoriesToday = knowledgeCounts.memoriesToday {
+      memoryCountToday = memoriesToday
+    }
+    if let tasksToday = knowledgeCounts.tasksToday {
+      taskCountToday = tasksToday
     }
     if knowledgeCounts.hasOmiDeviceConversations == true {
       accountHasOmiDeviceConversations = true

--- a/desktop/macos/Desktop/Sources/Rewind/Core/MemoryStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/MemoryStorage.swift
@@ -163,7 +163,8 @@ actor MemoryStorage {
     tags: [String]? = nil,
     tiers: [MemoryLayer]? = [.shortTerm, .longTerm],
     scope: MemoryRecordReadScope = .all,
-    includeDismissed: Bool = false
+    includeDismissed: Bool = false,
+    createdAfter: Date? = nil
   ) async throws -> Int {
     let db = try await ensureInitialized()
 
@@ -179,6 +180,10 @@ actor MemoryStorage {
 
       if let category = category {
         query = query.filter(Column("category") == category)
+      }
+
+      if let createdAfter = createdAfter {
+        query = query.filter(Column("createdAt") >= createdAfter)
       }
 
       query = Self.applyTierFilter(query, tiers: tiers)

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -3460,6 +3460,18 @@ actor RewindDatabase {
     }
   }
 
+  /// Get screenshot count captured at or after a date (e.g. start of today)
+  func getScreenshotCount(since date: Date) throws -> Int {
+    guard let dbQueue = dbQueue else {
+      throw RewindError.databaseNotInitialized
+    }
+
+    return try dbQueue.read { db in
+      try Int.fetchOne(
+        db, sql: "SELECT COUNT(*) FROM screenshots WHERE timestamp >= ?", arguments: [date]) ?? 0
+    }
+  }
+
   /// Get database statistics
   func getStats() throws -> (total: Int, indexed: Int, oldestDate: Date?, newestDate: Date?) {
     guard let dbQueue = dbQueue else {

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -141,6 +141,14 @@ struct RewindPage: View {
       isMonitoring = ProactiveAssistantsPlugin.shared.isMonitoring
       screenCaptureHealth = ProactiveAssistantsPlugin.shared.screenCaptureHealth
       isPageFocused = true
+      // Home filmstrip handoff: when screenshots are already loaded, honor a
+      // pending seek immediately (the fresh-load path is handled in
+      // onChange(of: viewModel.screenshots)).
+      if !viewModel.screenshots.isEmpty, let target = RewindSeekRequestStore.shared.consume() {
+        currentIndex = Self.nearestScreenshotIndex(to: target, in: viewModel.screenshots)
+        selectedGroupIndex = 0
+        scheduleLoadCurrentFrame()
+      }
     }
     .onReceive(NotificationCenter.default.publisher(for: .assistantMonitoringStateDidChange)) { _ in
       let pluginState = ProactiveAssistantsPlugin.shared.isMonitoring
@@ -166,8 +174,12 @@ struct RewindPage: View {
       viewModel.isTranscriptExpanded = expanded
     }
     .onChange(of: viewModel.screenshots) { oldScreenshots, newScreenshots in
-      // Try to preserve position on the same screenshot the user was viewing
-      if !oldScreenshots.isEmpty,
+      // Home filmstrip handoff: a pending seek wins over position restore.
+      if !newScreenshots.isEmpty, let target = RewindSeekRequestStore.shared.consume() {
+        currentIndex = Self.nearestScreenshotIndex(to: target, in: newScreenshots)
+        selectedGroupIndex = 0
+        scheduleLoadCurrentFrame()
+      } else if !oldScreenshots.isEmpty,
         currentIndex < oldScreenshots.count,
         let currentId = oldScreenshots[currentIndex].id,
         let newIndex = newScreenshots.firstIndex(where: { $0.id == currentId })
@@ -897,6 +909,20 @@ struct RewindPage: View {
 
     currentIndex = newIndex
     scheduleLoadCurrentFrame()
+  }
+
+  /// Nearest frame to a target moment (screenshots are timestamp-ascending).
+  static func nearestScreenshotIndex(to target: Date, in screenshots: [Screenshot]) -> Int {
+    guard !screenshots.isEmpty else { return 0 }
+    if let firstAtOrAfter = screenshots.firstIndex(where: { $0.timestamp >= target }) {
+      guard firstAtOrAfter > 0 else { return 0 }
+      let before = screenshots[firstAtOrAfter - 1]
+      let after = screenshots[firstAtOrAfter]
+      let beforeGap = target.timeIntervalSince(before.timestamp)
+      let afterGap = after.timestamp.timeIntervalSince(target)
+      return beforeGap <= afterGap ? firstAtOrAfter - 1 : firstAtOrAfter
+    }
+    return screenshots.count - 1
   }
 
   private func nextFrame() {

--- a/desktop/macos/Desktop/Sources/ViewModelContainer.swift
+++ b/desktop/macos/Desktop/Sources/ViewModelContainer.swift
@@ -10,6 +10,7 @@ class ViewModelContainer: ObservableObject {
   // ViewModels for each page
   let dashboardViewModel = DashboardViewModel()
   let homeStatusStore = HomeStatusStore()
+  let homeTodayStore = HomeTodayStore()
   let tasksViewModel = TasksViewModel()
   let appProvider = AppProvider()
   let memoriesViewModel = MemoriesViewModel()
@@ -141,6 +142,7 @@ class ViewModelContainer: ObservableObject {
     tasksStore.resetSessionState()
     dashboardViewModel.resetSessionState()
     homeStatusStore.resetSessionState()
+    homeTodayStore.resetSessionState()
     memoriesViewModel.resetSessionState()
     appProvider.resetSessionState()
     memoryGraphViewModel.resetSessionState()

--- a/desktop/macos/Desktop/Tests/ActivationProgressStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/ActivationProgressStoreTests.swift
@@ -132,6 +132,40 @@ final class ActivationProgressStoreTests: XCTestCase {
     XCTAssertFalse(storeB.isActivated)
   }
 
+  func testInPlaceOwnerSwitchClearsCelebrationAndProgress() async {
+    // Same store instance across an in-place account switch (the PR #9821
+    // bleed class): owner B must inherit neither A's progress nor A's
+    // transient celebration.
+    var ownerID: String? = "user-a"
+    let store = makeStore(ownerID: { ownerID })
+    store.markConversationCaptured(title: nil)
+    store.markAskedOmi()
+    XCTAssertTrue(store.isActivated)
+    XCTAssertTrue(store.celebrationPending)
+
+    ownerID = "user-b"
+    NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+    // The owner-change observer hops through a MainActor task.
+    for _ in 0..<10 {
+      await Task.yield()
+      if !store.celebrationPending && !store.isActivated { break }
+    }
+
+    XCTAssertFalse(store.celebrationPending)
+    XCTAssertFalse(store.isActivated)
+    XCTAssertEqual(store.progress, ActivationProgressStore.Progress())
+
+    // Switching back restores A's persisted progress — without celebration.
+    ownerID = "user-a"
+    NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+    for _ in 0..<10 {
+      await Task.yield()
+      if store.isActivated { break }
+    }
+    XCTAssertTrue(store.isActivated)
+    XCTAssertFalse(store.celebrationPending)
+  }
+
   func testSignedOutOwnerDoesNotPersist() {
     let store = makeStore(ownerID: { nil })
     store.markAskedOmi()

--- a/desktop/macos/Desktop/Tests/ActivationProgressStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/ActivationProgressStoreTests.swift
@@ -59,6 +59,25 @@ final class ActivationProgressStoreTests: XCTestCase {
     XCTAssertFalse(store.celebrationPending)
   }
 
+  func testFirstConversationDuringFirstWinCompletesStepWithoutGraduating() {
+    let store = makeStore()
+
+    // First-win is on screen; the user's FIRST conversation lands and the
+    // count refresh reports it. That completes the capture step but must not
+    // skip the ask step (no silent graduation).
+    store.noteFirstWinShown()
+    store.applyLifetimeCounts(conversations: 1, memories: 45)
+    XCTAssertTrue(store.progress.conversationCaptured)
+    XCTAssertFalse(store.progress.graduated)
+    XCTAssertFalse(store.isActivated)
+    XCTAssertTrue(store.shouldShowFirstWin(countsKnown: true))
+
+    // The ask step still completes the flow — with the celebration.
+    store.markAskedOmi()
+    XCTAssertTrue(store.isActivated)
+    XCTAssertTrue(store.celebrationPending)
+  }
+
   func testMemoriesAloneDoNotGraduate() {
     let store = makeStore()
 

--- a/desktop/macos/Desktop/Tests/ActivationProgressStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/ActivationProgressStoreTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class ActivationProgressStoreTests: XCTestCase {
+  private var suiteName: String!
+  private var defaults: UserDefaults!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "ActivationProgressStoreTests.\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)!
+  }
+
+  override func tearDown() async throws {
+    defaults.removePersistentDomain(forName: suiteName)
+    try await super.tearDown()
+  }
+
+  private func makeStore(
+    ownerID: @escaping () -> String? = { "user-a" },
+    now: @escaping () -> Date = Date.init
+  ) -> ActivationProgressStore {
+    ActivationProgressStore(defaults: defaults, ownerIDProvider: ownerID, now: now)
+  }
+
+  func testFirstWinRequiresKnownCounts() {
+    let store = makeStore()
+
+    // Counts still loading (nil) — never flash the new-user surface.
+    XCTAssertFalse(store.shouldShowFirstWin(countsKnown: false))
+    XCTAssertTrue(store.shouldShowFirstWin(countsKnown: true))
+  }
+
+  func testMarksActivateAndPersist() {
+    let store = makeStore()
+
+    store.markAskedOmi()
+    XCTAssertFalse(store.isActivated)
+    store.markConversationCaptured(title: "Standup")
+    XCTAssertTrue(store.isActivated)
+    XCTAssertEqual(store.progress.firstConversationTitle, "Standup")
+    XCTAssertFalse(store.shouldShowFirstWin(countsKnown: true))
+
+    // A fresh store for the same owner restores the persisted state.
+    let reloaded = makeStore()
+    XCTAssertTrue(reloaded.isActivated)
+  }
+
+  func testLifetimeConversationHistoryGraduatesVeterans() {
+    let store = makeStore()
+
+    // A veteran signing in on a fresh Mac: history arrives, first-win never shows.
+    store.applyLifetimeCounts(conversations: 2401, memories: 9000)
+    XCTAssertTrue(store.isActivated)
+    XCTAssertFalse(store.shouldShowFirstWin(countsKnown: true))
+    // Auto-graduation is silent — no celebration for veterans.
+    XCTAssertFalse(store.celebrationPending)
+  }
+
+  func testMemoriesAloneDoNotGraduate() {
+    let store = makeStore()
+
+    // Onboarding imports seed memories before any conversation exists.
+    store.applyLifetimeCounts(conversations: 0, memories: 45)
+    XCTAssertFalse(store.isActivated)
+    XCTAssertTrue(store.shouldShowFirstWin(countsKnown: true))
+  }
+
+  func testTimeBoxGraduatesPermissionSkippers() {
+    var currentTime = Date(timeIntervalSince1970: 1_000_000)
+    let store = makeStore(now: { currentTime })
+
+    store.noteFirstWinShown()
+    XCTAssertFalse(store.isActivated)
+
+    // 49 hours later the surface stops insisting even with nothing done.
+    currentTime = currentTime.addingTimeInterval(49 * 60 * 60)
+    store.noteFirstWinShown()
+    XCTAssertTrue(store.isActivated)
+    XCTAssertFalse(store.shouldShowFirstWin(countsKnown: true))
+  }
+
+  func testVisitCapGraduates() {
+    let store = makeStore()
+
+    for _ in 0..<(ActivationProgressStore.firstWinMaxVisits + 1) {
+      store.noteFirstWinShown()
+    }
+    XCTAssertTrue(store.isActivated)
+  }
+
+  func testCelebrationFiresOnceOnRealActivation() {
+    let store = makeStore()
+
+    store.markConversationCaptured(title: nil)
+    XCTAssertFalse(store.celebrationPending)
+    store.markAskedOmi()
+    XCTAssertTrue(store.celebrationPending)
+    store.consumeCelebration()
+    XCTAssertFalse(store.celebrationPending)
+  }
+
+  func testOwnerScopingIsolatesProgress() {
+    let storeA = makeStore(ownerID: { "user-a" })
+    storeA.markAskedOmi()
+    storeA.markConversationCaptured(title: nil)
+    XCTAssertTrue(storeA.isActivated)
+
+    // Another account on the same machine starts clean.
+    let storeB = makeStore(ownerID: { "user-b" })
+    XCTAssertFalse(storeB.isActivated)
+  }
+
+  func testSignedOutOwnerDoesNotPersist() {
+    let store = makeStore(ownerID: { nil })
+    store.markAskedOmi()
+    store.markConversationCaptured(title: nil)
+    XCTAssertTrue(store.isActivated)
+
+    // Nothing was written for a signed-out owner; a new store starts clean.
+    let reloaded = makeStore(ownerID: { nil })
+    XCTAssertFalse(reloaded.isActivated)
+  }
+}

--- a/desktop/macos/Desktop/Tests/ActivationProgressStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/ActivationProgressStoreTests.swift
@@ -101,13 +101,18 @@ final class ActivationProgressStoreTests: XCTestCase {
     XCTAssertFalse(store.shouldShowFirstWin(countsKnown: true))
   }
 
-  func testVisitCapGraduates() {
-    let store = makeStore()
+  func testSameDayRevisitsNeverGraduate() {
+    var currentTime = Date(timeIntervalSince1970: 1_000_000)
+    let store = makeStore(now: { currentTime })
 
-    for _ in 0..<(ActivationProgressStore.firstWinMaxVisits + 1) {
+    // Six Home visits within one session/day: one distinct-day visit, no
+    // graduation — the surface must survive normal tab switching.
+    for _ in 0..<6 {
       store.noteFirstWinShown()
+      currentTime = currentTime.addingTimeInterval(60)
     }
-    XCTAssertTrue(store.isActivated)
+    XCTAssertFalse(store.isActivated)
+    XCTAssertEqual(store.progress.firstWinVisits, 1)
   }
 
   func testCelebrationFiresOnceOnRealActivation() {

--- a/desktop/macos/Desktop/Tests/ActivationProgressStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/ActivationProgressStoreTests.swift
@@ -4,19 +4,14 @@ import XCTest
 
 @MainActor
 final class ActivationProgressStoreTests: XCTestCase {
-  private var suiteName: String!
-  private var defaults: UserDefaults!
-
-  override func setUp() async throws {
-    try await super.setUp()
-    suiteName = "ActivationProgressStoreTests.\(UUID().uuidString)"
-    defaults = UserDefaults(suiteName: suiteName)!
-  }
-
-  override func tearDown() async throws {
-    defaults.removePersistentDomain(forName: suiteName)
-    try await super.tearDown()
-  }
+  private lazy var defaults: UserDefaults = {
+    let suiteName = "ActivationProgressStoreTests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+    addTeardownBlock {
+      UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName)
+    }
+    return defaults
+  }()
 
   private func makeStore(
     ownerID: @escaping () -> String? = { "user-a" },

--- a/desktop/macos/Desktop/Tests/HomeStatusStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeStatusStoreTests.swift
@@ -418,6 +418,58 @@ final class HomeStatusStoreTests: XCTestCase {
     XCTAssertEqual(connectorStore.snapshot(for: email).primaryText, "12 emails")
   }
 
+  func testTodayCountsLoadAndSurviveNilRefresh() async {
+    let testDefaults = makeDefaults()
+    let defaults = testDefaults.defaults
+    defer { defaults.removePersistentDomain(forName: testDefaults.suiteName) }
+
+    var knowledgeLoads = 0
+    var screenshotTodayLoads = 0
+    let connectorStore = ImportConnectorStatusStore(defaults: defaults)
+    let store = HomeStatusStore(
+      connectorStatusStore: connectorStore,
+      defaults: defaults,
+      loader: HomeStatusLoader(
+        refreshConnectorStatuses: {},
+        loadScreenshotCount: { 1000 },
+        loadScreenshotCountToday: {
+          screenshotTodayLoads += 1
+          return screenshotTodayLoads == 1 ? 214 : nil
+        },
+        loadKnowledgeCounts: { _ in
+          knowledgeLoads += 1
+          let firstLoad = knowledgeLoads == 1
+          return HomeKnowledgeCounts(
+            conversations: 2401,
+            memories: 9000,
+            tasks: 40,
+            hasOmiDeviceConversations: false,
+            conversationsToday: firstLoad ? 3 : nil,
+            memoriesToday: firstLoad ? 12 : nil,
+            tasksToday: firstLoad ? 5 : nil
+          )
+        },
+        loadMemoryExportStatuses: { [:] }
+      ),
+      localDatabaseReady: true
+    )
+
+    await store.refreshIfNeeded(now: Date(timeIntervalSince1970: 10_000))
+    XCTAssertEqual(store.conversationCountToday, 3)
+    XCTAssertEqual(store.memoryCountToday, 12)
+    XCTAssertEqual(store.taskCountToday, 5)
+    XCTAssertEqual(store.screenshotCountToday, 214)
+    XCTAssertTrue(store.knowledgeCountsKnown)
+
+    // A failed source (nil) must not clobber the last good today values.
+    await store.refreshIfNeeded(
+      now: Date(timeIntervalSince1970: 10_000 + PollingConfig.activationCooldown))
+    XCTAssertEqual(store.conversationCountToday, 3)
+    XCTAssertEqual(store.memoryCountToday, 12)
+    XCTAssertEqual(store.taskCountToday, 5)
+    XCTAssertEqual(store.screenshotCountToday, 214)
+  }
+
   private func makeDefaults() -> (defaults: UserDefaults, suiteName: String) {
     let suiteName = "HomeStatusStoreTests.\(UUID().uuidString)"
     return (UserDefaults(suiteName: suiteName)!, suiteName)

--- a/desktop/macos/Desktop/Tests/HomeTodayModelTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeTodayModelTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class HomeTodayModelTests: XCTestCase {
+
+  // MARK: - Greeting
+
+  func testGreetingDaypartsAndName() {
+    XCTAssertEqual(HomeGreetingComposer.greeting(name: "Nik", hour: 9), "Good morning, Nik.")
+    XCTAssertEqual(HomeGreetingComposer.greeting(name: "Nik", hour: 14), "Good afternoon, Nik.")
+    XCTAssertEqual(HomeGreetingComposer.greeting(name: "Nik", hour: 22), "Good evening, Nik.")
+    XCTAssertEqual(HomeGreetingComposer.greeting(name: "Nik", hour: 2), "Good evening, Nik.")
+  }
+
+  func testGreetingNeverRendersPlaceholderName() {
+    // Legacy signed-in-without-a-name placeholder must read as a bare greeting.
+    XCTAssertEqual(HomeGreetingComposer.greeting(name: "there", hour: 14), "Good afternoon.")
+    XCTAssertEqual(HomeGreetingComposer.greeting(name: "  ", hour: 14), "Good afternoon.")
+    XCTAssertEqual(HomeGreetingComposer.greeting(name: nil, hour: 14), "Good afternoon.")
+  }
+
+  // MARK: - Proof line
+
+  func testProofLineShowsOnlyNonZeroTodayCounts() {
+    let segments = HomeGreetingComposer.proofSegments(
+      today: .init(conversations: 3, memories: 0, tasks: 5, screens: 214),
+      lifetimeConversations: 2401
+    )
+    XCTAssertEqual(
+      segments.map(\.text),
+      ["3 conversations", "5 tasks", "214 screens", "today"]
+    )
+    XCTAssertEqual(segments[0].destination, .conversations)
+    XCTAssertEqual(segments[1].destination, .tasks)
+    XCTAssertEqual(segments[2].destination, .rewind)
+    XCTAssertNil(segments[3].destination)
+  }
+
+  func testProofLineMorningCaseLeadsWithLifetime() {
+    // The common morning launch: nothing today yet, real history — must not
+    // render a row of zeros.
+    let segments = HomeGreetingComposer.proofSegments(
+      today: .init(conversations: 0, memories: 0, tasks: 0, screens: 0),
+      lifetimeConversations: 2401
+    )
+    XCTAssertEqual(segments.map(\.text), ["Quiet so far today —", "2,401 conversations remembered"])
+    XCTAssertEqual(segments[1].destination, .conversations)
+  }
+
+  func testProofLineTrueEmptyExplainsInsteadOfZeros() {
+    let segments = HomeGreetingComposer.proofSegments(
+      today: .init(conversations: 0, memories: 0, tasks: 0, screens: 0),
+      lifetimeConversations: 0
+    )
+    XCTAssertEqual(segments.count, 1)
+    XCTAssertNil(segments[0].destination)
+    XCTAssertFalse(segments[0].text.contains("0"))
+  }
+
+  func testProofLineTreatsUnknownCountsAsAbsent() {
+    let segments = HomeGreetingComposer.proofSegments(
+      today: .init(conversations: nil, memories: nil, tasks: nil, screens: nil),
+      lifetimeConversations: nil
+    )
+    XCTAssertEqual(segments.count, 1)
+    XCTAssertNil(segments[0].destination)
+  }
+
+  func testSingularPluralForms() {
+    let segments = HomeGreetingComposer.proofSegments(
+      today: .init(conversations: 1, memories: 1, tasks: 1, screens: 0),
+      lifetimeConversations: nil
+    )
+    XCTAssertEqual(segments.map(\.text), ["1 conversation", "1 memory", "1 task", "today"])
+  }
+
+  // MARK: - First-win memory quality gate
+
+  func testFilePathShapedMemoriesAreFiltered() {
+    XCTAssertFalse(FirstWinMemoryFilter.isDisplayable("~/Projects/omi/backend/main.py"))
+    XCTAssertFalse(FirstWinMemoryFilter.isDisplayable("/Users/nik/Documents/taxes-2026.pdf"))
+    XCTAssertFalse(FirstWinMemoryFilter.isDisplayable("src/utils/helpers/format_date.ts"))
+    XCTAssertFalse(FirstWinMemoryFilter.isDisplayable("report_final_v2.docx"))
+    XCTAssertFalse(FirstWinMemoryFilter.isDisplayable("   "))
+    XCTAssertFalse(FirstWinMemoryFilter.isDisplayable("short"))
+  }
+
+  func testHumanSentencesPassTheGate() {
+    XCTAssertTrue(
+      FirstWinMemoryFilter.isDisplayable("Nik is building Omi, an AI wearable company."))
+    XCTAssertTrue(
+      FirstWinMemoryFilter.isDisplayable("Your goal this quarter: close the seed round."))
+  }
+
+  func testDisplayableDedupesAndCaps() {
+    let texts = [
+      "Nik is building Omi, an AI wearable company.",
+      "nik is building omi, an ai wearable company.",
+      "~/Projects/omi/backend/main.py",
+      "Your goal this quarter: close the seed round.",
+      "Investor pitch Thursday with Meridian Ventures.",
+      "One more human sentence about the user here.",
+    ]
+    let result = FirstWinMemoryFilter.displayable(texts, limit: 3)
+    XCTAssertEqual(result.count, 3)
+    XCTAssertEqual(result[0], "Nik is building Omi, an AI wearable company.")
+    XCTAssertFalse(result.contains { $0.contains("main.py") })
+  }
+}

--- a/desktop/macos/Desktop/Tests/HomeTodayStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeTodayStoreTests.swift
@@ -59,6 +59,40 @@ final class HomeTodayStoreTests: XCTestCase {
     XCTAssertEqual(dismissedIDs, [3])
   }
 
+  func testAppActivationSpamIsThrottled() async {
+    var loads = 0
+    var currentTime = Date(timeIntervalSince1970: 1_000_000)
+    let store = HomeTodayStore(
+      loader: HomeTodayStore.Loader(
+        loadTodayInsights: { _ in
+          loads += 1
+          return []
+        },
+        loadFilmstrip: { _ in [] },
+        loadFirstWinMemories: { ([], 0) },
+        dismissInsight: { _ in }
+      ),
+      now: { currentTime }
+    )
+
+    await store.refresh(includeFirstWin: false)
+    XCTAssertEqual(loads, 1)
+
+    // A cmd-tab five seconds later must not resample the filmstrip.
+    currentTime = currentTime.addingTimeInterval(5)
+    await store.refresh(includeFirstWin: false)
+    XCTAssertEqual(loads, 1)
+
+    // Upgrading to the first-win pass always runs.
+    await store.refresh(includeFirstWin: true)
+    XCTAssertEqual(loads, 2)
+
+    // And the cooldown expiring allows a fresh pass.
+    currentTime = currentTime.addingTimeInterval(PollingConfig.activationCooldown)
+    await store.refresh(includeFirstWin: true)
+    XCTAssertEqual(loads, 3)
+  }
+
   func testResetClearsContent() async {
     let store = HomeTodayStore(
       loader: HomeTodayStore.Loader(

--- a/desktop/macos/Desktop/Tests/HomeTodayStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeTodayStoreTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class HomeTodayStoreTests: XCTestCase {
+
+  func testRefreshLoadsInsightsAndFilmstrip() async {
+    let insight = HomeTodayStore.InsightItem(
+      id: 7, text: "Deepgram spend is pacing 18% over last week", sourceApp: "Safari",
+      createdAt: Date())
+    let frame = Screenshot(timestamp: Date(), appName: "Xcode")
+    var firstWinLoads = 0
+    let store = HomeTodayStore(
+      loader: HomeTodayStore.Loader(
+        loadTodayInsights: { _ in [insight] },
+        loadFilmstrip: { _ in [frame] },
+        loadFirstWinMemories: {
+          firstWinLoads += 1
+          return (["Nik is building Omi, an AI wearable company."], 44)
+        },
+        dismissInsight: { _ in }
+      ))
+
+    await store.refresh(includeFirstWin: false)
+
+    XCTAssertEqual(store.content.insights, [insight])
+    XCTAssertEqual(store.content.filmstrip.count, 1)
+    // First-win data only loads for the first-win surface.
+    XCTAssertEqual(firstWinLoads, 0)
+    XCTAssertTrue(store.content.firstWinMemories.isEmpty)
+
+    await store.refresh(includeFirstWin: true)
+    XCTAssertEqual(firstWinLoads, 1)
+    XCTAssertEqual(store.content.firstWinMemoryCount, 44)
+    XCTAssertEqual(store.content.firstWinMemories.count, 1)
+  }
+
+  func testDismissRemovesRowImmediatelyAndPersists() async {
+    let insight = HomeTodayStore.InsightItem(
+      id: 3, text: "You have pushed the design review twice this week", sourceApp: "Calendar",
+      createdAt: Date())
+    var dismissedIDs: [Int64] = []
+    let store = HomeTodayStore(
+      loader: HomeTodayStore.Loader(
+        loadTodayInsights: { _ in [insight] },
+        loadFilmstrip: { _ in [] },
+        loadFirstWinMemories: { ([], 0) },
+        dismissInsight: { dismissedIDs.append($0) }
+      ))
+
+    await store.refresh(includeFirstWin: false)
+    XCTAssertEqual(store.content.insights.count, 1)
+
+    await store.dismissInsight(insight)
+
+    // Optimistic removal + storage dismissal both happen.
+    XCTAssertTrue(store.content.insights.isEmpty)
+    XCTAssertEqual(dismissedIDs, [3])
+  }
+
+  func testResetClearsContent() async {
+    let store = HomeTodayStore(
+      loader: HomeTodayStore.Loader(
+        loadTodayInsights: { _ in
+          [
+            HomeTodayStore.InsightItem(
+              id: 1, text: "An insight for the previous account", sourceApp: "Mail",
+              createdAt: Date())
+          ]
+        },
+        loadFilmstrip: { _ in [] },
+        loadFirstWinMemories: { ([], 0) },
+        dismissInsight: { _ in }
+      ))
+
+    await store.refresh(includeFirstWin: false)
+    XCTAssertFalse(store.content.insights.isEmpty)
+
+    store.resetSessionState()
+
+    // Account switch: no stale content may leak to the next owner.
+    XCTAssertEqual(store.content, HomeTodayStore.Content())
+  }
+}

--- a/desktop/macos/Desktop/Tests/RewindSeekRequestTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindSeekRequestTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class RewindSeekRequestTests: XCTestCase {
+
+  func testSeekRequestIsOneShot() {
+    let store = RewindSeekRequestStore.shared
+    let target = Date(timeIntervalSince1970: 500_000)
+    store.request(target)
+    XCTAssertEqual(store.consume(), target)
+    XCTAssertNil(store.consume())
+  }
+
+  func testNearestScreenshotIndexPicksClosestFrame() {
+    func frame(_ seconds: TimeInterval) -> Screenshot {
+      Screenshot(timestamp: Date(timeIntervalSince1970: seconds), appName: "Test")
+    }
+    let frames = [frame(100), frame(200), frame(400)]
+
+    // Exact hit, midpoints on both sides, and out-of-range clamps.
+    XCTAssertEqual(RewindPage.nearestScreenshotIndex(to: Date(timeIntervalSince1970: 200), in: frames), 1)
+    XCTAssertEqual(RewindPage.nearestScreenshotIndex(to: Date(timeIntervalSince1970: 130), in: frames), 0)
+    XCTAssertEqual(RewindPage.nearestScreenshotIndex(to: Date(timeIntervalSince1970: 180), in: frames), 1)
+    XCTAssertEqual(RewindPage.nearestScreenshotIndex(to: Date(timeIntervalSince1970: 390), in: frames), 2)
+    XCTAssertEqual(RewindPage.nearestScreenshotIndex(to: Date(timeIntervalSince1970: 50), in: frames), 0)
+    XCTAssertEqual(RewindPage.nearestScreenshotIndex(to: Date(timeIntervalSince1970: 900), in: frames), 2)
+    XCTAssertEqual(RewindPage.nearestScreenshotIndex(to: Date(), in: []), 0)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260720-home-today-redesign.json
+++ b/desktop/macos/changelog/unreleased/20260720-home-today-redesign.json
@@ -1,0 +1,3 @@
+{
+  "change": "Redesigned Home: your day at a glance — what Omi noticed, today's captured conversations, memories and screens, a Rewind filmstrip, and a first-win welcome that shows new users what Omi already learned during setup"
+}

--- a/desktop/macos/e2e/flows/home-stage.yaml
+++ b/desktop/macos/e2e/flows/home-stage.yaml
@@ -1,11 +1,20 @@
 version: 2
 name: home-stage
 tier: 2
-description: Redesigned Home stage transitions (hub/chat/connect) via automation bridge
+description: Redesigned Home stage transitions (hub/chat/connect) plus the Today/first-win surfaces via automation bridge
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/ActivationProgressStore.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeFirstWinSection.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeGreetingView.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeNoticedSection.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeRewindFilmstrip.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeStagePalette.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeTodayModel.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeTodayStore.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/RewindSeekRequestStore.swift
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
 preconditions:
   - automation_bridge_ready
@@ -57,6 +66,31 @@ steps:
       state.homeMode: hub
 
   - id: S7
+    name: Force the first-win surface (new-user Home)
+    bridge.action:
+      name: activation_force_first_win
+      params:
+        enabled: "true"
+    expect:
+      result.detail.forced: "true"
+
+  - id: S8
+    name: Activation state reflects the forced surface
+    bridge.action:
+      name: activation_state
+    expect:
+      result.detail.forced_first_win: "true"
+
+  - id: S9
+    name: Release the first-win override
+    bridge.action:
+      name: activation_force_first_win
+      params:
+        enabled: "false"
+    expect:
+      result.detail.forced: "false"
+
+  - id: S10
     name: Logs clean
     log.expect:
       absent:

--- a/desktop/macos/scripts/desktop-flow-lint.py
+++ b/desktop/macos/scripts/desktop-flow-lint.py
@@ -27,6 +27,7 @@ HUB_SOURCE = DESKTOP_DIR / "Desktop/Sources/FloatingControlBar/RealtimeHubContro
 VIEW_MODEL_ACTION_SOURCES = (
     DESKTOP_DIR / "Desktop/Sources/MainWindow/Pages/TasksPage.swift",
     DESKTOP_DIR / "Desktop/Sources/MainWindow/Pages/MemoriesPage.swift",
+    DESKTOP_DIR / "Desktop/Sources/MainWindow/Dashboard/ActivationProgressStore.swift",
 )
 
 TYPED_STEP_KEYS = {


### PR DESCRIPTION
# Home redesign: show users why Omi is valuable the moment the window opens

## Why (data)

Mined PostHog (project 302298, `$os=macOS`), Mixpanel, prod Firestore, and the interview-derived PRs before designing (full analyst reports in the session workspace; summary below):

- **Top users' Omi is an ambient memory machine, not a chat app.** Top cohort (630 users, ≥15 active days/30d): 81% record via mic daily, 68% system audio, 68% PTT; Firestore ground truth for the top 25: median **2,400 conversations, ~3,000 memories, 846 lifetime transcription hours — but only 655 chat messages ever**.
- **Home is the least-visited page in the app**: 91 users/month (2% of actives; 5% of even top users) — it showed a wordmark, zeroed counters, and three generic prompts.
- **Retention is decided in the first 48h by proof-of-delivery**: a real conversation captured = **8.9×** retained-vs-churned lift; the median churned user sends **zero** queries; a clicked proactive notification = **10.9×** (the strongest marker) — yet that advice is delivered on a surface with **0.69% CTR / 99.4% dismissed** (floating-bar notifications), and heavy users click it *less*.
- Onboarding's value steps get skipped (VoiceDemo 37%, FloatingBar demo 35%); permission steps get done. 1 in 3 users asked for Screen Recording never grants it.

## What changed

**Existing users — the "Today" hub** (was: wordmark + zeroed stat ribbon + 3 generic prompts):
- Greeting + **one ambient proof line**: "1 conversation · 226 memories · 24 tasks · 141 screens *today*" — each segment navigates; the morning case leads with lifetime memory ("Quiet so far today — 2,401 conversations remembered"); never a row of zeros. Replaces the 4-cell stat ribbon.
- **"What Omi noticed" is the single hero**: What-Matters-Now recommendations (full feedback contract kept) merged with today's local proactive insights — the 3-per-day advice stream finally reaching a surface where it can be read, as quiet hover-action rows instead of bordered 3-button cards.
- **"Today in Rewind" filmstrip**: sampled real frames of the user's day (the deepest hands-on feature, median 46 views/user among its users); click opens Rewind at that moment (one-shot seek handoff, `RewindSeekRequestStore`).
- Suggestion rows collapsed to one row of compact chips (personalized-first; chips never truncate — fewer render when tight).

**New users — the "first win" surface** (until activation = first conversation captured + first question asked, the two 48h retention markers):
- Hero: **"Omi already knows you."** — real onboarding-derived memories (quality-gated: file-scan spam shapes filtered) + total count line.
- Live Ask-Omi shortcut keycaps read from `ShortcutSettings` (never hardcoded), one ask affordance, guaranteed-answerable first chips ("What do you already know about me?" first).
- Honest permission-aware pipeline pills: mic/screen missing → the real fix (Permissions page), never a fake checkmark; completed pill shows the real captured conversation.
- Nil-safe gating: renders only after lifetime counts load; accounts with conversation history auto-graduate (a veteran on a fresh Mac never sees it); 48h/5-visit time-box so permission-skippers are never parked. Try-Asking popup suppressed while first-win owns the moment.

**Hygiene**: Home stage glow + hover tint neutralized and wordmark shadow removed (INV-UI-1 ratchet down — the old glow literal predated the check); stat-ribbon components removed with their usage. No screens deleted: sidebar, all pages, legacy home, and the 18-step onboarding flow (fresh #9847 interview work) are untouched.

## Screenshots

(attached below: before, Today hub, first-win — all captured from a running named bundle with real seeded data; plus the HTML mockup used for design review)

## Verification

- `xcrun swift build --build-tests` clean; clean-release build (`rm -rf .build && swift build -c release`) clean.
- Focused suites green: `HomeTodayModelTests` (10) · `ActivationProgressStoreTests` (9) · `HomeTodayStoreTests` (3) · `HomeStatusStoreTests` (incl. new today-counts test) · `RewindSeekRequestTests`.
- **Real path exercised on named bundle `omi-today-home`** (dev backend, seeded account): Today hub renders live counts, real personalized chip ("How do I fix ShipBob payment failure?"), real Rewind filmstrip frames (after fixing `RewindStorage.initialize()` ordering found during this verification); noticed-feed rows verified with two locally-seeded insight rows; first-win surface rendered via the new non-prod bridge action `activation_force_first_win` showing real account memories, live ⌘O keycaps, and the honest "Screen memory — Turn on →" pill (bundle genuinely lacks the TCC grant).
- UNVERIFIED (labeled honestly): the filmstrip → Rewind seek click-through was verified by unit test (`nearestScreenshotIndex`) + code path review, not a live cursor click (no-cursor policy on this machine); a genuinely fresh account's first-win (vs the forced QA state + gating unit tests) and the live first-conversation/first-query activation marks were not exercised end-to-end with a virgin account.
- `python3 .github/scripts/check_brand_ui.py` → OK: INV-UI-1 no purple increase across 19 changed UI files. `check_desktop_test_quality.py` → at/below baseline. `make preflight` green.
- Adversarial multi-agent review of the diff ran before opening; confirmed findings fixed.

## Invariants

Path-matched invariant IDs (all held; none behaviorally changed):

- **INV-UI-1**: neutral accents only — this PR *reduces* the violation surface (violet stage-glow literal → neutral, wordmark shadow removed). Brand ratchet check passes.
- **INV-CHAT-1**: one shared transcript across surfaces — chat write path untouched; the Home ask bar still sends through the same `ChatProvider.mainInstance`; the only additions are read-only stores and a product-side activation mark adjacent to existing send sites. No second transcript store.
- **INV-AUTH-1**: session death still owned by `AuthSessionCoordinator` — the diff touches `AppState+ListenEvents.swift` (one adjacent activation mark) and reads `AuthService.givenName` for the greeting; no auth/session transitions added or changed.
- **INV-MEM-1**: memory pipeline untouched — `MemoryStorage` gains a read-only `createdAfter` count filter; no memory writes, deletes, or sync-path changes.

Failure-Class: none

## Notes for reviewers

- `Advice/insight` rows come from local `ProactiveStorage` (type `.insight`); dismissing syncs the existing `isDismissed` flag. The notification pipeline is unchanged — this adds the surface the data says was missing, it does not remove notifications (volume reduction is a separate track).
- "Memories today" can be inflated on import-heavy day-one accounts (known memory-spam issue, separate cleanup track); on the first-win surface that number is intentionally the "learned during setup" count.
- Follow-up candidates (out of scope, from the design review): once-daily synthesized "Today recap" bullets via the existing `HomeSuggestionsStore` Gemini seam; hour-tick density timeline for Rewind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

