### PR TITLE
ci: skip superseded automatic dev backend candidates

### DIFF
--- a/.github/scripts/check_backend_deploy_source_admission.py
+++ b/.github/scripts/check_backend_deploy_source_admission.py
@@ -178,7 +178,7 @@ def validate_auto_workflow(text: str) -> list[str]:
         )
         for fragment, message in (
             (f"ref: {AUTO_PROOF_SHA}", "auto backend scope decision must inspect the triggering SHA"),
-            ("fetch-depth: 2", "auto backend scope decision must fetch the triggering commit parent"),
+            ("fetch-depth: 0", "auto backend scope decision must fetch ancestry for a supersession proof"),
         ):
             require_fragment(errors, scope_checkout, fragment, message)
         scope_decision = require_step(
@@ -189,12 +189,44 @@ def validate_auto_workflow(text: str) -> list[str]:
         )
         for fragment, message in (
             (f"RELEASE_SHA: {AUTO_PROOF_SHA}", "auto backend scope decision must bind the triggering SHA"),
+            (
+                "git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main",
+                "auto backend scope decision must refresh current origin/main before declaring supersession",
+            ),
+            (
+                "main_sha=\"$(git rev-parse --verify 'origin/main^{commit}'",
+                "auto backend scope decision must resolve current origin/main before declaring supersession",
+            ),
+            (
+                "[[ \"$RELEASE_SHA\" != \"$main_sha\" ]] && git merge-base --is-ancestor \"$RELEASE_SHA\" \"$main_sha\"",
+                "auto backend scope decision must prove a distinct triggering SHA is already on current main before a superseded no-op",
+            ),
+            (
+                "echo \"applies=true\" >> \"$GITHUB_OUTPUT\"",
+                "auto backend scope decision must continue to guarded admission when freshness is uncertain",
+            ),
+            (
+                "could not refresh current origin/main; preserving fail-closed source admission",
+                "auto backend scope decision must treat a main refresh failure as guarded admission, not supersession",
+            ),
+            (
+                "could not resolve current origin/main; preserving fail-closed source admission",
+                "auto backend scope decision must treat an unresolved current main as guarded admission, not supersession",
+            ),
+            ("echo \"applies=false\" >> \"$GITHUB_OUTPUT\"", "auto backend scope decision must publish a no-op result"),
+            (
+                "Backend development deploy superseded no-op",
+                "auto backend scope decision must summarize superseded candidates as green no-ops",
+            ),
+            (
+                "triggering SHA $RELEASE_SHA was superseded by current origin/main $main_sha",
+                "auto backend scope decision must name both triggering and current SHAs in a superseded summary",
+            ),
             ("git rev-parse \"${RELEASE_SHA}^\"", "auto backend scope decision must inspect the triggering parent"),
             (
                 "git diff --name-only \"$parent_sha\" \"$RELEASE_SHA\"",
                 "auto backend scope decision must diff the triggering SHA against its parent",
             ),
-            ("echo \"applies=false\" >> \"$GITHUB_OUTPUT\"", "auto backend scope decision must publish a no-op result"),
             ("Green no-op", "auto backend scope decision must summarize green no-ops"),
         ):
             require_fragment(errors, scope_decision, fragment, message)

