### PR TITLE
fix(admin): response reliability charts dropped newest days (HogQL default LIMIT 100)

### DIFF
--- a/web/admin/app/api/omi/stats/response-reliability/route.ts
+++ b/web/admin/app/api/omi/stats/response-reliability/route.ts
@@ -27,12 +27,16 @@ async function getReliabilityChannels(
   const channelByActor = new Map<string, ReliabilityChannel>();
   const db = getDb();
 
-  for (const actorIdChunk of chunk(actorIds, 30)) {
-    const snapshot = await db
-      .collection("users")
-      .where(admin.firestore.FieldPath.documentId(), "in", actorIdChunk)
-      .select("update_channel")
-      .get();
+  const snapshots = await Promise.all(
+    chunk(actorIds, 30).map((actorIdChunk) =>
+      db
+        .collection("users")
+        .where(admin.firestore.FieldPath.documentId(), "in", actorIdChunk)
+        .select("update_channel")
+        .get(),
+    ),
+  );
+  for (const snapshot of snapshots) {
     for (const doc of snapshot.docs) {
       const updateChannel = String(doc.get("update_channel") || "");
       channelByActor.set(
@@ -103,10 +107,10 @@ export async function GET(request: NextRequest) {
 
   const chatRows = chatAvailable ? chatResult.value : [];
   const voiceRows = voiceAvailable ? voiceResult.value : [];
-  if (
+  const truncated =
     chatRows.length >= RELIABILITY_ROW_LIMIT ||
-    voiceRows.length >= RELIABILITY_ROW_LIMIT
-  ) {
+    voiceRows.length >= RELIABILITY_ROW_LIMIT;
+  if (truncated) {
     console.warn("Response reliability rows hit the HogQL limit", {
       chatRows: chatRows.length,
       voiceRows: voiceRows.length,
@@ -132,6 +136,7 @@ export async function GET(request: NextRequest) {
     voiceRows,
     chatAvailable,
     voiceAvailable,
+    truncated,
   });
 
   return NextResponse.json({
@@ -143,6 +148,7 @@ export async function GET(request: NextRequest) {
       chatAvailable,
       voiceAvailable,
       channelByActor,
+      truncated,
     }),
   });
 }

--- a/web/admin/app/api/omi/stats/response-reliability/route.ts
+++ b/web/admin/app/api/omi/stats/response-reliability/route.ts
@@ -6,6 +6,7 @@ import { posthogResults } from "@/lib/posthog";
 import {
   buildChannelReliabilityPayloads,
   buildResponseReliabilityPayload,
+  RELIABILITY_ROW_LIMIT,
   type ReliabilityChannel,
   responseReliabilityQueries,
 } from "@/lib/response-reliability";
@@ -102,6 +103,16 @@ export async function GET(request: NextRequest) {
 
   const chatRows = chatAvailable ? chatResult.value : [];
   const voiceRows = voiceAvailable ? voiceResult.value : [];
+  if (
+    chatRows.length >= RELIABILITY_ROW_LIMIT ||
+    voiceRows.length >= RELIABILITY_ROW_LIMIT
+  ) {
+    console.warn("Response reliability rows hit the HogQL limit", {
+      chatRows: chatRows.length,
+      voiceRows: voiceRows.length,
+      limit: RELIABILITY_ROW_LIMIT,
+    });
+  }
   const actorIds = Array.from(
     new Set(
       [

--- a/web/admin/components/dashboard/response-reliability-summary.tsx
+++ b/web/admin/components/dashboard/response-reliability-summary.tsx
@@ -50,21 +50,28 @@ const rateWithCounts = (
   value: number,
   success: number,
   failure: number,
-): string => `${Number(value).toFixed(1)}% (${success}/${success + failure})`;
+): string => `${formatRate(value)} (${success}/${success + failure})`;
 
 function ChannelReliabilityChart({
   data,
+  daily,
 }: {
   data: ResponseReliabilitySeries;
+  daily: ReliabilityDailyPoint[];
 }) {
   const chat = data.summary.chat;
   const voice = data.summary.voice;
   const failures = (chat?.failure ?? 0) + (voice?.failure ?? 0);
-  const daily = trimDailyToCoverage(data.daily);
   const hasData = daily.length > 0;
 
   return (
     <div className="flex h-full min-w-0 flex-col gap-2">
+      {data.partial && (
+        <div className="flex items-center gap-1.5 text-xs text-amber-500">
+          <AlertTriangle className="h-3.5 w-3.5" />
+          Partial data — a telemetry source failed or rows were truncated.
+        </div>
+      )}
       <div
         className="grid divide-x border-y py-2 text-xs"
         style={{ gridTemplateColumns: "repeat(3, minmax(0, 1fr))" }}
@@ -120,24 +127,16 @@ function ChannelReliabilityChart({
                   item: { payload?: ReliabilityDailyPoint },
                 ) => {
                   const point = item.payload;
-                  if (!point) return [`${Number(value).toFixed(1)}%`, name];
-                  return name === "Chat success"
-                    ? [
-                        rateWithCounts(
-                          value,
-                          point.chatSuccess,
-                          point.chatFailure,
-                        ),
-                        name,
-                      ]
-                    : [
-                        rateWithCounts(
-                          value,
-                          point.voiceSuccess,
-                          point.voiceFailure,
-                        ),
-                        name,
-                      ];
+                  if (!point) return [formatRate(value), name];
+                  const isChat = name === "Chat success";
+                  return [
+                    rateWithCounts(
+                      value,
+                      isChat ? point.chatSuccess : point.voiceSuccess,
+                      isChat ? point.chatFailure : point.voiceFailure,
+                    ),
+                    name,
+                  ];
                 }}
                 contentStyle={tooltipStyle}
               />
@@ -189,6 +188,15 @@ export function useResponseReliabilityItems({
   );
 
   return useMemo(() => {
+    const covered = (channel: "production" | "beta") => {
+      const series = data?.channels?.[channel];
+      return series ? trimDailyToCoverage(series.daily) : [];
+    };
+    const coveredByChannel = {
+      production: covered("production"),
+      beta: covered("beta"),
+    };
+
     const render = (channel: "production" | "beta") => {
       if (isLoading || !token) {
         return <div className="h-full animate-pulse rounded-md bg-muted/20" />;
@@ -201,7 +209,12 @@ export function useResponseReliabilityItems({
           </div>
         );
       }
-      return <ChannelReliabilityChart data={data.channels[channel]} />;
+      return (
+        <ChannelReliabilityChart
+          data={data.channels[channel]}
+          daily={coveredByChannel[channel]}
+        />
+      );
     };
 
     const subtitle = (channel: "production" | "beta") => {
@@ -214,10 +227,10 @@ export function useResponseReliabilityItems({
         (chat?.failure ?? 0) +
         (voice?.success ?? 0) +
         (voice?.failure ?? 0);
-      const covered = trimDailyToCoverage(series.daily);
+      const trimmed = coveredByChannel[channel];
       const range =
-        covered.length > 0 && covered.length < series.daily.length
-          ? `Since ${formatDay(covered[0].date)}`
+        trimmed.length > 0 && trimmed.length < series.daily.length
+          ? `Since ${formatDay(trimmed[0].date)}`
           : `Last ${series.days} days`;
       return `${range} · ${judged.toLocaleString()} judged responses`;
     };

--- a/web/admin/components/dashboard/response-reliability-summary.tsx
+++ b/web/admin/components/dashboard/response-reliability-summary.tsx
@@ -16,9 +16,11 @@ import {
 
 import type { ChartItem } from "@/components/dashboard/resizable-chart-grid";
 import { authenticatedFetcher } from "@/hooks/useAuthToken";
-import type {
-  ResponseReliabilityPayload,
-  ResponseReliabilitySeries,
+import {
+  trimDailyToCoverage,
+  type ReliabilityDailyPoint,
+  type ResponseReliabilityPayload,
+  type ResponseReliabilitySeries,
 } from "@/lib/response-reliability";
 
 const tooltipStyle = {
@@ -44,6 +46,12 @@ const formatDay = (value: string) =>
     timeZone: "UTC",
   });
 
+const rateWithCounts = (
+  value: number,
+  success: number,
+  failure: number,
+): string => `${Number(value).toFixed(1)}% (${success}/${success + failure})`;
+
 function ChannelReliabilityChart({
   data,
 }: {
@@ -52,9 +60,8 @@ function ChannelReliabilityChart({
   const chat = data.summary.chat;
   const voice = data.summary.voice;
   const failures = (chat?.failure ?? 0) + (voice?.failure ?? 0);
-  const hasData = data.daily.some(
-    (point) => point.chatSuccessRate != null || point.voiceSuccessRate != null,
-  );
+  const daily = trimDailyToCoverage(data.daily);
+  const hasData = daily.length > 0;
 
   return (
     <div className="flex h-full min-w-0 flex-col gap-2">
@@ -89,7 +96,7 @@ function ChannelReliabilityChart({
       <div className="min-h-0 flex-1">
         {hasData ? (
           <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={data.daily}>
+            <LineChart data={daily}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
               <XAxis
                 dataKey="date"
@@ -107,10 +114,31 @@ function ChannelReliabilityChart({
               />
               <Tooltip
                 labelFormatter={(value) => formatDay(String(value))}
-                formatter={(value: number, name: string) => [
-                  `${Number(value).toFixed(1)}%`,
-                  name,
-                ]}
+                formatter={(
+                  value: number,
+                  name: string,
+                  item: { payload?: ReliabilityDailyPoint },
+                ) => {
+                  const point = item.payload;
+                  if (!point) return [`${Number(value).toFixed(1)}%`, name];
+                  return name === "Chat success"
+                    ? [
+                        rateWithCounts(
+                          value,
+                          point.chatSuccess,
+                          point.chatFailure,
+                        ),
+                        name,
+                      ]
+                    : [
+                        rateWithCounts(
+                          value,
+                          point.voiceSuccess,
+                          point.voiceFailure,
+                        ),
+                        name,
+                      ];
+                }}
                 contentStyle={tooltipStyle}
               />
               <Legend wrapperStyle={{ fontSize: 11 }} />
@@ -120,7 +148,7 @@ function ChannelReliabilityChart({
                 name="Chat success"
                 stroke="#22c55e"
                 strokeWidth={2}
-                dot={false}
+                dot={{ r: 2, fill: "#22c55e", strokeWidth: 0 }}
                 connectNulls
                 isAnimationActive={false}
               />
@@ -130,7 +158,7 @@ function ChannelReliabilityChart({
                 name="Voice success"
                 stroke="#06b6d4"
                 strokeWidth={2}
-                dot={false}
+                dot={{ r: 2, fill: "#06b6d4", strokeWidth: 0 }}
                 connectNulls
                 isAnimationActive={false}
               />
@@ -186,7 +214,12 @@ export function useResponseReliabilityItems({
         (chat?.failure ?? 0) +
         (voice?.success ?? 0) +
         (voice?.failure ?? 0);
-      return `Last 30 days · ${judged.toLocaleString()} judged responses`;
+      const covered = trimDailyToCoverage(series.daily);
+      const range =
+        covered.length > 0 && covered.length < series.daily.length
+          ? `Since ${formatDay(covered[0].date)}`
+          : `Last ${series.days} days`;
+      return `${range} · ${judged.toLocaleString()} judged responses`;
     };
 
     return [

--- a/web/admin/lib/__tests__/response-reliability.test.ts
+++ b/web/admin/lib/__tests__/response-reliability.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
   buildChannelReliabilityPayloads,
   buildResponseReliabilityPayload,
+  RELIABILITY_ROW_LIMIT,
   responseReliabilityQueries,
+  trimDailyToCoverage,
 } from "../response-reliability";
 
 describe("response reliability", () => {
@@ -315,5 +317,76 @@ describe("response reliability", () => {
     );
     expect(queries.chat).toContain("distinct_id AS actor_id");
     expect(queries.voice).toContain("distinct_id AS actor_id");
+  });
+
+  // Static query-contract check: PostHog's query API silently truncates any
+  // HogQL result to 100 rows when the query carries no explicit LIMIT. These
+  // queries are ordered day ASC, so that default cut exactly the newest days
+  // off the dashboard (lines stopped days before today).
+  it("carries an explicit LIMIT so PostHog's default 100-row cap cannot drop the newest days", () => {
+    const queries = responseReliabilityQueries(30);
+    expect(queries.chat).toContain(`LIMIT ${RELIABILITY_ROW_LIMIT}`);
+    expect(queries.voice).toContain(`LIMIT ${RELIABILITY_ROW_LIMIT}`);
+    expect(RELIABILITY_ROW_LIMIT).toBeGreaterThanOrEqual(10_000);
+  });
+
+  it("trims leading empty days to telemetry coverage but keeps interior gaps", () => {
+    const payload = buildResponseReliabilityPayload({
+      days: 7,
+      now: new Date("2026-07-20T12:00:00Z"),
+      chatAvailable: true,
+      voiceAvailable: true,
+      chatRows: [
+        [
+          "2026-07-17",
+          "chat_agent_query_started",
+          "main_chat",
+          "unknown",
+          2,
+          0,
+        ],
+        [
+          "2026-07-17",
+          "chat_agent_query_completed",
+          "main_chat",
+          "unknown",
+          2,
+          9000,
+        ],
+        [
+          "2026-07-19",
+          "chat_agent_query_started",
+          "main_chat",
+          "unknown",
+          1,
+          0,
+        ],
+        ["2026-07-19", "chat_agent_error", "main_chat", "agent_error", 1, 0],
+      ],
+      voiceRows: [],
+    });
+
+    const trimmed = trimDailyToCoverage(payload.daily);
+    expect(payload.daily).toHaveLength(7);
+    expect(trimmed.map((point) => point.date)).toEqual([
+      "2026-07-17",
+      "2026-07-18",
+      "2026-07-19",
+      "2026-07-20",
+    ]);
+    expect(trimmed[0].chatSuccessRate).toBe(100);
+    expect(trimmed[1].chatSuccessRate).toBeNull();
+    expect(trimmed[2].chatSuccessRate).toBe(0);
+
+    expect(trimDailyToCoverage([])).toEqual([]);
+    const empty = buildResponseReliabilityPayload({
+      days: 7,
+      now: new Date("2026-07-20T12:00:00Z"),
+      chatAvailable: true,
+      voiceAvailable: true,
+      chatRows: [],
+      voiceRows: [],
+    });
+    expect(trimDailyToCoverage(empty.daily)).toEqual([]);
   });
 });

--- a/web/admin/lib/__tests__/response-reliability.test.ts
+++ b/web/admin/lib/__tests__/response-reliability.test.ts
@@ -319,15 +319,59 @@ describe("response reliability", () => {
     expect(queries.voice).toContain("distinct_id AS actor_id");
   });
 
-  // Static query-contract check: PostHog's query API silently truncates any
-  // HogQL result to 100 rows when the query carries no explicit LIMIT. These
-  // queries are ordered day ASC, so that default cut exactly the newest days
-  // off the dashboard (lines stopped days before today).
+  // Static query-contract check: PostHog's query API silently fills LIMIT 100
+  // into any HogQL (sub)query without one. These queries are ordered day ASC,
+  // so that default cut exactly the newest days off the dashboard (lines
+  // stopped days before today). A trailing LIMIT after UNION ALL binds to the
+  // last arm only, so the voice union must be wrapped in a subquery with one
+  // outer LIMIT.
   it("carries an explicit LIMIT so PostHog's default 100-row cap cannot drop the newest days", () => {
     const queries = responseReliabilityQueries(30);
     expect(queries.chat).toContain(`LIMIT ${RELIABILITY_ROW_LIMIT}`);
-    expect(queries.voice).toContain(`LIMIT ${RELIABILITY_ROW_LIMIT}`);
-    expect(RELIABILITY_ROW_LIMIT).toBeGreaterThanOrEqual(10_000);
+    expect(queries.voice).toContain("SELECT * FROM (");
+    expect(queries.voice.replace(/\s+/g, " ")).toContain(
+      `) ORDER BY day ASC LIMIT ${RELIABILITY_ROW_LIMIT}`,
+    );
+    // The route detects truncation via rows.length >= RELIABILITY_ROW_LIMIT,
+    // so the constant must equal PostHog's served maximum — verified live:
+    // LIMIT 100000 returns exactly 50000 rows. A larger constant would make
+    // the overflow check unreachable and truncation undetectable.
+    expect(RELIABILITY_ROW_LIMIT).toBe(50_000);
+  });
+
+  it("marks the payload partial when rows hit the query row limit", () => {
+    const truncatedPayload = buildResponseReliabilityPayload({
+      days: 7,
+      now: new Date("2026-07-20T12:00:00Z"),
+      chatAvailable: true,
+      voiceAvailable: true,
+      truncated: true,
+      chatRows: [
+        [
+          "2026-07-20",
+          "chat_agent_query_completed",
+          "main_chat",
+          "unknown",
+          2,
+          4_000,
+        ],
+      ],
+      voiceRows: [],
+    });
+    expect(truncatedPayload.partial).toBe(true);
+
+    const channels = buildChannelReliabilityPayloads({
+      days: 7,
+      now: new Date("2026-07-20T12:00:00Z"),
+      chatAvailable: true,
+      voiceAvailable: true,
+      truncated: true,
+      chatRows: [],
+      voiceRows: [],
+      channelByActor: new Map(),
+    });
+    expect(channels.production.partial).toBe(true);
+    expect(channels.beta.partial).toBe(true);
   });
 
   it("trims leading empty days to telemetry coverage but keeps interior gaps", () => {
@@ -388,5 +432,50 @@ describe("response reliability", () => {
       voiceRows: [],
     });
     expect(trimDailyToCoverage(empty.daily)).toEqual([]);
+
+    // A first day with only cancellations is coverage (an all-cancelled
+    // rollout day is a signal), not a pre-coverage gap to trim away.
+    const excludedOnly = buildResponseReliabilityPayload({
+      days: 7,
+      now: new Date("2026-07-20T12:00:00Z"),
+      chatAvailable: true,
+      voiceAvailable: true,
+      chatRows: [
+        [
+          "2026-07-18",
+          "chat_agent_query_started",
+          "main_chat",
+          "unknown",
+          3,
+          0,
+        ],
+        [
+          "2026-07-18",
+          "chat_agent_query_cancelled",
+          "main_chat",
+          "unknown",
+          3,
+          0,
+        ],
+        [
+          "2026-07-19",
+          "chat_agent_query_started",
+          "main_chat",
+          "unknown",
+          1,
+          0,
+        ],
+        [
+          "2026-07-19",
+          "chat_agent_query_completed",
+          "main_chat",
+          "unknown",
+          1,
+          5_000,
+        ],
+      ],
+      voiceRows: [],
+    });
+    expect(trimDailyToCoverage(excludedOnly.daily)[0]?.date).toBe("2026-07-18");
   });
 });

--- a/web/admin/lib/posthog.ts
+++ b/web/admin/lib/posthog.ts
@@ -23,7 +23,9 @@ const SOFT_TTL_MS = 30 * 60 * 1000; // serve cached without re-querying for 30 m
 
 type CacheDoc = { payload: string; freshAt: number };
 
-async function readCache(key: string): Promise<{ results: unknown[]; freshAt: number } | null> {
+async function readCache(
+  key: string,
+): Promise<{ results: unknown[]; freshAt: number } | null> {
   try {
     const snap = await getDb().collection(CACHE_COLLECTION).doc(key).get();
     if (!snap.exists) return null;
@@ -39,7 +41,10 @@ async function writeCache(key: string, results: unknown[]): Promise<void> {
   try {
     const payload = JSON.stringify(results);
     if (payload.length > 900_000) return; // Firestore field cap ~1 MB; skip oversized
-    await getDb().collection(CACHE_COLLECTION).doc(key).set({ payload, freshAt: Date.now() });
+    await getDb()
+      .collection(CACHE_COLLECTION)
+      .doc(key)
+      .set({ payload, freshAt: Date.now() });
   } catch {
     // best-effort cache write; never block the response
   }
@@ -95,7 +100,8 @@ export async function cachedPosthogFetch(
     });
 
   const cached = await readCache(key);
-  if (cached && Date.now() - cached.freshAt < softTtlMs) return hit(cached.results);
+  if (cached && Date.now() - cached.freshAt < softTtlMs)
+    return hit(cached.results);
 
   const res = await posthogFetch(host, projectId, apiKey, query);
   if (res.ok) {
@@ -140,6 +146,17 @@ export async function posthogResults(
     }
     const raw = await res.json();
     const results = Array.isArray(raw.results) ? raw.results : [];
+    // PostHog fills LIMIT 100 into any HogQL (sub)query that has none and
+    // truncates silently — exactly 100 rows from a LIMIT-less query is the
+    // signature of that cap (it cut the newest days off response-reliability).
+    if (results.length === 100 && !/\blimit\b/i.test(query)) {
+      console.warn(
+        "PostHog returned exactly 100 rows for a query without LIMIT — likely truncated by the default cap",
+        {
+          querySnippet: query.replace(/\s+/g, " ").trim().slice(0, 160),
+        },
+      );
+    }
     await writeCache(key, results);
     return results;
   } catch (err) {

--- a/web/admin/lib/response-reliability.ts
+++ b/web/admin/lib/response-reliability.ts
@@ -101,6 +101,12 @@ const CHAT_COMPLETED = "chat_agent_query_completed";
 const CHAT_FAILED = "chat_agent_error";
 const CHAT_CANCELLED = "chat_agent_query_cancelled";
 
+// PostHog's query API silently applies LIMIT 100 when the query has no LIMIT.
+// These queries group by actor_id and order by day ASC, so the default limit
+// truncated exactly the newest days off the charts. Keep the explicit LIMIT at
+// PostHog's per-query maximum and have callers treat a full page as overflow.
+export const RELIABILITY_ROW_LIMIT = 10_000;
+
 const emptyMetric = (): MutableMetric => ({
   attempts: 0,
   success: 0,
@@ -223,6 +229,7 @@ export function responseReliabilityQueries(days: number): {
         AND toString(properties.surface) != 'floating_voice'
       GROUP BY day, event, surface, reason, actor_id
       ORDER BY day ASC
+      LIMIT ${RELIABILITY_ROW_LIMIT}
     `,
     voice: `
       SELECT
@@ -266,8 +273,23 @@ export function responseReliabilityQueries(days: number): {
         AND toString(properties.surface) = 'floating_voice'
       GROUP BY day, health_event, outcome, reason, route, intent, actor_id
       ORDER BY day ASC
+      LIMIT ${RELIABILITY_ROW_LIMIT}
     `,
   };
+}
+
+/**
+ * Drop leading days that have no judged responses so charts start where
+ * telemetry coverage actually begins instead of rendering weeks of empty axis.
+ * Interior gaps are kept — those are real usage gaps.
+ */
+export function trimDailyToCoverage(
+  daily: ReliabilityDailyPoint[],
+): ReliabilityDailyPoint[] {
+  const first = daily.findIndex(
+    (point) => point.chatSuccessRate != null || point.voiceSuccessRate != null,
+  );
+  return first === -1 ? [] : daily.slice(first);
 }
 
 export function buildResponseReliabilityPayload({

--- a/web/admin/lib/response-reliability.ts
+++ b/web/admin/lib/response-reliability.ts
@@ -101,11 +101,19 @@ const CHAT_COMPLETED = "chat_agent_query_completed";
 const CHAT_FAILED = "chat_agent_error";
 const CHAT_CANCELLED = "chat_agent_query_cancelled";
 
-// PostHog's query API silently applies LIMIT 100 when the query has no LIMIT.
+// PostHog's query API silently applies LIMIT 100 when a query has no LIMIT.
 // These queries group by actor_id and order by day ASC, so the default limit
-// truncated exactly the newest days off the charts. Keep the explicit LIMIT at
-// PostHog's per-query maximum and have callers treat a full page as overflow.
-export const RELIABILITY_ROW_LIMIT = 10_000;
+// truncated exactly the newest days off the charts. In HogQL a trailing
+// ORDER BY/LIMIT after UNION ALL binds to the last arm only (verified against
+// PostHog: `SELECT 1 UNION ALL SELECT 2 LIMIT 1` returns 2 rows), so the voice
+// union is wrapped in a subquery with one outer LIMIT.
+//
+// 50_000 is PostHog's served maximum, verified live: LIMIT 100000 returns
+// exactly 50000 rows. The route's overflow tripwire compares row counts
+// against this constant, so it must equal the effective cap — a larger value
+// would make `rows.length >= RELIABILITY_ROW_LIMIT` unreachable and
+// truncation undetectable (the tests pin this).
+export const RELIABILITY_ROW_LIMIT = 50_000;
 
 const emptyMetric = (): MutableMetric => ({
   attempts: 0,
@@ -232,6 +240,7 @@ export function responseReliabilityQueries(days: number): {
       LIMIT ${RELIABILITY_ROW_LIMIT}
     `,
     voice: `
+      SELECT * FROM (
       SELECT
         toString(toDate(timestamp)) AS day,
         toString(properties.health_event) AS health_event,
@@ -272,6 +281,7 @@ export function responseReliabilityQueries(days: number): {
         AND toIntOrZero(toString(properties.telemetry_schema_version)) >= 2
         AND toString(properties.surface) = 'floating_voice'
       GROUP BY day, health_event, outcome, reason, route, intent, actor_id
+      )
       ORDER BY day ASC
       LIMIT ${RELIABILITY_ROW_LIMIT}
     `,
@@ -279,15 +289,21 @@ export function responseReliabilityQueries(days: number): {
 }
 
 /**
- * Drop leading days that have no judged responses so charts start where
- * telemetry coverage actually begins instead of rendering weeks of empty axis.
- * Interior gaps are kept — those are real usage gaps.
+ * Drop leading days with no telemetry activity so charts start where coverage
+ * actually begins instead of rendering weeks of empty axis. A day with only
+ * excluded turns (cancellations, silent voice) still counts as coverage —
+ * an all-cancelled first day is a signal, not a gap. Interior gaps are kept —
+ * those are real usage gaps.
  */
 export function trimDailyToCoverage(
   daily: ReliabilityDailyPoint[],
 ): ReliabilityDailyPoint[] {
   const first = daily.findIndex(
-    (point) => point.chatSuccessRate != null || point.voiceSuccessRate != null,
+    (point) =>
+      point.chatSuccessRate != null ||
+      point.voiceSuccessRate != null ||
+      point.chatExcluded > 0 ||
+      point.voiceExcluded > 0,
   );
   return first === -1 ? [] : daily.slice(first);
 }
@@ -298,6 +314,7 @@ export function buildResponseReliabilityPayload({
   voiceRows,
   chatAvailable,
   voiceAvailable,
+  truncated = false,
   now = new Date(),
 }: {
   days: number;
@@ -305,6 +322,7 @@ export function buildResponseReliabilityPayload({
   voiceRows: unknown[];
   chatAvailable: boolean;
   voiceAvailable: boolean;
+  truncated?: boolean;
   now?: Date;
 }): ResponseReliabilitySeries {
   const safeDays = Math.min(Math.max(Math.trunc(days), 1), 90);
@@ -473,7 +491,7 @@ export function buildResponseReliabilityPayload({
   return {
     days: safeDays,
     generatedAt: now.getTime(),
-    partial: !chatAvailable || !voiceAvailable,
+    partial: !chatAvailable || !voiceAvailable || truncated,
     availability: {
       chat: chatAvailable,
       voice: voiceAvailable,
@@ -498,6 +516,7 @@ export function buildChannelReliabilityPayloads({
   chatAvailable,
   voiceAvailable,
   channelByActor,
+  truncated = false,
   now = new Date(),
 }: {
   days: number;
@@ -506,6 +525,7 @@ export function buildChannelReliabilityPayloads({
   chatAvailable: boolean;
   voiceAvailable: boolean;
   channelByActor: Map<string, ReliabilityChannel>;
+  truncated?: boolean;
   now?: Date;
 }): Record<ReliabilityChannel, ResponseReliabilitySeries> {
   const rowsForChannel = (
@@ -526,6 +546,7 @@ export function buildChannelReliabilityPayloads({
       voiceRows: rowsForChannel(voiceRows, 9, channel),
       chatAvailable,
       voiceAvailable,
+      truncated,
       now,
     });
 


### PR DESCRIPTION
## What

The response-reliability charts (added in #10175) were cutting off the newest days — production chat stopped at Jul 17 on a Jul 21 dashboard — and rendered mostly-empty 30-day axes. Root cause: the HogQL queries carried no `LIMIT`, so PostHog's query API filled in its **default LIMIT 100 per (sub)query**. Rows are grouped per `(day, event, surface, reason, actor)` and ordered `day ASC`, so the cap dropped exactly the newest days, worse every day as volume grows (raw PostHog had 21/11/32 started events on Jul 18–20 that never reached the chart).

## Fixes

- **Explicit `LIMIT 50000` on both queries.** 50k is PostHog's actual served maximum, verified live (`LIMIT 100000` returns exactly 50000 rows); the overflow tripwire compares `rows.length >= RELIABILITY_ROW_LIMIT`, so the constant must equal the effective cap — the test pins it.
- **Voice union wrapped in a subquery with one outer `ORDER BY`/`LIMIT`.** In HogQL a trailing LIMIT after `UNION ALL` binds to the last arm only (verified: `SELECT 1 UNION ALL SELECT 2 LIMIT 1` → 2 rows), so the physical_shortcut arm would have kept the default cap.
- **Truncation is user-visible, not just logged:** hitting the row limit sets `partial: true` through both payload builders and the chart renders the amber partial-data warning per `web/admin/AGENTS.md`; the route still logs details.
- **Axes trimmed to telemetry coverage** (`trimDailyToCoverage`): charts start at the first day with activity instead of 3 empty weeks; subtitle says "Since Jul 13" when coverage begins inside the window. A leading all-cancelled day counts as coverage (it's a signal); interior gaps are kept.
- **Tooltips show judged counts** (`76.5% (13/17)`) so small-sample swings (beta's 0% days are single failed responses) are interpretable; 2px dots mark real data points vs `connectNulls` interpolation.
- **Class-level tripwire in `posthogResults`:** warns whenever a LIMIT-less query returns exactly 100 rows (the default-cap signature) — covers every admin route. Remaining class instances (releases/notifications routes, cache-size skip) tracked in #10190.
- Firestore channel-lookup chunks now fetch in parallel (actor fan-out is no longer bounded by ~100 rows).

## Verification

- Replayed the exact production PostHog rows + Firestore channel map through `buildChannelReliabilityPayloads`: without LIMIT the chat series ends 2026-07-18; with it, 2026-07-20 (today has no judged responses yet).
- Ran the dashboard locally (`next dev`, dev-bypass auth, production PostHog + Firestore): production chat line continuous Jul 13–20 (141 judged, "Since Jul 13"), beta Jul 15–20 (13 judged), voice days Jul 16/18/20 intact through the wrapped union, tooltip counts visible. Verified in Chrome and a clean Playwright browser; API `partial=false` in the healthy state, 401 without auth, `days=7` and invalid `days` behave.
- UNION/LIMIT semantics and the 50k cap verified against the live PostHog instance (queries in commit messages).
- `web/admin`: vitest 31 passed (8 reliability tests), `tsc --noEmit` clean.
- Six-agent adversarial review; all its confirmed findings addressed in the second commit.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

Single-instance defect in queries added yesterday (#10175); the shared-layer recurrences are inventoried with evidence in #10190 rather than broadened into this PR. A class tripwire (exact-100-rows warn in `posthogResults`) lands here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

