### PR TITLE
ci: skip irrelevant auto dev backend deployments

### DIFF
--- a/.github/scripts/check_backend_deploy_source_admission.py
+++ b/.github/scripts/check_backend_deploy_source_admission.py
@@ -20,6 +20,7 @@ AUTO_DEPLOY_ADMITTED_SHA = "${{ needs.firestore_readiness.outputs.admitted_sha }
 MANUAL_ADMITTED_SHA = "${{ needs.firestore_readiness.outputs.admitted_sha }}"
 AUTO_SOURCE_ADMISSION_CONDITION = "\n".join(
     (
+        "needs.scope.outputs.applies == 'true' &&",
         "github.event.workflow_run.conclusion == 'success' &&",
         "github.event.workflow_run.event == 'push' &&",
         "github.event.workflow_run.run_attempt == 1 &&",
@@ -151,9 +152,61 @@ def validate_auto_workflow(text: str) -> list[str]:
 
     firestore_job = mapping_block(text, "firestore_readiness", 2)
     readiness_steps = None if firestore_job is None else mapping_block(firestore_job, "steps", 4)
+    scope_job = mapping_block(text, "scope", 2)
+    scope_steps = None if scope_job is None else mapping_block(scope_job, "steps", 4)
+    if scope_job is None:
+        errors.append("auto backend deploy is missing its unprivileged scope decision job")
+    else:
+        require_fragment(
+            errors,
+            scope_job,
+            "permissions:\n      contents: 'read'",
+            "auto backend scope decision must remain contents-read-only",
+        )
+        if "environment:" in scope_job:
+            errors.append("auto backend scope decision must not receive a deployment environment")
+        if "google-github-actions/auth" in scope_job or "gcloud" in scope_job:
+            errors.append("auto backend scope decision must not authenticate to cloud services")
+    if scope_steps is None:
+        errors.append("auto backend deploy scope decision must contain its steps")
+    else:
+        scope_checkout = require_step(
+            errors,
+            scope_steps,
+            "Checkout triggering main commit for scope decision",
+            "triggering-commit scope checkout",
+        )
+        for fragment, message in (
+            (f"ref: {AUTO_PROOF_SHA}", "auto backend scope decision must inspect the triggering SHA"),
+            ("fetch-depth: 2", "auto backend scope decision must fetch the triggering commit parent"),
+        ):
+            require_fragment(errors, scope_checkout, fragment, message)
+        scope_decision = require_step(
+            errors,
+            scope_steps,
+            "Decide whether the triggering commit can affect the backend deployment",
+            "backend deployment scope decision",
+        )
+        for fragment, message in (
+            (f"RELEASE_SHA: {AUTO_PROOF_SHA}", "auto backend scope decision must bind the triggering SHA"),
+            ("git rev-parse \"${RELEASE_SHA}^\"", "auto backend scope decision must inspect the triggering parent"),
+            (
+                "git diff --name-only \"$parent_sha\" \"$RELEASE_SHA\"",
+                "auto backend scope decision must diff the triggering SHA against its parent",
+            ),
+            ("echo \"applies=false\" >> \"$GITHUB_OUTPUT\"", "auto backend scope decision must publish a no-op result"),
+            ("Green no-op", "auto backend scope decision must summarize green no-ops"),
+        ):
+            require_fragment(errors, scope_decision, fragment, message)
     if firestore_job is None:
         errors.append("auto backend deploy is missing its source-admission job")
     else:
+        require_fragment(
+            errors,
+            firestore_job,
+            "needs: scope",
+            "auto source-admission job must depend on the scope decision",
+        )
         condition = folded_job_condition(firestore_job)
         if condition != AUTO_SOURCE_ADMISSION_CONDITION:
             errors.append(
@@ -267,8 +320,8 @@ def validate_auto_workflow(text: str) -> list[str]:
 
     if "github.sha" in text:
         errors.append("auto backend deploy must not use github.sha after workflow_run admission")
-    if text.count(AUTO_PROOF_SHA) != 1:
-        errors.append("auto backend deploy must use workflow_run.head_sha only in the current-main admission guard")
+    if text.count(AUTO_PROOF_SHA) != 3:
+        errors.append("auto backend deploy must use workflow_run.head_sha only in scope decision and current-main admission guard")
     if text.count(AUTO_PROOF_RUN_ATTEMPT) != 1:
         errors.append("auto backend deploy must use workflow_run.run_attempt only in the source-admission guard")
     if text.count(f"ref: {AUTO_FIRESTORE_ADMITTED_SHA}") != 1:

--- a/.github/scripts/test_check_backend_deploy_source_admission.py
+++ b/.github/scripts/test_check_backend_deploy_source_admission.py
@@ -196,6 +196,45 @@ class WorkflowContractTests(unittest.TestCase):
                     )
                 )
 
+    def test_auto_workflow_rejects_scope_bypasses_or_cloud_access(self) -> None:
+        cases = (
+            (
+                "readiness scope dependency",
+                "    needs: scope\n",
+                "",
+                "auto source-admission job must depend on the scope decision",
+            ),
+            (
+                "scope output predicate",
+                "needs.scope.outputs.applies == 'true' &&",
+                "needs.scope.outputs.applies == 'false' &&",
+                "auto source-admission job must use exactly the fail-closed Release Eligibility predicate",
+            ),
+            (
+                "triggering SHA checkout",
+                "ref: ${{ github.event.workflow_run.head_sha }}\n          fetch-depth: 2",
+                "ref: main\n          fetch-depth: 2",
+                "auto backend scope decision must inspect the triggering SHA",
+            ),
+            (
+                "parent diff",
+                'git diff --name-only "$parent_sha" "$RELEASE_SHA"',
+                'git diff --name-only "$parent_sha" HEAD',
+                "auto backend scope decision must diff the triggering SHA against its parent",
+            ),
+            (
+                "cloud authentication",
+                "    runs-on: ubuntu-latest-m\n    outputs:",
+                "    runs-on: ubuntu-latest-m\n    steps:\n      - uses: google-github-actions/auth@v3\n    outputs:",
+                "auto backend scope decision must not authenticate to cloud services",
+            ),
+        )
+        for name, old, new, expected in cases:
+            with self.subTest(name=name):
+                root = self.fixture_root()
+                self.mutate(root, CHECKER.AUTO_WORKFLOW_PATH, old, new)
+                self.assertIn(expected, CHECKER.validate(root))
+
     def test_auto_workflow_rejects_stale_or_unverified_source_admission(self) -> None:
         cases = (
             (

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -20,12 +20,69 @@ env:
   CANDIDATE_TAG: candidate
 
 jobs:
+  scope:
+    name: Decide backend deployment scope
+    # This unprivileged decision runs before source admission, Firestore
+    # readiness, image work, or any cloud mutation. workflow_run does not
+    # support a safe workflow-level paths filter, so inspect its immutable SHA.
+    permissions:
+      contents: 'read'
+    runs-on: ubuntu-latest-m
+    outputs:
+      applies: ${{ steps.scope.outputs.applies }}
+    steps:
+      - name: Checkout triggering main commit for scope decision
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
+
+      - name: Decide whether the triggering commit can affect the backend deployment
+        id: scope
+        env:
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          if ! git cat-file -e "${RELEASE_SHA}^{commit}"; then
+            echo "Cannot resolve triggering Release Eligibility SHA: $RELEASE_SHA" >&2
+            exit 1
+          fi
+
+          if ! parent_sha="$(git rev-parse "${RELEASE_SHA}^" 2>/dev/null)"; then
+            # An unavailable parent is uncertain scope: retain the existing
+            # exact-SHA admission and deployment path rather than skip.
+            echo "applies=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Backend development deploy scope"
+              echo "In scope: could not resolve the triggering commit parent."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "$parent_sha" "$RELEASE_SHA")"
+          printf 'Changed files for %s:\n%s\n' "$RELEASE_SHA" "$changed_files"
+          if grep -Eq '^(backend/|\.github/workflows/(gcp_backend_auto_dev|release-eligibility)\.yml$|\.github/actions/(release-eligibility|sync-backfill-lifecycle)/|\.github/scripts/(verify_auto_backend_release_admission|desktop_release_manifest|desktop_qualification_admission|desktop_qualification_evidence)\.py$)' <<<"$changed_files"; then
+            echo "applies=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Backend development deploy scope"
+              echo "In scope: the triggering commit can affect backend runtime or deployment inputs."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "applies=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Backend development deploy no-op"
+              echo "Green no-op: the triggering commit cannot affect backend runtime or deployment inputs."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   firestore_readiness:
     # A workflow_run can access deployment credentials, so never run source
     # code until the first completed proof identifies the exact current commit
     # on this repository's main branch. Every later checkout and release vector
     # uses that admitted SHA rather than a mutable default branch ref.
+    needs: scope
     if: >-
+      needs.scope.outputs.applies == 'true' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.run_attempt == 1 &&

--- a/backend/tests/unit/test_auto_dev_backend_scope.py
+++ b/backend/tests/unit/test_auto_dev_backend_scope.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = ROOT / '.github/workflows/gcp_backend_auto_dev.yml'
+
+
+def _load_admission_script():
+    path = ROOT / '.github/scripts/verify_auto_backend_release_admission.py'
+    spec = importlib.util.spec_from_file_location('verify_auto_backend_release_admission', path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _scope_job() -> dict:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding='utf-8'))
+    return workflow['jobs']['scope']
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(['git', *args], cwd=repo, text=True).strip()
+
+
+def _commit(repo: Path, relative_path: str) -> str:
+    path = repo / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f'{relative_path}\n', encoding='utf-8')
+    _git(repo, 'add', relative_path)
+    _git(repo, 'commit', '-m', f'change {relative_path}')
+    return _git(repo, 'rev-parse', 'HEAD')
+
+
+def _run_scope(repo: Path, sha: str) -> tuple[dict[str, str], str]:
+    output = repo / 'github-output.txt'
+    summary = repo / 'github-summary.md'
+    scope_step = next(step for step in _scope_job()['steps'] if step.get('id') == 'scope')
+    result = subprocess.run(
+        ['bash', '-c', scope_step['run']],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        env={
+            **os.environ,
+            'RELEASE_SHA': sha,
+            'GITHUB_OUTPUT': str(output),
+            'GITHUB_STEP_SUMMARY': str(summary),
+        },
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    values = dict(line.split('=', 1) for line in output.read_text(encoding='utf-8').splitlines())
+    return values, summary.read_text(encoding='utf-8')
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    _git(tmp_path, 'init')
+    _git(tmp_path, 'config', 'user.email', 'scope-test@example.invalid')
+    _git(tmp_path, 'config', 'user.name', 'Scope Test')
+    _commit(tmp_path, 'README.md')
+    return tmp_path
+
+
+def test_unrelated_desktop_change_exits_as_a_green_no_op(git_repo: Path) -> None:
+    desktop_sha = _commit(git_repo, 'desktop/macos/README.md')
+
+    outputs, summary = _run_scope(git_repo, desktop_sha)
+
+    assert outputs == {'applies': 'false'}
+    assert 'Green no-op' in summary
+
+
+@pytest.mark.parametrize(
+    'relative_path',
+    ('backend/main.py', '.github/actions/sync-backfill-lifecycle/action.yml'),
+)
+def test_backend_source_or_deploy_input_change_proceeds(git_repo: Path, relative_path: str) -> None:
+    relevant_sha = _commit(git_repo, relative_path)
+
+    outputs, _summary = _run_scope(git_repo, relevant_sha)
+
+    assert outputs == {'applies': 'true'}
+
+
+def test_stale_relevant_sha_reaches_and_fails_the_existing_admission_guard(git_repo: Path) -> None:
+    relevant_sha = _commit(git_repo, 'backend/main.py')
+    outputs, _summary = _run_scope(git_repo, relevant_sha)
+    admission = _load_admission_script()
+
+    assert outputs == {'applies': 'true'}
+    with pytest.raises(admission.AutomaticReleaseAdmissionError, match='still equal current main'):
+        admission.validate(
+            admission.AutomaticReleaseIdentity(
+                sha=relevant_sha,
+                main_sha='a' * 40,
+                checkout_sha='a' * 40,
+                run_attempt='1',
+            )
+        )
+
+
+def test_scope_job_is_unprivileged_and_gates_admission_before_cloud_steps() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding='utf-8'))
+    scope = workflow['jobs']['scope']
+    readiness = workflow['jobs']['firestore_readiness']
+    checkout = next(step for step in scope['steps'] if step.get('uses') == 'actions/checkout@v7')
+
+    assert scope['permissions'] == {'contents': 'read'}
+    assert 'environment' not in scope
+    assert checkout['with'] == {'ref': '${{ github.event.workflow_run.head_sha }}', 'fetch-depth': 2}
+    assert "needs.scope.outputs.applies == 'true'" in readiness['if']
+    assert 'google-github-actions/auth' not in str(scope)
+    assert 'gcloud' not in str(scope)


### PR DESCRIPTION
## Summary
- Adds an unprivileged, SHA-and-parent-diff scope decision to Auto Deploy Backend to Development.
- Completes unrelated desktop/docs commits as an explicit green no-op before source admission, Firestore readiness, cloud credentials, image work, or deployment.
- Retains the existing exact immutable-SHA admission, backend-stack development concurrency, Firestore read-only readiness, candidate/traffic promotion, and post-deploy verification for relevant commits.

## Verification
- `pytest -q backend/tests/unit/test_auto_dev_backend_scope.py backend/tests/unit/test_verify_backend_release_vector.py backend/tests/unit/test_backend_runtime_env_validator.py` — 105 passed
- `actionlint -verbose -shellcheck '' .github/workflows/gcp_backend_auto_dev.yml` — 0 errors
- `make preflight` — passed (22 deterministic checks)

## Scope evidence
- Contract coverage executes the actual workflow scope shell step against temporary Git histories: unrelated desktop change => `applies=false` plus green no-op summary; backend source and sync-backfill deploy-action changes => `applies=true`; a stale relevant SHA proceeds to, and fails, the existing admission guard.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

