### PR TITLE
feat(desktop): connect-flow upgrades — live Notion MCP connection, guided Obsidian/Notion screens, Claude Code restart button

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
@@ -180,7 +180,14 @@ private struct ConnectOptionCard: View {
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                manualBlock(manualText(for: setup))
+                if let copyText = setup.copyText {
+                  manualBlock(copyText)
+                } else {
+                  manualBlock("Server URL: \(setup.serverURL)", copy: setup.serverURL)
+                  if destination.requiresHostedMCPKeyForSetup {
+                    manualBlock("Key: \(mcpKey ?? "YOUR_OMI_KEY")", copy: mcpKey ?? "YOUR_OMI_KEY")
+                  }
+                }
               }
             }
             .padding(.top, OmiSpacing.sm)
@@ -284,10 +291,14 @@ private struct ConnectOptionCard: View {
         Text(completion.title)
           .scaledFont(size: OmiType.body, weight: .semibold)
           .foregroundColor(OmiColors.textPrimary)
-        Text(completion.subtitle)
-          .scaledFont(size: OmiType.caption)
-          .foregroundColor(OmiColors.textTertiary)
-          .fixedSize(horizontal: false, vertical: true)
+        if destination == .claudeCode {
+          ClaudeCodeRestartSubtitle()
+        } else {
+          Text(completion.subtitle)
+            .scaledFont(size: OmiType.caption)
+            .foregroundColor(OmiColors.textTertiary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
       }
     }
     .padding(OmiSpacing.sm)
@@ -323,16 +334,6 @@ private struct ConnectOptionCard: View {
     return "Omi couldn't finish setup. Try again."
   }
 
-  private func manualText(for setup: MCPSetup) -> String {
-    if let copyText = setup.copyText {
-      return copyText
-    }
-    if destination.requiresHostedMCPKeyForSetup {
-      return "Server URL: \(setup.serverURL)\nKey: \(mcpKey ?? "YOUR_OMI_KEY")"
-    }
-    return "Server URL: \(setup.serverURL)"
-  }
-
   private var chatGPTDeveloperModeText: String {
     let clientID = destination.cloudOAuthClientID ?? ""
     let tokenAuthMethod = destination.cloudTokenAuthMethod ?? "none"
@@ -348,7 +349,9 @@ private struct ConnectOptionCard: View {
     ].joined(separator: "\n")
   }
 
-  private func manualBlock(_ text: String) -> some View {
+  /// `copy` overrides what the Copy button writes — used by label:value rows so
+  /// the clipboard gets the paste-able value, never the display label.
+  private func manualBlock(_ text: String, copy: String? = nil) -> some View {
     VStack(alignment: .leading, spacing: OmiSpacing.xs) {
       Text(text)
         .font(.system(size: 11, design: .monospaced))
@@ -358,7 +361,7 @@ private struct ConnectOptionCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
       Button {
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(text, forType: .string)
+        NSPasteboard.general.setString(copy ?? text, forType: .string)
         resultMessage = .success("Copied.")
       } label: {
         Text("Copy")
@@ -374,6 +377,36 @@ private struct ConnectOptionCard: View {
     .frame(maxWidth: .infinity, alignment: .leading)
     .background(
       RoundedRectangle(cornerRadius: OmiChrome.elementRadius, style: .continuous).fill(OmiColors.backgroundTertiary))
+  }
+}
+
+/// Setup-complete subtitle for Claude Code. Detects running CLI sessions: none →
+/// "you're all set"; some → the restart note plus an explicit button that stops
+/// them (SIGTERM; `claude --continue` resumes). Shared by ConnectOptionCard and
+/// MemoryExportDestinationSheet.
+struct ClaudeCodeRestartSubtitle: View {
+  @State private var pids: [pid_t] = []
+  @State private var didStop = false
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+      Text(ClaudeCodeSessions.completionSubtitle(sessionCount: pids.count, didStop: didStop))
+        .scaledFont(size: OmiType.caption)
+        .foregroundColor(OmiColors.textTertiary)
+        .fixedSize(horizontal: false, vertical: true)
+      if !didStop && !pids.isEmpty {
+        Button("Restart \(pids.count) running session\(pids.count == 1 ? "" : "s")") {
+          ClaudeCodeSessions.stop(pids)
+          didStop = true
+        }
+        .buttonStyle(.plain)
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+        .foregroundColor(OmiColors.textSecondary)
+      }
+    }
+    .task {
+      pids = await Task.detached { ClaudeCodeSessions.runningPIDs() }.value
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -743,10 +743,14 @@ struct MemoryExportDestinationSheet: View {
         Text(completion.title)
           .scaledFont(size: OmiType.subheading, weight: .semibold)
           .foregroundColor(OmiColors.textPrimary)
-        Text(completion.subtitle)
-          .scaledFont(size: OmiType.caption)
-          .foregroundColor(OmiColors.textTertiary)
-          .fixedSize(horizontal: false, vertical: true)
+        if destination == .claudeCode {
+          ClaudeCodeRestartSubtitle()
+        } else {
+          Text(completion.subtitle)
+            .scaledFont(size: OmiType.caption)
+            .foregroundColor(OmiColors.textTertiary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
       }
     }
     .padding(OmiSpacing.md)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -1001,6 +1001,11 @@ struct MemoryExportDestinationSheet: View {
       }
 
     case .obsidian:
+      let obsidianSteps = [
+        "Choose your vault folder",
+        "Omi writes your memories to Omi/Memories.md and opens Obsidian. Hit Sync anytime to refresh",
+        "If Obsidian asks “Do you trust the author of this vault?”, pick either option. Omi only adds a Markdown note",
+      ]
       VStack(alignment: .leading, spacing: OmiSpacing.md) {
         selectedLocationCard(
           title: model.obsidianVaultPath.isEmpty ? "No vault selected yet" : "Selected vault",
@@ -1016,9 +1021,20 @@ struct MemoryExportDestinationSheet: View {
         .foregroundColor(OmiColors.textSecondary)
         .scaledFont(size: OmiType.caption, weight: .medium)
 
-        Text("Omi writes a refreshed `Omi/Memories.md` file inside the selected vault.")
-          .scaledFont(size: OmiType.caption)
-          .foregroundColor(OmiColors.textTertiary)
+        VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+          ForEach(Array(obsidianSteps.enumerated()), id: \.offset) { index, step in
+            HStack(alignment: .top, spacing: OmiSpacing.sm) {
+              Text("\(index + 1).")
+                .scaledFont(size: OmiType.caption, weight: .semibold)
+                .foregroundColor(OmiColors.textTertiary)
+              Text(step)
+                .scaledFont(size: OmiType.caption)
+                .foregroundColor(OmiColors.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+          }
+        }
+        .padding(.top, OmiSpacing.hairline)
       }
 
     case .chatgpt, .claude, .gemini:

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -281,13 +281,15 @@ final class MemoryExportDestinationSheetModel: ObservableObject {
     do {
       switch destination {
       case .notion:
-        let result = try await MemoryExportService.shared.prepareManualExport(for: destination)
+        if !NotionMCPConnector.shared.isConnected {
+          statusMessage = "Approve Omi in your browser…"
+          try await NotionMCPConnector.shared.connect()
+        }
+        let result = try await MemoryExportService.shared.exportToNotion()
         await MainActor.run {
-          applyClipboard(from: result)
-          revealExportFile(from: result)
           openDestination(for: destination, url: result.destinationURL)
         }
-        statusMessage = "Copied \(result.memoryCount.formatted()) memories for Notion."
+        statusMessage = "Wrote \(result.memoryCount.formatted()) memories into Notion."
 
       case .obsidian:
         let vaultURL: URL
@@ -992,12 +994,45 @@ struct MemoryExportDestinationSheet: View {
   private var packSection: some View {
     switch destination {
     case .notion:
+      let notionConnected = NotionMCPConnector.shared.isConnected
+      let notionSteps = [
+        "Click Connect and approve Omi in your browser",
+        "Omi creates an Omi Memories page in your workspace. Hit Sync anytime to refresh",
+        "Find the page in your Notion sidebar or search",
+      ]
       VStack(alignment: .leading, spacing: OmiSpacing.md) {
-        Text(
-          "Omi copies a ready-to-paste Markdown page, saves a local backup, and opens Notion so you can drop it where you want."
+        selectedLocationCard(
+          title: notionConnected ? "Connected to Notion" : "Not connected yet",
+          value: notionConnected
+            ? (NotionMCPConnector.shared.memoriesPageURL?.absoluteString
+              ?? "First Sync creates your Omi Memories page.")
+            : "One browser approval connects your workspace."
         )
-        .scaledFont(size: OmiType.caption)
-        .foregroundColor(OmiColors.textTertiary)
+
+        if notionConnected {
+          Button("Disconnect") {
+            NotionMCPConnector.shared.disconnect()
+            statuses[.notion] = nil
+          }
+          .buttonStyle(.plain)
+          .foregroundColor(OmiColors.textSecondary)
+          .scaledFont(size: OmiType.caption, weight: .medium)
+        }
+
+        VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+          ForEach(Array(notionSteps.enumerated()), id: \.offset) { index, step in
+            HStack(alignment: .top, spacing: OmiSpacing.sm) {
+              Text("\(index + 1).")
+                .scaledFont(size: OmiType.caption, weight: .semibold)
+                .foregroundColor(OmiColors.textTertiary)
+              Text(step)
+                .scaledFont(size: OmiType.caption)
+                .foregroundColor(OmiColors.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+          }
+        }
+        .padding(.top, OmiSpacing.hairline)
       }
 
     case .obsidian:
@@ -1080,7 +1115,8 @@ struct MemoryExportDestinationSheet: View {
   private var actionTitle: (idle: String, running: String) {
     switch destination {
     case .notion:
-      return ("Copy & open", "Preparing…")
+      return NotionMCPConnector.shared.isConnected
+        ? ("Sync", "Syncing…") : ("Connect", "Connecting…")
     case .obsidian:
       return (model.obsidianVaultPath.isEmpty ? "Choose vault" : "Export", "Exporting…")
     case .chatgpt, .claude, .gemini:

--- a/desktop/macos/Desktop/Sources/MemoryExportExecutor.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportExecutor.swift
@@ -384,3 +384,59 @@ enum MemoryExportExecutor {
       systemPromptSuffix: ProactiveTaskExecute.systemPromptSuffix)
   }
 }
+
+/// Detects running Claude Code CLI sessions so the post-setup UI can offer to
+/// stop them (new MCP config only loads at session start). Stopping is safe-ish:
+/// Claude Code persists conversations, so `claude --continue` resumes them.
+enum ClaudeCodeSessions {
+  /// The CLI binary is ".../bin/claude" (native install) or ".../bin/claude.exe"
+  /// (pnpm/bun bundle). Claude Desktop and its helpers are capitalized
+  /// ("Claude", "Claude Helper") and must never match.
+  static func isClaudeCLI(executablePath: String) -> Bool {
+    let name = (executablePath as NSString).lastPathComponent
+    return name == "claude" || name == "claude.exe"
+  }
+
+  static func completionSubtitle(sessionCount: Int, didStop: Bool) -> String {
+    if didStop {
+      return "Sessions stopped — run claude --continue in your terminal to pick up where you left off."
+    }
+    if sessionCount == 0 {
+      return "You're all set — Omi Memory loads automatically in your next Claude Code session."
+    }
+    return "Restart Claude Code to load Omi Memory."
+  }
+
+  /// Current user's running Claude Code CLI processes.
+  static func runningPIDs() -> [pid_t] {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/ps")
+    process.arguments = ["-axo", "pid=,uid=,comm="]
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    do { try process.run() } catch { return [] }
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    guard let output = String(data: data, encoding: .utf8) else { return [] }
+    let uid = getuid()
+    var pids: [pid_t] = []
+    for line in output.split(separator: "\n") {
+      // comm may contain spaces — keep everything after pid and uid as the path.
+      let fields = line.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true)
+      guard fields.count == 3,
+        let pid = pid_t(fields[0]),
+        let lineUID = uid_t(fields[1]),
+        lineUID == uid,
+        isClaudeCLI(executablePath: String(fields[2]))
+      else { continue }
+      pids.append(pid)
+    }
+    return pids
+  }
+
+  static func stop(_ pids: [pid_t]) {
+    for pid in pids where pid > 0 {
+      kill(pid, SIGTERM)
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportService.swift
@@ -95,7 +95,7 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
 
   var subtitle: String {
     switch self {
-    case .notion: return "Copy-ready page export"
+    case .notion: return "Live page in your workspace"
     case .obsidian: return "Choose once, refresh anytime"
     case .chatgpt: return "Add Omi from the ChatGPT directory"
     case .claude: return "Live MCP or memory pack"
@@ -110,7 +110,7 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
 
   var description: String {
     switch self {
-    case .notion: return "Copy a ready-to-paste memory page and jump into Notion."
+    case .notion: return "Connect once and Omi keeps an Omi Memories page fresh in your workspace."
     case .obsidian: return "Write Omi memories into your Obsidian vault."
     case .chatgpt:
       return "Add Omi in ChatGPT, authorize once, and use your memories in every ChatGPT chat."
@@ -845,7 +845,7 @@ actor MemoryExportService {
     case .chatgpt, .claude:
       isConfigured = hasConnection
     case .notion, .gemini:
-      isConfigured = exportedCount > 0
+      isConfigured = destination == .notion ? NotionMCPConnector.shared.isConnected : exportedCount > 0
     }
 
     return MemoryExportStatus(
@@ -1331,7 +1331,7 @@ actor MemoryExportService {
     )
   }
 
-  private func fetchMemories(limit: Int) async throws -> [ServerMemory] {
+  func fetchMemories(limit: Int) async throws -> [ServerMemory] {
     do {
       let remoteMemories = try await APIClient.shared.getMemories(limit: limit)
       if !remoteMemories.isEmpty {
@@ -1349,7 +1349,7 @@ actor MemoryExportService {
     throw MemoryExportError.noMemories
   }
 
-  private func buildMarkdownPack(
+  func buildMarkdownPack(
     memories: [ServerMemory],
     destination: MemoryExportDestination
   ) -> String {
@@ -1398,7 +1398,7 @@ actor MemoryExportService {
     return directory
   }
 
-  private func persistStatus(
+  func persistStatus(
     destination: MemoryExportDestination,
     exportedCount: Int,
     detailText: String?,

--- a/desktop/macos/Desktop/Sources/NotionConnect/MemoryExportServiceNotion.swift
+++ b/desktop/macos/Desktop/Sources/NotionConnect/MemoryExportServiceNotion.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension MemoryExportService {
+  /// Writes memories to the "Omi Memories" page in the connected Notion
+  /// workspace over Notion's hosted MCP (create once, replace on later syncs).
+  func exportToNotion() async throws -> MemoryExportResult {
+    let memories = try await fetchMemories(limit: 400)
+    guard !memories.isEmpty else { throw MemoryExportError.noMemories }
+
+    let markdown = buildMarkdownPack(memories: memories, destination: .notion)
+    let pageURL = try await NotionMCPConnector.shared.syncMemories(markdown: markdown)
+
+    let detail = "Updated Notion page"
+    persistStatus(
+      destination: .notion,
+      exportedCount: memories.count,
+      detailText: detail,
+      filePath: nil
+    )
+    return MemoryExportResult(
+      memoryCount: memories.count,
+      detailText: detail,
+      destinationURL: pageURL,
+      fileURL: nil,
+      clipboardText: nil
+    )
+  }
+}

--- a/desktop/macos/Desktop/Sources/NotionConnect/NotionMCPConnector.swift
+++ b/desktop/macos/Desktop/Sources/NotionConnect/NotionMCPConnector.swift
@@ -152,9 +152,13 @@ final class NotionMCPConnector: @unchecked Sendable {
       expiresAt: Date().addingTimeInterval(expiresIn),
       clientID: clientID)
     let data = try JSONEncoder().encode(auth)
-    _ = DesktopKeychainStore.setString(
-      String(decoding: data, as: UTF8.self),
-      service: Self.keychainService, account: Self.keychainAccount)
+    guard
+      DesktopKeychainStore.setString(
+        String(decoding: data, as: UTF8.self),
+        service: Self.keychainService, account: Self.keychainAccount)
+    else {
+      throw ConnectError.badResponse("could not store Notion credentials in Keychain")
+    }
   }
 
   private func loadAuth() -> StoredAuth? {

--- a/desktop/macos/Desktop/Sources/NotionConnect/NotionMCPConnector.swift
+++ b/desktop/macos/Desktop/Sources/NotionConnect/NotionMCPConnector.swift
@@ -1,0 +1,438 @@
+import AppKit
+import CryptoKit
+import Foundation
+import Network
+
+/// Connects Omi to the user's Notion workspace over Notion's hosted MCP server
+/// (mcp.notion.com). One OAuth grant powers both directions: writing the
+/// "Omi Memories" page today, and reading workspace content into Omi later
+/// (the token also covers notion-search / notion-fetch).
+///
+/// Auth is standard MCP OAuth: dynamic client registration + PKCE + loopback
+/// redirect. No pre-registered client and no Notion app review is needed —
+/// the /register endpoint is open (verified live 2026-07-21).
+final class NotionMCPConnector: @unchecked Sendable {
+  static let shared = NotionMCPConnector()
+
+  private static let base = URL(string: "https://mcp.notion.com")!
+  private static let keychainService = "com.omi.desktop.notion-mcp"
+  private static let keychainAccount = "oauth"
+  private static let pageIDKey = "memoryExportNotionPageID"
+  private static let pageURLKey = "memoryExportNotionPageURL"
+  private static let userAgent = "omi-desktop/1.0"
+  private static let memoriesPageTitle = "Omi Memories"
+
+  struct StoredAuth: Codable {
+    var accessToken: String
+    var refreshToken: String?
+    var expiresAt: Date
+    var clientID: String
+  }
+
+  enum ConnectError: LocalizedError {
+    case timedOut
+    case badResponse(String)
+    case notConnected
+
+    var errorDescription: String? {
+      switch self {
+      case .timedOut: return "Notion authorization timed out. Try again."
+      case .badResponse(let detail): return "Notion setup failed: \(detail)"
+      case .notConnected: return "Connect Notion first."
+      }
+    }
+  }
+
+  var isConnected: Bool { loadAuth() != nil }
+
+  var memoriesPageURL: URL? {
+    UserDefaults.standard.string(forKey: Self.pageURLKey).flatMap(URL.init(string:))
+  }
+
+  func disconnect() {
+    DesktopKeychainStore.delete(service: Self.keychainService, account: Self.keychainAccount)
+    UserDefaults.standard.removeObject(forKey: Self.pageIDKey)
+    UserDefaults.standard.removeObject(forKey: Self.pageURLKey)
+  }
+
+  // MARK: - OAuth connect
+
+  /// Full browser OAuth: register a client for a fresh loopback port, open the
+  /// consent page, await the redirect, exchange the code, store tokens.
+  func connect() async throws {
+    let listener = try OAuthCallbackListener()
+    defer { listener.cancel() }
+    let redirectURI = "http://localhost:\(listener.port)/callback"
+
+    let registration = try await postJSON(
+      url: Self.base.appendingPathComponent("register"),
+      body: [
+        "client_name": "Omi Memory",
+        "redirect_uris": [redirectURI],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+      ])
+    guard let clientID = registration["client_id"] as? String else {
+      throw ConnectError.badResponse("client registration rejected")
+    }
+
+    let verifier = Self.randomURLSafe(64)
+    let challenge = Self.codeChallenge(for: verifier)
+    let state = Self.randomURLSafe(24)
+
+    guard
+      var components = URLComponents(
+        url: Self.base.appendingPathComponent("authorize"), resolvingAgainstBaseURL: false)
+    else {
+      throw ConnectError.badResponse("could not build the authorize URL")
+    }
+    components.queryItems = [
+      URLQueryItem(name: "client_id", value: clientID),
+      URLQueryItem(name: "response_type", value: "code"),
+      URLQueryItem(name: "redirect_uri", value: redirectURI),
+      URLQueryItem(name: "code_challenge", value: challenge),
+      URLQueryItem(name: "code_challenge_method", value: "S256"),
+      URLQueryItem(name: "state", value: state),
+    ]
+    guard let authorizeURL = components.url else {
+      throw ConnectError.badResponse("could not build the authorize URL")
+    }
+    _ = await MainActor.run { NSWorkspace.shared.open(authorizeURL) }
+
+    let params = try await listener.waitForCallback(timeout: 240)
+    guard params["state"] == state, let code = params["code"] else {
+      throw ConnectError.badResponse("authorization was denied or the redirect was invalid")
+    }
+
+    let token = try await postForm(
+      url: Self.base.appendingPathComponent("token"),
+      fields: [
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirectURI,
+        "client_id": clientID,
+        "code_verifier": verifier,
+      ])
+    try storeAuth(from: token, clientID: clientID)
+  }
+
+  // MARK: - Token lifecycle
+
+  static func needsRefresh(expiresAt: Date, now: Date = Date()) -> Bool {
+    now >= expiresAt.addingTimeInterval(-300)
+  }
+
+  private func validAccessToken() async throws -> String {
+    guard let auth = loadAuth() else { throw ConnectError.notConnected }
+    guard Self.needsRefresh(expiresAt: auth.expiresAt) else { return auth.accessToken }
+    guard let refreshToken = auth.refreshToken else { throw ConnectError.notConnected }
+    let token = try await postForm(
+      url: Self.base.appendingPathComponent("token"),
+      fields: [
+        "grant_type": "refresh_token",
+        "refresh_token": refreshToken,
+        "client_id": auth.clientID,
+      ])
+    try storeAuth(from: token, clientID: auth.clientID, fallbackRefreshToken: refreshToken)
+    guard let refreshed = loadAuth() else { throw ConnectError.notConnected }
+    return refreshed.accessToken
+  }
+
+  private func storeAuth(
+    from token: [String: Any], clientID: String, fallbackRefreshToken: String? = nil
+  ) throws {
+    guard let access = token["access_token"] as? String else {
+      throw ConnectError.badResponse("token exchange failed")
+    }
+    let expiresIn = (token["expires_in"] as? Double) ?? 3600
+    let auth = StoredAuth(
+      accessToken: access,
+      refreshToken: (token["refresh_token"] as? String) ?? fallbackRefreshToken,
+      expiresAt: Date().addingTimeInterval(expiresIn),
+      clientID: clientID)
+    let data = try JSONEncoder().encode(auth)
+    _ = DesktopKeychainStore.setString(
+      String(decoding: data, as: UTF8.self),
+      service: Self.keychainService, account: Self.keychainAccount)
+  }
+
+  private func loadAuth() -> StoredAuth? {
+    guard
+      let raw = DesktopKeychainStore.string(
+        service: Self.keychainService, account: Self.keychainAccount),
+      let auth = try? JSONDecoder().decode(StoredAuth.self, from: Data(raw.utf8))
+    else { return nil }
+    return auth
+  }
+
+  // MARK: - Memories page sync
+
+  /// Writes the markdown pack to the "Omi Memories" page: replaces content when
+  /// the page exists, creates it (and remembers its id) on first sync or if the
+  /// user deleted it.
+  func syncMemories(markdown: String) async throws -> URL? {
+    let token = try await validAccessToken()
+    let session = try await initializeSession(token: token)
+
+    if let pageID = UserDefaults.standard.string(forKey: Self.pageIDKey) {
+      let update = try await toolsCall(
+        name: "notion-update-page",
+        arguments: ["page_id": pageID, "command": "replace_content", "new_str": markdown],
+        token: token, session: session)
+      if !Self.toolCallFailed(update) {
+        return memoriesPageURL
+      }
+      // Page was likely deleted by the user; fall through and recreate.
+    }
+
+    let create = try await toolsCall(
+      name: "notion-create-pages",
+      arguments: [
+        "pages": [["properties": ["title": Self.memoriesPageTitle], "content": markdown]]
+      ],
+      token: token, session: session)
+    guard let record = Self.pageRecord(fromToolResult: create) else {
+      throw ConnectError.badResponse("Notion did not return the created page")
+    }
+    UserDefaults.standard.set(record.id, forKey: Self.pageIDKey)
+    UserDefaults.standard.set(record.url, forKey: Self.pageURLKey)
+    return URL(string: record.url)
+  }
+
+  // MARK: - MCP plumbing
+
+  private func initializeSession(token: String) async throws -> String? {
+    let (body, session) = try await mcpRequest(
+      payload: [
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": [
+          "protocolVersion": "2025-03-26", "capabilities": [:],
+          "clientInfo": ["name": "omi-desktop", "version": "1.0"],
+        ],
+      ], token: token, session: nil)
+    if body?["result"] == nil {
+      throw ConnectError.badResponse("MCP initialize failed")
+    }
+    _ = try? await mcpRequest(
+      payload: ["jsonrpc": "2.0", "method": "notifications/initialized", "params": [:]],
+      token: token, session: session)
+    return session
+  }
+
+  private func toolsCall(
+    name: String, arguments: [String: Any], token: String, session: String?
+  ) async throws -> [String: Any] {
+    let (body, _) = try await mcpRequest(
+      payload: [
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": ["name": name, "arguments": arguments],
+      ], token: token, session: session)
+    guard let body else { throw ConnectError.badResponse("empty MCP response") }
+    if let error = body["error"] as? [String: Any] {
+      throw ConnectError.badResponse((error["message"] as? String) ?? "MCP error")
+    }
+    return body
+  }
+
+  private func mcpRequest(
+    payload: [String: Any], token: String, session: String?
+  ) async throws -> ([String: Any]?, String?) {
+    var request = URLRequest(url: Self.base.appendingPathComponent("mcp"))
+    request.httpMethod = "POST"
+    request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
+    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    request.setValue(Self.userAgent, forHTTPHeaderField: "User-Agent")
+    if let session {
+      request.setValue(session, forHTTPHeaderField: "Mcp-Session-Id")
+    }
+    let (data, response) = try await URLSession.shared.data(for: request)
+    let http = response as? HTTPURLResponse
+    let newSession = http?.value(forHTTPHeaderField: "Mcp-Session-Id") ?? session
+    let text = String(decoding: data, as: UTF8.self)
+    let jsonText: String
+    if (http?.value(forHTTPHeaderField: "Content-Type") ?? "").contains("text/event-stream") {
+      guard let last = Self.lastSSEDataLine(text) else { return (nil, newSession) }
+      jsonText = last
+    } else {
+      jsonText = text
+    }
+    guard !jsonText.isEmpty,
+      let object = try? JSONSerialization.jsonObject(with: Data(jsonText.utf8)) as? [String: Any]
+    else { return (nil, newSession) }
+    return (object, newSession)
+  }
+
+  // MARK: - Pure helpers (unit-tested)
+
+  /// The MCP endpoint frames JSON-RPC responses as SSE; the response is the
+  /// last `data:` line of the stream.
+  static func lastSSEDataLine(_ body: String) -> String? {
+    var last: String?
+    for line in body.split(separator: "\n", omittingEmptySubsequences: true)
+    where line.hasPrefix("data:") {
+      last = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+    }
+    return (last?.isEmpty == false) ? last : nil
+  }
+
+  /// notion-create-pages returns its payload as JSON text inside content[0].text.
+  static func pageRecord(fromToolResult body: [String: Any]) -> (id: String, url: String)? {
+    guard
+      let result = body["result"] as? [String: Any],
+      let content = result["content"] as? [[String: Any]],
+      let text = content.first?["text"] as? String,
+      let parsed = try? JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any],
+      let page = (parsed["pages"] as? [[String: Any]])?.first,
+      let id = page["id"] as? String,
+      let url = page["url"] as? String
+    else { return nil }
+    return (id, url)
+  }
+
+  static func toolCallFailed(_ body: [String: Any]) -> Bool {
+    guard let result = body["result"] as? [String: Any] else { return true }
+    return (result["isError"] as? Bool) == true
+  }
+
+  // MARK: - HTTP + crypto helpers
+
+  private func postJSON(url: URL, body: [String: Any]) async throws -> [String: Any] {
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(Self.userAgent, forHTTPHeaderField: "User-Agent")
+    let (data, _) = try await URLSession.shared.data(for: request)
+    guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      throw ConnectError.badResponse("unexpected response from Notion")
+    }
+    return object
+  }
+
+  private func postForm(url: URL, fields: [String: String]) async throws -> [String: Any] {
+    var components = URLComponents()
+    components.queryItems = fields.map { URLQueryItem(name: $0.key, value: $0.value) }
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.httpBody = (components.percentEncodedQuery ?? "").data(using: .utf8)
+    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+    request.setValue(Self.userAgent, forHTTPHeaderField: "User-Agent")
+    let (data, _) = try await URLSession.shared.data(for: request)
+    guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      throw ConnectError.badResponse("token endpoint returned an unexpected response")
+    }
+    return object
+  }
+
+  private static func randomURLSafe(_ bytes: Int) -> String {
+    var buffer = [UInt8](repeating: 0, count: bytes)
+    _ = SecRandomCopyBytes(kSecRandomDefault, bytes, &buffer)
+    return Data(buffer).base64URLEncoded()
+  }
+
+  private static func codeChallenge(for verifier: String) -> String {
+    Data(SHA256.hash(data: Data(verifier.utf8))).base64URLEncoded()
+  }
+}
+
+extension Data {
+  fileprivate func base64URLEncoded() -> String {
+    base64EncodedString()
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "=", with: "")
+  }
+}
+
+/// One-shot loopback HTTP listener for the OAuth redirect. Binds a random high
+/// port on 127.0.0.1, serves a single GET, hands back its query parameters.
+private final class OAuthCallbackListener: @unchecked Sendable {
+  let port: UInt16
+  private let listener: NWListener
+  private let lock = NSLock()
+  private var continuation: CheckedContinuation<[String: String], Error>?
+
+  init() throws {
+    var created: (NWListener, UInt16)?
+    for _ in 0..<4 {
+      let candidate = UInt16.random(in: 45_000...59_000)
+      if let endpointPort = NWEndpoint.Port(rawValue: candidate),
+        let attempt = try? NWListener(using: .tcp, on: endpointPort)
+      {
+        created = (attempt, candidate)
+        break
+      }
+    }
+    guard let (listener, port) = created else {
+      throw NotionMCPConnector.ConnectError.badResponse("no free local port for the OAuth redirect")
+    }
+    self.listener = listener
+    self.port = port
+    listener.newConnectionHandler = { [weak self] connection in
+      self?.handle(connection)
+    }
+    listener.start(queue: DispatchQueue(label: "notion-oauth-callback"))
+  }
+
+  func cancel() {
+    listener.cancel()
+  }
+
+  func waitForCallback(timeout: TimeInterval) async throws -> [String: String] {
+    try await withCheckedThrowingContinuation { continuation in
+      lock.lock()
+      self.continuation = continuation
+      lock.unlock()
+      DispatchQueue.global().asyncAfter(deadline: .now() + timeout) { [weak self] in
+        self?.finish(with: .failure(NotionMCPConnector.ConnectError.timedOut))
+      }
+    }
+  }
+
+  private func finish(with result: Result<[String: String], Error>) {
+    lock.lock()
+    let continuation = self.continuation
+    self.continuation = nil
+    lock.unlock()
+    switch result {
+    case .success(let params): continuation?.resume(returning: params)
+    case .failure(let error): continuation?.resume(throwing: error)
+    }
+  }
+
+  private func handle(_ connection: NWConnection) {
+    connection.start(queue: DispatchQueue(label: "notion-oauth-conn"))
+    connection.receive(minimumIncompleteLength: 1, maximumLength: 8192) { [weak self] data, _, _, _ in
+      guard let self, let data, let request = String(data: data, encoding: .utf8) else {
+        connection.cancel()
+        return
+      }
+      let params = Self.queryParams(fromRequestLine: request)
+      let html = "<html><body><h2>Omi is connected to Notion. Close this tab.</h2></body></html>"
+      let response =
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: \(html.utf8.count)\r\nConnection: close\r\n\r\n\(html)"
+      connection.send(
+        content: Data(response.utf8),
+        completion: .contentProcessed { _ in connection.cancel() })
+      if !params.isEmpty {
+        self.finish(with: .success(params))
+      }
+    }
+  }
+
+  static func queryParams(fromRequestLine request: String) -> [String: String] {
+    guard let firstLine = request.split(separator: "\r\n").first,
+      firstLine.hasPrefix("GET "),
+      let path = firstLine.split(separator: " ").dropFirst().first,
+      let components = URLComponents(string: String(path))
+    else { return [:] }
+    var params: [String: String] = [:]
+    for item in components.queryItems ?? [] {
+      params[item.name] = item.value
+    }
+    return params
+  }
+}

--- a/desktop/macos/Desktop/Tests/ClaudeCodeSessionsTests.swift
+++ b/desktop/macos/Desktop/Tests/ClaudeCodeSessionsTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class ClaudeCodeSessionsTests: XCTestCase {
+  func testMatchesCLIBinariesOnly() {
+    // Native install and pnpm/bun bundle layouts.
+    XCTAssertTrue(ClaudeCodeSessions.isClaudeCLI(executablePath: "/Users/x/.local/bin/claude"))
+    XCTAssertTrue(
+      ClaudeCodeSessions.isClaudeCLI(
+        executablePath:
+          "/Users/x/Library/pnpm/global/5/.pnpm/@anthropic-ai+claude-code@2.1.190/node_modules/@anthropic-ai/claude-code/bin/claude.exe"
+      ))
+
+    // Claude Desktop and its helpers must never be killed.
+    XCTAssertFalse(
+      ClaudeCodeSessions.isClaudeCLI(executablePath: "/Applications/Claude.app/Contents/MacOS/Claude"))
+    XCTAssertFalse(
+      ClaudeCodeSessions.isClaudeCLI(
+        executablePath:
+          "/Applications/Claude.app/Contents/Frameworks/Claude Helper.app/Contents/MacOS/Claude Helper"))
+    XCTAssertFalse(
+      ClaudeCodeSessions.isClaudeCLI(executablePath: "/Applications/Claude.app/Contents/Helpers/chrome-native-host"))
+    XCTAssertFalse(ClaudeCodeSessions.isClaudeCLI(executablePath: "claudette"))
+  }
+
+  func testCompletionSubtitleStates() {
+    XCTAssertEqual(
+      ClaudeCodeSessions.completionSubtitle(sessionCount: 0, didStop: false),
+      "You're all set — Omi Memory loads automatically in your next Claude Code session.")
+    XCTAssertEqual(
+      ClaudeCodeSessions.completionSubtitle(sessionCount: 2, didStop: false),
+      "Restart Claude Code to load Omi Memory.")
+    XCTAssertEqual(
+      ClaudeCodeSessions.completionSubtitle(sessionCount: 2, didStop: true),
+      "Sessions stopped — run claude --continue in your terminal to pick up where you left off.")
+  }
+}

--- a/desktop/macos/Desktop/Tests/NotionMCPConnectorTests.swift
+++ b/desktop/macos/Desktop/Tests/NotionMCPConnectorTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class NotionMCPConnectorTests: XCTestCase {
+  func testLastSSEDataLineTakesFinalDataLine() {
+    let body = "event: message\ndata: {\"first\":1}\n\nevent: message\ndata: {\"second\":2}\n"
+    XCTAssertEqual(NotionMCPConnector.lastSSEDataLine(body), "{\"second\":2}")
+    XCTAssertNil(NotionMCPConnector.lastSSEDataLine("{\"plain\":\"json\"}"))
+    XCTAssertNil(NotionMCPConnector.lastSSEDataLine(""))
+  }
+
+  func testPageRecordParsesCreateResult() {
+    let inner = "{\"pages\":[{\"id\":\"abc-123\",\"url\":\"https://app.notion.com/p/abc123\"}]}"
+    let body: [String: Any] = ["result": ["content": [["type": "text", "text": inner]]]]
+    let record = NotionMCPConnector.pageRecord(fromToolResult: body)
+    XCTAssertEqual(record?.id, "abc-123")
+    XCTAssertEqual(record?.url, "https://app.notion.com/p/abc123")
+    XCTAssertNil(NotionMCPConnector.pageRecord(fromToolResult: ["result": ["content": []]]))
+  }
+
+  func testTokenRefreshWindow() {
+    let now = Date()
+    XCTAssertFalse(NotionMCPConnector.needsRefresh(expiresAt: now.addingTimeInterval(3600), now: now))
+    XCTAssertTrue(NotionMCPConnector.needsRefresh(expiresAt: now.addingTimeInterval(120), now: now))
+    XCTAssertTrue(NotionMCPConnector.needsRefresh(expiresAt: now.addingTimeInterval(-10), now: now))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260721-claude-code-restart-and-copy-value.json
+++ b/desktop/macos/changelog/unreleased/20260721-claude-code-restart-and-copy-value.json
@@ -1,0 +1,3 @@
+{
+  "change": "Claude Code setup now detects running CLI sessions and offers a one-click restart to load Omi Memory, and the manual setup cards copy just the paste-able value instead of the labeled text"
+}

--- a/desktop/macos/changelog/unreleased/20260721-notion-live-connect.json
+++ b/desktop/macos/changelog/unreleased/20260721-notion-live-connect.json
@@ -1,0 +1,3 @@
+{
+  "change": "Notion is now a live connection: approve Omi once in your browser and it keeps an Omi Memories page fresh in your workspace, replacing the copy-paste export"
+}

--- a/desktop/macos/changelog/unreleased/20260721-obsidian-guided-steps.json
+++ b/desktop/macos/changelog/unreleased/20260721-obsidian-guided-steps.json
@@ -1,0 +1,3 @@
+{
+  "change": "Obsidian setup now walks you through the steps like the Claude connector does, including what to do when Obsidian asks whether you trust the vault"
+}

--- a/desktop/macos/e2e/flows/memories.yaml
+++ b/desktop/macos/e2e/flows/memories.yaml
@@ -10,6 +10,8 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
   - desktop/macos/Desktop/Sources/ViewModelContainer.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+  - desktop/macos/Desktop/Sources/NotionConnect/NotionMCPConnector.swift
+  - desktop/macos/Desktop/Sources/NotionConnect/MemoryExportServiceNotion.swift
   - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Memories.swift
   - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+People.swift
   - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Persona.swift


### PR DESCRIPTION
# Connect-flow upgrades: Claude Code restart, guided Obsidian/Notion screens, live Notion MCP connection

## What

Improvements to the "Connect your AI" / memory export flow:

0. **Notion becomes a live connection over Notion's hosted MCP server** (`mcp.notion.com`), replacing the copy-paste memory pack. `NotionMCPConnector` performs the standard MCP OAuth (dynamic client registration + PKCE + loopback redirect — no pre-registered client, no Notion app review), stores tokens in the Keychain with refresh handling, and syncs the markdown pack to an "Omi Memories" page: `notion-create-pages` on first sync, `replace_content` updates after, recreation if the user deleted the page. The connect sheet shows guided numbered steps (same pattern as Obsidian below), a connection state card, and Connect/Sync actions. The granted token also covers `notion-search`/`notion-fetch` for a future Notion→Omi read direction.

1. **Claude Code completion card is now state-aware with a restart button.** After "Do it for me" completes, the card previously always said "Restart Claude Code to load Omi Memory" — wrong when no session is running, and unactionable when one is. Now the card detects the current user's running Claude Code CLI sessions:
   - none running → "You're all set — Omi Memory loads automatically in your next Claude Code session." (nothing to restart, no button)
   - sessions running → the restart note plus an explicit **"Restart N running sessions"** button that SIGTERMs them and then points at `claude --continue` to resume. The kill is only ever user-initiated.

   Detection matches the process basename `claude`/`claude.exe` for the current uid only, which covers native and pnpm/bun CLI installs while never matching Claude Desktop or its helpers ("Claude", "Claude Helper", chrome-native-host).

2. **Obsidian connect gets guided numbered steps** (same pattern as the Claude connector): choose vault, where memories land + Sync to refresh, and that Obsidian's first-open "Do you trust the author of this vault?" prompt is about the vault's own plugins — either choice works, Omi only adds a Markdown note.

3. **Manual-setup copy cards copy the paste-able value, not the display label.** In the grouped connect sheet, the Copy button under Claude (cloud)'s manual steps wrote `Server URL: https://…` (and `Key: …`) to the clipboard — label included — which breaks pasting into Claude's connector form. Display text keeps the label; the clipboard now gets just the URL/key. Command/config snippets (Claude Code, Codex, Hermes, OpenClaw) still copy their full text, which is correct for them.

## Product invariants affected

- **INV-INT-1** (path glob `Desktop/Sources/**/MemoryExport*`): compliant — Claude Code session detection/stop is deterministic (`ps` parse + `kill`), the Notion connection is a deterministic API/MCP client (no agent sent to do an API-reachable job, no element-anchoring heuristics), and the Notion setup flow ends with a functional probe (the sync itself creates/updates the page and stores its URL).
- **INV-MEM-1** (path glob `desktop/macos/Desktop/Sources/MemoryExportService.swift`): compliant — no tier changes; the Notion export reuses the existing `fetchMemories` path and default access policy, exactly as the Obsidian export does.

## Verification

- `xcrun swift build -c debug --package-path Desktop` — build complete.
- `xcrun swift test --package-path Desktop --filter ClaudeCodeSessionsTests` — 2 tests, 0 failures (CLI-vs-Desktop process matching, completion-subtitle states).
- Detection filter validated against live `ps` output: matched 5 running `claude.exe` CLI sessions, excluded `Claude.app` and all its helpers.
- Exercised in-app on a local named bundle (`omi-v5`): connect sheet shows the state-aware completion card and the value-only copy behaves as described.
- `make preflight` — green.

Failure-Class: none
