### PR TITLE
fix(desktop): repair APIClientRoutingTests after beta bundle removal

### DIFF
--- a/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
@@ -318,7 +318,7 @@ final class APIClientRoutingTests: XCTestCase {
       ))
     XCTAssertFalse(
       DesktopBackendEnvironment.shouldUseDevelopmentBackends(
-        bundleIdentifier: AppBuild.betaProductionBundleIdentifier,
+        bundleIdentifier: AppBuild.productionBundleIdentifier,
         updateChannel: "beta"
       ))
   }

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -368,12 +368,18 @@ import XCTest
     // omi-test-quality: source-inspection -- static contract: UI must not pre-parse user wording into a provider spawn.
     let windowSource = try floatingControlBarWindowSource()
     let source = try floatingControlBarViewSource()
+    let pillSource = try agentPillSource()
 
     XCTAssertFalse(windowSource.contains("providerDirective"))
     XCTAssertFalse(windowSource.contains("resolveDelegationAndDispatch"))
     XCTAssertTrue(windowSource.contains("await dispatchChatQuery("))
     XCTAssertFalse(source.contains("AgentPillFollowUpRoutingPolicy"))
-    XCTAssertTrue(source.contains("manager.continueAgent(from: pill, text: trimmed, attachments: staged)"))
+    // The typed "Ask this agent" field left the floating bar (4a8244742d);
+    // agent follow-ups now enter only through AgentPillsManager.continueAgent,
+    // which must hand the prompt to the coordinator model loop untouched.
+    XCTAssertFalse(pillSource.contains("AgentPillFollowUpRoutingPolicy"))
+    XCTAssertFalse(pillSource.contains("providerDirective"))
+    XCTAssertTrue(pillSource.contains("try await DesktopCoordinatorService.shared.continueAgent("))
   }
 
   func testSubagentChatRendersMarkdownAndLargeBackHitTarget() throws {
@@ -832,11 +838,14 @@ import XCTest
     XCTAssertFalse(body.contains("FloatingControlBarGeometry.targetFrame("))
   }
 
