### PR TITLE
docs(api): refresh app-client OpenAPI contract for apps_results

### DIFF
--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -1735,6 +1735,7 @@ export interface FolderMutationResponse {
 }
 
 export interface FullConversation {
+  apps_results?: Array<AppResult>;
   finished_at: string | null;
   id: string;
   language?: string | null;
@@ -2866,6 +2867,7 @@ export interface SimpleChatMessage {
 }
 
 export interface SimpleConversation {
+  apps_results?: Array<AppResult>;
   finished_at: string | null;
   id: string;
   language?: string | null;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -10837,6 +10837,14 @@
       },
       "FullConversation": {
         "properties": {
+          "apps_results": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/AppResult"
+            },
+            "title": "Apps Results",
+            "type": "array"
+          },
           "finished_at": {
             "anyOf": [
               {
@@ -17404,6 +17412,14 @@
       },
       "SimpleConversation": {
         "properties": {
+          "apps_results": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/AppResult"
+            },
+            "title": "Apps Results",
+            "type": "array"
+          },
           "finished_at": {
             "anyOf": [
               {

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -1735,6 +1735,7 @@ export interface FolderMutationResponse {
 }
 
 export interface FullConversation {
+  apps_results?: Array<AppResult>;
   finished_at: string | null;
   id: string;
   language?: string | null;
@@ -2866,6 +2867,7 @@ export interface SimpleChatMessage {
 }
 
 export interface SimpleConversation {
+  apps_results?: Array<AppResult>;
   finished_at: string | null;
   id: string;
   language?: string | null;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -1735,6 +1735,7 @@ export interface FolderMutationResponse {
 }
 
 export interface FullConversation {
+  apps_results?: Array<AppResult>;
   finished_at: string | null;
   id: string;
   language?: string | null;
@@ -2866,6 +2867,7 @@ export interface SimpleChatMessage {
 }
 
 export interface SimpleConversation {
+  apps_results?: Array<AppResult>;
   finished_at: string | null;
   id: string;
   language?: string | null;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -1735,6 +1735,7 @@ export interface FolderMutationResponse {
 }
 
 export interface FullConversation {
+  apps_results?: Array<AppResult>;
   finished_at: string | null;
   id: string;
   language?: string | null;
@@ -2866,6 +2867,7 @@ export interface SimpleChatMessage {
 }
 
 export interface SimpleConversation {
+  apps_results?: Array<AppResult>;
   finished_at: string | null;
   id: string;
   language?: string | null;


### PR DESCRIPTION
## Summary
The OpenAPI Contract workflow has been red on `main` since ~14:41 UTC today: PR #10111 (177117ad40) added `apps_results` to the MCP `SimpleConversation` model (inherited by `FullConversation`) but did not regenerate the committed app-client contract. Every open PR inherits the failing **Public Developer API contract** check.

This PR regenerates `docs/api-reference/app-client-openapi.json` (16 added lines — the `apps_results` field on both schemas). No code changes.

## Verification
- `backend/scripts/export_openapi.py --app-client --check` → `docs/api-reference/app-client-openapi.json is up to date` (was: "stale" before the regen; reproduced the exact CI failure locally first)
- Diff inspected: only the two `apps_results` schema additions, matching ed2ba41c5b.

Note: the check's error message says to run `export_openapi.py --write ../docs/api-reference/app-client-openapi.json`, which silently exports the **public** surface into the app-client file (surface defaults to `public`); the correct invocation needs `--app-client`. Follow-up issue to fix the message.

## Peer review
Independent agent review: APPROVE. Verified diff scope (1 file, 16 additive lines, no removals/auth changes), reran the contract check from the worktree (up to date), confirmed base == origin/main with nothing smuggled. Attribution corrected per review (#10111, not #10196).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

