### PR TITLE
fix(desktop): surface global-hotkey registration conflicts instead of swallowing them (swarm slice 1/N)

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -360,6 +360,28 @@ final class DesktopDiagnosticsManager {
       captureSentry: false)
   }
 
+  /// Records a global-hotkey registration failure surfaced by Carbon
+  /// `RegisterEventHotKey`.
+  ///
+  /// This is a hard-terminal failure — the shortcut will not fire on this machine
+  /// (typically another app, or a macOS System Settings > Keyboard > Shortcuts
+  /// entry — even a disabled one — already owns the combination). Because no
+  /// provider, mode, or correctness path switches and there is nothing to fail
+  /// open to, the telemetry contract routes this through the incident path, not
+  /// `recordFallback`. `isConflict` distinguishes `eventHotKeyExistsErr` (-9878),
+  /// which is a property of the user's machine, from other `OSStatus` values.
+  func recordHotkeyRegistrationFailed(osStatus: Int, keycode: Int, modifiers: Int, isConflict: Bool) {
+    recordUserVisibleIssue(
+      area: "startup",
+      failureClass: isConflict ? "hotkey_conflict" : "unknown",
+      phase: "startup",
+      extra: [
+        "osstatus": osStatus,
+        "keycode": keycode,
+        "modifiers": modifiers,
+      ])
+  }
+
   /// Records a beta-only typed error trail entry. The caller passes free-form local
   /// log text only for local classification; no message or error description is
   /// retained in the trail or cloud attachment.
@@ -640,6 +662,7 @@ final class DesktopDiagnosticsManager {
     "is_near_zero", "watchdog_eligible", "consecutive_silent_turns", "tcc_microphone_granted",
     "input_device_class", "recovery_action", "recovery_result", "threshold",
     "component", "operation", "outcome", "error_domain", "error_code",
+    "osstatus", "keycode", "modifiers",
   ]
 
   func writeDiagnosticsAttachment() -> URL? {
@@ -1097,7 +1120,7 @@ final class DesktopDiagnosticsManager {
       "silent_capture", "tool_stall", "agent_error", "agent_runtime", "attachment_upload",
       "authentication", "bridge_unavailable", "bridge_start_failed", "browser_extension_missing",
       "concurrent_request", "encoding", "quota", "resource_exhausted", "session_setup",
-      "timeout", "transient_network", "unknown", "user_report",
+      "hotkey_conflict", "timeout", "transient_network", "unknown", "user_report",
     ]
     return allowed.contains(label) ? label : "other"
   }
@@ -1107,6 +1130,7 @@ final class DesktopDiagnosticsManager {
     "turn_audio_seconds", "voiced_audio_seconds",
     "peak", "rms", "is_near_zero", "watchdog_eligible", "consecutive_silent_turns",
     "tcc_microphone_granted", "input_device_class", "recovery_action", "recovery_result",
+    "osstatus", "keycode", "modifiers",
   ]
 
   private static let allowedFallbackAreas: Set<String> = [

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/GlobalShortcutManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/GlobalShortcutManager.swift
@@ -74,11 +74,37 @@ class GlobalShortcutManager: @unchecked Sendable {
       NSLog("GlobalShortcutManager: Ask Omi shortcut is not a registerable hotkey")
       return
     }
-    registerHotKey(keyCode: Int(keyCode), modifiers: askOmiShortcut.carbonModifiers, id: .askOmi)
-    NSLog("GlobalShortcutManager: Registered Ask Omi shortcut: \(askOmiShortcut.displayLabel)")
+    let outcome = registerHotKey(keyCode: Int(keyCode), modifiers: askOmiShortcut.carbonModifiers, id: .askOmi)
+    // Gate the success log on the registration outcome. Previously this logged
+    // "Registered" unconditionally — even when Carbon had rejected the combo
+    // (e.g. another app owns it) — which made the silent failure actively misleading.
+    if outcome == .registered {
+      NSLog("GlobalShortcutManager: Registered Ask Omi shortcut: \(askOmiShortcut.displayLabel)")
+    }
   }
 
