### PR TITLE
fix(desktop): make AgentSync recovery and terminal chat content durable

### DIFF
--- a/desktop/macos/Desktop/Sources/AgentSyncService.swift
+++ b/desktop/macos/Desktop/Sources/AgentSyncService.swift
@@ -78,17 +78,15 @@ actor AgentSyncService {
     let excludedColumns: Set<String>
   }
 
-  private struct SchemaFailureEvidence {
-    let table: String
-    let generation: UInt64
-    let ownerID: String?
-    let failureOrdinal: Int
-  }
-
   /// Recovery state belongs to the effective owner, not to a particular loop
-  /// task. Repeated lifecycle starts must not mint a new cooldown allowance.
-  private struct RecoveryState {
+  /// task or aggregate sync result. A missing required table has its own
+  /// causal failure streak, so successful uploads from another table cannot
+  /// suppress its schema repair.
+  private struct RequiredSchemaRecoveryState {
     var ownerID: String?
+    var generation: UInt64
+    var table: String
+    var causalFailures: Int
     var lastAttemptAt: Date = .distantPast
     var attemptsInFailureStreak = 0
   }
@@ -109,8 +107,7 @@ actor AgentSyncService {
   private var syncGeneration: UInt64 = 0
   private var cursorOwnerID: String?
   private var latencyBackoffMultiplier: UInt64 = 1
-  private var schemaFailureEvidence: SchemaFailureEvidence?
-  private var recoveryState = RecoveryState()
+  private var requiredSchemaRecovery: RequiredSchemaRecoveryState?
   private let reuploadCooldown: TimeInterval = 30 * 60  // don't re-upload more than once per 30 min
   private let networkHooks: NetworkHooks
 
@@ -163,6 +160,11 @@ actor AgentSyncService {
 
   /// Start the sync loop. Called after the VM is ready and DB is uploaded.
   func start(vmIP: String, authToken: String) {
+    let generation = beginSync(vmIP: vmIP, authToken: authToken)
+    syncLoop(generation: generation)
+  }
+
+  private func beginSync(vmIP: String, authToken: String) -> UInt64 {
     syncGeneration &+= 1
     let generation = syncGeneration
     syncTask?.cancel()
@@ -176,16 +178,29 @@ actor AgentSyncService {
     lastTokenRefresh = .distantPast
     isPaused = false
     latencyBackoffMultiplier = 1
-    schemaFailureEvidence = nil
-    if recoveryState.ownerID != cursorOwnerID {
-      recoveryState = RecoveryState(ownerID: cursorOwnerID)
-    } else {
-      recoveryState.attemptsInFailureStreak = 0
+    if requiredSchemaRecovery?.ownerID != cursorOwnerID {
+      requiredSchemaRecovery = nil
+    } else if var recovery = requiredSchemaRecovery {
+      // A same-owner restart must keep its cooldown and bounded retry budget.
+      recovery.generation = generation
+      requiredSchemaRecovery = recovery
     }
     loadCursors(ownerID: cursorOwnerID)
     log("AgentSync: starting (vm=\(vmIP), tables=\(tables.count))")
-    syncLoop(generation: generation)
+    return generation
   }
+
+  #if DEBUG
+    /// Deterministically drives the production tick with the injected hooks.
+    /// It does not start a scheduler or add a transport protocol.
+    func startForTesting(vmIP: String, authToken: String) {
+      _ = beginSync(vmIP: vmIP, authToken: authToken)
+    }
+
+    func syncOnceForTesting() async {
+      await syncTick(generation: syncGeneration)
+    }
+  #endif
 
   /// Stop the sync loop. Normal shutdown flushes pending changes; an owner
   /// transition cancels without a final tick because credentials/storage have
@@ -261,7 +276,6 @@ actor AgentSyncService {
 
   private func syncTick(generation: UInt64) async {
     guard syncGeneration == generation else { return }
-    clearSchemaFailureEvidence(generation: generation, ownerID: cursorOwnerID)
     // Skip if user is signed out (tokens are cleared)
     guard await AuthState.shared.isSignedIn else { return }
     guard syncGeneration == generation else { return }
@@ -285,6 +299,13 @@ actor AgentSyncService {
         totalSynced += count
       }
     }
+
+    // Required-schema recovery is intentionally independent of aggregate
+    // availability. A healthy `action_items` upload cannot make a repeated
+    // `transcription_sessions` missing-table response disappear.
+    await checkAndTriggerRequiredSchemaRecovery(generation: generation)
+    guard syncGeneration == generation else { return }
+
     if anyFailed && totalSynced == 0 {
       consecutiveFailures += 1
       if consecutiveFailures == 1 || consecutiveFailures % 10 == 0 {
@@ -292,17 +313,11 @@ actor AgentSyncService {
           "AgentSync: backend unreachable (failures=\(consecutiveFailures), next retry in \(currentSyncInterval() / 1_000_000_000)s)"
         )
       }
-      // After 3 consecutive failures, check if the VM lost its database
-      if consecutiveFailures >= 3 {
-        await checkAndTriggerReupload(generation: generation)
-        guard syncGeneration == generation else { return }
-      }
     } else if totalSynced > 0 {
       if consecutiveFailures > 0 {
         log("AgentSync: backend reconnected after \(consecutiveFailures) failures")
       }
       consecutiveFailures = 0
-      recoveryState.attemptsInFailureStreak = 0
       log("AgentSync: pushed \(totalSynced) rows")
       saveCursors(generation: generation)
     }
@@ -331,19 +346,22 @@ actor AgentSyncService {
 
   // MARK: - Re-upload trigger
 
-  /// Called after 3 consecutive sync failures. `/health` normally catches a
-  /// missing database, while a recorded SQLite missing-table response catches
-  /// a partially initialized upload that still reports `databaseReady: true`.
-  private func checkAndTriggerReupload(generation: UInt64) async {
+  /// `/health` normally catches a missing database, while the table-bound
+  /// record catches a partial upload that still reports `databaseReady: true`.
+  private func checkAndTriggerRequiredSchemaRecovery(generation: UInt64) async {
     guard syncGeneration == generation else { return }
     guard let vmIP = vmIP, let authToken = authToken else { return }
     let ownerID = cursorOwnerID
-    guard recoveryState.ownerID == ownerID else { return }
-    guard networkHooks.now().timeIntervalSince(recoveryState.lastAttemptAt) >= reuploadCooldown else {
+    guard var recovery = requiredSchemaRecovery,
+      recovery.generation == generation,
+      recovery.ownerID == ownerID,
+      recovery.causalFailures >= 3
+    else { return }
+    guard networkHooks.now().timeIntervalSince(recovery.lastAttemptAt) >= reuploadCooldown else {
       log("AgentSync: skipping re-upload check (cooldown active)")
       return
     }
-    guard recoveryState.attemptsInFailureStreak < 2 else {
+    guard recovery.attemptsInFailureStreak < 2 else {
       log("AgentSync: skipping re-upload check (bounded recovery exhausted)")
       return
     }
@@ -359,29 +377,22 @@ actor AgentSyncService {
         return
       }
       guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
-      let evidence = schemaFailureEvidence
-      let evidenceBody = evidence.flatMap { evidence in
-        evidence.generation == generation && evidence.ownerID == ownerID
-          && evidence.failureOrdinal == consecutiveFailures
-          ? "no such table: \(evidence.table)"
-          : nil
-      }
       let readiness = Self.databaseReadiness(
         healthPayload: json,
-        syncFailureBody: evidenceBody
+        syncFailureBody: "no such table: \(recovery.table)"
       )
       guard readiness != .ready, readiness != .unknown else { return }
 
       log(
         "AgentSync: VM database is \(readiness == .missingRequiredSchema ? "missing required schema" : "not ready") — triggering re-upload"
       )
-      recoveryState.lastAttemptAt = networkHooks.now()
-      recoveryState.attemptsInFailureStreak += 1
+      recovery.lastAttemptAt = networkHooks.now()
+      recovery.attemptsInFailureStreak += 1
+      requiredSchemaRecovery = recovery
       let uploaded = await networkHooks.reuploadDatabase(vmIP, authToken)
       guard isCurrent(generation: generation, ownerID: ownerID) else { return }
       if uploaded {
-        clearSchemaFailureEvidence(generation: generation, ownerID: ownerID)
-        recoveryState.attemptsInFailureStreak = 0
+        clearRequiredSchemaRecovery(for: recovery.table, generation: generation, ownerID: ownerID)
       } else {
         log("AgentSync: database re-upload failed; retaining recovery evidence for its bounded retry")
       }
@@ -535,7 +546,7 @@ actor AgentSyncService {
       let result = await pushRows(spec.name, rows, generation: generation, ownerID: ownerID)
       guard syncGeneration == generation else { return 0 }
       if result == .success {
-        clearSchemaFailureEvidence(for: spec.name, generation: generation, ownerID: ownerID)
+        clearRequiredSchemaRecovery(for: spec.name, generation: generation, ownerID: ownerID)
         // Update cursor
         if spec.appendOnly {
           if let lastId = rows.last?["id"] as? Int64 {
@@ -581,21 +592,31 @@ actor AgentSyncService {
       && RuntimeOwnerIdentity.currentOwnerId() == ownerID
   }
 
-  private func clearSchemaFailureEvidence(generation: UInt64, ownerID: String?) {
-    guard let evidence = schemaFailureEvidence,
-      evidence.generation == generation,
-      evidence.ownerID == ownerID
+  private func clearRequiredSchemaRecovery(for table: String, generation: UInt64, ownerID: String?) {
+    guard let recovery = requiredSchemaRecovery,
+      recovery.table == table,
+      recovery.generation == generation,
+      recovery.ownerID == ownerID
     else { return }
-    schemaFailureEvidence = nil
+    requiredSchemaRecovery = nil
   }
 
-  private func clearSchemaFailureEvidence(for table: String, generation: UInt64, ownerID: String?) {
-    guard let evidence = schemaFailureEvidence,
-      evidence.table == table,
-      evidence.generation == generation,
-      evidence.ownerID == ownerID
-    else { return }
-    schemaFailureEvidence = nil
+  private func recordRequiredSchemaFailure(for table: String, generation: UInt64, ownerID: String?) {
+    guard isCurrent(generation: generation, ownerID: ownerID) else { return }
+    if var recovery = requiredSchemaRecovery,
+      recovery.table == table,
+      recovery.generation == generation,
+      recovery.ownerID == ownerID
+    {
+      recovery.causalFailures += 1
+      requiredSchemaRecovery = recovery
+    } else {
+      requiredSchemaRecovery = RequiredSchemaRecoveryState(
+        ownerID: ownerID,
+        generation: generation,
+        table: table,
+        causalFailures: 1)
+    }
   }
 
   private func pushRows(
@@ -639,12 +660,7 @@ actor AgentSyncService {
           healthPayload: ["databaseReady": true],
           syncFailureBody: body
         ) == .missingRequiredSchema {
-          schemaFailureEvidence = SchemaFailureEvidence(
-            table: table,
-            generation: generation,
-            ownerID: ownerID,
-            failureOrdinal: consecutiveFailures + 1
-          )
+          recordRequiredSchemaFailure(for: table, generation: generation, ownerID: ownerID)
         }
         log("AgentSync: push \(table) failed — HTTP \(httpResponse.statusCode): \(body)")
         return .networkError  // 5xx = server not ready, trigger backoff

--- a/desktop/macos/Desktop/Sources/AgentSyncService.swift
+++ b/desktop/macos/Desktop/Sources/AgentSyncService.swift
@@ -24,6 +24,40 @@ private struct AgentSyncRowsPayload: @unchecked Sendable {
 actor AgentSyncService {
   static let shared = AgentSyncService()
 
+  enum DatabaseReadiness: Equatable {
+    case ready
+    case missingDatabase
+    case missingRequiredSchema
+  }
+
+  private static let requiredRemoteTables: Set<String> = [
+    "transcription_sessions",
+    "action_items",
+    "memories",
+    "staged_tasks",
+    "live_notes",
+    "screenshots",
+    "transcription_segments",
+    "focus_sessions",
+    "observations",
+  ]
+
+  /// A successful `/health` response is not enough to admit incremental sync:
+  /// an interrupted database upload can leave SQLite open but without the
+  /// tables that this service owns. The sync endpoint's SQLite error is the
+  /// authoritative signal for that partial-schema state.
+  static func databaseReadiness(
+    healthPayload: [String: Any],
+    syncFailureBody: String? = nil
+  ) -> DatabaseReadiness {
+    guard healthPayload["databaseReady"] as? Bool == true else { return .missingDatabase }
+    guard let syncFailureBody else { return .ready }
+    let normalizedFailure = syncFailureBody.lowercased()
+    return requiredRemoteTables.contains(where: {
+      normalizedFailure.contains("no such table: \($0)")
+    }) ? .missingRequiredSchema : .ready
+  }
+
   struct NetworkHooks: Sendable {
     let fetchIDToken: @Sendable () async throws -> String
     let dataForRequest: @Sendable (URLRequest) async throws -> (Data, URLResponse)
@@ -65,6 +99,7 @@ actor AgentSyncService {
   private var cursorOwnerID: String?
   private var latencyBackoffMultiplier: UInt64 = 1
   private var lastReuploadAt: Date = .distantPast
+  private var lastRequiredSchemaFailureBody: String?
   private let reuploadCooldown: TimeInterval = 30 * 60  // don't re-upload more than once per 30 min
   private let networkHooks: NetworkHooks
 
@@ -128,6 +163,7 @@ actor AgentSyncService {
     isPaused = false
     latencyBackoffMultiplier = 1
     lastReuploadAt = .distantPast
+    lastRequiredSchemaFailureBody = nil
     loadCursors(ownerID: cursorOwnerID)
     log("AgentSync: starting (vm=\(vmIP), tables=\(tables.count))")
     syncLoop(generation: generation)
@@ -275,8 +311,9 @@ actor AgentSyncService {
 
   // MARK: - Re-upload trigger
 
-  /// Called after 3 consecutive sync failures. Hits /health — if the VM has no
-  /// database (e.g. it restarted and lost its data), triggers a full re-upload.
+  /// Called after 3 consecutive sync failures. `/health` normally catches a
+  /// missing database, while a recorded SQLite missing-table response catches
+  /// a partially initialized upload that still reports `databaseReady: true`.
   private func checkAndTriggerReupload(generation: UInt64) async {
     guard syncGeneration == generation else { return }
     guard let vmIP = vmIP, let authToken = authToken else { return }
@@ -289,14 +326,19 @@ actor AgentSyncService {
     do {
       let (data, _) = try await URLSession.shared.data(from: url)
       guard syncGeneration == generation else { return }
-      guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-        let dbReady = json["databaseReady"] as? Bool,
-        !dbReady
-      else { return }
+      guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+      let readiness = Self.databaseReadiness(
+        healthPayload: json,
+        syncFailureBody: lastRequiredSchemaFailureBody
+      )
+      guard readiness != .ready else { return }
 
-      log("AgentSync: VM has no database — triggering re-upload")
+      log(
+        "AgentSync: VM database is \(readiness == .missingRequiredSchema ? "missing required schema" : "not ready") — triggering re-upload"
+      )
       lastReuploadAt = Date()
       await AgentVMService.shared.reuploadDatabase(vmIP: vmIP, authToken: authToken)
+      lastRequiredSchemaFailureBody = nil
       guard syncGeneration == generation else { return }
     } catch {
       log("AgentSync: re-upload health check failed — \(error.localizedDescription)")
@@ -517,6 +559,12 @@ actor AgentSyncService {
         return .success
       } else if httpResponse.statusCode >= 500 {
         let body = String(data: data, encoding: .utf8) ?? ""
+        if Self.databaseReadiness(
+          healthPayload: ["databaseReady": true],
+          syncFailureBody: body
+        ) == .missingRequiredSchema {
+          lastRequiredSchemaFailureBody = body
+        }
         log("AgentSync: push \(table) failed — HTTP \(httpResponse.statusCode): \(body)")
         return .networkError  // 5xx = server not ready, trigger backoff
       } else {

--- a/desktop/macos/Desktop/Sources/AgentSyncService.swift
+++ b/desktop/macos/Desktop/Sources/AgentSyncService.swift
@@ -28,19 +28,8 @@ actor AgentSyncService {
     case ready
     case missingDatabase
     case missingRequiredSchema
+    case unknown
   }
-
-  private static let requiredRemoteTables: Set<String> = [
-    "transcription_sessions",
-    "action_items",
-    "memories",
-    "staged_tasks",
-    "live_notes",
-    "screenshots",
-    "transcription_segments",
-    "focus_sessions",
-    "observations",
-  ]
 
   /// A successful `/health` response is not enough to admit incremental sync:
   /// an interrupted database upload can leave SQLite open but without the
@@ -50,7 +39,8 @@ actor AgentSyncService {
     healthPayload: [String: Any],
     syncFailureBody: String? = nil
   ) -> DatabaseReadiness {
-    guard healthPayload["databaseReady"] as? Bool == true else { return .missingDatabase }
+    guard let databaseReady = healthPayload["databaseReady"] as? Bool else { return .unknown }
+    guard databaseReady else { return .missingDatabase }
     guard let syncFailureBody else { return .ready }
     let normalizedFailure = syncFailureBody.lowercased()
     return requiredRemoteTables.contains(where: {
@@ -61,11 +51,17 @@ actor AgentSyncService {
   struct NetworkHooks: Sendable {
     let fetchIDToken: @Sendable () async throws -> String
     let dataForRequest: @Sendable (URLRequest) async throws -> (Data, URLResponse)
+    let reuploadDatabase: @Sendable (_ vmIP: String, _ authToken: String) async -> Bool
+    let now: @Sendable () -> Date
     let tableSyncEnabled: Bool
 
     static let live = NetworkHooks(
       fetchIDToken: { try await AuthService.shared.getIdToken() },
       dataForRequest: { try await URLSession.shared.data(for: $0) },
+      reuploadDatabase: { vmIP, authToken in
+        await AgentVMService.shared.reuploadDatabase(vmIP: vmIP, authToken: authToken)
+      },
+      now: Date.init,
       tableSyncEnabled: true)
   }
 
@@ -80,6 +76,21 @@ actor AgentSyncService {
     let name: String
     let appendOnly: Bool  // true = cursor by id, false = cursor by updatedAt
     let excludedColumns: Set<String>
+  }
+
+  private struct SchemaFailureEvidence {
+    let table: String
+    let generation: UInt64
+    let ownerID: String?
+    let failureOrdinal: Int
+  }
+
+  /// Recovery state belongs to the effective owner, not to a particular loop
+  /// task. Repeated lifecycle starts must not mint a new cooldown allowance.
+  private struct RecoveryState {
+    var ownerID: String?
+    var lastAttemptAt: Date = .distantPast
+    var attemptsInFailureStreak = 0
   }
 
   // MARK: - State
@@ -98,8 +109,8 @@ actor AgentSyncService {
   private var syncGeneration: UInt64 = 0
   private var cursorOwnerID: String?
   private var latencyBackoffMultiplier: UInt64 = 1
-  private var lastReuploadAt: Date = .distantPast
-  private var lastRequiredSchemaFailureBody: String?
+  private var schemaFailureEvidence: SchemaFailureEvidence?
+  private var recoveryState = RecoveryState()
   private let reuploadCooldown: TimeInterval = 30 * 60  // don't re-upload more than once per 30 min
   private let networkHooks: NetworkHooks
 
@@ -118,7 +129,7 @@ actor AgentSyncService {
 
   // MARK: - Table definitions
 
-  private let tables: [TableSpec] = [
+  private static let tableSpecs: [TableSpec] = [
     // Mutable (cursor by updatedAt) — sessions before segments (FK dependency)
     TableSpec(name: "transcription_sessions", appendOnly: false, excludedColumns: []),
     TableSpec(
@@ -142,6 +153,9 @@ actor AgentSyncService {
     TableSpec(name: "observations", appendOnly: true, excludedColumns: []),
   ]
 
+  private let tables = AgentSyncService.tableSpecs
+  private static let requiredRemoteTables = Set(tableSpecs.map(\.name))
+
   // Tables with only a createdAt (no updatedAt) that are append-only but not tracked
   // by id — handled via appendOnly=true above.
 
@@ -162,8 +176,12 @@ actor AgentSyncService {
     lastTokenRefresh = .distantPast
     isPaused = false
     latencyBackoffMultiplier = 1
-    lastReuploadAt = .distantPast
-    lastRequiredSchemaFailureBody = nil
+    schemaFailureEvidence = nil
+    if recoveryState.ownerID != cursorOwnerID {
+      recoveryState = RecoveryState(ownerID: cursorOwnerID)
+    } else {
+      recoveryState.attemptsInFailureStreak = 0
+    }
     loadCursors(ownerID: cursorOwnerID)
     log("AgentSync: starting (vm=\(vmIP), tables=\(tables.count))")
     syncLoop(generation: generation)
@@ -243,6 +261,7 @@ actor AgentSyncService {
 
   private func syncTick(generation: UInt64) async {
     guard syncGeneration == generation else { return }
+    clearSchemaFailureEvidence(generation: generation, ownerID: cursorOwnerID)
     // Skip if user is signed out (tokens are cleared)
     guard await AuthState.shared.isSignedIn else { return }
     guard syncGeneration == generation else { return }
@@ -274,7 +293,7 @@ actor AgentSyncService {
         )
       }
       // After 3 consecutive failures, check if the VM lost its database
-      if consecutiveFailures == 3 {
+      if consecutiveFailures >= 3 {
         await checkAndTriggerReupload(generation: generation)
         guard syncGeneration == generation else { return }
       }
@@ -283,6 +302,7 @@ actor AgentSyncService {
         log("AgentSync: backend reconnected after \(consecutiveFailures) failures")
       }
       consecutiveFailures = 0
+      recoveryState.attemptsInFailureStreak = 0
       log("AgentSync: pushed \(totalSynced) rows")
       saveCursors(generation: generation)
     }
@@ -317,29 +337,54 @@ actor AgentSyncService {
   private func checkAndTriggerReupload(generation: UInt64) async {
     guard syncGeneration == generation else { return }
     guard let vmIP = vmIP, let authToken = authToken else { return }
-    guard Date().timeIntervalSince(lastReuploadAt) >= reuploadCooldown else {
+    let ownerID = cursorOwnerID
+    guard recoveryState.ownerID == ownerID else { return }
+    guard networkHooks.now().timeIntervalSince(recoveryState.lastAttemptAt) >= reuploadCooldown else {
       log("AgentSync: skipping re-upload check (cooldown active)")
+      return
+    }
+    guard recoveryState.attemptsInFailureStreak < 2 else {
+      log("AgentSync: skipping re-upload check (bounded recovery exhausted)")
       return
     }
 
     guard let url = URL(string: "http://\(vmIP):8080/health") else { return }
     do {
-      let (data, _) = try await URLSession.shared.data(from: url)
-      guard syncGeneration == generation else { return }
+      var request = URLRequest(url: url)
+      request.timeoutInterval = 15
+      let (data, response) = try await networkHooks.dataForRequest(request)
+      guard isCurrent(generation: generation, ownerID: ownerID) else { return }
+      guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+        log("AgentSync: re-upload health check returned a non-success response")
+        return
+      }
       guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+      let evidence = schemaFailureEvidence
+      let evidenceBody = evidence.flatMap { evidence in
+        evidence.generation == generation && evidence.ownerID == ownerID
+          && evidence.failureOrdinal == consecutiveFailures
+          ? "no such table: \(evidence.table)"
+          : nil
+      }
       let readiness = Self.databaseReadiness(
         healthPayload: json,
-        syncFailureBody: lastRequiredSchemaFailureBody
+        syncFailureBody: evidenceBody
       )
-      guard readiness != .ready else { return }
+      guard readiness != .ready, readiness != .unknown else { return }
 
       log(
         "AgentSync: VM database is \(readiness == .missingRequiredSchema ? "missing required schema" : "not ready") — triggering re-upload"
       )
-      lastReuploadAt = Date()
-      await AgentVMService.shared.reuploadDatabase(vmIP: vmIP, authToken: authToken)
-      lastRequiredSchemaFailureBody = nil
-      guard syncGeneration == generation else { return }
+      recoveryState.lastAttemptAt = networkHooks.now()
+      recoveryState.attemptsInFailureStreak += 1
+      let uploaded = await networkHooks.reuploadDatabase(vmIP, authToken)
+      guard isCurrent(generation: generation, ownerID: ownerID) else { return }
+      if uploaded {
+        clearSchemaFailureEvidence(generation: generation, ownerID: ownerID)
+        recoveryState.attemptsInFailureStreak = 0
+      } else {
+        log("AgentSync: database re-upload failed; retaining recovery evidence for its bounded retry")
+      }
     } catch {
       log("AgentSync: re-upload health check failed — \(error.localizedDescription)")
     }
@@ -486,9 +531,11 @@ actor AgentSyncService {
       guard !rows.isEmpty else { return 0 }
 
       // Push to VM
-      let result = await pushRows(spec.name, rows)
+      let ownerID = cursorOwnerID
+      let result = await pushRows(spec.name, rows, generation: generation, ownerID: ownerID)
       guard syncGeneration == generation else { return 0 }
       if result == .success {
+        clearSchemaFailureEvidence(for: spec.name, generation: generation, ownerID: ownerID)
         // Update cursor
         if spec.appendOnly {
           if let lastId = rows.last?["id"] as? Int64 {
@@ -528,8 +575,36 @@ actor AgentSyncService {
     case networkError
   }
 
-  private func pushRows(_ table: String, _ rows: [[String: Any]]) async -> PushResult {
-    guard let vmIP = vmIP, let authToken = authToken else { return .networkError }
+  private func isCurrent(generation: UInt64, ownerID: String?) -> Bool {
+    syncGeneration == generation
+      && cursorOwnerID == ownerID
+      && RuntimeOwnerIdentity.currentOwnerId() == ownerID
+  }
+
+  private func clearSchemaFailureEvidence(generation: UInt64, ownerID: String?) {
+    guard let evidence = schemaFailureEvidence,
+      evidence.generation == generation,
+      evidence.ownerID == ownerID
+    else { return }
+    schemaFailureEvidence = nil
+  }
+
+  private func clearSchemaFailureEvidence(for table: String, generation: UInt64, ownerID: String?) {
+    guard let evidence = schemaFailureEvidence,
+      evidence.table == table,
+      evidence.generation == generation,
+      evidence.ownerID == ownerID
+    else { return }
+    schemaFailureEvidence = nil
+  }
+
+  private func pushRows(
+    _ table: String,
+    _ rows: [[String: Any]],
+    generation: UInt64,
+    ownerID: String?
+  ) async -> PushResult {
+    guard isCurrent(generation: generation, ownerID: ownerID), let vmIP, let authToken else { return .networkError }
 
     // Send token both as query param (backward compat) and header (preferred)
     guard let url = URL(string: "http://\(vmIP):8080/sync?token=\(authToken)") else {
@@ -553,6 +628,7 @@ actor AgentSyncService {
 
     do {
       let (data, response) = try await networkHooks.dataForRequest(request)
+      guard isCurrent(generation: generation, ownerID: ownerID) else { return .networkError }
       guard let httpResponse = response as? HTTPURLResponse else { return .httpError }
 
       if httpResponse.statusCode == 200 {
@@ -563,7 +639,12 @@ actor AgentSyncService {
           healthPayload: ["databaseReady": true],
           syncFailureBody: body
         ) == .missingRequiredSchema {
-          lastRequiredSchemaFailureBody = body
+          schemaFailureEvidence = SchemaFailureEvidence(
+            table: table,
+            generation: generation,
+            ownerID: ownerID,
+            failureOrdinal: consecutiveFailures + 1
+          )
         }
         log("AgentSync: push \(table) failed — HTTP \(httpResponse.statusCode): \(body)")
         return .networkError  // 5xx = server not ready, trigger backoff

--- a/desktop/macos/Desktop/Sources/AgentVMService.swift
+++ b/desktop/macos/Desktop/Sources/AgentVMService.swift
@@ -27,7 +27,7 @@ actor AgentVMService {
           log("AgentVMService: VM already ready — vmName=\(status.vmName) ip=\(ip)")
           // Only upload if the VM doesn't have a database yet
           if await checkVMNeedsDatabase(vmIP: ip, authToken: status.authToken) {
-            await uploadDatabase(vmIP: ip, authToken: status.authToken)
+            _ = await uploadDatabase(vmIP: ip, authToken: status.authToken)
           } else {
             log("AgentVMService: VM already has database, skipping upload")
           }
@@ -43,7 +43,7 @@ actor AgentVMService {
           {
             log("AgentVMService: VM became ready — ip=\(ip)")
             if await checkVMNeedsDatabase(vmIP: ip, authToken: result.authToken) {
-              await uploadDatabase(vmIP: ip, authToken: result.authToken)
+              _ = await uploadDatabase(vmIP: ip, authToken: result.authToken)
             }
             await startIncrementalSync(vmIP: ip, authToken: result.authToken)
           }
@@ -110,7 +110,7 @@ actor AgentVMService {
     }
 
     // Step 3: Check if DB exists and upload it
-    await uploadDatabase(vmIP: ip, authToken: authToken)
+    _ = await uploadDatabase(vmIP: ip, authToken: authToken)
 
     // Step 4: Start incremental sync
     await startIncrementalSync(vmIP: ip, authToken: authToken)
@@ -159,9 +159,9 @@ actor AgentVMService {
 
   /// Re-upload the database to a VM that lost its data (e.g. after a restart).
   /// Called by AgentSyncService when it detects databaseReady: false on the VM.
-  func reuploadDatabase(vmIP: String, authToken: String) async {
+  func reuploadDatabase(vmIP: String, authToken: String) async -> Bool {
     log("AgentVMService: Re-uploading database to VM (triggered by sync failure)")
-    await uploadDatabase(vmIP: vmIP, authToken: authToken)
+    return await uploadDatabase(vmIP: vmIP, authToken: authToken)
   }
 
   /// Compression ratio as a whole-number percent. Guards against a zero
@@ -175,7 +175,7 @@ actor AgentVMService {
 
   /// Upload the local omi.db (gzip-compressed) to the VM's /upload endpoint.
   /// Pauses AgentSync during upload to prevent competing for memory and network.
-  private func uploadDatabase(vmIP: String, authToken: String) async {
+  private func uploadDatabase(vmIP: String, authToken: String) async -> Bool {
     await AgentSyncService.shared.pause()
     defer { Task { await AgentSyncService.shared.resume() } }
     // Find the local database path
@@ -189,7 +189,7 @@ actor AgentVMService {
 
     guard FileManager.default.fileExists(atPath: dbPath.path) else {
       log("AgentVMService: Local database not found at \(dbPath.path), skipping upload")
-      return
+      return false
     }
 
     // Get original file size
@@ -199,7 +199,7 @@ actor AgentVMService {
       originalSize = attrs[.size] as? UInt64 ?? 0
     } catch {
       log("AgentVMService: Failed to get DB size — \(error.localizedDescription)")
-      return
+      return false
     }
 
     log("AgentVMService: Compressing database (\(originalSize / 1024 / 1024) MB) via streaming gzip...")
@@ -217,7 +217,7 @@ actor AgentVMService {
       FileManager.default.createFile(atPath: tempGzPath.path, contents: nil)
       guard let outHandle = FileHandle(forWritingAtPath: tempGzPath.path) else {
         log("AgentVMService: Failed to create temp gzip file")
-        return
+        return false
       }
       process.standardOutput = outHandle
       try process.run()
@@ -227,7 +227,7 @@ actor AgentVMService {
       guard process.terminationStatus == 0 else {
         log("AgentVMService: gzip failed with exit code \(process.terminationStatus)")
         try? FileManager.default.removeItem(at: tempGzPath)
-        return
+        return false
       }
 
       let compressedAttrs = try FileManager.default.attributesOfItem(atPath: tempGzPath.path)
@@ -238,7 +238,7 @@ actor AgentVMService {
     } catch {
       log("AgentVMService: Compression failed — \(error.localizedDescription)")
       try? FileManager.default.removeItem(at: tempGzPath)
-      return
+      return false
     }
 
     log("AgentVMService: Uploading compressed database to \(vmIP)...")
@@ -247,7 +247,7 @@ actor AgentVMService {
     guard let uploadURL = URL(string: "http://\(vmIP):8080/upload?token=\(authToken)") else {
       log("AgentVMService: Invalid upload URL for IP \(vmIP)")
       try? FileManager.default.removeItem(at: tempGzPath)
-      return
+      return false
     }
     var request = URLRequest(url: uploadURL)
     request.httpMethod = "POST"
@@ -263,7 +263,7 @@ actor AgentVMService {
 
       guard let httpResponse = response as? HTTPURLResponse else {
         log("AgentVMService: Upload failed — invalid response")
-        return
+        return false
       }
 
       if httpResponse.statusCode == 200 {
@@ -274,13 +274,16 @@ actor AgentVMService {
         } else {
           log("AgentVMService: Upload complete")
         }
+        return true
       } else {
         let body = String(data: data, encoding: .utf8) ?? ""
         log("AgentVMService: Upload failed — HTTP \(httpResponse.statusCode): \(body)")
+        return false
       }
     } catch {
       try? FileManager.default.removeItem(at: tempGzPath)
       log("AgentVMService: Upload failed — \(error.localizedDescription)")
+      return false
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
+++ b/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
@@ -451,16 +451,15 @@ final class KernelTurnProjection {
   ) async -> KernelJournalTurn? {
     guard let lease = captureOwnerLease(ownerID: ownerID), let host else { return nil }
     guard await host.ensureBridgeStartedForKernel(), isCurrent(lease), let client else { return nil }
-    let acceptedText = message.flatMap { $0.text.isEmpty ? nil : $0.text } ?? acceptedContent
+    let acceptedText = Self.acceptedTerminalContent(message: message, acceptedContent: acceptedContent)
+    let acceptedBlocks = Self.acceptedTerminalContentBlocks(message: message, acceptedContent: acceptedContent)
     let terminalization = KernelJournalTurnTerminalization(
       turnId: turnId,
       producingRunId: producingRunId,
       producingAttemptId: producingAttemptId,
       disposition: disposition,
       content: disposition == .accept ? acceptedText : nil,
-      contentBlocksJSON: disposition == .accept
-        ? message.flatMap { ChatContentBlockCodec.encode($0.contentBlocks) }
-        : nil,
+      contentBlocksJSON: disposition == .accept ? ChatContentBlockCodec.encode(acceptedBlocks) : nil,
       resourcesJSON: disposition == .accept
         ? message.flatMap { ChatResource.encodeResourcesForPersistence($0.displayResources) }
           ?? acceptedResources.flatMap { resources in
@@ -481,6 +480,28 @@ final class KernelTurnProjection {
       log("KernelTurnProjection: journal terminalization failed (code=journal_terminalize_failed)")
       return nil
     }
+  }
+
+  /// The query result is the authoritative final material. The streaming row is
+  /// an optimistic projection and can lag its terminal callback; use it only
+  /// when the final result intentionally contains no text.
+  static func acceptedTerminalContent(message: ChatMessage?, acceptedContent: String?) -> String? {
+    if let acceptedContent, !acceptedContent.isEmpty { return acceptedContent }
+    return message.flatMap { $0.text.isEmpty ? nil : $0.text }
+  }
+
+  static func acceptedTerminalContentBlocks(
+    message: ChatMessage?,
+    acceptedContent: String?
+  ) -> [ChatContentBlock] {
+    guard let acceptedContent, !acceptedContent.isEmpty else { return message?.contentBlocks ?? [] }
+    let nonTextBlocks =
+      message?.contentBlocks.filter {
+        if case .text = $0 { return false }
+        return true
+      } ?? []
+    let messageID = message?.id ?? "terminal"
+    return [.text(id: "\(messageID):terminal", text: acceptedContent)] + nonTextBlocks
   }
 
   /// Terminalize an existing turn without sourcing payload from the current UI

--- a/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
@@ -69,6 +69,32 @@ private actor AgentSyncDelayedTokenGate {
 /// on a compound `(updatedAt, id)` cursor.
 final class AgentSyncBatchQueryTests: XCTestCase {
 
+  func testPartialSchemaIsNotReadyEvenWhenDatabaseReadyIsTrue() {
+    let readiness = AgentSyncService.databaseReadiness(
+      healthPayload: ["databaseReady": true],
+      syncFailureBody: "SQLite error: no such table: transcription_sessions"
+    )
+
+    XCTAssertEqual(
+      readiness,
+      .missingRequiredSchema,
+      "A VM that reports databaseReady while rejecting a required sync table must be re-provisioned by the existing upload owner"
+    )
+  }
+
+  func testUnrelatedSQLiteTableFailureDoesNotTriggerDatabaseReupload() {
+    let readiness = AgentSyncService.databaseReadiness(
+      healthPayload: ["databaseReady": true],
+      syncFailureBody: "SQLite error: no such table: scratch_cache"
+    )
+
+    XCTAssertEqual(
+      readiness,
+      .ready,
+      "Only tables owned by AgentSync prove its uploaded schema is partial; unrelated server faults must keep bounded retry behavior"
+    )
+  }
+
   func testMutableTableUsesCompoundCursor() {
     let (sql, args) = AgentSyncService.buildBatchQuery(
       tableName: "action_items",

--- a/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
@@ -95,6 +95,11 @@ final class AgentSyncBatchQueryTests: XCTestCase {
     )
   }
 
+  func testMalformedOrMissingHealthReadinessIsNotMissingDatabase() {
+    XCTAssertEqual(AgentSyncService.databaseReadiness(healthPayload: [:]), .unknown)
+    XCTAssertEqual(AgentSyncService.databaseReadiness(healthPayload: ["databaseReady": "false"]), .unknown)
+  }
+
   func testMutableTableUsesCompoundCursor() {
     let (sql, args) = AgentSyncService.buildBatchQuery(
       tableName: "action_items",
@@ -140,6 +145,8 @@ final class AgentSyncBatchQueryTests: XCTestCase {
       networkHooks: AgentSyncService.NetworkHooks(
         fetchIDToken: { await gate.fetchToken() },
         dataForRequest: { request in await gate.respond(to: request) },
+        reuploadDatabase: { _, _ in true },
+        now: Date.init,
         tableSyncEnabled: false))
 
     await service.start(vmIP: "owner-a-vm", authToken: "owner-a-auth")

--- a/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
@@ -1,3 +1,5 @@
+import Foundation
+import GRDB
 import XCTest
 
 @testable import Omi_Computer
@@ -59,6 +61,97 @@ private actor AgentSyncDelayedTokenGate {
 
   func requestURLs() -> [URL] {
     requests.compactMap(\.url)
+  }
+}
+
+private final class AgentSyncManualClock: @unchecked Sendable {
+  private let lock = NSLock()
+  private var value: Date
+
+  init(_ value: Date = Date(timeIntervalSince1970: 1_700_000_000)) {
+    self.value = value
+  }
+
+  func now() -> Date {
+    lock.withLock { value }
+  }
+
+  func advance(_ interval: TimeInterval) {
+    lock.withLock { value.addTimeInterval(interval) }
+  }
+}
+
+private actor AgentSyncRecoveryProbe {
+  enum HealthResponse {
+    case ready
+    case malformed
+    case status(Int)
+  }
+
+  private var missingTable: String?
+  private var healthResponse: HealthResponse = .ready
+  private var uploadResults: [Bool] = [true]
+  private var healthChecks = 0
+  private var uploads = 0
+  private var syncedTables: [String] = []
+
+  init(missingTable: String? = "transcription_sessions") {
+    self.missingTable = missingTable
+  }
+
+  func respond(to request: URLRequest) throws -> (Data, URLResponse) {
+    let url = try XCTUnwrap(request.url)
+    switch url.path {
+    case "/auth":
+      return (Data(), response(url, status: 200))
+    case "/sync":
+      let payload = try XCTUnwrap(request.httpBody)
+      let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: payload) as? [String: Any])
+      let table = try XCTUnwrap(json["table"] as? String)
+      syncedTables.append(table)
+      if table == missingTable {
+        return (Data("SQLite error: no such table: \(table)".utf8), response(url, status: 500))
+      }
+      return (Data(), response(url, status: 200))
+    case "/health":
+      healthChecks += 1
+      switch healthResponse {
+      case .ready:
+        return (try JSONSerialization.data(withJSONObject: ["databaseReady": true]), response(url, status: 200))
+      case .malformed:
+        return (Data("not-json".utf8), response(url, status: 200))
+      case .status(let status):
+        return (Data(), response(url, status: status))
+      }
+    default:
+      return (Data(), response(url, status: 404))
+    }
+  }
+
+  func reupload() -> Bool {
+    uploads += 1
+    return uploadResults.isEmpty ? false : uploadResults.removeFirst()
+  }
+
+  func setMissingTable(_ table: String?) {
+    missingTable = table
+  }
+
+  func setHealthResponse(_ response: HealthResponse) {
+    healthResponse = response
+  }
+
+  func setUploadResults(_ results: [Bool]) {
+    uploadResults = results
+  }
+
+  func counts() -> (healthChecks: Int, uploads: Int, syncedTables: [String]) {
+    (healthChecks, uploads, syncedTables)
+  }
+
+  private func response(_ url: URL, status: Int) -> URLResponse {
+    HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)
+      ?? URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
   }
 }
 
@@ -163,5 +256,157 @@ final class AgentSyncBatchQueryTests: XCTestCase {
     XCTAssertEqual(requestURLs.count, 1)
     XCTAssertEqual(requestURLs.first?.host, "owner-b-vm")
     XCTAssertEqual(requestURLs.first?.path, "/auth")
+  }
+}
+
+/// These tests drive `syncTick` through the same table reads and HTTP paths as
+/// the loop. The DEBUG-only clock/hook seam avoids a scheduler or bridge fault
+/// protocol while preserving production ownership and recovery behavior.
+final class AgentSyncRecoveryTests: XCTestCase {
+  private var storageFixture: RewindStorageTestIsolation.Fixture?
+  private var authSnapshot: RewindStorageTestIsolation.AuthSnapshot?
+
+  override func setUp() async throws {
+    try await super.setUp()
+    let fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "agent-sync-recovery")
+    storageFixture = fixture
+    authSnapshot = await MainActor.run { RewindStorageTestIsolation.captureAuthSnapshot() }
+    await MainActor.run { RewindStorageTestIsolation.signInForTests(userId: fixture.testUserId) }
+    try await insertSyncRows()
+  }
+
+  override func tearDown() async throws {
+    if let authSnapshot {
+      await MainActor.run { RewindStorageTestIsolation.restoreAuthSnapshot(authSnapshot) }
+    }
+    await RewindStorageTestIsolation.tearDown(userDir: storageFixture?.userDir)
+    try await super.tearDown()
+  }
+
+  func testMixedSuccessStillRecoversTheRepeatedRequiredTableFailure() async {
+    let probe = AgentSyncRecoveryProbe()
+    let service = makeService(probe: probe)
+    await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
+
+    await service.syncOnceForTesting()
+    await service.syncOnceForTesting()
+    await service.syncOnceForTesting()
+
+    let counts = await probe.counts()
+    XCTAssertTrue(
+      counts.syncedTables.contains("action_items"), "The control table must take the real /sync success path")
+    XCTAssertEqual(counts.syncedTables.filter { $0 == "transcription_sessions" }.count, 3)
+    XCTAssertEqual(counts.healthChecks, 1, "Three causal failures trigger one fail-closed /health check")
+    XCTAssertEqual(counts.uploads, 1, "The existing database-upload owner repairs the missing table exactly once")
+  }
+
+  func testMatchingTableSuccessClearsRecoveryButUnrelatedSuccessDoesNot() async throws {
+    let probe = AgentSyncRecoveryProbe()
+    let service = makeService(probe: probe)
+    await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
+
+    await service.syncOnceForTesting()
+    await service.syncOnceForTesting()
+    await probe.setMissingTable(nil)  // The previously failing table now succeeds.
+    await service.syncOnceForTesting()
+    await probe.setMissingTable("transcription_sessions")
+    try await touchTranscriptionSession()
+    await service.syncOnceForTesting()
+    await service.syncOnceForTesting()
+
+    var counts = await probe.counts()
+    XCTAssertEqual(counts.uploads, 0, "A matching success clears the earlier table's causal evidence")
+    await service.syncOnceForTesting()
+    counts = await probe.counts()
+    XCTAssertEqual(counts.uploads, 1, "Only three new failures of the same required table recover it")
+  }
+
+  func testMalformedAndNonSuccessHealthNeverUpload() async {
+    let probe = AgentSyncRecoveryProbe()
+    await probe.setHealthResponse(.malformed)
+    let service = makeService(probe: probe)
+    await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
+
+    for _ in 0..<3 { await service.syncOnceForTesting() }
+    var counts = await probe.counts()
+    XCTAssertEqual(counts.healthChecks, 1)
+    XCTAssertEqual(counts.uploads, 0)
+
+    await probe.setHealthResponse(.status(503))
+    await service.syncOnceForTesting()
+    counts = await probe.counts()
+    XCTAssertEqual(counts.uploads, 0, "Non-2xx health responses fail closed before upload")
+  }
+
+  func testSameOwnerRestartPreservesCooldownAndFailedUploadsStayBounded() async {
+    let probe = AgentSyncRecoveryProbe()
+    await probe.setUploadResults([false, false, false])
+    let clock = AgentSyncManualClock()
+    let service = makeService(probe: probe, clock: clock)
+    await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
+
+    for _ in 0..<3 { await service.syncOnceForTesting() }
+    var counts = await probe.counts()
+    XCTAssertEqual(counts.uploads, 1)
+
+    await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
+    await service.syncOnceForTesting()
+    counts = await probe.counts()
+    XCTAssertEqual(counts.uploads, 1, "Same-owner restart cannot mint a new cooldown allowance")
+
+    clock.advance(30 * 60 + 1)
+    await service.syncOnceForTesting()
+    counts = await probe.counts()
+    XCTAssertEqual(counts.uploads, 2)
+
+    clock.advance(30 * 60 + 1)
+    await service.syncOnceForTesting()
+    counts = await probe.counts()
+    XCTAssertEqual(counts.uploads, 2, "Failed recovery uploads stop at the existing bounded policy")
+  }
+
+  private func makeService(
+    probe: AgentSyncRecoveryProbe,
+    clock: AgentSyncManualClock = AgentSyncManualClock()
+  ) -> AgentSyncService {
+    AgentSyncService(
+      networkHooks: AgentSyncService.NetworkHooks(
+        fetchIDToken: { "test-firebase-token" },
+        dataForRequest: { request in try await probe.respond(to: request) },
+        reuploadDatabase: { _, _ in await probe.reupload() },
+        now: { clock.now() },
+        tableSyncEnabled: true))
+  }
+
+  private func insertSyncRows() async throws {
+    guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+      return XCTFail("Rewind database should be initialized")
+    }
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    try await dbQueue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO transcription_sessions (startedAt, source, createdAt, updatedAt)
+          VALUES (?, ?, ?, ?)
+          """,
+        arguments: [now, "desktop", now, now])
+      try db.execute(
+        sql: """
+          INSERT INTO action_items (description, createdAt, updatedAt)
+          VALUES (?, ?, ?)
+          """,
+        arguments: ["mixed-success control", now, now])
+    }
+  }
+
+  private func touchTranscriptionSession() async throws {
+    guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+      return XCTFail("Rewind database should be initialized")
+    }
+    try await dbQueue.write { db in
+      try db.execute(
+        sql: "UPDATE transcription_sessions SET updatedAt = ? WHERE id = 1",
+        arguments: [Date(timeIntervalSince1970: 1_700_000_001)])
+    }
   }
 }

--- a/desktop/macos/Desktop/Tests/ChatJournalWritePathTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatJournalWritePathTests.swift
@@ -149,6 +149,34 @@ final class ChatJournalWritePathTests: XCTestCase {
     XCTAssertEqual(attempts, 2, "A persistent journal failure must not retry indefinitely")
   }
 
+  func testAcceptedTerminalContentWinsOverStaleStreamingProjection() {
+    let full = "RELAUNCH-PERSIST-1784573311"
+    let staleStreamingMessage = ChatMessage(
+      id: "attempt-relaunch-assistant",
+      text: "RELAUNCH-PERSIST-1",
+      sender: .ai,
+      isStreaming: true
+    )
+
+    XCTAssertEqual(
+      KernelTurnProjection.acceptedTerminalContent(
+        message: staleStreamingMessage,
+        acceptedContent: full
+      ),
+      full,
+      "The accepted agent result, not a stale UI streaming buffer, is canonical terminal content"
+    )
+    let blocks = KernelTurnProjection.acceptedTerminalContentBlocks(
+      message: staleStreamingMessage,
+      acceptedContent: full
+    )
+    XCTAssertEqual(
+      ChatContentBlockCodec.encode(blocks),
+      ChatContentBlockCodec.encode([
+        .text(id: "attempt-relaunch-assistant:terminal", text: full)
+      ]))
+  }
+
   // MARK: - Bug 2: projection preserves local-only fields across replay
 
   func testProjectionPreservesLocalOnlyFieldsAcrossTerminalReplay() throws {

--- a/desktop/macos/Desktop/Tests/ChatJournalWritePathTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatJournalWritePathTests.swift
@@ -149,32 +149,67 @@ final class ChatJournalWritePathTests: XCTestCase {
     XCTAssertEqual(attempts, 2, "A persistent journal failure must not retry indefinitely")
   }
 
-  func testAcceptedTerminalContentWinsOverStaleStreamingProjection() {
+  func testAcceptedTerminalPayloadWinsOverStaleStreamingProjection() {
     let full = "RELAUNCH-PERSIST-1784573311"
+    let retainedResource = ChatResource.localGeneratedFile(
+      id: "artifact:relaunch",
+      title: "durable-result.txt",
+      subtitle: "text/plain",
+      mimeType: "text/plain",
+      uri: "file:///tmp/durable-result.txt")
     let staleStreamingMessage = ChatMessage(
       id: "attempt-relaunch-assistant",
       text: "RELAUNCH-PERSIST-1",
       sender: .ai,
-      isStreaming: true
+      isStreaming: true,
+      contentBlocks: [
+        .text(id: "attempt-relaunch-assistant:stream", text: "RELAUNCH-PERSIST-1"),
+        .thinking(id: "attempt-relaunch-assistant:thinking", text: "Retain this non-text block"),
+      ],
+      resources: [retainedResource]
     )
 
-    XCTAssertEqual(
-      KernelTurnProjection.acceptedTerminalContent(
-        message: staleStreamingMessage,
-        acceptedContent: full
-      ),
-      full,
-      "The accepted agent result, not a stale UI streaming buffer, is canonical terminal content"
-    )
+    let terminalText = KernelTurnProjection.acceptedTerminalContent(
+      message: staleStreamingMessage,
+      acceptedContent: full)
     let blocks = KernelTurnProjection.acceptedTerminalContentBlocks(
       message: staleStreamingMessage,
       acceptedContent: full
     )
     XCTAssertEqual(
-      ChatContentBlockCodec.encode(blocks),
-      ChatContentBlockCodec.encode([
-        .text(id: "attempt-relaunch-assistant:terminal", text: full)
-      ]))
+      terminalText, full, "The accepted agent result, not a stale UI buffer, is canonical terminal content")
+    XCTAssertEqual(blocks.count, 2)
+    guard case .text(let id, let text) = blocks[0] else {
+      return XCTFail("Terminal payload must start with one authoritative text block")
+    }
+    XCTAssertEqual(id, "attempt-relaunch-assistant:terminal")
+    XCTAssertEqual(text, full)
+    guard case .thinking(let thinkingID, let thinkingText) = blocks[1] else {
+      return XCTFail("Terminal payload must retain non-text streaming blocks")
+    }
+    XCTAssertEqual(thinkingID, "attempt-relaunch-assistant:thinking")
+    XCTAssertEqual(thinkingText, "Retain this non-text block")
+    XCTAssertEqual(staleStreamingMessage.displayResources, [retainedResource])
+  }
+
+  func testEmptyAcceptedContentKeepsTheIntentionalStreamingProjection() {
+    let message = ChatMessage(
+      id: "attempt-empty-terminal",
+      text: "intentional partial response",
+      sender: .ai,
+      isStreaming: true,
+      contentBlocks: [.text(id: "attempt-empty-terminal:stream", text: "intentional partial response")]
+    )
+
+    XCTAssertEqual(
+      KernelTurnProjection.acceptedTerminalContent(message: message, acceptedContent: ""),
+      "intentional partial response")
+    let blocks = KernelTurnProjection.acceptedTerminalContentBlocks(message: message, acceptedContent: "")
+    guard let first = blocks.first, case .text(let id, let text) = first else {
+      return XCTFail("An intentional empty result must keep the current structured projection")
+    }
+    XCTAssertEqual(id, "attempt-empty-terminal:stream")
+    XCTAssertEqual(text, "intentional partial response")
   }
 
   // MARK: - Bug 2: projection preserves local-only fields across replay

--- a/desktop/macos/agent/tests/conversation-journal.test.ts
+++ b/desktop/macos/agent/tests/conversation-journal.test.ts
@@ -409,14 +409,34 @@ describe("kernel conversation journal", () => {
     const stateDir = newStateDir();
     const store = new SqliteAgentStore({ stateDir, reconcileOnOpen: false });
     const fixture = insertSurface(store, "main_chat", "chat", "lost-terminal-ack");
-    const continuityKey = "logical-turn:lost-terminal-ack";
-    const userTurnId = `turn:${continuityKey}:user`;
-    const assistantTurnId = `turn:${continuityKey}:assistant`;
+    // Keep these identical to ChatProvider.messageIds(forAttemptId:): the
+    // attempt is the user identity and its `-assistant` suffix is the peer.
+    const attemptId = "RELAUNCH-PERSIST-1784573311";
+    const userTurnId = attemptId;
+    const assistantTurnId = `${attemptId}-assistant`;
+    const fullText = "RELAUNCH-PERSIST-1784573311";
+    const preservedSpawn = {
+      type: "agentSpawn" as const,
+      id: "lost-ack:spawn",
+      sessionId: fixture.sessionId,
+      runId: "run_lost_terminal_ack",
+      title: "Durable child",
+      objective: "Preserve the child card across terminal replay",
+    };
+    const terminalResource = {
+      id: "artifact:lost-terminal-ack",
+      origin: "generatedArtifact" as const,
+      title: "durable-result.txt",
+      state: "retained" as const,
+      artifactId: "artifact-lost-terminal-ack",
+      sessionId: fixture.sessionId,
+      runId: "run_lost_terminal_ack",
+    };
     const run = store.insertRun({
       sessionId: fixture.sessionId,
       runId: "run_lost_terminal_ack",
       clientId: "main-chat",
-      requestId: continuityKey,
+      requestId: attemptId,
       status: "succeeded",
       mode: "act",
     });
@@ -438,8 +458,8 @@ describe("kernel conversation journal", () => {
           surfaceKind: "main_chat",
           origin: "typed_chat" as const,
           status: "completed" as const,
-          content: "What survived the retry?",
-          contentBlocks: [{ type: "text" as const, id: "lost-ack:user", text: "What survived the retry?" }],
+          content: "Echo the durable nonce.",
+          contentBlocks: [{ type: "text" as const, id: "lost-ack:user", text: "Echo the durable nonce." }],
           createdAtMs: 10,
         },
         {
@@ -448,8 +468,11 @@ describe("kernel conversation journal", () => {
           surfaceKind: "main_chat",
           origin: "typed_chat" as const,
           status: "streaming" as const,
-          content: "",
-          contentBlocks: [],
+          content: "RELAUNCH-PERSIST-1",
+          contentBlocks: [
+            { type: "text" as const, id: "lost-ack:stream", text: "RELAUNCH-PERSIST-1" },
+            preservedSpawn,
+          ],
           producingRunId: run.runId,
           producingAttemptId: attempt.attemptId,
           createdAtMs: 11,
@@ -468,12 +491,13 @@ describe("kernel conversation journal", () => {
       producingRunId: run.runId,
       producingAttemptId: attempt.attemptId,
       disposition: "accept" as const,
-      content: "The canonical user and assistant turns.",
+      content: fullText,
       replaceContentBlocks: [{
         type: "text" as const,
         id: "lost-ack:assistant",
-        text: "The canonical user and assistant turns.",
+        text: fullText,
       }],
+      replaceResources: [terminalResource],
       nowMs: 12,
     };
     void terminalizeJournalTurn(store, terminalization); // terminal response lost after durable commit
@@ -484,25 +508,50 @@ describe("kernel conversation journal", () => {
     store.close();
 
     const relaunched = new SqliteAgentStore({ stateDir, reconcileOnOpen: false });
-    // `listJournalTurns` is an append-only revision replay (the streaming
-    // assistant revision is intentionally followed by its terminal revision).
-    // Durable logical rows live in `conversation_turns`; replay consumers
-    // upsert by turnId and therefore must still observe exactly one pair.
+    // Durable logical rows own canonical identity; revisions are deliberately
+    // append-only and must replay in sequence rather than through an ad hoc Map.
     expect(relaunched.allRows(
       "SELECT turn_id, role, status FROM conversation_turns WHERE conversation_id = ? ORDER BY turn_id",
       [fixture.conversationId],
     )).toEqual([
-      { turn_id: assistantTurnId, role: "assistant", status: "completed" },
       { turn_id: userTurnId, role: "user", status: "completed" },
+      { turn_id: assistantTurnId, role: "assistant", status: "completed" },
     ]);
     const replay = listJournalTurns(relaunched, {
       ownerId: fixture.ownerId,
       conversationId: fixture.conversationId,
     }).turns;
-    const canonicalReplay = new Map(replay.map((turn) => [turn.turnId, turn]));
-    expect(canonicalReplay.size).toBe(2);
-    expect(canonicalReplay.get(userTurnId)).toMatchObject({ role: "user", status: "completed" });
-    expect(canonicalReplay.get(assistantTurnId)).toMatchObject({ role: "assistant", status: "completed" });
+    expect(replay.map((turn) => [turn.turnId, turn.status])).toEqual([
+      [userTurnId, "completed"],
+      [assistantTurnId, "streaming"],
+      [assistantTurnId, "completed"],
+    ]);
+    const canonicalUser = relaunched.getRow(
+      "SELECT turn_id, role, status, content FROM conversation_turns WHERE conversation_id = ? AND turn_id = ?",
+      [fixture.conversationId, userTurnId],
+    );
+    const canonicalAssistant = relaunched.getRow(
+      `SELECT turn_id, role, status, content, content_blocks_json, resources_json
+       FROM conversation_turns WHERE conversation_id = ? AND turn_id = ?`,
+      [fixture.conversationId, assistantTurnId],
+    );
+    expect(canonicalUser).toMatchObject({
+      turn_id: userTurnId,
+      role: "user",
+      status: "completed",
+    });
+    expect(canonicalAssistant).toMatchObject({
+      turn_id: assistantTurnId,
+      role: "assistant",
+      status: "completed",
+      content: fullText,
+    });
+    expect(JSON.parse(String(canonicalAssistant.content_blocks_json))).toEqual([
+      { type: "text", id: "lost-ack:assistant", text: fullText },
+      preservedSpawn,
+    ]);
+    expect(JSON.parse(String(canonicalAssistant.resources_json))).toEqual([terminalResource]);
+    expect(String(canonicalAssistant.content)).not.toBe("RELAUNCH-PERSIST-1");
     relaunched.close();
   });
 

--- a/desktop/macos/agent/tests/conversation-journal.test.ts
+++ b/desktop/macos/agent/tests/conversation-journal.test.ts
@@ -405,6 +405,107 @@ describe("kernel conversation journal", () => {
     fixture.store.close();
   });
 
+  it("keeps one logical exchange durable across a lost terminal acknowledgement and relaunch", () => {
+    const stateDir = newStateDir();
+    const store = new SqliteAgentStore({ stateDir, reconcileOnOpen: false });
+    const fixture = insertSurface(store, "main_chat", "chat", "lost-terminal-ack");
+    const continuityKey = "logical-turn:lost-terminal-ack";
+    const userTurnId = `turn:${continuityKey}:user`;
+    const assistantTurnId = `turn:${continuityKey}:assistant`;
+    const run = store.insertRun({
+      sessionId: fixture.sessionId,
+      runId: "run_lost_terminal_ack",
+      clientId: "main-chat",
+      requestId: continuityKey,
+      status: "succeeded",
+      mode: "act",
+    });
+    const attempt = store.insertAttempt({
+      attemptId: "att_lost_terminal_ack",
+      runId: run.runId,
+      attemptNo: 1,
+      status: "succeeded",
+      adapterId: "fake",
+      adapterInstanceId: "fake:lost-terminal-ack",
+    });
+    const exchange = {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      turns: [
+        {
+          turnId: userTurnId,
+          role: "user" as const,
+          surfaceKind: "main_chat",
+          origin: "typed_chat" as const,
+          status: "completed" as const,
+          content: "What survived the retry?",
+          contentBlocks: [{ type: "text" as const, id: "lost-ack:user", text: "What survived the retry?" }],
+          createdAtMs: 10,
+        },
+        {
+          turnId: assistantTurnId,
+          role: "assistant" as const,
+          surfaceKind: "main_chat",
+          origin: "typed_chat" as const,
+          status: "streaming" as const,
+          content: "",
+          contentBlocks: [],
+          producingRunId: run.runId,
+          producingAttemptId: attempt.attemptId,
+          createdAtMs: 11,
+        },
+      ],
+    };
+
+    expect(recordJournalExchange(store, exchange).createdTurns).toHaveLength(2);
+    // The kernel committed before the caller lost its terminal RPC response.
+    // Replaying the same stable logical IDs is the bounded retry, not another write.
+    expect(recordJournalExchange(store, exchange).createdTurns).toHaveLength(0);
+    const terminalization = {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      turnId: assistantTurnId,
+      producingRunId: run.runId,
+      producingAttemptId: attempt.attemptId,
+      disposition: "accept" as const,
+      content: "The canonical user and assistant turns.",
+      replaceContentBlocks: [{
+        type: "text" as const,
+        id: "lost-ack:assistant",
+        text: "The canonical user and assistant turns.",
+      }],
+      nowMs: 12,
+    };
+    void terminalizeJournalTurn(store, terminalization); // terminal response lost after durable commit
+    expect(terminalizeJournalTurn(store, { ...terminalization, nowMs: 13 })).toMatchObject({
+      turnId: assistantTurnId,
+      status: "completed",
+    });
+    store.close();
+
+    const relaunched = new SqliteAgentStore({ stateDir, reconcileOnOpen: false });
+    // `listJournalTurns` is an append-only revision replay (the streaming
+    // assistant revision is intentionally followed by its terminal revision).
+    // Durable logical rows live in `conversation_turns`; replay consumers
+    // upsert by turnId and therefore must still observe exactly one pair.
+    expect(relaunched.allRows(
+      "SELECT turn_id, role, status FROM conversation_turns WHERE conversation_id = ? ORDER BY turn_id",
+      [fixture.conversationId],
+    )).toEqual([
+      { turn_id: assistantTurnId, role: "assistant", status: "completed" },
+      { turn_id: userTurnId, role: "user", status: "completed" },
+    ]);
+    const replay = listJournalTurns(relaunched, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+    }).turns;
+    const canonicalReplay = new Map(replay.map((turn) => [turn.turnId, turn]));
+    expect(canonicalReplay.size).toBe(2);
+    expect(canonicalReplay.get(userTurnId)).toMatchObject({ role: "user", status: "completed" });
+    expect(canonicalReplay.get(assistantTurnId)).toMatchObject({ role: "assistant", status: "completed" });
+    relaunched.close();
+  });
+
   it("rejects stale, unknown, and nonterminal attempt proofs without mutating the turn", () => {
     const fixture = newSurface("task_chat", "task", "terminal-authority");
     const run = fixture.store.insertRun({

--- a/desktop/macos/changelog/unreleased/20260720-agent-vm-schema-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260720-agent-vm-schema-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved recovery when an agent VM starts with an incomplete local database"
+}


### PR DESCRIPTION
## Summary

- Keep partial Agent VM schema recovery table-scoped, owner/generation-bound, and independent from aggregate sync success.
- Keep accepted terminal query text authoritative over stale streaming text, with structured Swift and canonical journal replay coverage.

## Verification

- `xcrun swift test --package-path Desktop --filter 'AgentSyncBatchQueryTests|AgentSyncRecoveryTests|ChatJournalWritePathTests'` — 20 passed.
- `npm test -- --run tests/conversation-journal.test.ts` — 41 passed.
- `ChatJournalWritePathTests` repeated 20 times — 20/20 passed.
- `./scripts/agent-logic-harness.sh` — passed (32.65s).
- `./scripts/desktop-core-harness.sh --self-check` — passed.
- `python3 scripts/check_desktop_test_quality.py` — passed.
- `make preflight` — 35 checks passed at final head.
- `scripts/pr-preflight --pr-body-file /tmp/pr10148-body.md` — 22 checks passed before the final base rebase; final `make preflight` validated current PR metadata/body with 35 checks.
- Named-bundle bridge smoke at final head `075b41b47baae5848fa52f4bd6ed8b7d4b028ada`: `/Applications/omi-golden-pr10148.app`, `com.omi.omi-golden-pr10148`, port `47794` — bridge healthy; it reports the expected isolated signed-out/cold profile.

## Known limitation

This PR deliberately uses layered proof rather than a bridge-level fault injector or general test transport. The AgentSync tests drive the production sync tick through a DEBUG-only seam; the Chat proof uses structured Swift payload tests and the actual canonical journal replay. The exact final head was built and launched as the isolated named bundle above, but its approved auth seed had no signed-in source session, so a live nonce echo was not possible. The closest deterministic terminalization fixture (`chat-hermetic`, local offline stack plus Rust stub) could not start because a foreign Firestore emulator already owns its fixed port 8085; no foreign process was stopped. Therefore this PR does not claim live or fixture terminal/relaunch E2E success and remains draft for independent review.

## Product invariants

- INV-AUTH-1
- INV-AGENT-*
- INV-CHAT-1
- INV-INT-1
- INV-VOICE-1

Failure-Class: FC-split-mutation-authority
