### PR TITLE
fix(backend): /v2/apps/search bypasses the review-score clamp

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "backend/routers/apps.py": 2387,
+    "backend/routers/apps.py": 2386,
     "backend/routers/chat.py": 1588,
     "backend/routers/developer.py": 2263,
     "backend/routers/mcp_sse.py": 1865,

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Body, Depends, Form, UploadFile, File, HTTPExcept
 from fastapi.responses import HTMLResponse
 
 from langchain_core.messages import SystemMessage, HumanMessage
-from utils.apps import fetch_app_chat_tools_from_manifest
+from utils.apps import _clamp_review_score, fetch_app_chat_tools_from_manifest
 from utils.executors import (
     critical_executor,
     db_executor,
@@ -702,10 +702,9 @@ def search_apps(
 
         # Calculate average from reviews
         reviews = apps_reviews.get(app_dict['id'], {})
-        sorted_reviews = list(reviews.values())
-        rating_avg = sum([x['score'] for x in sorted_reviews]) / len(sorted_reviews) if reviews else None
-        app_dict['rating_avg'] = rating_avg
-        app_dict['rating_count'] = len(sorted_reviews)
+        scores = [_clamp_review_score(x['score']) for x in reviews.values()]
+        app_dict['rating_avg'] = sum(scores) / len(scores) if scores else None
+        app_dict['rating_count'] = len(scores)
 
         # Skip a malformed/legacy app document rather than 500 the whole search page.
         try:

--- a/backend/tests/unit/test_app_review_score_clamp.py
+++ b/backend/tests/unit/test_app_review_score_clamp.py
@@ -99,3 +99,50 @@ def test_search_reports_no_rating_without_reviews(monkeypatch):
     result = _search_with_reviews(monkeypatch, {})
     assert result[0]['rating_avg'] is None
     assert result[0]['rating_count'] == 0
+
+
+def test_search_clamps_out_of_range_stored_review_score(monkeypatch):
+    """A drifted/legacy stored score must not escape through the search endpoint.
+
+    /v2/apps/search computed rating_avg itself and was the one aggregation path that
+    skipped _clamp_review_score, even though the helper's docstring says it closes the
+    bound "on the write and aggregation paths". App.rating_avg is unbounded, so a stored
+    score of 100 surfaced verbatim, passed any `rating` filter and pinned the app to the
+    top of sort=rating_desc — while every other listing endpoint reported 5.0.
+    """
+    reviews = {'u1': {'score': 100, 'review': 'gamed'}}
+    result = _search_with_reviews(monkeypatch, reviews)
+    assert result[0]['rating_avg'] == 5.0
+
+
+def test_search_clamps_negative_stored_review_score(monkeypatch):
+    reviews = {'u1': {'score': -50, 'review': 'sabotage'}}
+    result = _search_with_reviews(monkeypatch, reviews)
+    assert result[0]['rating_avg'] == 0.0
+
+
+def test_search_rating_matches_the_single_app_endpoint(monkeypatch):
+    """The search average must agree with utils.apps' aggregation for the same reviews."""
+    reviews = {'u1': {'score': 100, 'review': 'gamed'}, 'u2': {'score': 4, 'review': 'ok'}}
+    result = _search_with_reviews(monkeypatch, reviews)
+    expected = sum(_clamp_review_score(r['score']) for r in reviews.values()) / len(reviews)
+    assert result[0]['rating_avg'] == expected == 4.5
+
+
+def test_every_rating_avg_aggregation_clamps_its_scores():
+    """No aggregation may read a raw review score.
+
+    The bug this guards was a single averaging expression that skipped
+    _clamp_review_score while four identical ones in utils/apps.py applied it. Any line
+    that comprehends over review scores must clamp, so a future site cannot quietly
+    reintroduce the gap.
+    """
+    from pathlib import Path as _Path
+
+    backend = _Path(__file__).resolve().parents[2]
+    offenders = []
+    for relative in ('utils/apps.py', 'routers/apps.py'):
+        for number, line in enumerate((backend / relative).read_text(encoding='utf-8').splitlines(), start=1):
+            if "['score']" in line and ' for ' in line and '_clamp_review_score' not in line:
+                offenders.append(f'{relative}:{number}')
+    assert offenders == [], f'unclamped review-score aggregation at: {offenders}'

--- a/backend/tests/unit/test_app_review_score_clamp.py
+++ b/backend/tests/unit/test_app_review_score_clamp.py
@@ -50,3 +50,52 @@ def test_set_app_review_clamps_negative_score(monkeypatch):
     set_app_review("app1", "uid1", {"score": -3})
 
     assert captured["review"]["score"] == 0.0
+
+
+def _search_app_dict(app_id='a1'):
+    return {
+        'id': app_id,
+        'name': 'Good App',
+        'category': 'productivity',
+        'author': 'Someone',
+        'description': 'Does things',
+        'image': 'http://img',
+        'capabilities': ['chat'],
+    }
+
+
+def _search_with_reviews(monkeypatch, reviews):
+    """Run the real /v2/apps/search handler over one app carrying `reviews`."""
+    from routers import apps as routers_apps
+
+    app_dict = _search_app_dict()
+    monkeypatch.setattr(routers_apps, 'search_apps_db', lambda **kw: [dict(app_dict)])
+    monkeypatch.setattr(routers_apps, 'get_enabled_apps', lambda uid: set())
+    monkeypatch.setattr(routers_apps, 'get_apps_installs_count', lambda ids: {})
+    monkeypatch.setattr(routers_apps, 'get_apps_reviews', lambda ids: {'a1': reviews})
+    result = routers_apps.search_apps(
+        q=None,
+        category=None,
+        rating=None,
+        capability=None,
+        sort=None,
+        my_apps=None,
+        installed_apps=None,
+        offset=0,
+        limit=20,
+        uid='u1',
+    )
+    return result['data']
+
+
+def test_search_averages_in_range_review_scores(monkeypatch):
+    reviews = {'u1': {'score': 4, 'review': 'good'}, 'u2': {'score': 5, 'review': 'great'}}
+    result = _search_with_reviews(monkeypatch, reviews)
+    assert result[0]['rating_avg'] == 4.5
+    assert result[0]['rating_count'] == 2
+
+
+def test_search_reports_no_rating_without_reviews(monkeypatch):
+    result = _search_with_reviews(monkeypatch, {})
+    assert result[0]['rating_avg'] is None
+    assert result[0]['rating_count'] == 0


### PR DESCRIPTION
## Problem

`_clamp_review_score` exists because `ReviewAppRequest.score` is unbounded on the write path. Its comment is explicit about scope:

> The read path already bounds score with `Field(ge=0, le=5)`; this closes the same bound on the **write and aggregation paths**, where the request model leaves score unbounded.

Every aggregation site in `utils/apps.py` honours that — lines **306, 382, 425, 516** all average `_clamp_review_score(x['score'])`.

`routers/apps.py:699` computes `rating_avg` itself and was the **one aggregation path that skipped it**:

```python
rating_avg = sum([x['score'] for x in sorted_reviews]) / len(sorted_reviews) if reviews else None
```

`App.rating_avg` carries no bound (`Optional[float] = 0`), so a drifted or abusive stored score surfaces verbatim from search. A single stored review of `100` gives that app `rating_avg: 100.0`, which:

- clears any `rating` filter — `filtered_apps = [app for app in filtered_apps if (app.rating_avg or 0) >= rating]`
- pins it to the top of `sort=rating_desc` — `sorted(..., key=lambda a: (a.rating_avg or 0), reverse=True)`

…while `/v1/apps` reports `5.0` for the very same app.

## Fix

Use the same clamped expression as `utils/apps.py:425`, which this line is otherwise identical to:

```diff
-rating_avg = sum([x['score'] for x in sorted_reviews]) / len(sorted_reviews) if reviews else None
+rating_avg = (
+    sum([_clamp_review_score(x['score']) for x in sorted_reviews]) / len(sorted_reviews) if reviews else None
+)
```

## Commits

1. **`test:`** cover the search endpoint's rating aggregation for in-range scores (green on unmodified code) — the clamp suite previously never touched this endpoint.
2. **`fix:`** apply the clamp, with regression cases for an out-of-range and a negative stored score, plus an assertion that search now agrees with the `utils.apps` aggregation for identical reviews.
3. **`test:`** an invariant scan requiring *every* `sorted_reviews` averaging expression to clamp, so a sixth site can't silently reintroduce the gap.

Every commit is green, so the series stays bisectable.

## Verification

```
$ pytest tests/unit/test_app_review_score_clamp.py tests/unit/test_apps_search_poison_guard.py
19 passed

# restore the unclamped expression:
3 failed   (out-of-range, negative, and parity-with-utils)
# and the invariant scan pinpoints it:
AssertionError: unclamped review-score aggregation at: ['routers/apps.py:700']
```

I verified the invariant test in **both** directions — my first regex silently passed against the buggy tree, so it was rewritten until it actually fails on the pre-fix code.

`black --line-length 120 --check` → clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




## Failure class

Failure-Class: none

One aggregation site drifted from the shared clamp helper; no registered class covers it.
