### PR TITLE
fix(ci): make pre-push single-flight runner signal handling portable (Windows SIGHUP crash)

### DIFF
--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -17,6 +17,35 @@ from pathlib import Path
 POLL_SECONDS = 0.2
 STATUS_INTERVAL_SECONDS = 5.0
 
+# Signals forwarded to the owned child. SIGHUP is POSIX-only and is simply absent
+# on Windows, so the set is resolved against the host rather than assumed —
+# referencing signal.SIGHUP unconditionally raised AttributeError before any
+# pre-push check could run.
+FORWARDED_SIGNAL_NAMES = ("SIGINT", "SIGTERM", "SIGHUP")
+
+
+def forwardable_signals() -> tuple[int, ...]:
+    """Return the forwardable signals this platform actually defines."""
+    resolved = (getattr(signal, name, None) for name in FORWARDED_SIGNAL_NAMES)
+    return tuple(signum for signum in resolved if signum is not None)
+
+
+def signal_child(child: subprocess.Popen, signum: int) -> None:
+    """Forward a signal to the child, preferring its process group where supported.
+
+    The child is started with ``start_new_session=True``, so on POSIX it leads its
+    own process group and ``os.killpg`` reaches the whole tree. Windows has no
+    ``os.killpg``; fall back to signalling the process directly.
+    """
+    killpg = getattr(os, "killpg", None)
+    try:
+        if killpg is not None:
+            killpg(child.pid, signum)
+        else:
+            child.send_signal(signum)
+    except (ProcessLookupError, OSError):
+        pass
+
 
 def atomic_json(path: Path, value: dict) -> None:
     temporary = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
