### PR TITLE
fix push notification bodies rendering raw markdown

### DIFF
--- a/backend/tests/unit/test_notification_text.py
+++ b/backend/tests/unit/test_notification_text.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from testing.import_isolation import load_module_fresh
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+notification_text = load_module_fresh(
+    'utils.notification_text',
+    str(BACKEND_DIR / 'utils' / 'notification_text.py'),
+)
+to_plain_text = notification_text.to_plain_text
+
+
+def test_strips_bold_and_bullets() -> None:
+    assert to_plain_text("- **US President**: Donald Trump") == "• US President: Donald Trump"
+
+
+def test_strips_headings_code_and_links() -> None:
+    assert to_plain_text("## Title\nRun `omi start` and see [the docs](https://omi.me)") == (
+        "Title\nRun omi start and see the docs"
+    )
+
+
+def test_keeps_plain_text_and_intra_word_punctuation() -> None:
+    body = "Your file_name.txt is 3 * 4 wide and costs $5"
+    assert to_plain_text(body) == body
+
+
+def test_empty_body_is_unchanged() -> None:
+    assert to_plain_text('') == ''

--- a/backend/tests/unit/test_notification_token_cleanup.py
+++ b/backend/tests/unit/test_notification_token_cleanup.py
@@ -122,3 +122,21 @@ def test_send_notification_keeps_transient_failures() -> None:
         notifications.send_notification('user-1', 'omi', 'hello')
 
         notification_db.remove_bulk_tokens.assert_not_called()
+
+
+def test_send_notification_body_is_plain_text() -> None:
+    """Markdown in the body must not reach the OS notification (asterisks showed up literally)."""
+    with _loaded_notifications() as (notifications, notification_db, messaging):
+        notification_db.get_all_tokens.return_value = ['live-token']
+        messaging.send_each.return_value = _FakeBatchResponse([_FakeResponse(success=True)])
+
+        notifications.send_notification(
+            'user-1',
+            'omi says',
+            "- 🇺🇸 **US President**: Donald Trump\n- 🇮🇳 **India's President**: Droupadi Murmu",
+        )
+
+        sent_messages = messaging.send_each.call_args.args[0]
+        body = sent_messages[0].notification.body
+        assert '**' not in body
+        assert body == "• 🇺🇸 US President: Donald Trump\n• 🇮🇳 India's President: Droupadi Murmu"

--- a/backend/utils/notification_text.py
+++ b/backend/utils/notification_text.py
@@ -1,0 +1,43 @@
+"""Plain-text rendering for push notification bodies.
+
+Notification bodies are rendered by the OS, which has no markdown support: an
+answer written as ``**US President**: ...`` shows the literal asterisks on the
+lock screen. The markdown stays in the message payload (the app renders it in
+chat) — only the displayed body is flattened.
+"""
+
+import re
+
+_FENCE_RE = re.compile(r'^\s*```.*$', re.MULTILINE)
+_IMAGE_RE = re.compile(r'!\[([^\]]*)\]\([^)]*\)')
+_LINK_RE = re.compile(r'\[([^\]]*)\]\([^)]*\)')
+_HEADING_RE = re.compile(r'^\s{0,3}#{1,6}\s+', re.MULTILINE)
+_BLOCKQUOTE_RE = re.compile(r'^\s{0,3}>\s?', re.MULTILINE)
+_HORIZONTAL_RULE_RE = re.compile(r'^\s{0,3}([-*_])\s*(?:\1\s*){2,}$', re.MULTILINE)
+_BULLET_RE = re.compile(r'^(\s*)[-*+]\s+', re.MULTILINE)
+_INLINE_CODE_RE = re.compile(r'`+([^`]+)`+')
+_BOLD_ITALIC_RE = re.compile(r'(\*{1,3})(\S.*?\S|\S)\1', re.DOTALL)
+_UNDERSCORE_EMPHASIS_RE = re.compile(r'(?<![\w\\])(_{1,3})(\S.*?\S|\S)\1(?![\w])', re.DOTALL)
+_STRIKETHROUGH_RE = re.compile(r'~~(\S.*?\S|\S)~~', re.DOTALL)
+_BLANK_LINES_RE = re.compile(r'\n{3,}')
+
+
+def to_plain_text(body: str) -> str:
+    """Flatten markdown in ``body`` to what the OS should display."""
+    if not body:
+        return body
+
+    text = _FENCE_RE.sub('', body)
+    text = _IMAGE_RE.sub(r'\1', text)
+    text = _LINK_RE.sub(r'\1', text)
+    text = _HORIZONTAL_RULE_RE.sub('', text)
+    text = _HEADING_RE.sub('', text)
+    text = _BLOCKQUOTE_RE.sub('', text)
+    text = _BULLET_RE.sub(r'\1• ', text)
+    text = _INLINE_CODE_RE.sub(r'\1', text)
+    text = _BOLD_ITALIC_RE.sub(r'\2', text)
+    text = _UNDERSCORE_EMPHASIS_RE.sub(r'\2', text)
+    text = _STRIKETHROUGH_RE.sub(r'\1', text)
+    text = _BLANK_LINES_RE.sub('\n\n', text)
+
+    return text.strip()

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -15,6 +15,7 @@ from database.redis_db import (
     has_silent_user_notification_been_sent,
 )
 from database.auth import get_user_from_uid
