### PR TITLE
fix(ci): wait for qualification run terminal state before beta promotion trusts its conclusion

### DIFF
--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -19,6 +19,7 @@ def main() -> int:
     errors.extend(check_desktop_codemagic_release())
     errors.extend(check_desktop_preview_publishing())
     errors.extend(check_desktop_qualification_runner())
+    errors.extend(check_desktop_beta_promotion_qualification_gate())
     errors.extend(check_no_unprovisioned_beta_backend_hosts())
     errors.extend(check_mobile_codemagic_release_triggers())
     errors.extend(check_docs_workflow_scripts())
@@ -320,6 +321,45 @@ def check_desktop_qualification_runner() -> list[str]:
                 f"desktop beta candidate gate is missing UserNotifications callback evidence guard: {required_fragment}"
             )
     return errors
+
+
+def check_desktop_beta_promotion_qualification_gate() -> list[str]:
+    """Beta promotion must wait for the qualification run's terminal status
+    before trusting its conclusion.
+
+    desktop_qualify_beta.yml dispatches desktop_promote_beta.yml as its final
+    step, passing its own GITHUB_RUN_ID. At dispatch time that run's status is
+    still `in_progress` and `.conclusion` is null, so a bare
+    `conclusion == success` check races: it rejects a legitimate qualification,
+    or (if read once, later) could accept one whose post-dispatch steps failed
+    (#10186). The promotion must poll for `status == completed` first.
+    """
+    path = ROOT / ".github/workflows/desktop_promote_beta.yml"
+    if not path.exists():
+        return ["desktop release is missing the beta promotion workflow"]
+    text = path.read_text(encoding="utf-8")
+
+    # Gate applies only while promotion consumes a dispatched qualification run
+    # id. A future move to a workflow_run trigger (conclusion-filtered) removes
+    # the race by construction and drops this input.
+    if "qualification_run_id" not in text:
+        return []
+
+    conclusion_marker = "jq -r .conclusion"
+    status_marker = "jq -r .status"
+    if conclusion_marker not in text:
+        return ["beta promotion must verify the qualification run conclusion"]
+    if status_marker not in text or "completed" not in text:
+        return [
+            "beta promotion must wait for the qualification run to reach a terminal "
+            "status (completed) before checking its conclusion (#10186 race)"
+        ]
+    if text.index(status_marker) > text.index(conclusion_marker):
+        return [
+            "beta promotion checks the qualification run conclusion before waiting "
+            "for its terminal status (#10186 race)"
+        ]
+    return []
 
 
 def check_no_unprovisioned_beta_backend_hosts() -> list[str]:

--- a/.github/scripts/test_check_release_process_guards.py
+++ b/.github/scripts/test_check_release_process_guards.py
@@ -33,3 +33,49 @@ def test_beta_backend_guard_ignores_fixtures_but_rejects_shipped_source(tmp_path
         "shipped release source references unprovisioned beta backend host "
         "agent-beta.omi.me: app/lib/env.dart"
     ]
+
+
+def _write_promote_workflow(root, body: str) -> None:
+    path = root / ".github/workflows/desktop_promote_beta.yml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def test_beta_promotion_gate_requires_terminal_status_wait_before_conclusion(tmp_path, monkeypatch):
+    monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
+
+    # Race: reads .conclusion of the dispatched qualification_run_id with no wait.
+    _write_promote_workflow(
+        tmp_path,
+        'inputs:\n  qualification_run_id:\n'
+        'run: |\n'
+        '  run=$(gh api "repos/$REPO/actions/runs/$QUALIFICATION_RUN_ID")\n'
+        '  test "$(jq -r .conclusion <<<"$run")" = success\n',
+    )
+    assert GUARDS.check_desktop_beta_promotion_qualification_gate() == [
+        "beta promotion must wait for the qualification run to reach a terminal "
+        "status (completed) before checking its conclusion (#10186 race)"
+    ]
+
+    # Fixed: polls for status=completed before checking conclusion.
+    _write_promote_workflow(
+        tmp_path,
+        'inputs:\n  qualification_run_id:\n'
+        'run: |\n'
+        '  for _ in $(seq 1 60); do\n'
+        '    run=$(gh api "repos/$REPO/actions/runs/$QUALIFICATION_RUN_ID")\n'
+        '    [ "$(jq -r .status <<<"$run")" = completed ] && break\n'
+        '    sleep 10\n'
+        '  done\n'
+        '  test "$(jq -r .status <<<"$run")" = completed || exit 1\n'
+        '  test "$(jq -r .conclusion <<<"$run")" = success\n',
+    )
+    assert GUARDS.check_desktop_beta_promotion_qualification_gate() == []
+
+
+def test_beta_promotion_gate_is_na_without_a_dispatched_run_id(tmp_path, monkeypatch):
+    monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
+    # A workflow_run-triggered promotion removes the race by construction (no
+    # qualification_run_id input) — the gate does not apply.
+    _write_promote_workflow(tmp_path, "on:\n  workflow_run:\n    workflows: [desktop_qualify_beta]\n")
+    assert GUARDS.check_desktop_beta_promotion_qualification_gate() == []

