### PR TITLE
fix(desktop): own onboarding arrow monitor lifecycle

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -787,12 +787,6 @@ class AppState: ObservableObject {
 
 extension Notification.Name {
   static let resetOnboardingRequested = Notification.Name("resetOnboardingRequested")
-  /// Posted by the onboarding arrow-key monitor with a "targetStep" Int in
-  /// userInfo. The mounted OnboardingView applies it to its live @AppStorage —
-  /// the monitor closure must not mutate its own captured copy (writes there
-  /// never reach UserDefaults or the UI on all macOS versions).
-  static let onboardingStepNavigationRequested = Notification.Name(
-    "onboardingStepNavigationRequested")
   /// Posted when the system wakes from sleep
   static let systemDidWake = Notification.Name("systemDidWake")
   /// Posted when the screen is locked

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -108,8 +108,10 @@ struct DesktopHomeView: View {
             appState.hasCompletedOnboarding = true
           }
         } else {
-          OnboardingView(
-            appState: appState, chatProvider: viewModelContainer.chatProvider, onComplete: nil
+          OnboardingViewOwner(
+            appState: appState,
+            chatProvider: viewModelContainer.chatProvider,
+            onComplete: nil
           )
           .onAppear {
             log("DesktopHomeView: Showing OnboardingView (signed in, not onboarded)")

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingKeyboardNavigationCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingKeyboardNavigationCoordinator.swift
@@ -1,0 +1,104 @@
+import AppKit
+import Combine
+
+/// Owns the local arrow-key monitor for one mounted onboarding surface.
+///
+/// The coordinator deliberately has no app-global state. SwiftUI retains it with
+/// `@StateObject`, updates the live navigation bindings on every appearance, and
+/// tears it down whenever the onboarding surface disappears.
+@MainActor
+final class OnboardingKeyboardNavigationCoordinator: ObservableObject {
+  /// AppKit deliberately types monitor tokens as `Any`. These wrappers keep
+  /// that framework detail confined while allowing deterministic main-actor
+  /// cleanup from `deinit` under strict concurrency.
+  private final class MonitorToken: @unchecked Sendable {
+    let value: Any
+
+    init(_ value: Any) {
+      self.value = value
+    }
+  }
+
+  private final class MonitorHooks: @unchecked Sendable {
+    let install: EventMonitorInstaller
+    let remove: EventMonitorRemover
+
+    init(install: @escaping EventMonitorInstaller, remove: @escaping EventMonitorRemover) {
+      self.install = install
+      self.remove = remove
+    }
+  }
+
+  typealias EventHandler = (NSEvent) -> NSEvent?
+  typealias EventMonitorInstaller = (@escaping EventHandler) -> Any?
+  typealias EventMonitorRemover = (Any) -> Void
+
+  struct Navigation {
+    let isActive: () -> Bool
+    let focusedControlOwnsArrows: () -> Bool
+    let currentStep: () -> Int
+    let furthestStep: () -> Int
+    let apply: (OnboardingFlow.ArrowNavigation) -> Bool
+  }
+
+  private let monitorHooks: MonitorHooks
+  private var monitorToken: MonitorToken?
+  private var navigation: Navigation?
+
+  init(
+    installMonitor: @escaping EventMonitorInstaller = { handler in
+      NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+    },
+    removeMonitor: @escaping EventMonitorRemover = { token in
+      NSEvent.removeMonitor(token)
+    }
+  ) {
+    monitorHooks = MonitorHooks(install: installMonitor, remove: removeMonitor)
+  }
+
+  /// Installs exactly one monitor for this mounted owner. Calling this again
+  /// refreshes the live bindings without stacking a second monitor.
+  func mount(_ navigation: Navigation) {
+    self.navigation = navigation
+    guard monitorToken == nil else { return }
+    monitorToken = monitorHooks.install { [weak self] event in
+      guard let self else { return event }
+      return self.handle(event)
+    }.map(MonitorToken.init)
+  }
+
+  /// This is intentionally idempotent: completion can tear down eagerly and
+  /// SwiftUI disappearance can then converge on the same cleanup safely.
+  func unmount() {
+    navigation = nil
+    guard let monitorToken else { return }
+    monitorHooks.remove(monitorToken.value)
+    self.monitorToken = nil
+  }
+
+  deinit {
+    if let monitorToken {
+      monitorHooks.remove(monitorToken.value)
+    }
+  }
+
+  private func handle(_ event: NSEvent) -> NSEvent? {
+    guard let navigation, navigation.isActive() else { return event }
+    // Repeats are passed through deliberately: holding an arrow never races
+    // through skippable onboarding pages.
+    guard !event.isARepeat else { return event }
+    let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+    guard modifiers.subtracting([.function, .numericPad]).isEmpty else { return event }
+    guard !navigation.focusedControlOwnsArrows() else { return event }
+    guard
+      let action = OnboardingFlow.arrowNavigation(
+        keyCode: event.keyCode,
+        step: navigation.currentStep(),
+        furthestStep: navigation.furthestStep()
+      )
+    else {
+      return event
+    }
+    return navigation.apply(action) ? nil : event
+  }
+}

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingKeyboardNavigationCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingKeyboardNavigationCoordinator.swift
@@ -1,11 +1,7 @@
 import AppKit
 import Combine
 
-/// Owns the local arrow-key monitor for one mounted onboarding surface.
-///
-/// The coordinator deliberately has no app-global state. SwiftUI retains it with
-/// `@StateObject`, updates the live navigation bindings on every appearance, and
-/// tears it down whenever the onboarding surface disappears.
+/// Owns the local arrow-key monitor for the stable parent of the mounted onboarding surface.
 @MainActor
 final class OnboardingKeyboardNavigationCoordinator: ObservableObject {
   /// AppKit deliberately types monitor tokens as `Any`. These wrappers keep
@@ -41,9 +37,14 @@ final class OnboardingKeyboardNavigationCoordinator: ObservableObject {
     let apply: (OnboardingFlow.ArrowNavigation) -> Bool
   }
 
+  struct MountLease: Equatable {
+    fileprivate let generation: UInt64
+  }
+
   private let monitorHooks: MonitorHooks
   private var monitorToken: MonitorToken?
-  private var navigation: Navigation?
+  private var navigation: (lease: MountLease, value: Navigation)?
+  private var nextGeneration: UInt64 = 0
 
   init(
     installMonitor: @escaping EventMonitorInstaller = { handler in
@@ -56,20 +57,24 @@ final class OnboardingKeyboardNavigationCoordinator: ObservableObject {
     monitorHooks = MonitorHooks(install: installMonitor, remove: removeMonitor)
   }
 
-  /// Installs exactly one monitor for this mounted owner. Calling this again
-  /// refreshes the live bindings without stacking a second monitor.
-  func mount(_ navigation: Navigation) {
-    self.navigation = navigation
-    guard monitorToken == nil else { return }
+  /// Replaces the active child navigation atomically without stacking monitors.
+  /// A delayed disappearance can release only its own lease.
+  func mount(_ navigation: Navigation) -> MountLease {
+    nextGeneration &+= 1
+    let lease = MountLease(generation: nextGeneration)
+    self.navigation = (lease, navigation)
+    guard monitorToken == nil else { return lease }
     monitorToken = monitorHooks.install { [weak self] event in
       guard let self else { return event }
       return self.handle(event)
     }.map(MonitorToken.init)
+    return lease
   }
 
-  /// This is intentionally idempotent: completion can tear down eagerly and
-  /// SwiftUI disappearance can then converge on the same cleanup safely.
-  func unmount() {
+  /// Tears down only the active child's navigation. Stale child disappearance
+  /// is deliberately ignored after a replacement has acquired a newer lease.
+  func unmount(_ lease: MountLease?) {
+    guard let lease, navigation?.lease == lease else { return }
     navigation = nil
     guard let monitorToken else { return }
     monitorHooks.remove(monitorToken.value)
@@ -83,7 +88,7 @@ final class OnboardingKeyboardNavigationCoordinator: ObservableObject {
   }
 
   private func handle(_ event: NSEvent) -> NSEvent? {
-    guard let navigation, navigation.isActive() else { return event }
+    guard let navigation = navigation?.value, navigation.isActive() else { return event }
     // Repeats are passed through deliberately: holding an arrow never races
     // through skippable onboarding pages.
     guard !event.isARepeat else { return event }
@@ -100,5 +105,57 @@ final class OnboardingKeyboardNavigationCoordinator: ObservableObject {
       return event
     }
     return navigation.apply(action) ? nil : event
+  }
+}
+
+@MainActor
+enum OnboardingKeyboardResponderPolicy {
+  static func ownsArrows(in window: NSWindow?) -> Bool {
+    guard let window else { return false }
+    if window is FloatingControlBarWindow { return true }
+    return ownsArrows(firstResponder: window.firstResponder)
+  }
+
+  static func ownsArrows(firstResponder: NSResponder?) -> Bool {
+    var responder = firstResponder
+    while let current = responder {
+      if current is NSText || current is NSTextView { return true }
+      if let textField = current as? NSTextField, textField.isEditable { return true }
+      if let comboBox = current as? NSComboBox, comboBox.isEditable { return true }
+      if current is NSSegmentedControl || current is NSSlider || current is NSStepper
+        || current is NSScroller || current is NSTableView || current is NSOutlineView
+        || current is NSCollectionView
+      {
+        return true
+      }
+      let next = current.nextResponder
+      guard next !== current else { return false }
+      responder = next
+    }
+    return false
+  }
+}
+
+@MainActor
+enum OnboardingDefaultActionPoster {
+  static func post(in window: NSWindow?) -> Bool {
+    guard let window else { return false }
+    let events = [NSEvent.EventType.keyDown, .keyUp].compactMap { phase in
+      NSEvent.keyEvent(
+        with: phase,
+        location: .zero,
+        modifierFlags: [],
+        timestamp: ProcessInfo.processInfo.systemUptime,
+        windowNumber: window.windowNumber,
+        context: nil,
+        characters: "\r",
+        charactersIgnoringModifiers: "\r",
+        isARepeat: false,
+        keyCode: 36
+      )
+    }
+    guard events.count == 2 else { return false }
+    events.forEach { window.postEvent($0, atStart: false) }
+    return true
   }
 }

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
@@ -37,12 +37,8 @@ struct OnboardingView: View {
   @AppStorage("onboardingBYOKStepRemoved") private var hasRemovedBYOKStep = false
   @StateObject private var introCoordinator = OnboardingPagedIntroCoordinator()
   @StateObject private var graphViewModel = MemoryGraphViewModel()
+  @StateObject private var keyboardNavigationCoordinator = OnboardingKeyboardNavigationCoordinator()
   @FocusState private var contentFocused: Bool
-  /// Static, not @State: SwiftUI can recreate this view mid-flow (parent tree
-  /// identity changes), and a per-identity handle would leak the old monitor —
-  /// which keeps consuming arrow keys — while installing a second one. One
-  /// shared handle means re-install replaces instead of stacking.
-  private static var keyNavMonitor: Any?
 
   let steps = OnboardingFlow.steps
 
@@ -114,16 +110,10 @@ struct OnboardingView: View {
       hasInsertedBYOKStep = true
       hasRemovedBYOKStep = true
       introCoordinator.prepare(appState: appState)
-      installKeyNavigationMonitor()
+      mountKeyNavigation()
     }
     .onDisappear {
-      // Identity churn re-creates this view mid-flow, and the new identity's
-      // onAppear may run before this onDisappear — removing here would tear
-      // down the monitor it just installed. Only remove once onboarding is
-      // actually over; the handler also no-ops after completion.
-      if !isExportPreview, appState.hasCompletedOnboarding {
-        removeKeyNavigationMonitor()
-      }
+      keyboardNavigationCoordinator.unmount()
     }
     .task {
       guard !isExportPreview else { return }
@@ -138,16 +128,6 @@ struct OnboardingView: View {
       log("OnboardingView: resetOnboardingRequested — returning to the first onboarding step")
       currentStep = 0
       furthestStep = 0
-    }
-    .onReceive(
-      NotificationCenter.default.publisher(for: .onboardingStepNavigationRequested)
-    ) { note in
-      guard !isExportPreview, let requested = note.userInfo?["targetStep"] as? Int else { return }
-      guard
-        let target = OnboardingFlow.validatedNavigationTarget(
-          requested, currentStep: currentStep, furthestStep: furthestStep)
-      else { return }
-      currentStep = target
     }
   }
 
@@ -533,75 +513,61 @@ struct OnboardingView: View {
     currentStep = index
   }
 
-  /// Arrow-key navigation runs off a local `NSEvent` monitor rather than SwiftUI
-  /// `.onKeyPress`, because the "Ask a question" steps take key focus away from the
-  /// onboarding window (shortcut steps null the app menu + install their own key
-  /// monitor; demo steps hand focus to the floating Ask Omi panel). A monitor sees
-  /// the keystroke regardless of which of the app's windows is key.
-  private func installKeyNavigationMonitor() {
-    // The outer onAppear also runs on the already-completed branch — don't
-    // install an arrow monitor for a flow that isn't showing.
+  /// Arrow-key navigation uses one local monitor owned by this mounted view.
+  /// It deliberately stays connected to live `@AppStorage` bindings rather
+  /// than a copied view value or an app-global notification relay.
+  private func mountKeyNavigation() {
     guard !isExportPreview, !appState.hasCompletedOnboarding else { return }
-    removeKeyNavigationMonitor()
-    Self.keyNavMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-      handleArrowNavigation(event) ? nil : event
-    }
+    let currentStep = $currentStep
+    let furthestStep = $furthestStep
+    let appState = appState
+    keyboardNavigationCoordinator.mount(
+      .init(
+        isActive: { !appState.hasCompletedOnboarding },
+        focusedControlOwnsArrows: Self.focusedControlOwnsArrows,
+        currentStep: { currentStep.wrappedValue },
+        furthestStep: { furthestStep.wrappedValue },
+        apply: { action in
+          switch action {
+          case .jump(let target):
+            guard
+              let target = OnboardingFlow.validatedNavigationTarget(
+                target,
+                currentStep: currentStep.wrappedValue,
+                furthestStep: furthestStep.wrappedValue
+              )
+            else { return false }
+            currentStep.wrappedValue = target
+            return true
+          case .forwardDefaultAction:
+            return Self.handleForwardKey()
+          }
+        }
+      )
+    )
   }
 
-  private func removeKeyNavigationMonitor() {
-    if let monitor = Self.keyNavMonitor {
-      NSEvent.removeMonitor(monitor)
-      Self.keyNavMonitor = nil
+  private static func focusedControlOwnsArrows() -> Bool {
+    guard let keyWindow = NSApp.keyWindow else { return false }
+    if keyWindow is FloatingControlBarWindow { return true }
+
+    var responder: NSResponder? = keyWindow.firstResponder
+    while let current = responder {
+      if current is NSText || current is NSControl || current is NSTableView || current is NSOutlineView
+        || current is NSCollectionView
+      {
+        return true
+      }
+      responder = current.nextResponder
     }
-  }
-
-  /// Returns true when the event was consumed as a back/forward navigation.
-  /// Skips plain arrows while the user is typing (any text field, including the
-  /// floating Ask Omi bar) so the caret keeps moving instead of navigating.
-  ///
-  /// Runs inside the NSEvent monitor closure, which holds a detached copy of
-  /// this view. Mutating @AppStorage through that copy silently drops the write
-  /// on some macOS versions (it never reaches UserDefaults or the mounted
-  /// view), so this reads the persisted step state directly and posts the
-  /// target step for the mounted view's `.onReceive` to apply.
-  private func handleArrowNavigation(_ event: NSEvent) -> Bool {
-    guard !isExportPreview else { return false }
-    // The monitor may briefly outlive the flow (removal is deferred across
-    // identity churn); never swallow arrows once onboarding is done.
-    guard !UserDefaults.standard.bool(forKey: .hasCompletedOnboarding) else { return false }
-    // Only bare arrows navigate — leave shortcut chords (⌘/⌥/⌃/⇧) to their owners.
-    let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-    guard mods.subtracting([.function, .numericPad]).isEmpty else { return false }
-    // Typing in the floating bar or any text field owns the arrows.
-    if NSApp.keyWindow is FloatingControlBarWindow { return false }
-    if NSApp.keyWindow?.firstResponder is NSText { return false }
-
-    let defaults = UserDefaults.standard
-    let step = defaults.integer(forKey: .onboardingStep)
-    let frontier = defaults.integer(forKey: .onboardingFurthestStep)
-
-    switch OnboardingFlow.arrowNavigation(keyCode: event.keyCode, step: step, furthestStep: frontier)
-    {
-    case .jump(let target):
-      postStepNavigation(target)
-      return true
-    case .forwardDefaultAction:
-      return handleForwardKey() == .handled
-    case nil:
-      return false
-    }
-  }
-
-  private func postStepNavigation(_ target: Int) {
-    NotificationCenter.default.post(
-      name: .onboardingStepNavigationRequested, object: nil, userInfo: ["targetStep": target])
+    return false
   }
 
   /// Forward arrow == pressing the step's visible Continue button. Re-issuing the
   /// default-action key (Return) reuses each step's own gating (name/goal required,
   /// demo completion) instead of blindly advancing `currentStep`.
-  private func handleForwardKey() -> KeyPress.Result {
-    guard let window = NSApp.keyWindow else { return .ignored }
+  private static func handleForwardKey() -> Bool {
+    guard let window = NSApp.keyWindow else { return false }
     for phase in [NSEvent.EventType.keyDown, .keyUp] {
       guard
         let event = NSEvent.keyEvent(
@@ -613,12 +579,13 @@ struct OnboardingView: View {
       else { continue }
       window.postEvent(event, atStart: false)
     }
-    return .handled
+    return true
   }
 
   /// Complete onboarding — start all services and transition to the app
   private func handleOnboardingComplete() {
     log("OnboardingView: Onboarding complete")
+    keyboardNavigationCoordinator.unmount()
     AnalyticsManager.shared.onboardingCompleted()
 
     // Stop the AI if it's still running

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
@@ -4,6 +4,29 @@ import OmiTheme
 import SceneKit
 import SwiftUI
 
+/// Stable mounted owner for replaceable onboarding view identities. It keeps
+/// exactly one local monitor coordinator for the lifetime of this onboarding
+/// presentation, without app-global state.
+struct OnboardingViewOwner: View {
+  @ObservedObject var appState: AppState
+  @ObservedObject var chatProvider: ChatProvider
+  var onComplete: (() -> Void)? = nil
+  var exportStepOverride: Int? = nil
+  var isExportPreview = false
+  @StateObject private var keyboardNavigationCoordinator = OnboardingKeyboardNavigationCoordinator()
+
+  var body: some View {
+    OnboardingView(
+      appState: appState,
+      chatProvider: chatProvider,
+      onComplete: onComplete,
+      exportStepOverride: exportStepOverride,
+      isExportPreview: isExportPreview,
+      keyboardNavigationCoordinator: keyboardNavigationCoordinator
+    )
+  }
+}
+
 struct OnboardingView: View {
   @ObservedObject var appState: AppState
   @ObservedObject var chatProvider: ChatProvider
@@ -37,7 +60,8 @@ struct OnboardingView: View {
   @AppStorage("onboardingBYOKStepRemoved") private var hasRemovedBYOKStep = false
   @StateObject private var introCoordinator = OnboardingPagedIntroCoordinator()
   @StateObject private var graphViewModel = MemoryGraphViewModel()
-  @StateObject private var keyboardNavigationCoordinator = OnboardingKeyboardNavigationCoordinator()
+  @ObservedObject var keyboardNavigationCoordinator: OnboardingKeyboardNavigationCoordinator
+  @State private var keyboardNavigationLease: OnboardingKeyboardNavigationCoordinator.MountLease?
   @FocusState private var contentFocused: Bool
 
   let steps = OnboardingFlow.steps
@@ -113,7 +137,8 @@ struct OnboardingView: View {
       mountKeyNavigation()
     }
     .onDisappear {
-      keyboardNavigationCoordinator.unmount()
+      keyboardNavigationCoordinator.unmount(keyboardNavigationLease)
+      keyboardNavigationLease = nil
     }
     .task {
       guard !isExportPreview else { return }
@@ -513,18 +538,17 @@ struct OnboardingView: View {
     currentStep = index
   }
 
-  /// Arrow-key navigation uses one local monitor owned by this mounted view.
-  /// It deliberately stays connected to live `@AppStorage` bindings rather
-  /// than a copied view value or an app-global notification relay.
+  /// Arrow-key navigation borrows the stable parent's one monitor and keeps its
+  /// live bindings in the mounted child that currently holds the lease.
   private func mountKeyNavigation() {
     guard !isExportPreview, !appState.hasCompletedOnboarding else { return }
     let currentStep = $currentStep
     let furthestStep = $furthestStep
     let appState = appState
-    keyboardNavigationCoordinator.mount(
+    keyboardNavigationLease = keyboardNavigationCoordinator.mount(
       .init(
         isActive: { !appState.hasCompletedOnboarding },
-        focusedControlOwnsArrows: Self.focusedControlOwnsArrows,
+        focusedControlOwnsArrows: { OnboardingKeyboardResponderPolicy.ownsArrows(in: NSApp.keyWindow) },
         currentStep: { currentStep.wrappedValue },
         furthestStep: { furthestStep.wrappedValue },
         apply: { action in
@@ -547,45 +571,18 @@ struct OnboardingView: View {
     )
   }
 
-  private static func focusedControlOwnsArrows() -> Bool {
-    guard let keyWindow = NSApp.keyWindow else { return false }
-    if keyWindow is FloatingControlBarWindow { return true }
-
-    var responder: NSResponder? = keyWindow.firstResponder
-    while let current = responder {
-      if current is NSText || current is NSControl || current is NSTableView || current is NSOutlineView
-        || current is NSCollectionView
-      {
-        return true
-      }
-      responder = current.nextResponder
-    }
-    return false
-  }
-
   /// Forward arrow == pressing the step's visible Continue button. Re-issuing the
   /// default-action key (Return) reuses each step's own gating (name/goal required,
   /// demo completion) instead of blindly advancing `currentStep`.
   private static func handleForwardKey() -> Bool {
-    guard let window = NSApp.keyWindow else { return false }
-    for phase in [NSEvent.EventType.keyDown, .keyUp] {
-      guard
-        let event = NSEvent.keyEvent(
-          with: phase, location: .zero, modifierFlags: [],
-          timestamp: ProcessInfo.processInfo.systemUptime,
-          windowNumber: window.windowNumber, context: nil,
-          characters: "\r", charactersIgnoringModifiers: "\r",
-          isARepeat: false, keyCode: 36)
-      else { continue }
-      window.postEvent(event, atStart: false)
-    }
-    return true
+    OnboardingDefaultActionPoster.post(in: NSApp.keyWindow)
   }
 
   /// Complete onboarding — start all services and transition to the app
   private func handleOnboardingComplete() {
     log("OnboardingView: Onboarding complete")
-    keyboardNavigationCoordinator.unmount()
+    keyboardNavigationCoordinator.unmount(keyboardNavigationLease)
+    keyboardNavigationLease = nil
     AnalyticsManager.shared.onboardingCompleted()
 
     // Stop the AI if it's still running

--- a/desktop/macos/Desktop/Sources/ViewExporter.swift
+++ b/desktop/macos/Desktop/Sources/ViewExporter.swift
@@ -116,7 +116,13 @@ enum ViewExporter {
 
       (
         "12-onboarding",
-        { AnyView(OnboardingView(appState: AppState(), chatProvider: ChatProvider())) },
+        {
+          AnyView(
+            OnboardingViewOwner(
+              appState: AppState(),
+              chatProvider: ChatProvider()
+            ))
+        },
         CGSize(width: 900, height: 600)
       ),
 
@@ -177,7 +183,7 @@ enum ViewExporter {
     let step = onboardingExportSteps[index]
     let appState = AppState()
     appState.hasCompletedOnboarding = false
-    let view = OnboardingView(
+    let view = OnboardingViewOwner(
       appState: appState,
       chatProvider: ChatProvider(),
       exportStepOverride: step.1,

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -585,7 +585,7 @@ final class OnboardingFlowTests: XCTestCase {
       installMonitor: monitor.install,
       removeMonitor: monitor.remove
     )
-    weak let weakOwner = owner
+    let weakOwner = OnboardingWeakReference(owner)
     let navigation = OnboardingKeyboardNavigationCoordinator.Navigation(
       isActive: { true },
       focusedControlOwnsArrows: { false },
@@ -603,7 +603,7 @@ final class OnboardingFlowTests: XCTestCase {
 
     owner = nil
 
-    XCTAssertNil(weakOwner)
+    XCTAssertNil(weakOwner.value)
     XCTAssertEqual(monitor.removeCount, 2, "deinit must remove a mounted token safely")
   }
 
@@ -713,5 +713,13 @@ private final class OnboardingDefaultActionRecordingWindow: NSWindow {
 
   override func postEvent(_ event: NSEvent, atStart flag: Bool) {
     postedEvents.append(event)
+  }
+}
+
+private final class OnboardingWeakReference<Value: AnyObject> {
+  weak var value: Value?
+
+  init(_ value: Value?) {
+    self.value = value
   }
 }

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -434,26 +434,86 @@ final class OnboardingFlowTests: XCTestCase {
       }
     )
 
-    owner.mount(navigation)
-    owner.mount(navigation)
+    let firstLease = owner.mount(navigation)
+    let replacementLease = owner.mount(navigation)
 
     XCTAssertEqual(monitor.installCount, 1, "repeated mount must retain one monitor token")
     XCTAssertNil(monitor.dispatch(onboardingKeyEvent(keyCode: 124)))
     XCTAssertEqual(navigationCount, 1, "the installed monitor must call the mounted navigation owner")
     XCTAssertEqual(currentStep, 11)
+    owner.unmount(firstLease)
+    XCTAssertEqual(monitor.removeCount, 0, "the first lease is stale after replacement")
+    owner.unmount(replacementLease)
+    XCTAssertEqual(monitor.removeCount, 1)
   }
 
   @MainActor
-  func testKeyboardNavigationOwnerPreservesFocusedModifiedAndRepeatedArrows() {
+  func testKeyboardNavigationReplacementSharesOneMonitorAndIgnoresStaleUnmount() {
+    let monitor = OnboardingKeyboardMonitorSpy()
+    let owner = OnboardingKeyboardNavigationCoordinator(
+      installMonitor: monitor.install,
+      removeMonitor: monitor.remove
+    )
+    var outgoingMutations = 0
+    var replacementStep = 10
+
+    let firstLease = owner.mount(
+      .init(
+        isActive: { true },
+        focusedControlOwnsArrows: { false },
+        currentStep: { 10 },
+        furthestStep: { 15 },
+        apply: { _ in
+          outgoingMutations += 1
+          return true
+        }
+      ))
+    let replacementLease = owner.mount(
+      .init(
+        isActive: { true },
+        focusedControlOwnsArrows: { false },
+        currentStep: { replacementStep },
+        furthestStep: { 15 },
+        apply: { action in
+          guard case .jump(let target) = action else { return false }
+          replacementStep = target
+          return true
+        }
+      ))
+
+    XCTAssertEqual(monitor.installCount, 1, "a replacement must not install a second local monitor")
+    owner.unmount(firstLease)
+    XCTAssertNil(monitor.dispatch(onboardingKeyEvent(keyCode: 124)))
+    XCTAssertEqual(outgoingMutations, 0, "a stale owner must not receive navigation")
+    XCTAssertEqual(replacementStep, 11)
+    owner.unmount(replacementLease)
+    XCTAssertEqual(monitor.removeCount, 1, "the final active lease removes the one monitor")
+  }
+
+  @MainActor
+  func testKeyboardNavigationResponderPolicyPreservesTextAndDirectionalControlsButNotButtons() {
+    XCTAssertTrue(OnboardingKeyboardResponderPolicy.ownsArrows(firstResponder: NSTextView()))
+    XCTAssertTrue(OnboardingKeyboardResponderPolicy.ownsArrows(firstResponder: NSSegmentedControl()))
+    XCTAssertTrue(OnboardingKeyboardResponderPolicy.ownsArrows(firstResponder: NSStepper()))
+    XCTAssertFalse(
+      OnboardingKeyboardResponderPolicy.ownsArrows(
+        firstResponder: NSButton(title: "Continue", target: nil, action: nil)),
+      "ordinary default-action buttons must leave arrows available to onboarding navigation"
+    )
+  }
+
+  @MainActor
+  func testKeyboardNavigationPreservesFocusedModifiedAndRepeatedArrows() {
     let monitor = OnboardingKeyboardMonitorSpy()
     let owner = OnboardingKeyboardNavigationCoordinator(
       installMonitor: monitor.install,
       removeMonitor: monitor.remove
     )
     var navigationCount = 0
+    var firstResponder: NSResponder? = NSTextView()
     let navigation = OnboardingKeyboardNavigationCoordinator.Navigation(
       isActive: { true },
-      focusedControlOwnsArrows: { true },
+      focusedControlOwnsArrows: { OnboardingKeyboardResponderPolicy.ownsArrows(firstResponder: firstResponder) },
       currentStep: { 10 },
       furthestStep: { 15 },
       apply: { _ in
@@ -462,14 +522,17 @@ final class OnboardingFlowTests: XCTestCase {
       }
     )
 
-    owner.mount(navigation)
+    let textLease = owner.mount(navigation)
     let focusedArrow = onboardingKeyEvent(keyCode: 124)
     XCTAssertTrue(monitor.dispatch(focusedArrow) === focusedArrow)
 
-    owner.mount(
+    firstResponder = NSButton(title: "Continue", target: nil, action: nil)
+    let buttonLease = owner.mount(
       OnboardingKeyboardNavigationCoordinator.Navigation(
         isActive: { true },
-        focusedControlOwnsArrows: { false },
+        focusedControlOwnsArrows: {
+          OnboardingKeyboardResponderPolicy.ownsArrows(firstResponder: firstResponder)
+        },
         currentStep: { 10 },
         furthestStep: { 15 },
         apply: { _ in
@@ -477,23 +540,27 @@ final class OnboardingFlowTests: XCTestCase {
           return true
         }
       ))
+    XCTAssertNil(monitor.dispatch(onboardingKeyEvent(keyCode: 124)))
     let modifiedArrow = onboardingKeyEvent(keyCode: 124, modifierFlags: [.command])
     let repeatArrow = onboardingKeyEvent(keyCode: 124, isARepeat: true)
     XCTAssertTrue(monitor.dispatch(modifiedArrow) === modifiedArrow)
     XCTAssertTrue(monitor.dispatch(repeatArrow) === repeatArrow)
-    XCTAssertEqual(navigationCount, 0)
+    XCTAssertEqual(navigationCount, 1, "an ordinary button must not block onboarding navigation")
     XCTAssertEqual(monitor.installCount, 1, "updating mounted state must not install a second monitor")
+    owner.unmount(textLease)
+    XCTAssertEqual(monitor.removeCount, 0)
+    owner.unmount(buttonLease)
   }
 
   @MainActor
-  func testKeyboardNavigationOwnerInvokesRequiredStepDefaultActionOnce() {
+  func testKeyboardNavigationInvokesRequiredStepDefaultActionOnce() {
     let monitor = OnboardingKeyboardMonitorSpy()
     let owner = OnboardingKeyboardNavigationCoordinator(
       installMonitor: monitor.install,
       removeMonitor: monitor.remove
     )
-    var defaultActionCount = 0
-    owner.mount(
+    let window = OnboardingDefaultActionRecordingWindow()
+    let lease = owner.mount(
       OnboardingKeyboardNavigationCoordinator.Navigation(
         isActive: { true },
         focusedControlOwnsArrows: { false },
@@ -501,44 +568,14 @@ final class OnboardingFlowTests: XCTestCase {
         furthestStep: { 1 },
         apply: { action in
           guard case .forwardDefaultAction = action else { return false }
-          defaultActionCount += 1
-          return true
+          return OnboardingDefaultActionPoster.post(in: window)
         }
       ))
 
     XCTAssertNil(monitor.dispatch(onboardingKeyEvent(keyCode: 124)))
-    XCTAssertEqual(defaultActionCount, 1)
-  }
-
-  @MainActor
-  func testKeyboardNavigationOwnerRemovesExactlyOnceForEveryOnboardingExit() {
-    for exit in ["completion", "unmount", "sign-out", "recovery replacement", "window close"] {
-      let monitor = OnboardingKeyboardMonitorSpy()
-      let owner = OnboardingKeyboardNavigationCoordinator(
-        installMonitor: monitor.install,
-        removeMonitor: monitor.remove
-      )
-      var navigationCount = 0
-      owner.mount(
-        OnboardingKeyboardNavigationCoordinator.Navigation(
-          isActive: { true },
-          focusedControlOwnsArrows: { false },
-          currentStep: { 10 },
-          furthestStep: { 15 },
-          apply: { _ in
-            navigationCount += 1
-            return true
-          }
-        ))
-
-      owner.unmount()
-      owner.unmount()
-
-      XCTAssertEqual(monitor.removeCount, 1, "\(exit) must converge on one teardown")
-      let arrow = onboardingKeyEvent(keyCode: 124)
-      XCTAssertTrue(monitor.dispatch(arrow) === arrow, "\(exit) must leave arrows unconsumed")
-      XCTAssertEqual(navigationCount, 0, "\(exit) must detach mounted navigation")
-    }
+    XCTAssertEqual(window.postedEvents.map(\.type), [.keyDown, .keyUp])
+    XCTAssertTrue(window.postedEvents.allSatisfy { $0.keyCode == 36 })
+    owner.unmount(lease)
   }
 
   @MainActor
@@ -557,9 +594,9 @@ final class OnboardingFlowTests: XCTestCase {
       apply: { _ in true }
     )
 
-    owner?.mount(navigation)
-    owner?.unmount()
-    owner?.mount(navigation)
+    let firstLease = owner?.mount(navigation)
+    owner?.unmount(firstLease)
+    _ = owner?.mount(navigation)
     XCTAssertEqual(monitor.installCount, 2)
     XCTAssertEqual(monitor.removeCount, 1)
     XCTAssertNotEqual(monitor.installedTokens[0], monitor.installedTokens[1])
@@ -658,5 +695,23 @@ private final class OnboardingKeyboardMonitorSpy {
   func dispatch(_ event: NSEvent) -> NSEvent? {
     guard let handler else { return event }
     return handler(event)
+  }
+}
+
+@MainActor
+private final class OnboardingDefaultActionRecordingWindow: NSWindow {
+  private(set) var postedEvents: [NSEvent] = []
+
+  init() {
+    super.init(
+      contentRect: .zero,
+      styleMask: [.titled],
+      backing: .buffered,
+      defer: false
+    )
+  }
+
+  override func postEvent(_ event: NSEvent, atStart flag: Bool) {
+    postedEvents.append(event)
   }
 }

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 
 @testable import Omi_Computer
@@ -411,6 +412,164 @@ final class OnboardingFlowTests: XCTestCase {
     XCTAssertNil(OnboardingFlow.arrowNavigation(keyCode: 36, step: 5, furthestStep: 10))
   }
 
+  @MainActor
+  func testKeyboardNavigationOwnerInstallsOnceAndRoutesAcceptedArrowToMountedState() {
+    let monitor = OnboardingKeyboardMonitorSpy()
+    let owner = OnboardingKeyboardNavigationCoordinator(
+      installMonitor: monitor.install,
+      removeMonitor: monitor.remove
+    )
+    var currentStep = 10
+    var navigationCount = 0
+    let navigation = OnboardingKeyboardNavigationCoordinator.Navigation(
+      isActive: { true },
+      focusedControlOwnsArrows: { false },
+      currentStep: { currentStep },
+      furthestStep: { 15 },
+      apply: { action in
+        navigationCount += 1
+        guard case .jump(let target) = action else { return false }
+        currentStep = target
+        return true
+      }
+    )
+
+    owner.mount(navigation)
+    owner.mount(navigation)
+
+    XCTAssertEqual(monitor.installCount, 1, "repeated mount must retain one monitor token")
+    XCTAssertNil(monitor.dispatch(onboardingKeyEvent(keyCode: 124)))
+    XCTAssertEqual(navigationCount, 1, "the installed monitor must call the mounted navigation owner")
+    XCTAssertEqual(currentStep, 11)
+  }
+
+  @MainActor
+  func testKeyboardNavigationOwnerPreservesFocusedModifiedAndRepeatedArrows() {
+    let monitor = OnboardingKeyboardMonitorSpy()
+    let owner = OnboardingKeyboardNavigationCoordinator(
+      installMonitor: monitor.install,
+      removeMonitor: monitor.remove
+    )
+    var navigationCount = 0
+    let navigation = OnboardingKeyboardNavigationCoordinator.Navigation(
+      isActive: { true },
+      focusedControlOwnsArrows: { true },
+      currentStep: { 10 },
+      furthestStep: { 15 },
+      apply: { _ in
+        navigationCount += 1
+        return true
+      }
+    )
+
+    owner.mount(navigation)
+    let focusedArrow = onboardingKeyEvent(keyCode: 124)
+    XCTAssertTrue(monitor.dispatch(focusedArrow) === focusedArrow)
+
+    owner.mount(
+      OnboardingKeyboardNavigationCoordinator.Navigation(
+        isActive: { true },
+        focusedControlOwnsArrows: { false },
+        currentStep: { 10 },
+        furthestStep: { 15 },
+        apply: { _ in
+          navigationCount += 1
+          return true
+        }
+      ))
+    let modifiedArrow = onboardingKeyEvent(keyCode: 124, modifierFlags: [.command])
+    let repeatArrow = onboardingKeyEvent(keyCode: 124, isARepeat: true)
+    XCTAssertTrue(monitor.dispatch(modifiedArrow) === modifiedArrow)
+    XCTAssertTrue(monitor.dispatch(repeatArrow) === repeatArrow)
+    XCTAssertEqual(navigationCount, 0)
+    XCTAssertEqual(monitor.installCount, 1, "updating mounted state must not install a second monitor")
+  }
+
+  @MainActor
+  func testKeyboardNavigationOwnerInvokesRequiredStepDefaultActionOnce() {
+    let monitor = OnboardingKeyboardMonitorSpy()
+    let owner = OnboardingKeyboardNavigationCoordinator(
+      installMonitor: monitor.install,
+      removeMonitor: monitor.remove
+    )
+    var defaultActionCount = 0
+    owner.mount(
+      OnboardingKeyboardNavigationCoordinator.Navigation(
+        isActive: { true },
+        focusedControlOwnsArrows: { false },
+        currentStep: { 1 },
+        furthestStep: { 1 },
+        apply: { action in
+          guard case .forwardDefaultAction = action else { return false }
+          defaultActionCount += 1
+          return true
+        }
+      ))
+
+    XCTAssertNil(monitor.dispatch(onboardingKeyEvent(keyCode: 124)))
+    XCTAssertEqual(defaultActionCount, 1)
+  }
+
+  @MainActor
+  func testKeyboardNavigationOwnerRemovesExactlyOnceForEveryOnboardingExit() {
+    for exit in ["completion", "unmount", "sign-out", "recovery replacement", "window close"] {
+      let monitor = OnboardingKeyboardMonitorSpy()
+      let owner = OnboardingKeyboardNavigationCoordinator(
+        installMonitor: monitor.install,
+        removeMonitor: monitor.remove
+      )
+      var navigationCount = 0
+      owner.mount(
+        OnboardingKeyboardNavigationCoordinator.Navigation(
+          isActive: { true },
+          focusedControlOwnsArrows: { false },
+          currentStep: { 10 },
+          furthestStep: { 15 },
+          apply: { _ in
+            navigationCount += 1
+            return true
+          }
+        ))
+
+      owner.unmount()
+      owner.unmount()
+
+      XCTAssertEqual(monitor.removeCount, 1, "\(exit) must converge on one teardown")
+      let arrow = onboardingKeyEvent(keyCode: 124)
+      XCTAssertTrue(monitor.dispatch(arrow) === arrow, "\(exit) must leave arrows unconsumed")
+      XCTAssertEqual(navigationCount, 0, "\(exit) must detach mounted navigation")
+    }
+  }
+
+  @MainActor
+  func testKeyboardNavigationOwnerRemountsWithFreshTokenAndDeinitIsSafe() {
+    let monitor = OnboardingKeyboardMonitorSpy()
+    var owner: OnboardingKeyboardNavigationCoordinator? = OnboardingKeyboardNavigationCoordinator(
+      installMonitor: monitor.install,
+      removeMonitor: monitor.remove
+    )
+    weak let weakOwner = owner
+    let navigation = OnboardingKeyboardNavigationCoordinator.Navigation(
+      isActive: { true },
+      focusedControlOwnsArrows: { false },
+      currentStep: { 10 },
+      furthestStep: { 15 },
+      apply: { _ in true }
+    )
+
+    owner?.mount(navigation)
+    owner?.unmount()
+    owner?.mount(navigation)
+    XCTAssertEqual(monitor.installCount, 2)
+    XCTAssertEqual(monitor.removeCount, 1)
+    XCTAssertNotEqual(monitor.installedTokens[0], monitor.installedTokens[1])
+
+    owner = nil
+
+    XCTAssertNil(weakOwner)
+    XCTAssertEqual(monitor.removeCount, 2, "deinit must remove a mounted token safely")
+  }
+
   func testValidatedNavigationTargetPolicy() {
     // Backward always allowed, forward gated by canJump, range clamped.
     XCTAssertEqual(
@@ -447,5 +606,57 @@ final class OnboardingFlowTests: XCTestCase {
       .appendingPathComponent(name)
     // omi-test-quality: source-inspection -- static contract: forbids uncancellable deferred-advance patterns in step views
     return try String(contentsOf: sourceURL, encoding: .utf8)
+  }
+
+  @MainActor
+  private func onboardingKeyEvent(
+    keyCode: UInt16,
+    modifierFlags: NSEvent.ModifierFlags = [],
+    isARepeat: Bool = false
+  ) -> NSEvent {
+    guard
+      let event = NSEvent.keyEvent(
+        with: .keyDown,
+        location: .zero,
+        modifierFlags: modifierFlags,
+        timestamp: ProcessInfo.processInfo.systemUptime,
+        windowNumber: 0,
+        context: nil,
+        characters: "",
+        charactersIgnoringModifiers: "",
+        isARepeat: isARepeat,
+        keyCode: keyCode
+      )
+    else {
+      fatalError("Unable to create a synthetic key event")
+    }
+    return event
+  }
+}
+
+@MainActor
+private final class OnboardingKeyboardMonitorSpy {
+  private var handler: ((NSEvent) -> NSEvent?)?
+  private var nextToken = 0
+  private(set) var installCount = 0
+  private(set) var removeCount = 0
+  private(set) var installedTokens: [Int] = []
+
+  func install(_ handler: @escaping (NSEvent) -> NSEvent?) -> Any? {
+    installCount += 1
+    nextToken += 1
+    installedTokens.append(nextToken)
+    self.handler = handler
+    return nextToken
+  }
+
+  func remove(_ token: Any) {
+    removeCount += 1
+    handler = nil
+  }
+
+  func dispatch(_ event: NSEvent) -> NSEvent? {
+    guard let handler else { return event }
+    return handler(event)
   }
 }

--- a/desktop/macos/changelog/unreleased/20260720-onboarding-keyboard-lifecycle.json
+++ b/desktop/macos/changelog/unreleased/20260720-onboarding-keyboard-lifecycle.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed onboarding arrow keys remaining active after onboarding is dismissed"
+}

--- a/desktop/macos/e2e/flows/onboarding-flow.yaml
+++ b/desktop/macos/e2e/flows/onboarding-flow.yaml
@@ -8,6 +8,7 @@ app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingNotificationStepView.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingFlow.swift
+  - desktop/macos/Desktop/Sources/Onboarding/OnboardingKeyboardNavigationCoordinator.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingStepScaffold.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingPromptSuggestions.swift
@@ -50,3 +51,7 @@ steps:
   - id: S4
     name: 2nd brain label has no background
     do: "On any split onboarding step with the graph pane, confirm 'This is your 2nd brain' has no pill fill and no bottom gradient behind the label."
+
+  - id: S5
+    name: Keyboard navigation is scoped to mounted onboarding
+    do: "On a skippable onboarding step, press bare Left and Right once each and confirm one step per press; hold Right and confirm repeats do not advance. Focus an editable control and confirm arrows move its caret. Dismiss onboarding through reset, sign-out, recovery, or window close, then confirm arrows elsewhere are not consumed."


### PR DESCRIPTION
## Summary

- Move the one onboarding arrow-key coordinator into `OnboardingViewOwner`, the stable mounted parent of replaceable `OnboardingView` identities; the child borrows it rather than retaining its own coordinator.
- Replace per-instance cleanup with generation leases: B replaces A's live navigation without a second monitor, stale A disappearance is ignored, and final B teardown removes the token once.
- Narrow responder ownership to text/editable and directional AppKit controls; ordinary buttons retain onboarding arrow navigation. Required-step forwarding posts one real Return key down/up pair.

## Failure class

Failure-Class: FC-split-mutation-authority

The defect split the local monitor's lifecycle between replaceable SwiftUI identities. The stable mounted owner now has one coordinator and each child can release only its own generation lease.

## RED → GREEN evidence

- RED on the original PR head `2ba2a9c09d302f838f8924d92af678f8680eebdd`: the new replacement test constructed the then-per-identity owners; B installed a second monitor (`2 != 1`), stale A teardown left B unable to consume the arrow, and B's state did not mutate. This is an actual monitor-handler execution, not a source inspection.
- Exact merged base `eabc74f8aaa2b54014e7f3537081a4962ea57289` has no coordinator seam. An overlay naming the later coordinator would only fail to compile, so it was not represented as behavioral RED. Driving the base's private static monitor/responder policy would require new product instrumentation or a full hosted SwiftUI/AppKit integration harness; neither was added solely to manufacture a base failure.
- GREEN: the replacement test now drives A mount → B mount → stale A unmount ignored → one installed monitor → B consumes and mutates → B unmount removes exactly once. Policy tests instantiate real `NSTextView`, `NSSegmentedControl`, `NSStepper`, and `NSButton`; a real `NSWindow` records the required Return down/up posting.

## Verification

- `xcrun swift test --package-path Desktop --filter 'Omi_ComputerTests.OnboardingFlowTests/testKeyboardNavigation'` — 6 passed after rebuilding the package
- Same focused lifecycle/policy suite repeated 20 times — 20/20 passed
- `xcrun swift test --skip-build --package-path Desktop --filter 'Omi_ComputerTests.OnboardingFlowTests'` — 28 passed
- `python3 scripts/check_desktop_test_quality.py` — passed
- `./scripts/desktop-core-harness.sh --self-check` — passed
- `git diff --check` — passed
- `make preflight` — passed (existing advisory large-file warnings only)
- Named ad-hoc non-production bundle built, installed, and launched: `/Applications/omi-onboarding-keyboard-lifecycle.app` (`com.omi.omi-onboarding-keyboard-lifecycle`, automation port 47897). Auth, settings, and Rewind seeding were explicitly disabled.

## Limitation

The isolated offline auth-emulator journey remains blocked by a foreign process already using Firestore emulator port 8085. I used only normal worktree setup (`make dev-init`, then isolated-pip installation of the missing `python-dotenv` and `uvicorn` packages) and did not stop the foreign process, read/copy/log credentials, seed auth, or touch `/Applications/omi-dev-auth.app`. The named bundle launched signed out, so the authenticated onboarding UI path was not exercised live; hermetic lifecycle, responder-policy, and default-action coverage is the behavior evidence for this correction.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
