### PR TITLE
Persist the app summary results that _trigger_apps produces

### DIFF
--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -1025,3 +1025,81 @@ def test_trigger_apps_preferred_app_without_memories_capability_falls_through():
         process_conversation._trigger_apps("user-persona", conv)
 
     suggestion_mock.assert_called_once()
+
+
+# Regression: the durable write happens before _trigger_apps runs, so the app summary it produces
+# must be written back explicitly (like calendar_event / folder_id / audio_files already are).
+# Without that write-back the LLM output is computed and discarded: the detail view falls back to
+# structured.overview, a preferred summarization app never takes effect, the suggested-apps
+# endpoint stays empty, and PATCH /v1/conversations/{id}/summary has no entry to update.
+
+
+class _FakeAppResult:
+    """Mirrors the AppResult shape the persistence path consumes."""
+
+    def __init__(self, app_id, content):
+        self.app_id = app_id
+        self.content = content
+
+    def dict(self):
+        return {'app_id': self.app_id, 'content': self.content}
+
+
+def test_app_summary_results_reach_the_database(monkeypatch):
+    completed_conversation = Conversation(
+        id='conversation-apps',
+        created_at=datetime(2026, 7, 21, tzinfo=timezone.utc),
+        started_at=datetime(2026, 7, 21, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 7, 21, 0, 1, tzinfo=timezone.utc),
+        source=ConversationSource.omi,
+        structured=Structured(title='Title', overview='Overview'),
+        transcript_segments=[],
+        status=ConversationStatus.completed,
+        discarded=False,
+    )
+
+    persisted_payloads = []
+    updates = []
+
+    def persisted(_uid, payload, **_kwargs):
+        persisted_payloads.append(payload)
+        return True
+
+    def update_conversation(_uid, _conversation_id, data):
+        updates.append(data)
+
+    def fake_trigger_apps(_uid, conversation, **_kwargs):
+        # The real _trigger_apps only mutates the in-memory conversation.
+        conversation.suggested_summarization_apps = ['app-1']
+        conversation.apps_results = [_FakeAppResult('app-1', 'APP SUMMARY')]
+
+    input_conversation = MagicMock()
+    input_conversation.source = 'omi'
+    input_conversation.get_person_ids.return_value = []
+
+    monkeypatch.setattr(process_conversation, '_get_structured', lambda *a, **k: (MagicMock(), False))
+    monkeypatch.setattr(process_conversation, '_get_conversation_obj', lambda *a, **k: completed_conversation)
+    monkeypatch.setattr(process_conversation.lifecycle_service, 'persist_processed_conversation', persisted)
+    monkeypatch.setattr(process_conversation.lifecycle_service, 'create_completed_conversation', persisted)
+    monkeypatch.setattr(process_conversation, '_trigger_apps', fake_trigger_apps)
+    monkeypatch.setattr(process_conversation, 'submit_with_context', MagicMock())
+    monkeypatch.setattr(process_conversation.conversations_db, 'update_conversation', update_conversation)
+    monkeypatch.setattr(
+        process_conversation.conversations_db, 'create_audio_files_from_chunks', MagicMock(return_value=[])
+    )
+
+    process_conversation.process_conversation('uid', 'en', input_conversation)
+
+    # Everything that actually reached the database: the durable payload plus every write-back.
+    written = {}
+    for payload in persisted_payloads:
+        if isinstance(payload, dict):
+            written.update(payload)
+    for update in updates:
+        written.update(update)
+
+    results = written.get('apps_results')
+    assert results, 'app summary results never reached the database'
+    assert results[0]['app_id'] == 'app-1'
+    assert results[0]['content'] == 'APP SUMMARY'
+    assert written.get('suggested_summarization_apps') == ['app-1']

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -1218,6 +1218,15 @@ def process_conversation(
         _trigger_apps(
             uid, conversation, is_reprocess=is_reprocess, app_id=app_id, language_code=language_code, people=people
         )
+        # _trigger_apps only mutates the in-memory conversation and the durable write above already
+        # happened, so persist its output the same way the calendar_event/folder_id/audio_files
+        # write-backs do. Otherwise the app summary the LLM just produced is discarded.
+        if conversation.apps_results or conversation.suggested_summarization_apps:
+            app_updates = {
+                'apps_results': [result.dict() for result in conversation.apps_results],
+                'suggested_summarization_apps': conversation.suggested_summarization_apps,
+            }
+            conversations_db.update_conversation(uid, conversation.id, app_updates)
         if not is_reprocess:
             submit_with_context(postprocess_executor, save_structured_vector, uid, conversation)
             if TRANSCRIPT_CHUNK_INDEXING_ENABLED:


### PR DESCRIPTION
## Problem

`process_conversation` persists the completed generation before it runs any derived work:

```python
    conversation.status = ConversationStatus.completed
    if is_initial_creation:
        persisted = lifecycle_service.create_completed_conversation(uid, conversation.dict(), idempotent=True)
    else:
        persisted = lifecycle_service.persist_processed_conversation(uid, conversation.dict())
```

`_trigger_apps` runs about 100 lines later and only mutates the in-memory object:

```python
    conversation.suggested_summarization_apps = suggested_apps
    ...
    conversation.apps_results = []
    ...
        conversation.apps_results.append(AppResult(app_id=app.id, content=result))
```

Nothing writes those two fields back. The same reordering added write-backs for the other fields
mutated after the persist point, `calendar_event` and `folder_id` (and `audio_files` further down),
but `apps_results` and `suggested_summarization_apps` were missed. The only other writer of
`apps_results` anywhere in the backend is `update_conversation_summary`, a user-edit path that
read-modify-writes an entry that must already exist.

So the app summary is generated and then discarded on every conversation.

## What breaks

- The conversation detail view falls back to `structured.overview`, because `apps_results` is always
  empty. A user's explicitly preferred summarization app never has any visible effect.
- `GET /v1/conversations/{id}/suggested-apps` always returns an empty list, since
  `suggested_summarization_apps` is never stored.
- `PATCH /v1/conversations/{id}/summary` with an `app_id` always fails to find an entry to update.
- Reprocess with an `app_id` returns the new summary in the HTTP response while the stored value
  stays empty, so it reverts on the next fetch.

## Cost

`get_app_result` sends the full transcript and runs at the same model tier as conversation
structuring, making it one of the two most expensive calls in the pipeline. It is paid on every
conversation that resolves an app, and its entire output is currently thrown away. The suggestion
call that precedes it is re-paid on every reprocess for the same reason.

## Fix

Write the two fields back immediately after `_trigger_apps`, exactly the way the `calendar_event`,
`folder_id` and `audio_files` write-backs in the same function already do. `update_conversation`
resolves the document's `data_protection_level`, so this goes through the same encryption boundary
as those siblings.

`_trigger_apps` is deliberately left where it is rather than moved above the persist: it calls
`record_app_usage`, which is exactly the "derived work from a stale in-memory snapshot" the ordering
is there to prevent.

## Tests

Added `test_app_summary_results_reach_the_database` to the existing
`tests/unit/test_process_conversation_usage_context.py`, which already carries the heavy-dependency
bootstrap for this module. It runs the real `process_conversation`, captures both the durable
persist payload and every `update_conversation` write-back, and asserts the union of what actually
reached the database contains the app results and the suggested apps. The existing tests in that
file only assert on the in-memory conversation, which is why this was green.

## Verification

Run in `backend/`:

- `pytest tests/unit/test_process_conversation_usage_context.py -k app_summary_results_reach`: 1 passed
- prove-fail: with `utils/conversations/process_conversation.py` reverted to origin/main and
  confirmed byte-identical (`git diff origin/main` empty), the test fails with
  `AssertionError: app summary results never reached the database` and `assert []`. Reapplied: passes
- `pytest tests/unit/test_process_conversation_usage_context.py`: 21 passed
- the `conversation_lifecycle` workflow contract suite (test_conversation_lifecycle_contract,
  test_finalization_decision, test_check_conversation_lifecycle_writes,
  test_conversation_finalization_jobs, test_recording_sessions, test_listen_finalization_cloud_tasks)
  plus the file above: 142 passed
- `python scripts/check_conversation_lifecycle_writes.py`: passed
- `black --line-length 120 --skip-string-normalization --check`: clean
- `scripts/check_module_stub_pollution.py`: 0 violations
- `scripts/scan_async_blockers.py --dirs routers utils`: 0 findings
- `scripts/scan_import_time_side_effects.py`: 0 violations
- `.github/scripts/check_product_file_line_count_ratchet.py`: OK. The write-back is kept compact so
  the file stays at 1495 lines, under the 1500 threshold, rather than adding a new baseline entry
- `scripts/pr-preflight --suggest`: product invariants affected none, no failure-class declaration required


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

