### PR TITLE
fix(macos): make signed smoke entitlements temp file unique

### DIFF
--- a/desktop/macos/changelog/unreleased/20260721-signed-artifact-smoke-reliability.json
+++ b/desktop/macos/changelog/unreleased/20260721-signed-artifact-smoke-reliability.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved release reliability so new Omi Beta builds complete signed-artifact verification before they are published."
+}

--- a/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
+++ b/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
@@ -410,7 +410,7 @@ assert_signing_and_entitlements() {
   [[ -n "$runtime" ]] || fail "signed app is missing hardened runtime metadata"
 
   local entitlements
-  entitlements="$(mktemp "${TMPDIR:-/tmp}/omi-entitlements.XXXXXX.plist")"
+  entitlements="$(mktemp "${TMPDIR:-/tmp}/omi-entitlements.plist.XXXXXX")"
   codesign -d --entitlements :- "$APP_BUNDLE" >"$entitlements" 2>/dev/null || fail "could not read app entitlements"
 
   if /usr/libexec/PlistBuddy -c "Print :com.apple.security.get-task-allow" "$entitlements" >/dev/null 2>&1; then

--- a/desktop/macos/tests/test-signed-artifact-smoke.sh
+++ b/desktop/macos/tests/test-signed-artifact-smoke.sh
@@ -71,6 +71,27 @@ grep -q -- "--expected-bundle-id requires a value" /tmp/omi-smoke-preview-missin
 
 tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/omi-smoke-test.XXXXXX")"
 TMP_ROOTS+=("$tmp_root")
+
+# omi-test-quality: source-inspection -- static contract: this native mktemp
+# template must end in Xs, because only the macOS implementation can exercise
+# its suffix handling deterministically in this hermetic script test.
+entitlements_template="$tmp_root/$(python3 - "$SMOKE" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+match = re.search(r'entitlements="\$\(mktemp "\$\{TMPDIR:-/tmp\}/([^"/]+)"\)"', source)
+if match is None:
+    raise SystemExit("entitlements mktemp template is missing")
+print(match.group(1))
+PY
+)"
+first_entitlements_path="$(mktemp "$entitlements_template")"
+second_entitlements_path="$(mktemp "$entitlements_template")"
+[[ "$first_entitlements_path" != "$second_entitlements_path" ]] \
+  || fail "entitlements mktemp template must create a distinct path for each signed artifact smoke"
+
 tmp_app="$tmp_root/omi.app"
 mkdir -p "$tmp_app/Contents/MacOS" "$tmp_app/Contents/Resources" "$tmp_app/Contents/Frameworks"
 cat > "$tmp_app/Contents/Info.plist" <<'PLIST'


### PR DESCRIPTION
## Summary
- Fix the signed-artifact smoke entitlements `mktemp` template so BSD `mktemp` substitutes a trailing `XXXXXX` sequence.
- Add a hermetic regression test that invokes the production template twice and requires distinct files.

## Product invariants affected
- INV-AUTH-1

## Failure-Class
Failure-Class: none

## Verification
- RED: `cd desktop/macos && bash tests/test-signed-artifact-smoke.sh` failed before the fix with `mktemp: mkstemp failed on .../omi-entitlements.XXXXXX.plist: File exists`.
- GREEN: `cd desktop/macos && bash tests/test-signed-artifact-smoke.sh`
- `cd desktop/macos && bash -n scripts/smoke-signed-desktop-artifact.sh && bash -n tests/test-signed-artifact-smoke.sh && python3 scripts/check_desktop_test_quality.py`
- `python3 .github/scripts/check-release-process-guards.py`
- `python3 .github/scripts/test_check_desktop_auto_beta_candidate.py`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

