### PR TITLE
feat(admin): add response reliability by release channel

### DIFF
--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -28,6 +28,10 @@ When debugging issues for a specific user, check Sentry dashboard for crashes an
 - A desktop chat query starts after local concurrency/quota preflight and must
   emit exactly one terminal outcome: `completed`, `failed`, or `cancelled`.
   Intentional Stop and supersession are cancellations, never errors.
+- A physical voice shortcut turn emits one start and one terminal outcome from
+  the coordinator. Full-answer duration ends at playback drain; a later journal
+  failure does not rewrite a delivered response as missing. Intentional and
+  too-short endings are excluded from response-failure rates.
 - Query latency ends when the final answer is visible. Persistence, title
   generation, and other post-answer work have their own reliability signals and
   must not inflate user-visible query duration.

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -12,6 +12,8 @@ enum DesktopHealthEventName: String {
   case pttAudioCaptureWatchdogTriggered = "ptt_audio_capture_watchdog_triggered"
   case pttAudioCaptureDeviceRouteChanged = "ptt_audio_capture_device_route_changed"
   case pttCommitted = "ptt_committed"
+  case voiceTurnStarted = "voice_turn_started"
+  case voiceTurnTerminal = "voice_turn_terminal"
   case realtimeTokenMintFailed = "realtime_token_mint_failed"
   case realtimeProviderExpectedIdleTeardown = "realtime_provider_expected_idle_teardown"
   case realtimeProviderExpectedSessionRotation = "realtime_provider_expected_session_rotation"
@@ -355,21 +357,65 @@ final class DesktopDiagnosticsManager {
       captureSentry: false)
   }
 