@@ -174,14 +203,9 @@ def run_owned(
 
     def forward_signal(signum: int, _frame: object) -> None:
         if child is not None and child.poll() is None:
-            try:
-                os.killpg(child.pid, signum)
-            except ProcessLookupError:
-                pass
+            signal_child(child, signum)
 
-    previous_handlers = {
-        signum: signal.signal(signum, forward_signal) for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
-    }
+    previous_handlers = {signum: signal.signal(signum, forward_signal) for signum in forwardable_signals()}
     exit_code = 1
     try:
         print(f"Pre-push single-flight log: {log_path}")

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -7,6 +7,7 @@ from contextlib import redirect_stderr
 import io
 import json
 import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -14,8 +15,9 @@ import time
 import unittest
 import urllib.error
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+import preflight_runner
 from pr_metadata import TransientPRMetadataError, load_from_api, load_from_event_file
 from pr_preflight import changed_files, format_failure_class_suggest, resolve_pr_metadata, select_checks
 
@@ -492,6 +494,60 @@ class SingleFlightTests(unittest.TestCase):
                 first.stdout.read()
                 first.stdout.close()
             self.assertEqual(first.wait(), 0)
+
+
+class SignalPortabilityTests(unittest.TestCase):
+    """The single-flight wrapper must start on hosts without POSIX signal APIs.
+
+    Windows Python defines neither ``signal.SIGHUP`` nor ``os.killpg``. Building the
+    handler map from a hard-coded tuple containing SIGHUP raised AttributeError inside
+    ``run_owned()``, so every ``git push`` failed before the pre-push checks began.
+    These exercise the selection/forwarding seams directly — no real signal is sent.
+    """
+
+    def test_forwardable_signals_omits_signals_absent_on_host(self) -> None:
+        had_sighup = hasattr(signal, "SIGHUP")
+        original = getattr(signal, "SIGHUP", None)
+        try:
+            if had_sighup:
+                delattr(signal, "SIGHUP")  # simulate Windows
+            selected = preflight_runner.forwardable_signals()
+        finally:
+            if had_sighup:
+                signal.SIGHUP = original
+        self.assertIn(signal.SIGINT, selected)
+        self.assertIn(signal.SIGTERM, selected)
+        self.assertTrue(all(signum is not None for signum in selected))
+
+    @unittest.skipUnless(hasattr(signal, "SIGHUP"), "POSIX-only")
+    def test_forwardable_signals_includes_sighup_on_posix(self) -> None:
+        self.assertIn(signal.SIGHUP, preflight_runner.forwardable_signals())
+
+    @unittest.skipUnless(hasattr(os, "killpg"), "POSIX-only")
+    def test_forwards_to_process_group_when_available(self) -> None:
+        child = Mock(pid=4321)
+        with patch.object(os, "killpg") as killpg:
+            preflight_runner.signal_child(child, signal.SIGTERM)
+        killpg.assert_called_once_with(4321, signal.SIGTERM)
+        child.send_signal.assert_not_called()
+
+    def test_forwards_via_send_signal_when_process_groups_unavailable(self) -> None:
+        child = Mock(pid=4321)
+        had_killpg = hasattr(os, "killpg")
+        original = getattr(os, "killpg", None)
+        try:
+            if had_killpg:
+                delattr(os, "killpg")  # simulate Windows
+            preflight_runner.signal_child(child, signal.SIGTERM)
+        finally:
+            if had_killpg:
+                os.killpg = original
+        child.send_signal.assert_called_once_with(signal.SIGTERM)
+
+    def test_forwarding_swallows_dead_child(self) -> None:
+        child = Mock(pid=4321)
+        with patch.object(os, "killpg", side_effect=ProcessLookupError):
+            preflight_runner.signal_child(child, signal.SIGTERM)  # must not raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #9724.
Fixes #9610.

## Problem

The installed pre-push hook routes through `.github/scripts/preflight_runner.py`. `run_owned()` builds its signal handler map from a hard-coded tuple:

```python
previous_handlers = {
    signum: signal.signal(signum, forward_signal)
    for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
}
```

`signal.SIGHUP` is POSIX-only and does not exist on Windows, so merely *constructing that tuple* raises:

```
AttributeError: module 'signal' has no attribute 'SIGHUP'
  at preflight_runner.py:183
```

The wrapper exits 1 and Git rejects the push **before any pre-push check runs**, forcing Windows contributors onto `--no-verify`. `scripts/pre-push` works directly — only the single-flight wrapper fails.

The forwarding callback had the same class of problem: `os.killpg` is POSIX-only, so a signal arriving on Windows would raise `AttributeError` rather than stopping the child.

## Fix

Two module-level seams, so both are testable without sending a real signal to the test process:

- **`forwardable_signals()`** resolves the forward set against the host via `getattr(signal, name, None)`, skipping absent signals instead of exploding. POSIX keeps `SIGINT/SIGTERM/SIGHUP`; Windows gets `SIGINT/SIGTERM`.
- **`signal_child()`** prefers `os.killpg` — the child is started with `start_new_session=True`, so it leads its own process group and the whole tree is reached — and falls back to `child.send_signal()` where process groups are unavailable. It now also swallows `OSError` alongside `ProcessLookupError`, since `killpg` can fail with other OS errors against a dying child.

`run_owned()` becomes:

```python
previous_handlers = {signum: signal.signal(signum, forward_signal) for signum in forwardable_signals()}
```

Handler restoration and lock cleanup in the `finally` block are untouched.

## Acceptance criteria (#9610)

- [x] Register only signal constants that exist on the current platform — `forwardable_signals()`
- [x] Keep `os.killpg` process-group forwarding on POSIX — preferred branch in `signal_child()`
- [x] Fall back to `Popen.send_signal()` when `os.killpg` is unavailable
- [x] Preserve handler restoration and lock cleanup — `finally` block unchanged
- [x] Tests simulate missing `SIGHUP` and missing `os.killpg`
- [x] No dependency changes

The two remaining boxes in #9610 (`preflight_runner.py` executing on Windows Python, and a real `git push` completing there) need a Windows host to sign off — I verified the logic by simulating both missing APIs on POSIX.

## Tests

Added `SignalPortabilityTests` to `.github/scripts/test_pr_preflight.py` (already executed by `repo-checks.yml`), covering:

- signal selection with `SIGHUP` removed — simulating Windows
- `SIGHUP` present on POSIX
- forwarding to the process group when `os.killpg` exists
- `send_signal` fallback when `os.killpg` is absent
- a dead child (`ProcessLookupError`) not raising

## Verification

```
$ python -m unittest test_pr_preflight.SignalPortabilityTests
Ran 5 tests ... OK

# simulating Windows (SIGHUP deleted):
OLD expression      -> AttributeError: module 'signal' has no attribute 'SIGHUP'
forwardable_signals -> ['SIGINT', 'SIGTERM']
```

Full file: 26 tests, with 2 pre-existing failures that are **identical before and after** this change (they require a full clone; my sandbox used a shallow sparse checkout). `black --check --line-length 120` → clean, matching the pinned CI formatter.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Failure class

Failure-Class: none

Windows-only signal API portability in a repo tooling script; no registered class covers host-API availability in the pre-push runner.