-  func testSubagentComposerOnlyContinuesItsCanonicalSession() throws {
-    let viewSource = try floatingControlBarViewSource()
+  func testAgentFollowUpOnlyContinuesItsCanonicalSession() throws {
+    // omi-test-quality: source-inspection -- static contract: a pill follow-up must target the pill's
+    // canonical session (never spawn a sibling or re-route), including after the continue-agent await.
+    let pillSource = try agentPillSource()
 
-    XCTAssertFalse(viewSource.contains("AgentPillFollowUpRoutingPolicy"))
-    XCTAssertTrue(viewSource.contains("manager.continueAgent(from: pill, text: trimmed, attachments: staged)"))
+    XCTAssertFalse(pillSource.contains("AgentPillFollowUpRoutingPolicy"))
+    XCTAssertTrue(pillSource.contains("guard let sessionId = pill.canonicalSessionId"))
+    XCTAssertTrue(pillSource.contains("guard pill.canonicalSessionId == sessionId else { return }"))
   }
 
   func testSpawnAgentToolCallOpensSubagentChat() throws {
@@ -921,7 +930,6 @@ import XCTest
     let inputSource = String(viewSource[inputRange.lowerBound..<inputEnd.lowerBound])
 
     XCTAssertTrue(inputSource.contains(".beginVisibleMainQuery(message, fromVoice: false, animated: true)"))
-    XCTAssertTrue(viewSource.contains("state.archiveCurrentExchange(using: floatingChatProvider)"))
     XCTAssertTrue(viewSource.contains(".beginVisibleMainQuery(message, fromVoice: false, animated: true)"))
     XCTAssertFalse(inputSource.contains("state.showingAIResponse = true"))
     XCTAssertFalse(viewSource.contains("state.conversationSurface == .mainResponse || state.showingAIResponse"))

--- a/desktop/macos/Desktop/Tests/FloatingBarTimingSignalTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarTimingSignalTests.swift
@@ -33,15 +33,6 @@ final class FloatingBarTimingSignalTests: XCTestCase {
       "the transition should key off didBecomeKey, not a fixed delay")
   }
 
-  func testFollowUpFocusUsesViewLifecycle() throws {
-    let source = try floatingBarViewSource()
-    XCTAssertTrue(
-      source.contains(".task {"),
-      "follow-up focus should be driven by the view lifecycle (.task), not asyncAfter")
-    XCTAssertTrue(
-      source.contains("isFollowUpFocused = true"), "the field must still be focused on appear")
-  }
-
   /// Anti-regression: no new fixed-delay `asyncAfter` may be added under
   /// `FloatingControlBar/` above the pinned baseline. Recurses the directory the
   /// same way the Python ratchet does; comment mentions of the word are excluded

--- a/desktop/macos/changelog/unreleased/20260722-repair-desktop-test-suites.json
+++ b/desktop/macos/changelog/unreleased/20260722-repair-desktop-test-suites.json
@@ -1,0 +1,3 @@
+{
+  "change": "Repaired the desktop Swift test suites after the beta-bundle consolidation and floating-bar typing removal so CI reflects the current product surfaces"
+}


### PR DESCRIPTION
## Summary
Desktop Swift CI is red on `main`, blocking the Swift suites on every open PR. Two independent breakages, both repaired here (test-only changes):

1. **Compile break** — #10199's distribution consolidation removed `AppBuild.betaProductionBundleIdentifier`, but `APIClientRoutingTests.testProductionFamilyHasNoDevelopmentOverrideSeam` still referenced it. Fixed by asserting the production bundle on the `beta` update channel, preserving the intent (no update channel may flip the production family onto development backends).
2. **Four stale source-inspection tests** — 4a8244742d ("remove typing from the floating bar") refactored `FloatingControlBarView.swift` without updating its tripwire tests. Realigned with the product intent:
   - `testProviderRequestsStayInTheModelLoop`: retargeted to `AgentPill.swift`, the only live follow-up path (coordinator hand-off), with the forbidden-pattern tripwires extended there.
   - `testSubagentComposerOnlyContinuesItsCanonicalSession` → `testAgentFollowUpOnlyContinuesItsCanonicalSession`: now asserts the real canonical-session guard (`guard let sessionId = pill.canonicalSessionId` + post-await recheck) in `AgentPill.swift`.
   - `testTypedSendDelegatesResponseSizingToWindow`: dropped only the assertion whose surface was removed; `archiveCurrentExchange` remains asserted elsewhere and behaviorally covered by `FloatingControlBarStateTests`.
   - `testFollowUpFocusUsesViewLifecycle`: deleted — `isFollowUpFocused` has no remaining surface; the `asyncAfter` baseline ratchet still guards fixed-delay regressions.

## Verification (local, mac mini)
- `swift test --filter APIClientRoutingTests` → 60 tests, 0 failures (package compiles).
- `swift test --filter 'AgentPillLifecycleTests|FloatingBarTimingSignalTests'` → 77 tests, 0 failures (was 4 failures on main).
- Harness focus set (`AgentPillLifecycleTests|PushToTalkStateMachineTests|RealtimeHubSpawnAgentTests|FloatingControlBarStateTests`) → 136 tests, 0 failures.
- `python3 scripts/check_desktop_test_quality.py` → OK, debt at/below baseline.

## Peer review
Two independent agent reviews, both APPROVE: commit 1 (diff scope, semantics vs `DesktopBackendEnvironment`, no remaining symbol references, restore-the-constant correctly rejected) and commit 2 (per-test realignment verified against 4a8244742d's diff and live Sources; no weakened contracts found; test run independently reproduced).

Known related follow-up (out of scope): `.github/scripts/check-mobile-production-routing.py` still requires the removed `betaProductionBundleIdentifier` fragment and is broken on main for any PR touching AppBuild/DesktopBackendEnvironment/codemagic — needs its own fix.

## Failure class
Failure-Class: none

(Test-only repairs of symbols/strings orphaned by intentional refactors; no registered product failure class applies.)