+  func recordVoiceTurnStarted(turnID: String, intent: String) {
+    record(
+      .voiceTurnStarted,
+      properties: [
+        "attempt_id": turnID,
+        "intent": intent,
+        "telemetry_schema_version": 1,
+      ])
+  }
+
   func recordVoiceTurnTerminal(
+    turnID: String,
     reason: String,
     route: String,
+    intent: String,
+    durationMs: Int?,
+    answerDelivered: Bool,
     staleEventCount: Int,
     invalidTransitionCount: Int
   ) {
-    let breadcrumb = Breadcrumb(level: .info, category: "voice.turn.terminal")
-    breadcrumb.message = "Voice turn reached terminal state"
-    breadcrumb.data = [
+    var properties: [String: Any] = [
+      "attempt_id": turnID,
       "terminal_reason": reason,
+      "outcome": Self.voiceTurnOutcome(for: reason),
+      "response_outcome": Self.voiceResponseOutcome(for: reason, answerDelivered: answerDelivered),
       "route": route,
+      "intent": intent,
       "stale_event_count": staleEventCount,
       "invalid_transition_count": invalidTransitionCount,
+      "telemetry_schema_version": 1,
     ]
+    if let durationMs {
+      properties["duration_ms"] = max(0, durationMs)
+    }
+    record(.voiceTurnTerminal, properties: properties)
+
+    let breadcrumb = Breadcrumb(level: .info, category: "voice.turn.terminal")
+    breadcrumb.message = "Voice turn reached terminal state"
+    breadcrumb.data = properties
     SentrySDK.addBreadcrumb(breadcrumb)
+  }
+
+  static func voiceTurnOutcome(for reason: String) -> String {
+    switch reason {
+    case "success":
+      return "success"
+    case "too_short", "silent_rejected", "cancelled", "owner_changed",
+      "interrupted_by_barge_in", "explicit_interrupt", "cleanup":
+      return "excluded"
+    default:
+      return "failure"
+    }
+  }
+
+  static func voiceResponseOutcome(for reason: String, answerDelivered: Bool) -> String {
+    if answerDelivered || reason == "success" {
+      return "success"
+    }
+    return voiceTurnOutcome(for: reason)
   }
 
   func recordVoiceTurnAnomaly(kind: String, phase: String, route: String) {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnCoordinator.swift
@@ -98,6 +98,8 @@ final class VoiceTurnCoordinator {
   private var timeline: [VoiceTurnTimelineEntry] = []
   private let timelineLimit: Int
   private var timelineSequence: UInt64 = 0
+  private var turnStartedAt: [VoiceTurnID: ContinuousClock.Instant] = [:]
+  private var turnFullAnswerDurationMs: [VoiceTurnID: Int] = [:]
   private var pendingFacts: [VoiceTurnFact] = []
   private var isDrainingEvents = false
 
@@ -255,12 +257,19 @@ final class VoiceTurnCoordinator {
       lane: lane,
       identity: identity)
     publish(.playbackStartedScoped(turnID: turnID, lease: lease))
-    return activeTurn?.activeLease == lease ? .acquired(lease) : .staleTurn
+    guard activeTurn?.activeLease == lease else { return .staleTurn }
+    if lane != .filler {
+      turnFullAnswerDurationMs.removeValue(forKey: turnID)
+    }
+    return .acquired(lease)
   }
 
   @discardableResult
   func releaseOutput(_ lease: VoiceOutputLease) -> Bool {
     guard activeTurn?.activeLease == lease else { return false }
+    if lease.lane != .filler, let startedAt = turnStartedAt[lease.turnID] {
+      turnFullAnswerDurationMs[lease.turnID] = Self.elapsedMilliseconds(since: startedAt)
+    }
     publish(
       .playbackDrainedScoped(
         turnID: lease.turnID,
@@ -315,7 +324,15 @@ final class VoiceTurnCoordinator {
     if model.turn?.phase.isTerminal == true {
       publish(.reset)
     }
+    turnStartedAt[id] = ContinuousClock.now
     publish(.start(turnID: id, ownerID: ownerID ?? ownerIDProvider(), intent: intent))
+    if activeTurnID == id {
+      DesktopDiagnosticsManager.shared.recordVoiceTurnStarted(
+        turnID: id.description,
+        intent: intent.rawValue)
+    } else {
+      turnStartedAt.removeValue(forKey: id)
+    }
     return id
   }
 
@@ -453,9 +470,15 @@ final class VoiceTurnCoordinator {
       case .cancelAllDeadlines(let turnID):
         cancelAll(turnID: turnID)
       case .terminal(let terminal):
+        let terminalDurationMs = turnStartedAt.removeValue(forKey: terminal.turnID).map(Self.elapsedMilliseconds)
+        let fullAnswerDurationMs = turnFullAnswerDurationMs.removeValue(forKey: terminal.turnID)
         DesktopDiagnosticsManager.shared.recordVoiceTurnTerminal(
+          turnID: terminal.turnID.description,
           reason: terminal.reason.rawValue,
           route: Self.routeLabel(terminal.route),
+          intent: model.turn?.intent.rawValue ?? "unknown",
+          durationMs: fullAnswerDurationMs ?? terminalDurationMs,
+          answerDelivered: fullAnswerDurationMs != nil,
           staleEventCount: model.staleEventCount,
           invalidTransitionCount: model.invalidTransitionCount)
         log(
@@ -500,6 +523,14 @@ final class VoiceTurnCoordinator {
       .staleEventDropped, .invalidTransition:
       return nil
     }
+  }
+
+  private static func elapsedMilliseconds(since startedAt: ContinuousClock.Instant) -> Int {
+    let components = (ContinuousClock.now - startedAt).components
+    let milliseconds =
+      Int(components.seconds) * 1_000
+      + Int(components.attoseconds / 1_000_000_000_000_000)
+    return max(0, milliseconds)
   }
 
   private func schedule(turnID: VoiceTurnID, deadline: VoiceTurnDeadline, interval: TimeInterval) {

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -332,6 +332,40 @@ import XCTest
         ])
     }
 
+    func testVoiceTurnTerminalRecordsReliabilityAndFullAnswerDuration() throws {
+      DesktopDiagnosticsManager.shared.recordVoiceTurnTerminal(
+        turnID: "turn-123",
+        reason: "provider_no_response",
+        route: "hub",
+        intent: "hold",
+        durationMs: 4_250,
+        answerDelivered: false,
+        staleEventCount: 1,
+        invalidTransitionCount: 0)
+
+      let snapshot = try latestSnapshot()
+
+      XCTAssertEqual(snapshot["event"] as? String, "voice_turn_terminal")
+      XCTAssertEqual(snapshot["attempt_id"] as? String, "turn-123")
+      XCTAssertEqual(snapshot["terminal_reason"] as? String, "provider_no_response")
+      XCTAssertEqual(snapshot["outcome"] as? String, "failure")
+      XCTAssertEqual(snapshot["response_outcome"] as? String, "failure")
+      XCTAssertEqual(snapshot["route"] as? String, "hub")
+      XCTAssertEqual(snapshot["intent"] as? String, "hold")
+      XCTAssertEqual(snapshot["duration_ms"] as? Int, 4_250)
+      XCTAssertEqual(snapshot["telemetry_schema_version"] as? Int, 1)
+    }
+
+    func testVoiceTurnOutcomeExcludesUserControlledEnds() {
+      XCTAssertEqual(DesktopDiagnosticsManager.voiceTurnOutcome(for: "success"), "success")
+      XCTAssertEqual(DesktopDiagnosticsManager.voiceTurnOutcome(for: "cancelled"), "excluded")
+      XCTAssertEqual(DesktopDiagnosticsManager.voiceTurnOutcome(for: "too_short"), "excluded")
+      XCTAssertEqual(DesktopDiagnosticsManager.voiceTurnOutcome(for: "playback_failed"), "failure")
+      XCTAssertEqual(
+        DesktopDiagnosticsManager.voiceResponseOutcome(for: "journal_failed", answerDelivered: true),
+        "success")
+    }
+
     private func assertLatestHealthSnapshot(
       event: DesktopHealthEventName,
       contains expected: [String: Any] = [:],

--- a/desktop/macos/Desktop/Tests/VoiceTurnCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnCoordinatorTests.swift
@@ -5,6 +5,30 @@ import XCTest
 
 @MainActor
 final class VoiceTurnCoordinatorTests: XCTestCase {
+  func testTerminalTelemetryUsesThePhysicalTurnBoundary() throws {
+    DesktopDiagnosticsManager.shared.resetForTests()
+    defer { DesktopDiagnosticsManager.shared.resetForTests() }
+
+    let coordinator = VoiceTurnCoordinator(scheduler: ManualVoiceTurnScheduler())
+    let turnID = coordinator.begin(intent: .hold)
+    coordinator.publish(.finish(turnID: turnID, reason: .providerNoResponse))
+
+    let url = try XCTUnwrap(DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment())
+    defer { try? FileManager.default.removeItem(at: url) }
+    let data = try Data(contentsOf: url)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+    let start = try XCTUnwrap(snapshots.first { $0["event"] as? String == "voice_turn_started" })
+    let terminal = try XCTUnwrap(snapshots.first { $0["event"] as? String == "voice_turn_terminal" })
+
+    XCTAssertEqual(start["attempt_id"] as? String, turnID.description)
+    XCTAssertEqual(terminal["attempt_id"] as? String, turnID.description)
+    XCTAssertEqual(terminal["terminal_reason"] as? String, "provider_no_response")
+    XCTAssertEqual(terminal["outcome"] as? String, "failure")
+    XCTAssertEqual(terminal["response_outcome"] as? String, "failure")
+    XCTAssertNotNil(terminal["duration_ms"] as? Int)
+  }
+
   func testNestedDeferredHubCommitQueuesWithoutSynchronousStateMutation() {
     let coordinator = VoiceTurnCoordinator(scheduler: ManualVoiceTurnScheduler())
     var sawQueuedPreCommitState = false
@@ -497,6 +521,8 @@ final class VoiceTurnCoordinatorTests: XCTestCase {
   }
 
   func testNonHubJournalAcceptanceWaitsForIndependentPlaybackFence() throws {
+    DesktopDiagnosticsManager.shared.resetForTests()
+    defer { DesktopDiagnosticsManager.shared.resetForTests() }
     let coordinator = VoiceTurnCoordinator(scheduler: ManualVoiceTurnScheduler())
     let turnID = coordinator.begin(intent: .hold)
     coordinator.publish(.selectRoute(turnID: turnID, route: .deepgramBatch))
@@ -526,6 +552,95 @@ final class VoiceTurnCoordinatorTests: XCTestCase {
     XCTAssertTrue(coordinator.releaseOutput(lease))
     XCTAssertEqual(coordinator.model.lastTerminal?.turnID, turnID)
     XCTAssertEqual(coordinator.model.lastTerminal?.reason, .success)
+
+    let url = try XCTUnwrap(DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment())
+    defer { try? FileManager.default.removeItem(at: url) }
+    let data = try Data(contentsOf: url)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+    let terminal = try XCTUnwrap(snapshots.first { $0["event"] as? String == "voice_turn_terminal" })
+    XCTAssertEqual(terminal["response_outcome"] as? String, "success")
+    XCTAssertNotNil(terminal["duration_ms"] as? Int)
+  }
+
+  func testDeliveredVoiceAnswerDoesNotBecomeResponseFailureWhenJournalFailsLater() throws {
+    DesktopDiagnosticsManager.shared.resetForTests()
+    defer { DesktopDiagnosticsManager.shared.resetForTests() }
+    let coordinator = VoiceTurnCoordinator(scheduler: ManualVoiceTurnScheduler())
+    let turnID = coordinator.begin(intent: .hold)
+    coordinator.publish(.selectRoute(turnID: turnID, route: .deepgramBatch))
+    coordinator.publish(.finalize(turnID: turnID))
+    coordinator.publish(.transcriptionStarted(turnID: turnID))
+    coordinator.publish(.transcriptionFinal(turnID: turnID, text: "hello"))
+    let providerIdentity = try XCTUnwrap(coordinator.activeTurn?.providerEffectIdentity)
+    coordinator.publish(
+      .providerResponseStartedScoped(
+        turnID: turnID,
+        identity: providerIdentity,
+        sessionID: nil,
+        responseID: nil))
+    guard
+      case .acquired(let lease) = coordinator.acquireOutput(
+        .selectedVoiceFallback, turnID: turnID)
+    else { return XCTFail("expected output lease") }
+    let token = try XCTUnwrap(coordinator.nonHubCompletionToken(for: turnID))
+
+    XCTAssertTrue(coordinator.releaseOutput(lease))
+    XCTAssertTrue(coordinator.completeNonHubProvider(token, outcome: .journalFailed))
+    XCTAssertEqual(coordinator.model.lastTerminal?.reason, .journalFailed)
+
+    let url = try XCTUnwrap(DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment())
+    defer { try? FileManager.default.removeItem(at: url) }
+    let data = try Data(contentsOf: url)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+    let terminal = try XCTUnwrap(snapshots.first { $0["event"] as? String == "voice_turn_terminal" })
+    XCTAssertEqual(terminal["outcome"] as? String, "failure")
+    XCTAssertEqual(terminal["response_outcome"] as? String, "success")
+  }
+
+  func testFillerDrainDoesNotHideLaterVoicePlaybackFailure() throws {
+    DesktopDiagnosticsManager.shared.resetForTests()
+    defer { DesktopDiagnosticsManager.shared.resetForTests() }
+    let coordinator = VoiceTurnCoordinator(scheduler: ManualVoiceTurnScheduler())
+    let turnID = coordinator.begin(intent: .hold)
+    coordinator.publish(.selectRoute(turnID: turnID, route: .deepgramBatch))
+    coordinator.publish(.finalize(turnID: turnID))
+    coordinator.publish(.transcriptionStarted(turnID: turnID))
+    coordinator.publish(.transcriptionFinal(turnID: turnID, text: "hello"))
+    let providerIdentity = try XCTUnwrap(coordinator.activeTurn?.providerEffectIdentity)
+    coordinator.publish(
+      .providerResponseStartedScoped(
+        turnID: turnID,
+        identity: providerIdentity,
+        sessionID: nil,
+        responseID: nil))
+
+    guard case .acquired(let filler) = coordinator.acquireOutput(.filler, turnID: turnID) else {
+      return XCTFail("expected filler lease")
+    }
+    XCTAssertTrue(coordinator.releaseOutput(filler))
+    guard
+      case .acquired(let response) = coordinator.acquireOutput(
+        .selectedVoiceFallback, turnID: turnID)
+    else { return XCTFail("expected response lease") }
+
+    coordinator.publish(
+      .playbackFailedScoped(
+        turnID: turnID,
+        identity: response.identity,
+        leaseID: response.id,
+        message: "playback failed"))
+    XCTAssertEqual(coordinator.model.lastTerminal?.reason, .playbackFailed)
+
+    let url = try XCTUnwrap(DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment())
+    defer { try? FileManager.default.removeItem(at: url) }
+    let data = try Data(contentsOf: url)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+    let terminal = try XCTUnwrap(snapshots.first { $0["event"] as? String == "voice_turn_terminal" })
+    XCTAssertEqual(terminal["outcome"] as? String, "failure")
+    XCTAssertEqual(terminal["response_outcome"] as? String, "failure")
   }
 
   func testNonHubCompletionTokenCannotCloseReplacementTurn() throws {

--- a/web/admin/app/(protected)/dashboard/page.tsx
+++ b/web/admin/app/(protected)/dashboard/page.tsx
@@ -53,6 +53,7 @@ import {
   type ChartItem,
 } from "@/components/dashboard/resizable-chart-grid";
 import { AgentPromptWidget } from "@/components/dashboard/agent-prompt-widget";
+import { useResponseReliabilityItems } from "@/components/dashboard/response-reliability-summary";
 import { Sparkles } from "lucide-react";
 
 // --- Types ---
@@ -1668,6 +1669,7 @@ export default function AnalyticsPage() {
   // ─────────────────────────────────────────────────────────────────────
 
   const chatRatingsItems = useChatRatingsItems({ token });
+  const responseReliabilityItems = useResponseReliabilityItems({ token });
 
   const cpuMobile = profitability?.summary.avgCostPerUserMobile ?? null;
   const cpuDesktop = profitability?.summary.avgCostPerUserDesktop ?? null;
@@ -2208,6 +2210,7 @@ export default function AnalyticsPage() {
   // can drag any item anywhere; this is just the default layout.
   const unifiedItems = useMemo<ChartItem[]>(() => {
     return [
+      ...responseReliabilityItems,
       ...topKpiAndNewWidgets,
 
       profitabilityHeader,
@@ -2240,7 +2243,8 @@ export default function AnalyticsPage() {
       ...chatRatingsItems,
     ];
   }, [
-    topKpiAndNewWidgets, profitCharts, revenueCharts, macosKpis, macosGrowthCharts,
+    responseReliabilityItems, topKpiAndNewWidgets, profitCharts, revenueCharts,
+    macosKpis, macosGrowthCharts,
     notificationKpis, notificationCharts, ratingsAndUsageCharts, viralCharts,
     retentionView, retentionCharts, chatRatingsItems,
     // Inline header/control items capture state via closures; React's

--- a/web/admin/app/api/omi/stats/response-reliability/route.ts
+++ b/web/admin/app/api/omi/stats/response-reliability/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { verifyAdmin } from "@/lib/auth";
+import admin, { getDb } from "@/lib/firebase/admin";
+import { posthogResults } from "@/lib/posthog";
+import {
+  buildChannelReliabilityPayloads,
+  buildResponseReliabilityPayload,
+  type ReliabilityChannel,
+  responseReliabilityQueries,
+} from "@/lib/response-reliability";
+
+export const dynamic = "force-dynamic";
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+async function getReliabilityChannels(
+  actorIds: string[],
+): Promise<Map<string, ReliabilityChannel>> {
+  const channelByActor = new Map<string, ReliabilityChannel>();
+  const db = getDb();
+
+  for (const actorIdChunk of chunk(actorIds, 30)) {
+    const snapshot = await db
+      .collection("users")
+      .where(admin.firestore.FieldPath.documentId(), "in", actorIdChunk)
+      .select("update_channel")
+      .get();
+    for (const doc of snapshot.docs) {
+      const updateChannel = String(doc.get("update_channel") || "");
+      channelByActor.set(
+        doc.id,
+        updateChannel === "beta" || updateChannel === "staging"
+          ? "beta"
+          : "production",
+      );
+    }
+  }
+
+  for (const actorId of actorIds) {
+    if (!channelByActor.has(actorId)) channelByActor.set(actorId, "production");
+  }
+  return channelByActor;
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const projectId = process.env.POSTHOG_PROJECT_ID;
+  const host = (process.env.POSTHOG_HOST || "https://us.posthog.com").replace(
+    /\/$/,
+    "",
+  );
+  if (!apiKey || !projectId) {
+    return NextResponse.json(
+      { error: "PostHog credentials not configured" },
+      { status: 500 },
+    );
+  }
+
+  const requestedDays = Number.parseInt(
+    request.nextUrl.searchParams.get("days") || "30",
+    10,
+  );
+  const days = Math.min(
+    Math.max(Number.isFinite(requestedDays) ? requestedDays : 30, 7),
+    90,
+  );
+  const queries = responseReliabilityQueries(days);
+  const [chatResult, voiceResult] = await Promise.allSettled([
+    posthogResults(host, projectId, apiKey, queries.chat),
+    posthogResults(host, projectId, apiKey, queries.voice),
+  ]);
+
+  const chatAvailable = chatResult.status === "fulfilled";
+  const voiceAvailable = voiceResult.status === "fulfilled";
+  if (!chatAvailable && !voiceAvailable) {
+    console.error("Response reliability queries failed", {
+      chat: chatResult.status === "rejected" ? chatResult.reason : null,
+      voice: voiceResult.status === "rejected" ? voiceResult.reason : null,
+    });
+    return NextResponse.json(
+      { error: "Response reliability data is temporarily unavailable" },
+      { status: 502 },
+    );
+  }
+
+  if (!chatAvailable || !voiceAvailable) {
+    console.warn("Response reliability data is partial", {
+      chatAvailable,
+      voiceAvailable,
+    });
+  }
+
+  const chatRows = chatAvailable ? chatResult.value : [];
+  const voiceRows = voiceAvailable ? voiceResult.value : [];
+  const actorIds = Array.from(
+    new Set(
+      [
+        ...chatRows.map((row) =>
+          Array.isArray(row) ? String(row[6] ?? "") : "",
+        ),
+        ...voiceRows.map((row) =>
+          Array.isArray(row) ? String(row[9] ?? "") : "",
+        ),
+      ].filter(Boolean),
+    ),
+  );
+  const channelByActor = await getReliabilityChannels(actorIds);
+  const aggregate = buildResponseReliabilityPayload({
+    days,
+    chatRows,
+    voiceRows,
+    chatAvailable,
+    voiceAvailable,
+  });
+
+  return NextResponse.json({
+    ...aggregate,
+    channels: buildChannelReliabilityPayloads({
+      days,
+      chatRows,
+      voiceRows,
+      chatAvailable,
+      voiceAvailable,
+      channelByActor,
+    }),
+  });
+}

--- a/web/admin/components/dashboard/response-reliability-summary.tsx
+++ b/web/admin/components/dashboard/response-reliability-summary.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useMemo } from "react";
+import useSWR from "swr";
+import { AlertTriangle, MessageSquare, Mic2 } from "lucide-react";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import type { ChartItem } from "@/components/dashboard/resizable-chart-grid";
+import { authenticatedFetcher } from "@/hooks/useAuthToken";
+import type {
+  ResponseReliabilityPayload,
+  ResponseReliabilitySeries,
+} from "@/lib/response-reliability";
+
+const tooltipStyle = {
+  backgroundColor: "hsl(var(--card))",
+  border: "1px solid hsl(var(--border))",
+  borderRadius: "8px",
+};
+
+const formatRate = (value: number | null | undefined) =>
+  value == null ? "N/A" : `${value.toFixed(1)}%`;
+
+const formatSeconds = (value: number | null | undefined) =>
+  value == null
+    ? "N/A"
+    : value < 60
+      ? `${value.toFixed(1)}s`
+      : `${(value / 60).toFixed(1)}m`;
+
+const formatDay = (value: string) =>
+  new Date(`${value}T00:00:00Z`).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+
+function ChannelReliabilityChart({
+  data,
+}: {
+  data: ResponseReliabilitySeries;
+}) {
+  const chat = data.summary.chat;
+  const voice = data.summary.voice;
+  const failures = (chat?.failure ?? 0) + (voice?.failure ?? 0);
+  const hasData = data.daily.some(
+    (point) => point.chatSuccessRate != null || point.voiceSuccessRate != null,
+  );
+
+  return (
+    <div className="flex h-full min-w-0 flex-col gap-2">
+      <div
+        className="grid divide-x border-y py-2 text-xs"
+        style={{ gridTemplateColumns: "repeat(3, minmax(0, 1fr))" }}
+      >
+        <div className="pr-3">
+          <span className="text-muted-foreground">Chat success</span>
+          <div className="mt-0.5 font-semibold tabular-nums">
+            {formatRate(chat?.successRate)} · avg{" "}
+            {formatSeconds(chat?.averageFullAnswerSeconds)}
+          </div>
+        </div>
+        <div className="px-3">
+          <span className="text-muted-foreground">Voice success</span>
+          <div className="mt-0.5 font-semibold tabular-nums">
+            {formatRate(voice?.successRate)} · avg{" "}
+            {formatSeconds(voice?.averageFullAnswerSeconds)}
+          </div>
+        </div>
+        <div className="pl-3">
+          <span className="text-muted-foreground">Failures</span>
+          <div
+            className={`mt-0.5 font-semibold tabular-nums ${failures > 0 ? "text-red-600" : ""}`}
+          >
+            {failures.toLocaleString()}
+          </div>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1">
+        {hasData ? (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data.daily}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+              <XAxis
+                dataKey="date"
+                tickFormatter={formatDay}
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+                minTickGap={24}
+              />
+              <YAxis
+                domain={[0, 100]}
+                tickFormatter={(value) => `${value}%`}
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+                width={42}
+              />
+              <Tooltip
+                labelFormatter={(value) => formatDay(String(value))}
+                formatter={(value: number, name: string) => [
+                  `${Number(value).toFixed(1)}%`,
+                  name,
+                ]}
+                contentStyle={tooltipStyle}
+              />
+              <Legend wrapperStyle={{ fontSize: 11 }} />
+              <Line
+                type="monotone"
+                dataKey="chatSuccessRate"
+                name="Chat success"
+                stroke="#22c55e"
+                strokeWidth={2}
+                dot={false}
+                connectNulls
+                isAnimationActive={false}
+              />
+              <Line
+                type="monotone"
+                dataKey="voiceSuccessRate"
+                name="Voice success"
+                stroke="#06b6d4"
+                strokeWidth={2}
+                dot={false}
+                connectNulls
+                isAnimationActive={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            No response telemetry for this channel yet
+          </div>
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Excludes cancellations and silent or too-short voice turns.
+      </p>
+    </div>
+  );
+}
+
+export function useResponseReliabilityItems({
+  token,
+}: {
+  token: string | null;
+}): ChartItem[] {
+  const { data, error, isLoading } = useSWR<ResponseReliabilityPayload>(
+    token ? ["/api/omi/stats/response-reliability?days=30", token] : null,
+    authenticatedFetcher,
+    { revalidateOnFocus: false },
+  );
+
+  return useMemo(() => {
+    const render = (channel: "production" | "beta") => {
+      if (isLoading || !token) {
+        return <div className="h-full animate-pulse rounded-md bg-muted/20" />;
+      }
+      if (error || !data?.channels) {
+        return (
+          <div className="flex h-full items-center justify-center gap-2 text-sm text-red-600">
+            <AlertTriangle className="h-4 w-4" /> Response reliability is
+            temporarily unavailable.
+          </div>
+        );
+      }
+      return <ChannelReliabilityChart data={data.channels[channel]} />;
+    };
+
+    const subtitle = (channel: "production" | "beta") => {
+      const series = data?.channels?.[channel];
+      if (!series) return "Last 30 days";
+      const chat = series.summary.chat;
+      const voice = series.summary.voice;
+      const judged =
+        (chat?.success ?? 0) +
+        (chat?.failure ?? 0) +
+        (voice?.success ?? 0) +
+        (voice?.failure ?? 0);
+      return `Last 30 days · ${judged.toLocaleString()} judged responses`;
+    };
+
+    return [
+      {
+        id: "response-reliability-production",
+        title: "Production response reliability",
+        subtitle: subtitle("production"),
+        icon: <MessageSquare className="h-4 w-4" />,
+        initialLayout: { cols: 6, rows: 5 },
+        render: () => render("production"),
+      },
+      {
+        id: "response-reliability-beta",
+        title: "Beta response reliability",
+        subtitle: subtitle("beta"),
+        icon: <Mic2 className="h-4 w-4" />,
+        initialLayout: { cols: 6, rows: 5 },
+        render: () => render("beta"),
+      },
+    ];
+  }, [data, error, isLoading, token]);
+}

--- a/web/admin/lib/__tests__/response-reliability.test.ts
+++ b/web/admin/lib/__tests__/response-reliability.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildChannelReliabilityPayloads,
+  buildResponseReliabilityPayload,
+  responseReliabilityQueries,
+} from "../response-reliability";
+
+describe("response reliability", () => {
+  it("aggregates delivery rate, failures, exclusions, gaps, and full-answer speed", () => {
+    const payload = buildResponseReliabilityPayload({
+      days: 7,
+      now: new Date("2026-07-20T12:00:00Z"),
+      chatAvailable: true,
+      voiceAvailable: true,
+      chatRows: [
+        [
+          "2026-07-20",
+          "chat_agent_query_started",
+          "main_chat",
+          "unknown",
+          12,
+          0,
+        ],
+        [
+          "2026-07-20",
+          "chat_agent_query_completed",
+          "main_chat",
+          "unknown",
+          8,
+          32_000,
+        ],
+        ["2026-07-20", "chat_agent_error", "main_chat", "timeout", 2, 0],
+        [
+          "2026-07-20",
+          "chat_agent_query_cancelled",
+          "main_chat",
+          "unknown",
+          1,
+          0,
+        ],
+      ],
+      voiceRows: [
+        [
+          "2026-07-20",
+          "voice_turn_started",
+          "unknown",
+          "unknown",
+          "unknown",
+          "hold",
+          6,
+          0,
+        ],
+        [
+          "2026-07-20",
+          "voice_turn_terminal",
+          "success",
+          "success",
+          "hub",
+          "hold",
+          4,
+          20_000,
+        ],
+        [
+          "2026-07-20",
+          "voice_turn_terminal",
+          "failure",
+          "playback_failed",
+          "hub",
+          "hold",
+          1,
+          0,
+        ],
+        [
+          "2026-07-20",
+          "voice_turn_terminal",
+          "excluded",
+          "cancelled",
+          "hub",
+          "hold",
+          1,
+          0,
+        ],
+      ],
+    });
+
+    expect(payload.summary.chat).toMatchObject({
+      attempts: 12,
+      success: 8,
+      failure: 2,
+      excluded: 1,
+      unresolved: 1,
+      successRate: 80,
+      averageFullAnswerSeconds: 4,
+    });
+    expect(payload.summary.voice).toMatchObject({
+      attempts: 6,
+      success: 4,
+      failure: 1,
+      excluded: 1,
+      unresolved: 0,
+      successRate: 80,
+      averageFullAnswerSeconds: 5,
+    });
+    expect(payload.summary.overall).toMatchObject({
+      success: 12,
+      failure: 3,
+      successRate: 80,
+    });
+    expect(payload.failureReasons).toEqual([
+      { source: "chat", reason: "timeout", count: 2 },
+      { source: "voice", reason: "playback_failed", count: 1 },
+    ]);
+    expect(payload.availability.voiceCoverageStart).toBe("2026-07-20");
+    expect(payload.daily.at(-1)).toMatchObject({
+      chatSuccessRate: 80,
+      voiceSuccessRate: 80,
+      chatAverageSeconds: 4,
+      voiceAverageSeconds: 5,
+    });
+  });
+
+  it("marks an unavailable source partial instead of fabricating zero reliability", () => {
+    const payload = buildResponseReliabilityPayload({
+      days: 7,
+      now: new Date("2026-07-20T12:00:00Z"),
+      chatAvailable: true,
+      voiceAvailable: false,
+      chatRows: [
+        [
+          "2026-07-20",
+          "chat_agent_query_completed",
+          "main_chat",
+          "unknown",
+          2,
+          4_000,
+        ],
+      ],
+      voiceRows: [],
+    });
+
+    expect(payload.partial).toBe(true);
+    expect(payload.summary.chat?.successRate).toBe(100);
+    expect(payload.summary.voice).toBeNull();
+    expect(payload.daily.at(-1)?.voiceSuccessRate).toBeNull();
+  });
+
+  it("shows historical floating voice reliability until physical shortcut telemetry exists", () => {
+    const legacy = [
+      [
+        "2026-07-20",
+        "voice_turn_started",
+        "unknown",
+        "unknown",
+        "floating_voice",
+        "legacy",
+        5,
+        0,
+        "floating_voice",
+      ],
+      [
+        "2026-07-20",
+        "voice_turn_terminal",
+        "success",
+        "unknown",
+        "floating_voice",
+        "legacy",
+        4,
+        8_000,
+        "floating_voice",
+      ],
+      [
+        "2026-07-20",
+        "voice_turn_terminal",
+        "failure",
+        "timeout",
+        "floating_voice",
+        "legacy",
+        1,
+        0,
+        "floating_voice",
+      ],
+    ];
+    const legacyPayload = buildResponseReliabilityPayload({
+      days: 7,
+      now: new Date("2026-07-20T12:00:00Z"),
+      chatAvailable: true,
+      voiceAvailable: true,
+      chatRows: [],
+      voiceRows: legacy,
+    });
+
+    expect(legacyPayload.summary.voice).toMatchObject({
+      attempts: 5,
+      success: 4,
+      failure: 1,
+      successRate: 80,
+      averageFullAnswerSeconds: 2,
+    });
+
+    const physicalPayload = buildResponseReliabilityPayload({
+      days: 7,
+      now: new Date("2026-07-20T12:00:00Z"),
+      chatAvailable: true,
+      voiceAvailable: true,
+      chatRows: [],
+      voiceRows: [
+        ...legacy,
+        [
+          "2026-07-20",
+          "voice_turn_started",
+          "unknown",
+          "unknown",
+          "hub",
+          "hold",
+          2,
+          0,
+          "physical_shortcut",
+        ],
+        [
+          "2026-07-20",
+          "voice_turn_terminal",
+          "success",
+          "success",
+          "hub",
+          "hold",
+          2,
+          6_000,
+          "physical_shortcut",
+        ],
+      ],
+    });
+
+    expect(physicalPayload.summary.voice).toMatchObject({
+      attempts: 2,
+      success: 2,
+      failure: 0,
+      successRate: 100,
+      averageFullAnswerSeconds: 3,
+    });
+  });
+
+  it("splits response reliability by the user's release channel", () => {
+    const chatRows = [
+      [
+        "2026-07-20",
+        "chat_agent_query_started",
+        "main_chat",
+        "unknown",
+        2,
+        0,
+        "prod-user",
+      ],
+      [
+        "2026-07-20",
+        "chat_agent_query_completed",
+        "main_chat",
+        "unknown",
+        2,
+        4_000,
+        "prod-user",
+      ],
+      [
+        "2026-07-20",
+        "chat_agent_query_started",
+        "main_chat",
+        "unknown",
+        1,
+        0,
+        "beta-user",
+      ],
+      [
+        "2026-07-20",
+        "chat_agent_error",
+        "main_chat",
+        "timeout",
+        1,
+        0,
+        "beta-user",
+      ],
+    ];
+    const channels = buildChannelReliabilityPayloads({
+      days: 7,
+      now: new Date("2026-07-20T12:00:00Z"),
+      chatAvailable: true,
+      voiceAvailable: true,
+      chatRows,
+      voiceRows: [],
+      channelByActor: new Map([
+        ["prod-user", "production"],
+        ["beta-user", "beta"],
+      ]),
+    });
+
+    expect(channels.production.summary.chat).toMatchObject({
+      attempts: 2,
+      success: 2,
+      failure: 0,
+      successRate: 100,
+    });
+    expect(channels.beta.summary.chat).toMatchObject({
+      attempts: 1,
+      success: 0,
+      failure: 1,
+      successRate: 0,
+    });
+  });
+
+  it("clamps the query window before interpolating HogQL", () => {
+    const queries = responseReliabilityQueries(500);
+    expect(queries.chat).toContain("toStartOfDay(now()) - INTERVAL 89 DAY");
+    expect(queries.voice).toContain("toStartOfDay(now()) - INTERVAL 89 DAY");
+    expect(queries.voice).toContain(
+      "toString(properties.surface) = 'floating_voice'",
+    );
+    expect(queries.chat).toContain("distinct_id AS actor_id");
+    expect(queries.voice).toContain("distinct_id AS actor_id");
+  });
+});

--- a/web/admin/lib/response-reliability.ts
+++ b/web/admin/lib/response-reliability.ts
@@ -1,0 +1,514 @@
+export type ReliabilitySource = "chat" | "voice";
+export type ReliabilityChannel = "production" | "beta";
+
+export interface ReliabilityMetric {
+  attempts: number;
+  success: number;
+  failure: number;
+  excluded: number;
+  unresolved: number;
+  successRate: number | null;
+  failureRate: number | null;
+  averageFullAnswerSeconds: number | null;
+}
+
+export interface ReliabilityDailyPoint {
+  date: string;
+  chatSuccess: number;
+  chatFailure: number;
+  chatExcluded: number;
+  chatSuccessRate: number | null;
+  chatAverageSeconds: number | null;
+  voiceSuccess: number;
+  voiceFailure: number;
+  voiceExcluded: number;
+  voiceSuccessRate: number | null;
+  voiceAverageSeconds: number | null;
+}
+
+export interface ReliabilityBreakdown {
+  label: string;
+  success: number;
+  failure: number;
+  excluded: number;
+  successRate: number | null;
+  averageFullAnswerSeconds: number | null;
+}
+
+export interface ReliabilityFailureReason {
+  source: ReliabilitySource;
+  reason: string;
+  count: number;
+}
+
+export interface ResponseReliabilitySeries {
+  days: number;
+  generatedAt: number;
+  partial: boolean;
+  availability: {
+    chat: boolean;
+    voice: boolean;
+    voiceCoverageStart: string | null;
+  };
+  summary: {
+    overall: ReliabilityMetric | null;
+    chat: ReliabilityMetric | null;
+    voice: ReliabilityMetric | null;
+  };
+  daily: ReliabilityDailyPoint[];
+  failureReasons: ReliabilityFailureReason[];
+  chatSurfaces: ReliabilityBreakdown[];
+  voiceRoutes: ReliabilityBreakdown[];
+}
+
+export interface ResponseReliabilityPayload extends ResponseReliabilitySeries {
+  channels: Record<ReliabilityChannel, ResponseReliabilitySeries>;
+}
+
+type ChatRow = [
+  date: unknown,
+  event: unknown,
+  surface: unknown,
+  reason: unknown,
+  count: unknown,
+  durationMs: unknown,
+  actorId?: unknown,
+];
+
+type VoiceRow = [
+  date: unknown,
+  healthEvent: unknown,
+  outcome: unknown,
+  reason: unknown,
+  route: unknown,
+  intent: unknown,
+  count: unknown,
+  durationMs: unknown,
+  source?: unknown,
+  actorId?: unknown,
+];
+
+type MutableMetric = {
+  attempts: number;
+  success: number;
+  failure: number;
+  excluded: number;
+  durationMs: number;
+};
+
+const CHAT_STARTED = "chat_agent_query_started";
+const CHAT_COMPLETED = "chat_agent_query_completed";
+const CHAT_FAILED = "chat_agent_error";
+const CHAT_CANCELLED = "chat_agent_query_cancelled";
+
+const emptyMetric = (): MutableMetric => ({
+  attempts: 0,
+  success: 0,
+  failure: 0,
+  excluded: 0,
+  durationMs: 0,
+});
+
+const numberValue = (value: unknown): number => {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const textValue = (value: unknown, fallback = "unknown"): string => {
+  const text = String(value ?? "").trim();
+  return text || fallback;
+};
+
+const percent = (numerator: number, denominator: number): number | null =>
+  denominator > 0 ? Math.round((numerator / denominator) * 10_000) / 100 : null;
+
+const averageSeconds = (
+  durationMs: number,
+  successes: number,
+): number | null =>
+  successes > 0 ? Math.round((durationMs / successes / 1_000) * 10) / 10 : null;
+
+const finalizeMetric = (metric: MutableMetric): ReliabilityMetric => {
+  const judged = metric.success + metric.failure;
+  const terminals = judged + metric.excluded;
+  return {
+    attempts: metric.attempts,
+    success: metric.success,
+    failure: metric.failure,
+    excluded: metric.excluded,
+    unresolved: Math.max(0, metric.attempts - terminals),
+    successRate: percent(metric.success, judged),
+    failureRate: percent(metric.failure, judged),
+    averageFullAnswerSeconds: averageSeconds(metric.durationMs, metric.success),
+  };
+};
+
+const mergeMetric = (target: MutableMetric, source: MutableMetric): void => {
+  target.attempts += source.attempts;
+  target.success += source.success;
+  target.failure += source.failure;
+  target.excluded += source.excluded;
+  target.durationMs += source.durationMs;
+};
+
+const addMetric = (
+  map: Map<string, MutableMetric>,
+  key: string,
+  update: (metric: MutableMetric) => void,
+): void => {
+  const metric = map.get(key) ?? emptyMetric();
+  update(metric);
+  map.set(key, metric);
+};
+
+function buildDayKeys(days: number, now: Date): string[] {
+  const end = new Date(now);
+  end.setUTCHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (days - 1));
+
+  const keys: string[] = [];
+  for (
+    const date = new Date(start);
+    date <= end;
+    date.setUTCDate(date.getUTCDate() + 1)
+  ) {
+    keys.push(date.toISOString().slice(0, 10));
+  }
+  return keys;
+}
+
+const finalizeBreakdowns = (
+  metrics: Map<string, MutableMetric>,
+): ReliabilityBreakdown[] =>
+  Array.from(metrics.entries())
+    .map(([label, metric]) => {
+      const finalized = finalizeMetric(metric);
+      return {
+        label,
+        success: finalized.success,
+        failure: finalized.failure,
+        excluded: finalized.excluded,
+        successRate: finalized.successRate,
+        averageFullAnswerSeconds: finalized.averageFullAnswerSeconds,
+      };
+    })
+    .sort(
+      (a, b) =>
+        b.success +
+        b.failure +
+        b.excluded -
+        (a.success + a.failure + a.excluded),
+    );
+
+export function responseReliabilityQueries(days: number): {
+  chat: string;
+  voice: string;
+} {
+  const safeDays = Math.min(Math.max(Math.trunc(days), 1), 90);
+  return {
+    chat: `
+      SELECT
+        toString(toDate(timestamp)) AS day,
+        event,
+        coalesce(nullIf(toString(properties.surface), ''), 'unknown') AS surface,
+        coalesce(nullIf(toString(properties.error_class), ''), 'unknown') AS reason,
+        count() AS event_count,
+        sum(if(event = '${CHAT_COMPLETED}', toFloatOrZero(toString(properties.duration_ms)), 0)) AS duration_ms,
+        distinct_id AS actor_id
+      FROM events
+      WHERE event IN ('${CHAT_STARTED}', '${CHAT_COMPLETED}', '${CHAT_FAILED}', '${CHAT_CANCELLED}')
+        AND timestamp >= toStartOfDay(now()) - INTERVAL ${safeDays - 1} DAY
+        AND toIntOrZero(toString(properties.telemetry_schema_version)) >= 2
+        AND toString(properties.surface) != 'floating_voice'
+      GROUP BY day, event, surface, reason, actor_id
+      ORDER BY day ASC
+    `,
+    voice: `
+      SELECT
+        toString(toDate(timestamp)) AS day,
+        toString(properties.health_event) AS health_event,
+        coalesce(nullIf(toString(properties.response_outcome), ''), 'unknown') AS outcome,
+        coalesce(nullIf(toString(properties.terminal_reason), ''), 'unknown') AS reason,
+        coalesce(nullIf(toString(properties.route), ''), 'unknown') AS route,
+        coalesce(nullIf(toString(properties.intent), ''), 'unknown') AS intent,
+        count() AS event_count,
+        sum(if(toString(properties.response_outcome) = 'success', toFloatOrZero(toString(properties.duration_ms)), 0)) AS duration_ms,
+        'physical_shortcut' AS source,
+        distinct_id AS actor_id
+      FROM events
+      WHERE event = 'desktop_health_event'
+        AND properties.health_event IN ('voice_turn_started', 'voice_turn_terminal')
+        AND timestamp >= toStartOfDay(now()) - INTERVAL ${safeDays - 1} DAY
+        AND toIntOrZero(toString(properties.telemetry_schema_version)) >= 1
+        AND properties.intent IN ('hold', 'locked')
+      GROUP BY day, health_event, outcome, reason, route, intent, actor_id
+      UNION ALL
+      SELECT
+        toString(toDate(timestamp)) AS day,
+        if(event = '${CHAT_STARTED}', 'voice_turn_started', 'voice_turn_terminal') AS health_event,
+        if(
+          event = '${CHAT_COMPLETED}',
+          'success',
+          if(event = '${CHAT_FAILED}', 'failure', if(event = '${CHAT_CANCELLED}', 'excluded', 'unknown'))
+        ) AS outcome,
+        coalesce(nullIf(toString(properties.error_class), ''), 'unknown') AS reason,
+        'floating_voice' AS route,
+        'legacy' AS intent,
+        count() AS event_count,
+        sum(if(event = '${CHAT_COMPLETED}', toFloatOrZero(toString(properties.duration_ms)), 0)) AS duration_ms,
+        'floating_voice' AS source,
+        distinct_id AS actor_id
+      FROM events
+      WHERE event IN ('${CHAT_STARTED}', '${CHAT_COMPLETED}', '${CHAT_FAILED}', '${CHAT_CANCELLED}')
+        AND timestamp >= toStartOfDay(now()) - INTERVAL ${safeDays - 1} DAY
+        AND toIntOrZero(toString(properties.telemetry_schema_version)) >= 2
+        AND toString(properties.surface) = 'floating_voice'
+      GROUP BY day, health_event, outcome, reason, route, intent, actor_id
+      ORDER BY day ASC
+    `,
+  };
+}
+
+export function buildResponseReliabilityPayload({
+  days,
+  chatRows,
+  voiceRows,
+  chatAvailable,
+  voiceAvailable,
+  now = new Date(),
+}: {
+  days: number;
+  chatRows: unknown[];
+  voiceRows: unknown[];
+  chatAvailable: boolean;
+  voiceAvailable: boolean;
+  now?: Date;
+}): ResponseReliabilitySeries {
+  const safeDays = Math.min(Math.max(Math.trunc(days), 1), 90);
+  const chat = emptyMetric();
+  const voice = emptyMetric();
+  const chatByDay = new Map<string, MutableMetric>();
+  const voiceByDay = new Map<string, MutableMetric>();
+  const chatSurfaces = new Map<string, MutableMetric>();
+  const voiceRoutes = new Map<string, MutableMetric>();
+  const failureReasonCounts = new Map<string, number>();
+  let voiceCoverageStart: string | null = null;
+
+  if (chatAvailable) {
+    for (const rawRow of chatRows) {
+      if (!Array.isArray(rawRow)) continue;
+      const [
+        dateRaw,
+        eventRaw,
+        surfaceRaw,
+        reasonRaw,
+        countRaw,
+        durationMsRaw,
+      ] = rawRow as ChatRow;
+      const date = textValue(dateRaw, "");
+      const event = textValue(eventRaw, "");
+      const surface = textValue(surfaceRaw);
+      const reason = textValue(reasonRaw);
+      const count = numberValue(countRaw);
+      const durationMs = numberValue(durationMsRaw);
+      if (!date || count <= 0) continue;
+
+      const update = (metric: MutableMetric) => {
+        if (event === CHAT_STARTED) metric.attempts += count;
+        if (event === CHAT_COMPLETED) {
+          metric.success += count;
+          metric.durationMs += durationMs;
+        }
+        if (event === CHAT_FAILED) metric.failure += count;
+        if (event === CHAT_CANCELLED) metric.excluded += count;
+      };
+      update(chat);
+      addMetric(chatByDay, date, update);
+      addMetric(chatSurfaces, surface, update);
+      if (event === CHAT_FAILED) {
+        const key = `chat:${reason}`;
+        failureReasonCounts.set(
+          key,
+          (failureReasonCounts.get(key) ?? 0) + count,
+        );
+      }
+    }
+  }
+
+  if (voiceAvailable) {
+    const hasPhysicalVoiceRows = voiceRows.some(
+      (rawRow) =>
+        Array.isArray(rawRow) &&
+        textValue((rawRow as VoiceRow)[8], "physical_shortcut") ===
+          "physical_shortcut" &&
+        numberValue((rawRow as VoiceRow)[6]) > 0,
+    );
+    for (const rawRow of voiceRows) {
+      if (!Array.isArray(rawRow)) continue;
+      const [
+        dateRaw,
+        healthEventRaw,
+        outcomeRaw,
+        reasonRaw,
+        routeRaw,
+        ,
+        countRaw,
+        durationMsRaw,
+        sourceRaw,
+      ] = rawRow as VoiceRow;
+      const source = textValue(sourceRaw, "physical_shortcut");
+      if (
+        hasPhysicalVoiceRows
+          ? source !== "physical_shortcut"
+          : source !== "floating_voice"
+      )
+        continue;
+      const date = textValue(dateRaw, "");
+      const healthEvent = textValue(healthEventRaw, "");
+      const outcome = textValue(outcomeRaw, "");
+      const reason = textValue(reasonRaw);
+      const route = textValue(routeRaw);
+      const count = numberValue(countRaw);
+      const durationMs = numberValue(durationMsRaw);
+      if (!date || count <= 0) continue;
+
+      const update = (metric: MutableMetric) => {
+        if (healthEvent === "voice_turn_started") metric.attempts += count;
+        if (healthEvent !== "voice_turn_terminal") return;
+        if (outcome === "success") {
+          metric.success += count;
+          metric.durationMs += durationMs;
+        } else if (outcome === "failure") {
+          metric.failure += count;
+        } else if (outcome === "excluded") {
+          metric.excluded += count;
+        }
+      };
+      update(voice);
+      addMetric(voiceByDay, date, update);
+      if (healthEvent === "voice_turn_terminal") {
+        const currentCoverageStart: string | null = voiceCoverageStart;
+        if (
+          currentCoverageStart === null ||
+          date.localeCompare(currentCoverageStart) < 0
+        ) {
+          voiceCoverageStart = date;
+        }
+        addMetric(voiceRoutes, route, update);
+        if (outcome === "failure") {
+          const key = `voice:${reason}`;
+          failureReasonCounts.set(
+            key,
+            (failureReasonCounts.get(key) ?? 0) + count,
+          );
+        }
+      }
+    }
+  }
+
+  const overall = emptyMetric();
+  if (chatAvailable) mergeMetric(overall, chat);
+  if (voiceAvailable) mergeMetric(overall, voice);
+
+  const daily = buildDayKeys(safeDays, now).map(
+    (date): ReliabilityDailyPoint => {
+      const chatDay = chatByDay.get(date) ?? emptyMetric();
+      const voiceDay = voiceByDay.get(date) ?? emptyMetric();
+      const chatFinal = finalizeMetric(chatDay);
+      const voiceFinal = finalizeMetric(voiceDay);
+      return {
+        date,
+        chatSuccess: chatFinal.success,
+        chatFailure: chatFinal.failure,
+        chatExcluded: chatFinal.excluded,
+        chatSuccessRate: chatAvailable ? chatFinal.successRate : null,
+        chatAverageSeconds: chatAvailable
+          ? chatFinal.averageFullAnswerSeconds
+          : null,
+        voiceSuccess: voiceFinal.success,
+        voiceFailure: voiceFinal.failure,
+        voiceExcluded: voiceFinal.excluded,
+        voiceSuccessRate: voiceAvailable ? voiceFinal.successRate : null,
+        voiceAverageSeconds: voiceAvailable
+          ? voiceFinal.averageFullAnswerSeconds
+          : null,
+      };
+    },
+  );
+
+  const failureReasons = Array.from(failureReasonCounts.entries())
+    .map(([key, count]): ReliabilityFailureReason => {
+      const [source, ...reasonParts] = key.split(":");
+      return {
+        source: source as ReliabilitySource,
+        reason: reasonParts.join(":"),
+        count,
+      };
+    })
+    .sort((a, b) => b.count - a.count);
+
+  return {
+    days: safeDays,
+    generatedAt: now.getTime(),
+    partial: !chatAvailable || !voiceAvailable,
+    availability: {
+      chat: chatAvailable,
+      voice: voiceAvailable,
+      voiceCoverageStart,
+    },
+    summary: {
+      overall: chatAvailable || voiceAvailable ? finalizeMetric(overall) : null,
+      chat: chatAvailable ? finalizeMetric(chat) : null,
+      voice: voiceAvailable ? finalizeMetric(voice) : null,
+    },
+    daily,
+    failureReasons,
+    chatSurfaces: chatAvailable ? finalizeBreakdowns(chatSurfaces) : [],
+    voiceRoutes: voiceAvailable ? finalizeBreakdowns(voiceRoutes) : [],
+  };
+}
+
+export function buildChannelReliabilityPayloads({
+  days,
+  chatRows,
+  voiceRows,
+  chatAvailable,
+  voiceAvailable,
+  channelByActor,
+  now = new Date(),
+}: {
+  days: number;
+  chatRows: unknown[];
+  voiceRows: unknown[];
+  chatAvailable: boolean;
+  voiceAvailable: boolean;
+  channelByActor: Map<string, ReliabilityChannel>;
+  now?: Date;
+}): Record<ReliabilityChannel, ResponseReliabilitySeries> {
+  const rowsForChannel = (
+    rows: unknown[],
+    actorIndex: number,
+    channel: ReliabilityChannel,
+  ) =>
+    rows.filter(
+      (row) =>
+        Array.isArray(row) &&
+        channelByActor.get(textValue(row[actorIndex])) === channel,
+    );
+
+  const build = (channel: ReliabilityChannel) =>
+    buildResponseReliabilityPayload({
+      days,
+      chatRows: rowsForChannel(chatRows, 6, channel),
+      voiceRows: rowsForChannel(voiceRows, 9, channel),
+      chatAvailable,
+      voiceAvailable,
+      now,
+    });
+
+  return {
+    production: build("production"),
+    beta: build("beta"),
+  };
+}


### PR DESCRIPTION
## Summary

- add two response-reliability graphs to the existing admin dashboard, split by Production and Beta update channel
- show Chat success, Voice success, failure count, and average full-answer latency from the submitted shortcut boundary
- emit physical voice-turn start/terminal telemetry while using existing floating-voice lifecycle telemetry until the new desktop events accumulate

## Verification

- `cd web/admin && npm run check && npm run build` — 28 tests passed, typecheck/build passed (existing lint warnings only)
- `cd desktop/macos && ./scripts/agent-logic-harness.sh --swift-only` — focused lifecycle/state tests passed
- live local API returned HTTP 200 with distinct Production and Beta summaries
- rendered the real dashboard at `http://127.0.0.1:3100/dashboard`; `.cross-review-verify.png` shows exactly two standard draggable/resizable dashboard graph tiles with explicit Voice success

## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

