### PR TITLE
fix(app): capture location before recording

### DIFF
--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -4,24 +4,20 @@ import 'dart:io';
 
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:collection/collection.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:flutter_provider_utilities/flutter_provider_utilities.dart';
-import 'package:geolocator/geolocator.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import 'package:omi/backend/http/api/conversations.dart';
-import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/services/auth_service.dart';
 import 'package:omi/services/bridges/ble_bridge.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
-import 'package:omi/backend/schema/geolocation.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/backend/schema/person.dart';
 import 'package:omi/backend/schema/structured.dart';
@@ -32,6 +28,7 @@ import 'package:omi/providers/device_onboarding_provider.dart';
 import 'package:omi/services/capture/capture_external_actions.dart';
 import 'package:omi/services/capture/capture_metrics_tracker.dart';
 import 'package:omi/services/capture/conversation_source_for_device.dart';
+import 'package:omi/services/capture/conversation_location_capture.dart';
 import 'package:omi/services/capture/freemium_threshold_tracker.dart';
 import 'package:omi/services/connectivity_service.dart';
 import 'package:omi/services/services.dart';
@@ -72,6 +69,8 @@ class CaptureController extends ChangeNotifier
   static const MethodChannel _nativeBleTranscriptChannel = MethodChannel('com.friend.ios/native_ble_transcript');
   static const int _maxInProgressConversationRefreshAttempts = 30;
   static const Duration _inProgressConversationRefreshInterval = Duration(seconds: 2);
+
+  final ConversationLocationCapture _conversationLocationCapture = ConversationLocationCapture();
 
   CaptureExternalActions externalActions;
   DeviceOnboardingProvider? deviceOnboardingProvider;
@@ -1315,36 +1314,12 @@ class CaptureController extends ChangeNotifier
     notifyListeners();
   }
 
-  /// Sends current geolocation to backend if location services are enabled and permission is granted
-  Future<void> _sendCurrentGeolocation() async {
-    try {
-      if (!await Geolocator.isLocationServiceEnabled()) {
-        Logger.log('Location service is not enabled, skipping geolocation update');
-        return;
-      }
-
-      final permission = await Geolocator.checkPermission();
-      if (permission == LocationPermission.denied || permission == LocationPermission.deniedForever) {
-        Logger.log('Location permission not granted, skipping geolocation update');
-        return;
-      }
-
-      final position = await Geolocator.getCurrentPosition();
-      final geolocation = Geolocation(
-        latitude: position.latitude,
-        longitude: position.longitude,
-        altitude: position.altitude,
-        accuracy: position.accuracy,
-        time: position.timestamp.toUtc(),
-      );
-
-      await updateUserGeolocation(geolocation: geolocation);
-    } catch (e) {
-      Logger.error('Error sending geolocation: $e');
-    }
-  }
-
   streamRecording() async {
+    // The backend snapshots its cached location when finalizing a conversation.
+    // Complete this bounded update before any live or batch capture path can
+    // create/finalize that conversation.
+    await _conversationLocationCapture.captureAndUpload();
+
     // Mode is fixed for the whole session at start. On iOS and Android the phone
     // mic can capture Transcribe Later (batch) audio: explicitly when the user
     // enabled it, or automatically as an offline fallback when there is no
@@ -1366,9 +1341,6 @@ class CaptureController extends ChangeNotifier
       updateRecordingState(RecordingState.stop);
       return;
     }
-
-    // Send current location when conversation starts
-    _sendCurrentGeolocation();
 
     // prepare
     await changeAudioRecordProfile(audioCodec: BleAudioCodec.pcm16, sampleRate: 16000);
@@ -1541,8 +1513,9 @@ class CaptureController extends ChangeNotifier
 
     bool wasPaused = _isPaused;
 
-    // Send current location when conversation starts
-    _sendCurrentGeolocation();
+    // Ensure even very short device recordings have a location in Redis before
+    // the backend is able to finalize their conversation.
+    await _conversationLocationCapture.captureAndUpload();
 
     await _resetStateVariables();
     await _resetState();

