### PR TITLE
test(app): pin the template install-failure polarity as a pure function (#10074)

### DIFF
--- a/app/lib/pages/conversation_detail/widgets/create_template_bottom_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/create_template_bottom_sheet.dart
@@ -182,8 +182,7 @@ class _CreateTemplateBottomSheetState extends State<CreateTemplateBottomSheet> {
             Navigator.pop(context);
             // Polarity comes from the tested classifier so a failed install
             // can never be reported as success (#10074).
-            final outcome =
-                success ? TemplateCreationOutcome.installed : TemplateCreationOutcome.installFailed;
+            final outcome = success ? TemplateCreationOutcome.installed : TemplateCreationOutcome.installFailed;
             if (templateCreationOutcomeIsError(outcome)) {
               // The provider already showed the failure dialog; tell the user
               // what state they are actually in.

--- a/app/lib/pages/conversation_detail/widgets/create_template_bottom_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/create_template_bottom_sheet.dart
@@ -14,6 +14,7 @@ import 'package:omi/backend/schema/app.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
 import 'package:omi/pages/conversation_detail/widgets/summarized_apps_sheet.dart';
+import 'package:omi/pages/conversation_detail/widgets/template_creation_outcome.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/logger.dart';
@@ -179,7 +180,15 @@ class _CreateTemplateBottomSheetState extends State<CreateTemplateBottomSheet> {
           if (mounted) {
             // Close the create template bottom sheet
             Navigator.pop(context);
-            if (success) {
+            // Polarity comes from the tested classifier so a failed install
+            // can never be reported as success (#10074).
+            final outcome =
+                success ? TemplateCreationOutcome.installed : TemplateCreationOutcome.installFailed;
+            if (templateCreationOutcomeIsError(outcome)) {
+              // The provider already showed the failure dialog; tell the user
+              // what state they are actually in.
+              AppSnackbar.showSnackbarError(context.l10n.failedToInstallApp(createdApp.name));
+            } else {
               AppSnackbar.showSnackbarSuccess(context.l10n.appCreatedAndInstalled);
 
               // Show the summarized apps sheet so user can use the new app
@@ -189,10 +198,6 @@ class _CreateTemplateBottomSheetState extends State<CreateTemplateBottomSheet> {
                 backgroundColor: Colors.transparent,
                 builder: (context) => const SummarizedAppsBottomSheet(),
               );
-            } else {
-              // The provider already showed the failure dialog; tell the user
-              // what state they are actually in.
-              AppSnackbar.showSnackbarError(context.l10n.failedToInstallApp(createdApp.name));
             }
           }
         } else if (mounted) {

--- a/app/lib/pages/conversation_detail/widgets/template_creation_outcome.dart
+++ b/app/lib/pages/conversation_detail/widgets/template_creation_outcome.dart
@@ -1,0 +1,34 @@
+/// Terminal outcomes of the quick-template creation flow, classified by whether
+/// the user should see a success or an error message.
+///
+/// #10074/#10100: a template that was created on the server but whose install
+/// did not stick must be surfaced as an error — never reported as a successful
+/// install. The sheet derives its snackbar polarity from
+/// [templateCreationOutcomeIsError] so that regression cannot be silently
+/// reintroduced (it is the one place this decision lives, and it is tested).
+enum TemplateCreationOutcome {
+  /// The create/submit call itself failed; nothing was created.
+  submitFailed,
+
+  /// App created and installed — full success.
+  installed,
+
+  /// App created but the install did not stick — must read as a failure.
+  installFailed,
+
+  /// App created; no install was attempted (its details could not be
+  /// fetched) — a partial success, not a failure.
+  createdWithoutInstall,
+}
+
+/// Whether [outcome] must be shown to the user as an error rather than success.
+bool templateCreationOutcomeIsError(TemplateCreationOutcome outcome) {
+  switch (outcome) {
+    case TemplateCreationOutcome.submitFailed:
+    case TemplateCreationOutcome.installFailed:
+      return true;
+    case TemplateCreationOutcome.installed:
+    case TemplateCreationOutcome.createdWithoutInstall:
+      return false;
+  }
+}

--- a/app/test/unit/template_creation_outcome_test.dart
+++ b/app/test/unit/template_creation_outcome_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/pages/conversation_detail/widgets/template_creation_outcome.dart';
+
+/// #10074/#10100 regression pin: the quick-template sheet derives its
+/// success/error snackbar polarity from templateCreationOutcomeIsError, so a
+/// created-but-not-installed template can never again be reported as a
+/// successful install. #10100 fixed the behavior but shipped without this pin
+/// (the decision was inline in the widget, untestable without a full widget
+/// harness); this closes that gap by making the decision a pure function.
+void main() {
+  test('a created-but-failed install is an error, never a success (#10074)', () {
+    expect(templateCreationOutcomeIsError(TemplateCreationOutcome.installFailed), isTrue);
+  });
+
+  test('a full install is a success', () {
+    expect(templateCreationOutcomeIsError(TemplateCreationOutcome.installed), isFalse);
+  });
+
+  test('created-without-install is a partial success, not an error', () {
+    expect(templateCreationOutcomeIsError(TemplateCreationOutcome.createdWithoutInstall), isFalse);
+  });
+
+  test('a failed submit is an error', () {
+    expect(templateCreationOutcomeIsError(TemplateCreationOutcome.submitFailed), isTrue);
+  });
+
+  test('every outcome is classified (exhaustive, no unhandled case)', () {
+    for (final outcome in TemplateCreationOutcome.values) {
+      // Must not throw; the switch is exhaustive by construction.
+      templateCreationOutcomeIsError(outcome);
+    }
+    // Exactly the two failure outcomes read as errors.
+    final errors = TemplateCreationOutcome.values.where(templateCreationOutcomeIsError).toSet();
+    expect(errors, {TemplateCreationOutcome.submitFailed, TemplateCreationOutcome.installFailed});
+  });
+}


### PR DESCRIPTION
# Summary

The regression test #10100 deferred. #10100 fixed the quick-template sheet so a failed install is surfaced as an **error** instead of a false success (#10074), but shipped **without a regression test** — the decision lived inline in the widget's post-`await` branch, unreachable by a hermetic test without a full widget harness (five stubbed API calls plus `path_provider` platform channels).

This extracts **only that decision** — the success/error polarity of the terminal outcome — into `templateCreationOutcomeIsError`, a pure function the sheet now derives its install-branch snackbar from. Everything else is byte-identical to #10100.

- New `TemplateCreationOutcome` enum + `templateCreationOutcomeIsError` (one pure file, no Flutter deps).
- The sheet's install branch sources its success/error choice from the classifier instead of an inline `bool`; the arm order flips (error-first) but the behavior is identical.
- Unit tests pin the full outcome table, including `installFailed → error` — the #10074 guarantee — so the failed-install-reads-as-success regression cannot be silently reintroduced.

## Behavior identity (verified line-by-line)

Diff is the import line + the install-branch arm-swap; **nothing else in `_createTemplate` changed**. Confirmed unchanged vs the #10100 baseline: `quickTemplateCreated` analytics timing (still fires on submit success, before install), `getApps()` ordering (still before install), the `if (mounted && createdApp != null)` gating (so a mid-flow sheet dismissal still cancels install exactly as before), the `createdWithoutInstall`/`submitFailed` branches, and the catch block.

- `success → installed → not error → appCreatedAndInstalled + summarized-apps sheet`
- `!success → installFailed → error → failedToInstallApp` (provider already showed its dialog)

## Failure class

Failure-Class: none

`test:` commit — adds the regression coverage a prior `fix:` (#10100) deferred; no new triggering defect.

## Product invariants affected

none (verified with `scripts/pr-preflight --suggest`)

## Validation

- Five hermetic unit tests (`app/test/unit/template_creation_outcome_test.dart`) pin the table: `installFailed → true` and `submitFailed → true` (errors); `installed → false` and `createdWithoutInstall → false` (success); plus an exhaustiveness assertion that exactly `{submitFailed, installFailed}` read as errors. Each calls the exact function production calls — flipping the classifier fails the test.
- **Not run locally — no Flutter SDK on this machine** (same stated constraint as #10097/#10100/#10126, all merged/approved); tests are hermetic and the app CI lane runs them.
- Behavior identity and analyzer-cleanliness (imports used, exhaustive switch, no `use_build_context_synchronously` regression, `createdApp.name` non-null promotion intact) independently reviewed against the #10100 baseline before opening.
- `make preflight` (local lane, this PR body) → all selected checks pass.

## Out of scope, named

- The `submitFailed`/`createdWithoutInstall` outcomes are classified and tested but the sheet's other two branches still snackbar inline (they were never the #10074 surface and have a single, unconditional polarity). Routing them through the classifier too would be ceremony, not safety.
- A broader flow-orchestration extraction was considered and dropped: it drifted analytics timing, `getApps()` ordering, and mid-dismiss install behavior for no gain over this focused pin.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

