### PR TITLE
fix(app): discover Ray-Ban Meta glasses by their EssilorLuxottica codename

### DIFF
--- a/app/lib/services/devices/discovery/rayban_meta_discoverer.dart
+++ b/app/lib/services/devices/discovery/rayban_meta_discoverer.dart
@@ -83,12 +83,20 @@ class RayBanMetaDiscoverer extends DeviceDiscoverer {
   /// Explicit product-name match for the audio-only fallback. Without the
   /// toolkit the HFP port name is the only identity signal, so match Meta's
   /// product names precisely rather than anything containing 'glass'.
+  ///
+  /// Ray-Ban / Oakley Meta glasses do not advertise a friendly "Ray-Ban" name
+  /// over Bluetooth — they expose an EssilorLuxottica codename, observed on
+  /// hardware as `EL AI 000F` (and matching `EL AI <hex>` on the desktop app).
+  /// Match that codename family too, or real glasses are silently filtered out
+  /// of discovery. The `EL AI ` prefix (note the trailing space before the
+  /// unit id) is specific enough not to swallow names like "El Camino AI".
   static bool looksLikeMetaGlasses(String portName) {
     final lower = portName.toLowerCase();
     return lower.contains('ray-ban') ||
         lower.contains('rayban') ||
         lower.contains('oakley meta') ||
-        lower.contains('meta glasses');
+        lower.contains('meta glasses') ||
+        lower.startsWith('el ai ');
   }
 
   @override

--- a/app/test/unit/rayban_meta_device_test.dart
+++ b/app/test/unit/rayban_meta_device_test.dart
@@ -187,11 +187,21 @@ void main() {
       expect(RayBanMetaDiscoverer.looksLikeMetaGlasses('Oakley Meta HSTN'), isTrue);
       expect(RayBanMetaDiscoverer.looksLikeMetaGlasses('Meta Glasses'), isTrue);
 
+      // Real glasses advertise an EssilorLuxottica codename over Bluetooth HFP,
+      // not a "Ray-Ban" string. Observed on hardware as `EL AI 000F`; without
+      // this the glasses never appear in the audio-only scan.
+      expect(RayBanMetaDiscoverer.looksLikeMetaGlasses('EL AI 000F'), isTrue);
+      expect(RayBanMetaDiscoverer.looksLikeMetaGlasses('el ai 1a2b'), isTrue);
+
       // Must not swallow other glasses/audio devices.
       expect(RayBanMetaDiscoverer.looksLikeMetaGlasses('OmiGlass'), isFalse);
       expect(RayBanMetaDiscoverer.looksLikeMetaGlasses('OpenGlass'), isFalse);
       expect(RayBanMetaDiscoverer.looksLikeMetaGlasses('AirPods Pro'), isFalse);
       expect(RayBanMetaDiscoverer.looksLikeMetaGlasses('Car Audio'), isFalse);
+      // The `EL AI ` codename match is prefix-anchored — do not swallow these.
+      expect(RayBanMetaDiscoverer.looksLikeMetaGlasses('El Camino AI'), isFalse);
+      expect(RayBanMetaDiscoverer.looksLikeMetaGlasses('Elaine AI Speaker'), isFalse);
+      expect(RayBanMetaDiscoverer.looksLikeMetaGlasses('Michael AI'), isFalse);
     });
   });
 }


### PR DESCRIPTION
## What

Real Ray-Ban / Oakley Meta glasses do **not** advertise a "Ray-Ban" name over Bluetooth — they expose an EssilorLuxottica codename, observed on hardware as **`EL AI 000F`**. The audio-only discoverer's `looksLikeMetaGlasses` only matched `ray-ban` / `rayban` / `oakley meta` / `meta glasses`, so paired glasses were **silently filtered out of the scan** and never appeared as a connectable device.

This adds the `EL AI ` codename family to the matcher (prefix-anchored so it can't swallow "El Camino AI" / "Michael AI").

## Why

Confirmed on a user's iPhone: the glasses were paired and **Connected** in iOS Settings → Bluetooth as **`EL AI 000F`**, but did not appear in Omi's device scan (only "Omi" showed). The same `looksLikeMetaGlasses` matcher gates both `RayBanMetaDiscoverer.discover()` and `RayBanMetaTransport.connect()`, so the too-strict name filter blocked **both** discovery and connection of the microphone path.

## How it was tested

- Extended `app/test/unit/rayban_meta_device_test.dart` — the matcher now accepts `EL AI 000F` / `el ai 1a2b` and still rejects `El Camino AI`, `Elaine AI Speaker`, `Michael AI`, `OmiGlass`, `AirPods Pro`, `Car Audio`. Runs in mobile PR CI (`flutter test`).
- Logic cross-checked independently (all cases pass).

## Scope / verification boundary

- This is the **audio-only (microphone)** path — the default shipped build. It does not touch the camera/DAT path.
- **On-device confirmation is pending a mobile release** — Flutter can't be built/run in the authoring environment, so CI (`flutter test` / analyzer ratchet) is the automated gate and the reporter's device is the end-to-end check. If glasses still don't appear after this ships, the next thing to check is whether iOS lists them as a `.bluetoothHFP` input via `getBluetoothHfpInputNames()`.

## Follow-ups (not in this PR)

- Add a **Ray-Ban Meta tile** to the Connection Guide grid (`connection_guide_sheet.dart`) so there's a guided entry point, and add it to the device guide docs — once on-device connection is confirmed.
- Consider a **manual "pick your Bluetooth mic" fallback** (as the desktop app does) so glasses with any future/other codename connect without relying on a name allowlist.

Failure-Class: none

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxLsaxtwVNDTWAZFfJp9q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

