### PR TITLE
fix(backend): semaphore cache prune drops the live loop's entry, doubling the concurrency cap

### DIFF
--- a/backend/tests/unit/test_async_http_infrastructure.py
+++ b/backend/tests/unit/test_async_http_infrastructure.py
@@ -68,6 +68,7 @@ from utils.http_client import (
     _webhook_circuit_breakers,
     _latest_wins_versions,
     _semaphores,
+    _SEMAPHORE_CACHE_MAX,
     _CIRCUIT_BREAKER_FAILURE_THRESHOLD,
     _CIRCUIT_BREAKER_RECOVERY_TIMEOUT,
 )
@@ -284,6 +285,44 @@ class TestSemaphoreGetters:
         sem1 = get_webhook_semaphore()
         sem2 = get_webhook_semaphore()
         assert sem1 is sem2
+
+    @pytest.mark.asyncio
+    async def test_pruning_keeps_the_running_loops_semaphore(self):
+        """Crossing the cache cap must not swap the live loop's existing semaphore.
+
+        The prune used _semaphores.clear(), which dropped the running loop's entries too.
+        A caller already holding permits on the old Semaphore kept them while the next
+        caller received a brand-new one, so the effective concurrency briefly doubled —
+        the opposite of what the cap exists for. The docstring already promised the main
+        loop's semaphores "are stable" and that only short-lived asyncio.run() entries
+        are pruned.
+        """
+        _semaphores.clear()
+        webhook_before = get_webhook_semaphore()
+        live_loop_id = id(asyncio.get_running_loop())
+
+        # Fill the cache past the cap with entries from other (destroyed) loops.
+        for i in range(_SEMAPHORE_CACHE_MAX + 5):
+            _semaphores[(live_loop_id + 1 + i, 'webhook')] = asyncio.Semaphore(1)
+
+        # A new name for this loop is what triggers the prune.
+        get_maps_semaphore()
+
+        assert get_webhook_semaphore() is webhook_before, 'the running loop lost its semaphore to the prune'
+
+    @pytest.mark.asyncio
+    async def test_pruning_still_bounds_the_cache(self):
+        """The prune must drop the foreign-loop entries it was added for."""
+        _semaphores.clear()
+        get_webhook_semaphore()
+        live_loop_id = id(asyncio.get_running_loop())
+        for i in range(_SEMAPHORE_CACHE_MAX + 5):
+            _semaphores[(live_loop_id + 1 + i, 'webhook')] = asyncio.Semaphore(1)
+
+        get_maps_semaphore()  # crosses the cap, triggering the prune
+
+        assert all(key[0] == live_loop_id for key in _semaphores), 'foreign-loop entries survived'
+        assert len(_semaphores) == 2  # webhook + maps, both for this loop
 
     def test_different_loops_return_different_instances(self):
         """Different asyncio.run() calls get isolated semaphores."""

--- a/backend/utils/http_client.py
+++ b/backend/utils/http_client.py
@@ -201,9 +201,21 @@ def _get_semaphore(name: str, limit: int) -> asyncio.Semaphore:
     if key not in _semaphores:
         # Prune stale entries from destroyed loops when cache grows large
         if len(_semaphores) > _SEMAPHORE_CACHE_MAX:
-            _semaphores.clear()
+            _evict_foreign_loop_semaphores(id(loop))
         _semaphores[key] = asyncio.Semaphore(limit)
     return _semaphores[key]
+
+
+def _evict_foreign_loop_semaphores(live_loop_id: int) -> None:
+    """Drop semaphores belonging to loops other than the one running now.
+
+    Mirrors _evict_stale_circuit_breakers / _evict_stale_latest_wins: remove only what is
+    stale. A blanket clear() also dropped the running loop's own entry, so the next caller
+    got a fresh Semaphore while in-flight tasks still held permits on the old one — briefly
+    allowing twice the concurrency the limit exists to cap.
+    """
+    for key in [k for k in _semaphores if k[0] != live_loop_id]:
+        del _semaphores[key]
 
 
 def get_webhook_semaphore() -> asyncio.Semaphore:


### PR DESCRIPTION
## Problem

`_get_semaphore` keys semaphores by `(loop_id, name)` and prunes when the cache grows past `_SEMAPHORE_CACHE_MAX`. Its docstring sets the contract:

> The main FastAPI event loop … reuses the same `loop_id` for the lifetime of the process, so **its semaphores are stable**. Entries from short-lived `asyncio.run()` loops are pruned when the cache grows beyond `_SEMAPHORE_CACHE_MAX`.

But the prune is a blanket `clear()`:

```python
if key not in _semaphores:
    if len(_semaphores) > _SEMAPHORE_CACHE_MAX:
        _semaphores.clear()          # <- also discards the running loop's entries
    _semaphores[key] = asyncio.Semaphore(limit)
```

Tasks already holding permits keep them on the **old** `Semaphore` while the next caller is handed a **fresh** one. For the duration of those in-flight requests the effective concurrency is up to **twice** the configured limit — 128 rather than 64 for webhooks. That is the opposite of what the cap exists for.

It's reachable in the normal way: sync FastAPI endpoints call `asyncio.run()`, each new loop adds an entry, and crossing 100 triggers the prune while running under the main loop.

## Fix

Evict only entries belonging to *other* loops:

```python
def _evict_foreign_loop_semaphores(live_loop_id: int) -> None:
    for key in [k for k in _semaphores if k[0] != live_loop_id]:
        del _semaphores[key]
```

This mirrors the two sibling evictors already in this module — `_evict_stale_circuit_breakers` and `_evict_stale_latest_wins` — which both remove just the stale keys rather than emptying the map.

## Tests

The prune path had **no coverage**: `_SEMAPHORE_CACHE_MAX` appears in no test, and the existing cases only cover same-loop identity and cross-loop isolation.

- crossing the cap leaves the running loop's existing semaphore **identical**
- the prune still drops every foreign-loop entry, so the cache stays bounded

One implementation note worth flagging for review: the prune only runs when a **new** key is created, so the tests request a *second* semaphore name to trigger it. My first draft asked for the same name again, which returns the cached entry and exercised nothing — those tests passed against the buggy code until I corrected them.

## Verification

```
$ pytest tests/unit/test_async_http_infrastructure.py
47 passed

# restore _semaphores.clear():
2 failed   (test_pruning_keeps_the_running_loops_semaphore,
            test_pruning_still_bounds_the_cache)

module-scope sys.modules gate : 756 files, 0 violations
black --line-length 120       : clean
fast-unit CPU                 : 0.06s max (limit 1.00s)
```

## Failure class

Failure-Class: none

A cache eviction that discards live state along with stale state; no registered class covers it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