--- a/.github/workflows/desktop_promote_beta.yml
+++ b/.github/workflows/desktop_promote_beta.yml
@@ -90,7 +90,21 @@ jobs:
           git fetch --force origin "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
           TARGET_SHA=$(git rev-list -n1 "$RELEASE_TAG")
           [[ "$QUALIFICATION_RUN_ID" =~ ^[0-9]+$ ]] || { echo 'qualification_run_id must be numeric' >&2; exit 1; }
-          run=$(gh api "repos/$REPO/actions/runs/$QUALIFICATION_RUN_ID")
+          # The qualification run dispatches this promotion as its final step, so
+          # at dispatch time its status is still in_progress and .conclusion is
+          # null. Wait for the run to reach a terminal state before trusting its
+          # conclusion — otherwise a bare `conclusion == success` check either
+          # rejects a legitimate qualification (null != success) or, checked once
+          # too early, could accept one whose post-dispatch steps still fail
+          # (#10186). Poll for status=completed up to 10 minutes, then require
+          # success.
+          run=""
+          for _ in $(seq 1 60); do
+            run=$(gh api "repos/$REPO/actions/runs/$QUALIFICATION_RUN_ID")
+            [ "$(jq -r .status <<<"$run")" = completed ] && break
+            sleep 10
+          done
+          test "$(jq -r .status <<<"$run")" = completed || { echo 'qualification run did not reach a terminal state within the poll window' >&2; exit 1; }
           test "$(jq -r .conclusion <<<"$run")" = success
           test "$(jq -r .repository.full_name <<<"$run")" = "$REPO"
           test "$(jq -r .head_repository.full_name <<<"$run")" = "$REPO"


### PR DESCRIPTION
# Summary

`desktop_qualify_beta.yml` dispatches `desktop_promote_beta.yml` **as its final step**, passing its own `$GITHUB_RUN_ID` as `qualification_run_id`. `desktop_promote_beta` then asserted:

```bash
run=$(gh api "repos/$REPO/actions/runs/$QUALIFICATION_RUN_ID")
test "$(jq -r .conclusion <<<"$run")" = success
```

At dispatch time that qualification run is still `in_progress` and its `.conclusion` is `null` — so the check **races**: `test null = success` rejects a legitimate qualification, or (evaluated once, later) could accept one whose post-dispatch steps still fail (#10186).

Latent today because automatic beta promotion is paused (`DESKTOP_AUTO_BETA_ENABLED=false`), but it would block or mis-accept promotions once the pause lifts — the issue asks for a guard/test before that.

Fix: promotion now **polls the qualification run for `status=completed`** (up to 10 min) before requiring `conclusion=success`.

Fixes #10186.

# Why wait for terminal status (not just re-check conclusion)

Waiting for the terminal state is what makes the check honest — it neither rejects a run that simply hasn't concluded yet, nor trusts a mid-run conclusion that later steps could still flip to `failure`. This is the issue's suggested direction ("poll/verify the run's terminal conclusion rather than trusting a mid-run dispatch").

No deadlock: `gh workflow run` is fire-and-forget, so the qualify run's dispatch step returns immediately and the run concludes independently right after — promotion's poll sees `completed` within seconds.

# Guard

`check-release-process-guards.py` (an always-run release-policy check) gains `check_desktop_beta_promotion_qualification_gate`: while promotion consumes a dispatched `qualification_run_id`, it must wait for `status=completed` before the conclusion check, and that wait must precede it. A future move to a `workflow_run` trigger (conclusion-filtered) removes the race by construction and drops the input, so the gate becomes N/A then.

# Failure class

Failure-Class: none

No registered class covers a CI handoff trusting a self-referential in-progress run's conclusion; single instance, guarded in the existing release-process guard.

# Product invariants affected

none (verified with `scripts/pr-preflight --suggest`)

# Validation

- `python3 .github/scripts/check-release-process-guards.py` → passes on the fix; **errors** when the poll is removed (`beta promotion must wait for the qualification run to reach a terminal status … (#10186 race)`).
- `test_check_release_process_guards.py` → **3 passed** — covers the race (rejected), the fixed poll shape (accepted), and the `workflow_run`-trigger N/A case.
- Both `desktop_promote_beta.yml` and `desktop_qualify_beta.yml` parse (`yaml.safe_load`) and are **actionlint clean**.
- `check-manifest-contract` → 20 passed.
- `make preflight` (local lane, this PR body) → all selected checks pass.

Not exercised live: a real qualify→promote dispatch (can't drive GitHub's run scheduler locally). The race mechanism is a documented Actions behavior (a run's `.conclusion` is null until it terminates); the guard pins the poll-before-conclusion shape.

# Out of scope, named

- The larger alternative — retriggering promotion via a `workflow_run: completed` event so a mid-run dispatch is impossible — is a bigger restructure of the trigger + inputs; this PR fixes the root race so the existing dispatch path is correct, and the guard already treats the `workflow_run` form as valid (N/A) if a future PR migrates to it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

