### PR TITLE
fix(backend): BYOK headers for unenrolled providers bypass fingerprint validation

### DIFF
--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -898,6 +898,20 @@ class TestBYOKFingerprintValidation:
 
     @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
     @patch('database.users.get_byok_state')
+    def test_valid_request_exposes_exactly_the_enrolled_keys(self, mock_get_state):
+        """A passing BYOK request makes the enrolled provider keys available downstream."""
+        from utils.byok import _byok_ctx, validate_byok_request, get_byok_keys
+
+        mock_get_state.return_value = self._mock_byok_state()
+        token = _byok_ctx.set(dict(self._valid_request_keys))
+        try:
+            validate_byok_request('byok-uid')
+            assert set(get_byok_keys()) == set(self._enrolled_fingerprints)
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
     def test_partial_headers_when_byok_active_raises_403(self, mock_get_state):
         """BYOK-active user sending SOME but not all headers → 403 (incomplete BYOK attempt)."""
         from fastapi import HTTPException

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -912,6 +912,46 @@ class TestBYOKFingerprintValidation:
 
     @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
     @patch('database.users.get_byok_state')
+    def test_header_for_unenrolled_provider_is_not_used(self, mock_get_state):
+        """A header the enrollment cannot vouch for must never reach the provider clients.
+
+        _check_byok_validity documents that "every header key's SHA-256 must match the
+        enrolled fingerprint", but it iterated the *enrolled* fingerprints. A header for a
+        provider absent from the enrollment was therefore never examined and stayed in the
+        request context, so get_byok_keys() handed it to downstream LLM calls unvalidated.
+        """
+        from utils.byok import _byok_ctx, validate_byok_request, get_byok_keys
+
+        mock_get_state.return_value = self._mock_byok_state()
+        keys = dict(self._valid_request_keys)
+        keys['unenrolled_provider'] = 'sk-never-enrolled-and-never-fingerprinted'
+        token = _byok_ctx.set(keys)
+        try:
+            validate_byok_request('byok-uid')
+            exposed = get_byok_keys()
+            assert 'unenrolled_provider' not in exposed
+            assert set(exposed) == set(self._enrolled_fingerprints)
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
+    def test_enrolled_keys_survive_alongside_an_unenrolled_header(self, mock_get_state):
+        """Dropping the unenrolled header must not disturb the enrolled ones."""
+        from utils.byok import _byok_ctx, validate_byok_request, get_byok_keys
+
+        mock_get_state.return_value = self._mock_byok_state()
+        keys = dict(self._valid_request_keys)
+        keys['unenrolled_provider'] = 'sk-never-enrolled'
+        token = _byok_ctx.set(keys)
+        try:
+            validate_byok_request('byok-uid')
+            assert get_byok_keys() == self._valid_request_keys
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
     def test_partial_headers_when_byok_active_raises_403(self, mock_get_state):
         """BYOK-active user sending SOME but not all headers → 403 (incomplete BYOK attempt)."""
         from fastapi import HTTPException

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -202,6 +202,13 @@ def _check_byok_validity(uid: str) -> Optional[str]:
         if request_fp != stored_fp:
             return f"BYOK key fingerprint mismatch for provider: {provider}"
 
+    # A header for a provider the user never enrolled has no stored fingerprint, so the
+    # loop above never sees it and it would reach the provider clients unvalidated. Drop
+    # it, mirroring the non-enrolled-user path above: anything we cannot verify must not
+    # be used, and downstream falls back to Omi's own key for that provider.
+    if any(provider not in stored_fingerprints for provider in request_keys):
+        _byok_ctx.set({p: key for p, key in request_keys.items() if p in stored_fingerprints})
+
     return None
 
 


### PR DESCRIPTION
## Problem

`_check_byok_validity` states its contract in its own docstring:

> If user IS BYOK-active **and sends BYOK headers** → **every header key's** SHA-256 must match the enrolled fingerprint. Mismatch → error string.

But the loop walks the **enrolled fingerprints**, not the headers:

```python
for provider, stored_fp in stored_fingerprints.items():
    raw_key = request_keys.get(provider)
    if not raw_key:
        return f"BYOK key header missing for enrolled provider: {provider}"
    ...
```

A header for a provider that is **absent from the enrollment** has no stored fingerprint to compare against, is never examined, and stays in `_byok_ctx`. `get_byok_keys()` then hands it to the provider clients, so a key the enrollment cannot vouch for is used for real LLM calls.

Concretely — a user enrolled for `openai` only, sending:

```python
{'openai': '<valid, matching fingerprint>', 'anthropic': '<anything at all>'}
```

passes validation today, and the `anthropic` value is exposed downstream unvalidated.

Reached from `utils/other/endpoints.py` inside `get_current_user_uid`, i.e. every authenticated HTTP endpoint.

## Fix

The non-enrolled-user path two blocks above already takes the correct posture — it clears the headers so *"downstream code always uses Omi's own keys"*. Apply the same rule to the unverifiable subset of an enrolled user's headers:

```python
if any(provider not in stored_fingerprints for provider in request_keys):
    _byok_ctx.set({p: key for p, key in request_keys.items() if p in stored_fingerprints})
```

Enrolled keys are untouched.

**Dropping rather than raising 403 is deliberate:** it closes the hole without breaking a client that sends an extra header, and matches the existing clear-and-continue behaviour for keys that cannot be verified. Happy to switch to a 403 if you prefer the stricter posture — it's the same branch.

## Commits

1. **`test:`** pin which keys a *valid* BYOK request exposes downstream — the suite asserted validation outcomes but never what `get_byok_keys()` hands to the clients afterwards. Green on unmodified code.
2. **`fix:`** drop unverifiable headers, with the regression cases.

Both commits are green.

## Tests

Added to `tests/unit/test_byok_security.py` (reusing its existing `get_byok_state` patching — no new harness):

- a header for an unenrolled provider is absent from `get_byok_keys()`
- the enrolled keys still come through intact alongside it

Existing coverage only exercised valid / missing / mismatched **enrolled** providers, so this path was untested.

## Verification

```
$ pytest tests/unit/test_byok_security.py -k unenrolled
2 passed        # pre-fix: 2 failed

file total: 70 -> 73 passing
```

The 11 unrelated `ImportError` failures in this file are pre-existing in my sandbox (missing optional deps) and are present on `main` too — this file is green in CI.

```
module-scope sys.modules gate : 756 files, 0 violations
line-count ratchet            : no increase
black --line-length 120       : clean
fast-unit CPU                 : well under the 1.00s limit
```

Confirmed not intentional by grepping `_check_byok_validity` / `validate_byok_request` across the whole test tree.

## Failure class

Failure-Class: none

A validation loop iterating the wrong collection; no registered class covers it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

