### PR TITLE
fix(backend): app-review push notifications say "None reviewed <app>"

### DIFF
--- a/backend/tests/unit/test_app_review_notification_names.py
+++ b/backend/tests/unit/test_app_review_notification_names.py
@@ -1,0 +1,83 @@
+"""App-review notifications must not address users as "None".
+
+``database.auth.get_user_from_uid`` always emits a ``display_name`` key — it is built
+from ``firebase_admin``'s UserRecord, whose ``display_name`` is ``None`` for any account
+created without one (email/password signup, Apple private-relay). ``dict.get(key,
+default)`` only falls back when the key is *absent*, so the stored ``None`` was used
+verbatim and the push title read "None reviewed Weather".
+
+Isolation: utils/notifications.py pulls firebase_admin at import, so it is loaded through
+the sanctioned Tier-2 reserve seam (stub_modules + load_module_fresh) inside a fixture.
+See backend/docs/test_isolation.md.
+"""
+
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Iterator
+
+import pytest
+
+from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _module(name: str, **attributes: Any) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    return module
+
+
+@contextmanager
+def _notifications_with_user(user: Any) -> Iterator[Any]:
+    """Load utils.notifications with get_user_from_uid returning `user`."""
+    stubs = {
+        name: AutoMockModule(name)
+        for name in (
+            'firebase_admin',
+            'firebase_admin.messaging',
+            'firebase_admin.auth',
+            'database.notifications',
+            'database.redis_db',
+            'utils.llm.notifications',
+        )
+    }
+    stubs['database.auth'] = _module('database.auth', get_user_from_uid=lambda _uid: user)
+    with stub_modules(stubs):
+        yield load_module_fresh('utils.notifications', str(BACKEND_DIR / 'utils' / 'notifications.py'))
+
+
+def _firebase_user(display_name: Any) -> dict:
+    """Exactly the shape database.auth.get_user_from_uid returns."""
+    return {
+        'uid': 'u1',
+        'email': 'a@b.c',
+        'email_verified': True,
+        'phone_number': None,
+        'display_name': display_name,
+        'photo_url': None,
+        'disabled': False,
+    }
+
+
+def _capture_titles(notifications):
+    sent = []
+    notifications.send_notification = lambda uid, title, body, data=None: sent.append(title)
+    return sent
+
+
+def test_real_names_are_still_used():
+    with _notifications_with_user(_firebase_user('Ada')) as notifications:
+        titles = _capture_titles(notifications)
+        notifications.send_new_app_review_notification('owner', 'reviewer', 'app1', 'Weather', 'Great!')
+        notifications.send_app_review_reply_notification('reviewer', 'owner', 'thanks!', 'app1', 'Weather')
+    assert titles == ['Ada reviewed Weather', 'Ada (Weather)']
+
+
+def test_missing_user_record_still_falls_back():
+    with _notifications_with_user(None) as notifications:
+        titles = _capture_titles(notifications)
+        notifications.send_new_app_review_notification('owner', 'reviewer', 'app1', 'Weather', 'Great!')
+    assert titles == ['A user reviewed Weather']

--- a/backend/tests/unit/test_app_review_notification_names.py
+++ b/backend/tests/unit/test_app_review_notification_names.py
@@ -68,6 +68,22 @@ def _capture_titles(notifications):
     return sent
 
 
+@pytest.mark.parametrize('display_name', [None, ''])
+def test_new_review_falls_back_when_the_reviewer_has_no_name(display_name):
+    with _notifications_with_user(_firebase_user(display_name)) as notifications:
+        titles = _capture_titles(notifications)
+        notifications.send_new_app_review_notification('owner', 'reviewer', 'app1', 'Weather', 'Great!')
+    assert titles == ['A user reviewed Weather']
+
+
+@pytest.mark.parametrize('display_name', [None, ''])
+def test_reply_falls_back_when_the_owner_has_no_name(display_name):
+    with _notifications_with_user(_firebase_user(display_name)) as notifications:
+        titles = _capture_titles(notifications)
+        notifications.send_app_review_reply_notification('reviewer', 'owner', 'thanks!', 'app1', 'Weather')
+    assert titles == ['The developer (Weather)']
+
+
 def test_real_names_are_still_used():
     with _notifications_with_user(_firebase_user('Ada')) as notifications:
         titles = _capture_titles(notifications)

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -406,7 +406,7 @@ def send_app_review_reply_notification(
 ):
     """Sends a notification to a user when their app review receives a reply."""
     app_owner = get_user_from_uid(app_owner_uid)
