### PR TITLE
fix(backend): every rate-limit window after the first serves one request too few

### DIFF
--- a/backend/tests/unit/test_rate_limit_json_failopen.py
+++ b/backend/tests/unit/test_rate_limit_json_failopen.py
@@ -14,6 +14,8 @@ import sys
 import types
 from unittest.mock import MagicMock, patch
 
+from fastapi import HTTPException
+
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
 
@@ -112,8 +114,43 @@ def _stored(cache, key='rate_limit:ep:1.2.3.4'):
     return json.loads(cache[key])
 
 
+def _allowed_in_window(cache, *, per_window, window, now):
+    """Number of requests served before the window starts returning 429."""
+    allowed = 0
+    with patch.object(ep_mod, 'cached', cache), patch.object(ep_mod.time, 'time', lambda: now):
+        while allowed <= per_window + 1:
+            try:
+                ep_mod.rate_limit_custom('ep', _req(), per_window, window)
+            except HTTPException:
+                break
+            allowed += 1
+    return allowed
+
+
 def test_first_window_reserves_exactly_one_request():
     cache = {}
     with patch.object(ep_mod, 'cached', cache):
         assert ep_mod.rate_limit_custom('ep', _req(), 5, 3600) is True
     assert _stored(cache)['remaining'] == 4
+
+
+def test_window_reset_reserves_the_same_as_a_first_request():
+    """An expired window is a fresh window; it must not start a request short.
+
+    The reset branch set `remaining = requests_per_window - 1` and then fell through to
+    the shared `remaining -= 1`, storing N-2, while the first-ever request stored N-1.
+    """
+    now = 1_800_000_000
+    cache = {'rate_limit:ep:1.2.3.4': json.dumps({'timestamp': now - 3600, 'remaining': 0})}
+    with patch.object(ep_mod, 'cached', cache), patch.object(ep_mod.time, 'time', lambda: now):
+        assert ep_mod.rate_limit_custom('ep', _req(), 5, 3600) is True
+    assert _stored(cache)['remaining'] == 4
+
+
+def test_every_window_serves_the_full_quota():
+    now = 1_800_000_000
+    cache = {}
+    first = _allowed_in_window(cache, per_window=5, window=3600, now=now)
+    second = _allowed_in_window(cache, per_window=5, window=3600, now=now + 3600)
+    third = _allowed_in_window(cache, per_window=5, window=3600, now=now + 7200)
+    assert (first, second, third) == (5, 5, 5)

--- a/backend/tests/unit/test_rate_limit_json_failopen.py
+++ b/backend/tests/unit/test_rate_limit_json_failopen.py
@@ -6,6 +6,7 @@ utils/other/endpoints.py has a heavy import graph, so we import it under a stub 
 """
 
 import importlib.abc
+import json
 import importlib.machinery
 import importlib.util
 import os
@@ -105,3 +106,14 @@ def test_partial_cache_entry_fails_open():
     with patch.object(ep_mod, 'cached', {'rate_limit:ep:1.2.3.4': '{"foo": 1}'}):  # missing remaining/timestamp
         result = ep_mod.rate_limit_custom('ep', _req(), 60, 60)
     assert result is True
+
+
+def _stored(cache, key='rate_limit:ep:1.2.3.4'):
+    return json.loads(cache[key])
+
+
+def test_first_window_reserves_exactly_one_request():
+    cache = {}
+    with patch.object(ep_mod, 'cached', cache):
+        assert ep_mod.rate_limit_custom('ep', _req(), 5, 3600) is True
+    assert _stored(cache)['remaining'] == 4

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -338,7 +338,10 @@ def rate_limit_custom(endpoint: str, request: Request, requests_per_window: int,
 
         # Check if the time window has expired
         if current_time - timestamp >= window_seconds:
-            remaining = requests_per_window - 1  # Reset the counter for the new window
+            # A new window starts with the full quota; the shared decrement below charges
+            # this request, matching the first-request branch. Subtracting here too spent
+            # one slot twice and left every window after the first one request short.
+            remaining = requests_per_window
             timestamp = current_time
         elif remaining == 0:
             raise HTTPException(status_code=429, detail="Too Many Requests")


### PR DESCRIPTION
## Problem

`rate_limit_custom` charges the current request with a single shared decrement, but the window-reset branch has **already** spent a slot:

```python
if current_time - timestamp >= window_seconds:
    remaining = requests_per_window - 1  # Reset the counter for the new window
    timestamp = current_time
elif remaining == 0:
    raise HTTPException(status_code=429, detail="Too Many Requests")

remaining -= 1
```

The first-ever request takes the `else` branch and stores `requests_per_window - 1`. A request that *rolls the window over* stores `requests_per_window - 2` — the same situation recorded one lower.

**Every window after the first serves one fewer request than configured, permanently.** With `requests_per_window=5` the served counts per window are `5, 4, 4, 4, …`.

## Impact

Reachable from every caller:

- `routers/phone_calls.py` — phone verification (5/hour) and verify-check (30/minute)
- `routers/fair_use_admin.py` — case status (10/minute)

A user who verifies a phone number in two consecutive hours is cut off a request early in the second hour.

## Fix

The reset branch hands over the full quota and lets the shared decrement charge this request, exactly as the first-request branch does:

```diff
-remaining = requests_per_window - 1  # Reset the counter for the new window
+remaining = requests_per_window
```

## Commits

1. **`test:`** pin the first-request contract — the window bookkeeping had no coverage at all (the two existing cases only assert fail-open on a corrupt entry). Green on unmodified code.
2. **`fix:`** the off-by-one, with the regression cases.

Both commits are green, so the series stays bisectable.

## Tests

Added to the existing `test_rate_limit_json_failopen.py`, reusing its stub-finder harness — **no new isolation seam and no new dependency**:

- a reset window reserves the same as a first request
- three consecutive windows each serve the full quota — `(5, 5, 5)`

Against the pre-fix code these are `(5, 4, 4)` and the stored `remaining` is `3` rather than `4`.

## Verification

```
$ pytest tests/unit/test_rate_limit_json_failopen.py
5 passed          # pre-fix: assert 3 == 4 / assert (5, 4, 4) == (5, 5, 5)

module-scope sys.modules gate : 756 files, 0 violations
line-count ratchet            : no increase
black --line-length 120       : clean
fast-unit CPU                 : 0.01s (limit 1.00s)
```

I confirmed this is not intended behaviour by grepping the function name across the whole test tree (not by filename): `rate_limit_custom` appears only in `test_rate_limit_json_failopen.py`, and no test asserts `remaining` or the reset path. `test_rate_limiting.py` covers a different, Redis-backed limiter.

## Failure class

Failure-Class: none

An off-by-one in a single counter reset; no registered class covers it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

