### PR TITLE
feat(desktop): add privacy-safe incident diagnostics

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -1,10 +1,10 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/AuthService.swift": 3298,
+    "desktop/macos/Desktop/Sources/AuthService.swift": 3294,
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
-    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4252,
+    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4240,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1578,
-    "desktop/macos/Desktop/Sources/OmiApp.swift": 1641
+    "desktop/macos/Desktop/Sources/OmiApp.swift": 1638
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/AuthService.swift": "Apple first-auth name capture signals observers (authNameDidUpdate) and persists the name to Firebase so it survives reinstalls.",

--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -303,6 +303,15 @@ class AnalyticsManager {
     if hadPreviousSession && !lastCleanExit {
       log("Analytics: Previous session did not exit cleanly — reporting crash")
       let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+      let attachmentURL = DesktopDiagnosticsManager.shared.writeIncidentDiagnosticsAttachment(
+        area: "crash",
+        failureClass: "unknown",
+        phase: "startup")
+      defer {
+        if let attachmentURL {
+          try? FileManager.default.removeItem(at: attachmentURL)
+        }
+      }
       SentrySDK.capture(message: "App Crash Detected") { scope in
         scope.setLevel(.warning)
         scope.setTag(value: "app_crash_detected", key: "diagnostic")
@@ -311,6 +320,13 @@ class AnalyticsManager {
             "app_version": version,
             "os_version": ProcessInfo.processInfo.operatingSystemVersionString,
           ], key: "crash")
+        if let attachmentURL {
+          scope.addAttachment(
+            Attachment(
+              path: attachmentURL.path,
+              filename: "desktop-incident-diagnostics.json",
+              contentType: "application/json"))
+        }
       }
     }
   }
