### PR TITLE
fix(backend): unbreak main — ws-b lifecycle tests rotted when the wall clock passed their pinned NOW + TTL

### DIFF
--- a/backend/tests/unit/test_ws_b_short_term_lifecycle.py
+++ b/backend/tests/unit/test_ws_b_short_term_lifecycle.py
@@ -120,7 +120,13 @@ from tests.unit.test_ws_i_write_convergence import (
     _trusted_account_generation,
 )
 
-NOW = datetime(2026, 6, 20, 12, 0, tzinfo=timezone.utc)
+# Anchored to the real clock rather than a fixed calendar date. Several cases persist an
+# item through write_canonical_extraction_memory, which has no clock parameter and stamps
+# captured_at from the real clock, and then drive processing with now=NOW. A fixed NOW
+# meant expires_at (NOW + DEFAULT_SHORT_TERM_TTL_DAYS) eventually fell behind real
+# captured_at, and the short_term "expires_at must be after captured_at" invariant started
+# failing on its own — with no code change — once the wall clock passed that date.
+NOW = datetime.now(timezone.utc).replace(hour=12, minute=0, second=0, microsecond=0)
 
 _WS_B_RUNTIME_MODULE_NAMES = (
     "database.memory_apply_store",


### PR DESCRIPTION
## `main` is currently red, and this is why

Every recent **Backend Unit Tests** run on `main` fails with the same 7 failures in `tests/unit/test_ws_b_short_term_lifecycle.py`. No code change caused it — the suite rotted on a date.

The file pins:

```python
NOW = datetime(2026, 6, 20, 12, 0, tzinfo=timezone.utc)
```

Seven cases persist an item with `write_canonical_extraction_memory`, which **takes no clock parameter** and stamps `captured_at` from the real clock, then drive processing with `now=NOW`. The processed patch sets:

```python
expires_at = default_short_term_expiry(now)   # now + DEFAULT_SHORT_TERM_TTL_DAYS (30)
```

So `expires_at` was frozen at `2026-06-20 + 30d = 2026-07-20`, while `captured_at` tracked real time. `MemoryItem.validate_tier_invariants` requires:

```python
if self.expires_at <= self.captured_at:
    raise ValueError("short_term expires_at must be after captured_at")
```

That held until the wall clock passed **2026-07-20** — and then stopped.

Observed directly:

```
DEBUG id=manual-required-processed tier=short_term
      captured_at=2026-07-21 00:48:56+00:00     <- real clock
      expires_at=2026-07-20 12:00:00+00:00      <- NOW + 30d
```

```
real now      : 2026-07-21
hardcoded NOW : 2026-06-20
NOW + 30d TTL : 2026-07-20   <- bomb armed once real now passed this
```

All seven failures surface as `error_code='ValidationError'`:

```
FAILED test_required_processing_receipt_unlocks_durable_promotion
FAILED test_required_processing_receipt_is_bound_to_current_content_and_revision
FAILED test_required_processor_retry_rebases_operation_after_unrelated_head_advance
FAILED test_inflight_promotion_cannot_overwrite_negative_user_review
FAILED test_required_promotion_merges_exact_existing_long_term
FAILED test_required_promotion_merges_multiple_sources_in_same_run
FAILED test_required_promotion_retry_after_supersede_failure_is_idempotent_across_run_ids
```

## Fix

Anchor `NOW` to the real clock (today at 12:00 UTC) so the injected clock and the real `captured_at` can never drift apart by more than the TTL:

```python
NOW = datetime.now(timezone.utc).replace(hour=12, minute=0, second=0, microsecond=0)
```

`NOW` remains a single fixed value for the whole run, so the tests stay deterministic — it simply no longer rots.

**Test-only change.** The production behaviour isn't at fault: the mismatch is between the test's injected clock and the un-injectable one inside `write_canonical_extraction_memory`. Giving that function a `now` parameter would be the deeper fix, but it changes a production signature to serve a test, so I've left it — happy to do it that way if you'd prefer.

## Verification

```
$ pytest tests/unit/test_ws_b_short_term_lifecycle.py
25 passed          # restoring the fixed date reproduces exactly the 7 CI failures

module-scope sys.modules gate : 756 files, 0 violations
line-count ratchet            : no increase
black --line-length 120       : clean
fast-unit CPU                 : 0.02s max (limit 1.00s)
```

## Heads-up on the same shape elsewhere

Five other unit files pin the same `2026-06-20` date — `test_canonical_consolidation`, `test_canonical_maintenance_ordering`, `test_canonical_consolidation_apply`, `test_canonical_kg_promotion`, `test_v3_canary_approval_artifact`. They pass today because none mixes a real-clock write with a TTL computed off `NOW`, but they carry the same latent shape. I've left them alone rather than widen this PR.

## Failure class

Failure-Class: none

A test clock that goes stale against a real-clock write; no registered class covers it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

