### PR TITLE
fix(backend): deleting a folder orphaned its conversations (is_default was never True)

### DIFF
--- a/backend/database/folders.py
+++ b/backend/database/folders.py
@@ -193,9 +193,18 @@ def delete_folder(uid: str, folder_id: str, move_to_folder_id: Optional[str] = N
     # Find target folder
     target_folder_id: Optional[str] = move_to_folder_id
     if not target_folder_id:
-        # Find the default folder (usually 'Other')
-        folders = get_folders(uid)
-        default_folder = next((f for f in folders if f.get('is_default')), None)
+        # Find the default folder. Never the folder being deleted — moving conversations
+        # into it would leave them orphaned once it is removed below.
+        candidates = [f for f in get_folders(uid) if str(f.get('id')) != folder_id]
+        default_folder = next((f for f in candidates if f.get('is_default')), None)
+        if not default_folder:
+            # Folders provisioned before is_default was computed correctly have the flag
+            # unset, so fall back to the folder the 'other' category maps to.
+            fallback_mapping = CATEGORY_TO_FOLDER_MAPPING['other']
+            default_folder = next(
+                (f for f in candidates if f.get('category_mapping') == fallback_mapping),
+                None,
+            )
         if default_folder:
             target_folder_id = str(default_folder['id'])
 
@@ -266,7 +275,11 @@ def initialize_system_folders(uid: str) -> List[Dict[str, Any]]:
             'created_at': now,
             'updated_at': now,
             'order': i,
-            'is_default': folder_config['category_mapping'] == 'other',
+            # The folder the catch-all 'other' category lands in is the default
+            # destination. Comparing against the literal 'other' never matched, because
+            # no SYSTEM_FOLDERS entry uses that category_mapping — so no folder was ever
+            # marked default and delete_folder had nowhere to move conversations.
+            'is_default': folder_config['category_mapping'] == CATEGORY_TO_FOLDER_MAPPING['other'],
             'is_system': True,
             'category_mapping': folder_config['category_mapping'],
             'conversation_count': 0,

--- a/backend/tests/unit/test_folder_delete_default_fallback.py
+++ b/backend/tests/unit/test_folder_delete_default_fallback.py
@@ -10,63 +10,41 @@ mappings ``work``/``personal``/``social`` — never ``other``. So every folder w
 with ``is_default=False``, the lookup always returned ``None``, the move block was
 skipped entirely, and the conversations kept a ``folder_id`` pointing at a folder that
 had just been deleted: invisible in every folder listing and 404 on fetch.
+
+Isolation: ``database.folders`` pulls ``database._client`` (a Firestore client) at
+import, so the module is loaded through the sanctioned Tier-2 reserve seam
+(``testing.import_isolation.stub_modules`` + ``load_module_fresh``) inside a fixture —
+never a module-scope ``sys.modules`` mutation. See backend/docs/test_isolation.md.
 """
 
 import os
-import sys
+from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock
 
 import pytest
 
-os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+from testing.import_isolation import load_module_fresh, stub_modules
+
+_BACKEND = Path(__file__).resolve().parents[2]
 
 
-class _AutoMockModule(ModuleType):
-    """Module stub that returns a MagicMock for any missing attribute."""
-
-    def __getattr__(self, name):
-        if name.startswith('__') and name.endswith('__'):
-            raise AttributeError(name)
-        mock = MagicMock()
-        setattr(self, name, mock)
-        return mock
-
-
-def _install_google_stubs() -> None:
-    """Stand in for google.cloud only when it is genuinely unavailable.
-
-    CI installs the real client library; this keeps the test runnable in a minimal
-    environment without shadowing the real package where it exists.
-    """
-    try:  # pragma: no cover - depends on the environment
-        from google.cloud import firestore  # noqa: F401
-        from google.cloud.firestore_v1 import FieldFilter  # noqa: F401
-
-        return
-    except ImportError:
-        pass
-
-    google_pkg = sys.modules.setdefault('google', _AutoMockModule('google'))
-    google_pkg.__path__ = []  # type: ignore[attr-defined]
-    cloud_pkg = _AutoMockModule('google.cloud')
-    cloud_pkg.__path__ = []  # type: ignore[attr-defined]
-    firestore_v1 = _AutoMockModule('google.cloud.firestore_v1')
-    firestore_v1.FieldFilter = MagicMock()  # type: ignore[attr-defined]
-    sys.modules['google.cloud'] = cloud_pkg
-    sys.modules['google.cloud.firestore'] = _AutoMockModule('google.cloud.firestore')
-    sys.modules['google.cloud.firestore_v1'] = firestore_v1
-
-
-_install_google_stubs()
-sys.modules.setdefault('database._client', _AutoMockModule('database._client'))
-
-import database.folders as folders_db  # noqa: E402
+@pytest.fixture(scope="module")
+def folders_db():
+    """Load a fresh ``database.folders`` against a stubbed Firestore client module."""
+    client_stub = ModuleType("database._client")
+    client_stub.db = MagicMock()  # replaced per-test by the fixtures below
+    with stub_modules({"database._client": client_stub}):
+        module = load_module_fresh(
+            "database.folders",
+            os.path.join(str(_BACKEND), "database", "folders.py"),
+        )
+        yield module
 
 
 @pytest.fixture
-def provisioned(monkeypatch):
-    """The folders the REAL initialize_system_folders writes, with a fresh user.
+def provisioned(monkeypatch, folders_db):
+    """The folders the REAL initialize_system_folders writes, for a fresh user.
 
     Driving the production function (rather than restating its logic here) is what makes
     these assertions a regression test for the is_default computation itself.
@@ -80,7 +58,7 @@ def provisioned(monkeypatch):
 
 
 @pytest.fixture
-def firestore(monkeypatch):
+def firestore(monkeypatch, folders_db):
     """Mock Firestore, capturing the folder_id each conversation is reassigned to."""
     batch = MagicMock()
     moved = []
@@ -104,13 +82,13 @@ class TestSystemFolderDefaultFlag:
         defaults = [f['name'] for f in provisioned if f['is_default']]
         assert len(defaults) == 1, f"expected exactly one default folder, got {defaults}"
 
-    def test_default_folder_is_where_the_other_category_lands(self, provisioned):
+    def test_default_folder_is_where_the_other_category_lands(self, provisioned, folders_db):
         # The delete_folder docstring calls it "the default 'Other' folder"; the 'other'
         # category maps to a real system folder, and that folder is the default.
         default = next(f for f in provisioned if f['is_default'])
         assert default['category_mapping'] == folders_db.CATEGORY_TO_FOLDER_MAPPING['other']
 
-    def test_no_system_folder_uses_the_literal_other_mapping(self):
+    def test_no_system_folder_uses_the_literal_other_mapping(self, folders_db):
         # The reason the original `== 'other'` comparison could never be True.
         assert all(cfg['category_mapping'] != 'other' for cfg in folders_db.SYSTEM_FOLDERS)
 
@@ -124,7 +102,7 @@ class TestDeleteFolderRelocatesConversations:
     def _default_id(provisioned):
         return next(f['id'] for f in provisioned if f['is_default'])
 
-    def test_conversations_move_to_default_when_no_target_given(self, monkeypatch, provisioned, firestore):
+    def test_conversations_move_to_default_when_no_target_given(self, monkeypatch, provisioned, firestore, folders_db):
         _db, moved = firestore
         monkeypatch.setattr(folders_db, 'get_folders', lambda uid: provisioned)
 
@@ -132,7 +110,7 @@ class TestDeleteFolderRelocatesConversations:
 
         assert moved == [self._default_id(provisioned)], "conversation was not relocated to the default folder"
 
-    def test_falls_back_when_legacy_folders_have_flag_unset(self, monkeypatch, provisioned, firestore):
+    def test_falls_back_when_legacy_folders_have_flag_unset(self, monkeypatch, provisioned, firestore, folders_db):
         # Users provisioned before the fix have is_default=False on every folder.
         _db, moved = firestore
         legacy = [{**f, 'is_default': False} for f in provisioned]
@@ -145,7 +123,7 @@ class TestDeleteFolderRelocatesConversations:
         )
         assert moved == [expected], "legacy folders left the conversation orphaned"
 
-    def test_never_targets_the_folder_being_deleted(self, monkeypatch, provisioned, firestore):
+    def test_never_targets_the_folder_being_deleted(self, monkeypatch, provisioned, firestore, folders_db):
         # Deleting the default folder itself must not move conversations into it.
         _db, moved = firestore
         monkeypatch.setattr(folders_db, 'get_folders', lambda uid: provisioned)
@@ -155,7 +133,7 @@ class TestDeleteFolderRelocatesConversations:
 
         assert default_id not in moved, "conversations were moved into the folder being deleted"
 
-    def test_explicit_target_is_respected(self, monkeypatch, provisioned, firestore):
+    def test_explicit_target_is_respected(self, monkeypatch, provisioned, firestore, folders_db):
         _db, moved = firestore
         monkeypatch.setattr(folders_db, 'get_folders', lambda uid: provisioned)
         social_id = next(f['id'] for f in provisioned if f['category_mapping'] == 'social')

--- a/backend/tests/unit/test_folder_delete_default_fallback.py
+++ b/backend/tests/unit/test_folder_delete_default_fallback.py
@@ -1,0 +1,165 @@
+"""Deleting a folder must relocate its conversations to the default folder.
+
+``delete_folder(uid, folder_id)`` with no ``move_to_folder_id`` promises (per its
+docstring) to move the folder's conversations to the default folder. It selects that
+folder with ``next((f for f in folders if f.get('is_default')), None)``.
+
+``initialize_system_folders`` used to compute the flag as
+``folder_config['category_mapping'] == 'other'``, but SYSTEM_FOLDERS only defines the
+mappings ``work``/``personal``/``social`` — never ``other``. So every folder was written
+with ``is_default=False``, the lookup always returned ``None``, the move block was
+skipped entirely, and the conversations kept a ``folder_id`` pointing at a folder that
+had just been deleted: invisible in every folder listing and 404 on fetch.
+"""
+
+import os
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+
+class _AutoMockModule(ModuleType):
+    """Module stub that returns a MagicMock for any missing attribute."""
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+def _install_google_stubs() -> None:
+    """Stand in for google.cloud only when it is genuinely unavailable.
+
+    CI installs the real client library; this keeps the test runnable in a minimal
+    environment without shadowing the real package where it exists.
+    """
+    try:  # pragma: no cover - depends on the environment
+        from google.cloud import firestore  # noqa: F401
+        from google.cloud.firestore_v1 import FieldFilter  # noqa: F401
+
+        return
+    except ImportError:
+        pass
+
+    google_pkg = sys.modules.setdefault('google', _AutoMockModule('google'))
+    google_pkg.__path__ = []  # type: ignore[attr-defined]
+    cloud_pkg = _AutoMockModule('google.cloud')
+    cloud_pkg.__path__ = []  # type: ignore[attr-defined]
+    firestore_v1 = _AutoMockModule('google.cloud.firestore_v1')
+    firestore_v1.FieldFilter = MagicMock()  # type: ignore[attr-defined]
+    sys.modules['google.cloud'] = cloud_pkg
+    sys.modules['google.cloud.firestore'] = _AutoMockModule('google.cloud.firestore')
+    sys.modules['google.cloud.firestore_v1'] = firestore_v1
+
+
+_install_google_stubs()
+sys.modules.setdefault('database._client', _AutoMockModule('database._client'))
+
+import database.folders as folders_db  # noqa: E402
+
+
+@pytest.fixture
+def provisioned(monkeypatch):
+    """The folders the REAL initialize_system_folders writes, with a fresh user.
+
+    Driving the production function (rather than restating its logic here) is what makes
+    these assertions a regression test for the is_default computation itself.
+    """
+    folders_ref = MagicMock()
+    folders_ref.limit.return_value.stream.return_value = []  # no existing folders
+    db = MagicMock()
+    db.collection.return_value.document.return_value.collection.return_value = folders_ref
+    monkeypatch.setattr(folders_db, 'db', db)
+    return folders_db.initialize_system_folders('uid')
+
+
+@pytest.fixture
+def firestore(monkeypatch):
+    """Mock Firestore, capturing the folder_id each conversation is reassigned to."""
+    batch = MagicMock()
+    moved = []
+    batch.update.side_effect = lambda ref, payload: moved.append(payload['folder_id'])
+
+    conversation = MagicMock()
+    db = MagicMock()
+    db.batch.return_value = batch
+    user_ref = db.collection.return_value.document.return_value
+    user_ref.collection.return_value.where.return_value.stream.return_value = [conversation]
+
+    monkeypatch.setattr(folders_db, 'db', db)
+    monkeypatch.setattr(folders_db, 'update_folder_conversation_count', MagicMock())
+    return db, moved
+
+
+class TestSystemFolderDefaultFlag:
+    """Assertions against the folders initialize_system_folders actually writes."""
+
+    def test_exactly_one_provisioned_folder_is_marked_default(self, provisioned):
+        defaults = [f['name'] for f in provisioned if f['is_default']]
+        assert len(defaults) == 1, f"expected exactly one default folder, got {defaults}"
+
+    def test_default_folder_is_where_the_other_category_lands(self, provisioned):
+        # The delete_folder docstring calls it "the default 'Other' folder"; the 'other'
+        # category maps to a real system folder, and that folder is the default.
+        default = next(f for f in provisioned if f['is_default'])
+        assert default['category_mapping'] == folders_db.CATEGORY_TO_FOLDER_MAPPING['other']
+
+    def test_no_system_folder_uses_the_literal_other_mapping(self):
+        # The reason the original `== 'other'` comparison could never be True.
+        assert all(cfg['category_mapping'] != 'other' for cfg in folders_db.SYSTEM_FOLDERS)
+
+
+class TestDeleteFolderRelocatesConversations:
+    @staticmethod
+    def _work_id(provisioned):
+        return next(f['id'] for f in provisioned if f['category_mapping'] == 'work')
+
+    @staticmethod
+    def _default_id(provisioned):
+        return next(f['id'] for f in provisioned if f['is_default'])
+
+    def test_conversations_move_to_default_when_no_target_given(self, monkeypatch, provisioned, firestore):
+        _db, moved = firestore
+        monkeypatch.setattr(folders_db, 'get_folders', lambda uid: provisioned)
+
+        assert folders_db.delete_folder('uid', self._work_id(provisioned)) is True
+
+        assert moved == [self._default_id(provisioned)], "conversation was not relocated to the default folder"
+
+    def test_falls_back_when_legacy_folders_have_flag_unset(self, monkeypatch, provisioned, firestore):
+        # Users provisioned before the fix have is_default=False on every folder.
+        _db, moved = firestore
+        legacy = [{**f, 'is_default': False} for f in provisioned]
+        monkeypatch.setattr(folders_db, 'get_folders', lambda uid: legacy)
+
+        folders_db.delete_folder('uid', self._work_id(provisioned))
+
+        expected = next(
+            f['id'] for f in provisioned if f['category_mapping'] == folders_db.CATEGORY_TO_FOLDER_MAPPING['other']
+        )
+        assert moved == [expected], "legacy folders left the conversation orphaned"
+
+    def test_never_targets_the_folder_being_deleted(self, monkeypatch, provisioned, firestore):
+        # Deleting the default folder itself must not move conversations into it.
+        _db, moved = firestore
+        monkeypatch.setattr(folders_db, 'get_folders', lambda uid: provisioned)
+        default_id = self._default_id(provisioned)
+
+        folders_db.delete_folder('uid', default_id)
+
+        assert default_id not in moved, "conversations were moved into the folder being deleted"
+
+    def test_explicit_target_is_respected(self, monkeypatch, provisioned, firestore):
+        _db, moved = firestore
+        monkeypatch.setattr(folders_db, 'get_folders', lambda uid: provisioned)
+        social_id = next(f['id'] for f in provisioned if f['category_mapping'] == 'social')
+
+        folders_db.delete_folder('uid', self._work_id(provisioned), move_to_folder_id=social_id)
+
+        assert moved == [social_id]


### PR DESCRIPTION
## Problem

`DELETE /v1/folders/{id}` without `move_to_folder_id` returns 204 but **leaves every conversation in that folder pointing at a folder that no longer exists** — the conversations vanish from all folder listings and 404 on fetch.

`delete_folder`'s docstring promises: *"If move_to_folder_id is not provided, moves to the default 'Other' folder."* It finds that folder with:

```python
default_folder = next((f for f in folders if f.get('is_default')), None)
```

But **no folder ever has `is_default=True`.** `initialize_system_folders` computes it as:

```python
'is_default': folder_config['category_mapping'] == 'other',
```

and `SYSTEM_FOLDERS` only defines the mappings `work`, `personal`, `social` — **never `other`**. So all three system folders are written `is_default=False`, and user-created folders hard-code `False` (`folders.py:137`). The lookup always returns `None`, `target_folder_id` stays `None`, and the entire relocation block is skipped before `folder_ref.delete()`.

`is_default` has exactly one consumer in this module, so the flag was effectively dead code.

## Fix

1. **Derive the flag from the mapping that already defines the catch-all destination.** `CATEGORY_TO_FOLDER_MAPPING['other'] == 'personal'`, so Personal *is* the "Other" bucket the docstring means:

```diff
-'is_default': folder_config['category_mapping'] == 'other',
+'is_default': folder_config['category_mapping'] == CATEGORY_TO_FOLDER_MAPPING['other'],
```

Deriving it (rather than hard-coding `'personal'`) keeps the two in sync if the mapping ever changes.

2. **Back-compat fallback.** Users provisioned before this fix already have `is_default=False` stored on every folder, so `delete_folder` falls back to the same `'other'` mapping when no folder carries the flag — repairing existing accounts without a migration.

3. **Never target the folder being deleted.** With a live flag, deleting the default folder itself would otherwise move its conversations *into the folder about to be removed*, re-orphaning them.

## Tests

New `tests/unit/test_folder_delete_default_fallback.py` (7 tests). Importantly these drive the **real** `initialize_system_folders` with a mocked Firestore rather than restating its logic, so they regress the `is_default` computation itself:

- exactly one provisioned folder is default, and it is where the `'other'` category lands
- no system folder uses the literal `'other'` mapping (the root cause)
- conversations relocate to the default when no target is given
- legacy folders with the flag unset still relocate (no orphaning)
- the folder being deleted is never chosen as the target
- an explicit `move_to_folder_id` still wins

## Verification

```
$ pytest tests/unit/test_folder_delete_default_fallback.py
7 passed

# revert both parts of the fix:
5 failed, 2 passed
```

The other folder suites still pass (27 tests). `black --line-length 120 --check` → clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




## Failure class

Failure-Class: none

A dead feature flag that made a documented fallback unreachable; no registered class covers it.
