### PR TITLE
ci(desktop): halve Swift CI wall time

### DIFF
--- a/.github/scripts/test_desktop_swift_ci_contract.py
+++ b/.github/scripts/test_desktop_swift_ci_contract.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Contract test for desktop-swift-ci.yml toolchain pinning and cache-key integrity.
 
-Fails if either CI job loses Xcode selection, version assertion, version logging,
+Fails if a Swift CI job loses Xcode selection, version assertion, version logging,
 or if the SwiftPM cache key omits Package.swift, Package.resolved, or toolchain
 identity.  This is the Rung-0 guard from #9843: every downstream strictness claim
 depends on knowing which compiler the flags run against.
@@ -21,8 +21,8 @@ PRE_PUSH_PATH = REPO_ROOT / "scripts/pre-push"
 EXPECTED_XCODE_VERSION = "16.4"
 EXPECTED_XCODE_BUILD = "16F6"
 EXPECTED_XCODE_APP = f"/Applications/Xcode_{EXPECTED_XCODE_VERSION}.app"
-JOBS = ["changes", "desktop-swift", "desktop-swift-release-compile"]
-MACOS_JOBS = ["desktop-swift", "desktop-swift-release-compile"]
+JOBS = ["changes", "desktop-swift-static", "desktop-swift-tests", "desktop-swift", "desktop-swift-release-compile"]
+MACOS_JOBS = ["desktop-swift-static", "desktop-swift-tests", "desktop-swift-release-compile"]
 
 
 def _workflow_text() -> str:
@@ -58,14 +58,16 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
     # --- per-job assertions ------------------------------------------------
 
     def test_both_jobs_call_the_canonical_pinned_toolchain_runner(self):
-        debug_job = self.jobs["desktop-swift"]
+        for job_id in MACOS_JOBS:
+            with self.subTest(job=job_id):
+                self.assertIn("run-swift-ci.sh --select-toolchain", self.jobs[job_id])
+
+        test_job = self.jobs["desktop-swift-tests"]
         release_job = self.jobs["desktop-swift-release-compile"]
 
-        self.assertIn("run-swift-ci.sh --select-toolchain", debug_job)
-        self.assertIn("run-swift-ci.sh --test", debug_job)
-        self.assertIn("run-swift-ci.sh --select-toolchain", release_job)
+        self.assertIn("run-swift-ci.sh --test", test_job)
         self.assertIn("run-swift-ci.sh --release-compile", release_job)
-        self.assertIn("run-swift-ci.sh --release-notification-regression", debug_job)
+        self.assertIn("run-swift-ci.sh --release-notification-regression", test_job)
 
     def test_change_detection_happens_before_macos_allocation(self):
         """#9440: non-desktop changes must not claim a costly macOS runner."""
@@ -77,7 +79,8 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
         self.assertIn("diff_base", changes)
 
         for job_id, output in (
-            ("desktop-swift", "should_run"),
+            ("desktop-swift-static", "should_run"),
+            ("desktop-swift-tests", "should_run"),
             ("desktop-swift-release-compile", "should_release_compile"),
         ):
             with self.subTest(job=job_id):
@@ -86,16 +89,19 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
                 self.assertIn(f"needs.changes.outputs.{output}", job)
                 self.assertNotIn("Check changed files", job)
 
-        # The debug job needs full history (fetch-depth: 0) for manifest checks
-        # that call git diff/merge-base; the release compile can stay shallow.
-        debug_job = self.jobs["desktop-swift"]
-        self.assertIn("fetch-depth: 0", debug_job)
+        # Static checks need full history for git diff/merge-base. The test and
+        # release-compile jobs can stay shallow because they do not resolve a
+        # diff base themselves.
+        static_job = self.jobs["desktop-swift-static"]
+        self.assertIn("fetch-depth: 0", static_job)
+        test_job = self.jobs["desktop-swift-tests"]
+        self.assertIn("fetch-depth: 1", test_job)
         release_job = self.jobs["desktop-swift-release-compile"]
         self.assertIn("fetch-depth: 1", release_job)
 
     def test_notification_boundary_runs_targeted_release_regression(self):
         changes = self.jobs["changes"]
