### PR TITLE
fix(admin): guard admin HogQL queries against PostHog's silent 100-row cap

### DIFF
--- a/.github/failure-classes/FC-silent-query-row-cap.json
+++ b/.github/failure-classes/FC-silent-query-row-cap.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "FC-silent-query-row-cap",
+  "violated_contract": "A HogQL analytics query must bound its own result size explicitly; it must not rely on PostHog's default, which silently fills LIMIT 100 into any LIMIT-less query (and each UNION arm) and truncates the overflow with no error.",
+  "canonical_prevention": "Wrap LIMIT-less queries with the shared withPosthogRowLimit helper in web/admin/lib/posthog.ts (one outer LIMIT over a subquery, so a trailing limit cannot bind to a single UNION arm); do not append a bare LIMIT or leave admin queries capless.",
+  "evidence_prs": [10191],
+  "scope_hints": ["web/admin/**"],
+  "status": "open"
+}

--- a/web/admin/app/api/omi/releases/route.ts
+++ b/web/admin/app/api/omi/releases/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
+import { withPosthogRowLimit } from "@/lib/posthog";
 import {
   desktopQualificationFromMetadata,
   desktopReleaseLifecycle,
@@ -106,7 +107,9 @@ async function posthogQuery(query: string): Promise<any> {
         Authorization: `Bearer ${POSTHOG_API_KEY}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
+      body: JSON.stringify({
+        query: { kind: "HogQLQuery", query: withPosthogRowLimit(query) },
+      }),
       cache: "no-store",
     },
   );

--- a/web/admin/app/api/omi/stats/notifications/route.ts
+++ b/web/admin/app/api/omi/stats/notifications/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/firebase/admin';
 import { verifyAdmin } from '@/lib/auth';
-import { cachedPosthogFetch } from '@/lib/posthog';
+import { cachedPosthogFetch, withPosthogRowLimit } from '@/lib/posthog';
 import { getPayload, setPayload } from '@/lib/payload-cache';
 
 export const dynamic = 'force-dynamic';
@@ -37,7 +37,7 @@ type FloatingBarCtrStats = {
 };
 
 async function queryPostHog(host: string, projectId: string, apiKey: string, query: string) {
-  const response = await cachedPosthogFetch(host, projectId, apiKey, query);
+  const response = await cachedPosthogFetch(host, projectId, apiKey, withPosthogRowLimit(query));
 
   if (!response.ok) {
     const text = await response.text();

--- a/web/admin/lib/__tests__/posthog.test.ts
+++ b/web/admin/lib/__tests__/posthog.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { POSTHOG_MAX_ROWS, withPosthogRowLimit } from "../posthog";
+
+describe("withPosthogRowLimit", () => {
+  it("wraps a LIMIT-less grouped query with an explicit outer limit", () => {
+    const query = `
+      SELECT version, event, count() AS cnt
+      FROM events
+      WHERE event IN ('App Crash Detected', 'App Launched')
+      GROUP BY version, event
+    `;
+    const guarded = withPosthogRowLimit(query);
+    expect(guarded).toContain(`LIMIT ${POSTHOG_MAX_ROWS}`);
+    // The original query must survive intact inside the subquery so grouping,
+    // aliases, and column order are unchanged.
+    expect(guarded).toContain("GROUP BY version, event");
+    expect(guarded).toMatch(/SELECT \* FROM \(/);
+  });
+
+  it("caps a UNION whose trailing LIMIT would otherwise bind to the last arm only", () => {
+    // A trailing LIMIT on a UNION binds to the final arm, so a naive append
+    // would not bound the whole result. Wrapping puts the limit outside both.
+    const query = "SELECT 1 UNION ALL SELECT 2";
+    const guarded = withPosthogRowLimit(query, 5);
+    expect(guarded).toBe(
+      "SELECT * FROM (\nSELECT 1 UNION ALL SELECT 2\n) LIMIT 5",
+    );
+  });
+
+  it("keeps a caller-pinned inner limit authoritative (outer cap is a no-op)", () => {
+    const guarded = withPosthogRowLimit("SELECT day FROM events LIMIT 10");
+    // Inner LIMIT 10 binds first; the outer high cap never reduces below it.
+    expect(guarded).toContain("LIMIT 10");
+    expect(guarded).toContain(`LIMIT ${POSTHOG_MAX_ROWS}`);
+  });
+
+  it("strips a trailing semicolon so the subquery wrap stays valid", () => {
+    const guarded = withPosthogRowLimit("SELECT day FROM events;");
+    expect(guarded).not.toContain(";");
+    expect(guarded).toBe(
+      `SELECT * FROM (\nSELECT day FROM events\n) LIMIT ${POSTHOG_MAX_ROWS}`,
+    );
+  });
+
+  it("defaults to PostHog's served maximum row count", () => {
+    expect(POSTHOG_MAX_ROWS).toBe(50_000);
+  });
+});

--- a/web/admin/lib/posthog.ts
+++ b/web/admin/lib/posthog.ts
@@ -18,6 +18,31 @@
 import { createHash } from "crypto";
 import { getDb } from "@/lib/firebase/admin";
 
+// PostHog's query API fills `LIMIT 100` into any HogQL query (and each UNION
+// arm) that carries none, then truncates silently — a grouped query returning
+// >100 rows loses the overflow with no error. This is the highest row count
+// PostHog will actually serve: `LIMIT 100000` returns exactly 50000 rows (the
+// ad-hoc 100000/500000 limits scattered across routes overstate what they get).
+export const POSTHOG_MAX_ROWS = 50_000;
+
+/**
+ * Guard a LIMIT-less HogQL query against PostHog's silent 100-row cap.
+ *
+ * A trailing `LIMIT` binds to the last arm of a `UNION` only (verified:
+ * `SELECT 1 UNION ALL SELECT 2 LIMIT 1` returns 2 rows), so appending a limit
+ * is unsafe. We always wrap the query as a subquery with one outer limit, which
+ * caps the whole result regardless of unions or grouping. Callers whose query
+ * already pins its own limit are unaffected — the inner limit binds first and
+ * the outer high cap is a no-op.
+ */
+export function withPosthogRowLimit(
+  query: string,
+  limit: number = POSTHOG_MAX_ROWS,
+): string {
+  const inner = query.trim().replace(/;\s*$/, "");
+  return `SELECT * FROM (\n${inner}\n) LIMIT ${limit}`;
+}
+
 const CACHE_COLLECTION = "admin_stats_cache";
 const SOFT_TTL_MS = 30 * 60 * 1000; // serve cached without re-querying for 30 min
 
@@ -40,7 +65,16 @@ async function readCache(
 async function writeCache(key: string, results: unknown[]): Promise<void> {
   try {
     const payload = JSON.stringify(results);
-    if (payload.length > 900_000) return; // Firestore field cap ~1 MB; skip oversized
+    if (payload.length > 900_000) {
+      // Firestore field cap ~1 MB; skip oversized. Log it — silently skipping
+      // means the heaviest queries lose caching + stale-on-throttle fallback
+      // exactly when they grow large, with no signal that it happened.
+      console.warn(
+        `PostHog result too large to cache (${payload.length} bytes, ${results.length} rows) — skipping cache write`,
+        { key },
+      );
+      return;
+    }
     await getDb()
       .collection(CACHE_COLLECTION)
       .doc(key)


### PR DESCRIPTION
## What

Adds a shared `withPosthogRowLimit` guard so admin HogQL queries can't be silently truncated at PostHog's default 100-row cap, and applies it to the two remaining LIMIT-less routes.

## Why (from #10190)

> PostHog's query API fills `LIMIT 100` into any HogQL (sub)query that carries none and truncates silently. … The class remains elsewhere:
> - `web/admin/app/api/omi/releases/route.ts` groups by version×event over 60 days with no LIMIT … 5 events × ~40–80 desktop versions plausibly exceeds 100 rows **today**, so per-version crash/launch/feedback counts may already read as 0 for most versions.
> - `web/admin/app/api/omi/stats/notifications/route.ts` runs day-grouped queries with an unclamped `days` param.
> - ~5 routes each hand-fixed this with ad-hoc limits … per AGENTS.md, 2+ fixes sharing a cause warrant a reusable guard in the shared layer (`web/admin/lib/posthog.ts`).

PR #10191 hand-fixed this for the response-reliability charts; this is the reusable guard the issue asks for.

## Changes

- **`web/admin/lib/posthog.ts`** — new `withPosthogRowLimit(query, limit=POSTHOG_MAX_ROWS)` and `POSTHOG_MAX_ROWS = 50000` (PostHog's actual served max — `LIMIT 100000` returns 50000). Wraps the query as a subquery under one outer `LIMIT` so a trailing limit can't bind to a single `UNION` arm (the exact trap the issue documents: `SELECT 1 UNION ALL SELECT 2 LIMIT 1` → 2 rows). A caller-pinned inner limit stays authoritative.
- **`releases/route.ts`** and **`stats/notifications/route.ts`** — route through the guard.
- **`writeCache`** — logs (instead of silently dropping) results too large to cache, so the "heaviest queries lose caching exactly when they grow large" bound noted in the issue is observable.
- Registers the new failure class **FC-silent-query-row-cap** (`Failure-Class: new`).

## Verified

- `npm run typecheck` — clean.
- `npm run lint` — 0 errors (only pre-existing `<img>` warnings in unrelated files).
- `npx vitest run lib/` — 20 passed, incl. 5 new tests in `lib/__tests__/posthog.test.ts` (wrap of a LIMIT-less grouped query, `UNION`-arm binding, caller-pinned inner limit, trailing-semicolon stripping, default max).
- Confirmed the emitted SQL for the real releases metrics query is now `SELECT * FROM ( … GROUP BY version, event ) LIMIT 50000` — GROUP BY intact inside the subquery, column order preserved (route reads positionally).
- Live behavior against PostHog project 302298 was verified by the issue reporter; not independently re-run here (no prod PostHog access from this environment).

Auto-generated from issue feedback by the mini issues-improver. Review before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

