### PR TITLE
fix(release): mktemp templates must end with XXXXXX for the dual smoke

### DIFF
--- a/desktop/macos/changelog/unreleased/20260721-dual-smoke-mktemp.json
+++ b/desktop/macos/changelog/unreleased/20260721-dual-smoke-mktemp.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a release-pipeline check that blocked the first side-by-side Omi Beta build from publishing"
+}

--- a/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
+++ b/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
@@ -410,7 +410,10 @@ assert_signing_and_entitlements() {
   [[ -n "$runtime" ]] || fail "signed app is missing hardened runtime metadata"
 
   local entitlements
-  entitlements="$(mktemp "${TMPDIR:-/tmp}/omi-entitlements.XXXXXX.plist")"
+  # macOS mktemp does not substitute X's followed by a suffix — the literal
+  # template file then collides when the smoke runs twice in one build
+  # (stable + Omi Beta). Templates must end with XXXXXX.
+  entitlements="$(mktemp "${TMPDIR:-/tmp}/omi-entitlements.XXXXXX")"
   codesign -d --entitlements :- "$APP_BUNDLE" >"$entitlements" 2>/dev/null || fail "could not read app entitlements"
 
   if /usr/libexec/PlistBuddy -c "Print :com.apple.security.get-task-allow" "$entitlements" >/dev/null 2>&1; then
@@ -581,7 +584,7 @@ prepare_notification_callback_canary() {
   [[ "$RUN_LAUNCH" == true ]] || fail "--notification-callback-canary requires --launch"
 
   if [[ -z "$NOTIFICATION_CALLBACK_MARKER" ]]; then
-    NOTIFICATION_CALLBACK_MARKER="$(mktemp "${TMPDIR:-/tmp}/omi-notification-callback.XXXXXX.json")"
+    NOTIFICATION_CALLBACK_MARKER="$(mktemp "${TMPDIR:-/tmp}/omi-notification-callback.XXXXXX")"
     NOTIFICATION_CALLBACK_MARKER_IS_TEMP=true
   fi
   rm -f "$NOTIFICATION_CALLBACK_MARKER"

--- a/desktop/macos/tests/test-signed-artifact-smoke.sh
+++ b/desktop/macos/tests/test-signed-artifact-smoke.sh
@@ -135,4 +135,12 @@ fi
 grep -q "SUFeedURL mismatch" /tmp/omi-smoke-beta-feed.err \
   && fail "--expected-feed-url should accept the identity-scoped feed"
 
+# Regression (v0.12.91 build failure): macOS mktemp creates the LITERAL template
+# file when characters follow the final XXXXXX, so the second smoke invocation
+# in one build (stable then Omi Beta) dies with "File exists". Every template
+# must end with XXXXXX.
+if grep -nE 'mktemp (-d )?"[^"]*XXXXXX[^"]+"' "$SMOKE"; then
+  fail "mktemp template with a suffix after XXXXXX breaks repeat smoke invocations"
+fi
+
 echo "signed artifact smoke tests passed"


### PR DESCRIPTION
## Fix: dual smoke fails on macOS mktemp suffix templates

First real run of the dual-identity smoke (v0.12.91) failed: macOS mktemp creates the LITERAL template file when characters follow the final XXXXXX (`omi-entitlements.XXXXXX.plist`), so the second smoke invocation in one build (the Omi Beta artifact from #10059) died with `File exists` and correctly fail-closed the candidate. Evidence: Codemagic build 6a5f010e997989ee56595dd1, step "Smoke signed desktop artifact" — stable smoke fully green, beta smoke died at entitlements extraction.

Both suffixed templates now end with XXXXXX, and `tests/test-signed-artifact-smoke.sh` gains a tripwire rejecting any suffixed template.

## Product invariants affected

- INV-AUTH-1

(path-glob match only: the smoke script carries the auth-storage canary; this change touches temp-file naming, not any auth/session behavior — the canary's assertions are unchanged.)

## Failure class

Failure-Class: none

Defect introduced by tonight's #10059 dual-smoke; never shipped a user-facing failure. Verified: `bash desktop/macos/tests/test-signed-artifact-smoke.sh` green (includes the new tripwire); bash -n both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

