### PR TITLE
fix(backend): focus stats count a zero-second distraction as a full minute

### DIFF
--- a/backend/database/focus_sessions.py
+++ b/backend/database/focus_sessions.py
@@ -15,6 +15,10 @@ from ._client import db
 
 logger = logging.getLogger(__name__)
 
+# A distraction that was recorded but never measured still represents lost focus, so it is
+# charged this much rather than being ignored. Applies only to an unknown duration.
+DEFAULT_DISTRACTED_SECONDS = 60
+
 
 def _user_col(uid: str, collection: str) -> Any:
     """Shorthand for users/{uid}/{collection}."""
@@ -83,10 +87,11 @@ def get_focus_stats(uid: str, date: Optional[str] = None) -> Dict[str, Any]:
             total_focus_seconds += s.get('duration_seconds') or 0
         elif s.get('status') == 'distracted':
             distracted_count += 1
-            total_distracted_seconds += s.get('duration_seconds') or 60
+            distracted_seconds = s.get('duration_seconds') or DEFAULT_DISTRACTED_SECONDS
+            total_distracted_seconds += distracted_seconds
             app = str(s.get('app_or_site', 'Unknown'))
             entry = distractions.setdefault(app, {'total_seconds': 0, 'count': 0})
-            entry['total_seconds'] += s.get('duration_seconds') or 60
+            entry['total_seconds'] += distracted_seconds
             entry['count'] += 1
 
     top = sorted(distractions.items(), key=lambda x: x[1]['total_seconds'], reverse=True)[:5]

--- a/backend/database/focus_sessions.py
+++ b/backend/database/focus_sessions.py
@@ -87,7 +87,11 @@ def get_focus_stats(uid: str, date: Optional[str] = None) -> Dict[str, Any]:
             total_focus_seconds += s.get('duration_seconds') or 0
         elif s.get('status') == 'distracted':
             distracted_count += 1
-            distracted_seconds = s.get('duration_seconds') or DEFAULT_DISTRACTED_SECONDS
+            # Only an *unknown* duration earns the default. duration_seconds is
+            # Optional[int] with ge=0, so a stored 0 is a real zero-second distraction and
+            # `or` would have silently rounded it up to a full minute.
+            raw_duration = s.get('duration_seconds')
+            distracted_seconds = DEFAULT_DISTRACTED_SECONDS if raw_duration is None else raw_duration
             total_distracted_seconds += distracted_seconds
             app = str(s.get('app_or_site', 'Unknown'))
             entry = distractions.setdefault(app, {'total_seconds': 0, 'count': 0})

--- a/backend/tests/unit/test_focus_stats_aggregation.py
+++ b/backend/tests/unit/test_focus_stats_aggregation.py
@@ -103,6 +103,25 @@ class TestDistractedSessions:
         assert result['distracted_minutes'] == 1
         assert result['top_distractions'][0]['total_seconds'] == 60
 
+    def test_explicit_zero_duration_is_not_rounded_up_to_a_minute(self, stats):
+        # duration_seconds is Optional[int] with ge=0 on both the model and the route,
+        # so 0 is a valid measured value and must be distinguished from None. `or 60`
+        # conflated them and invented a minute of distraction that never happened.
+        result = stats([_session('distracted', 0)])
+        assert result['distracted_minutes'] == 0
+        assert result['distracted_count'] == 1
+        assert result['top_distractions'] == [{'app_or_site': 'Slack', 'total_seconds': 0, 'count': 1}]
+
+    def test_zero_duration_sessions_do_not_inflate_the_daily_total(self, stats):
+        # Ten zero-second distractions previously reported ten minutes of lost focus.
+        result = stats([_session('distracted', 0) for _ in range(10)])
+        assert result['distracted_minutes'] == 0
+
+    def test_zero_and_unknown_durations_are_scored_differently(self, stats):
+        result = stats([_session('distracted', 0, app='Slack'), _session('distracted', _MISSING, app='X')])
+        by_app = {entry['app_or_site']: entry['total_seconds'] for entry in result['top_distractions']}
+        assert by_app == {'Slack': 0, 'X': 60}
+
 
 class TestTopDistractions:
     def test_ranked_by_total_seconds_and_counted_per_app(self, stats):

