### PR TITLE
fix(backend): a null capture_confidence crashes the whole What Matters Now evaluation

### DIFF
--- a/backend/tests/unit/test_task_recommendations.py
+++ b/backend/tests/unit/test_task_recommendations.py
@@ -1005,6 +1005,83 @@ def test_accepted_task_capture_confidence_gates_shortlist_eligibility():
     assert [subject.subject_id for subject in shortlist] == ['task-accepted-high']
 
 
+def test_malformed_stored_capture_confidence_does_not_break_the_evaluation():
+    """A null or boolean capture_confidence must degrade to 0.0, not crash or score 1.0.
+
+    `dict.get(key, default)` returns None when the key is present holding null, so the
+    0.0 default never fired and `float(None)` raised TypeError out of _build_subjects —
+    taking down the entire What Matters Now projection, not just the offending row.
+    A stored `True` was worse than a crash: float(True) == 1.0 marked a poison row
+    maximally confident and shortlist-eligible. database.candidates._stored_confidence
+    already guards both cases when reading these same action_items fields.
+    """
+    canonical = EvidenceRef(
+        kind=EvidenceKind.conversation,
+        id='conversation-1',
+        scope=EvidenceScope.canonical,
+    ).model_dump(mode='json')
+    base = {
+        'status': 'active',
+        'due_at': NOW + timedelta(days=1),
+        'updated_at': NOW,
+        'provenance': [canonical],
+    }
+    state = {
+        'tasks': [
+            {**base, 'task_id': 'task-null-confidence', 'description': 'Null confidence', 'capture_confidence': None},
+            {**base, 'task_id': 'task-bool-confidence', 'description': 'Bool confidence', 'capture_confidence': True},
+            {**base, 'task_id': 'task-str-confidence', 'description': 'Str confidence', 'capture_confidence': 'high'},
+            {**base, 'task_id': 'task-good', 'description': 'Send the budget', 'capture_confidence': 0.95},
+        ],
+        'candidates': [],
+        'goals': [],
+        'workstreams': [],
+        'artifacts': [],
+    }
+
+    subjects = recommendations._build_subjects(state, context=None, open_loop_snapshots=[], now=NOW)
+    by_id = {subject.subject_id: subject for subject in subjects}
+
+    assert by_id['task-null-confidence'].facts.capture_confidence == 0.0
+    assert by_id['task-bool-confidence'].facts.capture_confidence == 0.0
+    assert by_id['task-str-confidence'].facts.capture_confidence == 0.0
+    for poisoned in ('task-null-confidence', 'task-bool-confidence', 'task-str-confidence'):
+        assert not by_id[poisoned].eligibility.passes_recommendation_gates
+
+    # The healthy row still evaluates — one bad document must not sink the projection.
+    assert by_id['task-good'].facts.capture_confidence == 0.95
+    shortlist = recommendations.filter_shortlist(subjects, set())
+    assert [subject.subject_id for subject in shortlist] == ['task-good']
+
+
+def test_malformed_candidate_confidence_does_not_break_the_evaluation():
+    """Same guard for the candidate reads (capture_confidence / ownership_confidence)."""
+    state = {
+        'tasks': [],
+        'candidates': [
+            {
+                'candidate_id': 'candidate-null',
+                'status': 'pending',
+                'subject_kind': 'task_change',
+                'task_change': {'description': 'Review the deck', 'due_at': NOW + timedelta(days=1)},
+                'capture_confidence': None,
+                'ownership_confidence': None,
+                'updated_at': NOW,
+                'evidence_refs': [],
+            }
+        ],
+        'goals': [],
+        'workstreams': [],
+        'artifacts': [],
+    }
+
+    subjects = recommendations._build_subjects(state, context=None, open_loop_snapshots=[], now=NOW)
+
+    by_id = {subject.subject_id: subject for subject in subjects}
+    assert by_id['candidate-null'].facts.capture_confidence == 0.0
+    assert not by_id['candidate-null'].eligibility.passes_recommendation_gates
+
+
 def test_recently_created_manual_task_qualifies_without_reanimating_old_edits_or_generated_rows():
     state = {
         'tasks': [

--- a/backend/utils/task_intelligence/recommendations.py
+++ b/backend/utils/task_intelligence/recommendations.py
@@ -166,6 +166,19 @@ def _days_to_due(due_at: Any, now: datetime) -> Optional[float]:
     return float(int(seconds // 86400) if seconds >= 0 else -int((-seconds) // 86400))
 
 
+def _stored_confidence(value: Any) -> float:
+    """Coerce a stored confidence to a float, treating anything malformed as 0.0.
+
+    Mirrors ``database.candidates._stored_confidence``, which already reads these very
+    fields off ``action_items`` documents. ``dict.get(key, default)`` returns ``None``
+    when the key is present with a null value, so the default never fires and a bare
+    ``float(...)`` raises TypeError; booleans must not be promoted to 1.0/0.0 either.
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return 0.0
+
+
 def _recent(updated_at: Any, now: datetime) -> bool:
     updated = _as_aware(updated_at)
     return updated is not None and now - updated <= timedelta(days=7)
@@ -341,7 +354,7 @@ def _build_subjects(
         raw_owner = task.get('owner')
         owner = raw_owner.value if isinstance(raw_owner, TaskOwner) else str(raw_owner or '')
         trusted_manual_task = str(task.get('source') or '') == 'manual' and owner == TaskOwner.user.value
-        capture_confidence = 1.0 if trusted_manual_task else float(task.get('capture_confidence', 0.0))
+        capture_confidence = 1.0 if trusted_manual_task else _stored_confidence(task.get('capture_confidence'))
         facts = DeterministicFacts(
             days_to_due=_days_to_due(task.get('due_at'), now),
             someone_blocked=False,
@@ -392,8 +405,8 @@ def _build_subjects(
         proposal: dict[str, Any] = raw_proposal if isinstance(raw_proposal, dict) else {}
         headline = str(task_change.get('description') or proposal.get('title') or 'Review suggested work')
         goal_id = str(candidate.get('goal_id') or '')
-        confidence = float(candidate.get('capture_confidence', 0))
-        ownership_confidence = float(candidate.get('ownership_confidence', 0))
+        confidence = _stored_confidence(candidate.get('capture_confidence'))
+        ownership_confidence = _stored_confidence(candidate.get('ownership_confidence'))
         facts = DeterministicFacts(
             days_to_due=_days_to_due(task_change.get('due_at'), now),
             has_concrete_next_action=bool(headline.strip()),


### PR DESCRIPTION
## Problem

`_build_subjects` coerces stored confidences with a bare `float()`:

```python
capture_confidence = 1.0 if trusted_manual_task else float(task.get('capture_confidence', 0.0))
confidence = float(candidate.get('capture_confidence', 0))
ownership_confidence = float(candidate.get('ownership_confidence', 0))
```

`dict.get(key, default)` returns `None` when the key **is present holding a null** — the default only fires when the key is *absent*. So a single stored null raises:

```
TypeError: float() argument must be a string or a real number, not 'NoneType'
  recommendations.py:357  (tasks)
  recommendations.py:408  (candidates)
```

That propagates straight out of `_build_subjects`, so the user's **entire What Matters Now projection fails** — every task and candidate, not just the one malformed row. A stored string does the same.

A stored **boolean is worse than a crash**: `float(True) == 1.0` silently marks a poison row maximally confident and therefore shortlist-eligible.

## Root cause

The repo already has the correct reader for these exact fields on these exact `action_items` documents — `database/candidates.py::_stored_confidence`:

```python
def _stored_confidence(value: Any) -> float:
    if isinstance(value, (int, float)) and not isinstance(value, bool):
        return float(value)
    return 0.0
```

`database/candidates.py` uses it when reading `capture_confidence`/`ownership_confidence` off a claimed task. So the same field was being read two different ways — one guarded, one not.

## Fix

Add the matching guard in `recommendations.py` and use it at all three sites. Malformed values degrade to `0.0`, which fails the `MINIMUM_CAPTURE_CONFIDENCE` gate — exactly the behaviour the existing *missing-key* tests already assert — while healthy rows continue to evaluate normally.

I defined a local helper rather than importing the private `_stored_confidence` across the `database` → `utils` boundary; happy to promote it to a shared public helper instead if you'd prefer one definition.

## Tests

Existing coverage only exercises well-formed and *missing-key* confidences, never a stored null / bool / string. Added:

- `test_malformed_stored_capture_confidence_does_not_break_the_evaluation` — null, bool and string rows all degrade to `0.0` and stay ineligible, while a healthy `0.95` row is still the sole shortlist entry (one bad document must not sink the projection).
- `test_malformed_candidate_confidence_does_not_break_the_evaluation` — same guard for the candidate reads.

## Verification

Driving the real `_build_subjects`:

```
fixed:    t-null confidence=0.0 eligible=False
          t-bool confidence=0.0 eligible=False
          t-str  confidence=0.0 eligible=False
          t-good confidence=0.95   shortlist: ['t-good']

original: TypeError: float() argument must be a string or a real number, not 'NoneType'
          (recommendations.py:357 tasks / :408 candidates)
```

`black --line-length 120 --check` → clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




## Failure class

Failure-Class: FC-malformed-doc-read

A stored null in an action_items document turns _build_subjects into a TypeError that fails the whole What Matters Now read.
