### PR TITLE
fix(desktop): preserve beta diagnostics privacy boundary

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -62,7 +62,9 @@ final class DesktopDiagnosticsManager {
 
   private let lock = NSLock()
   private var snapshots: [DesktopHealthSnapshot] = []
+  private var betaTrailSnapshots: [DesktopHealthSnapshot] = []
   private let snapshotLimit = 150
+  private let betaTrailSnapshotLimit = 50
   private var consecutiveNearZeroPTTTurns = 0
   private var lastPTTWatchdogIncidentAt: Date?
   private var lastUserVisibleSentryIncidentAt: [String: Date] = [:]
@@ -368,18 +370,26 @@ final class DesktopDiagnosticsManager {
   ) {
     guard enabled else { return }
     let nsError = error as NSError?
-    record(
-      .betaDiagnosticTrail,
-      properties: [
-        "component": betaComponent(for: message),
-        "operation": "error",
-        "phase": "handling",
-        "outcome": "failed",
-        "failure_class": betaFailureClass(for: nsError),
-        "error_domain": betaErrorDomain(nsError?.domain),
-        "error_code": betaErrorCode(nsError?.code),
-      ],
-      trackRemotely: false)
+    let snapshot = DesktopHealthSnapshot(
+      timestamp: Date(),
+      event: .betaDiagnosticTrail,
+      properties: commonProperties().merging(
+        sanitized([
+          "component": betaComponent(for: message),
+          "operation": "error",
+          "phase": "handling",
+          "outcome": "failed",
+          "failure_class": betaFailureClass(for: nsError),
+          "error_domain": betaErrorDomain(nsError?.domain),
+          "error_code": betaErrorCode(nsError?.code),
+        ])
+      ) { _, new in new })
+    lock.lock()
+    betaTrailSnapshots.append(snapshot)
+    if betaTrailSnapshots.count > betaTrailSnapshotLimit {
+      betaTrailSnapshots.removeFirst(betaTrailSnapshots.count - betaTrailSnapshotLimit)
+    }
+    lock.unlock()
   }
 
   func recordVoiceTurnStarted(turnID: String, intent: String) {
@@ -584,9 +594,12 @@ final class DesktopDiagnosticsManager {
     includeBetaDiagnostics: Bool = BetaEnhancedDiagnosticsConfiguration.isEnabled
   ) -> [[String: Any]] {
     lock.lock()
-    let current = snapshots.compactMap { snapshot -> [String: Any]? in
-      guard includeBetaDiagnostics || snapshot.event != .betaDiagnosticTrail else { return nil }
-      return cloudSafeSnapshot(snapshot, includeBetaDiagnostics: includeBetaDiagnostics)
+    var current = snapshots.map { cloudSafeSnapshot($0, includeBetaDiagnostics: includeBetaDiagnostics) }
+    if includeBetaDiagnostics {
+      current.append(
+        contentsOf: betaTrailSnapshots.map {
+          cloudSafeSnapshot($0, includeBetaDiagnostics: true)
+        })
     }
     lock.unlock()
     return current
@@ -655,16 +668,20 @@ final class DesktopDiagnosticsManager {
       area: area,
       failureClass: failureClass,
       phase: phase)
-    let payload: [String: Any] = [
+    var payload: [String: Any] = [
       "generated_at": ISO8601DateFormatter.desktopDiagnostics.string(from: Date()),
       "privacy": "redacted_incident_context",
       "incident": incident,
       "snapshots": currentCloudSnapshotsForSentry(includeBetaDiagnostics: includeBetaDiagnostics),
-      "redacted_log_tail": redactedLogTail(
+    ]
+    // Beta uploads the independently assembled typed trail only. The free-form
+    // local-log tail remains available exclusively to the existing non-beta path.
+    if !includeBetaDiagnostics {
+      payload["redacted_log_tail"] = redactedLogTail(
         logPath: logPath,
         maxLines: maxLogLines,
-        strictCloudRedaction: true),
-    ]
+        strictCloudRedaction: true)
+    }
     return writeDiagnosticsPayload(payload, prefix: "omi-desktop-incident")
   }
 
@@ -827,6 +844,7 @@ final class DesktopDiagnosticsManager {
     func resetForTests() {
       lock.lock()
       snapshots.removeAll()
+      betaTrailSnapshots.removeAll()
       consecutiveNearZeroPTTTurns = 0
       lastPTTWatchdogIncidentAt = nil
       lastUserVisibleSentryIncidentAt.removeAll()

--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -459,9 +459,10 @@ func logError(_ message: String, error: Error? = nil) {
     error: error,
     enabled: enhancedBetaDiagnostics)
 
-  // Stable keeps the existing low-volume transient-error behavior. Beta captures
-  // these typed failures with the expanded diagnostic trail for release triage.
-  if isNonActionableTransient(error), !enhancedBetaDiagnostics { return }
+  // Transient network/IO errors (offline, timeouts, cancellations, socket resets)
+  // remain local-only. A beta trail entry can join a later authoritative incident,
+  // but a transient alone must not create a new Sentry event.
+  if isNonActionableTransient(error) { return }
 
   guard !isDevBuild else { return }
 

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -118,6 +118,7 @@ import XCTest
       let trail = try XCTUnwrap(
         snapshots.first(where: { $0["event"] as? String == "beta_diagnostic_trail" }))
 
+      XCTAssertNil(root["redacted_log_tail"])
       XCTAssertEqual(trail["component"] as? String, "chat")
       XCTAssertEqual(trail["failure_class"] as? String, "timeout")
       XCTAssertEqual(trail["error_domain"] as? String, "url")
@@ -146,6 +147,28 @@ import XCTest
       XCTAssertFalse(snapshots.contains { $0["event"] as? String == "beta_diagnostic_trail" })
     }
 
+    func testBetaTrailIsBoundedIndependentlyFromIncidentSnapshots() throws {
+      for _ in 0..<55 {
+        DesktopDiagnosticsManager.shared.recordBetaLogError(
+          message: "Chat bridge timed out",
+          error: NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut),
+          enabled: true)
+      }
+
+      let url = try XCTUnwrap(
+        DesktopDiagnosticsManager.shared.writeIncidentDiagnosticsAttachment(
+          area: "chat",
+          failureClass: "timeout",
+          phase: "query",
+          includeBetaDiagnostics: true))
+      defer { try? FileManager.default.removeItem(at: url) }
+
+      let data = try Data(contentsOf: url)
+      let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+      let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+      let betaTrail = snapshots.filter { $0["event"] as? String == "beta_diagnostic_trail" }
+      XCTAssertEqual(betaTrail.count, 50)
+    }
     func testPTTSilentTurnCreatesUserVisibleIssueSnapshot() throws {
       DesktopDiagnosticsManager.shared.recordPTTSilentTurn(
         source: "hub",

--- a/desktop/macos/changelog/unreleased/20260721-beta-enhanced-diagnostics-privacy.json
+++ b/desktop/macos/changelog/unreleased/20260721-beta-enhanced-diagnostics-privacy.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved the privacy and noise controls for Beta Enhanced Diagnostics."
+}


### PR DESCRIPTION
## Summary
- Restore the existing unconditional suppression of non-actionable transient errors, so Beta no longer turns ordinary retry/cancellation/offline paths into Sentry incidents.
- Keep Beta’s structured diagnostic trail local until an existing authoritative incident capture.
- Make Beta incident attachments typed-only: omit the marker-filtered local log tail entirely.
- Store the Beta trail in its own capped 50-entry buffer so it cannot evict user-visible incident or watchdog context.

## Privacy and reliability impact
- No raw error message or provider-supplied log line is added to the Beta trail.
- Beta cloud attachments carry allowlisted snapshot metadata only; `redacted_log_tail` is excluded.
- Existing Stable/non-Beta attachment behavior is unchanged.

## Validation
- `xcrun swift test --package-path Desktop --filter 'BetaEnhancedDiagnosticsConfigurationTests|DesktopDiagnosticsManagerTests|SentryBeforeSendScrubTests'`
- `./scripts/swiftlint-wrapper.sh lint`
- `python3 scripts/check_desktop_test_quality.py`
- `git diff --cached --check`

## Failure-Class
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

