### PR TITLE
ci: correct #10230 full-history supersession speed regression

### DIFF
--- a/.github/scripts/check_backend_deploy_source_admission.py
+++ b/.github/scripts/check_backend_deploy_source_admission.py
@@ -178,9 +178,11 @@ def validate_auto_workflow(text: str) -> list[str]:
         )
         for fragment, message in (
             (f"ref: {AUTO_PROOF_SHA}", "auto backend scope decision must inspect the triggering SHA"),
-            ("fetch-depth: 0", "auto backend scope decision must fetch ancestry for a supersession proof"),
+            ("fetch-depth: 2", "auto backend scope decision must shallow-fetch only the triggering parent diff"),
         ):
             require_fragment(errors, scope_checkout, fragment, message)
+        if "fetch-depth: 0" in scope_checkout:
+            errors.append("auto backend scope decision must not fetch full history")
         scope_decision = require_step(
             errors,
             scope_steps,
@@ -188,39 +190,45 @@ def validate_auto_workflow(text: str) -> list[str]:
             "backend deployment scope decision",
         )
         for fragment, message in (
+            (f"GH_TOKEN: ${{{{ github.token }}}}", "auto backend scope decision must use its read-only GitHub token"),
             (f"RELEASE_SHA: {AUTO_PROOF_SHA}", "auto backend scope decision must bind the triggering SHA"),
             (
-                "git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main",
-                "auto backend scope decision must refresh current origin/main before declaring supersession",
+                '"$api_base/repos/$GITHUB_REPOSITORY/git/ref/heads/main"',
+                "auto backend scope decision must resolve current main through the bounded GitHub ref API",
             ),
             (
-                "main_sha=\"$(git rev-parse --verify 'origin/main^{commit}'",
-                "auto backend scope decision must resolve current origin/main before declaring supersession",
+                '"$api_base/repos/$GITHUB_REPOSITORY/compare/$RELEASE_SHA...$main_sha"',
+                "auto backend scope decision must compare the immutable triggering SHA to the resolved main SHA through GitHub",
             ),
             (
-                "[[ \"$RELEASE_SHA\" != \"$main_sha\" ]] && git merge-base --is-ancestor \"$RELEASE_SHA\" \"$main_sha\"",
-                "auto backend scope decision must prove a distinct triggering SHA is already on current main before a superseded no-op",
+                'if .ref == "refs/heads/main" and .object.type == "commit"',
+                "auto backend scope decision must bind the current-main ref response identity",
             ),
             (
-                "echo \"applies=true\" >> \"$GITHUB_OUTPUT\"",
-                "auto backend scope decision must continue to guarded admission when freshness is uncertain",
+                '.base_commit.sha == $release_sha and .head_commit.sha == $main_sha',
+                "auto backend scope decision must bind compare base and head identities",
             ),
             (
-                "could not refresh current origin/main; preserving fail-closed source admission",
-                "auto backend scope decision must treat a main refresh failure as guarded admission, not supersession",
+                '.status == "behind"',
+                "auto backend scope decision must require GitHub's behind status for a superseded no-op",
             ),
             (
-                "could not resolve current origin/main; preserving fail-closed source admission",
-                "auto backend scope decision must treat an unresolved current main as guarded admission, not supersession",
+                'if [[ "$comparison" == "behind" ]]; then',
+                "auto backend scope decision must only no-op after confirmed supersession",
             ),
+            (
+                "supersession API proof was unavailable or ambiguous; preserving fail-closed source admission",
+                "auto backend scope decision must treat API or identity ambiguity as guarded admission",
+            ),
+            ("echo \"applies=true\" >> \"$GITHUB_OUTPUT\"", "auto backend scope decision must continue to guarded admission when supersession is uncertain"),
             ("echo \"applies=false\" >> \"$GITHUB_OUTPUT\"", "auto backend scope decision must publish a no-op result"),
             (
                 "Backend development deploy superseded no-op",
                 "auto backend scope decision must summarize superseded candidates as green no-ops",
             ),
             (
-                "triggering SHA $RELEASE_SHA was superseded by current origin/main $main_sha",
-                "auto backend scope decision must name both triggering and current SHAs in a superseded summary",
+                "GitHub compare confirmed triggering SHA $RELEASE_SHA is behind current main $main_sha",
+                "auto backend scope decision must name both bound SHAs in a superseded summary",
             ),
             ("git rev-parse \"${RELEASE_SHA}^\"", "auto backend scope decision must inspect the triggering parent"),
             (
@@ -230,6 +238,16 @@ def validate_auto_workflow(text: str) -> list[str]:
             ("Green no-op", "auto backend scope decision must summarize green no-ops"),
         ):
             require_fragment(errors, scope_decision, fragment, message)
+        fallback_summary = "supersession API proof was unavailable or ambiguous; preserving fail-closed source admission"
+        if scope_decision.count(fallback_summary) != 2:
+            errors.append("auto backend scope decision must treat API or identity ambiguity as guarded admission")
+        for forbidden, message in (
+            ("git fetch --no-tags", "auto backend scope decision must not fetch local main history for supersession"),
+            ("git merge-base", "auto backend scope decision must not use local merge-base supersession proof"),
+            ("origin/main", "auto backend scope decision must not resolve local origin/main for supersession"),
+        ):
+            if forbidden in scope_decision:
+                errors.append(message)
     if firestore_job is None:
         errors.append("auto backend deploy is missing its source-admission job")
     else:

--- a/.github/scripts/test_check_backend_deploy_source_admission.py
+++ b/.github/scripts/test_check_backend_deploy_source_admission.py
@@ -212,9 +212,15 @@ class WorkflowContractTests(unittest.TestCase):
             ),
             (
                 "triggering SHA checkout",
-                "ref: ${{ github.event.workflow_run.head_sha }}\n          # Full history is required only here: a green no-op is safe only when\n          # the triggering SHA is proven to be an ancestor of current main.\n          fetch-depth: 0",
-                "ref: main\n          # Full history is required only here: a green no-op is safe only when\n          # the triggering SHA is proven to be an ancestor of current main.\n          fetch-depth: 0",
+                "ref: ${{ github.event.workflow_run.head_sha }}\n          # The parent diff is the only local scope proof required here. Current\n          # main/supersession proof below is bounded to read-only GitHub API calls.\n          fetch-depth: 2",
+                "ref: main\n          # The parent diff is the only local scope proof required here. Current\n          # main/supersession proof below is bounded to read-only GitHub API calls.\n          fetch-depth: 2",
                 "auto backend scope decision must inspect the triggering SHA",
+            ),
+            (
+                "full-history checkout",
+                "fetch-depth: 2",
+                "fetch-depth: 0",
+                "auto backend scope decision must shallow-fetch only the triggering parent diff",
             ),
             (
                 "parent diff",
@@ -235,32 +241,50 @@ class WorkflowContractTests(unittest.TestCase):
                 self.mutate(root, CHECKER.AUTO_WORKFLOW_PATH, old, new)
                 self.assertIn(expected, CHECKER.validate(root))
 
-    def test_auto_workflow_rejects_supersession_no_op_bypasses(self) -> None:
-        """Static tripwires for the green no-op decision before privileged jobs."""
+    def test_auto_workflow_rejects_api_supersession_proof_bypasses(self) -> None:
+        """Static tripwires for the bounded read-only green no-op proof."""
         cases = (
             (
-                "current candidate treated as stale",
-                '[[ "$RELEASE_SHA" != "$main_sha" ]] && git merge-base --is-ancestor "$RELEASE_SHA" "$main_sha"',
-                'git merge-base --is-ancestor "$RELEASE_SHA" "$main_sha"',
-                "auto backend scope decision must prove a distinct triggering SHA is already on current main before a superseded no-op",
+                "wrong ref endpoint",
+                '"$api_base/repos/$GITHUB_REPOSITORY/git/ref/heads/main"',
+                '"$api_base/repos/$GITHUB_REPOSITORY/git/ref/heads/release"',
+                "auto backend scope decision must resolve current main through the bounded GitHub ref API",
             ),
             (
-                "no current-main refresh",
-                "git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main",
-                "git fetch --no-tags origin +refs/heads/release:refs/remotes/origin/main",
-                "auto backend scope decision must refresh current origin/main before declaring supersession",
+                "wrong compare endpoint",
+                '"$api_base/repos/$GITHUB_REPOSITORY/compare/$RELEASE_SHA...$main_sha"',
+                '"$api_base/repos/$GITHUB_REPOSITORY/compare/$main_sha...$RELEASE_SHA"',
+                "auto backend scope decision must compare the immutable triggering SHA to the resolved main SHA through GitHub",
             ),
             (
-                "unknown main becomes no-op",
-                "could not resolve current origin/main; preserving fail-closed source admission",
-                "triggering SHA $RELEASE_SHA was superseded by current origin/main $main_sha",
-                "auto backend scope decision must treat an unresolved current main as guarded admission, not supersession",
+                "unbound compare identity",
+                '.base_commit.sha == $release_sha and .head_commit.sha == $main_sha',
+                '.base_commit.sha == $main_sha and .head_commit.sha == $release_sha',
+                "auto backend scope decision must bind compare base and head identities",
             ),
             (
-                "ambiguous stale summary",
-                "triggering SHA $RELEASE_SHA was superseded by current origin/main $main_sha",
-                "triggering candidate was superseded",
-                "auto backend scope decision must name both triggering and current SHAs in a superseded summary",
+                "unconfirmed supersession",
+                'if [[ "$comparison" == "behind" ]]; then',
+                'if [[ "$comparison" == "identical" ]]; then',
+                "auto backend scope decision must only no-op after confirmed supersession",
+            ),
+            (
+                "ambiguous API becomes no-op",
+                "supersession API proof was unavailable or ambiguous; preserving fail-closed source admission",
+                "GitHub compare confirmed triggering SHA $RELEASE_SHA is behind current main $main_sha",
+                "auto backend scope decision must treat API or identity ambiguity as guarded admission",
+            ),
+            (
+                "local merge-base proof",
+                "git diff --name-only \"$parent_sha\" \"$RELEASE_SHA\"",
+                "git merge-base --is-ancestor \"$RELEASE_SHA\" \"$main_sha\"\n          git diff --name-only \"$parent_sha\" \"$RELEASE_SHA\"",
+                "auto backend scope decision must not use local merge-base supersession proof",
+            ),
+            (
+                "local main history fetch",
+                "git diff --name-only \"$parent_sha\" \"$RELEASE_SHA\"",
+                "git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main\n          git diff --name-only \"$parent_sha\" \"$RELEASE_SHA\"",
+                "auto backend scope decision must not fetch local main history for supersession",
             ),
         )
         for name, old, new, expected in cases:

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -35,13 +35,14 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-          # Full history is required only here: a green no-op is safe only when
-          # the triggering SHA is proven to be an ancestor of current main.
-          fetch-depth: 0
+          # The parent diff is the only local scope proof required here. Current
+          # main/supersession proof below is bounded to read-only GitHub API calls.
+          fetch-depth: 2
 
       - name: Decide whether the triggering commit can affect the backend deployment
         id: scope
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
@@ -50,31 +51,56 @@ jobs:
             exit 1
           fi
 
-          # A stale Release Eligibility result must not occupy the deployment
-          # queue or reach a deployment environment. Only a successful refresh
-          # plus ancestry proof may turn it into a green no-op; every resolution
-          # failure continues to the retained current-main admission guard.
-          if ! git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main; then
+          # The scope checkout is intentionally shallow. A stale Release
+          # Eligibility result may be a green no-op only after two bounded,
+          # read-only GitHub API proofs bind the current main and comparison
+          # identities. Any API, JSON, or identity ambiguity falls through to
+          # the privileged current-main source-admission guard below.
+          api_base="${GITHUB_API_URL:-https://api.github.com}"
+          ref_path="$(mktemp)"
+          compare_path="$(mktemp)"
+          trap 'rm -f "$ref_path" "$compare_path"' EXIT
+          api_headers=(
+            -H "Authorization: Bearer $GH_TOKEN"
+            -H "Accept: application/vnd.github+json"
+            -H "X-GitHub-Api-Version: 2022-11-28"
+          )
+          ref_status="$(curl --silent --show-error --output "$ref_path" --write-out '%{http_code}' \
+            "${api_headers[@]}" \
+            "$api_base/repos/$GITHUB_REPOSITORY/git/ref/heads/main" || true)"
+          if [[ "$ref_status" != "200" ]] || ! main_sha="$(jq -er '
+            if .ref == "refs/heads/main" and .object.type == "commit" and (.object.sha | test("^[0-9a-f]{40}$"))
+            then .object.sha else error("unexpected main ref identity") end
+          ' "$ref_path" 2>/dev/null)"; then
             echo "applies=true" >> "$GITHUB_OUTPUT"
             {
               echo "### Backend development deploy scope"
-              echo "In scope: could not refresh current origin/main; preserving fail-closed source admission."
+              echo "In scope: supersession API proof was unavailable or ambiguous; preserving fail-closed source admission."
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          if ! main_sha="$(git rev-parse --verify 'origin/main^{commit}' 2>/dev/null)"; then
+          compare_status="$(curl --silent --show-error --output "$compare_path" --write-out '%{http_code}' \
+            "${api_headers[@]}" \
+            "$api_base/repos/$GITHUB_REPOSITORY/compare/$RELEASE_SHA...$main_sha" || true)"
+          if [[ "$compare_status" != "200" ]] || ! comparison="$(jq -er \
+            --arg release_sha "$RELEASE_SHA" \
+            --arg main_sha "$main_sha" '
+              if .base_commit.sha == $release_sha and .head_commit.sha == $main_sha and
+                (.status == "behind" or .status == "ahead" or .status == "identical" or .status == "diverged")
+              then .status else error("unexpected comparison identity") end
+            ' "$compare_path" 2>/dev/null)"; then
             echo "applies=true" >> "$GITHUB_OUTPUT"
             {
               echo "### Backend development deploy scope"
-              echo "In scope: could not resolve current origin/main; preserving fail-closed source admission."
+              echo "In scope: supersession API proof was unavailable or ambiguous; preserving fail-closed source admission."
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          if [[ "$RELEASE_SHA" != "$main_sha" ]] && git merge-base --is-ancestor "$RELEASE_SHA" "$main_sha"; then
+          if [[ "$comparison" == "behind" ]]; then
             echo "applies=false" >> "$GITHUB_OUTPUT"
             {
               echo "### Backend development deploy superseded no-op"
-              echo "Green no-op: triggering SHA $RELEASE_SHA was superseded by current origin/main $main_sha."
+              echo "Green no-op: GitHub compare confirmed triggering SHA $RELEASE_SHA is behind current main $main_sha."
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi


### PR DESCRIPTION
## Summary
- Corrects #10230's full-history speed regression by restoring the early immutable workflow-run scope checkout to `fetch-depth: 2`.
- Replaces local full-history/merge-base supersession proof with two bounded, read-only GitHub REST API calls: resolve `main` via `/git/ref/heads/main`, then compare `RELEASE_SHA...main_sha`.
- Allows a green superseded no-op only for an HTTP 200, identity-bound compare response with `status == behind`; API/JSON/identity uncertainty remains `applies=true` and reaches the existing current-main admission guard.

## Safety
- Preserves unrelated-file parent-diff scope decisions, deployment concurrency, candidate/mutation paths, and the post-scope fail-closed current-main source-admission guard.
- No live GCP credentials or cloud mutation used.

## Verification
- `python3 .github/scripts/test_check_backend_deploy_source_admission.py`
- `python3 .github/scripts/check_backend_deploy_source_admission.py`
- `actionlint .github/workflows/gcp_backend_auto_dev.yml`
- `scripts/pr-preflight --pr-body-file /tmp/omi-pr-10230-supersession-api-body.md`
- `make preflight`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

