### PR TITLE
fix(app): keep staging routing to opted-in iOS TestFlight builds

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -735,6 +735,16 @@ class SharedPreferencesUtil {
 
   bool get companionAssociationPrompted => getBool('companionAssociationPrompted');
 
+  //------------------------ TestFlight API Environment ----------------------//
+
+  /// Which API environment the iOS TestFlight user prefers: 'staging' or 'production'.
+  /// Default is 'production' so new TestFlight installs hit prod by default.
+  String get testFlightApiEnvironment => getString('testFlightApiEnvironment', defaultValue: 'production');
+
+  set testFlightApiEnvironment(String value) => saveString('testFlightApiEnvironment', value);
+
+  bool get testFlightUseStagingApi => testFlightApiEnvironment == 'staging';
+
   //--------------------------- Announcements ---------------------------------//
 
   // Last known app version - used to detect app upgrades

--- a/app/lib/env/dev_env.dart
+++ b/app/lib/env/dev_env.dart
@@ -21,6 +21,10 @@ final class DevEnv implements EnvFields {
   final String? apiBaseUrl = _DevEnv.apiBaseUrl;
 
   @override
+  @EnviedField(varName: 'STAGING_API_URL', obfuscate: true)
+  final String? stagingApiUrl = _DevEnv.stagingApiUrl;
+
+  @override
   @EnviedField(varName: 'GOOGLE_MAPS_API_KEY', obfuscate: true)
   final String? googleMapsApiKey = _DevEnv.googleMapsApiKey;
 

--- a/app/lib/env/env.dart
+++ b/app/lib/env/env.dart
@@ -29,6 +29,34 @@ abstract class Env {
   // static String? get apiBaseUrl => 'https://omi-backend.ngrok.app/';
   static String? get apiBaseUrl => _apiBaseUrlOverride ?? _instance.apiBaseUrl;
 
+  /// Staging API URL from STAGING_API_URL env var. Null when not configured.
+  /// Only iOS TestFlight builds may opt into this at runtime (see main.dart);
+  /// Android and production-store builds always stay on [apiBaseUrl].
+  static String? get stagingApiUrl {
+    final url = _instance.stagingApiUrl;
+    if (url == null || url.isEmpty) return null;
+    return url;
+  }
+
+  /// Whether STAGING_API_URL is configured in the environment.
+  static bool get isStagingConfigured => stagingApiUrl != null;
+
+  /// True when the effective backend is the configured staging backend.
+  static bool get isUsingStagingApi {
+    final effective = apiBaseUrl;
+    final staging = stagingApiUrl;
+    if (effective == null || staging == null) return false;
+    return _normalizeUrl(effective) == _normalizeUrl(staging);
+  }
+
+  static String _normalizeUrl(String url) {
+    var s = url.trim().toLowerCase();
+    while (s.endsWith('/')) {
+      s = s.substring(0, s.length - 1);
+    }
+    return s;
+  }
+
   /// Production-family packages have one pinned backend authority. This runs
   /// during startup so a misconfigured signing group fails before networking.
   static void validateStartupRouting({required bool productionFamily, String? configuredApiBaseUrl}) {
@@ -80,6 +108,8 @@ abstract class EnvFields {
   String? get posthogApiKey;
 
   String? get apiBaseUrl;
+
+  String? get stagingApiUrl;
 
   String? get googleMapsApiKey;
 

--- a/app/lib/env/prod_env.dart
+++ b/app/lib/env/prod_env.dart
@@ -21,6 +21,10 @@ final class ProdEnv implements EnvFields {
   final String? apiBaseUrl = _ProdEnv.apiBaseUrl;
 
   @override
+  @EnviedField(varName: 'STAGING_API_URL', obfuscate: true)
+  final String? stagingApiUrl = _ProdEnv.stagingApiUrl;
+
+  @override
   @EnviedField(varName: 'GOOGLE_MAPS_API_KEY', obfuscate: true)
   final String? googleMapsApiKey = _ProdEnv.googleMapsApiKey;
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -38,6 +38,7 @@ import 'package:omi/l10n/app_localizations.dart';
 import 'package:omi/pages/apps/providers/add_app_provider.dart';
 import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
 import 'package:omi/pages/payments/payment_method_provider.dart';
+import 'package:omi/pages/settings/developer.dart';
 import 'package:omi/providers/action_items_provider.dart';
 import 'package:omi/providers/announcement_provider.dart';
 import 'package:omi/providers/app_provider.dart';
@@ -157,10 +158,27 @@ Future _init() async {
 
   await SharedPreferencesUtil.init();
 
-  // TestFlight remains a distribution/telemetry signal; production-family
-  // builds always use the established production backend.
+  // TestFlight environment detection — must be after SharedPreferencesUtil.init()
+  // so the user's opt-in preference can be read. Staging is iOS-TestFlight-only
+  // and opt-in (default production); Android and production-store builds always
+  // stay on prod — isTestFlight() is false off iOS, and startup routing pins the
+  // base URL for every production-family build before this override can run.
   if (F.env == Environment.prod) {
-    Env.isTestFlight = await EnvironmentDetector.isTestFlight();
+    final isTestFlight = await EnvironmentDetector.isTestFlight();
+    if (isTestFlight) {
+      Env.isTestFlight = true;
+      if (SharedPreferencesUtil().testFlightUseStagingApi) {
+        final staging = Env.stagingApiUrl;
+        if (staging != null) {
+          Env.overrideApiBaseUrl(staging);
+          debugPrint('TestFlight detected: using staging backend ($staging)');
+        } else {
+          debugPrint('TestFlight detected: staging preferred but STAGING_API_URL not configured, using production');
+        }
+      } else {
+        debugPrint('TestFlight detected: user chose production backend');
+      }
+    }
   }
 
   bool isAuth = (await AuthService.instance.getIdToken()) != null;
@@ -398,7 +416,41 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
               ErrorWidget.builder = (errorDetails) {
                 return CustomErrorWidget(errorMessage: errorDetails.exceptionAsString());
               };
-              final content = child!;
+              Widget content;
+              if (Env.isUsingStagingApi) {
+                final topPadding = MediaQuery.of(context).padding.top;
+                content = Column(
+                  children: [
+                    GestureDetector(
+                      onTap: () {
+                        MyApp.navigatorKey.currentState?.push(
+                          MaterialPageRoute(builder: (context) => const DeveloperSettingsPage()),
+                        );
+                      },
+                      child: Container(
+                        width: double.infinity,
+                        padding: EdgeInsets.only(top: topPadding + 4, bottom: 4),
+                        color: Colors.orange.shade800,
+                        child: Text(
+                          context.l10n.staging.toUpperCase(),
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                            decoration: TextDecoration.none,
+                          ),
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: MediaQuery.removePadding(context: context, removeTop: true, child: child!),
+                    ),
+                  ],
+                );
+              } else {
+                content = child!;
+              }
               return PlatformService.isIOS && Env.posthogApiKey != null
                   ? RageClickContextTracker(child: content)
                   : content;

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -109,6 +109,34 @@ class _DeveloperSettingsPageState extends State<_DeveloperSettingsPageView> {
     );
   }
 
+  void _showApiSwitchDialog(BuildContext context, String targetEnvironment) {
+    final targetName = targetEnvironment == 'production' ? context.l10n.production : context.l10n.staging;
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: const Color(0xFF1C1C1E),
+        title: Text(context.l10n.switchApiConfirmTitle, style: const TextStyle(color: Colors.white)),
+        content: Text(context.l10n.switchApiConfirmBody(targetName), style: const TextStyle(color: Colors.white70)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text(context.l10n.cancel, style: const TextStyle(color: Colors.grey)),
+          ),
+          TextButton(
+            onPressed: () async {
+              Navigator.of(ctx).pop();
+              final message = context.l10n.apiEnvSavedRestartRequired;
+              await SharedPreferencesUtil().saveString('testFlightApiEnvironment', targetEnvironment);
+              if (!context.mounted) return;
+              AppSnackbar.showSnackbar(message, duration: const Duration(seconds: 5));
+            },
+            child: Text(context.l10n.switchAndRestart, style: const TextStyle(color: Colors.orange)),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildSectionHeader(String title, {String? subtitle, Widget? trailing}) {
     return Padding(
       padding: const EdgeInsets.only(left: 4, right: 4, bottom: 12),
@@ -1731,6 +1759,151 @@ class _DeveloperSettingsPageState extends State<_DeveloperSettingsPageView> {
                       ],
                     ),
                   ),
+
+                  // API Environment Section (iOS TestFlight only, requires STAGING_API_URL env var)
+                  if (Env.isTestFlight && Env.isStagingConfigured) ...[
+                    const SizedBox(height: 32),
+                    _buildSectionHeader(context.l10n.apiEnvironment, subtitle: context.l10n.apiEnvironmentDescription),
+                    Container(
+                      padding: const EdgeInsets.all(16),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF1C1C1E),
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            decoration: BoxDecoration(
+                              color: const Color(0xFF2A2A2E),
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  child: GestureDetector(
+                                    onTap: () {
+                                      if (!SharedPreferencesUtil().testFlightUseStagingApi) return;
+                                      _showApiSwitchDialog(context, 'production');
+                                    },
+                                    child: Container(
+                                      padding: const EdgeInsets.symmetric(vertical: 12),
+                                      decoration: BoxDecoration(
+                                        color: !SharedPreferencesUtil().testFlightUseStagingApi
+                                            ? const Color(0xFF22C55E)
+                                            : Colors.transparent,
+                                        borderRadius: BorderRadius.circular(10),
+                                      ),
+                                      child: Column(
+                                        children: [
+                                          Text(
+                                            context.l10n.production,
+                                            style: TextStyle(
+                                              color: !SharedPreferencesUtil().testFlightUseStagingApi
+                                                  ? Colors.white
+                                                  : Colors.grey.shade400,
+                                              fontSize: 14,
+                                              fontWeight: FontWeight.w600,
+                                            ),
+                                          ),
+                                          const SizedBox(height: 2),
+                                          Text(
+                                            'api.omi.me',
+                                            style: TextStyle(
+                                              color: !SharedPreferencesUtil().testFlightUseStagingApi
+                                                  ? Colors.white70
+                                                  : Colors.grey.shade600,
+                                              fontSize: 11,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                                Expanded(
+                                  child: GestureDetector(
+                                    onTap: () {
+                                      if (SharedPreferencesUtil().testFlightUseStagingApi) return;
+                                      _showApiSwitchDialog(context, 'staging');
+                                    },
+                                    child: Container(
+                                      padding: const EdgeInsets.symmetric(vertical: 12),
+                                      decoration: BoxDecoration(
+                                        color: SharedPreferencesUtil().testFlightUseStagingApi
+                                            ? Colors.orange.shade800
+                                            : Colors.transparent,
+                                        borderRadius: BorderRadius.circular(10),
+                                      ),
+                                      child: Column(
+                                        children: [
+                                          Text(
+                                            context.l10n.staging,
+                                            style: TextStyle(
+                                              color: SharedPreferencesUtil().testFlightUseStagingApi
+                                                  ? Colors.white
+                                                  : Colors.grey.shade400,
+                                              fontSize: 14,
+                                              fontWeight: FontWeight.w600,
+                                            ),
+                                          ),
+                                          const SizedBox(height: 2),
+                                          Text(
+                                            Uri.parse(Env.stagingApiUrl!).host,
+                                            style: TextStyle(
+                                              color: SharedPreferencesUtil().testFlightUseStagingApi
+                                                  ? Colors.white70
+                                                  : Colors.grey.shade600,
+                                              fontSize: 11,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Row(
+                            children: [
+                              FaIcon(FontAwesomeIcons.circleInfo, color: Colors.grey.shade600, size: 12),
+                              const SizedBox(width: 6),
+                              Text(
+                                context.l10n.switchRequiresRestart,
+                                style: TextStyle(color: Colors.grey.shade600, fontSize: 12),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                    if (SharedPreferencesUtil().testFlightUseStagingApi) ...[
+                      const SizedBox(height: 8),
+                      Container(
+                        margin: const EdgeInsets.symmetric(horizontal: 4),
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Colors.orange.shade900.withValues(alpha: 0.3),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: Colors.orange.shade700.withValues(alpha: 0.5)),
+                        ),
+                        child: Row(
+                          children: [
+                            Icon(Icons.warning_amber_rounded, color: Colors.orange.shade300, size: 20),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                context.l10n.stagingDisclaimer,
+                                style: TextStyle(color: Colors.orange.shade300, fontSize: 12),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ],
 
                   // Manual Firmware Flash (only when device connected)
                   Builder(

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -92,6 +92,8 @@ class _TestEnvFields implements EnvFields {
   @override
   String? get apiBaseUrl => null;
   @override
+  String? get stagingApiUrl => null;
+  @override
   String? get googleMapsApiKey => null;
   @override
   String? get intercomAppId => null;

--- a/app/test/unit/env_test.dart
+++ b/app/test/unit/env_test.dart
@@ -15,6 +15,8 @@ class _TestEnvFields implements EnvFields {
   @override
   String? get apiBaseUrl => 'https://api.omi.me/';
   @override
+  String? get stagingApiUrl => null;
+  @override
   String? get googleMapsApiKey => null;
   @override
   String? get intercomAppId => null;
@@ -99,5 +101,38 @@ void main() {
     expect(mainSource, contains('validateApplicationStartupRouting();'));
     expect(mainSource.indexOf('validateApplicationStartupRouting();'),
         lessThan(mainSource.indexOf('ServiceManager.init()')));
+  });
+
+  group('staging routing stays TestFlight-only', () {
+    test('isUsingStagingApi is false when staging is not configured', () {
+      // Android/production builds bake no STAGING_API_URL, so nothing can match.
+      expect(Env.isStagingConfigured, isFalse);
+      expect(Env.isUsingStagingApi, isFalse);
+    });
+
+    test('the staging override is reachable only inside the TestFlight branch', () {
+      // Regression guard: a compile-time/build-identity flag once routed Android
+      // beta to staging. The override must stay nested under isTestFlight.
+      final mainSource = File('lib/main.dart').readAsStringSync();
+      final testFlightBranch = mainSource.indexOf('if (isTestFlight) {');
+      final override = mainSource.indexOf('Env.overrideApiBaseUrl(staging)');
+      expect(testFlightBranch, greaterThan(-1));
+      expect(override, greaterThan(testFlightBranch));
+      // It must also be gated on the user's opt-in preference.
+      final optIn = mainSource.indexOf('testFlightUseStagingApi');
+      expect(optIn, greaterThan(testFlightBranch));
+      expect(optIn, lessThan(override));
+    });
+
+    test('no build-identity flag can opt a non-TestFlight build into staging', () {
+      final mainSource = File('lib/main.dart').readAsStringSync();
+      final detectorSource = File('lib/utils/environment_detector.dart').readAsStringSync();
+      for (final source in [mainSource, detectorSource]) {
+        expect(source, isNot(contains('OMI_BETA_RELEASE_RING')));
+        expect(source, isNot(contains('shouldUseBetaReleaseRing')));
+      }
+      // TestFlight detection itself must remain iOS-only.
+      expect(detectorSource, contains('if (!Platform.isIOS) return false;'));
+    });
   });
 }

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -80,6 +80,7 @@ workflows:
           echo INSTABUG_API_KEY=$INSTABUG_API_KEY >> .env
           echo ONESIGNAL_APP_ID=$ONESIGNAL_APP_ID >> .env
           echo API_BASE_URL=https://api.omi.me/ >> .env
+          echo STAGING_API_URL=https://api.omiapi.com/ >> .env
           echo GROWTHBOOK_API_KEY=$GROWTHBOOK_API_KEY >> .env
           echo GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY >> .env
           echo INTERCOM_APP_ID=$INTERCOM_APP_ID >> .env
@@ -519,6 +520,7 @@ workflows:
           echo INSTABUG_API_KEY=$INSTABUG_API_KEY >> .env
           echo ONESIGNAL_APP_ID=$ONESIGNAL_APP_ID >> .env
           echo API_BASE_URL=https://api.omi.me/ >> .env
+          echo STAGING_API_URL=https://api.omiapi.com/ >> .env
           echo GROWTHBOOK_API_KEY=$GROWTHBOOK_API_KEY >> .env
           echo GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY >> .env
           echo INTERCOM_APP_ID=$INTERCOM_APP_ID >> .env
@@ -1073,6 +1075,7 @@ workflows:
           echo INSTABUG_API_KEY=$INSTABUG_API_KEY >> .env
           echo ONESIGNAL_APP_ID=$ONESIGNAL_APP_ID >> .env
           echo API_BASE_URL=https://api.omi.me/ >> .env
+          echo STAGING_API_URL=https://api.omiapi.com/ >> .env
           echo GROWTHBOOK_API_KEY=$GROWTHBOOK_API_KEY >> .env
           echo GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY >> .env
           echo INTERCOM_APP_ID=$INTERCOM_APP_ID >> .env


### PR DESCRIPTION
## Problem

Android beta builds were reaching the staging backend. Staging is meant to be an
iOS TestFlight-only, opt-in capability.

## Change

Restores staging selection as an **iOS TestFlight-only, opt-in** path, and keeps
every other production-family build on production.

- `Env.stagingApiUrl` / `isStagingConfigured` / `isUsingStagingApi`, backed by a
  `STAGING_API_URL` envied field on both prod and dev env classes.
- `testFlightApiEnvironment` preference, **defaulting to `production`** — a
  TestFlight install only reaches staging after an explicit opt-in.
- `main.dart` selects staging solely inside the `isTestFlight` branch, and only
  when that preference is set. Restores the orange `STAGING` banner.
- Developer settings regains the Production | Staging toggle, gated on
  `Env.isTestFlight && Env.isStagingConfigured`.
- `codemagic.yaml` bakes `STAGING_API_URL` into the **iOS workflows only**.

## Why Android cannot reach staging

Three independent layers, any one of which is sufficient:

1. `EnvironmentDetector.isTestFlight()` returns `false` unless `Platform.isIOS`,
   so the override never runs on Android.
2. Android workflows bake no `STAGING_API_URL`, so there is no staging backend to
   select even if the runtime gate were bypassed.
3. `Env.validateStartupRouting` still hard-pins every production-family build's
   baked config to `https://api.omi.me/` before networking starts.

Selection is driven only by runtime TestFlight detection plus a user opt-in — no
build-identity/compile-time flag can place a build in staging, and a regression
test asserts that.

## Tests

- `test/unit/env_test.dart`: new `staging routing stays TestFlight-only` group —
  the override stays nested under `isTestFlight` behind the opt-in, and no
  build-identity flag can select staging. 11/11 pass.
- `test/providers/capture_provider_test.dart` + `env_test.dart`: 77/77 pass.
- `bash scripts/analyze_ratchet.sh`: passed (`prefer_const_constructors` improved,
  451 vs baseline 465).
- `dart format --line-length 120`: clean.

## Note

Shipping this to users requires a fresh Android internal-track build; the live
build predates the fix.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

