### PR TITLE
Reject an empty audio frame instead of stopping the Modulate send loop

### DIFF
--- a/backend/tests/unit/test_modulate_empty_frame_send_loop.py
+++ b/backend/tests/unit/test_modulate_empty_frame_send_loop.py
@@ -1,0 +1,74 @@
+"""Regression: an empty audio frame must not shut down the Modulate send loop.
+
+``b''`` is ``SafeModulateSocket``'s shutdown sentinel -- ``finish()`` enqueues it and
+``_send_loop`` breaks on it. ``send()`` did not reject an empty payload, so a zero-length audio
+frame enqueued that sentinel and ended the send loop mid-session. The socket is not marked dead in
+that path, so ``is_connection_dead`` stays False and ``send()`` keeps returning True: every later
+frame is queued to a loop nobody is reading, and the user's transcription silently stops for the
+rest of the session with no error and no reconnect. Both Parakeet sockets already guard with
+``if not data: return True``.
+
+Empty frames are reachable from the live path: ``send_live_stt_audio`` passes its ``audio``
+straight to ``stt_socket.send`` with no emptiness check, ``decide_multi_channel_stt_send`` takes
+``pcm_len`` only for usage accounting and never requires it to be non-zero, and
+``resample_pcm(b'', ...)`` returns ``b''`` (so a zero-length client frame, or a PCM multi-channel
+frame carrying only its channel byte, produces one).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from utils.stt.streaming import SafeModulateSocket
+
+REAL_AUDIO = b'real_audio_chunk'
+
+
+def _drive_send_loop(frames):
+    """Drive a real SafeModulateSocket over `frames`; return the frames that reached the provider."""
+    provider_frames = []
+    real_audio_seen = asyncio.Event()
+
+    async def record_provider_frame(frame):
+        provider_frames.append(frame)
+        if frame == REAL_AUDIO:
+            real_audio_seen.set()
+
+    ws = AsyncMock()
+    ws.send = AsyncMock(side_effect=record_provider_frame)
+    ws.close = AsyncMock()
+    loop = asyncio.new_event_loop()
+
+    async def run():
+        sock = SafeModulateSocket(ws, lambda _segments: None, loop, preseconds=0)
+        sock.set_wav_header(b'')
+        sock._recv_task.cancel()
+        for frame in frames:
+            sock.send(frame)
+        try:
+            await asyncio.wait_for(real_audio_seen.wait(), timeout=2)
+        except asyncio.TimeoutError:
+            # Let the caller's assertion report the real problem instead of a timeout traceback.
+            pass
+        sock.finish()
+        try:
+            await asyncio.wait_for(sock._send_task, timeout=2)
+        except asyncio.TimeoutError:
+            pass
+        await asyncio.gather(sock._recv_task, return_exceptions=True)
+        return provider_frames
+
+    try:
+        return loop.run_until_complete(run())
+    finally:
+        loop.close()
+
+
+def test_empty_audio_frame_does_not_stop_the_send_loop():
+    # The empty frame arrives first, then real audio. The real audio must still be delivered.
+    frames = _drive_send_loop([b'', REAL_AUDIO])
+    assert REAL_AUDIO in frames, 'send loop stopped on the empty frame; later audio never reached the provider'
+
+
+def test_normal_audio_still_streams_and_finish_stops_the_loop():
+    frames = _drive_send_loop([REAL_AUDIO])
+    assert REAL_AUDIO in frames

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -724,6 +724,13 @@ class SafeModulateSocket(STTSocket):
         with self._lock:
             if self._dead or self._closed:
                 return False
+            if not data:
+                # b'' is this socket's shutdown sentinel: _send_loop breaks on it and finish()
+                # uses it to stop the loop. Enqueuing an empty audio frame would therefore end
+                # the send loop mid-session while the socket still reports itself alive, so every
+                # later frame would be queued and never sent. The Parakeet sockets guard the same
+                # way. The header stays pending because _header_sent is only set once it is queued.
+                return True
             prepend_header = not self._header_sent and self._wav_header is not None
             queued_data = (self._wav_header or b'') + data if prepend_header else data
 


### PR DESCRIPTION
## Problem

`SafeModulateSocket` uses `b''` as its shutdown sentinel: `finish()` enqueues it and `_send_loop`
breaks on it.

```python
async def _send_loop(self) -> None:
    while not self._closed and not self._dead:
        data = await self._send_queue.get()
        if data == b'':
            break
```

`send()` did not reject an empty payload, so a zero-length audio frame enqueued that same sentinel
and ended the send loop mid-session.

The failure is silent and permanent for the rest of the session:

- the socket is not marked dead on that path, so `is_connection_dead` stays False and
  `live_stt_socket_is_dead()` reports it healthy
- `send()` keeps returning True, so `send_live_stt_audio` believes audio is flowing and never
  terminates or reconnects the session
- every later frame is queued to a loop nobody is reading

The user's transcription simply stops, with no error surfaced to the client.

## Reachability

An empty frame reaches `send()` from the live path:

- `send_live_stt_audio` (`utils/stt/live_failure.py`) passes its `audio` straight to
  `stt_socket.send(audio)` with no emptiness check.
- `decide_multi_channel_stt_send` (`utils/transcribe_decisions.py`) computes
  `should_send = socket_available and not fair_use_dg_budget_exhausted`. It takes `pcm_len` only for
  usage accounting and never requires it to be non-zero.
- `resample_pcm(b'', ...)` returns `b''`.
- In `_handle_multi_channel_audio` the `if not audio: return` guard sits inside the opus branch
  only. On the pcm codec path `audio = data[1:]`, so a frame carrying just its channel byte
  produces `b''`.

## Fix

Reject an empty payload in `SafeModulateSocket.send`, matching the guard both Parakeet sockets
already have (`if not data: return True`). The wav header stays pending because `_header_sent` is
only set once the header is actually queued, so the next real frame still prepends it.

## Tests

`tests/unit/test_modulate_empty_frame_send_loop.py` (new) drives a real `SafeModulateSocket` send
loop against a fake provider websocket, in the same harness style as the existing
`test_modulate_stt.py`:

- an empty frame followed by real audio: the real audio still reaches the provider
- normal audio still streams, and `finish()` still stops the loop

## Verification

Run in `backend/`:

- `pytest tests/unit/test_modulate_empty_frame_send_loop.py`: 2 passed
- prove-fail: with `utils/stt/streaming.py` reverted to origin/main and confirmed byte-identical
  (`git diff origin/main` empty), the empty-frame test fails with
  `assert b'real_audio_chunk' in []`, i.e. the provider received nothing at all after the empty
  frame. Reapplied: 2 passed
- `pytest tests/unit/test_modulate_stt.py tests/unit/test_live_stt_failure.py tests/unit/test_modulate_empty_frame_send_loop.py`: 108 passed
- `black --line-length 120 --skip-string-normalization --check`: clean
- `pyright -p pyrightconfig.json utils/stt/streaming.py`: 0 errors
- `scripts/check_module_stub_pollution.py`: 0 violations
- `scripts/scan_async_blockers.py --dirs routers utils`: 0 findings
- `scripts/scan_import_time_side_effects.py`: 0 violations
- `.github/scripts/check_product_file_line_count_ratchet.py`: OK, no line-count increase
- `scripts/pr-preflight --suggest`: product invariants affected none, no failure-class declaration required

## Impact

Any session on the Modulate STT provider, one of the two default serving providers, that receives a
single zero-length audio frame loses transcription for the rest of the session, silently and with no
reconnect. The guard is one condition and matches the two sibling sockets.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

