### PR TITLE
fix(desktop): repair red main — restore Omi Beta production family + re-anchor floating-bar tripwires

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -4,13 +4,13 @@
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4239,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1578,
-    "desktop/macos/Desktop/Sources/OmiApp.swift": 1638
+    "desktop/macos/Desktop/Sources/OmiApp.swift": 1645
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/AuthService.swift": "Apple first-auth name capture signals observers (authNameDidUpdate) and persists the name to Firebase so it survives reinstalls.",
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": "Reach-error card gains a debug bridge action so the actionable failure surface is verifiable in-process.",
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
-    "desktop/macos/Desktop/Sources/OmiApp.swift": "shared openMainAppWindow helper for menu bar + Open Omi shortcut"
+    "desktop/macos/Desktop/Sources/OmiApp.swift": "Restored stable-only legacy-cleanup guard: Omi Beta is production-family again and must never terminate the running stable app."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/AppBuild.swift
+++ b/desktop/macos/Desktop/Sources/AppBuild.swift
@@ -2,6 +2,14 @@ import Foundation
 
 enum AppBuild {
   static let productionBundleIdentifier = "com.omi.computer-macos"
+  /// Identity of installed "Omi Beta.app" bundles. The separately packaged beta artifact
+  /// is retired (single-artifact release), but already-installed beta apps keep this
+  /// bundle id, and INV-DATA-1 pins every production-family identity to the canonical
+  /// production customer data plane.
+  static let betaProductionBundleIdentifier = "com.omi.computer-macos.beta"
+  static let productionFamilyBundleIdentifiers: Set<String> = [
+    productionBundleIdentifier, betaProductionBundleIdentifier,
+  ]
   static let desktopDevBundleIdentifier = "com.omi.desktop-dev"
   static let externalPreviewBundleIdentifierPrefix = "com.omi.preview."
   static let externalPreviewMarkerInfoKey = "OMIExternalPreview"
@@ -37,7 +45,7 @@ enum AppBuild {
 
     var isNonProduction: Bool {
       bundleIdentifier.hasPrefix("com.omi.")
-        && bundleIdentifier != AppBuild.productionBundleIdentifier
+        && !AppBuild.productionFamilyBundleIdentifiers.contains(bundleIdentifier)
     }
 
     var allowsLocalAutomation: Bool {
@@ -95,11 +103,23 @@ enum AppBuild {
   }
 
   static var isProductionBundle: Bool {
-    bundleIdentifier == productionBundleIdentifier
+    productionFamilyBundleIdentifiers.contains(bundleIdentifier)
   }
 
   static var isExternalPreview: Bool {
     buildConfiguration.isExternalPreview
+  }
+
+  /// Legacy "Omi Computer.app" cleanup force-terminates running
+  /// `com.omi.computer-macos` processes and deletes the old bundle — strictly
+  /// stable-lineage housekeeping. Only the stable identity may run it: Omi Beta
+  /// or a dev bundle doing so would kill the user's running stable app.
+  static var mayRunLegacyStableAppCleanup: Bool {
+    mayRunLegacyStableAppCleanup(bundleIdentifier: bundleIdentifier)
+  }
+
+  static func mayRunLegacyStableAppCleanup(bundleIdentifier: String) -> Bool {
+    bundleIdentifier == productionBundleIdentifier
   }
 
   /// Only local development bundles expose the loopback automation/debug bridge. Published

--- a/desktop/macos/Desktop/Sources/DesktopBackendEnvironment.swift
+++ b/desktop/macos/Desktop/Sources/DesktopBackendEnvironment.swift
@@ -29,7 +29,9 @@ enum DesktopBackendEnvironment {
     // Named/dev bundles route to the dev backend by default. Explicit launch
     // URLs still win below so local harnesses and intentionally-targeted tests
     // remain possible.
-    if bundleIdentifier != AppBuild.productionBundleIdentifier {
+    // The Omi Beta identity is a production-family artifact, not a dev bundle:
+    // installed beta apps must keep the production customer data plane (INV-DATA-1).
+    if !AppBuild.productionFamilyBundleIdentifiers.contains(bundleIdentifier) {
       return true
     }
 

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -1463,6 +1463,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
   }
 
   private func cleanupLegacyAppBundles() {
+    // Stable-only: this takeover kills running com.omi.computer-macos processes
+    // and deletes the legacy bundle. From Omi Beta or a dev bundle it would
+    // terminate the user's running stable app instead of a stale duplicate.
+    guard AppBuild.mayRunLegacyStableAppCleanup else {
+      log("Skipping legacy app cleanup: not the stable production identity")
+      return
+    }
     let currentPath = Bundle.main.bundlePath
     let oldAppPaths = [
       "/Applications/Omi Computer.app",

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -373,7 +373,9 @@ import XCTest
     XCTAssertFalse(windowSource.contains("resolveDelegationAndDispatch"))
     XCTAssertTrue(windowSource.contains("await dispatchChatQuery("))
     XCTAssertFalse(source.contains("AgentPillFollowUpRoutingPolicy"))
-    XCTAssertTrue(source.contains("manager.continueAgent(from: pill, text: trimmed, attachments: staged)"))
+    // The bar has no typed pill composer since typing moved to the app's chat:
+    // pill steering routes to the main app instead of parsing wording locally.
+    XCTAssertTrue(source.contains("(NSApp.delegate as? AppDelegate)?.openMainAppWindow()"))
   }
 
   func testSubagentChatRendersMarkdownAndLargeBackHitTarget() throws {
@@ -832,11 +834,14 @@ import XCTest
     XCTAssertFalse(body.contains("FloatingControlBarGeometry.targetFrame("))
   }
 
-  func testSubagentComposerOnlyContinuesItsCanonicalSession() throws {
+  func testSubagentFollowUpsOnlyContinueTheCanonicalSession() throws {
+    // omi-test-quality: source-inspection -- static contract: the bar's typed composer is gone; follow-ups continue only through the manager bound to the pill's canonical session.
     let viewSource = try floatingControlBarViewSource()
+    let pillSource = try agentPillSource()
 
     XCTAssertFalse(viewSource.contains("AgentPillFollowUpRoutingPolicy"))
-    XCTAssertTrue(viewSource.contains("manager.continueAgent(from: pill, text: trimmed, attachments: staged)"))
+    XCTAssertTrue(pillSource.contains("guard pill.canonicalSessionId == sessionId else { return }"))
+    XCTAssertTrue(pillSource.contains("DesktopCoordinatorService.shared.continueAgent("))
   }
 
   func testSpawnAgentToolCallOpensSubagentChat() throws {
@@ -921,7 +926,10 @@ import XCTest
     let inputSource = String(viewSource[inputRange.lowerBound..<inputEnd.lowerBound])
 
     XCTAssertTrue(inputSource.contains(".beginVisibleMainQuery(message, fromVoice: false, animated: true)"))
-    XCTAssertTrue(viewSource.contains("state.archiveCurrentExchange(using: floatingChatProvider)"))
+    // Archiving the previous exchange moved into the window alongside sizing;
+    // the view must not archive on its own.
+    XCTAssertFalse(viewSource.contains("archiveCurrentExchange"))
+    XCTAssertTrue(windowSource.contains("state.archiveCurrentExchange(using: self.historyChatProvider)"))
     XCTAssertTrue(viewSource.contains(".beginVisibleMainQuery(message, fromVoice: false, animated: true)"))
     XCTAssertFalse(inputSource.contains("state.showingAIResponse = true"))
     XCTAssertFalse(viewSource.contains("state.conversationSurface == .mainResponse || state.showingAIResponse"))

--- a/desktop/macos/Desktop/Tests/AppBuildProductionFamilyTests.swift
+++ b/desktop/macos/Desktop/Tests/AppBuildProductionFamilyTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class AppBuildProductionFamilyTests: XCTestCase {
+  func testProductionFamilyContainsStableAndBetaIdentities() {
+    // INV-DATA-1: installed Omi Beta apps are production-family customers and
+    // must never leave the production data plane.
+    XCTAssertEqual(
+      AppBuild.productionFamilyBundleIdentifiers,
+      [AppBuild.productionBundleIdentifier, AppBuild.betaProductionBundleIdentifier])
+  }
+
+  func testOnlyStableIdentityMayRunLegacyStableAppCleanup() {
+    // The legacy "Omi Computer.app" cleanup force-terminates running stable
+    // processes; Omi Beta running it would kill the side-by-side stable app.
+    XCTAssertTrue(
+      AppBuild.mayRunLegacyStableAppCleanup(bundleIdentifier: AppBuild.productionBundleIdentifier))
+    XCTAssertFalse(
+      AppBuild.mayRunLegacyStableAppCleanup(
+        bundleIdentifier: AppBuild.betaProductionBundleIdentifier))
+    XCTAssertFalse(
+      AppBuild.mayRunLegacyStableAppCleanup(bundleIdentifier: AppBuild.desktopDevBundleIdentifier))
+    XCTAssertFalse(
+      AppBuild.mayRunLegacyStableAppCleanup(bundleIdentifier: "com.omi.omi-feature-test"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/FloatingBarTimingSignalTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarTimingSignalTests.swift
@@ -33,15 +33,6 @@ final class FloatingBarTimingSignalTests: XCTestCase {
       "the transition should key off didBecomeKey, not a fixed delay")
   }
 
-  func testFollowUpFocusUsesViewLifecycle() throws {
-    let source = try floatingBarViewSource()
-    XCTAssertTrue(
-      source.contains(".task {"),
-      "follow-up focus should be driven by the view lifecycle (.task), not asyncAfter")
-    XCTAssertTrue(
-      source.contains("isFollowUpFocused = true"), "the field must still be focused on appear")
-  }
-
   /// Anti-regression: no new fixed-delay `asyncAfter` may be added under
   /// `FloatingControlBar/` above the pinned baseline. Recurses the directory the
   /// same way the Python ratchet does; comment mentions of the word are excluded

--- a/desktop/macos/changelog/unreleased/20260721-beta-production-family-restore.json
+++ b/desktop/macos/changelog/unreleased/20260721-beta-production-family-restore.json
@@ -1,0 +1,3 @@
+{
+    "change": "Omi Beta installs stay on the production backend and never terminate the stable app during legacy cleanup"
+}


### PR DESCRIPTION
## Summary

Desktop Swift CI on `main` is red (run 29859561700) from two independent mid-air collisions, which also fail every open desktop PR through the merge-ref, and the fail-closed release candidate gate is blocked. This PR repairs main.

**1. Beta production identity removed while INV-DATA-1 landed (commit 2, `fix:`)**

`dba3af2522` (restore single macOS artifact) removed `AppBuild.betaProductionBundleIdentifier` / `productionFamilyBundleIdentifiers` while #10216 was in flight; #10216 then merged INV-DATA-1 plus `check-mobile-production-routing.py` and `APIClientRoutingTests` asserting the beta identity stays on the production data plane. Result on main: the test target does not compile, the routing checker fails — and the live defect the guards exist for: `DesktopBackendEnvironment.shouldUseDevelopmentBackends` routed installed Omi Beta apps (`com.omi.computer-macos.beta`) to the development backend, off their production customer data plane.

Restored the boundary the locked invariant demands:
- `AppBuild`: beta identity + production-family set are back; `isNonProduction` / `isProductionBundle` key off the family set.
- `DesktopBackendEnvironment`: production-family bundles fall through to production routing.
- Re-restored the stable-only legacy `Omi Computer.app` cleanup gate from `d5a8ba9ced` (also dropped by `dba3af2522`): with beta production-family again, an ungated cleanup from a beta install would force-terminate the user's running stable app.
- `AppBuildProductionFamilyTests` (new) covers the family set and the cleanup gate.

The single-artifact packaging direction of `dba3af2522` (Beta as a channel pointer over the immutable Omi.zip/omi.dmg pair) is untouched; only identity/routing semantics for already-installed beta bundles are restored.

**2. Floating-bar tripwire tests broken by typing removal (commit 1, test-only)**

`4a8244742d` removed typing from the floating bar (pill steering routes to the main app via Continue in Omi) but left the source-inspection tripwires anchored on the deleted composer. Re-encoded the new contract in `AgentPillLifecycleTests` (in-model-loop anchor is now the Continue-in-Omi route; canonical-session guard lives in the manager; archiving moved into the window) and deleted `FloatingBarTimingSignalTests.testFollowUpFocusUsesViewLifecycle`, whose follow-up field no longer exists. These are static tripwires re-anchored to current sources, not behavioral coverage.

## Product invariants

- INV-DATA-1 — this PR restores the production-family routing authority the invariant pins; its guard (`production-data-plane-routing` / `check-mobile-production-routing.py`) goes from failing to passing on main. `APIClientRoutingTests` compiles and passes again.
- INV-AUTH-1 — matched by path glob only (`DesktopBackendEnvironment.swift` hosts `authBaseURL`); auth session behavior is unchanged, `desktop-auth-session-ratchet` passes.

Failure-Class: FC-customer-data-plane-divergence

## Verification (local)

- `xcrun swift test --filter "AgentPillLifecycleTests|FloatingBarTimingSignalTests|APIClientRoutingTests|AppBuildProductionFamilyTests"` — 139 tests, 0 failures (test target compiles again; was: compile error on `betaProductionBundleIdentifier`, then 4 tripwire failures matching the red main run).
- Full suite: `./scripts/run-swift-ci.sh --test` — all suites green (local Xcode; the pinned 16.4 result is this PR's own CI run).
- `python3 .github/scripts/run_checks.py --lane ci --platform macos` — 17 checks pass, including `production-data-plane-routing` (failing on main) and `desktop-test-quality`.
- `scripts/pr-preflight --pr-body-file` with this body — 21 checks pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

