### PR TITLE
fix(release): harden immutable desktop promotion

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -36,7 +36,7 @@ checks:
     reason: "advisory desktop release evidence and drift report"
   - id: desktop-qualification-immutable-dispatch
     command: ["python3", ".github/scripts/test_desktop_qualification_dispatch.py"]
-    triggers: ["codemagic.yaml", ".github/workflows/desktop_qualify_beta.yml", ".github/scripts/test_desktop_qualification_dispatch.py", ".github/checks-manifest.yaml"]
+    triggers: ["codemagic.yaml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_beta.yml", ".github/scripts/test_desktop_qualification_dispatch.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "candidate qualification must dispatch and rebuild at one immutable candidate tag SHA"
   - id: desktop-changelog-io-tests
@@ -372,12 +372,12 @@ checks:
     reason: "#10163 mutation-tests production-family mobile API routing"
   - id: stable-pointer-precondition-cli
     command: ["python3", ".github/scripts/check_stable_pointer_precondition.py", "--help"]
-    triggers: [".github/workflows/desktop_promote_prod.yml", ".github/scripts/check_stable_pointer_precondition.py", ".github/scripts/verify_stable_appcast.py", ".github/scripts/test_stable_promotion_verifiers.py", ".github/checks-manifest.yaml"]
+    triggers: [".github/workflows/desktop_promote_prod.yml", ".github/scripts/check_stable_pointer_precondition.py", ".github/scripts/require_stable_promotion_confirmation.py", ".github/scripts/verify_stable_appcast.py", ".github/scripts/test_stable_promotion_verifiers.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#10163 keeps Stable retry acknowledgement and appcast verification executable"
   - id: stable-pointer-precondition-fixtures
     command: ["python3", ".github/scripts/test_stable_promotion_verifiers.py"]
-    triggers: [".github/workflows/desktop_promote_prod.yml", ".github/scripts/check_stable_pointer_precondition.py", ".github/scripts/verify_stable_appcast.py", ".github/scripts/test_stable_promotion_verifiers.py", ".github/checks-manifest.yaml"]
+    triggers: [".github/workflows/desktop_promote_prod.yml", ".github/scripts/check_stable_pointer_precondition.py", ".github/scripts/require_stable_promotion_confirmation.py", ".github/scripts/verify_stable_appcast.py", ".github/scripts/test_stable_promotion_verifiers.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#10163 mutation-sensitive Stable retry and default-channel feed fixtures"
   - id: stable-static-publication-fixtures

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -31,9 +31,14 @@ checks:
     reason: "immutable desktop app/backend release-unit contract"
   - id: desktop-release-doctor-v1
     command: ["python3", ".github/scripts/test_desktop_release_doctor.py"]
-    triggers: [".github/schemas/desktop-release-evidence-v1.schema.json", ".github/scripts/desktop_release_doctor.py", ".github/scripts/desktop_release_doctor_report.py", ".github/scripts/test_desktop_release_doctor.py", ".github/workflows/desktop_release_doctor.yml"]
+    triggers: [".github/schemas/desktop-release-evidence-v1.schema.json", ".github/scripts/desktop_release_doctor.py", ".github/scripts/desktop_release_doctor_report.py", ".github/scripts/test_desktop_release_doctor.py", ".github/workflows/desktop_release_doctor.yml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "advisory desktop release evidence and drift report"
+  - id: desktop-qualification-immutable-dispatch
+    command: ["python3", ".github/scripts/test_desktop_qualification_dispatch.py"]
+    triggers: ["codemagic.yaml", ".github/workflows/desktop_qualify_beta.yml", ".github/scripts/test_desktop_qualification_dispatch.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "candidate qualification must dispatch and rebuild at one immutable candidate tag SHA"
   - id: desktop-changelog-io-tests
     command: ["python3", ".github/scripts/test_desktop_changelog.py"]
     triggers: [".github/scripts/desktop-changelog.py", ".github/scripts/test_desktop_changelog.py", ".github/checks-manifest.yaml"]
@@ -375,6 +380,11 @@ checks:
     triggers: [".github/workflows/desktop_promote_prod.yml", ".github/scripts/check_stable_pointer_precondition.py", ".github/scripts/verify_stable_appcast.py", ".github/scripts/test_stable_promotion_verifiers.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#10163 mutation-sensitive Stable retry and default-channel feed fixtures"
+  - id: stable-static-publication-fixtures
+    command: ["python3", ".github/scripts/test_verify_stable_static_artifacts.py"]
+    triggers: [".github/workflows/desktop_promote_prod.yml", ".github/scripts/desktop_repair_installer.py", ".github/scripts/verify_stable_static_artifacts.py", ".github/scripts/test_verify_stable_static_artifacts.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "Stable static latest.json and index.html must exactly render the retained qualified manifest"
 
 exempt:
   - path: ".github/scripts/check-desktop-auto-beta-candidate.py"

--- a/.github/scripts/check-desktop-prod-promotion-policy.py
+++ b/.github/scripts/check-desktop-prod-promotion-policy.py
@@ -9,6 +9,9 @@ REQUIRED = (
     "on:\n  workflow_dispatch:",
     "confirm:",
     "promote-stable",
+    "Require explicit Stable confirmation",
+    "require_stable_promotion_confirmation.py",
+    '--operation "$OPERATION" --confirm "$CONFIRM"',
     "operation:",
     "expected_current_release_id:",
     "expected_generation:",
@@ -57,6 +60,10 @@ def validate(text: str) -> list[str]:
             errors.append(f"stable pointer promotion must not contain backend deployment or bypass path: {forbidden}")
     if "\n  push:" in text or "\n  schedule:" in text or "\n  release:" in text:
         errors.append("stable pointer promotion must remain manual-only")
+    confirmation = text.find("Require explicit Stable confirmation")
+    for later_step in ("Checkout promotion controls", "Generate Omi Bot token", "Google Auth"):
+        if confirmation == -1 or confirmation > text.find(later_step):
+            errors.append(f"Stable confirmation must fail closed before {later_step}")
     order = [text.find(fragment) for fragment in ORDERED_STEPS]
     if -1 in order or order != sorted(order):
         errors.append("stable promotion must fetch and verify retained identity before pointer mutation, then bridge and verify")

--- a/.github/scripts/check-desktop-prod-promotion-policy.py
+++ b/.github/scripts/check-desktop-prod-promotion-policy.py
@@ -32,6 +32,7 @@ REQUIRED = (
     "Authorization: Bearer $ACCESS_TOKEN",
     "appcast.xml?identity=stable",
     "verify_stable_appcast.py",
+    "verify_stable_static_artifacts.py",
     ".event",
     ".path",
     "--if-generation-match=0",

--- a/.github/scripts/check-direct-backend-production-admission.py
+++ b/.github/scripts/check-direct-backend-production-admission.py
@@ -21,6 +21,41 @@ DIAGNOSTIC = "ERROR: checked-out HEAD $CHECKED_OUT_SHA is not an ancestor of fre
 PERSISTED_IMAGE_IDENTITY = 'echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_ENV"'
 
 
+def _has_unadmitted_persistent_image_write(text: str) -> bool:
+    """Reject IMAGE_TAG writes to GITHUB_ENV across complete shell run blocks.
+
+    YAML literal blocks can split a printf/redirection across lines and heredocs
+    put the assignment after the redirection. Search both directions after
+    removing the one exact admitted persistence command.
+    """
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        match = re.match(r"^(?P<indent>\s*)run:\s*(?P<command>.*)$", line)
+        if not match:
+            continue
+        command = match.group("command")
+        if command in {"|", ">", "|-", ">-"}:
+            indent = len(match.group("indent"))
+            block: list[str] = []
+            for body_line in lines[index + 1 :]:
+                if body_line.strip() and len(body_line) - len(body_line.lstrip()) <= indent:
+                    break
+                block.append(body_line)
+            command = "\n".join(block)
+        residual = command.replace(PERSISTED_IMAGE_IDENTITY, "")
+        direct_write = re.search(
+            r"(?m)(?:(?:echo|printf)\b[^\n]*\bIMAGE_TAG\s*=[^\n]*(?:\\\s*\n[^\n]*)*|\bIMAGE_TAG\s*=[^\n]*)>>\s*['\"]?\$GITHUB_ENV['\"]?",
+            residual,
+        )
+        heredoc_write = re.search(
+            r"(?s)(?:cat|tee)\b.*?(?:>>|>)\s*['\"]?\$GITHUB_ENV['\"]?.*?<<.*?\n.*?\bIMAGE_TAG\s*=",
+            residual,
+        )
+        if direct_write or heredoc_write:
+            return True
+    return False
+
+
 def validate(root: Path) -> list[str]:
     errors: list[str] = []
     for relative in WORKFLOWS:
@@ -40,10 +75,6 @@ def validate(root: Path) -> list[str]:
             errors.append(f"{relative} must not check out a second source after production admission")
         if text.count(HEAD_IDENTITY) != 1:
             errors.append(f"{relative} must establish checked-out source identity exactly once")
-        persistent_image_writes = [
-            line.strip()
-            for line in re.findall(r"(?m)^[^\n]*\bIMAGE_TAG=[^\n]*>>\s*[\"']?\$GITHUB_ENV[\"']?[^\n]*$", text)
-        ]
         image_authorities = []
         for line in text.splitlines():
             assignment = re.match(r"^\s*(?:run:\s+)?IMAGE_TAG=(.*)$", line)
@@ -52,7 +83,8 @@ def validate(root: Path) -> list[str]:
         if (
             text.count(IMAGE_IDENTITY) != 1
             or image_authorities != [IMAGE_IDENTITY]
-            or persistent_image_writes != [PERSISTED_IMAGE_IDENTITY]
+            or text.count(PERSISTED_IMAGE_IDENTITY) != 1
+            or _has_unadmitted_persistent_image_write(text)
         ):
             errors.append(f"{relative} must establish its immutable image tag exactly once from checked-out HEAD")
     return errors

--- a/.github/scripts/check-gcp-backend-production-boundary.py
+++ b/.github/scripts/check-gcp-backend-production-boundary.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 WORKFLOW = Path(".github/workflows/gcp_backend.yml")
 EARLY_PROD_ALL_REJECTION = 'if [[ "$DEPLOY_ENVIRONMENT" == "prod" && "$DEPLOY_TARGETS" == "all" ]]; then'
@@ -15,12 +16,31 @@ AUDIENCE_DIFFERENCE_GUARD = '''[[ "$identity_audience" != "$candidate_url" ]] ||
 CANDIDATE_REQUEST_TARGET = '--candidate-url "${{ steps.transcription-candidate.outputs.url }}"'
 
 
+def _validation_job(text: str) -> str:
+    match = re.search(r"(?ms)^  validate-production-boundary:\n(.*?)(?=^  [a-zA-Z0-9_-]+:\n|\Z)", text)
+    return match.group(1) if match else ""
+
+
+def _rejects_before_side_effects(text: str) -> bool:
+    job = _validation_job(text)
+    rejection = job.find(EARLY_PROD_ALL_REJECTION)
+    if rejection < 0:
+        return False
+    before = job[:rejection]
+    # The rejection is deliberately the validation job's first executable
+    # action. Any action or shell step above it can acquire credentials, fetch
+    # source, or mutate external state before the unsupported request stops.
+    return not re.search(r"(?m)^\s*-\s+(?:uses:|run:)", before)
+
+
 def validate(root: Path) -> list[str]:
     path = root / WORKFLOW
     text = path.read_text(encoding="utf-8") if path.exists() else ""
     errors: list[str] = []
     if text.count(EARLY_PROD_ALL_REJECTION) != 1:
         errors.append("gcp_backend.yml must reject exactly environment=prod, deploy_targets=all before side effects")
+    elif not _rejects_before_side_effects(text):
+        errors.append("gcp_backend.yml must reject prod,all before checkout, auth, credentials, or shell side effects")
     if CANONICAL_AUDIENCE not in text or "BACKEND_CLOUD_RUN_IAM_AUDIENCE" in text:
         errors.append("gcp_backend.yml must derive the Cloud Run IAM audience only from backend status.url")
     if AUDIENCE_DIFFERENCE_GUARD not in text:

--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -299,7 +299,6 @@ def check_desktop_qualification_runner() -> list[str]:
         "check-desktop-auto-beta-candidate.py",
         "--automatic",
         "--no-promote",
-        "desktop_promote_beta.yml",
         "actions/create-github-app-token@v3",
         "desktop-beta-qualification-${{ inputs.release_tag }}",
         "cancel-in-progress: false",

--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -294,7 +294,7 @@ def check_desktop_qualification_runner() -> list[str]:
         "self-hosted",
         "macos",
         "omi-desktop-qualification",
-        "ref: main",
+        "ref: ${{ github.sha }}",
         "docker info",
         "check-desktop-auto-beta-candidate.py",
         "--automatic",

--- a/.github/scripts/desktop_release_doctor.py
+++ b/.github/scripts/desktop_release_doctor.py
@@ -68,6 +68,8 @@ def _metadata_from_release_body(body: object) -> tuple[dict[str, str], bool]:
         "qualifiedBetaSha",
         "qualifiedBetaTier",
         "qualifiedBetaEvidence",
+        "edSignature",
+        "betaEdSignature",
     )
     public_metadata = {key: metadata[key] for key in safe_keys if key in metadata}
     human_prose = PRIVATE_KEY_VALUE_BLOCK_RE.sub("", body)
@@ -178,15 +180,22 @@ def _project_release_summary(release: object) -> dict[str, object]:
         return _unavailable("GitHub release response was not an object")
     metadata, stale_human_prose = _metadata_from_release_body(release.get("body"))
     assets = release.get("assets", [])
-    asset_names = [
-        asset.get("name") for asset in assets if isinstance(asset, dict) and isinstance(asset.get("name"), str)
-    ]
+    asset_identities = {
+        asset["name"]: {
+            key: asset[key]
+            for key in ("url", "browser_download_url", "digest")
+            if isinstance(asset.get(key), str)
+        }
+        for asset in assets
+        if isinstance(asset, dict) and isinstance(asset.get("name"), str)
+    }
     return {
         "tag_name": _optional_string(release.get("tagName")),
         "is_draft": release.get("isDraft") is True,
         "is_prerelease": release.get("isPrerelease") is True,
         "metadata": metadata,
-        "asset_names": asset_names,
+        "asset_names": sorted(asset_identities),
+        "asset_identities": asset_identities,
         "stale_human_prose": stale_human_prose,
     }
 
@@ -289,7 +298,15 @@ def collect_snapshot(
                 "build_number",
                 "source_sha",
                 "zip_sha256",
+                "zip_url",
                 "dmg_sha256",
+                "dmg_url",
+                "beta_zip_sha256",
+                "beta_zip_url",
+                "beta_dmg_sha256",
+                "beta_dmg_url",
+                "ed_signature",
+                "beta_ed_signature",
                 "qualification",
             ),
         ),

--- a/.github/scripts/desktop_release_doctor_report.py
+++ b/.github/scripts/desktop_release_doctor_report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from urllib.parse import unquote, urlparse
 from datetime import datetime, timezone
 
 
@@ -140,30 +141,52 @@ def _github_surfaces(snapshot: dict[str, object], release_id: str, phase: str) -
         return [_unavailable_surface("github_release", {"release_id": release_id}, github)], {}
 
     metadata_raw = github.get("metadata")
-    metadata = metadata_raw if isinstance(metadata_raw, dict) else {}
+    metadata = dict(metadata_raw) if isinstance(metadata_raw, dict) else {}
     assets = github.get("asset_names")
     asset_names = set(assets) if isinstance(assets, list) and all(isinstance(item, str) for item in assets) else set()
-    expected_assets = {"Omi.zip"}
+    identities = github.get("asset_identities")
+    identities = identities if isinstance(identities, dict) else {}
+    manifest = snapshot.get("manifest")
+    manifest = manifest if isinstance(manifest, dict) else {}
+    expected_assets = {"Omi.zip", "Omi.Beta.zip", "omi-beta.dmg"}
+    dmg_name = _asset_name(_optional_string(manifest.get("dmg_url")))
+    if dmg_name not in {"omi.dmg", "Omi.dmg"}:
+        dmg_name = "omi.dmg"
+    expected_assets.add(dmg_name)
     missing_assets = sorted(expected_assets - asset_names)
+    drifted_assets = _drifted_assets(identities, manifest, metadata, expected_assets)
+    legacy_degraded = (
+        phase in {"beta", "stable"}
+        and _optional_string(metadata.get("isLive")).lower() in {"true", "1", "yes"}
+        and not _optional_string(metadata.get("qualifiedBetaEvidence"))
+        and bool(missing_assets)
+    )
+    metadata["_legacy_degraded"] = legacy_degraded
     valid = (
         github.get("tag_name") == release_id
         and github.get("is_draft") is False
         and github.get("is_prerelease") is False
         and not missing_assets
+        and not drifted_assets
     )
+    status = "PASS" if valid else "WARN" if legacy_degraded else "FAIL"
+    classification = "aligned" if valid else "legacy_degraded" if legacy_degraded else "customer_visible_split"
     release_surface = _surface(
         "github_release",
-        "PASS" if valid else "FAIL",
-        "aligned" if valid else "customer_visible_split",
+        status,
+        classification,
         {"release_id": release_id, "published": True, "required_assets": sorted(expected_assets)},
         {
             "release_id": github.get("tag_name"),
             "is_draft": github.get("is_draft"),
             "is_prerelease": github.get("is_prerelease"),
             "missing_assets": missing_assets,
+            "drifted_assets": drifted_assets,
         },
         "GitHub release identity and required signed artifact are present."
         if valid
+        else "Live legacy release has incomplete four-asset evidence and is explicitly degraded."
+        if legacy_degraded
         else "GitHub release is missing, non-published, or does not match the requested release.",
     )
     prose_surface = _surface(
@@ -187,6 +210,44 @@ def _github_surfaces(snapshot: dict[str, object], release_id: str, phase: str) -
     return [release_surface, prose_surface], metadata
 
 
+def _asset_name(url: str) -> str:
+    return unquote(urlparse(url).path).rsplit("/", 1)[-1] if url else ""
+
+
+def _asset_digest(identity: object) -> str:
+    if not isinstance(identity, dict):
+        return ""
+    return _optional_string(identity.get("sha256")) or _optional_string(identity.get("digest")).removeprefix("sha256:")
+
+
+def _asset_url(identity: object) -> str:
+    if not isinstance(identity, dict):
+        return ""
+    return _optional_string(identity.get("url")) or _optional_string(identity.get("browser_download_url"))
+
+
+def _drifted_assets(
+    identities: dict[str, object], manifest: dict[str, object], metadata: dict[str, object], expected_assets: set[str]
+) -> list[str]:
+    fields = {
+        "Omi.zip": ("zip_url", "zip_sha256"),
+        _asset_name(_optional_string(manifest.get("dmg_url"))): ("dmg_url", "dmg_sha256"),
+        "Omi.Beta.zip": ("beta_zip_url", "beta_zip_sha256"),
+        "omi-beta.dmg": ("beta_dmg_url", "beta_dmg_sha256"),
+    }
+    drifted = []
+    for name in expected_assets:
+        url_key, sha_key = fields.get(name, ("", ""))
+        identity = identities.get(name)
+        if not url_key or _asset_url(identity) != _optional_string(manifest.get(url_key)) or _asset_digest(identity) != _optional_string(manifest.get(sha_key)):
+            drifted.append(name)
+    if _optional_string(metadata.get("edSignature")) != _optional_string(manifest.get("ed_signature")):
+        drifted.append("Omi.zip")
+    if _optional_string(metadata.get("betaEdSignature")) != _optional_string(manifest.get("beta_ed_signature")):
+        drifted.append("Omi.Beta.zip")
+    return sorted(set(drifted))
+
+
 def _manifest_surface(snapshot: dict[str, object], release_id: str, tag_sha: str, phase: str, metadata: dict[str, object]) -> dict[str, object]:
     manifest = snapshot.get("manifest", _unavailable("collector did not provide the canonical manifest"))
     expected = {"release_id": release_id, "source_sha": tag_sha}
@@ -199,7 +260,8 @@ def _manifest_surface(snapshot: dict[str, object], release_id: str, tag_sha: str
     evidence = _optional_string(qualification.get("evidence_asset")) if isinstance(qualification, dict) else ""
     metadata_evidence = _optional_string(metadata.get("qualifiedBetaEvidence"))
     required = phase in {"beta", "stable"}
-    valid = manifest_id == release_id and manifest_sha == tag_sha and (not required or bool(evidence))
+    legacy_degraded = metadata.get("_legacy_degraded") is True
+    valid = manifest_id == release_id and manifest_sha == tag_sha and (not required or bool(evidence) or legacy_degraded)
     if metadata_evidence and evidence and metadata_evidence != evidence:
         valid = False
     raw_plus_lookup = manifest_id == release_id.replace("+", " ")
@@ -213,11 +275,13 @@ def _manifest_surface(snapshot: dict[str, object], release_id: str, tag_sha: str
         repair = "Read the Firestore manifest through a URL-encoded release ID, then repair the manifest or pointer without changing the release tag."
     return _surface(
         "canonical_manifest",
-        "PASS" if valid else "FAIL",
-        "aligned" if valid else "reversible_drift",
+        "WARN" if legacy_degraded and valid else "PASS" if valid else "FAIL",
+        "legacy_degraded" if legacy_degraded and valid else "aligned" if valid else "reversible_drift",
         {**expected, "qualification_evidence": metadata_evidence or None},
         {"release_id": manifest_id or None, "source_sha": manifest_sha or None, "qualification_evidence": evidence or None},
-        message,
+        "Legacy manifest is explicitly degraded because it predates four-asset qualification evidence."
+        if legacy_degraded and valid
+        else message,
         repair,
     )
 

--- a/.github/scripts/require_stable_promotion_confirmation.py
+++ b/.github/scripts/require_stable_promotion_confirmation.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Fail closed unless a Stable pointer mutation has explicit operator intent."""
+
+from __future__ import annotations
+
+import argparse
+
+
+CONFIRMATION = "promote-stable"
+OPERATIONS = {"promote", "repoint"}
+
+
+def validate(*, operation: str, confirm: str) -> None:
+    if operation not in OPERATIONS:
+        raise ValueError(f"unsupported Stable operation: {operation}")
+    if confirm != CONFIRMATION:
+        raise ValueError(f"confirm must be exactly: {CONFIRMATION}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--operation", required=True)
+    parser.add_argument("--confirm", required=True)
+    args = parser.parse_args()
+    try:
+        validate(operation=args.operation, confirm=args.confirm)
+    except ValueError as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_check_direct_backend_production_admission.py
+++ b/.github/scripts/test_check_direct_backend_production_admission.py
@@ -70,6 +70,34 @@ class DirectBackendProductionAdmissionTests(unittest.TestCase):
                     target.write_text(target.read_text(encoding="utf-8") + "\n" + mutation, encoding="utf-8")
                     self.assertTrue(CHECKER.validate(root))
 
+    def test_rejects_multiline_and_heredoc_persistent_image_overrides(self) -> None:
+        mutations = (
+            """      - name: multiline image override
+        run: |
+          printf 'IMAGE_TAG=latest\\n' \\
+            >> \"$GITHUB_ENV\"
+""",
+            """      - name: heredoc image override
+        run: |
+          cat >> \"$GITHUB_ENV\" <<'EOF'
+          IMAGE_TAG=latest
+          EOF
+""",
+        )
+        for relative in CHECKER.WORKFLOWS:
+            for mutation in mutations:
+                with self.subTest(workflow=relative, mutation=mutation.splitlines()[0].strip()):
+                    with tempfile.TemporaryDirectory() as directory:
+                        root = Path(directory)
+                        for fixture_relative in CHECKER.WORKFLOWS:
+                            source = ROOT / fixture_relative
+                            target = root / fixture_relative
+                            target.parent.mkdir(parents=True, exist_ok=True)
+                            shutil.copy2(source, target)
+                        target = root / relative
+                        target.write_text(target.read_text(encoding="utf-8") + "\n" + mutation, encoding="utf-8")
+                        self.assertTrue(CHECKER.validate(root))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_check_gcp_backend_production_boundary.py
+++ b/.github/scripts/test_check_gcp_backend_production_boundary.py
@@ -56,6 +56,23 @@ class GcpBackendProductionBoundaryTests(unittest.TestCase):
                 workflow.write_text(original.replace(expected, replacement, 1), encoding="utf-8")
                 self.assertTrue(CHECKER.validate(root))
 
+    def test_rejects_side_effects_before_the_prod_all_rejection(self) -> None:
+        original = (ROOT / ".github/workflows/gcp_backend.yml").read_text(encoding="utf-8")
+        marker = "      - name: Reject unsupported production deployment boundary before side effects\n"
+        mutations = {
+            "checkout": "      - uses: actions/checkout@v7\n",
+            "google_auth": "      - uses: google-github-actions/auth@v3\n",
+            "shell_mutation": "      - run: gcloud run services update unsafe --region us-central1\n",
+        }
+        for name, mutation in mutations.items():
+            with self.subTest(mutation=name), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                workflow = root / ".github/workflows/gcp_backend.yml"
+                workflow.parent.mkdir(parents=True)
+                self.assertIn(marker, original)
+                workflow.write_text(original.replace(marker, mutation + marker, 1), encoding="utf-8")
+                self.assertTrue(CHECKER.validate(root))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_desktop_qualification_dispatch.py
+++ b/.github/scripts/test_desktop_qualification_dispatch.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Static contract for immutable candidate qualification dispatch and checkout."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CODEMAGIC = ROOT / "codemagic.yaml"
+QUALIFIER = ROOT / ".github/workflows/desktop_qualify_beta.yml"
+
+
+def validate(root: Path) -> list[str]:
+    codemagic = (root / "codemagic.yaml").read_text(encoding="utf-8")
+    qualifier = (root / ".github/workflows/desktop_qualify_beta.yml").read_text(encoding="utf-8")
+    errors: list[str] = []
+    dispatch = codemagic.split("gh workflow run desktop_qualify_beta.yml", 1)[1].split("then", 1)[0]
+    if '--ref "$CM_TAG"' not in dispatch:
+        errors.append("Codemagic must dispatch qualification at the immutable candidate tag ref")
+    if "ref: ${{ github.sha }}" not in qualifier:
+        errors.append("qualification must check out the immutable event SHA, never mutable main")
+    if "ref: main" in qualifier:
+        errors.append("qualification must not check out mutable main")
+    if "CHECKOUT_SHA=$(git rev-parse HEAD)" not in qualifier or "EVENT_SHA: ${{ github.sha }}" not in qualifier:
+        errors.append("candidate validation must compare the fetched candidate tag against the checked-out event SHA")
+    return errors
+
+
+class DesktopQualificationDispatchTests(unittest.TestCase):
+    def test_current_configuration_uses_the_candidate_tag_and_event_sha(self) -> None:
+        self.assertEqual(validate(ROOT), [])
+
+    def test_mutations_drop_tag_ref_or_reintroduce_mutable_checkout(self) -> None:
+        codemagic = CODEMAGIC.read_text(encoding="utf-8")
+        qualifier = QUALIFIER.read_text(encoding="utf-8")
+        mutations = (
+            (codemagic.replace('--ref "$CM_TAG" \\\n              ', "", 1), qualifier),
+            (codemagic, qualifier.replace("ref: ${{ github.sha }}", "ref: main", 1)),
+            (codemagic, qualifier.replace("CHECKOUT_SHA=$(git rev-parse HEAD)", "CHECKOUT_SHA=$(git rev-parse \"$RELEASE_TAG\")", 1)),
+        )
+        for changed_codemagic, changed_qualifier in mutations:
+            with self.subTest(mutation=changed_codemagic != codemagic), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                (root / ".github/workflows").mkdir(parents=True)
+                (root / "codemagic.yaml").write_text(changed_codemagic, encoding="utf-8")
+                (root / ".github/workflows/desktop_qualify_beta.yml").write_text(changed_qualifier, encoding="utf-8")
+                self.assertTrue(validate(root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_desktop_qualification_dispatch.py
+++ b/.github/scripts/test_desktop_qualification_dispatch.py
@@ -11,11 +11,13 @@ import unittest
 ROOT = Path(__file__).resolve().parents[2]
 CODEMAGIC = ROOT / "codemagic.yaml"
 QUALIFIER = ROOT / ".github/workflows/desktop_qualify_beta.yml"
+BETA_PROMOTION = ROOT / ".github/workflows/desktop_promote_beta.yml"
 
 
 def validate(root: Path) -> list[str]:
     codemagic = (root / "codemagic.yaml").read_text(encoding="utf-8")
     qualifier = (root / ".github/workflows/desktop_qualify_beta.yml").read_text(encoding="utf-8")
+    beta_promotion = (root / ".github/workflows/desktop_promote_beta.yml").read_text(encoding="utf-8")
     errors: list[str] = []
     dispatch = codemagic.split("gh workflow run desktop_qualify_beta.yml", 1)[1].split("then", 1)[0]
     if '--ref "$CM_TAG"' not in dispatch:
@@ -26,27 +28,110 @@ def validate(root: Path) -> list[str]:
         errors.append("qualification must not check out mutable main")
     if "CHECKOUT_SHA=$(git rev-parse HEAD)" not in qualifier or "EVENT_SHA: ${{ github.sha }}" not in qualifier:
         errors.append("candidate validation must compare the fetched candidate tag against the checked-out event SHA")
+    if "gh workflow run desktop_promote_beta.yml" in qualifier:
+        errors.append("qualification must not dispatch beta promotion before its run has completed")
+
+    for fragment, message in (
+        (
+            '  workflow_run:\n    workflows: ["Qualify Desktop Beta Candidate"]\n    types: [completed]',
+            "automatic beta promotion must be triggered only by completed qualification runs",
+        ),
+        (
+            "github.event.workflow_run.conclusion == 'success'",
+            "automatic beta promotion must require a successful qualification conclusion",
+        ),
+        (
+            "github.event.workflow_run.event == 'workflow_dispatch'",
+            "automatic beta promotion must require the trusted workflow_dispatch qualifier",
+        ),
+        (
+            "github.event.workflow_run.repository.full_name == github.repository",
+            "automatic beta promotion must require a same-repository workflow run",
+        ),
+        (
+            "github.event.workflow_run.head_repository.full_name == github.repository",
+            "automatic beta promotion must reject fork-sourced qualification",
+        ),
+        (
+            "github.event.workflow_run.path == '.github/workflows/desktop_qualify_beta.yml'",
+            "automatic beta promotion must require the desktop qualification workflow path",
+        ),
+        (
+            "RELEASE_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.release_tag }}",
+            "automatic beta promotion must derive its release tag from the completed qualifier",
+        ),
+        (
+            "QUALIFICATION_RUN_ID: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || inputs.qualification_run_id }}",
+            "automatic beta promotion must use the completed qualifier run ID",
+        ),
+        (
+            'test "$(jq -r .head_branch <<<"$run")" = "$RELEASE_TAG"',
+            "automatic beta promotion must bind qualification evidence to the release tag",
+        ),
+        (
+            'test "$(jq -r .head_sha <<<"$run")" = "$TARGET_SHA"',
+            "automatic beta promotion must bind qualification evidence to the exact tag SHA",
+        ),
+        (
+            'test "$QUALIFICATION_RUN_ID" = "$QUALIFIER_EVENT_RUN_ID"',
+            "automatic beta promotion must use the triggering completed qualification run",
+        ),
+        (
+            'test "$QUALIFIER_EVENT_HEAD_SHA" = "$TARGET_SHA"',
+            "automatic beta promotion must bind the triggering qualifier SHA to the release tag",
+        ),
+    ):
+        if fragment not in beta_promotion:
+            errors.append(message)
     return errors
 
 
 class DesktopQualificationDispatchTests(unittest.TestCase):
-    def test_current_configuration_uses_the_candidate_tag_and_event_sha(self) -> None:
+    def test_current_configuration_uses_the_candidate_tag_and_completed_qualifier(self) -> None:
         self.assertEqual(validate(ROOT), [])
 
     def test_mutations_drop_tag_ref_or_reintroduce_mutable_checkout(self) -> None:
         codemagic = CODEMAGIC.read_text(encoding="utf-8")
         qualifier = QUALIFIER.read_text(encoding="utf-8")
+        beta_promotion = BETA_PROMOTION.read_text(encoding="utf-8")
         mutations = (
-            (codemagic.replace('--ref "$CM_TAG" \\\n              ', "", 1), qualifier),
-            (codemagic, qualifier.replace("ref: ${{ github.sha }}", "ref: main", 1)),
-            (codemagic, qualifier.replace("CHECKOUT_SHA=$(git rev-parse HEAD)", "CHECKOUT_SHA=$(git rev-parse \"$RELEASE_TAG\")", 1)),
+            (codemagic.replace('--ref "$CM_TAG" \\\n              ', "", 1), qualifier, beta_promotion),
+            (codemagic, qualifier.replace("ref: ${{ github.sha }}", "ref: main", 1), beta_promotion),
+            (
+                codemagic,
+                qualifier.replace("CHECKOUT_SHA=$(git rev-parse HEAD)", "CHECKOUT_SHA=$(git rev-parse \"$RELEASE_TAG\")", 1),
+                beta_promotion,
+            ),
+            (codemagic, qualifier + '\n          gh workflow run desktop_promote_beta.yml\n', beta_promotion),
+            (
+                codemagic,
+                qualifier,
+                beta_promotion.replace("github.event.workflow_run.conclusion == 'success'", "github.event.workflow_run.conclusion == 'failure'", 1),
+            ),
+            (
+                codemagic,
+                qualifier,
+                beta_promotion.replace(
+                    "github.event.workflow_run.head_repository.full_name == github.repository",
+                    "github.event.workflow_run.head_repository.full_name == 'attacker/omi'",
+                    1,
+                ),
+            ),
+            (
+                codemagic,
+                qualifier,
+                beta_promotion.replace('test "$(jq -r .head_sha <<<"$run")" = "$TARGET_SHA"', 'test "$(jq -r .head_sha <<<"$run")" = main', 1),
+            ),
         )
-        for changed_codemagic, changed_qualifier in mutations:
+        for changed_codemagic, changed_qualifier, changed_beta_promotion in mutations:
             with self.subTest(mutation=changed_codemagic != codemagic), tempfile.TemporaryDirectory() as directory:
                 root = Path(directory)
                 (root / ".github/workflows").mkdir(parents=True)
                 (root / "codemagic.yaml").write_text(changed_codemagic, encoding="utf-8")
                 (root / ".github/workflows/desktop_qualify_beta.yml").write_text(changed_qualifier, encoding="utf-8")
+                (root / ".github/workflows/desktop_promote_beta.yml").write_text(
+                    changed_beta_promotion, encoding="utf-8"
+                )
                 self.assertTrue(validate(root))
 
 

--- a/.github/scripts/test_desktop_release_doctor.py
+++ b/.github/scripts/test_desktop_release_doctor.py
@@ -49,12 +49,35 @@ def healthy_snapshot(*, phase: str = "beta") -> dict[str, object]:
                 "isLive": "true",
                 "qualifiedBetaEvidence": "qualification-evidence-0.12.72+12072.json",
             },
-            "asset_names": ["Omi.zip", "omi.dmg", "qualification-evidence-0.12.72+12072.json"],
+            "asset_names": ["Omi.zip", "omi.dmg", "Omi.Beta.zip", "omi-beta.dmg", "qualification-evidence-0.12.72+12072.json"],
+            "asset_identities": {
+                "Omi.zip": {"url": f"https://example.test/{RELEASE_ID}/Omi.zip", "sha256": "1" * 64},
+                "omi.dmg": {"url": f"https://example.test/{RELEASE_ID}/omi.dmg", "sha256": "2" * 64},
+                "Omi.Beta.zip": {"url": f"https://example.test/{RELEASE_ID}/Omi.Beta.zip", "sha256": "3" * 64},
+                "omi-beta.dmg": {"url": f"https://example.test/{RELEASE_ID}/omi-beta.dmg", "sha256": "4" * 64},
+            },
+            "metadata": {
+                "channel": phase,
+                "isLive": "true",
+                "qualifiedBetaEvidence": "qualification-evidence-0.12.72+12072.json",
+                "edSignature": "stable-signature",
+                "betaEdSignature": "beta-signature",
+            },
             "stale_human_prose": False,
         },
         "manifest": {
             "release_id": RELEASE_ID,
             "source_sha": SOURCE_SHA,
+            "zip_url": f"https://example.test/{RELEASE_ID}/Omi.zip",
+            "zip_sha256": "1" * 64,
+            "dmg_url": f"https://example.test/{RELEASE_ID}/omi.dmg",
+            "dmg_sha256": "2" * 64,
+            "beta_zip_url": f"https://example.test/{RELEASE_ID}/Omi.Beta.zip",
+            "beta_zip_sha256": "3" * 64,
+            "beta_dmg_url": f"https://example.test/{RELEASE_ID}/omi-beta.dmg",
+            "beta_dmg_sha256": "4" * 64,
+            "ed_signature": "stable-signature",
+            "beta_ed_signature": "beta-signature",
             "qualification": {"evidence_asset": "qualification-evidence-0.12.72+12072.json"},
         },
         "pointers": {"beta": pointer, "stable": pointer if phase == "stable" else {"release_id": "v0.12.71+12071-macos"}},
@@ -90,6 +113,42 @@ class DesktopReleaseDoctorTests(unittest.TestCase):
         self.assertEqual(report["overall"], "FAIL")
         self.assertEqual(prose["status"], "FAIL")
         self.assertEqual(prose["classification"], "reversible_drift")
+
+    def test_candidate_missing_any_of_the_four_installers_never_qualifies(self) -> None:
+        snapshot = healthy_snapshot(phase="candidate")
+        snapshot["github_release"]["asset_names"].remove("omi-beta.dmg")
+        snapshot["github_release"]["asset_identities"].pop("omi-beta.dmg")
+        report = doctor.evaluate_snapshot(snapshot)
+        release = surface(report, "github_release")
+        self.assertEqual(report["overall"], "FAIL")
+        self.assertEqual(release["status"], "FAIL")
+        self.assertIn("omi-beta.dmg", release["actual"]["missing_assets"])
+
+    def test_asset_url_hash_or_signature_drift_never_reports_aligned(self) -> None:
+        snapshot = healthy_snapshot()
+        snapshot["github_release"]["asset_identities"]["Omi.Beta.zip"]["sha256"] = "f" * 64
+        snapshot["github_release"]["metadata"]["betaEdSignature"] = "different-signature"
+        report = doctor.evaluate_snapshot(snapshot)
+        release = surface(report, "github_release")
+        self.assertEqual(report["overall"], "FAIL")
+        self.assertEqual(release["classification"], "customer_visible_split")
+        self.assertIn("Omi.Beta.zip", release["actual"]["drifted_assets"])
+
+    def test_live_legacy_record_is_explicitly_degraded_not_a_qualified_pass(self) -> None:
+        snapshot = healthy_snapshot(phase="stable")
+        snapshot["github_release"]["asset_names"] = ["Omi.zip", "omi.dmg"]
+        snapshot["github_release"]["asset_identities"] = {
+            key: value
+            for key, value in snapshot["github_release"]["asset_identities"].items()
+            if key in {"Omi.zip", "omi.dmg"}
+        }
+        snapshot["github_release"]["metadata"]["qualifiedBetaEvidence"] = ""
+        snapshot["manifest"]["qualification"] = {}
+        report = doctor.evaluate_snapshot(snapshot)
+        release = surface(report, "github_release")
+        self.assertEqual(report["overall"], "WARN")
+        self.assertEqual(release["status"], "WARN")
+        self.assertEqual(release["classification"], "legacy_degraded")
 
     def test_plus_tag_pointer_mismatch_fails_with_repair_direction(self) -> None:
         snapshot = healthy_snapshot()

--- a/.github/scripts/test_stable_promotion_verifiers.py
+++ b/.github/scripts/test_stable_promotion_verifiers.py
@@ -20,6 +20,8 @@ def _load(name: str):
 
 APPCAST = _load("verify_stable_appcast.py")
 POINTER = _load("check_stable_pointer_precondition.py")
+CONFIRMATION = _load("require_stable_promotion_confirmation.py")
+POLICY = _load("check-desktop-prod-promotion-policy.py")
 
 
 def _fields(release_id: str, generation: int) -> dict:
@@ -27,6 +29,28 @@ def _fields(release_id: str, generation: int) -> dict:
 
 
 class StablePromotionVerifierTests(unittest.TestCase):
+    def test_confirmation_rejects_wrong_or_missing_token_for_every_stable_mutation(self):
+        for operation in ("promote", "repoint"):
+            for confirm in ("", "promote-beta"):
+                with self.subTest(operation=operation, confirm=confirm or "missing"):
+                    with self.assertRaisesRegex(ValueError, "confirm must be exactly"):
+                        CONFIRMATION.validate(operation=operation, confirm=confirm)
+            CONFIRMATION.validate(operation=operation, confirm="promote-stable")
+
+    def test_policy_requires_confirmation_before_authentication_or_mutation(self):
+        original = (ROOT / POLICY.WORKFLOW).read_text(encoding="utf-8")
+        mutations = (
+            original.replace("      - name: Require explicit Stable confirmation\n", "      - name: Confirmation moved too late\n", 1),
+            original.replace("--operation \"$OPERATION\" --confirm \"$CONFIRM\"", "--operation \"$OPERATION\" --confirm promote-beta", 1),
+        )
+        for changed in mutations:
+            with self.subTest(mutation=changed != original), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                workflow = root / POLICY.WORKFLOW
+                workflow.parent.mkdir(parents=True)
+                workflow.write_text(changed, encoding="utf-8")
+                self.assertTrue(POLICY.validate(workflow.read_text(encoding="utf-8")))
+
     def test_lost_response_retry_accepts_only_the_expected_next_generation(self):
         POINTER.verify(
             beta=_fields("target", 4),

--- a/.github/scripts/test_verify_stable_static_artifacts.py
+++ b/.github/scripts/test_verify_stable_static_artifacts.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Regression tests for retained-manifest stable static publication verification."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(name: str):
+    path = ROOT / ".github/scripts" / name
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+VERIFIER = _load("verify_stable_static_artifacts.py")
+REPAIR = _load("desktop_repair_installer.py")
+
+
+def manifest() -> dict[str, object]:
+    return {
+        "release_id": "v0.12.72+12072-macos",
+        "platform": "macos",
+        "version": "0.12.72",
+        "build_number": 12072,
+        "source_sha": "a" * 40,
+        "dmg_url": "https://github.com/BasedHardware/omi/releases/download/v0.12.72%2B12072-macos/omi.dmg",
+        "dmg_sha256": "b" * 64,
+        "published_at": "2026-07-21T00:00:00Z",
+    }
+
+
+class StableStaticArtifactVerifierTests(unittest.TestCase):
+    def test_accepts_exact_json_and_html_rendered_from_the_retained_manifest(self) -> None:
+        bundle = REPAIR.build_repair_bundle(manifest(), "gs://updates-bucket")
+        VERIFIER.verify(bundle["latest"], bundle["landing_page"], manifest(), "gs://updates-bucket")
+
+    def test_rejects_stale_or_altered_identity_in_either_published_artifact(self) -> None:
+        bundle = REPAIR.build_repair_bundle(manifest(), "gs://updates-bucket")
+        mutations = (
+            ({**bundle["latest"], "release_id": "v0.12.71+12071-macos"}, bundle["landing_page"]),
+            ({**bundle["latest"], "installer_sha256": "c" * 64}, bundle["landing_page"]),
+            (bundle["latest"], bundle["landing_page"].replace("omi.dmg", "latest.dmg")),
+        )
+        for latest, index in mutations:
+            with self.subTest(mutation=latest != bundle["latest"]):
+                with self.assertRaises(ValueError):
+                    VERIFIER.verify(latest, index, manifest(), "gs://updates-bucket")
+
+    def test_cli_reads_the_exact_downloaded_static_files(self) -> None:
+        bundle = REPAIR.build_repair_bundle(manifest(), "gs://updates-bucket")
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)
+            manifest_path = path / "manifest.json"
+            latest_path = path / "latest.json"
+            index_path = path / "index.html"
+            manifest_path.write_text(json.dumps(manifest()), encoding="utf-8")
+            latest_path.write_text(json.dumps(bundle["latest"]), encoding="utf-8")
+            index_path.write_text(bundle["landing_page"], encoding="utf-8")
+            self.assertEqual(
+                VERIFIER.main([
+                    "--manifest", str(manifest_path), "--latest", str(latest_path), "--index", str(index_path),
+                    "--bucket", "gs://updates-bucket",
+                ]),
+                0,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/verify_stable_static_artifacts.py
+++ b/.github/scripts/verify_stable_static_artifacts.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Verify exact Stable static publication against the retained manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from desktop_repair_installer import build_repair_bundle
+
+
+def verify(latest: object, index: str, manifest: dict, bucket: str) -> None:
+    """Fail closed unless both public stable artifacts equal the manifest render.
+
+    The retained manifest is the authority. Re-rendering its static repair
+    bundle makes the release ID, immutable DMG URL, SHA-256, and HTML download
+    target one comparison rather than trusting mutable release metadata.
+    """
+    if not isinstance(latest, dict):
+        raise ValueError("published stable latest.json must be a JSON object")
+    expected = build_repair_bundle(manifest, bucket)
+    if latest != expected["latest"]:
+        raise ValueError("published stable latest.json differs from the retained manifest identity")
+    if index != expected["landing_page"]:
+        raise ValueError("published stable index.html differs from the retained manifest installer identity")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--latest", type=Path, required=True)
+    parser.add_argument("--index", type=Path, required=True)
+    parser.add_argument("--bucket", required=True)
+    args = parser.parse_args(argv)
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    latest = json.loads(args.latest.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+        raise ValueError("retained manifest must be a JSON object")
+    verify(latest, args.index.read_text(encoding="utf-8"), manifest, args.bucket)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/desktop_promote_beta.yml
+++ b/.github/workflows/desktop_promote_beta.yml
@@ -1,6 +1,9 @@
 name: Promote Qualified Desktop Beta
 
 on:
+  workflow_run:
+    workflows: ["Qualify Desktop Beta Candidate"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       release_tag:
@@ -25,8 +28,23 @@ concurrency:
   group: desktop-beta-promotion
   cancel-in-progress: false
 
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.release_tag }}
+  QUALIFICATION_RUN_ID: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || inputs.qualification_run_id }}
+  AUTOMATIC_REQUEST: ${{ github.event_name == 'workflow_run' || inputs.automatic }}
+  QUALIFIER_EVENT_RUN_ID: ${{ github.event.workflow_run.id }}
+  QUALIFIER_EVENT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+
 jobs:
   promote:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'workflow_dispatch' &&
+      github.event.workflow_run.repository.full_name == github.repository &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.path == '.github/workflows/desktop_qualify_beta.yml' &&
+      github.event.workflow_run.name == 'Qualify Desktop Beta Candidate')
     environment: prod
     runs-on: ubuntu-latest
     steps:
@@ -44,10 +62,9 @@ jobs:
           private-key: ${{ secrets.OMI_BOT_PRIVATE_KEY }}
 
       - name: Validate automatic beta request
-        if: ${{ inputs.automatic }}
+        if: ${{ env.AUTOMATIC_REQUEST == 'true' }}
         env:
           AUTO_BETA_ENABLED: ${{ vars.DESKTOP_AUTO_BETA_ENABLED }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
           if [[ "${AUTO_BETA_ENABLED,,}" == "false" ]]; then
@@ -68,8 +85,8 @@ jobs:
       - name: Download immutable qualification evidence
         uses: actions/download-artifact@v7
         with:
-          name: desktop-qualification-evidence-${{ inputs.release_tag }}
-          run-id: ${{ inputs.qualification_run_id }}
+          name: desktop-qualification-evidence-${{ env.RELEASE_TAG }}
+          run-id: ${{ env.QUALIFICATION_RUN_ID }}
           github-token: ${{ github.token }}
           path: /tmp/desktop-qualification-evidence
 
@@ -77,9 +94,7 @@ jobs:
         id: candidate
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
           REPO: ${{ github.repository }}
-          QUALIFICATION_RUN_ID: ${{ inputs.qualification_run_id }}
         run: |
           set -euo pipefail
           if ! printf '%s\n' "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+(\.[0-9]+)?\+[0-9]+-macos$'; then
@@ -96,9 +111,13 @@ jobs:
           test "$(jq -r .head_repository.full_name <<<"$run")" = "$REPO"
           test "$(jq -r .event <<<"$run")" = workflow_dispatch
           test "$(jq -r .path <<<"$run")" = .github/workflows/desktop_qualify_beta.yml
-          test "$(jq -r .head_branch <<<"$run")" = main
+          test "$(jq -r .head_branch <<<"$run")" = "$RELEASE_TAG"
           test "$(jq -r .name <<<"$run")" = 'Qualify Desktop Beta Candidate'
           test "$(jq -r .head_sha <<<"$run")" = "$TARGET_SHA"
+          if [[ "$GITHUB_EVENT_NAME" == workflow_run ]]; then
+            test "$QUALIFICATION_RUN_ID" = "$QUALIFIER_EVENT_RUN_ID"
+            test "$QUALIFIER_EVENT_HEAD_SHA" = "$TARGET_SHA"
+          fi
           gh release view "$RELEASE_TAG" --repo "$REPO" \
             --json tagName,body,isDraft,isPrerelease,publishedAt,assets \
             > /tmp/desktop-beta-release.json
@@ -154,7 +173,6 @@ jobs:
       - name: Advance explicit beta pointer
         env:
           PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
           ADMIN_KEY=$(gcloud secrets versions access latest --secret=ADMIN_KEY --project "$PROJECT_ID")
@@ -175,7 +193,6 @@ jobs:
       - name: Mark GitHub release live beta
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -264,4 +281,4 @@ jobs:
           ADMIN_KEY=$(gcloud secrets versions access latest --secret=ADMIN_KEY --project "$PROJECT_ID")
           curl -fsS -X POST -H "secret-key: $ADMIN_KEY" \
             https://api.omi.me/v2/desktop/clear-cache >/dev/null
-          echo "Promoted ${{ inputs.release_tag }} to qualified beta." >> "$GITHUB_STEP_SUMMARY"
+          echo "Promoted $RELEASE_TAG to qualified beta." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/desktop_promote_prod.yml
+++ b/.github/workflows/desktop_promote_prod.yml
@@ -89,7 +89,7 @@ jobs:
           test "$(jq -r .head_repository.full_name <<<"$run")" = "$REPO"
           test "$(jq -r .event <<<"$run")" = workflow_dispatch
           test "$(jq -r .path <<<"$run")" = .github/workflows/desktop_qualify_beta.yml
-          test "$(jq -r .head_branch <<<"$run")" = main
+          test "$(jq -r .head_branch <<<"$run")" = "$RELEASE_TAG"
           test "$(jq -r .name <<<"$run")" = 'Qualify Desktop Beta Candidate'
           test "$(jq -r .head_sha <<<"$run")" = "$TARGET_SHA"
       - name: Google Auth
@@ -236,4 +236,11 @@ jobs:
           PY
           curl -fsS 'https://api.omi.me/v2/desktop/appcast.xml?identity=stable' > /tmp/stable-appcast.xml
           python3 .github/scripts/verify_stable_appcast.py --manifest /tmp/desktop-release-manifest.json --feed /tmp/stable-appcast.xml
-          echo "Stable pointer, exact manifest hashes, and appcast verified for $RELEASE_TAG." >> "$GITHUB_STEP_SUMMARY"
+          gcloud storage cat "$GCS_DESKTOP_UPDATES_BUCKET/stable/latest.json" > /tmp/published-stable-latest.json
+          gcloud storage cat "$GCS_DESKTOP_UPDATES_BUCKET/stable/index.html" > /tmp/published-stable-index.html
+          python3 .github/scripts/verify_stable_static_artifacts.py \
+            --manifest /tmp/desktop-release-manifest.json \
+            --latest /tmp/published-stable-latest.json \
+            --index /tmp/published-stable-index.html \
+            --bucket "$GCS_DESKTOP_UPDATES_BUCKET"
+          echo "Stable pointer, exact manifest hashes, appcast, and published static artifacts verified for $RELEASE_TAG." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/desktop_promote_prod.yml
+++ b/.github/workflows/desktop_promote_prod.yml
@@ -52,6 +52,15 @@ jobs:
     environment: prod
     runs-on: ubuntu-latest
     steps:
+      - name: Require explicit Stable confirmation
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+          OPERATION: ${{ inputs.operation }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/require_stable_promotion_confirmation.py \
+            --operation "$OPERATION" --confirm "$CONFIRM"
+
       - name: Checkout promotion controls
         uses: actions/checkout@v7
         with:
@@ -72,11 +81,9 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ inputs.release_tag }}
-          CONFIRM: ${{ inputs.confirm }}
           QUALIFICATION_RUN_ID: ${{ inputs.qualification_run_id }}
         run: |
           set -euo pipefail
-          test "$CONFIRM" = promote-stable || { echo 'confirm must be exactly: promote-stable' >&2; exit 1; }
           printf '%s\n' "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+(\.[0-9]+)?\+[0-9]+-macos$' || {
             echo "Invalid macOS release tag: $RELEASE_TAG" >&2; exit 1;
           }

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -28,12 +28,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout qualification controls
+      - name: Checkout exact qualification event source
         uses: actions/checkout@v7
         with:
-          # Manual workflow dispatch permits choosing a ref. Never execute
-          # branch-controlled scripts on this privileged self-hosted runner.
-          ref: main
+          # Codemagic dispatches this workflow only at the validated candidate
+          # tag. Pin the checkout to GitHub's immutable event SHA so neither a
+          # later main commit nor a mutable local tag ref can alter the bytes
+          # that qualification rebuilds.
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Generate Omi Bot token
@@ -49,6 +51,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           REPO: ${{ github.repository }}
+          EVENT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           if ! printf '%s\n' "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+-macos$'; then
@@ -70,7 +73,8 @@ jobs:
           LATEST_TAG=$(git for-each-ref --count=1 --sort=-v:refname --format='%(refname:strip=2)' 'refs/tags/v*-macos')
           test -n "$LATEST_TAG"
           TARGET_SHA=$(git rev-list -n1 "$RELEASE_TAG")
-          CHECKOUT_SHA=$(git rev-parse "$RELEASE_TAG")
+          CHECKOUT_SHA=$(git rev-parse HEAD)
+          test "$CHECKOUT_SHA" = "$EVENT_SHA"
           rm -rf /tmp/desktop-beta-qualification
           mkdir -p /tmp/desktop-beta-qualification
           gh release view "$RELEASE_TAG" --repo "$REPO" \

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -21,7 +21,7 @@ concurrency:
 
 # This workflow deliberately runs only on the dedicated, trusted macOS runner.
 # Do not add pull_request or push triggers: the runner has Docker and a GitHub
-# App token that can request beta promotion after exact qualification passes.
+# App token for reading immutable candidate evidence.
 jobs:
   qualify:
     runs-on: [self-hosted, macos, omi-desktop-qualification]
@@ -143,16 +143,3 @@ jobs:
           name: desktop-qualification-evidence-${{ inputs.release_tag }}
           path: /tmp/desktop-beta-qualification/qualification-evidence.json
           if-no-files-found: error
-
-      - name: Request protected beta promotion
-        if: steps.candidate.outcome == 'success' && steps.qualify.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          gh workflow run desktop_promote_beta.yml --repo "$REPO" \
-            -f release_tag="$RELEASE_TAG" \
-            -f automatic=true \
-            -f qualification_run_id="$GITHUB_RUN_ID"

--- a/backend/tests/unit/test_desktop_release_scripts.py
+++ b/backend/tests/unit/test_desktop_release_scripts.py
@@ -385,8 +385,9 @@ def test_stable_workflow_allows_retained_repoint_but_requires_current_beta_for_p
     assert 'ref: main' in workflow
 
 
-def test_qualification_run_is_bound_to_the_exact_main_dispatch_and_workflow():
-    for workflow in (PROMOTE_BETA_WORKFLOW.read_text(), PROMOTE_PROD_WORKFLOW.read_text()):
+def test_qualification_run_is_bound_to_the_exact_candidate_tag_and_workflow():
+    beta_workflow = PROMOTE_BETA_WORKFLOW.read_text()
+    for workflow in (beta_workflow, PROMOTE_PROD_WORKFLOW.read_text()):
         assert 'gh api "repos/$REPO/actions/runs/$QUALIFICATION_RUN_ID"' in workflow
         assert 'jq -r .repository.full_name' in workflow
         assert 'jq -r .head_repository.full_name' in workflow
@@ -394,9 +395,13 @@ def test_qualification_run_is_bound_to_the_exact_main_dispatch_and_workflow():
         assert '= workflow_dispatch' in workflow
         assert 'jq -r .path' in workflow
         assert '= .github/workflows/desktop_qualify_beta.yml' in workflow
-        assert 'jq -r .head_branch' in workflow
-        assert '= main' in workflow
-        assert 'jq -r .head_sha' in workflow
+        assert 'test "$(jq -r .head_branch <<<"$run")" = "$RELEASE_TAG"' in workflow
+        assert 'test "$(jq -r .head_sha <<<"$run")" = "$TARGET_SHA"' in workflow
+
+    assert "workflow_run:" in beta_workflow
+    assert "github.event.workflow_run.conclusion == 'success'" in beta_workflow
+    assert 'test "$QUALIFICATION_RUN_ID" = "$QUALIFIER_EVENT_RUN_ID"' in beta_workflow
+    assert 'test "$QUALIFIER_EVENT_HEAD_SHA" = "$TARGET_SHA"' in beta_workflow
 
 
 def test_beta_promotion_controls_are_pinned_to_main_and_only_accept_lost_response_generation_plus_one():

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2925,6 +2925,7 @@ workflows:
           # duplicate dispatches; this bounded retry only handles dispatch I/O.
           for attempt in 1 2 3; do
             if gh workflow run desktop_qualify_beta.yml --repo "$GITHUB_REPO" \
+              --ref "$CM_TAG" \
               -f release_tag="$CM_TAG"; then
               echo "Trusted qualification dispatch accepted for $CM_TAG on attempt $attempt."
               exit 0

--- a/desktop/macos/Desktop/Sources/AppBuild.swift
+++ b/desktop/macos/Desktop/Sources/AppBuild.swift
@@ -7,6 +7,8 @@ enum AppBuild {
   /// it runs side-by-side with stable. Must stay in sync with
   /// `DesktopStorageIdentity.betaProductionBundleIdentifier` (asserted by a unit test).
   static let betaProductionBundleIdentifier = "com.omi.computer-macos.beta"
+  /// Stable and Omi Beta use distinct bundle identities but share the same
+  /// production backend family.
   static let productionFamilyBundleIdentifiers: Set<String> = [
     productionBundleIdentifier, betaProductionBundleIdentifier,
   ]

--- a/desktop/macos/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportService.swift
@@ -16,8 +16,8 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
 
   var id: String { rawValue }
 
-  /// Base of the hosted Omi API for this build — stable channel hits prod
-  /// (api.omi.me), beta hits dev (api.omiapi.com). Always ends with "/".
+  /// Base of the hosted Omi API for this build — Stable and Omi Beta are both
+  /// production-family clients of api.omi.me. Always ends with "/".
   static var mcpBaseURL: String {
     DesktopBackendEnvironment.pythonBaseURL()
   }

--- a/desktop/macos/changelog/unreleased/20260721-beta-release-promotion-hardening.json
+++ b/desktop/macos/changelog/unreleased/20260721-beta-release-promotion-hardening.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved the reliability and identity verification of Omi Beta qualification and update promotion"
+}

--- a/desktop/macos/e2e/SKILL.md
+++ b/desktop/macos/e2e/SKILL.md
@@ -231,12 +231,11 @@ path arms; `requery_fires_without_suppress=true` confirms the injected push *wou
 have requeried without the drag guard. Non-production bundles only.
 
 ### 2g. Inspect the feedback payload without submitting (SET-02)
-`FeedbackView.submitFeedback()` always fires a real Sentry event and attaches the app log
-plus a `desktop_diagnostics.json`, so there's no way to verify the payload is token-free
-without spamming Sentry. `dump_feedback_payload_dryrun` (non-prod only) assembles the
-**same** payload — the report title (`feedbackReportTitle`) and the diagnostics JSON
-(`writeDiagnosticsAttachment`, the exact builder the real submit uses) — and returns it
-**without** calling `SentrySDK`, so the diagnostics JSON can be secret-scanned.
+`FeedbackView.submitFeedback()` always fires a real Sentry event and attaches privacy-safe,
+redacted/allowlisted diagnostics in `desktop_diagnostics.json`; it does not upload a raw app
+log. `dump_feedback_payload_dryrun` (non-prod only) assembles the **same** report title
+(`feedbackReportTitle`) and diagnostics JSON (`writeDiagnosticsAttachment`, the exact builder
+the real submit uses) without calling `SentrySDK`, so the diagnostics JSON can be secret-scanned.
 
 ```bash
 cd desktop/macos
@@ -250,9 +249,9 @@ print("title:", d["sentry_message"]); print("secret hits:", hits or "NONE")'
 ```
 Assert `sentry_capture_invoked=false`, `would_submit_to_sentry=false`, and **no secret
 hits** in `diagnostics_json`. Empty `message` yields the "User Report (logs only)" title.
-The action returns the log only as **metadata** (`log_attachment_filename`/`_exists`/`_bytes`) —
-never its contents — so the bridge response itself can't leak the raw log. To confirm no
-Sentry event fired, check the app log has no "User report submitted to Sentry" line.
+The action returns diagnostics attachment metadata only (`log_attachment_filename`/`_exists`/
+`_bytes`) — never raw log contents — so the bridge response itself cannot leak app logs. To
+confirm no Sentry event fired, check the app log has no "User report submitted to Sentry" line.
 
 ### 2h. Prove /state survives a wedged main thread (bridge responsiveness)
 `GET /state` refreshes live UI fields on the MainActor. If the main thread is wedged


### PR DESCRIPTION
## Summary

Follow-up to #10163 that closes the final immutable-release review gaps discovered after the original PR merged.

- Dispatches privileged qualification at the exact candidate tag and checks out the event SHA.
- Triggers automatic Beta promotion only from a completed, successful, same-repository qualification `workflow_run`; the qualifier no longer dispatches promotion while still in progress.
- Verifies Stable static JSON/HTML publication against the retained manifest.
- Requires all four Stable/Beta installer identities in the release doctor.
- Requires typed confirmation before both Stable promote and retained-manifest repoint operations.
- Strengthens production deployment mutation guards for pre-auth rejection ordering and multiline persistent image overrides.
- Corrects stale Beta backend/bundle/diagnostics documentation.

## Product invariants affected

- INV-AUTH-1
- INV-INT-1
- INV-MEM-1

Failure-Class: FC-split-mutation-authority

## Verification

- Candidate-tag/completed-qualification mutation tests
- Stable confirmation/static publication tests
- Four-asset release doctor tests
- Production boundary/direct-writer mutation tests
- Desktop release and update backend suites
- `actionlint` on touched workflows
- `make preflight`
- `git diff --check`

## Safety

No workflow was dispatched. No cloud resource, release asset, Beta/Stable pointer, appcast, production bundle, credential, or deployment was mutated.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

