### PR TITLE
fix(desktop): prevent logger I/O crashes

### DIFF
--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 import Sentry
 
 enum OmiLogPathResolver {
@@ -38,11 +39,75 @@ func omiLogFilePath() -> String { logFile }
 func omiLogLaunchID() -> String { logLaunchID }
 
 private let logQueue = DispatchQueue(label: "me.omi.logger", qos: .utility)
+private let logFailureDiagnostics = Logger(subsystem: "me.omi.desktop", category: "file-logger")
 private let dateFormatter: DateFormatter = {
   let formatter = DateFormatter()
   formatter.dateFormat = "HH:mm:ss.SSS"  // Added milliseconds for perf tracking
   return formatter
 }()
+
+/// Appends to a file using Foundation's throwing APIs. Legacy `FileHandle.write(_:)`
+/// raises an Objective-C exception for I/O failures, which aborts a Swift process.
+enum OmiLogFileAppender {
+  static func append(
+    _ data: Data,
+    to file: URL,
+    openFile: (URL) throws -> FileHandle = { try FileHandle(forWritingTo: $0) },
+    seekToEnd: (FileHandle) throws -> Void = { try $0.seekToEnd() },
+    write: (FileHandle, Data) throws -> Void = { try $0.write(contentsOf: $1) },
+    close: (FileHandle) throws -> Void = { try $0.close() }
+  ) -> Result<Void, Error> {
+    var handle: FileHandle?
+    do {
+      let openedHandle = try openFile(file)
+      handle = openedHandle
+      try seekToEnd(openedHandle)
+      try write(openedHandle, data)
+      try close(openedHandle)
+      return .success(())
+    } catch {
+      // A failed seek or write can leave the handle open; closing is best-effort
+      // here because the original I/O failure is the useful diagnostic.
+      if let handle {
+        try? close(handle)
+      }
+      return .failure(error)
+    }
+  }
+}
+
+/// Bounds diagnostics when every file write fails (for example, on a full disk).
+/// Instances are confined to the serial log queue.
+final class OmiLogFileFailureReporter: @unchecked Sendable {
+  private var didReport = false
+  private let emit: (Error) -> Void
+
+  init(emit: @escaping (Error) -> Void) {
+    self.emit = emit
+  }
+
+  func report(_ error: Error) {
+    guard !didReport else { return }
+    didReport = true
+    emit(error)
+  }
+}
+
+/// Records a local-log failure without recursing into the unavailable file logger.
+private func reportLogFileWriteFailure(_ error: Error) {
+  let nsError = error as NSError
+  let diagnostic = "Local log write failed; dropped entry (domain=\(nsError.domain), code=\(nsError.code))"
+  logFailureDiagnostics.error("\(diagnostic, privacy: .public)")
+
+  // A breadcrumb accompanies any later crash report without turning expected disk
+  // exhaustion into a high-volume Sentry error event.
+  guard !AppBuild.isNonProduction else { return }
+  let breadcrumb = Breadcrumb(level: .error, category: "file-logger")
+  breadcrumb.message = diagnostic
+  SentrySDK.addBreadcrumb(breadcrumb)
+}
+
+private let logFileFailureReporter = OmiLogFileFailureReporter(emit: reportLogFileWriteFailure)
 
 /// Append data to the log file on a background queue (non-blocking)
 private func appendToLogFile(_ line: String) {
@@ -132,6 +197,17 @@ private func logLine(timestamp: String, category: String, message: String) -> St
   "[\(timestamp)] [\(category)] [bundle_id=\(logBundleIdentifier) pid=\(logProcessID)] \(message)"
 }
 
+func writeToLogFile(
+  _ data: Data,
+  to file: URL,
+  appendFile: (Data, URL) -> Result<Void, Error>,
+  reportFailure: (Error) -> Void
+) {
+  if case .failure(let error) = appendFile(data, file) {
+    reportFailure(error)
+  }
+}
+
 /// Shared file-write implementation (must be called on logQueue)
 private func writeToLogFile(_ data: Data) {
   if !didEnsureLogFilePermissions {
@@ -143,15 +219,18 @@ private func writeToLogFile(_ data: Data) {
       && ensureLogFileOwnerOnly(atPath: logFile)
   }
   if FileManager.default.fileExists(atPath: logFile) {
-    if let handle = FileHandle(forWritingAtPath: logFile) {
-      handle.seekToEndOfFile()
-      handle.write(data)
-      handle.closeFile()
-    }
+    writeToLogFile(
+      data,
+      to: URL(fileURLWithPath: logFile),
+      appendFile: { data, file in OmiLogFileAppender.append(data, to: file) },
+      reportFailure: { logFileFailureReporter.report($0) })
   } else {
     // Recreate owner-only if the file was removed mid-session.
-    FileManager.default.createFile(
+    let created = FileManager.default.createFile(
       atPath: logFile, contents: data, attributes: [.posixPermissions: 0o600])
+    if !created {
+      logFileFailureReporter.report(CocoaError(.fileWriteUnknown))
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Tests/LoggerPermissionsTests.swift
+++ b/desktop/macos/Desktop/Tests/LoggerPermissionsTests.swift
@@ -97,6 +97,119 @@ final class LoggerPermissionsTests: XCTestCase {
     XCTAssertEqual(try posixPermissions(of: path), 0o700)
   }
 
+  func testLogFileAppenderReturnsFailureWhenWriteThrowsAfterSeek() throws {
+    let path = tempDir.appendingPathComponent("write-failure.log")
+    XCTAssertTrue(FileManager.default.createFile(atPath: path.path, contents: Data()))
+    var didSeek = false
+    var closeAttempts = 0
+
+    let result = OmiLogFileAppender.append(
+      Data("log line\n".utf8),
+      to: path,
+      seekToEnd: { handle in
+        didSeek = true
+        try handle.seekToEnd()
+      },
+      write: { _, _ in throw TestError.writeFailure },
+      close: { handle in
+        closeAttempts += 1
+        try handle.close()
+      })
+
+    XCTAssertTrue(didSeek)
+    XCTAssertEqual(closeAttempts, 1)
+    if case .success = result {
+      XCTFail("A failed write must be returned instead of escaping as an exception")
+    }
+  }
+
+  func testLogFileAppenderClosesHandleAfterSeekFailure() throws {
+    let path = tempDir.appendingPathComponent("seek-failure.log")
+    XCTAssertTrue(FileManager.default.createFile(atPath: path.path, contents: Data()))
+    var closeAttempts = 0
+
+    let result = OmiLogFileAppender.append(
+      Data("log line\n".utf8),
+      to: path,
+      seekToEnd: { _ in throw TestError.seekFailure },
+      close: { handle in
+        closeAttempts += 1
+        try handle.close()
+      })
+
+    XCTAssertEqual(closeAttempts, 1)
+    if case .success = result {
+      XCTFail("A failed seek must be returned instead of escaping as an exception")
+    }
+  }
+
+  func testLogFileAppenderReturnsFailureWhenCloseThrowsAfterWrite() throws {
+    let path = tempDir.appendingPathComponent("close-failure.log")
+    XCTAssertTrue(FileManager.default.createFile(atPath: path.path, contents: Data()))
+    var didWrite = false
+
+    let result = OmiLogFileAppender.append(
+      Data("log line\n".utf8),
+      to: path,
+      write: { handle, data in
+        didWrite = true
+        try handle.write(contentsOf: data)
+      },
+      close: { handle in
+        try handle.close()
+        throw TestError.closeFailure
+      })
+
+    XCTAssertTrue(didWrite)
+    if case .success = result {
+      XCTFail("A close failure must be returned instead of being silently discarded")
+    }
+  }
+
+  func testWriteToLogFileReportsCloseFailure() throws {
+    let path = tempDir.appendingPathComponent("reported-close-failure.log")
+    XCTAssertTrue(FileManager.default.createFile(atPath: path.path, contents: Data()))
+    var reportedFailures = 0
+
+    writeToLogFile(
+      Data("log line\n".utf8),
+      to: path,
+      appendFile: { data, file in
+        OmiLogFileAppender.append(
+          data,
+          to: file,
+          close: { handle in
+            try handle.close()
+            throw TestError.closeFailure
+          })
+      },
+      reportFailure: { _ in reportedFailures += 1 })
+
+    XCTAssertEqual(reportedFailures, 1)
+  }
+
+  func testWriteToLogFileReportsOnlyFirstPersistentFailure() {
+    let path = tempDir.appendingPathComponent("persistent-failure.log")
+    var reportedFailures = 0
+    let reporter = OmiLogFileFailureReporter { _ in reportedFailures += 1 }
+    let appendFailure: (Data, URL) -> Result<Void, Error> = { _, _ in .failure(TestError.writeFailure) }
+
+    writeToLogFile(Data("first\n".utf8), to: path, appendFile: appendFailure) { error in
+      reporter.report(error)
+    }
+    writeToLogFile(Data("second\n".utf8), to: path, appendFile: appendFailure) { error in
+      reporter.report(error)
+    }
+
+    XCTAssertEqual(reportedFailures, 1)
+  }
+
+  private enum TestError: Error {
+    case seekFailure
+    case writeFailure
+    case closeFailure
+  }
+
   private func posixPermissions(of path: String) throws -> Int {
     let attributes = try FileManager.default.attributesOfItem(atPath: path)
     let number = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)

--- a/desktop/macos/changelog/unreleased/20260720-nonfatal-local-log-writes.json
+++ b/desktop/macos/changelog/unreleased/20260720-nonfatal-local-log-writes.json
@@ -1,0 +1,3 @@
+{
+  "change": "Prevent Omi Desktop from quitting when a local diagnostic log write fails, while preserving the failure details for later crash diagnosis"
+}


### PR DESCRIPTION
## Summary
- Replace the desktop logger's exception-raising legacy file writes with throwing Foundation APIs.
- Drop failed log entries safely and record the first sanitized error domain/code in Unified Logging and a Sentry breadcrumb.
- Add regression coverage for write-time failure handling and bounded failure diagnostics through the production writer seam.

## Failure Class
Failure-Class: none

## Verification
- `xcrun swift test --package-path Desktop --filter LoggerPermissionsTests`
- `./scripts/swift-test-suites.sh`
- `xcrun swift build -c debug --package-path Desktop`
- Named-bundle packaging reached signing but was not launched: this host has no Apple Development signing identity, and ad-hoc signing was intentionally not enabled because it can reset existing Omi Screen Recording permissions.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