-    owner_name = app_owner.get('display_name', 'The developer') if app_owner else 'The developer'
+    owner_name = (app_owner or {}).get('display_name') or 'The developer'
     title = f'{owner_name} ({app_name})'
     body = reply_body
     data = {'app_id': app_id, 'type': 'app_review_reply', 'navigate_to': f'/apps/{app_id}'}
@@ -418,7 +418,7 @@ def send_new_app_review_notification(
 ):
     """Sends a notification to the app owner when a new review is submitted."""
     reviewer = get_user_from_uid(reviewer_uid)
-    reviewer_name = reviewer.get('display_name', 'A user') if reviewer else 'A user'
+    reviewer_name = (reviewer or {}).get('display_name') or 'A user'
     title = f'{reviewer_name} reviewed {app_name}'
     body = review_body
     data = {'app_id': app_id, 'type': 'new_app_review', 'navigate_to': f'/apps/{app_id}'}


### PR DESCRIPTION
## Problem

Both app-review notifications resolve a display name with `dict.get`'s default:

```python
owner_name = app_owner.get('display_name', 'The developer') if app_owner else 'The developer'
reviewer_name = reviewer.get('display_name', 'A user') if reviewer else 'A user'
```

But `database.auth.get_user_from_uid` builds its dict from `firebase_admin`'s `UserRecord` and **always emits the key**:

```python
return {
    'uid': user.uid,
    ...
    'display_name': user.display_name,
    ...
}
```

`display_name` is `None` for any account created without one — email/password signup, Apple private-relay. Since the key is *present*, `dict.get` never falls back and the `None` is formatted straight into the push title:

```
"None reviewed Weather"
"None (Weather)"
```

Reachable from the review endpoints in `routers/apps.py` (1239, 1278, 1317).

## Fix

Fall back on the **value**, not the key's absence:

```diff
-owner_name = app_owner.get('display_name', 'The developer') if app_owner else 'The developer'
+owner_name = (app_owner or {}).get('display_name') or 'The developer'
```

This matches the repo's own idiom — `utils/users.py` does `return name or default`, and `routers/apps.py:788` already guards with `get_user_from_uid(uid) or {}`.

## Commits

1. **`test:`** pin the titles for a user who *has* a name and for a missing user record — these notifications had **no assertions anywhere** (the only reference in the suite is a `patch.object` mock). Green on unmodified code.
2. **`fix:`** fall back on the value, with the regression cases.

Both commits are green, so the series stays bisectable.

## Tests

New `tests/unit/test_app_review_notification_names.py`, loading `utils.notifications` through the sanctioned `stub_modules` + `load_module_fresh` seam (no module-scope `sys.modules` mutation):

- `display_name` of `None` or `''` → `"A user reviewed Weather"` / `"The developer (Weather)"`
- a real name is still used
- a missing user record still falls back

Whitespace-only names are deliberately **not** handled — that keeps the fix to one expression and consistent with the existing `name or default` idiom.

## Verification

```
$ pytest tests/unit/test_app_review_notification_names.py
6 passed          # pre-fix: assert ['None reviewed Weather'] == ['A user reviewed Weather']

module-scope sys.modules gate : 757 files, 0 violations
line-count ratchet            : no increase
black --line-length 120       : clean
fast-unit CPU                 : 0.02s (limit 1.00s)
```

Confirmed not intentional by grepping the function names across the whole test tree (not by filename).

## Failure class

Failure-Class: none

A `dict.get` default that cannot fire because the key is always present; no registered class covers it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