--- a/app/lib/services/capture/conversation_location_capture.dart
+++ b/app/lib/services/capture/conversation_location_capture.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+
+import 'package:geolocator/geolocator.dart';
+
+import 'package:omi/backend/http/api/users.dart';
+import 'package:omi/backend/schema/geolocation.dart';
+import 'package:omi/utils/logger.dart';
+
+typedef LocationServiceEnabled = Future<bool> Function();
+typedef LocationPermissionReader = Future<LocationPermission> Function();
+typedef CurrentPositionReader = Future<Position> Function();
+typedef LastPositionReader = Future<Position?> Function();
+typedef GeolocationUploader = Future<bool> Function(Geolocation geolocation);
+
+/// Captures the location that belongs to a recording before the backend can
+/// finalize its conversation.
+class ConversationLocationCapture {
+  ConversationLocationCapture({
+    LocationServiceEnabled? isLocationServiceEnabled,
+    LocationPermissionReader? checkPermission,
+    CurrentPositionReader? getCurrentPosition,
+    LastPositionReader? getLastKnownPosition,
+    GeolocationUploader? upload,
+    this.currentPositionTimeout = const Duration(seconds: 1),
+    this.totalTimeout = const Duration(seconds: 3),
+  })  : _isLocationServiceEnabled = isLocationServiceEnabled ?? Geolocator.isLocationServiceEnabled,
+        _checkPermission = checkPermission ?? Geolocator.checkPermission,
+        _getCurrentPosition = getCurrentPosition ?? Geolocator.getCurrentPosition,
+        _getLastKnownPosition = getLastKnownPosition ?? Geolocator.getLastKnownPosition,
+        _upload = upload ?? ((geolocation) => updateUserGeolocation(geolocation: geolocation));
+
+  final LocationServiceEnabled _isLocationServiceEnabled;
+  final LocationPermissionReader _checkPermission;
+  final CurrentPositionReader _getCurrentPosition;
+  final LastPositionReader _getLastKnownPosition;
+  final GeolocationUploader _upload;
+  final Duration currentPositionTimeout;
+  final Duration totalTimeout;
+
+  Future<bool> captureAndUpload() async {
+    try {
+      return await _captureAndUpload().timeout(totalTimeout);
+    } on TimeoutException {
+      Logger.log('Conversation location capture timed out; recording will continue');
+      return false;
+    } catch (e) {
+      Logger.error('Error capturing conversation location: $e');
+      return false;
+    }
+  }
+
+  Future<bool> _captureAndUpload() async {
+    if (!await _isLocationServiceEnabled()) {
+      Logger.log('Location service is not enabled, skipping conversation location');
+      return false;
+    }
+
+    final permission = await _checkPermission();
+    if (permission == LocationPermission.denied || permission == LocationPermission.deniedForever) {
+      Logger.log('Location permission not granted, skipping conversation location');
+      return false;
+    }
+
+    Position? position;
+    try {
+      position = await _getCurrentPosition().timeout(currentPositionTimeout);
+    } on TimeoutException {
+      // A recent OS fix is preferable to losing the conversation location when
+      // a fresh GPS fix is slow indoors.
+      position = await _getLastKnownPosition();
+    }
+    if (position == null) return false;
+
+    return _upload(
+      Geolocation(
+        latitude: position.latitude,
+        longitude: position.longitude,
+        altitude: position.altitude,
+        accuracy: position.accuracy,
+        time: position.timestamp.toUtc(),
+      ),
+    );
+  }
+}

--- a/app/test/unit/conversation_location_capture_test.dart
+++ b/app/test/unit/conversation_location_capture_test.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:geolocator/geolocator.dart';
+
+import 'package:omi/backend/schema/geolocation.dart';
+import 'package:omi/services/capture/conversation_location_capture.dart';
+
+void main() {
+  test('uploads a fresh position before recording starts', () async {
+    Geolocation? uploaded;
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.always,
+      getCurrentPosition: () async => _position(latitude: 28.6139, longitude: 77.2090),
+      getLastKnownPosition: () async => null,
+      upload: (geolocation) async {
+        uploaded = geolocation;
+        return true;
+      },
+    );
+
+    expect(await capture.captureAndUpload(), isTrue);
+    expect(uploaded?.latitude, 28.6139);
+    expect(uploaded?.longitude, 77.2090);
+  });
+
+  test('uses the last known position when a fresh fix is slow', () async {
+    Geolocation? uploaded;
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.whileInUse,
+      getCurrentPosition: () => Completer<Position>().future,
+      getLastKnownPosition: () async => _position(latitude: 51.5072, longitude: -0.1276),
+      upload: (geolocation) async {
+        uploaded = geolocation;
+        return true;
+      },
+      currentPositionTimeout: const Duration(milliseconds: 1),
+    );
+
+    expect(await capture.captureAndUpload(), isTrue);
+    expect(uploaded?.latitude, 51.5072);
+    expect(uploaded?.longitude, -0.1276);
+  });
+
+  test('does not upload without location permission', () async {
+    var uploads = 0;
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.denied,
+      getCurrentPosition: () async => _position(latitude: 1, longitude: 2),
+      getLastKnownPosition: () async => null,
+      upload: (_) async {
+        uploads++;
+        return true;
+      },
+    );
+
+    expect(await capture.captureAndUpload(), isFalse);
+    expect(uploads, 0);
+  });
+}
+
+Position _position({required double latitude, required double longitude}) {
+  return Position(
+    latitude: latitude,
+    longitude: longitude,
+    timestamp: DateTime.utc(2026, 7, 21),
+    accuracy: 8,
+    altitude: 220,
+    altitudeAccuracy: 2,
+    heading: 0,
+    headingAccuracy: 0,
+    speed: 0,
+    speedAccuracy: 0,
+  );
+}


### PR DESCRIPTION
## What changed and why

Follow-up to #9887: capture and upload conversation location before phone-mic or Omi-device recording begins, including Transcribe Later batch paths. Previously, location upload was fire-and-forget and batch recording returned before it ran, leaving new conversations without coordinates for the Daily Recap map.

## Product invariants affected

none

## How it was verified

- `flutter test test/unit/conversation_location_capture_test.dart test/widgets/daily_summary_card_test.dart` — all 7 focused location-capture and map-rendering tests passed.
- `scripts/analyze_ratchet.sh` — passed; `prefer_const_constructors` and `unnecessary_import` counts improved.
- `scripts/pr-preflight --base upstream/main --head HEAD --pr-body-file /tmp/daily-recap-location-pr-body.md --head-branch fix-daily-recap-location-capture` — all 10 selected checks passed against the final three-file diff.
- `dart format --line-length 120 ...` and `git diff --check` — passed.
- `bash app/test.sh` — 914 tests passed, then 7 unrelated widget tests failed because the local Flutter SDK could not decode `shaders/ink_sparkle.frag` (`Unsupported runtime stages format version`). The focused tests above passed in the same environment.
- Physical-device verification was not completed because the local Xcode installation lacks the iOS 26.5 platform and a usable development provisioning setup.

## Tests

- `app/test/unit/conversation_location_capture_test.dart`
  - verifies a fresh position is uploaded;
  - verifies a slow fresh fix falls back to the OS last-known position; and
  - verifies denied location permission performs no upload and does not block recording.
- Existing `app/test/widgets/daily_summary_card_test.dart` coverage verifies valid recap coordinates render a fitted map and missing or invalid coordinates do not.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