-        job = self.jobs["desktop-swift"]
+        job = self.jobs["desktop-swift-tests"]
         for path in (
             "AppState[+]Permissions[.]swift",
             "Sources/.*Notification.*[.]swift",
@@ -108,6 +114,17 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
         self.assertIn("--release-notification-regression", job)
         self.assertIn("should_notification_release_regression", job)
         self.assertIn("UserNotificationCallbackBridgeTests/", _runner_text())
+
+    def test_stable_release_gate_requires_both_parallel_jobs(self):
+        """The required check name must fail closed on either parallel lane."""
+        gate = self.jobs["desktop-swift"]
+
+        self.assertIn("name: Desktop Swift Build & Tests", gate)
+        self.assertIn("desktop-swift-static", gate)
+        self.assertIn("desktop-swift-tests", gate)
+        self.assertIn("always()", gate)
+        self.assertIn('test "$STATIC_RESULT" = success', gate)
+        self.assertIn('test "$TEST_RESULT" = success', gate)
 
     def test_canonical_runner_fails_closed_on_the_pinned_toolchain(self):
         runner = _runner_text()
@@ -141,8 +158,8 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
     def test_cache_key_includes_manifest_and_lockfile_and_toolchain(self):
         """The SwiftPM cache key must include Package.swift, Package.resolved,
         and a toolchain identity component."""
-        job = self.jobs["desktop-swift"]
-        self.assertIn("uses: actions/cache", job, "desktop-swift must have a cache step")
+        job = self.jobs["desktop-swift-tests"]
+        self.assertIn("uses: actions/cache", job, "desktop-swift-tests must have a cache step")
         key_match = re.search(r"key:\s*([^\n]+)", job)
         self.assertIsNotNone(key_match, "desktop-swift cache step must declare a key")
         key = key_match.group(1)
@@ -165,22 +182,16 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
             key,
             "cache key must include Package.resolved hashFiles",
         )
-        self.assertIn(
-            "swift-format-wrapper.sh",
-            key,
-            "cache key must invalidate when the pinned formatter provenance changes",
-        )
-        self.assertIn(
-            "swiftlint-wrapper.sh",
-            key,
-            "cache key must invalidate when the pinned linter provenance changes",
-        )
-        self.assertIn("~/.cache/omi-swift-format", job)
-        self.assertIn("~/.cache/omi-swiftlint", job)
+        static_job = self.jobs["desktop-swift-static"]
+        static_key = re.search(r"key:\s*([^\n]+)", static_job).group(1)
+        self.assertIn("swift-format-wrapper.sh", static_key)
+        self.assertIn("swiftlint-wrapper.sh", static_key)
+        self.assertIn("~/.cache/omi-swift-format", static_job)
+        self.assertIn("~/.cache/omi-swiftlint", static_job)
 
     def test_cache_saves_completed_build_state_after_a_test_failure(self):
         """A retry should reuse SwiftPM's validated incremental build state."""
-        job = self.jobs["desktop-swift"]
+        job = self.jobs["desktop-swift-tests"]
         self.assertIn("id: swiftpm-cache", job)
         self.assertIn("uses: actions/cache/restore@v6", job)
         self.assertIn("uses: actions/cache/save@v6", job)
@@ -204,7 +215,7 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
     def test_manifest_checks_use_the_changed_diff_base_on_pushes(self):
         """Pushes must lint the just-pushed diff, not checkout's origin/main HEAD."""
         changes = self.jobs["changes"]
