### PR TITLE
fix(release): bind Codemagic dispatch credential

### DIFF
--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -111,6 +111,10 @@ def check_desktop_codemagic_release() -> list[str]:
             errors.append(f"desktop qualification handoff is missing reliable dispatch fragment: {required_fragment}")
     dispatch_start = desktop_workflow_body.find("Dispatch trusted macOS beta qualification")
     dispatch_body = desktop_workflow_body[dispatch_start:] if dispatch_start != -1 else ""
+    if 'GH_TOKEN="${GITHUB_TOKEN:?desktop_secrets GITHUB_TOKEN is required for qualification dispatch}"' not in dispatch_body:
+        errors.append(
+            "Codemagic qualification dispatch must bind GH_TOKEN to the scoped desktop_secrets GITHUB_TOKEN"
+        )
     if "gh release edit \"$CM_TAG\"" in dispatch_body:
         errors.append("Codemagic must not write release-body dispatch state outside the trusted workflow serialiser")
     if "candidate remains non-live" not in desktop_workflow_body:

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2923,8 +2923,13 @@ workflows:
           set -euo pipefail
           # Per-tag GitHub concurrency and immutable qualification evidence own
           # duplicate dispatches; this bounded retry only handles dispatch I/O.
+          # Codemagic also loads appstore_credentials, whose legacy GH_TOKEN
+          # takes precedence over GITHUB_TOKEN in the GitHub CLI. Bind this
+          # handoff explicitly to the desktop_secrets token that is scoped for
+          # candidate-release and Actions-dispatch access.
           for attempt in 1 2 3; do
-            if gh workflow run desktop_qualify_beta.yml --repo "$GITHUB_REPO" \
+            if GH_TOKEN="${GITHUB_TOKEN:?desktop_secrets GITHUB_TOKEN is required for qualification dispatch}" \
+              gh workflow run desktop_qualify_beta.yml --repo "$GITHUB_REPO" \
               -f release_tag="$CM_TAG"; then
               echo "Trusted qualification dispatch accepted for $CM_TAG on attempt $attempt."
               exit 0

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1915,6 +1915,11 @@ workflows:
   #   RESEND_API_KEY
   #   SENTRY_AUTH_TOKEN, SENTRY_ADMIN_UID, SENTRY_WEBHOOK_SECRET
   #   REDIS_DB_HOST, REDIS_DB_PORT, REDIS_DB_PASSWORD
+  #   GITHUB_TOKEN                    — repo-scoped fine-grained token used only to dispatch
+  #                                     desktop_qualify_beta.yml; requires GitHub Actions: write.
+  #                                     Add Contents: write only if this credential is also used for
+  #                                     candidate-release publishing. Do not reuse the legacy
+  #                                     appstore_credentials GH_TOKEN for qualification dispatch.
   #   DESKTOP_AUTO_BETA_ENABLED       — optional emergency pause; set to false to leave candidates non-live
   #   NOTE: MACOS_DEVELOPER_ID_P12/P12_PASSWORD must NOT be in this group — they live in appstore_credentials
   #


### PR DESCRIPTION
## Summary
- Bind the Codemagic qualification `gh workflow run` command to `desktop_secrets` `GITHUB_TOKEN`.
- Prevent the legacy `appstore_credentials` `GH_TOKEN` from silently taking precedence in GitHub CLI.
- Add a release-process guard for that credential-binding contract.

## Product invariants affected
- INV-AUTH-1 — this change only selects the scoped CI credential; it does not alter end-user auth behavior.

## Verification
- `python3 .github/scripts/check-release-process-guards.py`
- `ruby -e 'require "yaml"; YAML.load_file("codemagic.yaml")'`
- Shell contract test with conflicting fake `GH_TOKEN` and `GITHUB_TOKEN`, confirming dispatch receives the scoped value.
- `make preflight`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

