### PR TITLE
fix(desktop): refresh home totals and paginate conversations

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
@@ -1,11 +1,11 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1621,
+    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1631,
     "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3510,
     "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": 1856
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": "Surfaced task ids (backend id or local_<rowid>) resolve through one shared identity helper, so mutating an unsynced task no longer no-ops or throws recordNotFound.",
+    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": "Task visibility writes now emit the shared Home-count invalidation after logging, so Dashboard totals refresh without waiting for an activation cooldown.",
     "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": "Nullable screenshot capture provenance preserves the canonical-memory device identity and prevents multi-Mac screen activity from overwriting local row IDs.",
     "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": "Search-result rows load a downsampled ImageIO thumbnail instead of the full-resolution screenshot, so a long results list no longer retains full-size images behind a 120x80 view."
   },

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1631,
+    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1643,
     "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3510,
     "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": 1856
   },

--- a/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
@@ -27,6 +27,14 @@ extension AppState {
     NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
   }
 
+  var canLoadMoreConversations: Bool {
+    conversationRepository.hasMore
+  }
+
+  func loadMoreConversations() async {
+    await conversationRepository.loadMore()
+  }
+
   /// Optimistically update star state, then settle from the canonical mutation response.
   func setConversationStarred(_ conversationId: String, starred: Bool) async {
     do {

--- a/desktop/macos/Desktop/Sources/MainWindow/Conversations/ConversationRepository.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Conversations/ConversationRepository.swift
@@ -70,7 +70,7 @@ struct ConversationRepositorySnapshot: Equatable {
 }
 
 protocol ConversationRemoteDataSource: Sendable {
-  func list(query: ConversationListQuery) async throws -> [ServerConversation]
+  func list(query: ConversationListQuery, offset: Int, limit: Int) async throws -> [ServerConversation]
   func count(query: ConversationListQuery) async throws -> Int
   func detail(id: String) async throws -> ServerConversation
   func search(text: String) async throws -> [ServerConversation]
@@ -97,11 +97,11 @@ protocol ConversationLocalDataSource: Sendable {
 }
 
 struct LiveConversationRemoteDataSource: ConversationRemoteDataSource {
-  func list(query: ConversationListQuery) async throws -> [ServerConversation] {
+  func list(query: ConversationListQuery, offset: Int, limit: Int) async throws -> [ServerConversation] {
     let range = query.dateRange
     return try await APIClient.shared.getConversations(
-      limit: 50,
-      offset: 0,
+      limit: limit,
+      offset: offset,
       statuses: [.completed, .processing],
       includeDiscarded: false,
       startDate: range.start,
@@ -255,9 +255,12 @@ final class ConversationRepository {
   private var mutationWaiters: [String: [MutationWaiter]] = [:]
   private var deletionTokens: [String: UUID] = [:]
   private var currentQuery: ConversationListQuery?
+  private var nextPageOffset = 0
+  private var isLoadingMore = false
 
   private(set) var conversations: [ServerConversation] = []
   private(set) var count: Int?
+  private(set) var hasMore = false
   private(set) var isLoading = false
   private(set) var error: String?
   var onSnapshot: ((ConversationRepositorySnapshot) -> Void)?
@@ -290,6 +293,13 @@ final class ConversationRepository {
     self.init(remote: LiveConversationRemoteDataSource(), local: LiveConversationLocalDataSource())
   }
 
+  private static let pageSize = 50
+
+  private static func hasMorePages(loaded: Int, pageSize: Int, totalCount: Int?, received: Int) -> Bool {
+    guard received == pageSize else { return false }
+    return totalCount.map { loaded < $0 } ?? true
+  }
+
   func load(query: ConversationListQuery, includeCache: Bool = true) async {
     let session = cacheWriteScope.capture()
     requestGeneration += 1
@@ -301,6 +311,8 @@ final class ConversationRepository {
     if queryChanged {
       conversations = []
       count = nil
+      nextPageOffset = 0
+      hasMore = false
       emit(.cache)
     }
 
@@ -328,7 +340,7 @@ final class ConversationRepository {
     }
 
     do {
-      async let listTask = remote.list(query: query)
+      async let listTask = remote.list(query: query, offset: 0, limit: Self.pageSize)
       async let countTask = remote.count(query: query)
       let server = try await listTask
       let serverCount = try? await countTask
@@ -347,6 +359,13 @@ final class ConversationRepository {
       mutationBaselines = mutationBaselines.filter { pendingMutations[$0.key] != nil }
       conversations = result.conversations
       count = serverCount ?? count
+      nextPageOffset = server.count
+      hasMore = Self.hasMorePages(
+        loaded: nextPageOffset,
+        pageSize: Self.pageSize,
+        totalCount: count,
+        received: server.count
+      )
       isLoading = false
       emit(.server)
       await storeInBackground(server, session: session)
@@ -362,6 +381,49 @@ final class ConversationRepository {
 
   func refresh(query: ConversationListQuery) async {
     await load(query: query, includeCache: false)
+  }
+
+  /// Fetch the next server page without discarding conversations already visible.
+  /// The backend owns each returned row; the existing page order remains stable.
+  func loadMore() async {
+    guard let query = currentQuery, hasMore, !isLoading, !isLoadingMore else { return }
+
+    let session = cacheWriteScope.capture()
+    requestGeneration += 1
+    let generation = requestGeneration
+    let offset = nextPageOffset
+    isLoadingMore = true
+    defer { isLoadingMore = false }
+
+    do {
+      let server = try await remote.list(query: query, offset: offset, limit: Self.pageSize)
+      guard generation == requestGeneration, currentQuery == query else { return }
+
+      let result = ConversationReconciliationPolicy.mergeList(
+        server: server,
+        current: [],
+        pendingMutations: pendingMutations,
+        pendingMutationTTL: .greatestFiniteMagnitude
+      )
+      for conversation in server where result.pendingMutations[conversation.id] != nil {
+        updateMutationBaseline(id: conversation.id, canonical: conversation)
+      }
+      pendingMutations = result.pendingMutations
+      mutationBaselines = mutationBaselines.filter { pendingMutations[$0.key] != nil }
+      mergeNextPage(result.conversations)
+      nextPageOffset = offset + server.count
+      hasMore = Self.hasMorePages(
+        loaded: nextPageOffset,
+        pageSize: Self.pageSize,
+        totalCount: count,
+        received: server.count
+      )
+      emit(.server)
+      await storeInBackground(server, session: session)
+    } catch {
+      guard generation == requestGeneration else { return }
+      emit(.server)
+    }
   }
 
   func search(text: String) async throws -> [ServerConversation] {
@@ -483,11 +545,29 @@ final class ConversationRepository {
     deletionTokens = [:]
     conversations = []
     count = nil
+    nextPageOffset = 0
+    hasMore = false
+    isLoadingMore = false
     error = nil
     isLoading = false
     pendingMutations = [:]
     mutationBaselines = [:]
     emit(.server)
+  }
+
+  private func mergeNextPage(_ page: [ServerConversation]) {
+    var indexByID = [String: Int]()
+    for (index, conversation) in conversations.enumerated() {
+      indexByID[conversation.id] = index
+    }
+    for conversation in page {
+      if let index = indexByID[conversation.id] {
+        conversations[index] = conversation
+      } else {
+        indexByID[conversation.id] = conversations.count
+        conversations.append(conversation)
+      }
+    }
   }
 
   private func mutate(

--- a/desktop/macos/Desktop/Sources/MainWindow/Conversations/ConversationRepository.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Conversations/ConversationRepository.swift
@@ -260,6 +260,7 @@ final class ConversationRepository {
 
   private(set) var conversations: [ServerConversation] = []
   private(set) var count: Int?
+  private var isCountAuthoritative = false
   private(set) var hasMore = false
   private(set) var isLoading = false
   private(set) var error: String?
@@ -308,6 +309,9 @@ final class ConversationRepository {
     currentQuery = query
     isLoading = true
     error = nil
+    // A cached count is useful for display but must never suppress a full
+    // server page when the authoritative count request is unavailable.
+    isCountAuthoritative = false
     if queryChanged {
       conversations = []
       count = nil
@@ -358,12 +362,15 @@ final class ConversationRepository {
       pendingMutations = result.pendingMutations
       mutationBaselines = mutationBaselines.filter { pendingMutations[$0.key] != nil }
       conversations = result.conversations
-      count = serverCount ?? count
+      if let serverCount {
+        count = serverCount
+        isCountAuthoritative = true
+      }
       nextPageOffset = server.count
       hasMore = Self.hasMorePages(
         loaded: nextPageOffset,
         pageSize: Self.pageSize,
-        totalCount: count,
+        totalCount: isCountAuthoritative ? count : nil,
         received: server.count
       )
       isLoading = false
@@ -415,7 +422,7 @@ final class ConversationRepository {
       hasMore = Self.hasMorePages(
         loaded: nextPageOffset,
         pageSize: Self.pageSize,
-        totalCount: count,
+        totalCount: isCountAuthoritative ? count : nil,
         received: server.count
       )
       emit(.server)
@@ -545,6 +552,7 @@ final class ConversationRepository {
     deletionTokens = [:]
     conversations = []
     count = nil
+    isCountAuthoritative = false
     nextPageOffset = 0
     hasMore = false
     isLoadingMore = false

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -396,6 +396,17 @@ struct ConversationsPage: View {
             appState: appState
           )
 
+          if appState.canLoadMoreConversations {
+            Button("Load older conversations") {
+              Task {
+                await appState.loadMoreConversations()
+              }
+            }
+            .buttonStyle(.bordered)
+            .padding(.bottom, OmiSpacing.md)
+            .accessibilityIdentifier("conversations-load-more")
+          }
+
           // Floating merge action bar
           if isMultiSelectMode && !selectedConversationIds.isEmpty {
             mergeActionBar

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -396,7 +396,7 @@ struct ConversationsPage: View {
             appState: appState
           )
 
-          if appState.canLoadMoreConversations {
+          if appState.canLoadMoreConversations && !(isMultiSelectMode && !selectedConversationIds.isEmpty) {
             Button("Load older conversations") {
               Task {
                 await appState.loadMoreConversations()

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/HomeStatusStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/HomeStatusStore.swift
@@ -138,6 +138,7 @@ final class HomeStatusStore: ObservableObject {
       .store(in: &cancellables)
 
     NotificationCenter.default.publisher(for: .homeKnowledgeCountsDidChange)
+      .receive(on: DispatchQueue.main)
       .sink { [weak self] _ in
         self?.refreshKnowledgeCountsAfterImport()
       }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/HomeStatusStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/HomeStatusStore.swift
@@ -1,6 +1,23 @@
 import Combine
 import Foundation
 
+extension Notification.Name {
+  /// Posted after local memory/task visibility changes so Home never waits for
+  /// the activation cooldown before showing the new totals.
+  static let homeKnowledgeCountsDidChange = Notification.Name("com.omi.desktop.homeKnowledgeCountsDidChange")
+}
+
+enum HomeKnowledgeCountInvalidation {
+  static func post() {
+    NotificationCenter.default.post(name: .homeKnowledgeCountsDidChange, object: nil)
+  }
+
+  static func post(logMessage: @autoclosure () -> String) {
+    log(logMessage())
+    post()
+  }
+}
+
 struct HomeKnowledgeCounts: Equatable, Sendable {
   let conversations: Int?
   let memories: Int?
@@ -76,6 +93,8 @@ final class HomeStatusStore: ObservableObject {
   private var refreshTask: Task<Void, Never>?
   private var refreshID: UUID?
   private var latestKnowledgeRefreshID: UUID?
+  private var knowledgeRefreshTask: Task<Void, Never>?
+  private var knowledgeRefreshQueued = false
   private var refreshGeneration = 0
   private var cancellables = Set<AnyCancellable>()
 
@@ -113,6 +132,12 @@ final class HomeStatusStore: ObservableObject {
       .store(in: &cancellables)
 
     connectorStatusStore.connectorDidSync
+      .sink { [weak self] _ in
+        self?.refreshKnowledgeCountsAfterImport()
+      }
+      .store(in: &cancellables)
+
+    NotificationCenter.default.publisher(for: .homeKnowledgeCountsDidChange)
       .sink { [weak self] _ in
         self?.refreshKnowledgeCountsAfterImport()
       }
@@ -176,6 +201,9 @@ final class HomeStatusStore: ObservableObject {
     refreshTask = nil
     refreshID = nil
     latestKnowledgeRefreshID = nil
+    knowledgeRefreshTask?.cancel()
+    knowledgeRefreshTask = nil
+    knowledgeRefreshQueued = false
     lastRefreshAt = .distantPast
     localDatabaseReady = false
     screenshotCount = nil
@@ -222,17 +250,36 @@ final class HomeStatusStore: ObservableObject {
   }
 
   private func refreshKnowledgeCountsAfterImport() {
+    ensureCurrentSessionScope()
+    guard knowledgeRefreshTask == nil else {
+      knowledgeRefreshQueued = true
+      return
+    }
+
     let generation = refreshGeneration
     let knowledgeRefreshID = beginKnowledgeRefresh()
-    Task { [weak self] in
+    let task = Task { [weak self] in
       guard let self else { return }
       let counts = await self.loader.loadKnowledgeCounts(!self.accountHasOmiDeviceConversations)
       guard !Task.isCancelled,
         generation == self.refreshGeneration,
         knowledgeRefreshID == self.latestKnowledgeRefreshID
-      else { return }
+      else {
+        self.completeKnowledgeRefresh(id: knowledgeRefreshID)
+        return
+      }
       self.apply(knowledgeCounts: counts)
+      self.completeKnowledgeRefresh(id: knowledgeRefreshID)
     }
+    knowledgeRefreshTask = task
+  }
+
+  private func completeKnowledgeRefresh(id: UUID) {
+    guard id == latestKnowledgeRefreshID else { return }
+    knowledgeRefreshTask = nil
+    guard knowledgeRefreshQueued else { return }
+    knowledgeRefreshQueued = false
+    refreshKnowledgeCountsAfterImport()
   }
 
   private func beginKnowledgeRefresh() -> UUID {

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -553,11 +553,12 @@ actor ActionItemStorage {
     try authorization.require()
     let db = try await ensureInitialized()
 
-    let (skipped, adopted) = try await authorization.withCommitLease {
-      try await db.write { database -> (Int, Int) in
+    let (skipped, adopted, visibilityChanged) = try await authorization.withCommitLease {
+      try await db.write { database -> (Int, Int, Bool) in
         try authorization.require()
         var skipped = 0
         var adopted = 0
+        var visibilityChanged = false
         for item in items {
           if var existingRecord =
             try ActionItemRecord
@@ -577,7 +578,10 @@ actor ActionItemStorage {
               skipped += 1
               continue
             }
+            let wasVisible = !existingRecord.completed && !existingRecord.deleted
             existingRecord.updateFrom(item)
+            visibilityChanged =
+              visibilityChanged || wasVisible != (!existingRecord.completed && !existingRecord.deleted)
             try existingRecord.update(database)
           } else if var orphan =
             try ActionItemRecord
@@ -594,9 +598,11 @@ actor ActionItemStorage {
             // and a stricter match here causes the orphan to never be adopted,
             // leaving the manual unsynced and producing a duplicate row on every
             // pull that returns the same task.
+            let wasVisible = !orphan.completed && !orphan.deleted
             orphan.backendId = item.id
             orphan.backendSynced = true
             orphan.updateFrom(item)
+            visibilityChanged = visibilityChanged || wasVisible != (!orphan.completed && !orphan.deleted)
             try orphan.update(database)
             adopted += 1
           } else {
@@ -613,22 +619,28 @@ actor ActionItemStorage {
               newRecord.relevanceScore = maxScore + 1
               newRecord.scoredAt = Date()
             }
+            if !newRecord.completed && !newRecord.deleted {
+              visibilityChanged = true
+            }
             try newRecord.insert(database)
           }
         }
         try authorization.require()
-        return (skipped, adopted)
+        return (skipped, adopted, visibilityChanged)
       }
     }
 
+    let message: String
     if skipped > 0 || adopted > 0 {
-      HomeKnowledgeCountInvalidation.post(
-        logMessage:
-          "ActionItemStorage: Synced \(items.count) task action items from backend (skipped \(skipped) newer local, adopted \(adopted) orphans)"
-      )
+      message =
+        "ActionItemStorage: Synced \(items.count) task action items from backend (skipped \(skipped) newer local, adopted \(adopted) orphans)"
     } else {
-      HomeKnowledgeCountInvalidation.post(
-        logMessage: "ActionItemStorage: Synced \(items.count) task action items from backend")
+      message = "ActionItemStorage: Synced \(items.count) task action items from backend"
+    }
+    if visibilityChanged {
+      HomeKnowledgeCountInvalidation.post(logMessage: message)
+    } else {
+      log(message)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -622,11 +622,13 @@ actor ActionItemStorage {
     }
 
     if skipped > 0 || adopted > 0 {
-      log(
-        "ActionItemStorage: Synced \(items.count) task action items from backend (skipped \(skipped) newer local, adopted \(adopted) orphans)"
+      HomeKnowledgeCountInvalidation.post(
+        logMessage:
+          "ActionItemStorage: Synced \(items.count) task action items from backend (skipped \(skipped) newer local, adopted \(adopted) orphans)"
       )
     } else {
-      log("ActionItemStorage: Synced \(items.count) task action items from backend")
+      HomeKnowledgeCountInvalidation.post(
+        logMessage: "ActionItemStorage: Synced \(items.count) task action items from backend")
     }
   }
 
@@ -698,7 +700,9 @@ actor ActionItemStorage {
     }
 
     if reconciled > 0 {
-      log("ActionItemStorage: Reconciled \(reconciled) dashboard visibility fields from backend")
+      HomeKnowledgeCountInvalidation.post(
+        logMessage: "ActionItemStorage: Reconciled \(reconciled) dashboard visibility fields from backend"
+      )
     }
     return reconciled
   }
@@ -743,7 +747,9 @@ actor ActionItemStorage {
     }
 
     if deleted > 0 {
-      log("ActionItemStorage: Hard-deleted \(deleted) absent tasks during full sync")
+      HomeKnowledgeCountInvalidation.post(
+        logMessage: "ActionItemStorage: Hard-deleted \(deleted) absent tasks during full sync"
+      )
     }
   }
 
@@ -796,7 +802,7 @@ actor ActionItemStorage {
     }
 
     if deleted > 0 {
-      log("ActionItemStorage: hard-deleted \(deleted) absent tasks")
+      HomeKnowledgeCountInvalidation.post(logMessage: "ActionItemStorage: hard-deleted \(deleted) absent tasks")
     }
 
     return deleted
@@ -833,7 +839,8 @@ actor ActionItemStorage {
       }
     }
 
-    log("ActionItemStorage: Hard deleted action item with backendId \(backendId)")
+    HomeKnowledgeCountInvalidation.post(
+      logMessage: "ActionItemStorage: Hard deleted action item with backendId \(backendId)")
   }
 
   // MARK: - Local Extraction Operations
@@ -880,7 +887,8 @@ actor ActionItemStorage {
         }
       }
     }
-    log("ActionItemStorage: Inserted local action item (id: \(inserted.id ?? -1))")
+    HomeKnowledgeCountInvalidation.post(
+      logMessage: "ActionItemStorage: Inserted local action item (id: \(inserted.id ?? -1))")
     return inserted
   }
 
@@ -983,7 +991,8 @@ actor ActionItemStorage {
       }
     }
 
-    log("ActionItemStorage: Locally set completed=\(completed) for \(backendId)")
+    HomeKnowledgeCountInvalidation.post(
+      logMessage: "ActionItemStorage: Locally set completed=\(completed) for \(backendId)")
   }
 
   /// Optimistically update task fields locally (before API call)
@@ -1115,7 +1124,8 @@ actor ActionItemStorage {
       }
     }
 
-    log("ActionItemStorage: Hard-deleted action item with backendId \(backendId)")
+    HomeKnowledgeCountInvalidation.post(
+      logMessage: "ActionItemStorage: Hard-deleted action item with backendId \(backendId)")
   }
 
   // MARK: - FTS5 Search & Context Methods

--- a/desktop/macos/Desktop/Sources/Rewind/Core/MemoryStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/MemoryStorage.swift
@@ -449,9 +449,10 @@ actor MemoryStorage {
   func syncServerMemories(_ memories: [ServerMemory]) async throws {
     let db = try await ensureInitialized()
 
-    let (skipped, adopted) = try await db.write { database -> (Int, Int) in
+    let (skipped, adopted, inserted) = try await db.write { database -> (Int, Int, Int) in
       var skipped = 0
       var adopted = 0
+      var inserted = 0
       for memory in memories {
         if var existingRecord =
           try MemoryRecord
@@ -488,6 +489,7 @@ actor MemoryStorage {
         } else {
           do {
             _ = try MemoryRecord.from(memory).inserted(database)
+            inserted += 1
           } catch let dbError as DatabaseError where dbError.resultCode == .SQLITE_CONSTRAINT {
             // Race: record already exists — update instead
             if var record = try MemoryRecord.filter(Column("backendId") == memory.id).fetchOne(database) {
@@ -497,7 +499,7 @@ actor MemoryStorage {
           }
         }
       }
-      return (skipped, adopted)
+      return (skipped, adopted, inserted)
     }
 
     if skipped > 0 || adopted > 0 {
@@ -507,7 +509,9 @@ actor MemoryStorage {
     } else {
       log("MemoryStorage: Synced \(memories.count) memories from backend")
     }
-    HomeKnowledgeCountInvalidation.post()
+    if inserted > 0 {
+      HomeKnowledgeCountInvalidation.post()
+    }
   }
 
   /// Upsert a server snapshot, then tombstone synced locals whose backendId is absent.

--- a/desktop/macos/Desktop/Sources/Rewind/Core/MemoryStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/MemoryStorage.swift
@@ -507,6 +507,7 @@ actor MemoryStorage {
     } else {
       log("MemoryStorage: Synced \(memories.count) memories from backend")
     }
+    HomeKnowledgeCountInvalidation.post()
   }
 
   /// Upsert a server snapshot, then tombstone synced locals whose backendId is absent.
@@ -546,6 +547,7 @@ actor MemoryStorage {
     }
 
     log("MemoryStorage: Inserted local memory (id: \(inserted.id ?? -1))")
+    HomeKnowledgeCountInvalidation.post()
     return inserted
   }
 
@@ -693,6 +695,7 @@ actor MemoryStorage {
     }
 
     log("MemoryStorage: Soft deleted memory \(id)")
+    HomeKnowledgeCountInvalidation.post()
   }
 
   /// Soft-delete synced memories tied to a deleted conversation (local cache hygiene).
@@ -700,13 +703,17 @@ actor MemoryStorage {
   func softDeleteMemoriesByConversationId(_ conversationId: String) async throws -> Int {
     let db = try await ensureInitialized()
 
-    return try await db.write { database -> Int in
+    let deleted = try await db.write { database -> Int in
       try database.execute(
         sql: "UPDATE memories SET deleted = 1, updatedAt = ? WHERE deleted = 0 AND conversationId = ?",
         arguments: [Date(), conversationId]
       )
       return database.changesCount
     }
+    if deleted > 0 {
+      HomeKnowledgeCountInvalidation.post()
+    }
+    return deleted
   }
 
   /// Soft delete a memory by backend ID
@@ -721,6 +728,7 @@ actor MemoryStorage {
     }
 
     log("MemoryStorage: Soft deleted memory with backendId \(backendId)")
+    HomeKnowledgeCountInvalidation.post()
   }
 
   /// Restore a soft-deleted memory by backend ID. Used by undo/delete-failure paths;
@@ -736,6 +744,7 @@ actor MemoryStorage {
     }
 
     log("MemoryStorage: Restored memory with backendId \(backendId)")
+    HomeKnowledgeCountInvalidation.post()
   }
 
   /// Soft-delete synced memories whose backendId is no longer present on the
@@ -749,7 +758,7 @@ actor MemoryStorage {
   ) async throws -> Int {
     let db = try await ensureInitialized()
 
-    return try await db.write { database -> Int in
+    let removed = try await db.write { database -> Int in
       var query =
         MemoryRecord
         .filter(Column("backendId") != nil)
@@ -768,6 +777,10 @@ actor MemoryStorage {
       }
       return removed
     }
+    if removed > 0 {
+      HomeKnowledgeCountInvalidation.post()
+    }
+    return removed
   }
 
   /// Soft delete memories within a tier scope.
@@ -788,6 +801,7 @@ actor MemoryStorage {
     }
 
     log("MemoryStorage: Soft deleted memories for scope \(scope.sqlTierRawValues)")
+    HomeKnowledgeCountInvalidation.post()
   }
 
   /// Update content by backend ID

--- a/desktop/macos/Desktop/Tests/ConversationRepositoryTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationRepositoryTests.swift
@@ -100,6 +100,27 @@ final class ConversationRepositoryTests: XCTestCase {
     XCTAssertEqual(remote.listRequests.map(\.limit), [50, 50])
   }
 
+  func testLoadMoreRemainsAvailableWhenServerCountFailsOverCachedCount() async {
+    let firstPage = (0..<50).map { index in
+      makeConversation(id: "conversation-\(index)", title: "Conversation \(index)", revision: 100 - Double(index))
+    }
+    let second = makeConversation(id: "second", title: "Older", revision: 1)
+    let remote = FakeConversationRemote(listResult: .success(firstPage), countResult: .failure(TestFailure.offline))
+    let repository = ConversationRepository(
+      remote: remote,
+      local: FakeConversationLocal(listResult: firstPage, count: 50)
+    )
+
+    await repository.load(query: .all)
+    XCTAssertTrue(repository.hasMore)
+
+    remote.listResult = .success([second])
+    await repository.loadMore()
+
+    XCTAssertEqual(repository.conversations.map(\.id), firstPage.map(\.id) + ["second"])
+    XCTAssertEqual(remote.listRequests.map(\.offset), [0, 50])
+  }
+
   func testDetailPaintsCachedTranscriptThenRevalidatesServerOwnedFields() async throws {
     let seed = makeConversation(title: "List title", overview: "List summary", revision: 1)
     let cachedDetail = makeConversation(

--- a/desktop/macos/Desktop/Tests/ConversationRepositoryTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationRepositoryTests.swift
@@ -83,6 +83,23 @@ final class ConversationRepositoryTests: XCTestCase {
     XCTAssertFalse(snapshots.last?.isLoading ?? true)
   }
 
+  func testLoadMoreAppendsTheNextServerPageWithoutReplacingTheVisibleList() async {
+    let firstPage = (0..<50).map { index in
+      makeConversation(id: "conversation-\(index)", title: "Conversation \(index)", revision: 100 - Double(index))
+    }
+    let second = makeConversation(id: "second", title: "Older", revision: 1)
+    let remote = FakeConversationRemote(listResult: .success(firstPage), countResult: .success(51))
+    let repository = ConversationRepository(remote: remote, local: FakeConversationLocal())
+
+    await repository.load(query: .all, includeCache: false)
+    remote.listResult = .success([second])
+    await repository.loadMore()
+
+    XCTAssertEqual(repository.conversations.map(\.id), firstPage.map(\.id) + ["second"])
+    XCTAssertEqual(remote.listRequests.map(\.offset), [0, 50])
+    XCTAssertEqual(remote.listRequests.map(\.limit), [50, 50])
+  }
+
   func testDetailPaintsCachedTranscriptThenRevalidatesServerOwnedFields() async throws {
     let seed = makeConversation(title: "List title", overview: "List summary", revision: 1)
     let cachedDetail = makeConversation(
@@ -858,6 +875,7 @@ private final class FakeConversationRemote: ConversationRemoteDataSource {
   var titleHandler: ((String) async throws -> ServerConversation)?
   var deleteHandler: ((String) async throws -> Void)?
   var deletedIds: [String] = []
+  var listRequests: [(offset: Int, limit: Int)] = []
 
   init(
     listResult: Result<[ServerConversation], Error> = .success([]),
@@ -879,7 +897,8 @@ private final class FakeConversationRemote: ConversationRemoteDataSource {
     self.deleteResult = deleteResult
   }
 
-  func list(query: ConversationListQuery) async throws -> [ServerConversation] {
+  func list(query: ConversationListQuery, offset: Int, limit: Int) async throws -> [ServerConversation] {
+    listRequests.append((offset: offset, limit: limit))
     if let listHandler { return try await listHandler(query) }
     return try listResult.get()
   }

--- a/desktop/macos/Desktop/Tests/HomeStatusStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeStatusStoreTests.swift
@@ -444,7 +444,9 @@ final class HomeStatusStoreTests: XCTestCase {
     )
 
     await store.refreshIfNeeded(now: Date(timeIntervalSince1970: 40_000))
-    NotificationCenter.default.post(name: .homeKnowledgeCountsDidChange, object: nil)
+    await Task.detached {
+      NotificationCenter.default.post(name: .homeKnowledgeCountsDidChange, object: nil)
+    }.value
     for _ in 0..<100 where knowledgeLoads < 2 {
       await Task.yield()
     }

--- a/desktop/macos/Desktop/Tests/HomeStatusStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeStatusStoreTests.swift
@@ -418,6 +418,42 @@ final class HomeStatusStoreTests: XCTestCase {
     XCTAssertEqual(connectorStore.snapshot(for: email).primaryText, "12 emails")
   }
 
+  func testKnowledgeCountChangeRefreshesCountsDuringActivationCooldown() async {
+    let testDefaults = makeDefaults()
+    let defaults = testDefaults.defaults
+    defer { defaults.removePersistentDomain(forName: testDefaults.suiteName) }
+
+    var knowledgeLoads = 0
+    let store = HomeStatusStore(
+      connectorStatusStore: ImportConnectorStatusStore(defaults: defaults),
+      defaults: defaults,
+      loader: HomeStatusLoader(
+        refreshConnectorStatuses: {},
+        loadScreenshotCount: { nil },
+        loadKnowledgeCounts: { _ in
+          knowledgeLoads += 1
+          return HomeKnowledgeCounts(
+            conversations: nil,
+            memories: knowledgeLoads,
+            tasks: knowledgeLoads,
+            hasOmiDeviceConversations: nil
+          )
+        },
+        loadMemoryExportStatuses: { [:] }
+      )
+    )
+
+    await store.refreshIfNeeded(now: Date(timeIntervalSince1970: 40_000))
+    NotificationCenter.default.post(name: .homeKnowledgeCountsDidChange, object: nil)
+    for _ in 0..<100 where knowledgeLoads < 2 {
+      await Task.yield()
+    }
+
+    XCTAssertEqual(knowledgeLoads, 2)
+    XCTAssertEqual(store.memoryCount, 2)
+    XCTAssertEqual(store.taskCount, 2)
+  }
+
   private func makeDefaults() -> (defaults: UserDefaults, suiteName: String) {
     let suiteName = "HomeStatusStoreTests.\(UUID().uuidString)"
     return (UserDefaults(suiteName: suiteName)!, suiteName)

--- a/desktop/macos/changelog/unreleased/20260720-refresh-home-counts-and-load-older-conversations.json
+++ b/desktop/macos/changelog/unreleased/20260720-refresh-home-counts-and-load-older-conversations.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Home memory and task totals not refreshing after changes, and added a way to load older conversations"
+}


### PR DESCRIPTION
## Summary
- refresh Home memory and incomplete-task totals immediately after authoritative local visibility changes instead of waiting for the activation cooldown
- add a user-visible **Load older conversations** control backed by offset pagination, preserving loaded rows and pending mutations

## Issues
Fixes #8124
Refs #9355

## Product invariants affected

- INV-MEM-1

## Failure class
Failure-Class: none

## Validation
- `OMI_PR_BODY_FILE=/tmp/omi-pr-body.md make preflight` — passed
- `xcrun swift test --package-path Desktop --filter 'HomeStatusStoreTests|ConversationRepositoryTests|ConversationReconciliationPolicyTests|TasksStoreObserverTests|MemoriesViewModelObserverTests'` — 57 tests passed
- `xcrun swift build -c debug --package-path Desktop` — passed

## Manual exercise
A named bundle build completed through app assembly, but launch was blocked because this Mac has no Apple Development signing identity. The supported ad-hoc fallback was not used because it would reset Screen Recording permissions for existing Omi apps.