-  private func registerHotKey(keyCode: Int, modifiers: Int, id: HotKeyID) {
+  /// Outcome of a Carbon `RegisterEventHotKey` attempt, classified for telemetry.
+  enum HotKeyRegistrationOutcome: Equatable {
+    case registered
+    case alreadyInUse
+    case otherFailure
+  }
+
+  /// Pure classifier over the `OSStatus` returned by `RegisterEventHotKey`.
+  ///
+  /// Extracted from `registerHotKey` so the registration-failure decision is
+  /// unit-testable without driving the real Carbon call, which cannot be made to
+  /// return a conflict status hermetically. `eventHotKeyExistsErr` (-9878,
+  /// CarbonEvents.h) means another app — or a macOS System Settings > Keyboard >
+  /// Shortcuts entry, even a disabled one — already owns this (keyCode, modifiers)
+  /// pair in the global Carbon hotkey namespace; the shortcut is dead on that machine.
+  static func classifyRegistration(_ status: OSStatus) -> HotKeyRegistrationOutcome {
+    if status == noErr { return .registered }
+    if Int(status) == eventHotKeyExistsErr { return .alreadyInUse }
+    return .otherFailure
+  }
+
+  private func registerHotKey(keyCode: Int, modifiers: Int, id: HotKeyID) -> HotKeyRegistrationOutcome {
     var hotKeyRef: EventHotKeyRef?
     let hotKeyID = EventHotKeyID(signature: FourCharCode(0x4F4D_4921), id: id.rawValue)  // "OMI!"
 
@@ -87,11 +113,22 @@ class GlobalShortcutManager: @unchecked Sendable {
       GetApplicationEventTarget(), 0, &hotKeyRef
     )
 
-    if status == noErr, let ref = hotKeyRef {
+    let outcome = Self.classifyRegistration(status)
+    if outcome == .registered, let ref = hotKeyRef {
       hotKeyRefs[id] = ref
     } else {
+      // The shortcut will not fire on this machine. Keep the local NSLog for
+      // debugging and surface the failure to ops/Sentry via the incident path
+      // (NOT recordFallback — this is a hard-terminal failure with no mode switch).
+      // User-visible conflict surfacing in shortcut settings is tracked separately.
       NSLog("GlobalShortcutManager: Failed to register hotkey (keycode \(keyCode)), error: \(status)")
+      DesktopDiagnosticsManager.shared.recordHotkeyRegistrationFailed(
+        osStatus: Int(status),
+        keycode: keyCode,
+        modifiers: modifiers,
+        isConflict: outcome == .alreadyInUse)
     }
+    return outcome
   }
 
   private func handleHotKeyEvent(_ event: EventRef) -> OSStatus {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/GlobalShortcutManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/GlobalShortcutManager.swift
@@ -90,16 +90,24 @@ class GlobalShortcutManager: @unchecked Sendable {
     case otherFailure
   }
 
-  /// Pure classifier over the `OSStatus` returned by `RegisterEventHotKey`.
+  /// Pure classifier over a `RegisterEventHotKey` result pair: the Carbon
+  /// `OSStatus` and whether a non-nil `EventHotKeyRef` was stored. This is the
+  /// controllable test seam — the real Carbon call cannot be made to return a
+  /// conflict status (or noErr with a nil ref) hermetically, so the registration
+  /// decision is unit-tested through this pure function instead.
   ///
-  /// Extracted from `registerHotKey` so the registration-failure decision is
-  /// unit-testable without driving the real Carbon call, which cannot be made to
-  /// return a conflict status hermetically. `eventHotKeyExistsErr` (-9878,
-  /// CarbonEvents.h) means another app — or a macOS System Settings > Keyboard >
-  /// Shortcuts entry, even a disabled one — already owns this (keyCode, modifiers)
-  /// pair in the global Carbon hotkey namespace; the shortcut is dead on that machine.
-  static func classifyRegistration(_ status: OSStatus) -> HotKeyRegistrationOutcome {
-    if status == noErr { return .registered }
+  /// A registration is successful ONLY when the status is `noErr` AND a non-nil
+  /// `EventHotKeyRef` was stored. Carbon can report `noErr` without filling the
+  /// out-ref; the prior code treated `status == noErr` with a nil ref as failure,
+  /// and this must stay failure — otherwise `registerHotKey` returns `.registered`
+  /// and `registerAskOmi` logs "Registered" for a shortcut that will never fire.
+  /// `eventHotKeyExistsErr` (-9878, CarbonEvents.h) means another app — or a macOS
+  /// System Settings > Keyboard > Shortcuts entry, even a disabled one — already
+  /// owns this (keyCode, modifiers) pair in the global Carbon hotkey namespace;
+  /// the shortcut is dead on that machine (its ref is nil, but the conflict flavor
+  /// is preserved for telemetry regardless of ref presence).
+  static func classifyRegistration(_ status: OSStatus, refPresent: Bool) -> HotKeyRegistrationOutcome {
+    if status == noErr, refPresent { return .registered }
     if Int(status) == eventHotKeyExistsErr { return .alreadyInUse }
     return .otherFailure
   }
@@ -113,7 +121,7 @@ class GlobalShortcutManager: @unchecked Sendable {
       GetApplicationEventTarget(), 0, &hotKeyRef
     )
 
-    let outcome = Self.classifyRegistration(status)
+    let outcome = Self.classifyRegistration(status, refPresent: hotKeyRef != nil)
     if outcome == .registered, let ref = hotKeyRef {
       hotKeyRefs[id] = ref
     } else {

--- a/desktop/macos/Desktop/Tests/GlobalShortcutManagerRegistrationTests.swift
+++ b/desktop/macos/Desktop/Tests/GlobalShortcutManagerRegistrationTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+
+@testable import Omi_Computer
+
+#if DEBUG
+  // omi-release-compile: this suite drives DEBUG-only test seams (resetForTests); the
+  // release-mode notification regression step must compile the bundle without them.
+
+  /// Behavioral coverage for the global-hotkey registration failure boundary.
+  ///
+  /// `RegisterEventHotKey` (Carbon) cannot be made to return a conflict status in a
+  /// hermetic test, so the registration-failure *decision* was extracted into the pure
+  /// `GlobalShortcutManager.classifyRegistration` classifier (the controllable seam).
+  /// The telemetry contract is then asserted by driving the production
+  /// `recordHotkeyRegistrationFailed` wrapper and reading the incident snapshot — the
+  /// same hermetic pattern used by `DesktopDiagnosticsManagerTests`.
+  final class GlobalShortcutManagerRegistrationTests: XCTestCase {
+    override func setUp() {
+      super.setUp()
+      DesktopDiagnosticsManager.shared.resetForTests()
+    }
+
+    override func tearDown() {
+      DesktopDiagnosticsManager.shared.resetForTests()
+      super.tearDown()
+    }
+
+    // MARK: - Registration outcome classifier (pure; no Carbon)
+
+    func testClassifyNoErrIsRegistered() {
+      XCTAssertEqual(GlobalShortcutManager.classifyRegistration(noErr), .registered)
+    }
+
+    func testClassifyEventHotKeyExistsErrIsConflict() {
+      // eventHotKeyExistsErr == -9878 (CarbonEvents.h): another app — or a macOS
+      // System Settings > Keyboard > Shortcuts entry, even a disabled one — already
+      // owns this (keyCode, modifiers) pair globally. Pure machine axis.
+      XCTAssertEqual(
+        GlobalShortcutManager.classifyRegistration(OSStatus(-9878)), .alreadyInUse)
+    }
+
+    func testClassifyOtherNonZeroStatusIsOtherFailure() {
+      // paramErr (-50) / eventInternalErr (-9870): programmer/runtime errors, not a
+      // machine-axis conflict, so they must NOT classify as .alreadyInUse.
+      XCTAssertEqual(
+        GlobalShortcutManager.classifyRegistration(OSStatus(-50)), .otherFailure)
+      XCTAssertEqual(
+        GlobalShortcutManager.classifyRegistration(OSStatus(-9870)), .otherFailure)
+    }
+
+    // MARK: - Telemetry contract (incident path, NOT recordFallback)
+
+    func testHotKeyConflictRecordsUserVisibleIssueIncident() throws {
+      // Cmd+O (keyCode 31) is the default Ask Omi binding; cmdKey == 256 (Carbon Events.h).
+      DesktopDiagnosticsManager.shared.recordHotkeyRegistrationFailed(
+        osStatus: -9878,
+        keycode: 31,
+        modifiers: 256,
+        isConflict: true)
+
+      let snapshot = try latestSnapshot()
+      XCTAssertEqual(snapshot["event"] as? String, "user_visible_issue")
+      XCTAssertEqual(snapshot["area"] as? String, "startup")
+      XCTAssertEqual(snapshot["failure_class"] as? String, "hotkey_conflict")
+      XCTAssertEqual(snapshot["phase"] as? String, "startup")
+      // osstatus/keycode/modifiers must survive the allowedIncidentExtraKeys filter
+      // (a regression here means the incident reaches ops with no Carbon detail).
+      XCTAssertEqual(snapshot["osstatus"] as? Int, -9878)
+      XCTAssertEqual(snapshot["keycode"] as? Int, 31)
+      XCTAssertEqual(snapshot["modifiers"] as? Int, 256)
+    }
+
+    func testNonConflictRegistrationFailureClassifiesAsUnknown() throws {
+      DesktopDiagnosticsManager.shared.recordHotkeyRegistrationFailed(
+        osStatus: -50,
+        keycode: 31,
+        modifiers: 256,
+        isConflict: false)
+
+      let snapshot = try latestSnapshot()
+      XCTAssertEqual(snapshot["event"] as? String, "user_visible_issue")
+      // Non-conflict failures reuse the existing `unknown` label rather than the
+      // conflict-specific class, so ops can discriminate the machine-axis cause.
+      XCTAssertEqual(snapshot["failure_class"] as? String, "unknown")
+      XCTAssertEqual(snapshot["osstatus"] as? Int, -50)
+    }
+
+    private func latestSnapshot(
+      file: StaticString = #filePath,
+      line: UInt = #line
+    ) throws -> [String: Any] {
+      let url = try XCTUnwrap(
+        DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment(),
+        file: file,
+        line: line)
+      defer { try? FileManager.default.removeItem(at: url) }
+
+      let data = try Data(contentsOf: url)
+      let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+      let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+      return try XCTUnwrap(snapshots.last, file: file, line: line)
+    }
+  }
+#endif

--- a/desktop/macos/Desktop/Tests/GlobalShortcutManagerRegistrationTests.swift
+++ b/desktop/macos/Desktop/Tests/GlobalShortcutManagerRegistrationTests.swift
@@ -27,25 +27,45 @@ import XCTest
 
     // MARK: - Registration outcome classifier (pure; no Carbon)
 
-    func testClassifyNoErrIsRegistered() {
-      XCTAssertEqual(GlobalShortcutManager.classifyRegistration(noErr), .registered)
+    func testClassifyNoErrWithRefIsRegistered() {
+      // The only success path: Carbon reports noErr AND stores a non-nil ref.
+      XCTAssertEqual(GlobalShortcutManager.classifyRegistration(noErr, refPresent: true), .registered)
+    }
+
+    // MARK: - noErr / nil-ref boundary (the exact regression this suite guards)
+
+    func testClassifyNoErrWithNilRefIsOtherFailure() {
+      // Carbon can report noErr without storing an EventHotKeyRef. This is the
+      // boundary an independent review flagged: previously classifyRegistration(noErr)
+      // returned .registered, so registerHotKey returned .registered and
+      // registerAskOmi logged "Registered" for a shortcut that will never fire,
+      // even though the else branch had just recorded a registration failure. The
+      // prior code treated status==noErr with a nil ref as failure; a registration
+      // is successful ONLY when BOTH the status is noErr AND a non-nil ref exists.
+      // Driving the pure controllable seam is the prescribed verification — the real
+      // Carbon call cannot be made to return noErr with a nil ref hermetically.
+      XCTAssertEqual(
+        GlobalShortcutManager.classifyRegistration(noErr, refPresent: false), .otherFailure)
     }
 
     func testClassifyEventHotKeyExistsErrIsConflict() {
       // eventHotKeyExistsErr == -9878 (CarbonEvents.h): another app — or a macOS
       // System Settings > Keyboard > Shortcuts entry, even a disabled one — already
-      // owns this (keyCode, modifiers) pair globally. Pure machine axis.
+      // owns this (keyCode, modifiers) pair globally. Pure machine axis. The ref is
+      // nil on conflict, but the conflict flavor is preserved regardless so the
+      // isConflict telemetry discrimination holds.
       XCTAssertEqual(
-        GlobalShortcutManager.classifyRegistration(OSStatus(-9878)), .alreadyInUse)
+        GlobalShortcutManager.classifyRegistration(OSStatus(-9878), refPresent: false), .alreadyInUse)
     }
 
     func testClassifyOtherNonZeroStatusIsOtherFailure() {
       // paramErr (-50) / eventInternalErr (-9870): programmer/runtime errors, not a
-      // machine-axis conflict, so they must NOT classify as .alreadyInUse.
+      // machine-axis conflict, so they must NOT classify as .alreadyInUse. A nil ref
+      // is the norm for these statuses, but the outcome is .otherFailure either way.
       XCTAssertEqual(
-        GlobalShortcutManager.classifyRegistration(OSStatus(-50)), .otherFailure)
+        GlobalShortcutManager.classifyRegistration(OSStatus(-50), refPresent: false), .otherFailure)
       XCTAssertEqual(
-        GlobalShortcutManager.classifyRegistration(OSStatus(-9870)), .otherFailure)
+        GlobalShortcutManager.classifyRegistration(OSStatus(-9870), refPresent: false), .otherFailure)
     }
 
     // MARK: - Telemetry contract (incident path, NOT recordFallback)


### PR DESCRIPTION
## What

Converts a silent OS-boundary failure into a reported one. `GlobalShortcutManager.registerHotKey` swallowed the `RegisterEventHotKey` `OSStatus` with a bare `NSLog`, and `registerAskOmi` then logged `"Registered Ask Omi shortcut"` **unconditionally** — so when Carbon rejected the combo the failure was both silent *and* actively misleading (the log claimed success). This is the first, evidence-led slice of the PTT/chat silent-failure swarm (Lane A): it makes the swarm's primary metric — silent failures converted to reported ones — move by one.

## Swarm context — this is slice 1 of N

Six independent read-only scouts investigated the swarm axes (synthesized findings in the commit/PR comments). This PR ships exactly **one** highest-confidence candidate. The rest are deliberately deferred:

| Finding | Disposition |
|---|---|
| **S1 — Global hotkey registration swallowed** | ✅ **This PR.** Verified 3 ways; narrowest (single production file + additive telemetry); the only raw-`NSLog` OS-boundary failure site in the PTT/shortcut/audio paths. |
| S2 — Secure Event Input suppresses PTT | ❌ **Dropped after verification.** PTT modifier-only activation uses `NSEvent` `.flagsChanged`, which SEI does **not** suppress (only `.keyDown`/`.keyUp` are). All four PTT presets are modifier-only, so the dominant path is unaffected. Filing the minority custom-key carve-out + the unrelated SEI barge-in sidebar as issues. |
| Audio `retryOrGiveUp` silent give-up | 📋 **Follow-up issue.** Strong candidate (mirrors `onSilentMicDetected`, no enum extension), but broader (3 files, touches the live PTT capture path). Better as its own slice. |
| `AgentBridge` session-token refresh (chat_bridge) | 📋 **Follow-up issue.** Textbook `recordFallback` case (credential switch), single call site, but has **no hermetic unit-test seam today**; verification needs a new `tier: fault` flow (clone `chat-fault-5xx.yaml` as `status:401`). The fault-injector scout confirmed fault flows belong *after* a Lane A fix. |
| S4 — hardcoded `sampleRate = 16000` | ✅ **No patch — already resolved.** Those three sites are constants fed to 16kHz-trained models/endpoints, not divisors. The real divide-by-zero boundary (`resampledFrameCapacity`) is already guarded + tested (`AudioCaptureResampleCapacityTests.swift`). #9649/#10105 were prior instances of *that* boundary. No third patch warranted. |
| Lane B fault vocab (audio/permission/display) | 📋 **Follow-up.** `omi-fault-inject.sh` is HTTP-only by design; non-HTTP faults belong as bridge actions driving the app's own seams. Lands after a Lane A fix for the flow to prove. |
| Settings-UI conflict surfacing ("prompt for a different binding") | 📋 **Follow-up.** The brief's full S1 fix is "surface a real conflict state in shortcut settings." This PR is the *observability* half; the user-visible settings half is a separate, strings-touching PR. |

No `ChatProvider.swift` or `FloatingControlBarWindow.swift` changes. No notch typed chat. No speculative retries / timing tweaks / blanket fallbacks.

## The change

- `GlobalShortcutManager`: extract a pure `HotKeyRegistrationOutcome` classifier over the Carbon `OSStatus` (`.registered` / `.alreadyInUse` / `.otherFailure`). `registerHotKey` routes the failure branch to the incident path; the misleading success log is gated on `.registered`. Success-path branch logic is unchanged.
- `DesktopDiagnosticsManager`: new `recordHotkeyRegistrationFailed(osStatus:keycode:modifiers:isConflict:)` wrapper around the existing private `recordUserVisibleIssue`. Three closed-set additions: `hotkey_conflict` to `safeIncidentLabel`; `osstatus`/`keycode`/`modifiers` to `allowedIncidentExtraKeys` **and** `cloudIncidentSnapshotKeys` (so the Carbon detail reaches both the snapshot and the Sentry attachment). These are labels/keys on an existing event, **not** new PostHog events or one-off counters.

## Telemetry-contract choice: incident, not fallback

Per `docs/agents/fallback-telemetry.md`, `recordFallback` is for branches that switch provider/mode/correctness or fail open. A hotkey that won't register is a **hard-terminal** failure (no continue, nothing to switch to) → the incident mechanism (`recordUserVisibleIssue` → PostHog `user_visible_issue` + Sentry `.warning`), exactly like `recordPTTSilentTurn`. `recordFallback` is deliberately **not** used.

## Evidence standard

- **Machine configuration:** a Mac where another app (Raycast / Alfred / Magnet / BetterTouchTool / a screenshot tool / …) or a **macOS System Settings → Keyboard → Shortcuts** entry — even a *disabled* one — has already registered the Ask Omi combination globally. The default Ask Omi binding is **⌘O** (`keyCode 31`, `ShortcutSettings.defaultAskOmiShortcut`), the universal File → Open combo and therefore unusually collision-prone.
- **API basis:** Carbon/HIToolbox `eventHotKeyExistsErr == -9878` (`CarbonEvents.h`). Hammerspoon issue #1261 reproduces this exactly (`RegisterEventHotKey failed: -9878` when the combo is owned by System Settings — including unticked entries — or another app). Pure machine axis, not our code.
- **Verification:** `GlobalShortcutManagerRegistrationTests` (5 cases) — classifier purity (`noErr` → `.registered`; `-9878` → `.alreadyInUse`; `-50`/`-9870` → `.otherFailure`) and the telemetry contract (the incident snapshot carries `area=startup`, `failure_class=hotkey_conflict`, `phase=startup`, and `osstatus`/`keycode`/`modifiers` survive the closed allowlist filter). Existing `DesktopDiagnosticsManagerTests` / `ShortcutSettingsTests` / `PushToTalkShortcutActivationTests` (27 cases) stay green. **The real conflict cannot be staged on our machines** (it depends on what else the user has installed), so the controllable-seam test is the prescribed verification per the swarm brief's evidence standard. A full named-bundle launch is not additionally informative for this slice: the success path is provably unchanged (`if outcome == .registered` ⟺ old `if status == noErr`), so the unit test already proves a normal registration does **not** trip a false-positive `hotkey_conflict` incident.
- **Expected telemetry/log outcome:** at app launch on an affected machine, a `desktop_health_event` `user_visible_issue` with `failure_class=hotkey_conflict` (Sentry-captured on prod/beta, 60 s de-duped per `area:failureClass`), where today there is none. On unaffected machines: no new incident; the previously-unconditional `"Registered Ask Omi shortcut"` log now only prints on real success.

## Product invariants affected

- **INV-CHAT-1** (path-based match only). `GlobalShortcutManager.swift` falls under the `desktop/macos/Desktop/Sources/FloatingControlBar/**` glob. This change adds registration-failure telemetry only; it does not touch the shared transcript, kernel projection, floating viewport, journal write-path, or introduce any second store — so the chat-continuity contract is unaffected and no guard-test update is needed.

## Definition of Done

- [x] Behavior change covered by a behavioral test through a controllable seam
- [x] Focused tests green (5 new + 27 existing); module compiles (`xcrun swift build` via the test target's `@testable import Omi_Computer`)
- [x] swift-format + SwiftLint (0 violations / 2445 files) + `check_desktop_test_quality.py` clean
- [x] `scripts/pr-preflight --suggest` → INV-CHAT-1 path-match named below (contract unaffected)
- [x] `Failure-Class` declared below and validated with `scripts/failure-class`
- [x] No new `TODO`/`FIXME`/`HACK`; no new CI gate/ratchet/guide

Failure-Class: none

No existing failure class fits the silent-OS-boundary archetype (the registry covers backend/release/runtime contracts, none for hotkey or OS-boundary observability), and `new` cannot be bootstrapped pre-merge: a new class definition requires a non-empty `evidence_prs` list of merged PR numbers. This is the first instance of the swarm's silent-OS-boundary class; a follow-up can register `FC-silent-os-boundary-failure` once this PR lands and supplies the first evidence number.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