+from utils.notification_text import to_plain_text
 from .llm.notifications import (
     generate_notification_message,
     generate_credit_limit_notification,
@@ -240,6 +241,7 @@ def send_notification(
 ) -> None:
     """Send notification to all user's devices. Optionally pass pre-fetched tokens to avoid DB lookup."""
     logger.info(f'send_notification to user {user_id}')
+    body = to_plain_text(body)
     tag = _generate_notification_tag(user_id, title, body, data)
     notification = messaging.Notification(title=title, body=body)
     _send_to_user(user_id, tag, notification=notification, data=data, tokens=tokens)
@@ -250,6 +252,7 @@ async def send_notification_async(
 ) -> None:
     """Async counterpart used by event-loop callers while preserving the sync public API."""
     logger.info(f'send_notification to user {user_id}')
+    body = to_plain_text(body)
     tag = _generate_notification_tag(user_id, title, body, data)
     notification = messaging.Notification(title=title, body=body)
     await _send_to_user_async(user_id, tag, notification=notification, data=data, tokens=tokens)
@@ -367,6 +370,7 @@ async def send_bulk_notification(user_tokens: List[str], title: str, body: str) 
     try:
         batch_size = 500
         num_batches = math.ceil(len(user_tokens) / batch_size)
+        body = to_plain_text(body)
         tag = _generate_tag(f"bulk:{title}:{body}")
         notification = messaging.Notification(title=title, body=body)
 


### PR DESCRIPTION
## Problem

Asking Omi a question from the device delivers the answer as a push notification, and the answer is markdown. The raw markdown string was passed straight through as the FCM notification body, which the OS renders literally — so the lock screen showed:

```
- 🇺🇸 **US President**: Donald Trump
- 🇮🇳 **India's President**: Droupadi Murmu (PM is Narendra Modi)
```

The markdown itself is correct and still needed: the in-app chat bubble renders it as bold. Only the OS-rendered display body is wrong.

## Fix

The notification display body is a plain-text surface, so flattening belongs to the notification layer, not to each caller.

- New `backend/utils/notification_text.py` — `to_plain_text()` flattens bold/italic/strikethrough, inline code and fences, headings, blockquotes, horizontal rules, links and images (keeping their text), and rewrites `-`/`*`/`+` bullets as `•`. Intra-word underscores (`file_name.txt`) and standalone `*` are left alone.
- Applied in `backend/utils/notifications.py` at the three places an FCM `Notification` is constructed — `send_notification`, `send_notification_async`, `send_bulk_notification` — so every push path is covered at once (chat answers, new memories, app messages, daily summaries, bulk sends).
- The `data` payload keeps the original markdown, so in-app chat rendering is unchanged. Web (`web/app/src/hooks/useNotifications.ts`) displays the same FCM body and is fixed by the same change with no client edit.

Result for the reported case:

```
• 🇺🇸 US President: Donald Trump
• 🇮🇳 India's President: Droupadi Murmu (PM is Narendra Modi)
```

## Tests

- `backend/tests/unit/test_notification_text.py` — 4 unit cases covering bold/bullets, headings/code/links, plain text left untouched, and empty input.
- `backend/tests/unit/test_notification_token_cleanup.py` — behavioral regression that drives `send_notification` through the stubbed FCM boundary with the exact reported body and asserts the string reaching FCM contains no `**`. This would have caught the bug.

## Verification

```
$ backend/.venv/bin/python -m pytest -q tests/unit/test_notification_text.py tests/unit/test_notification_token_cleanup.py
7 passed in 0.14s
```

A full `backend/test.sh` run reported failures in `test_verify_backend_release_vector.py` and `test_backend_runtime_env_validator.py`; both pass standalone (`31 passed`, `87 passed 3 skipped`) and are release-vector / env-manifest checks unrelated to notifications — they trip `test.sh`'s 0.12s per-test timing guard when the machine is loaded. `scripts/pr-preflight --suggest`: no product invariants affected, no failure-class declaration required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

