### PR TITLE
feat(desktop): add beta enhanced diagnostics

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -18,6 +18,7 @@ enum DesktopHealthEventName: String {
   case realtimeProviderPolicyClose = "realtime_provider_policy_close"
   case realtimeProviderSessionError = "realtime_provider_session_error"
   case userVisibleIssue = "user_visible_issue"
+  case betaDiagnosticTrail = "beta_diagnostic_trail"
   case fallbackTriggered = "fallback_triggered"
 }
 
@@ -355,6 +356,30 @@ final class DesktopDiagnosticsManager {
       captureSentry: false)
   }
 
+  /// Records a beta-only typed error trail entry. The caller passes free-form local
+  /// log text only for local classification; no message or error description is
+  /// retained in the trail or cloud attachment.
+  func recordBetaLogError(
+    message: String,
+    error: Error?,
+    enabled: Bool = BetaEnhancedDiagnosticsConfiguration.isEnabled
+  ) {
+    guard enabled else { return }
+    let nsError = error as NSError?
+    record(
+      .betaDiagnosticTrail,
+      properties: [
+        "component": betaComponent(for: message),
+        "operation": "error",
+        "phase": "handling",
+        "outcome": "failed",
+        "failure_class": betaFailureClass(for: nsError),
+        "error_domain": betaErrorDomain(nsError?.domain),
+        "error_code": betaErrorCode(nsError?.code),
+      ],
+      trackRemotely: false)
+  }
+
   func recordVoiceTurnTerminal(
     reason: String,
     route: String,
@@ -509,9 +534,14 @@ final class DesktopDiagnosticsManager {
     return current
   }
 
-  private func currentCloudSnapshotsForSentry() -> [[String: Any]] {
+  private func currentCloudSnapshotsForSentry(
+    includeBetaDiagnostics: Bool = BetaEnhancedDiagnosticsConfiguration.isEnabled
+  ) -> [[String: Any]] {
     lock.lock()
-    let current = snapshots.map { cloudSafeSnapshot($0) }
+    let current = snapshots.compactMap { snapshot -> [String: Any]? in
+      guard includeBetaDiagnostics || snapshot.event != .betaDiagnosticTrail else { return nil }
+      return cloudSafeSnapshot(snapshot, includeBetaDiagnostics: includeBetaDiagnostics)
+    }
     lock.unlock()
     return current
   }
@@ -520,13 +550,20 @@ final class DesktopDiagnosticsManager {
     currentSnapshotsForSentry()
   }
 
-  private func cloudSafeSnapshot(_ snapshot: DesktopHealthSnapshot) -> [String: Any] {
+  private func cloudSafeSnapshot(
+    _ snapshot: DesktopHealthSnapshot,
+    includeBetaDiagnostics: Bool
+  ) -> [String: Any] {
     var result: [String: Any] = [
       "timestamp": ISO8601DateFormatter.desktopDiagnostics.string(from: snapshot.timestamp),
       "event": snapshot.event.rawValue,
     ]
 
-    guard snapshot.event == .userVisibleIssue || snapshot.event == .pttAudioCaptureWatchdogTriggered else {
+    let includesTypedIncidentContext =
+      snapshot.event == .userVisibleIssue
+      || snapshot.event == .pttAudioCaptureWatchdogTriggered
+      || (includeBetaDiagnostics && snapshot.event == .betaDiagnosticTrail)
+    guard includesTypedIncidentContext else {
       return result
     }
 
@@ -543,6 +580,7 @@ final class DesktopDiagnosticsManager {
     "source", "mode", "hub_active", "turn_audio_seconds", "voiced_audio_seconds", "peak", "rms",
     "is_near_zero", "watchdog_eligible", "consecutive_silent_turns", "tcc_microphone_granted",
     "input_device_class", "recovery_action", "recovery_result", "threshold",
+    "component", "operation", "outcome", "error_domain", "error_code",
   ]
 
   func writeDiagnosticsAttachment() -> URL? {
@@ -563,7 +601,8 @@ final class DesktopDiagnosticsManager {
     failureClass: String,
     phase: String,
     logPath: String = omiLogFilePath(),
-    maxLogLines: Int = 200
+    maxLogLines: Int = 200,
+    includeBetaDiagnostics: Bool = BetaEnhancedDiagnosticsConfiguration.isEnabled
   ) -> URL? {
     let incident = incidentProperties(
       id: incidentID,
@@ -574,7 +613,7 @@ final class DesktopDiagnosticsManager {
       "generated_at": ISO8601DateFormatter.desktopDiagnostics.string(from: Date()),
       "privacy": "redacted_incident_context",
       "incident": incident,
-      "snapshots": currentCloudSnapshotsForSentry(),
+      "snapshots": currentCloudSnapshotsForSentry(includeBetaDiagnostics: includeBetaDiagnostics),
       "redacted_log_tail": redactedLogTail(
         logPath: logPath,
         maxLines: maxLogLines,
@@ -915,6 +954,48 @@ final class DesktopDiagnosticsManager {
 
   private func rounded(_ value: Double) -> Double {
     (value * 100).rounded() / 100
+  }
+
+  private func betaComponent(for message: String) -> String {
+    let value = message.lowercased()
+    if value.contains("chat") || value.contains("bridge") { return "chat" }
+    if value.contains("realtime") || value.contains("omni") { return "realtime" }
+    if value.contains("ptt") || value.contains("audio") || value.contains("transcription") { return "audio" }
+    if value.contains("bluetooth") || value.contains("wifi") || value.contains("device") { return "device" }
+    if value.contains("auth") || value.contains("sign") { return "auth" }
+    if value.contains("sync") || value.contains("wal") { return "sync" }
+    if value.contains("update") || value.contains("sparkle") { return "update" }
+    if value.contains("rewind") || value.contains("screen") { return "capture" }
+    return "app"
+  }
+
+  private func betaFailureClass(for error: NSError?) -> String {
+    guard let error else { return "unknown" }
+    if error.domain == NSURLErrorDomain {
+      switch error.code {
+      case NSURLErrorTimedOut: return "timeout"
+      case NSURLErrorNotConnectedToInternet, NSURLErrorCannotConnectToHost: return "network_unavailable"
+      default: return "network_error"
+      }
+    }
+    if error.domain == NSPOSIXErrorDomain { return "posix_error" }
+    if error.domain == NSCocoaErrorDomain { return "cocoa_error" }
+    return "other"
+  }
+
+  private func betaErrorDomain(_ domain: String?) -> String {
+    switch domain {
+    case NSURLErrorDomain: return "url"
+    case NSPOSIXErrorDomain: return "posix"
+    case NSCocoaErrorDomain: return "cocoa"
+    case nil: return "none"
+    default: return "other"
+    }
+  }
+
+  private func betaErrorCode(_ code: Int?) -> Int {
+    guard let code else { return 0 }
+    return max(-9_999, min(9_999, code))
   }
 
   private func classifyInputDevice(_ description: String?) -> String {

--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -453,9 +453,15 @@ func logError(_ message: String, error: Error? = nil) {
   // Always persist locally; only the Sentry capture is filtered/rate-limited below.
   appendToLogFile(line)
 
-  // Transient network/IO errors (offline, timeouts, cancellations, socket resets)
-  // are not actionable bugs — keep them as local logs + breadcrumbs only.
-  if isNonActionableTransient(error) { return }
+  let enhancedBetaDiagnostics = BetaEnhancedDiagnosticsConfiguration.isEnabled
+  DesktopDiagnosticsManager.shared.recordBetaLogError(
+    message: message,
+    error: error,
+    enabled: enhancedBetaDiagnostics)
+
+  // Stable keeps the existing low-volume transient-error behavior. Beta captures
+  // these typed failures with the expanded diagnostic trail for release triage.
+  if isNonActionableTransient(error), !enhancedBetaDiagnostics { return }
 
   guard !isDevBuild else { return }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
@@ -32,11 +32,45 @@ extension SettingsContentView {
       preferencesSubsection
       advancedCategoryHeader(title: "Troubleshooting", icon: "wrench.and.screwdriver")
       troubleshootingSubsection
+      if AppBuild.isBetaProductionBundle {
+        advancedCategoryHeader(title: "Beta Diagnostics", icon: "waveform.path.ecg")
+        betaDiagnosticsSubsection
+      }
       advancedCategoryHeader(title: "Developer API Keys", icon: "key")
       developerKeysSubsection
 
       advancedCategoryHeader(title: "Dev Tools", icon: "hammer")
       devToolsSubsection
+    }
+  }
+
+  // MARK: - Beta Diagnostics
+
+  var betaDiagnosticsSubsection: some View {
+    settingsCard(settingId: "advanced.beta.enhanced_diagnostics") {
+      HStack(spacing: OmiSpacing.lg) {
+        Image(systemName: "waveform.path.ecg")
+          .scaledFont(size: OmiType.subheading)
+          .foregroundColor(OmiColors.textSecondary)
+          .frame(width: 24, height: 24)
+
+        VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+          Text("Enhanced Diagnostics")
+            .scaledFont(size: OmiType.subheading, weight: .semibold)
+            .foregroundColor(OmiColors.textPrimary)
+          Text(
+            "Share additional technical failure context to improve this beta. No prompts, transcripts, or raw log files are included."
+          )
+          .scaledFont(size: OmiType.body)
+          .foregroundColor(OmiColors.textTertiary)
+        }
+
+        Spacer()
+
+        Toggle("Enhanced Diagnostics", isOn: $betaEnhancedDiagnosticsEnabled)
+          .toggleStyle(OmiToggleStyle())
+          .labelsHidden()
+      }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -315,6 +315,7 @@ struct SettingsContentView: View {
 
   // Dev Mode setting
   @AppStorage("devModeEnabled") var devModeEnabled = false
+  @AppStorage(BetaEnhancedDiagnosticsConfiguration.defaultsKey) var betaEnhancedDiagnosticsEnabled = true
 
   // Browser Extension settings
   @AppStorage("playwrightUseExtension") var playwrightUseExtension = true

--- a/desktop/macos/Desktop/Sources/Telemetry/BetaEnhancedDiagnosticsConfiguration.swift
+++ b/desktop/macos/Desktop/Sources/Telemetry/BetaEnhancedDiagnosticsConfiguration.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Beta-only enhanced diagnostics are enabled by default and can be disabled in
+/// Advanced Settings. Stable and development bundles never use this path.
+enum BetaEnhancedDiagnosticsConfiguration {
+  static let defaultsKey = "betaEnhancedDiagnosticsEnabled"
+
+  static var isEnabled: Bool {
+    isEnabled(bundleIdentifier: AppBuild.bundleIdentifier, defaults: .standard)
+  }
+
+  static func isEnabled(bundleIdentifier: String, defaults: UserDefaults) -> Bool {
+    guard bundleIdentifier == AppBuild.betaProductionBundleIdentifier else { return false }
+    guard defaults.object(forKey: defaultsKey) != nil else { return true }
+    return defaults.bool(forKey: defaultsKey)
+  }
+}

--- a/desktop/macos/Desktop/Tests/BetaEnhancedDiagnosticsConfigurationTests.swift
+++ b/desktop/macos/Desktop/Tests/BetaEnhancedDiagnosticsConfigurationTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class BetaEnhancedDiagnosticsConfigurationTests: XCTestCase {
+  private var defaults: UserDefaults?
+  private var suiteName = ""
+
+  override func setUp() {
+    super.setUp()
+    suiteName = "BetaEnhancedDiagnosticsConfigurationTests.\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)
+  }
+
+  override func tearDown() {
+    defaults?.removePersistentDomain(forName: suiteName)
+    defaults = nil
+    super.tearDown()
+  }
+
+  func testBetaDefaultsToEnhancedDiagnosticsEnabled() {
+    guard let defaults else {
+      XCTFail("Expected isolated UserDefaults suite")
+      return
+    }
+    XCTAssertTrue(
+      BetaEnhancedDiagnosticsConfiguration.isEnabled(
+        bundleIdentifier: AppBuild.betaProductionBundleIdentifier,
+        defaults: defaults))
+  }
+
+  func testBetaRespectsAdvancedOptOut() {
+    guard let defaults else {
+      XCTFail("Expected isolated UserDefaults suite")
+      return
+    }
+    defaults.set(false, forKey: BetaEnhancedDiagnosticsConfiguration.defaultsKey)
+
+    XCTAssertFalse(
+      BetaEnhancedDiagnosticsConfiguration.isEnabled(
+        bundleIdentifier: AppBuild.betaProductionBundleIdentifier,
+        defaults: defaults))
+  }
+
+  func testStableNeverEnablesEnhancedDiagnostics() {
+    guard let defaults else {
+      XCTFail("Expected isolated UserDefaults suite")
+      return
+    }
+    defaults.set(true, forKey: BetaEnhancedDiagnosticsConfiguration.defaultsKey)
+
+    XCTAssertFalse(
+      BetaEnhancedDiagnosticsConfiguration.isEnabled(
+        bundleIdentifier: AppBuild.productionBundleIdentifier,
+        defaults: defaults))
+  }
+}

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -97,6 +97,55 @@ import XCTest
       XCTAssertTrue(tail.contains("silent capture detected"))
     }
 
+    func testBetaTrailIncludesTypedErrorContextWithoutRawMessage() throws {
+      DesktopDiagnosticsManager.shared.recordBetaLogError(
+        message: "Chat bridge returned Alice's private conversation title",
+        error: NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut),
+        enabled: true)
+
+      let url = try XCTUnwrap(
+        DesktopDiagnosticsManager.shared.writeIncidentDiagnosticsAttachment(
+          area: "chat",
+          failureClass: "timeout",
+          phase: "query",
+          includeBetaDiagnostics: true))
+      defer { try? FileManager.default.removeItem(at: url) }
+
+      let data = try Data(contentsOf: url)
+      let json = String(data: data, encoding: .utf8) ?? ""
+      let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+      let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+      let trail = try XCTUnwrap(
+        snapshots.first(where: { $0["event"] as? String == "beta_diagnostic_trail" }))
+
+      XCTAssertEqual(trail["component"] as? String, "chat")
+      XCTAssertEqual(trail["failure_class"] as? String, "timeout")
+      XCTAssertEqual(trail["error_domain"] as? String, "url")
+      XCTAssertEqual(trail["error_code"] as? Int, NSURLErrorTimedOut)
+      XCTAssertFalse(json.contains("Alice"))
+      XCTAssertFalse(json.contains("private conversation title"))
+    }
+
+    func testBetaTrailIsExcludedWhenEnhancedDiagnosticsIsDisabled() throws {
+      DesktopDiagnosticsManager.shared.recordBetaLogError(
+        message: "Chat bridge timed out",
+        error: NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut),
+        enabled: true)
+
+      let url = try XCTUnwrap(
+        DesktopDiagnosticsManager.shared.writeIncidentDiagnosticsAttachment(
+          area: "chat",
+          failureClass: "timeout",
+          phase: "query",
+          includeBetaDiagnostics: false))
+      defer { try? FileManager.default.removeItem(at: url) }
+
+      let data = try Data(contentsOf: url)
+      let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+      let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+      XCTAssertFalse(snapshots.contains { $0["event"] as? String == "beta_diagnostic_trail" })
+    }
+
     func testPTTSilentTurnCreatesUserVisibleIssueSnapshot() throws {
       DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
         source: "hub",

--- a/desktop/macos/changelog/unreleased/20260721-beta-enhanced-diagnostics.json
+++ b/desktop/macos/changelog/unreleased/20260721-beta-enhanced-diagnostics.json
@@ -1,0 +1,3 @@
+{
+  "change": "Beta builds now collect additional bounded technical diagnostics by default to help resolve reliability issues faster. You can disable Enhanced Diagnostics in Settings → Advanced."
+}

--- a/desktop/macos/e2e/flows/settings-basic.yaml
+++ b/desktop/macos/e2e/flows/settings-basic.yaml
@@ -10,6 +10,7 @@ covers:
   - desktop/macos/Desktop/Sources/MemoryExportService.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Integrations.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
+  - desktop/macos/Desktop/Sources/Telemetry/BetaEnhancedDiagnosticsConfiguration.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/AppRuleEditorView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SearchableDropdown.swift
   - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Settings.swift


### PR DESCRIPTION
## Summary
- Enable a beta-only enhanced diagnostics trail by default, with a user opt-out in **Settings → Advanced**.
- Add typed beta error entries to incident attachments: component, operation, phase, outcome, bounded failure class, error-domain bucket, and bounded error code.
- Capture transient failures for beta triage while preserving existing Stable behavior.
- Add a macOS release-note disclosure; onboarding remains unchanged.

## Privacy and scope
- Stable and development bundles never enable this path.
- The setting removes beta trail entries from future incident attachments immediately.
- No raw logger message, prompt, transcript, response, URL, path, device name, token, or credential is stored in the beta trail.
- Existing incident attachment bounds, redaction, and Sentry deduplication remain in effect.

## Validation
- `xcrun swift test --package-path Desktop` — 2,866 tests passed.
- `./scripts/swiftlint-wrapper.sh lint`
- `python3 scripts/check_desktop_test_quality.py`
- `python3 scripts/check-e2e-flow-coverage.py --base origin/main --strict`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