-        job = self.jobs["desktop-swift"]
+        job = self.jobs["desktop-swift-static"]
         self.assertIn('echo "diff_base=$DIFF_BASE" >> "$GITHUB_OUTPUT"', changes)
         self.assertIn(
             '--base "${{ needs.changes.outputs.diff_base }}"',
@@ -225,17 +236,17 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
         """The workflow must not retain a toolchain setup while bypassing the shared runner."""
         wf_text = WORKFLOW_PATH.read_text(encoding="utf-8")
         tampered = wf_text.replace("run-swift-ci.sh --test", "swift-test-suites.sh", 1)
-        combined = _job_text(tampered, "desktop-swift")
+        combined = _job_text(tampered, "desktop-swift-tests")
         self.assertNotIn("run-swift-ci.sh --test", combined)
 
     def test_adversarial_cache_key_weakening_detected(self):
         """A cache key without Package.resolved or toolchain identity is caught."""
         wf_text = WORKFLOW_PATH.read_text(encoding="utf-8")
         tampered = wf_text.replace(
-            "desktop-swift-xcode164-${{ hashFiles('desktop/macos/Desktop/Package.swift', 'desktop/macos/Desktop/Package.resolved', 'desktop/macos/scripts/swift-format-wrapper.sh', 'desktop/macos/scripts/swiftlint-wrapper.sh') }}",
+            "desktop-swift-build-xcode164-${{ hashFiles('desktop/macos/Desktop/Package.swift', 'desktop/macos/Desktop/Package.resolved') }}",
             "desktop-swift-${{ hashFiles('desktop/macos/Desktop/Package.swift') }}",
         )
-        job = _job_text(tampered, "desktop-swift")
+        job = _job_text(tampered, "desktop-swift-tests")
         key = re.search(r"key:\s*([^\n]+)", job).group(1)
         self.assertNotIn("Package.resolved", key)
 

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -79,8 +79,13 @@ jobs:
           echo "should_notification_release_regression=$SHOULD_NOTIFICATION_RELEASE_REGRESSION" >> "$GITHUB_OUTPUT"
           echo "desktop_swift=$DESKTOP_SWIFT package_swift=$PACKAGE_SWIFT package_resolved=$PACKAGE_RESOLVED should_run=$SHOULD_RUN should_release_compile=$SHOULD_RELEASE_COMPILE should_notification_release_regression=$SHOULD_NOTIFICATION_RELEASE_REGRESSION"
 
-  desktop-swift:
-    name: Desktop Swift Build & Tests
+  # The Swift test suite and the macOS-only manifest checks have no runtime
+  # dependency on one another. Keeping them in separate jobs puts their slow
+  # paths on the critical path only once, instead of serializing both on a
+  # single macOS runner. The small aggregate job below remains the stable
+  # release-gate check name and fails unless both jobs succeed.
+  desktop-swift-static:
+    name: Desktop Swift Static Contracts
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: macos-15
@@ -93,6 +98,47 @@ jobs:
       - name: Select and assert pinned Xcode 16.4
         run: desktop/macos/scripts/run-swift-ci.sh --select-toolchain
 
+      - name: Restore Swift formatter and linter tools
+        id: swift-tools-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ~/.cache/omi-swift-format
+            ~/.cache/omi-swiftlint
+          key: ${{ runner.os }}-desktop-swift-tools-xcode164-${{ hashFiles('desktop/macos/scripts/swift-format-wrapper.sh', 'desktop/macos/scripts/swiftlint-wrapper.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-desktop-swift-tools-xcode164-
+
+      - name: Install uv for manifest checks
+        uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84
+
+      - name: Run macOS-scoped manifest checks
+        run: |
+          python3 .github/scripts/run_checks.py --lane ci --platform macos --base "${{ needs.changes.outputs.diff_base }}" --skip-pr-body-checks
+
+      - name: Save Swift formatter and linter tools after checks
+        if: ${{ always() && steps.swift-tools-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ~/.cache/omi-swift-format
+            ~/.cache/omi-swiftlint
+          key: ${{ runner.os }}-desktop-swift-tools-xcode164-${{ hashFiles('desktop/macos/scripts/swift-format-wrapper.sh', 'desktop/macos/scripts/swiftlint-wrapper.sh') }}
+
+  desktop-swift-tests:
+    name: Desktop Swift Test Suites
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
+    runs-on: macos-15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Select and assert pinned Xcode 16.4
+        run: desktop/macos/scripts/run-swift-ci.sh --select-toolchain
+
       - name: Restore SwiftPM build products
         id: swiftpm-cache
         uses: actions/cache/restore@v6
@@ -100,11 +146,9 @@ jobs:
           path: |
             ~/Library/Caches/org.swift.swiftpm
             desktop/macos/Desktop/.build
-            ~/.cache/omi-swift-format
-            ~/.cache/omi-swiftlint
-          key: ${{ runner.os }}-desktop-swift-xcode164-${{ hashFiles('desktop/macos/Desktop/Package.swift', 'desktop/macos/Desktop/Package.resolved', 'desktop/macos/scripts/swift-format-wrapper.sh', 'desktop/macos/scripts/swiftlint-wrapper.sh') }}
+          key: ${{ runner.os }}-desktop-swift-build-xcode164-${{ hashFiles('desktop/macos/Desktop/Package.swift', 'desktop/macos/Desktop/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-desktop-swift-xcode164-
+            ${{ runner.os }}-desktop-swift-build-xcode164-
 
       - name: Install Swift system dependencies
         run: brew install pkg-config webp
@@ -118,13 +162,6 @@ jobs:
             echo "== $t"
             bash "$t"
           done
-
-      - name: Install uv for manifest checks
-        uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84
-
-      - name: Run macOS-scoped manifest checks
-        run: |
-          python3 .github/scripts/run_checks.py --lane ci --platform macos --base "${{ needs.changes.outputs.diff_base }}" --skip-pr-body-checks
 
       # Debug build+test only on the PR critical path. Release compile is a
       # separate job (main push, or PRs that touch Package.swift) so we do not
@@ -153,9 +190,23 @@ jobs:
           path: |
             ~/Library/Caches/org.swift.swiftpm
             desktop/macos/Desktop/.build
-            ~/.cache/omi-swift-format
-            ~/.cache/omi-swiftlint
-          key: ${{ runner.os }}-desktop-swift-xcode164-${{ hashFiles('desktop/macos/Desktop/Package.swift', 'desktop/macos/Desktop/Package.resolved', 'desktop/macos/scripts/swift-format-wrapper.sh', 'desktop/macos/scripts/swiftlint-wrapper.sh') }}
+          key: ${{ runner.os }}-desktop-swift-build-xcode164-${{ hashFiles('desktop/macos/Desktop/Package.swift', 'desktop/macos/Desktop/Package.resolved') }}
+
+  desktop-swift:
+    # Keep this name stable: desktop release planning requires this exact
+    # check to pass for the source SHA that will be tagged.
+    name: Desktop Swift Build & Tests
+    needs: [changes, desktop-swift-static, desktop-swift-tests]
+    if: ${{ always() && needs.changes.outputs.should_run == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require static contracts and Swift tests
+        env:
+          STATIC_RESULT: ${{ needs.desktop-swift-static.result }}
+          TEST_RESULT: ${{ needs.desktop-swift-tests.result }}
+        run: |
+          test "$STATIC_RESULT" = success
+          test "$TEST_RESULT" = success
 
   desktop-swift-release-compile:
     name: Desktop Swift Release Compile


### PR DESCRIPTION
## Summary

- split independent macOS static-contract and isolated Swift-test work into parallel jobs
- retain `Desktop Swift Build & Tests` as a fail-closed aggregate required check for release planning
- cache SwiftPM build products separately from the formatter/linter tool cache

## Timing analysis

On representative Desktop Swift CI runs, the single macOS job spent 8m32s in manifest checks and 10m50s in the full isolated Swift suite, sequentially. The two phases now run concurrently, reducing expected wall-clock time from about 18–23 minutes to the slower lane plus the aggregate check (roughly 9–11 minutes).

## Product invariants

- none

## Verification

- `python3 .github/scripts/test_desktop_swift_ci_contract.py` — passed (15 tests)
- `python3 .github/scripts/test_desktop_manifest_routes.py` — passed (4 tests)
- `make preflight` — passed (13 selected checks)
- `OMI_SWIFT_TEST_SUITE_WORKERS=4 ./scripts/swift-test-suites.sh` in `desktop/macos` — passed with local Xcode 26.6; the exact CI wrapper correctly rejects this host because CI pins Xcode 16.4
- `git diff --check` — passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