--- a/.github/scripts/test_check_backend_deploy_source_admission.py
+++ b/.github/scripts/test_check_backend_deploy_source_admission.py
@@ -212,8 +212,8 @@ class WorkflowContractTests(unittest.TestCase):
             ),
             (
                 "triggering SHA checkout",
-                "ref: ${{ github.event.workflow_run.head_sha }}\n          fetch-depth: 2",
-                "ref: main\n          fetch-depth: 2",
+                "ref: ${{ github.event.workflow_run.head_sha }}\n          # Full history is required only here: a green no-op is safe only when\n          # the triggering SHA is proven to be an ancestor of current main.\n          fetch-depth: 0",
+                "ref: main\n          # Full history is required only here: a green no-op is safe only when\n          # the triggering SHA is proven to be an ancestor of current main.\n          fetch-depth: 0",
                 "auto backend scope decision must inspect the triggering SHA",
             ),
             (
@@ -227,6 +227,40 @@ class WorkflowContractTests(unittest.TestCase):
                 "    runs-on: ubuntu-latest-m\n    outputs:",
                 "    runs-on: ubuntu-latest-m\n    steps:\n      - uses: google-github-actions/auth@v3\n    outputs:",
                 "auto backend scope decision must not authenticate to cloud services",
+            ),
+        )
+        for name, old, new, expected in cases:
+            with self.subTest(name=name):
+                root = self.fixture_root()
+                self.mutate(root, CHECKER.AUTO_WORKFLOW_PATH, old, new)
+                self.assertIn(expected, CHECKER.validate(root))
+
+    def test_auto_workflow_rejects_supersession_no_op_bypasses(self) -> None:
+        """Static tripwires for the green no-op decision before privileged jobs."""
+        cases = (
+            (
+                "current candidate treated as stale",
+                '[[ "$RELEASE_SHA" != "$main_sha" ]] && git merge-base --is-ancestor "$RELEASE_SHA" "$main_sha"',
+                'git merge-base --is-ancestor "$RELEASE_SHA" "$main_sha"',
+                "auto backend scope decision must prove a distinct triggering SHA is already on current main before a superseded no-op",
+            ),
+            (
+                "no current-main refresh",
+                "git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main",
+                "git fetch --no-tags origin +refs/heads/release:refs/remotes/origin/main",
+                "auto backend scope decision must refresh current origin/main before declaring supersession",
+            ),
+            (
+                "unknown main becomes no-op",
+                "could not resolve current origin/main; preserving fail-closed source admission",
+                "triggering SHA $RELEASE_SHA was superseded by current origin/main $main_sha",
+                "auto backend scope decision must treat an unresolved current main as guarded admission, not supersession",
+            ),
+            (
+                "ambiguous stale summary",
+                "triggering SHA $RELEASE_SHA was superseded by current origin/main $main_sha",
+                "triggering candidate was superseded",
+                "auto backend scope decision must name both triggering and current SHAs in a superseded summary",
             ),
         )
         for name, old, new, expected in cases:
@@ -251,8 +285,8 @@ class WorkflowContractTests(unittest.TestCase):
             ),
             (
                 "stale main fetch",
-                "git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main",
-                "git fetch --no-tags origin +refs/heads/release:refs/remotes/origin/main",
+                "RELEASE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}\n        run: |\n          set -euo pipefail\n          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main",
+                "RELEASE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}\n        run: |\n          set -euo pipefail\n          git fetch --no-tags origin +refs/heads/release:refs/remotes/origin/main",
                 "automatic source admission must refresh current main",
             ),
             (

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -35,7 +35,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-          fetch-depth: 2
+          # Full history is required only here: a green no-op is safe only when
+          # the triggering SHA is proven to be an ancestor of current main.
+          fetch-depth: 0
 
       - name: Decide whether the triggering commit can affect the backend deployment
         id: scope
@@ -46,6 +48,35 @@ jobs:
           if ! git cat-file -e "${RELEASE_SHA}^{commit}"; then
             echo "Cannot resolve triggering Release Eligibility SHA: $RELEASE_SHA" >&2
             exit 1
+          fi
+
+          # A stale Release Eligibility result must not occupy the deployment
+          # queue or reach a deployment environment. Only a successful refresh
+          # plus ancestry proof may turn it into a green no-op; every resolution
+          # failure continues to the retained current-main admission guard.
+          if ! git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main; then
+            echo "applies=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Backend development deploy scope"
+              echo "In scope: could not refresh current origin/main; preserving fail-closed source admission."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if ! main_sha="$(git rev-parse --verify 'origin/main^{commit}' 2>/dev/null)"; then
+            echo "applies=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Backend development deploy scope"
+              echo "In scope: could not resolve current origin/main; preserving fail-closed source admission."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [[ "$RELEASE_SHA" != "$main_sha" ]] && git merge-base --is-ancestor "$RELEASE_SHA" "$main_sha"; then
+            echo "applies=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Backend development deploy superseded no-op"
+              echo "Green no-op: triggering SHA $RELEASE_SHA was superseded by current origin/main $main_sha."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
 
           if ! parent_sha="$(git rev-parse "${RELEASE_SHA}^" 2>/dev/null)"; then


### PR DESCRIPTION
## Summary
- Complete superseded automatic development backend deployment candidates as an explicit green scope-job no-op, naming the triggering and current `origin/main` SHAs.
- Treat inability to refresh or resolve current `origin/main` as uncertain and continue to the existing fail-closed current-main source-admission guard.
- Preserve the retained admission guard so a post-scope main advance rejects the deployment before credentials, Firestore readiness, image work, or mutation.

This supersedes **only automatic development deployment candidates**. It does not alter production deployment behavior.

## Verification
- `python3 .github/scripts/check_backend_deploy_source_admission.py`
- `python3 .github/scripts/test_check_backend_deploy_source_admission.py`
- `actionlint .github/workflows/gcp_backend_auto_dev.yml`
- `scripts/pr-preflight --pr-body-file /tmp/omi-pr-superseded-auto-dev-noop.md`
- `make preflight`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