@@ -551,6 +567,9 @@ class AnalyticsManager {
   func chatQueryTelemetry(_ event: ChatQueryTelemetryEvent) {
     let payload = event.analyticsPayload
     PostHogManager.shared.track(payload.eventName, properties: payload.properties)
+    if case .failed(_, _, let errorClass, _) = event {
+      DesktopDiagnosticsManager.shared.recordChatFailure(errorClass: errorClass.rawValue)
+    }
     let diagnosticKeys = [
       "duration_ms", "error_class", "cancel_reason", "partial_response",
       "surface", "harness", "runtime_surface",

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -1282,10 +1282,9 @@ class AuthService {
     Task { await FloatingBarUsageLimiter.shared.fetchPlan() }
 
     if !AnalyticsManager.isDevBuild {
-      let sentryUser = User(userId: userId)
-      sentryUser.email = AuthState.shared.userEmail
-      sentryUser.username = displayName.isEmpty ? nil : displayName
-      SentrySDK.setUser(sentryUser)
+      // Keep Sentry correlation opaque; PII remains in the application/backend,
+      // not crash and error reports.
+      SentrySDK.setUser(User(userId: userId))
     }
 
     NSLog("OMI AUTH: Apple Sign in complete!")
@@ -1576,12 +1575,9 @@ class AuthService {
       // floating bar read it); without this it stays nil/old until launch.
       Task { await FloatingBarUsageLimiter.shared.fetchPlan() }
 
-      // Set Sentry user context for error tracking (skip in dev builds)
+      // Set opaque Sentry user context for error correlation (skip in dev builds).
       if !AnalyticsManager.isDevBuild {
-        let sentryUser = User(userId: userId)
-        sentryUser.email = tokenResult.email
-        sentryUser.username = displayName.isEmpty ? nil : displayName
-        SentrySDK.setUser(sentryUser)
+        SentrySDK.setUser(User(userId: userId))
       }
 
       NSLog("OMI AUTH: Sign in complete!")

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -3299,18 +3299,14 @@ final class DesktopAutomationActionRegistry {
     }
 
     // SET-02: assemble the exact payload FeedbackView.submitFeedback() would
-    // attach — the report title + the desktop_diagnostics.json attachment + the
-    // log-attachment metadata — WITHOUT calling SentrySDK, so a harness can grep
-    // the diagnostics JSON for secrets without firing a real Sentry event. The
-    // title and diagnostics JSON come from the same builders the real submit
-    // uses (feedbackReportTitle / writeDiagnosticsAttachment), so the dry-run
-    // can't diverge from what ships. The raw log is attached unredacted to Sentry
-    // by design (trusted sink, explicit user report); we surface only its
-    // metadata here — never its contents — so the bridge response can't leak it.
+    // attach — the report title plus a redacted incident diagnostics attachment —
+    // WITHOUT calling SentrySDK. The dry-run uses the same builders as the real
+    // submit path, so a harness can secret-scan the attachment without a cloud
+    // side effect and cannot drift toward a raw-log upload.
     register(
       name: "dump_feedback_payload_dryrun",
       summary:
-        "Assemble the feedback report payload (title + desktop_diagnostics.json + log-attachment metadata) without submitting to Sentry; returns the diagnostics JSON for secret-scanning. Non-prod only.",
+        "Assemble the feedback report payload (title + redacted desktop_diagnostics.json) without submitting to Sentry; returns the diagnostics JSON for secret-scanning. Non-prod only.",
       params: ["message"]
     ) { params in
       guard AppBuild.isNonProduction else {
@@ -3324,7 +3320,11 @@ final class DesktopAutomationActionRegistry {
         "would_submit_to_sentry": "false",
       ]
 
-      if let url = DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment() {
+      if let url = DesktopDiagnosticsManager.shared.writeIncidentDiagnosticsAttachment(
+        area: "other",
+        failureClass: "user_report",
+        phase: "other"
+      ) {
         defer { try? FileManager.default.removeItem(at: url) }
         if let data = try? Data(contentsOf: url), let json = String(data: data, encoding: .utf8) {
           detail["diagnostics_json"] = json
@@ -3334,18 +3334,6 @@ final class DesktopAutomationActionRegistry {
         }
       } else {
         detail["diagnostics_error"] = "attachment_write_failed"
-      }
-
-      let logPath = omiLogFilePath()
-      let logExists = FileManager.default.fileExists(atPath: logPath)
-      detail["log_attachment_filename"] = (logPath as NSString).lastPathComponent
-      detail["log_attachment_exists"] = logExists ? "true" : "false"
-      if logExists,
-        let attributes = try? FileManager.default.attributesOfItem(atPath: logPath),
-        let size = attributes[.size] as? NSNumber
-      {
-        // int64Value, not intValue (Int32): the log can exceed 2 GB in a long dev session.
-        detail["log_attachment_bytes"] = "\(size.int64Value)"
       }
       return detail
     }

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -17,6 +17,7 @@ enum DesktopHealthEventName: String {
   case realtimeProviderExpectedSessionRotation = "realtime_provider_expected_session_rotation"
   case realtimeProviderPolicyClose = "realtime_provider_policy_close"
   case realtimeProviderSessionError = "realtime_provider_session_error"
+  case userVisibleIssue = "user_visible_issue"
   case fallbackTriggered = "fallback_triggered"
 }
 
@@ -61,8 +62,10 @@ final class DesktopDiagnosticsManager {
   private let snapshotLimit = 150
   private var consecutiveNearZeroPTTTurns = 0
   private var lastPTTWatchdogIncidentAt: Date?
+  private var lastUserVisibleSentryIncidentAt: [String: Date] = [:]
   private let pttWatchdogThreshold = 3
   private let pttWatchdogDedupWindow: TimeInterval = 15 * 60
+  private let userVisibleSentryDedupWindow: TimeInterval = 60
   private let pttWatchdogMinimumAudioSeconds: Double = 0.35
 
   private init() {}
@@ -318,6 +321,14 @@ final class DesktopDiagnosticsManager {
 
     record(.pttAudioCaptureSilentTurn, properties: properties)
 
+    if nearZero && micPermissionGranted && watchdogEligible {
+      recordUserVisibleIssue(
+        area: "ptt",
+        failureClass: "silent_capture",
+        phase: "audio_capture",
+        extra: properties)
+    }
+
     guard nearZero && micPermissionGranted && watchdogEligible && consecutiveNearZeroPTTTurns >= pttWatchdogThreshold
     else { return }
     recordPTTWatchdogTriggered(latestProperties: properties)
@@ -332,6 +343,16 @@ final class DesktopDiagnosticsManager {
         "hub_active": hubActive,
       ],
       trackRemotely: false)
+  }
+
+  /// Records a typed chat failure as a fleet-health metric. The existing bounded
+  /// `logError` path owns the matching Sentry incident to avoid duplicate capture.
+  func recordChatFailure(errorClass: String) {
+    recordUserVisibleIssue(
+      area: "chat",
+      failureClass: errorClass,
+      phase: "query",
+      captureSentry: false)
   }
 
   func recordVoiceTurnTerminal(
@@ -488,24 +509,78 @@ final class DesktopDiagnosticsManager {
     return current
   }
 
+  private func currentCloudSnapshotsForSentry() -> [[String: Any]] {
+    lock.lock()
+    let current = snapshots.map { cloudSafeSnapshot($0) }
+    lock.unlock()
+    return current
+  }
+
+  private func currentSnapshotsForLocalExport() -> [[String: Any]] {
+    currentSnapshotsForSentry()
+  }
+
+  private func cloudSafeSnapshot(_ snapshot: DesktopHealthSnapshot) -> [String: Any] {
+    var result: [String: Any] = [
+      "timestamp": ISO8601DateFormatter.desktopDiagnostics.string(from: snapshot.timestamp),
+      "event": snapshot.event.rawValue,
+    ]
+
+    guard snapshot.event == .userVisibleIssue || snapshot.event == .pttAudioCaptureWatchdogTriggered else {
+      return result
+    }
+
+    for key in DesktopDiagnosticsManager.cloudIncidentSnapshotKeys {
+      if let value = snapshot.properties[key] {
+        result[key] = value
+      }
+    }
+    return result
+  }
+
+  private static let cloudIncidentSnapshotKeys: Set<String> = [
+    "area", "failure_class", "phase", "build", "build_number", "os_version", "device_model",
+    "source", "mode", "hub_active", "turn_audio_seconds", "voiced_audio_seconds", "peak", "rms",
+    "is_near_zero", "watchdog_eligible", "consecutive_silent_turns", "tcc_microphone_granted",
+    "input_device_class", "recovery_action", "recovery_result", "threshold",
+  ]
+
   func writeDiagnosticsAttachment() -> URL? {
     let payload: [String: Any] = [
       "generated_at": ISO8601DateFormatter.desktopDiagnostics.string(from: Date()),
       "privacy": "safe_operational_fields_only",
       "snapshots": currentSnapshotsForSentry(),
     ]
-    guard JSONSerialization.isValidJSONObject(payload),
-      let data = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted])
-    else { return nil }
-    let url = FileManager.default.temporaryDirectory
-      .appendingPathComponent("omi-desktop-diagnostics-\(UUID().uuidString).json")
-    do {
-      try data.write(to: url, options: .atomic)
-      return url
-    } catch {
-      log("DesktopDiagnostics: failed to write diagnostics attachment")
-      return nil
-    }
+    return writeDiagnosticsPayload(payload, prefix: "omi-desktop-diagnostics")
+  }
+
+  /// Creates a bounded, redacted local-context attachment for a cloud incident.
+  /// This intentionally replaces raw `omi.log` uploads: the attachment includes
+  /// safe health snapshots and a scrubbed tail only, never the entire log file.
+  func writeIncidentDiagnosticsAttachment(
+    incidentID: String = UUID().uuidString,
+    area: String,
+    failureClass: String,
+    phase: String,
+    logPath: String = omiLogFilePath(),
+    maxLogLines: Int = 200
+  ) -> URL? {
+    let incident = incidentProperties(
+      id: incidentID,
+      area: area,
+      failureClass: failureClass,
+      phase: phase)
+    let payload: [String: Any] = [
+      "generated_at": ISO8601DateFormatter.desktopDiagnostics.string(from: Date()),
+      "privacy": "redacted_incident_context",
+      "incident": incident,
+      "snapshots": currentCloudSnapshotsForSentry(),
+      "redacted_log_tail": redactedLogTail(
+        logPath: logPath,
+        maxLines: maxLogLines,
+        strictCloudRedaction: true),
+    ]
+    return writeDiagnosticsPayload(payload, prefix: "omi-desktop-incident")
   }
 
   // MARK: - Local (offline) diagnostics export
@@ -551,7 +626,7 @@ final class DesktopDiagnosticsManager {
     }
     sections.append(header.joined(separator: "\n"))
 
-    let snapshots = currentSnapshotsForSentry()
+    let snapshots = currentSnapshotsForLocalExport()
     if JSONSerialization.isValidJSONObject(snapshots),
       let data = try? JSONSerialization.data(withJSONObject: snapshots, options: [.prettyPrinted]),
       let json = String(data: data, encoding: .utf8)
@@ -567,7 +642,11 @@ final class DesktopDiagnosticsManager {
 
   /// Read up to `maxLines` from the end of the log file, redacting anything that
   /// looks like a secret (tokens, JWTs, credential kv pairs) line by line.
-  private func redactedLogTail(logPath: String, maxLines: Int) -> String {
+  private func redactedLogTail(
+    logPath: String,
+    maxLines: Int,
+    strictCloudRedaction: Bool = false
+  ) -> String {
     guard let handle = FileHandle(forReadingAtPath: logPath) else {
       return "(no readable log file at \(logPath))"
     }
@@ -588,7 +667,9 @@ final class DesktopDiagnosticsManager {
     }
     let lines = content.split(separator: "\n", omittingEmptySubsequences: false)
     let tail = lines.suffix(max(0, maxLines))
-    return tail.map { redactSensitive(String($0)) }.joined(separator: "\n")
+    return tail.map {
+      redactSensitive(String($0), strictCloudRedaction: strictCloudRedaction)
+    }.joined(separator: "\n")
   }
 
   /// Defensive best-effort redaction. The desktop log is not expected to contain
@@ -605,6 +686,12 @@ final class DesktopDiagnosticsManager {
       ("(?i)(authorization:\\s*basic)\\s+[A-Za-z0-9+/=]{8,}", "$1 [redacted]"),
       // Bare OpenAI-style API keys.
       ("sk-[A-Za-z0-9_-]{20,}", "sk-[redacted]"),
+      // Email addresses and absolute filesystem paths are operationally unnecessary
+      // in a cloud diagnostic attachment.
+      ("(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}", "[redacted-email]"),
+      ("/(?:Users|private|tmp|var|Applications)/[^\\s\\\"']+", "/[redacted-path]"),
+      // URLs can contain query parameters and opaque resource identifiers.
+      ("https?://[^\\s\\\"']+", "https://[redacted-url]"),
       // key=..., token: ..., password="..." in query strings, JSON, or kv logs.
       (
         "(?i)(api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|password|passwd|secret|client[_-]?secret|authorization)([\"']?\\s*[=:]\\s*[\"']?)[A-Za-z0-9._~+/=-]{6,}",
@@ -616,7 +703,33 @@ final class DesktopDiagnosticsManager {
     }
   }()
 
-  private func redactSensitive(_ line: String) -> String {
+  private static let safeOperationalLogMarkers = [
+    "ptt", "audio_capture", "audiocapture", "silent capture", "voiceturn", "voice turn",
+    "realtime", "sentry", "desktopdiagnostics", "app crash", "crash recovery",
+    "chat telemetry event=",
+  ]
+
+  private static let contentBearingLogMarkers = [
+    "conversation", "transcript", "prompt", "response", "message", "memory", "title",
+    "window", "screen", "ocr", "clipboard",
+  ]
+
+  private func redactSensitive(_ line: String, strictCloudRedaction: Bool = false) -> String {
+    let normalized = line.lowercased()
+    if strictCloudRedaction, normalized.contains("device=[") {
+      return "[redacted-device-bearing-log-line]"
+    }
+    if strictCloudRedaction,
+      DesktopDiagnosticsManager.contentBearingLogMarkers.contains(where: normalized.contains)
+    {
+      return "[redacted-content-bearing-log-line]"
+    }
+    if strictCloudRedaction,
+      !DesktopDiagnosticsManager.safeOperationalLogMarkers.contains(where: normalized.contains)
+    {
+      return "[redacted-unclassified-log-line]"
+    }
+
     var result = line
     for (regex, template) in DesktopDiagnosticsManager.redactionPatterns {
       let range = NSRange(result.startIndex..., in: result)
@@ -631,9 +744,101 @@ final class DesktopDiagnosticsManager {
       snapshots.removeAll()
       consecutiveNearZeroPTTTurns = 0
       lastPTTWatchdogIncidentAt = nil
+      lastUserVisibleSentryIncidentAt.removeAll()
       lock.unlock()
     }
   #endif
+
+  private func shouldCaptureIncident(area: String, failureClass: String) -> Bool {
+    let key = "\(area):\(failureClass)"
+    let now = Date()
+    lock.lock()
+    defer { lock.unlock() }
+    if let last = lastUserVisibleSentryIncidentAt[key],
+      now.timeIntervalSince(last) < userVisibleSentryDedupWindow
+    {
+      return false
+    }
+    lastUserVisibleSentryIncidentAt[key] = now
+    return true
+  }
+
+  private func recordUserVisibleIssue(
+    area: String,
+    failureClass: String,
+    phase: String,
+    extra: [String: Any] = [:],
+    captureSentry: Bool = true
+  ) {
+    let incidentID = UUID().uuidString
+    var properties: [String: Any] = [
+      "area": safeIncidentArea(area),
+      "failure_class": safeIncidentLabel(failureClass),
+      "phase": safeIncidentPhase(phase),
+    ]
+    let allowedExtras = sanitized(extra).filter {
+      DesktopDiagnosticsManager.allowedIncidentExtraKeys.contains($0.key)
+    }
+    for (key, value) in allowedExtras where properties[key] == nil {
+      properties[key] = value
+    }
+    record(.userVisibleIssue, properties: properties)
+
+    let sentryProperties = properties.merging(["incident_id": incidentID]) { _, new in new }
+    guard captureSentry,
+      !AppBuild.isNonProduction,
+      shouldCaptureIncident(
+        area: properties["area"] as? String ?? "other",
+        failureClass: properties["failure_class"] as? String ?? "other"),
+      let attachmentURL = writeIncidentDiagnosticsAttachment(
+        incidentID: incidentID,
+        area: area,
+        failureClass: failureClass,
+        phase: phase)
+    else { return }
+    defer { try? FileManager.default.removeItem(at: attachmentURL) }
+
+    SentrySDK.capture(message: "Desktop user-visible issue") { scope in
+      scope.setLevel(.warning)
+      scope.setTag(value: properties["area"] as? String ?? "other", key: "diagnostic_area")
+      scope.setTag(value: properties["failure_class"] as? String ?? "other", key: "failure_class")
+      scope.setContext(value: sentryProperties, key: "desktop_incident")
+      scope.addAttachment(
+        Attachment(
+          path: attachmentURL.path,
+          filename: "desktop-incident-diagnostics.json",
+          contentType: "application/json"))
+    }
+  }
+
+  private func incidentProperties(
+    id: String,
+    area: String,
+    failureClass: String,
+    phase: String
+  ) -> [String: String] {
+    [
+      "incident_id": id,
+      "area": safeIncidentArea(area),
+      "failure_class": safeIncidentLabel(failureClass),
+      "phase": safeIncidentPhase(phase),
+    ]
+  }
+
+  private func writeDiagnosticsPayload(_ payload: [String: Any], prefix: String) -> URL? {
+    guard JSONSerialization.isValidJSONObject(payload),
+      let data = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted])
+    else { return nil }
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("\(prefix)-\(UUID().uuidString).json")
+    do {
+      try data.write(to: url, options: .atomic)
+      return url
+    } catch {
+      log("DesktopDiagnostics: failed to write diagnostics attachment")
+      return nil
+    }
+  }
 
   private func record(
     _ event: DesktopHealthEventName,
@@ -673,15 +878,8 @@ final class DesktopDiagnosticsManager {
       "recovery_result": "not_attempted",
     ]) { _, new in new }
     record(.pttAudioCaptureWatchdogTriggered, properties: properties)
-
-    SentrySDK.capture(message: "PTT Silent Capture Watchdog Triggered") { scope in
-      scope.setLevel(.warning)
-      scope.setTag(value: "ptt_silent_capture_watchdog", key: "diagnostic")
-      scope.setContext(value: properties, key: "audio_capture")
-      scope.setContext(
-        value: ["snapshots": self.currentSnapshotsForSentry()],
-        key: "desktop_health_snapshots")
-    }
+    // The initial user-visible silent-capture incident owns the Sentry attachment.
+    // Keep this threshold event in PostHog without duplicating an incident upload.
   }
 
   private func commonProperties() -> [String: Any] {
@@ -734,6 +932,37 @@ final class DesktopDiagnosticsManager {
     default: return "unknown"
     }
   }
+
+  private func safeIncidentArea(_ area: String) -> String {
+    switch area {
+    case "ptt", "chat", "realtime", "crash", "startup": return area
+    default: return "other"
+    }
+  }
+
+  private func safeIncidentPhase(_ phase: String) -> String {
+    switch phase {
+    case "audio_capture", "transcript", "query", "runtime", "session", "startup", "other": return phase
+    default: return "other"
+    }
+  }
+
+  private func safeIncidentLabel(_ label: String) -> String {
+    let allowed: Set<String> = [
+      "silent_capture", "tool_stall", "agent_error", "agent_runtime", "attachment_upload",
+      "authentication", "bridge_unavailable", "bridge_start_failed", "browser_extension_missing",
+      "concurrent_request", "encoding", "quota", "resource_exhausted", "session_setup",
+      "timeout", "transient_network", "unknown", "user_report",
+    ]
+    return allowed.contains(label) ? label : "other"
+  }
+
+  private static let allowedIncidentExtraKeys: Set<String> = [
+    "source", "mode", "hub_active",
+    "turn_audio_seconds", "voiced_audio_seconds",
+    "peak", "rms", "is_near_zero", "watchdog_eligible", "consecutive_silent_turns",
+    "tcc_microphone_granted", "input_device_class", "recovery_action", "recovery_result",
+  ]
 
   private static let allowedFallbackAreas: Set<String> = [
     "sync_dispatch",

--- a/desktop/macos/Desktop/Sources/FeedbackView.swift
+++ b/desktop/macos/Desktop/Sources/FeedbackView.swift
@@ -6,8 +6,8 @@ import UniformTypeIdentifiers
 /// The Sentry event title used when a user submits feedback. Shared by the real
 /// `submitFeedback()` path and the non-prod dry-run bridge action so the dry-run
 /// can never drift from the title that actually ships to Sentry (SET-02).
-func feedbackReportTitle(for message: String) -> String {
-  message.isEmpty ? "User Report (logs only)" : "User Report: \(message)"
+func feedbackReportTitle(for _: String) -> String {
+  "User Report"
 }
 
 /// Filename of the JSON diagnostics attachment on the feedback Sentry event.
@@ -94,7 +94,7 @@ struct FeedbackView: View {
           .font(.headline)
 
         Text(
-          "App logs will be included automatically. Optionally describe what went wrong, or save a redacted diagnostics file to share manually."
+          "Redacted diagnostics will be included automatically. Notes, name, and email stay on this device for privacy; save a diagnostics file to share them manually."
         )
         .font(.caption)
         .foregroundColor(.secondary)
@@ -158,15 +158,14 @@ struct FeedbackView: View {
     // Submit to Sentry with log file attachment (dev + prod — user explicitly chose to report)
     let sentryMessage = feedbackReportTitle(for: message)
 
-    // Capture event with log file attached via scope
-    let eventId = SentrySDK.capture(message: sentryMessage) { scope in
-      let logPath = omiLogFilePath()
-      let logFilename = (logPath as NSString).lastPathComponent
-      if FileManager.default.fileExists(atPath: logPath) {
-        let attachment = Attachment(path: logPath, filename: logFilename, contentType: "text/plain")
-        scope.addAttachment(attachment)
-      }
-      if let diagnosticsURL = DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment() {
+    // Attach bounded, redacted diagnostics rather than the raw local log or
+    // user-entered feedback text.
+    let diagnosticsURL = DesktopDiagnosticsManager.shared.writeIncidentDiagnosticsAttachment(
+      area: "other",
+      failureClass: "user_report",
+      phase: "other")
+    SentrySDK.capture(message: sentryMessage) { scope in
+      if let diagnosticsURL {
         let attachment = Attachment(
           path: diagnosticsURL.path,
           filename: feedbackDiagnosticsAttachmentFilename,
@@ -174,21 +173,13 @@ struct FeedbackView: View {
         scope.addAttachment(attachment)
       }
     }
-
-    // Also send as Sentry feedback if there's a message
-    if !message.isEmpty {
-      let feedback = SentryFeedback(
-        message: message,
-        name: name.trimmingCharacters(in: .whitespacesAndNewlines),
-        email: email.trimmingCharacters(in: .whitespacesAndNewlines),
-        associatedEventId: eventId
-      )
-      SentrySDK.capture(feedback: feedback)
+    if let diagnosticsURL {
+      try? FileManager.default.removeItem(at: diagnosticsURL)
     }
 
-    log(
-      "User report submitted to Sentry (logs attached, message: \(message.isEmpty ? "none" : "yes"))"
-    )
+    // The user-entered text, name, and email are intentionally not sent to Sentry.
+    // The report's diagnostic attachment is the privacy-safe cloud evidence path.
+    log("User report diagnostics submitted to Sentry")
 
     // Show success
     OmiMotion.withGated {

--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -234,11 +234,8 @@ func logSync(_ message: String) {
   print(line)
   fflush(stdout)
 
-  if !isDevBuild {
-    let breadcrumb = Breadcrumb(level: .info, category: "app")
-    breadcrumb.message = message
-    SentrySDK.addBreadcrumb(breadcrumb)
-  }
+  // Free-form messages stay in the local log. Cloud incidents carry a bounded,
+  // redacted diagnostic attachment when an error is captured instead.
 
   appendToLogFileSync(line)
 }
@@ -250,11 +247,8 @@ func log(_ message: String) {
   print(line)
   fflush(stdout)
 
-  if !isDevBuild {
-    let breadcrumb = Breadcrumb(level: .info, category: "app")
-    breadcrumb.message = message
-    SentrySDK.addBreadcrumb(breadcrumb)
-  }
+  // Free-form messages stay in the local log. Cloud incidents carry a bounded,
+  // redacted diagnostic attachment when an error is captured instead.
 
   appendToLogFile(line)
 }
@@ -374,11 +368,8 @@ func logError(_ message: String, error: Error? = nil) {
   print(line)
   fflush(stdout)
 
-  if !isDevBuild {
-    let breadcrumb = Breadcrumb(level: .error, category: "error")
-    breadcrumb.message = fullMessage
-    SentrySDK.addBreadcrumb(breadcrumb)
-  }
+  // Keep raw error messages local. Sentry receives a stable incident event below
+  // with a redacted local diagnostic attachment.
 
   // Always persist locally; only the Sentry capture is filtered/rate-limited below.
   appendToLogFile(line)
@@ -392,25 +383,46 @@ func logError(_ message: String, error: Error? = nil) {
   // Collapse repeated identical errors so a single root cause doesn't flood Sentry.
   guard shouldCaptureToSentry(fullMessage) else { return }
 
-  // Capture error context in Sentry without passing the raw Swift Error object.
-  // Some Swift-native error payloads can crash inside Sentry's reflection path.
+  // Free-form error text stays local. Cloud capture is a stable title plus typed
+  // error metadata and a redacted diagnostic attachment.
+  let attachmentURL = DesktopDiagnosticsManager.shared.writeIncidentDiagnosticsAttachment(
+    area: "other",
+    failureClass: "other",
+    phase: "other")
+  defer {
+    if let attachmentURL {
+      try? FileManager.default.removeItem(at: attachmentURL)
+    }
+  }
   if let error = error {
     let nsError = error as NSError
     let errorType = String(reflecting: type(of: error))
-    SentrySDK.capture(message: fullMessage) { scope in
+    SentrySDK.capture(message: "Desktop error") { scope in
       scope.setLevel(.error)
       scope.setContext(
         value: [
-          "message": message,
           "error_type": errorType,
           "error_domain": nsError.domain,
           "error_code": nsError.code,
-          "localized_description": errorDesc,
         ], key: "app_context")
+      if let attachmentURL {
+        scope.addAttachment(
+          Attachment(
+            path: attachmentURL.path,
+            filename: "desktop-incident-diagnostics.json",
+            contentType: "application/json"))
+      }
     }
   } else {
-    SentrySDK.capture(message: fullMessage) { scope in
+    SentrySDK.capture(message: "Desktop error") { scope in
       scope.setLevel(.error)
+      if let attachmentURL {
+        scope.addAttachment(
+          Attachment(
+            path: attachmentURL.path,
+            filename: "desktop-incident-diagnostics.json",
+            contentType: "application/json"))
+      }
     }
   }
 }

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -489,13 +489,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
     // Identify user if already signed in
     if AuthState.shared.isSignedIn {
       AnalyticsManager.shared.identify()
-      // Set Sentry user context (now enabled for dev builds too)
-      if let email = AuthState.shared.userEmail {
-        let sentryUser = Sentry.User()
-        sentryUser.email = email
-        sentryUser.username =
-          AuthService.shared.displayName.isEmpty ? nil : AuthService.shared.displayName
-        SentrySDK.setUser(sentryUser)
+      // Set an opaque Sentry user identifier for incident correlation. Do not
+      // attach email or display name to crash/error reports.
+      if let userID = AuthState.shared.userId {
+        SentrySDK.setUser(Sentry.User(userId: userID))
       }
       // Fetch API keys after first-window warmup settles. First-use paths call waitForKeys().
       scheduleAPIKeyFetch()

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -1647,8 +1647,12 @@ import XCTest
     XCTAssertTrue(source.contains("let breadcrumb = Breadcrumb(level: .info, category: \"lifecycle\")"))
     XCTAssertTrue(source.contains("breadcrumb.message = \"App Terminating\""))
     XCTAssertFalse(source.contains("SentrySDK.capture(message: \"App Terminating\")"))
+    XCTAssertFalse(
+      loggerSource.contains("breadcrumb.message = message"),
+      "free-form local log messages must not be sent as Sentry breadcrumbs")
     XCTAssertTrue(
-      loggerSource.contains("if !isDevBuild {\n    let breadcrumb = Breadcrumb(level: .info, category: \"app\")"))
+      loggerSource.contains("writeIncidentDiagnosticsAttachment("),
+      "actionable errors must send bounded redacted diagnostics instead")
     XCTAssertTrue(loggerSource.contains("guard !isDevBuild else { return }"))
   }
 

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -35,9 +35,11 @@ import XCTest
       let data = try Data(contentsOf: url)
       let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
       let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
-      let snapshot = try XCTUnwrap(snapshots.last)
+      let snapshot = try XCTUnwrap(
+        snapshots.first(where: { $0["event"] as? String == "user_visible_issue" }))
 
-      XCTAssertEqual(snapshot["event"] as? String, "ptt_audio_capture_silent_turn")
+      XCTAssertEqual(snapshot["event"] as? String, "user_visible_issue")
+      XCTAssertEqual(snapshot["area"] as? String, "ptt")
       XCTAssertEqual(snapshot["input_device_class"] as? String, "built_in_mic")
       XCTAssertEqual(snapshot["peak"] as? Int, 0)
       XCTAssertEqual(snapshot["rms"] as? Int, 0)
@@ -46,6 +48,84 @@ import XCTest
       XCTAssertFalse(json.contains("Alice"))
       XCTAssertFalse(json.contains("private microphone"))
       XCTAssertFalse(json.contains("id=123"))
+    }
+
+    func testIncidentAttachmentUsesRedactedBoundedLocalLogContext() throws {
+      let logURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("omi-incident-log-\(UUID().uuidString).txt")
+      try """
+      [12:00:00] [app] PTT capture started
+      [12:00:01] [app] PTT device=[David's AirPods]
+      Authorization: Bearer very-sensitive-token-value
+      user@example.com opened /Users/example/Documents/private.txt
+      Conversation title: confidential meeting notes
+      Arbitrary component message: this must not reach cloud
+      [12:00:02] [error] silent capture detected
+      """.write(to: logURL, atomically: true, encoding: .utf8)
+      defer { try? FileManager.default.removeItem(at: logURL) }
+      DesktopDiagnosticsManager.shared.recordWalUploadFailed(
+        walId: "private-wal-id",
+        reason: "backend returned customer-specific private detail")
+
+      let url = try XCTUnwrap(
+        DesktopDiagnosticsManager.shared.writeIncidentDiagnosticsAttachment(
+          area: "ptt",
+          failureClass: "silent_capture",
+          phase: "audio_capture",
+          logPath: logURL.path,
+          maxLogLines: 20))
+      defer { try? FileManager.default.removeItem(at: url) }
+
+      let data = try Data(contentsOf: url)
+      let json = String(data: data, encoding: .utf8) ?? ""
+      let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+      let incident = try XCTUnwrap(root["incident"] as? [String: String])
+      let tail = try XCTUnwrap(root["redacted_log_tail"] as? String)
+
+      XCTAssertEqual(incident["area"], "ptt")
+      XCTAssertEqual(incident["failure_class"], "silent_capture")
+      XCTAssertEqual(incident["phase"], "audio_capture")
+      XCTAssertFalse(tail.contains("very-sensitive-token-value"))
+      XCTAssertFalse(tail.contains("user@example.com"))
+      XCTAssertFalse(tail.contains("/Users/example/Documents/private.txt"))
+      XCTAssertFalse(tail.contains("confidential meeting notes"))
+      XCTAssertFalse(tail.contains("this must not reach cloud"))
+      XCTAssertFalse(tail.contains("David's AirPods"))
+      XCTAssertFalse(json.contains("private-wal-id"))
+      XCTAssertFalse(json.contains("customer-specific private detail"))
+      XCTAssertTrue(tail.contains("PTT capture started"))
+      XCTAssertTrue(tail.contains("silent capture detected"))
+    }
+
+    func testPTTSilentTurnCreatesUserVisibleIssueSnapshot() throws {
+      DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
+        source: "hub",
+        mode: "hold",
+        audioSeconds: 1.2,
+        voicedSeconds: 0,
+        peak: 0,
+        rms: 0,
+        deviceDescription: "built-in microphone",
+        micPermissionGranted: true,
+        hubActive: true)
+
+      let snapshot = try latestSnapshot()
+      XCTAssertEqual(snapshot["event"] as? String, "user_visible_issue")
+      XCTAssertEqual(snapshot["area"] as? String, "ptt")
+      XCTAssertEqual(snapshot["failure_class"] as? String, "silent_capture")
+      XCTAssertEqual(snapshot["phase"] as? String, "audio_capture")
+    }
+
+    func testChatFailureCreatesUserVisibleIssueSnapshot() throws {
+      DesktopDiagnosticsManager.shared.recordChatFailure(errorClass: "tool_stall")
+
+      let snapshot = try latestSnapshot()
+      XCTAssertEqual(snapshot["event"] as? String, "user_visible_issue")
+      XCTAssertEqual(snapshot["area"] as? String, "chat")
+      XCTAssertEqual(snapshot["failure_class"] as? String, "tool_stall")
+      XCTAssertEqual(snapshot["phase"] as? String, "query")
+      XCTAssertNil(snapshot["incident_id"])
+      XCTAssertNil(snapshot["attempt_id"])
     }
 
     func testSilentTurnRecordsRecoveryActionAndResult() throws {

--- a/desktop/macos/Desktop/Tests/FeedbackPayloadDryRunTests.swift
+++ b/desktop/macos/Desktop/Tests/FeedbackPayloadDryRunTests.swift
@@ -40,8 +40,8 @@ import XCTest
       // Same diagnostics builder the real Sentry attachment uses — the dry-run
       // returns the identical JSON, not a parallel reimplementation.
       XCTAssertTrue(
-        block.contains("DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment()"),
-        "dry-run must build the diagnostics JSON via the shared attachment builder")
+        block.contains("DesktopDiagnosticsManager.shared.writeIncidentDiagnosticsAttachment("),
+        "dry-run must build the redacted incident diagnostics via the shared attachment builder")
       // Same title builder the real submit uses.
       XCTAssertTrue(
         block.contains("feedbackReportTitle(for:"),
@@ -61,21 +61,14 @@ import XCTest
         "dry-run must declare that no Sentry capture happened")
     }
 
-    func testDryRunReturnsLogMetadataOnlyNotContents() throws {
+    func testDryRunReturnsRedactedDiagnosticsInsteadOfRawLogMetadata() throws {
       let block = try dryRunActionBlock()
-      // The raw log is attached unredacted to Sentry by design; the dry-run must
-      // surface only metadata so the bridge response can't leak the log itself.
-      XCTAssertTrue(block.contains("log_attachment_filename"))
-      XCTAssertTrue(block.contains("log_attachment_exists"))
-      // Targeted guard: reject the common ways of reading the log *contents* keyed
-      // on logPath. Not exhaustive (a FileHandle read would slip past), but paired
-      // with the positive metadata-only assertions above it pins the intent.
-      XCTAssertFalse(
-        block.contains("contentsOfFile: logPath"),
-        "dry-run must not read the raw log contents into its response")
-      XCTAssertFalse(
-        block.contains("contentsOf: URL(fileURLWithPath: logPath)"),
-        "dry-run must not read the raw log contents into its response")
+      XCTAssertFalse(block.contains("log_attachment_filename"))
+      XCTAssertFalse(block.contains("log_attachment_exists"))
+      XCTAssertFalse(block.contains("omiLogFilePath()"))
+      XCTAssertTrue(
+        block.contains("writeIncidentDiagnosticsAttachment("),
+        "dry-run must inspect the same redacted attachment used by submitFeedback")
     }
 
     func testRealSubmitSharesTheSameBuilders() throws {
@@ -92,9 +85,9 @@ import XCTest
 
     // MARK: - Behavioral: shared title builder + payload shape
 
-    func testReportTitleBuilderMatchesTheShippedStrings() {
-      XCTAssertEqual(feedbackReportTitle(for: ""), "User Report (logs only)")
-      XCTAssertEqual(feedbackReportTitle(for: "mic dropped"), "User Report: mic dropped")
+    func testReportTitleBuilderNeverIncludesUserProvidedText() {
+      XCTAssertEqual(feedbackReportTitle(for: ""), "User Report")
+      XCTAssertEqual(feedbackReportTitle(for: "mic dropped"), "User Report")
     }
 
     func testDiagnosticsPayloadIsParseableAndCarriesPrivacyMarker() throws {

--- a/desktop/macos/changelog/unreleased/20260721-privacy-safe-incident-diagnostics.json
+++ b/desktop/macos/changelog/unreleased/20260721-privacy-safe-incident-diagnostics.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved Desktop reliability diagnostics for PTT, chat, crashes, and feedback while keeping cloud reports privacy-safe and redacted."
+}


### PR DESCRIPTION
## Summary
- Add typed, rate-limited user-visible PTT and chat reliability metrics.
- Attach bounded, cloud-safe incident context to Sentry crashes, actionable errors, and feedback diagnostics.
- Remove default Sentry email/display-name identity and generic free-form log breadcrumbs.
- Replace raw feedback-log attachments with redacted diagnostics only.

## Privacy impact
- Cloud incident bundles retain only allowlisted incident snapshot fields and bounded operational log lines.
- Raw feedback text, name, email, local paths, tokens, device names, generic log text, and backend detail strings are excluded.
- Temporary Sentry attachment files are deleted after capture.

## Product invariants affected
- INV-AUTH-1

## Failure class
- observability_privacy_regression

## Validation
- `xcrun swift test --package-path Desktop` — 2,856 tests passed.
- Focused diagnostics, feedback, and export suites passed.
- `xcrun swift build -c debug --package-path Desktop` passed.
- SwiftLint, test-quality, and diff hygiene passed.

## Follow-up
- This is the first privacy-safe incident slice; universal lifecycle correlation and a full PostHog schema firewall remain separate work.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

