### PR TITLE
fix(backend): developer memory vector search returns 500 for any limit in 51..100

### DIFF
--- a/backend/tests/unit/test_developer_memory_adapter.py
+++ b/backend/tests/unit/test_developer_memory_adapter.py
@@ -565,6 +565,40 @@ def test_developer_vector_adapter_uses_hydrated_vector_service_and_preserves_ran
     assert all((item['policy']['archive_capability'] is False for item in results))
 
 
+def test_developer_vector_adapter_serves_limits_above_the_default_candidate_budget():
+    """A limit inside the route's advertised window must not blow up the request.
+
+    GET /v1/dev/user/memories/vector/search declares `limit: int = Query(10, ge=1, le=100)`
+    and the developer_api branch of execute_default_read_vector_search admits up to 100.
+    But fetch_default_vector_memory_search defaults max_candidates to
+    DEFAULT_MEMORY_VECTOR_MAX_CANDIDATES (50) and rejects max_candidates < limit, so every
+    limit in 51..100 raised "max_candidates must be between limit and 100" — an HTTP 500
+    on an input the route says is valid.
+    """
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    items = [_memory_item(f'long-{i}', tier=MemoryTier.long_term, now=now, content=f'coffee {i}') for i in range(3)]
+    db_client = _FirestoreFake({f'users/u1/memory_items/{item.memory_id}': _stored_item(item) for item in items})
+    decision = read_default_read_rollout(
+        uid='u1',
+        db_client=_FirestoreFake({'users/u1/memory_control/state': _enabled_rollout_doc()}),
+        consumer='developer_api',
+    )
+
+    def vector_query(uid, query, *, mode, limit):
+        return _VectorCandidateResult(
+            hits=[_hit(item, score=0.9 - index * 0.01) for index, item in enumerate(items)],
+            rejected_count=0,
+        )
+
+    result = search_memory_default_developer_memories_vector(
+        uid='u1', query='coffee', limit=60, db_client=db_client, rollout_decision=decision, vector_query=vector_query
+    )
+
+    assert result.read_decision == MemoryReadDecision.USE_MEMORY
+    assert result.fallback_reason is None
+    assert [item['id'] for item in result.memories] == ['long-0', 'long-1', 'long-2']
+
+
 def test_developer_vector_adapter_returns_denied_decision_before_vector_or_memory_reads_when_rollout_or_grant_disabled():
     now = datetime.now(timezone.utc).replace(microsecond=0)
     fresh_short_term = _memory_item('fresh-short-term', now=now, content='coffee fresh short term')

--- a/backend/utils/memory/default_read_surface.py
+++ b/backend/utils/memory/default_read_surface.py
@@ -14,7 +14,10 @@ from utils.memory.default_read_rollout import (
     disabled_default_read_rollout_decision,
 )
 from utils.memory.product_memory_read_service import fetch_default_product_memory_search
-from utils.memory.vector_search_service import fetch_default_vector_memory_search
+from utils.memory.vector_search_service import (
+    DEFAULT_MEMORY_VECTOR_MAX_CANDIDATES,
+    fetch_default_vector_memory_search,
+)
 
 T = TypeVar('T')
 MemoryPayload = dict[str, Any]
@@ -170,6 +173,12 @@ def fetch_default_read_vector(
         policy=policy,
         vector_query=vector_query,
         limit=bounded_limit,
+        # The candidate budget must cover the requested limit — fetch_default_vector_memory_search
+        # rejects max_candidates < limit. Its default is 50 while the developer_api branch above
+        # admits up to 100, so limits of 51..100 raised ValueError (HTTP 500) instead of returning
+        # results. Only widen the budget when the caller actually asked for more than the default;
+        # bounded_limit never exceeds MAX_MEMORY_VECTOR_SEARCH_LIMIT, so this stays in range.
+        max_candidates=max(DEFAULT_MEMORY_VECTOR_MAX_CANDIDATES, bounded_limit),
         required_projection_commit_id=projection_commit_id,
         required_account_generation=decision.rollout_capabilities.account_generation,
         now=now,


### PR DESCRIPTION
## Problem

`GET /v1/dev/user/memories/vector/search` advertises:

```python
limit: int = Query(10, ge=1, le=100)
```

and `execute_default_read_vector_search` admits that whole range for this consumer:

```python
bounded_limit = max(1, min(limit, 100 if consumer == MemoryConsumer.developer_api else 20))
```

…but it then calls `fetch_default_vector_memory_search` **without** `max_candidates`, so the service applies its default `DEFAULT_MEMORY_VECTOR_MAX_CANDIDATES = 50` and rejects the request outright:

```python
def _validate_max_candidates(*, max_candidates, bounded_limit):
    if ... or max_candidates < bounded_limit ...:
        raise ValueError(f'max_candidates must be between limit and {MAX_MEMORY_VECTOR_SEARCH_LIMIT}')
```

`_validate_limit` permits up to `MAX_MEMORY_VECTOR_SEARCH_LIMIT = 100`, so nothing clamps the limit first. **Every developer_api vector search with `limit` in 51..100 raises out of the router as an HTTP 500** — on an input the route's own signature declares valid. `limit <= 50` is unaffected.

Reproduced directly against the real validators:

```
DEFAULT_MAX_CANDIDATES = 50   MAX_LIMIT = 100
limit= 10 -> OK
limit= 50 -> OK
limit= 51 -> ValueError: max_candidates must be between limit and 100   <-- HTTP 500
limit= 60 -> ValueError: ...                                            <-- HTTP 500
limit=100 -> ValueError: ...                                            <-- HTTP 500
```

## Fix

Size the candidate budget to the request, so it always satisfies the service's own *"max_candidates between limit and 100"* contract:

```diff
     limit=bounded_limit,
+    max_candidates=max(DEFAULT_MEMORY_VECTOR_MAX_CANDIDATES, bounded_limit),
```

The default 50-candidate budget is unchanged for `limit <= 50`; it only widens when the caller explicitly asked for more, and `bounded_limit` never exceeds `MAX_MEMORY_VECTOR_SEARCH_LIMIT`, so the value always stays in range.

I chose this over clamping `bounded_limit` down to 50 because clamping would silently return fewer rows than the caller requested while the route still advertises `le=100`. Happy to switch to the clamp if you'd rather cap read amplification — it's a one-line change either way.

## Tests

Every existing case in `test_developer_memory_adapter.py` passes `limit=10`, so this range was uncovered. Added `test_developer_vector_adapter_serves_limits_above_the_default_candidate_budget`, driving the real adapter at `limit=60` through the existing Firestore/vector fakes.

## Verification

```
$ pytest tests/unit/test_developer_memory_adapter.py
25 passed

# revert the fix:
1 failed, 24 passed   <- exactly the new test, with the ValueError
```

`black --line-length 120 --check` → clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




## Product invariants affected

- INV-MEM-1

This change only widens the vector candidate budget so the requested limit can be served; it does not alter the tier set, the canonical collection, or the Short-term + Long-term default access policy.


## Failure class

Failure-Class: none

A caller-supplied limit exceeding an internal candidate budget; the input is well-formed, so FC-malformed-doc-read does not apply.

