### PR TITLE
fix(backend): mentor notifications reorder the conversation when a segment has start=0

### DIFF
--- a/backend/tests/unit/test_mentor_notifications.py
+++ b/backend/tests/unit/test_mentor_notifications.py
@@ -370,6 +370,47 @@ def test_process_mentor_notification_not_enough_segments():
     assert result is None
 
 
+def test_zero_start_keeps_the_opening_line_first():
+    """A segment with start=0.0 must keep its own timestamp, not wall-clock time.
+
+    `start` is an offset into the recording, so the first segment of every conversation
+    is 0.0. The buffer used `segment.get('start', 0) or current_time`, and because 0.0 is
+    falsy the opening line was stamped with time.time() (~1.7e9). The messages are handed
+    to the mentor LLM via `sorted(..., key=timestamp)`, so the first thing the user said
+    arrived as the *last* line of the transcript.
+    """
+    message_buffer.buffers.clear()
+
+    segments = [
+        {"text": f"Segment number {i} with some conversation content", "start": float(i), "is_user": i % 2 == 0}
+        for i in range(12)
+    ]
+
+    result = process_mentor_notification("test_uid_zero_start", segments)
+
+    assert result is not None
+    timestamps = [m['timestamp'] for m in result]
+    assert timestamps[0] == 0.0, f"opening segment lost its start offset: {timestamps[0]}"
+    assert timestamps == sorted(timestamps)
+    assert result[0]['text'].startswith("Segment number 0"), result[0]['text']
+    assert result[-1]['text'].startswith("Segment number 11"), result[-1]['text']
+
+
+def test_missing_start_still_falls_back_to_current_time():
+    """A segment with no `start` key keeps the wall-clock fallback."""
+    message_buffer.buffers.clear()
+    before = time.time()
+
+    segments = [
+        {"text": f"Segment number {i} with some conversation content", "is_user": i % 2 == 0} for i in range(12)
+    ]
+
+    result = process_mentor_notification("test_uid_missing_start", segments)
+
+    assert result is not None
+    assert all(m['timestamp'] >= before for m in result)
+
+
 def test_process_mentor_notification_accumulates():
     """process_mentor_notification should accumulate across calls and not clear on evaluation."""
     message_buffer.buffers.clear()

--- a/backend/utils/mentor_notifications.py
+++ b/backend/utils/mentor_notifications.py
@@ -115,7 +115,12 @@ def process_mentor_notification(uid: str, segments: List[Dict[str, Any]]) -> Lis
 
         text = segment['text'].strip()
         if text:
-            timestamp = segment.get('start', 0) or current_time
+            # `start` is an offset into the recording, so the first segment of every
+            # conversation is 0.0 — falsy but perfectly valid. `or current_time` replaced
+            # it with wall-clock time, which sorted the opening line last (and broke the
+            # 2-second coalescing below). Only a genuinely absent start should fall back.
+            start_offset = segment.get('start')
+            timestamp = current_time if start_offset is None else start_offset
             is_user = segment.get('is_user', False)
 
             # Count words after silence


### PR DESCRIPTION
## Problem

The mentor message buffer stamps every segment with:

```python
timestamp = segment.get('start', 0) or current_time
```

`start` is an **offset into the recording**, so the first segment of every conversation is `0.0` — falsy, but a perfectly valid value. `or current_time` therefore throws it away and substitutes `time.time()` (~1.7e9).

Those buffered messages are handed to the mentor LLM via:

```python
sorted_messages = sorted(buffer_data['messages'], key=lambda x: x['timestamp'])
```

So the **opening line of the conversation sorts last**, and the model is shown the transcript with the user's first utterance presented as the final one. The bogus timestamp also defeats the `abs(prev_ts - timestamp) < 2.0` coalescing that merges consecutive same-speaker segments.

## Fix

Only fall back when `start` is genuinely absent:

```diff
-timestamp = segment.get('start', 0) or current_time
+start_offset = segment.get('start')
+timestamp = current_time if start_offset is None else start_offset
```

## Tests

The timestamp path was entirely uncovered — the `_make_segments` helper always uses `start: 1000 + i`, and no test in the file sets `start` to `0`. Added:

- `test_zero_start_keeps_the_opening_line_first` — 12 segments at `start=0.0..11.0`; asserts the opening segment keeps timestamp `0.0`, the list is ordered, and "Segment number 0" is first / "Segment number 11" is last.
- `test_missing_start_still_falls_back_to_current_time` — guards the intended fallback for a segment with no `start` key.

## Verification

Driving the real `process_mentor_notification` with segments at `start=0.0..11.0`:

```
fixed:    first timestamp: 0.0   first text: "Segment number 0..."   last: "Segment number 11..."
original: first timestamp: 1.0   last text:  "Segment number 0..."   <- opening line delivered last
          AssertionError: opening segment lost start offset: 1.0
```

`black --line-length 120 --check` → clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




## Failure class

Failure-Class: none

A falsy-zero default in an in-memory buffer, not a persisted-document read; no registered class covers it.
