### PR TITLE
fix(ci): scope desktop-swift-ci main runs per-SHA so the release source gate can't deadlock

### DIFF
--- a/.github/scripts/test_desktop_swift_ci_contract.py
+++ b/.github/scripts/test_desktop_swift_ci_contract.py
@@ -264,6 +264,39 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
             "gate condition must be absent after removal",
         )
 
+    # --- concurrency scoping (#10177) --------------------------------------
+
+    def test_main_push_concurrency_group_is_scoped_per_sha(self):
+        """A push to main (no PR number) must group by commit SHA, not the ref.
+
+        A shared per-ref group with cancel-in-progress meant every main push
+        cancelled the previous commit's in-progress run, so the release source
+        gate never saw a green run for the newest desktop SHA (#10177). The
+        non-PR fallback must therefore be github.sha.
+        """
+        group = re.search(r"^concurrency:\n  group:\s*([^\n]+)", _workflow_text(), re.MULTILINE)
+        self.assertIsNotNone(group, "workflow must declare a concurrency group")
+        group_expr = group.group(1)
+        self.assertIn("github.event.pull_request.number", group_expr, "PRs still group by PR number")
+        self.assertIn("github.sha", group_expr, "non-PR (main push) runs must group per commit SHA")
+        self.assertNotRegex(
+            group_expr,
+            r"pull_request\.number\s*\}\}\s*\|\|\s*github\.ref\b|pull_request\.number\s*\|\|\s*github\.ref\b",
+            "main pushes must not share a per-ref cancel-in-progress group (#10177)",
+        )
+
+    def test_adversarial_shared_per_ref_concurrency_detected(self):
+        """Reverting the fallback to github.ref re-introduces the shared
+        per-ref group that deadlocked the release source gate — the guard
+        above must reject it."""
+        tampered = _workflow_text().replace(
+            "github.event.pull_request.number || github.sha",
+            "github.event.pull_request.number || github.ref",
+        )
+        group_expr = re.search(r"^concurrency:\n  group:\s*([^\n]+)", tampered, re.MULTILINE).group(1)
+        self.assertRegex(group_expr, r"pull_request\.number\s*\|\|\s*github\.ref\b")
+        self.assertNotIn("github.sha", group_expr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -6,8 +6,14 @@ on:
   pull_request:
     branches: main
 
+# On a PR, group by PR number so a newer push supersedes the older run. On a
+# push to main there is no PR number, so group by the commit SHA — NOT the ref:
+# a shared per-ref group meant every main push cancelled the previous commit's
+# in-progress run, so on a busy night the newest desktop commit never produced a
+# green source-proof and desktop_auto_release deadlocked on its source gate
+# (#10177). Per-SHA groups let each main commit's run complete.
 concurrency:
-  group: desktop-swift-${{ github.event.pull_request.number || github.ref }}
+  group: desktop-swift-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# Summary

`desktop-swift-ci.yml` grouped its concurrency by `github.event.pull_request.number || github.ref`. On a **push to main** there is no PR number, so every main push shared the single group `desktop-swift-refs/heads/main` with `cancel-in-progress: true` — each new push cancelled the previous commit's in-progress run.

On a busy night the newest desktop commit's `Desktop Swift Build & Tests` run kept getting cancelled before it finished (#10177: `e298ad2331` cancelled 3×), so `desktop_auto_release`'s "newest-desktop-SHA has a green source run" gate had nothing to accept and refused to cut v0.12.91 — it shipped only via `break_glass`.

Fix: the non-PR fallback is now **`github.sha`**, so each main commit's run gets its own concurrency group and completes instead of being cancelled by the next push.

Fixes #10177.

# Why this shape

- **PRs unchanged:** `github.event.pull_request.number` is still first, so a newer push to the same PR supersedes the older run (the desirable cancel-in-progress behavior).
- **Main pushes:** fall through to `github.sha` — unique per commit, so an unrelated later push can't cancel the run that the release source gate needs. This is exactly the issue's suggested direction ("scope the group per head SHA").
- `cancel-in-progress` stays: for a per-SHA group it only supersedes a manual rerun of the *same* commit, which is what you want.

# Failure class

Failure-Class: none

# Product invariants affected

none (verified with `scripts/pr-preflight --suggest`)

# Validation

- Regression guard added to the existing `test_desktop_swift_ci_contract.py` (already wired into the checks manifest, triggered by `desktop-swift-ci.yml`): the concurrency group must use `github.sha` for the non-PR case, plus an adversarial test that a revert to the shared per-ref group is detected.
- `python3 .github/scripts/test_desktop_swift_ci_contract.py` → **17 passed** (2 new).
- **Old-code check:** reverting the workflow fallback to `github.ref` fails the new guard (1/17) — it catches exactly the deadlock condition.
- Workflow YAML parses (`yaml.safe_load`).
- `make preflight` (local lane, this PR body) → all selected checks pass.

Not exercised live: a real busy-night main-push storm (can't reproduce GitHub's concurrency scheduler locally). The mechanism is a documented GitHub Actions concurrency behavior; the contract test pins the group expression that produces the correct per-SHA scoping.

# Out of scope, named

- The alternative the issue floats — having the planner accept the merged PR's head-check as source proof — is a larger planner change; this PR fixes the root cause (the CI run being cancelled) so the existing gate works as designed.
- Other workflows' concurrency groups are not audited here; if any share the same per-ref pattern on main they'd deserve the same fix, but this PR is scoped to the one that deadlocked.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

