### PR TITLE
fix(desktop): bind AgentSync recovery to replacement VM

### DIFF
--- a/desktop/macos/Desktop/Sources/AgentSyncService.swift
+++ b/desktop/macos/Desktop/Sources/AgentSyncService.swift
@@ -84,6 +84,7 @@ actor AgentSyncService {
   /// suppress its schema repair.
   private struct RequiredSchemaRecoveryState {
     var ownerID: String?
+    var vmIP: String
     var generation: UInt64
     var table: String
     var causalFailures: Int
@@ -178,7 +179,7 @@ actor AgentSyncService {
     lastTokenRefresh = .distantPast
     isPaused = false
     latencyBackoffMultiplier = 1
-    if requiredSchemaRecovery?.ownerID != cursorOwnerID {
+    if requiredSchemaRecovery?.ownerID != cursorOwnerID || requiredSchemaRecovery?.vmIP != vmIP {
       requiredSchemaRecovery = nil
     } else if var recovery = requiredSchemaRecovery {
       // A same-owner restart must keep its cooldown and bounded retry budget.
@@ -355,6 +356,7 @@ actor AgentSyncService {
     guard var recovery = requiredSchemaRecovery,
       recovery.generation == generation,
       recovery.ownerID == ownerID,
+      recovery.vmIP == vmIP,
       recovery.causalFailures >= 3
     else { return }
     guard networkHooks.now().timeIntervalSince(recovery.lastAttemptAt) >= reuploadCooldown else {
@@ -371,7 +373,7 @@ actor AgentSyncService {
       var request = URLRequest(url: url)
       request.timeoutInterval = 15
       let (data, response) = try await networkHooks.dataForRequest(request)
-      guard isCurrent(generation: generation, ownerID: ownerID) else { return }
+      guard isCurrent(generation: generation, ownerID: ownerID, vmIP: vmIP) else { return }
       guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
         log("AgentSync: re-upload health check returned a non-success response")
         return
@@ -390,9 +392,9 @@ actor AgentSyncService {
       recovery.attemptsInFailureStreak += 1
       requiredSchemaRecovery = recovery
       let uploaded = await networkHooks.reuploadDatabase(vmIP, authToken)
-      guard isCurrent(generation: generation, ownerID: ownerID) else { return }
+      guard isCurrent(generation: generation, ownerID: ownerID, vmIP: vmIP) else { return }
       if uploaded {
-        clearRequiredSchemaRecovery(for: recovery.table, generation: generation, ownerID: ownerID)
+        clearRequiredSchemaRecovery(for: recovery.table, generation: generation, ownerID: ownerID, vmIP: vmIP)
       } else {
         log("AgentSync: database re-upload failed; retaining recovery evidence for its bounded retry")
       }
@@ -406,10 +408,11 @@ actor AgentSyncService {
   private func refreshFirebaseToken(generation: UInt64) async {
     guard syncGeneration == generation else { return }
     guard let vmIP = vmIP, let authToken = authToken else { return }
+    let ownerID = cursorOwnerID
 
     do {
       let idToken = try await networkHooks.fetchIDToken()
-      guard syncGeneration == generation else { return }
+      guard isCurrent(generation: generation, ownerID: ownerID, vmIP: vmIP) else { return }
       // Send token both as query param (backward compat) and header (preferred)
       guard let url = URL(string: "http://\(vmIP):8080/auth?token=\(authToken)") else { return }
       var request = URLRequest(url: url)
@@ -422,7 +425,7 @@ actor AgentSyncService {
       request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
       let (_, response) = try await networkHooks.dataForRequest(request)
-      guard syncGeneration == generation else { return }
+      guard isCurrent(generation: generation, ownerID: ownerID, vmIP: vmIP) else { return }
       if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
         lastTokenRefresh = Date()
         log("AgentSync: Firebase token refreshed on VM")
@@ -543,10 +546,11 @@ actor AgentSyncService {
 
       // Push to VM
       let ownerID = cursorOwnerID
-      let result = await pushRows(spec.name, rows, generation: generation, ownerID: ownerID)
-      guard syncGeneration == generation else { return 0 }
+      guard let vmIP else { return 0 }
+      let result = await pushRows(spec.name, rows, generation: generation, ownerID: ownerID, vmIP: vmIP)
+      guard isCurrent(generation: generation, ownerID: ownerID, vmIP: vmIP) else { return 0 }
       if result == .success {
-        clearRequiredSchemaRecovery(for: spec.name, generation: generation, ownerID: ownerID)
+        clearRequiredSchemaRecovery(for: spec.name, generation: generation, ownerID: ownerID, vmIP: vmIP)
         // Update cursor
         if spec.appendOnly {
           if let lastId = rows.last?["id"] as? Int64 {
@@ -586,33 +590,37 @@ actor AgentSyncService {
     case networkError
   }
 
-  private func isCurrent(generation: UInt64, ownerID: String?) -> Bool {
+  private func isCurrent(generation: UInt64, ownerID: String?, vmIP: String) -> Bool {
     syncGeneration == generation
       && cursorOwnerID == ownerID
+      && self.vmIP == vmIP
       && RuntimeOwnerIdentity.currentOwnerId() == ownerID
   }
 
-  private func clearRequiredSchemaRecovery(for table: String, generation: UInt64, ownerID: String?) {
+  private func clearRequiredSchemaRecovery(for table: String, generation: UInt64, ownerID: String?, vmIP: String) {
     guard let recovery = requiredSchemaRecovery,
       recovery.table == table,
       recovery.generation == generation,
-      recovery.ownerID == ownerID
+      recovery.ownerID == ownerID,
+      recovery.vmIP == vmIP
     else { return }
     requiredSchemaRecovery = nil
   }
 
-  private func recordRequiredSchemaFailure(for table: String, generation: UInt64, ownerID: String?) {
-    guard isCurrent(generation: generation, ownerID: ownerID) else { return }
+  private func recordRequiredSchemaFailure(for table: String, generation: UInt64, ownerID: String?, vmIP: String) {
+    guard isCurrent(generation: generation, ownerID: ownerID, vmIP: vmIP) else { return }
     if var recovery = requiredSchemaRecovery,
       recovery.table == table,
       recovery.generation == generation,
-      recovery.ownerID == ownerID
+      recovery.ownerID == ownerID,
+      recovery.vmIP == vmIP
     {
       recovery.causalFailures += 1
       requiredSchemaRecovery = recovery
-    } else {
+    } else if requiredSchemaRecovery == nil {
       requiredSchemaRecovery = RequiredSchemaRecoveryState(
         ownerID: ownerID,
+        vmIP: vmIP,
         generation: generation,
         table: table,
         causalFailures: 1)
@@ -623,9 +631,10 @@ actor AgentSyncService {
     _ table: String,
     _ rows: [[String: Any]],
     generation: UInt64,
-    ownerID: String?
+    ownerID: String?,
+    vmIP: String
   ) async -> PushResult {
-    guard isCurrent(generation: generation, ownerID: ownerID), let vmIP, let authToken else { return .networkError }
+    guard isCurrent(generation: generation, ownerID: ownerID, vmIP: vmIP), let authToken else { return .networkError }
 
     // Send token both as query param (backward compat) and header (preferred)
     guard let url = URL(string: "http://\(vmIP):8080/sync?token=\(authToken)") else {
@@ -649,7 +658,7 @@ actor AgentSyncService {
 
     do {
       let (data, response) = try await networkHooks.dataForRequest(request)
-      guard isCurrent(generation: generation, ownerID: ownerID) else { return .networkError }
+      guard isCurrent(generation: generation, ownerID: ownerID, vmIP: vmIP) else { return .networkError }
       guard let httpResponse = response as? HTTPURLResponse else { return .httpError }
 
       if httpResponse.statusCode == 200 {
@@ -660,7 +669,7 @@ actor AgentSyncService {
           healthPayload: ["databaseReady": true],
           syncFailureBody: body
         ) == .missingRequiredSchema {
-          recordRequiredSchemaFailure(for: table, generation: generation, ownerID: ownerID)
+          recordRequiredSchemaFailure(for: table, generation: generation, ownerID: ownerID, vmIP: vmIP)
         }
         log("AgentSync: push \(table) failed — HTTP \(httpResponse.statusCode): \(body)")
         return .networkError  // 5xx = server not ready, trigger backoff

--- a/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
@@ -81,6 +81,91 @@ private final class AgentSyncManualClock: @unchecked Sendable {
   }
 }
 
+private actor AgentSyncReplacementCallbackGate {
+  enum Endpoint: Hashable {
+    case sync
+    case health
+    case upload
+  }
+
+  private let suspended: Set<Endpoint>
+  private var started: Set<Endpoint> = []
+  private var startWaiters: [Endpoint: [CheckedContinuation<Void, Never>]] = [:]
+  private var releaseContinuations: [Endpoint: CheckedContinuation<Void, Never>] = [:]
+  private var reuploadVMs: [String] = []
+
+  init(suspending endpoint: Endpoint) {
+    suspended = [endpoint]
+  }
+
+  func respond(to request: URLRequest) async throws -> (Data, URLResponse) {
+    let url = try XCTUnwrap(request.url)
+    let endpoint: Endpoint? =
+      switch url.path {
+      case "/sync": .sync
+      case "/health": .health
+      default: nil
+      }
+    if url.host == "old-vm", let endpoint, suspended.contains(endpoint) {
+      await suspend(endpoint)
+    }
+
+    switch url.path {
+    case "/auth":
+      return (Data(), response(url, status: 200))
+    case "/sync":
+      let payload = try XCTUnwrap(request.httpBody)
+      let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: payload) as? [String: Any])
+      let table = try XCTUnwrap(json["table"] as? String)
+      if table == "transcription_sessions" {
+        return (Data("SQLite error: no such table: \(table)".utf8), response(url, status: 500))
+      }
+      return (Data(), response(url, status: 200))
+    case "/health":
+      return (try JSONSerialization.data(withJSONObject: ["databaseReady": true]), response(url, status: 200))
+    default:
+      return (Data(), response(url, status: 404))
+    }
+  }
+
+  func reupload(vmIP: String) async -> Bool {
+    reuploadVMs.append(vmIP)
+    if vmIP == "old-vm", suspended.contains(.upload) {
+      await suspend(.upload)
+    }
+    return true
+  }
+
+  func waitUntilStarted(_ endpoint: Endpoint) async {
+    guard !started.contains(endpoint) else { return }
+    await withCheckedContinuation { continuation in
+      startWaiters[endpoint, default: []].append(continuation)
+    }
+  }
+
+  func release(_ endpoint: Endpoint) {
+    releaseContinuations.removeValue(forKey: endpoint)?.resume()
+  }
+
+  func uploadVMs() -> [String] {
+    reuploadVMs
+  }
+
+  private func suspend(_ endpoint: Endpoint) async {
+    started.insert(endpoint)
+    let waiters = startWaiters.removeValue(forKey: endpoint) ?? []
+    waiters.forEach { $0.resume() }
+    await withCheckedContinuation { continuation in
+      releaseContinuations[endpoint] = continuation
+    }
+  }
+
+  private func response(_ url: URL, status: Int) -> URLResponse {
+    HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)
+      ?? URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+  }
+}
+
 private actor AgentSyncRecoveryProbe {
   enum HealthResponse {
     case ready
@@ -88,7 +173,7 @@ private actor AgentSyncRecoveryProbe {
     case status(Int)
   }
 
-  private var missingTable: String?
+  private var missingTables: Set<String>
   private var healthResponse: HealthResponse = .ready
   private var uploadResults: [Bool] = [true]
   private var healthChecks = 0
@@ -96,7 +181,7 @@ private actor AgentSyncRecoveryProbe {
   private var syncedTables: [String] = []
 
   init(missingTable: String? = "transcription_sessions") {
-    self.missingTable = missingTable
+    missingTables = missingTable.map { [$0] } ?? []
   }
 
   func respond(to request: URLRequest) throws -> (Data, URLResponse) {
@@ -109,7 +194,7 @@ private actor AgentSyncRecoveryProbe {
       let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: payload) as? [String: Any])
       let table = try XCTUnwrap(json["table"] as? String)
       syncedTables.append(table)
-      if table == missingTable {
+      if missingTables.contains(table) {
         return (Data("SQLite error: no such table: \(table)".utf8), response(url, status: 500))
       }
       return (Data(), response(url, status: 200))
@@ -134,7 +219,11 @@ private actor AgentSyncRecoveryProbe {
   }
 
   func setMissingTable(_ table: String?) {
-    missingTable = table
+    missingTables = table.map { [$0] } ?? []
+  }
+
+  func setMissingTables(_ tables: Set<String>) {
+    missingTables = tables
   }
 
   func setHealthResponse(_ response: HealthResponse) {
@@ -300,6 +389,25 @@ final class AgentSyncRecoveryTests: XCTestCase {
     XCTAssertEqual(counts.uploads, 1, "The existing database-upload owner repairs the missing table exactly once")
   }
 
+  func testTwoMissingRequiredTablesDoNotAlternateAwayTheSelectedRecovery() async {
+    let probe = AgentSyncRecoveryProbe()
+    await probe.setMissingTables(["transcription_sessions", "action_items"])
+    let service = makeService(probe: probe)
+    await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
+
+    for _ in 0..<3 { await service.syncOnceForTesting() }
+
+    let counts = await probe.counts()
+    XCTAssertEqual(counts.syncedTables.filter { $0 == "transcription_sessions" }.count, 3)
+    XCTAssertEqual(counts.syncedTables.filter { $0 == "action_items" }.count, 3)
+    XCTAssertTrue(
+      counts.syncedTables.contains("memories"),
+      "A successful required table must not suppress recovery for the selected missing table"
+    )
+    XCTAssertEqual(counts.healthChecks, 1, "Alternating missing tables must still reach the causal recovery threshold")
+    XCTAssertEqual(counts.uploads, 1, "One selected causal table produces one bounded repair")
+  }
+
   func testMatchingTableSuccessClearsRecoveryButUnrelatedSuccessDoesNot() async throws {
     let probe = AgentSyncRecoveryProbe()
     let service = makeService(probe: probe)
@@ -365,6 +473,84 @@ final class AgentSyncRecoveryTests: XCTestCase {
     XCTAssertEqual(counts.uploads, 2, "Failed recovery uploads stop at the existing bounded policy")
   }
 
+  func testSameOwnerReplacementVMResetsOldRecoveryEvidenceCooldownAndBudget() async {
+    let probe = AgentSyncRecoveryProbe()
+    await probe.setUploadResults([false, false, false])
+    let clock = AgentSyncManualClock()
+    let service = makeService(probe: probe, clock: clock)
+    await service.startForTesting(vmIP: "old-vm", authToken: "test-token")
+
+    for _ in 0..<3 { await service.syncOnceForTesting() }
+    clock.advance(30 * 60 + 1)
+    await service.syncOnceForTesting()
+    var counts = await probe.counts()
+    XCTAssertEqual(counts.uploads, 2, "The old VM exhausts its bounded retry budget")
+
+    await service.startForTesting(vmIP: "replacement-vm", authToken: "test-token")
+    await service.syncOnceForTesting()
+    await service.syncOnceForTesting()
+    counts = await probe.counts()
+    XCTAssertEqual(counts.uploads, 2, "Replacement must not upload from stale old-VM evidence")
+
+    await service.syncOnceForTesting()
+    counts = await probe.counts()
+    XCTAssertEqual(counts.uploads, 3, "Replacement gets a fresh causal threshold and bounded retry budget")
+  }
+
+  func testDelayedOldVMSyncResponseCannotCreateReplacementRecoveryEvidence() async {
+    let gate = AgentSyncReplacementCallbackGate(suspending: .sync)
+    let service = makeService(gate: gate)
+    await service.startForTesting(vmIP: "old-vm", authToken: "test-token")
+    let oldTick = Task { await service.syncOnceForTesting() }
+    await gate.waitUntilStarted(.sync)
+
+    await service.startForTesting(vmIP: "replacement-vm", authToken: "test-token")
+    await gate.release(.sync)
+    await oldTick.value
+    for _ in 0..<3 { await service.syncOnceForTesting() }
+
+    let uploadVMs = await gate.uploadVMs()
+    XCTAssertEqual(uploadVMs, ["replacement-vm"])
+  }
+
+  func testDelayedOldVMHealthResponseCannotSpendReplacementRecoveryBudget() async {
+    let gate = AgentSyncReplacementCallbackGate(suspending: .health)
+    let service = makeService(gate: gate)
+    await service.startForTesting(vmIP: "old-vm", authToken: "test-token")
+    await service.syncOnceForTesting()
+    await service.syncOnceForTesting()
+    let oldTick = Task { await service.syncOnceForTesting() }
+    await gate.waitUntilStarted(.health)
+
+    await service.startForTesting(vmIP: "replacement-vm", authToken: "test-token")
+    await gate.release(.health)
+    await oldTick.value
+    for _ in 0..<3 { await service.syncOnceForTesting() }
+
+    let uploadVMs = await gate.uploadVMs()
+    XCTAssertEqual(uploadVMs, ["replacement-vm"])
+  }
+
+  func testDelayedOldVMUploadResponseCannotClearReplacementRecoveryEvidence() async {
+    let gate = AgentSyncReplacementCallbackGate(suspending: .upload)
+    let service = makeService(gate: gate)
+    await service.startForTesting(vmIP: "old-vm", authToken: "test-token")
+    await service.syncOnceForTesting()
+    await service.syncOnceForTesting()
+    let oldTick = Task { await service.syncOnceForTesting() }
+    await gate.waitUntilStarted(.upload)
+
+    await service.startForTesting(vmIP: "replacement-vm", authToken: "test-token")
+    await service.syncOnceForTesting()
+    await service.syncOnceForTesting()
+    await gate.release(.upload)
+    await oldTick.value
+    await service.syncOnceForTesting()
+
+    let uploadVMs = await gate.uploadVMs()
+    XCTAssertEqual(uploadVMs, ["old-vm", "replacement-vm"])
+  }
+
   private func makeService(
     probe: AgentSyncRecoveryProbe,
     clock: AgentSyncManualClock = AgentSyncManualClock()
@@ -375,6 +561,16 @@ final class AgentSyncRecoveryTests: XCTestCase {
         dataForRequest: { request in try await probe.respond(to: request) },
         reuploadDatabase: { _, _ in await probe.reupload() },
         now: { clock.now() },
+        tableSyncEnabled: true))
+  }
+
+  private func makeService(gate: AgentSyncReplacementCallbackGate) -> AgentSyncService {
+    AgentSyncService(
+      networkHooks: AgentSyncService.NetworkHooks(
+        fetchIDToken: { "test-firebase-token" },
+        dataForRequest: { request in try await gate.respond(to: request) },
+        reuploadDatabase: { vmIP, _ in await gate.reupload(vmIP: vmIP) },
+        now: Date.init,
         tableSyncEnabled: true))
   }
 
@@ -392,10 +588,16 @@ final class AgentSyncRecoveryTests: XCTestCase {
         arguments: [now, "desktop", now, now])
       try db.execute(
         sql: """
-          INSERT INTO action_items (description, createdAt, updatedAt)
-          VALUES (?, ?, ?)
+            INSERT INTO action_items (description, createdAt, updatedAt)
+            VALUES (?, ?, ?)
           """,
         arguments: ["mixed-success control", now, now])
+      try db.execute(
+        sql: """
+          INSERT INTO memories (content, category, createdAt, updatedAt)
+          VALUES (?, ?, ?, ?)
+          """,
+        arguments: ["mixed-success recovery control", "system", now, now])
     }
   }
 

--- a/desktop/macos/changelog/unreleased/20260720-agent-vm-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260720-agent-vm-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved recovery when your Agent VM database needs to be restored"
+}


### PR DESCRIPTION
## Summary

- pin AgentSync partial-schema recovery to one selected missing required table so multiple failures cannot alternate away the threshold
- bind recovery evidence, cooldown, retry budget, and delayed callback guards to owner, generation, and VM IP
- reset recovery state when the same owner receives a replacement VM
- add production-tick regressions for two missing required tables and delayed old-VM sync, health, and upload callbacks

## Why

The merged partial-schema recovery could fail to repair two simultaneously missing tables because they replaced the single causal recovery slot every tick. A same-owner replacement VM could also inherit stale recovery evidence and exhausted retry state from the old VM.

## Product invariants affected

- INV-AUTH-1

## Verification

- RED: the two-table and replacement-VM regression tests failed against the merged implementation before the production fix
- `xcrun swift test --package-path Desktop --filter 'AgentSyncBatchQueryTests|AgentSyncRecoveryTests|AgentVMCompressionRatioTests|ChatJournalWritePathTests|KernelTurnRecordedProjectionTests'` — 56 passed after rebasing onto current `main`
- `python3 scripts/check_desktop_test_quality.py` — passed
- `./scripts/agent-logic-harness.sh` — passed
- `./scripts/desktop-core-harness.sh --self-check` — passed
- `git diff --check` — passed
- `make preflight` — passed before packaging; rerun after rebase

Failure-Class: FC-split-mutation-authority


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