--- a/backend/tests/unit/test_focus_stats_aggregation.py
+++ b/backend/tests/unit/test_focus_stats_aggregation.py
@@ -1,0 +1,123 @@
+"""Aggregation behaviour of database.focus_sessions.get_focus_stats.
+
+``get_focus_stats`` reads sessions through ``get_focus_sessions`` and folds them into
+focused/distracted totals plus a top-distractions ranking. Patching that reader is the
+seam: it exercises the real aggregation without Firestore.
+
+A distracted session whose ``duration_seconds`` is unknown is deliberately charged a
+one-minute default, because a distraction that was recorded but never measured still
+represents lost focus. That default must apply only to a genuinely *unknown* duration.
+"""
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _AutoMockModule(ModuleType):
+    """Module stub that returns a MagicMock for any missing attribute."""
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+def _install_google_stubs() -> None:
+    """Stand in for google.cloud only when it is genuinely unavailable."""
+    try:  # pragma: no cover - depends on the environment
+        from google.cloud import firestore  # noqa: F401
+        from google.cloud.firestore_v1.base_query import FieldFilter  # noqa: F401
+
+        return
+    except ImportError:
+        pass
+
+    google_pkg = sys.modules.setdefault('google', _AutoMockModule('google'))
+    google_pkg.__path__ = []  # type: ignore[attr-defined]
+    cloud_pkg = _AutoMockModule('google.cloud')
+    cloud_pkg.__path__ = []  # type: ignore[attr-defined]
+    base_query = _AutoMockModule('google.cloud.firestore_v1.base_query')
+    base_query.FieldFilter = MagicMock()  # type: ignore[attr-defined]
+    firestore_v1 = _AutoMockModule('google.cloud.firestore_v1')
+    firestore_v1.__path__ = []  # type: ignore[attr-defined]
+    sys.modules['google.cloud'] = cloud_pkg
+    sys.modules['google.cloud.firestore'] = _AutoMockModule('google.cloud.firestore')
+    sys.modules['google.cloud.firestore_v1'] = firestore_v1
+    sys.modules['google.cloud.firestore_v1.base_query'] = base_query
+
+
+_install_google_stubs()
+sys.modules.setdefault('database._client', _AutoMockModule('database._client'))
+
+import database.focus_sessions as focus_db  # noqa: E402
+
+
+@pytest.fixture
+def stats(monkeypatch):
+    """Return a caller that folds the supplied sessions through the real aggregation."""
+
+    def _run(sessions):
+        monkeypatch.setattr(focus_db, 'get_focus_sessions', lambda uid, date=None, limit=0, offset=0: sessions)
+        return focus_db.get_focus_stats('uid', date='2026-07-21')
+
+    return _run
+
+
+def _session(status, seconds, app='Slack'):
+    session = {'status': status, 'app_or_site': app}
+    if seconds is not _MISSING:
+        session['duration_seconds'] = seconds
+    return session
+
+
+_MISSING = object()
+
+
+class TestFocusedSessions:
+    def test_focused_durations_are_summed(self, stats):
+        result = stats([_session('focused', 120), _session('focused', 60)])
+        assert result['focused_minutes'] == 3
+        assert result['focused_count'] == 2
+
+    def test_focused_session_without_duration_contributes_nothing(self, stats):
+        result = stats([_session('focused', _MISSING)])
+        assert result['focused_minutes'] == 0
+        assert result['focused_count'] == 1
+
+
+class TestDistractedSessions:
+    def test_distracted_durations_are_summed(self, stats):
+        result = stats([_session('distracted', 90), _session('distracted', 30)])
+        assert result['distracted_minutes'] == 2
+        assert result['distracted_count'] == 2
+
+    def test_unknown_distracted_duration_is_charged_one_minute(self, stats):
+        # An unmeasured distraction still represents lost focus, so it is charged a
+        # default minute rather than being ignored.
+        result = stats([_session('distracted', _MISSING)])
+        assert result['distracted_minutes'] == 1
+        assert result['top_distractions'][0]['total_seconds'] == 60
+
+
+class TestTopDistractions:
+    def test_ranked_by_total_seconds_and_counted_per_app(self, stats):
+        result = stats(
+            [
+                _session('distracted', 30, app='Slack'),
+                _session('distracted', 30, app='Slack'),
+                _session('distracted', 300, app='X'),
+            ]
+        )
+        assert [entry['app_or_site'] for entry in result['top_distractions']] == ['X', 'Slack']
+        slack = next(e for e in result['top_distractions'] if e['app_or_site'] == 'Slack')
+        assert slack == {'app_or_site': 'Slack', 'total_seconds': 60, 'count': 2}
+
+    def test_session_count_spans_both_statuses(self, stats):
+        result = stats([_session('focused', 60), _session('distracted', 60)])
+        assert result['session_count'] == 2
+        assert result['date'] == '2026-07-21'


### PR DESCRIPTION
## Problem

`get_focus_stats` charges an unmeasured distraction a one-minute default, using `or`:

```python
total_distracted_seconds += s.get('duration_seconds') or 60
entry['total_seconds']   += s.get('duration_seconds') or 60
```

But `duration_seconds` is `Optional[int]` with **`ge=0`** on both the model and the route:

```python
# models/focus_session.py
duration_seconds: Optional[int] = Field(default=None, ge=0, description='Session duration in seconds, if known.')
# routers/focus_sessions.py
duration_seconds: int | None = Field(None, ge=0, le=86400)
```

and `create_focus_session` stores whatever the client sent. The schema draws a real distinction — **`None` = unknown, `0` = measured and zero** — but `or` collapses both to the default. A genuine zero-second distracted session is reported as **60 seconds of lost focus**.

Ten such sessions invent ten minutes of distraction that never happened, inflating `distracted_minutes` and pushing the offending app up the `top_distractions` ranking. (The `focused` branch never had this problem — it falls back to `0`.)

## Fix

Reserve the default for a genuinely missing duration:

```diff
-distracted_seconds = s.get('duration_seconds') or DEFAULT_DISTRACTED_SECONDS
+raw_duration = s.get('duration_seconds')
+distracted_seconds = DEFAULT_DISTRACTED_SECONDS if raw_duration is None else raw_duration
```

This mirrors the fix already applied to the same bug class in `database.staged_tasks.migrate_ai_tasks`, whose regression test records the identical reasoning: *"The key now maps only a genuinely missing (None) score to 999."*

## Commits

1. **`test:`** characterize the aggregation — `get_focus_stats` had **no unit coverage at all**, so the existing behaviour is pinned first (all green on unmodified code).
2. **`refactor:`** lift the twice-repeated magic `60` to `DEFAULT_DISTRACTED_SECONDS` and compute it once per session. Pure refactor; step 1's tests pass unchanged.
3. **`fix:`** distinguish `None` from `0`, plus the three regression cases.

Every commit is green, so the series stays bisectable.

## Verification

```
$ pytest tests/unit/test_focus_stats_aggregation.py
9 passed

# restore the `or` expression:
3 failed, 6 passed
  - test_explicit_zero_duration_is_not_rounded_up_to_a_minute
  - test_zero_duration_sessions_do_not_inflate_the_daily_total
  - test_zero_and_unknown_durations_are_scored_differently
```

`black --line-length 120 --check` → clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

