### PR TITLE
fix(desktop/rewind): gate RewindDatabase.currentUserId behind OSAllocatedUnfairLock (SCA-8)

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
@@ -1,12 +1,12 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1643,
-    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3510,
+    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3516,
     "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": 1856
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": "Task visibility writes now emit the shared Home-count invalidation after logging, so Dashboard totals refresh without waiting for an activation cooldown.",
-    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": "Nullable screenshot capture provenance preserves the canonical-memory device identity and prevents multi-Mac screen activity from overwriting local row IDs.",
+    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": "currentUserId is gated by an OSAllocatedUnfairLock to fix a cross-executor data race (actor/MainActor/nonisolated shutdown); the Sendable lock + computed accessor replace the prior unsafe static var (SCA-8).",
     "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": "Search-result rows load a downsampled ImageIO thumbnail instead of the full-resolution screenshot, so a long results list no longer retains full-size images behind a 120x80 view."
   },
   "threshold": 1500

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -1,6 +1,7 @@
 import Foundation
 @preconcurrency import GRDB
 import OmiSupport
+import os
 
 /// Actor-based database manager for Rewind screenshots
 actor RewindDatabase {
@@ -34,9 +35,23 @@ actor RewindDatabase {
   /// (recovery replaces the pool) — kept distinct from `initGeneration` so bumping it
   /// on open does not break the in-flight-close detection in `initialize()`.
   private var poolEpoch: Int = 0
+  /// Lock-protected storage backing `currentUserId`. `OSAllocatedUnfairLock` is
+  /// `Sendable` and its critical section is synchronous (no actor hop, no
+  /// suspension), so reads/writes from the `RewindDatabase` actor, `MainActor`
+  /// (`AgentVMService`), and the `nonisolated` `markCleanShutdown()` termination
+  /// path are all atomic — replacing the prior `nonisolated(unsafe)` data race
+  /// on `String?`'s refcounted heap storage (SCA-8).
+  private static let currentUserIdLock = OSAllocatedUnfairLock<String?>(initialState: nil)
 
-  /// Static user ID for nonisolated markCleanShutdown (set by configure(userId:))
-  nonisolated(unsafe) static var currentUserId: String?
+  /// The user ID this database is configured for (nil = not yet configured →
+  /// "anonymous"). Set by `configure(userId:)` / `retargetEffectiveOwner(to:)`
+  /// and read synchronously during termination (`markCleanShutdown`) and from
+  /// `MainActor` (`AgentVMService`). Lock-gated, so concurrent access from any
+  /// executor is race-free.
+  static var currentUserId: String? {
+    get { currentUserIdLock.withLock { $0 } }
+    set { currentUserIdLock.withLock { $0 = newValue } }
+  }
 
   /// Runtime error tracking: consecutive SQLITE_IOERR/CORRUPT errors during normal queries.
   /// When this hits the threshold, we close the database so the next initialize() attempt

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -35,19 +35,10 @@ actor RewindDatabase {
   /// (recovery replaces the pool) — kept distinct from `initGeneration` so bumping it
   /// on open does not break the in-flight-close detection in `initialize()`.
   private var poolEpoch: Int = 0
-  /// Lock-protected storage backing `currentUserId`. `OSAllocatedUnfairLock` is
-  /// `Sendable` and its critical section is synchronous (no actor hop, no
-  /// suspension), so reads/writes from the `RewindDatabase` actor, `MainActor`
-  /// (`AgentVMService`), and the `nonisolated` `markCleanShutdown()` termination
-  /// path are all atomic — replacing the prior `nonisolated(unsafe)` data race
-  /// on `String?`'s refcounted heap storage (SCA-8).
-  private static let currentUserIdLock = OSAllocatedUnfairLock<String?>(initialState: nil)
 
-  /// The user ID this database is configured for (nil = not yet configured →
-  /// "anonymous"). Set by `configure(userId:)` / `retargetEffectiveOwner(to:)`
-  /// and read synchronously during termination (`markCleanShutdown`) and from
-  /// `MainActor` (`AgentVMService`). Lock-gated, so concurrent access from any
-  /// executor is race-free.
+  /// Lock-gated (`OSAllocatedUnfairLock`) so concurrent access from the actor,
+  /// `MainActor` (`AgentVMService`), and nonisolated shutdown is race-free (SCA-8).
+  private static let currentUserIdLock = OSAllocatedUnfairLock<String?>(initialState: nil)
   static var currentUserId: String? {
     get { currentUserIdLock.withLock { $0 } }
     set { currentUserIdLock.withLock { $0 = newValue } }

--- a/desktop/macos/Desktop/Tests/RewindDatabaseCurrentUserIdConcurrencyTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindDatabaseCurrentUserIdConcurrencyTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for SCA-8: `RewindDatabase.currentUserId` was a
+/// `nonisolated(unsafe) static var String?`, racy across the `RewindDatabase`
+/// actor, `MainActor` (`AgentVMService`), and the `nonisolated`
+/// `markCleanShutdown()` termination path. It is now lock-gated. These tests
+/// pin the race-free contract: every read returns a coherent value written by
+/// some writer (never a torn/garbage pointer), and round-trip get/set works
+/// from any executor.
+final class RewindDatabaseCurrentUserIdConcurrencyTests: XCTestCase {
+
+  override func tearDown() async throws {
+    // Restore the default unconfigured state regardless of what a test wrote.
+    RewindDatabase.currentUserId = nil
+    try await super.tearDown()
+  }
+
+  func testCurrentUserIdRoundTripsThroughLock() {
+    // Sanity: the computed property preserves the exact value written, including
+    // nil. If the lock-backed accessor were wired incorrectly this would fail.
+    RewindDatabase.currentUserId = nil
+    XCTAssertNil(RewindDatabase.currentUserId)
+
+    let id = "sca8-roundtrip-\(UUID().uuidString)"
+    RewindDatabase.currentUserId = id
+    XCTAssertEqual(RewindDatabase.currentUserId, id)
+
+    RewindDatabase.currentUserId = nil
+    XCTAssertNil(RewindDatabase.currentUserId)
+  }
+
+  func testConcurrentReadWriteIsRaceFree() async throws {
+    // Concurrent writers each own a distinct ID; readers sample continuously.
+    // Under the prior `nonisolated(unsafe)` storage a concurrent write+read of
+    // a refcounted `String?` could return a torn value or trap on use-after-free
+    // in the string's heap storage. With the lock, every read must return either
+    // nil or one of the writer-owned strings — never anything else.
+    let writerCount = 8
+    let readersPerWriter = 4
+    let writerIDs = (0..<writerCount).map { _ in "sca8-writer-\(UUID().uuidString)" }
+
+    // Seed with nil so readers can also observe the unconfigured state.
+    RewindDatabase.currentUserId = nil
+
+    let validValues = Set(writerIDs + [nil as String?])
+
+    await withTaskGroup(of: Void.self) { group in
+      for id in writerIDs {
+        group.addTask {
+          // Hammer writes from this task's executor.
+          for _ in 0..<5_000 {
+            RewindDatabase.currentUserId = id
+          }
+        }
+        for _ in 0..<readersPerWriter {
+          group.addTask {
+            // Hammer reads from independent concurrent tasks.
+            for _ in 0..<5_000 {
+              let snapshot = RewindDatabase.currentUserId
+              XCTAssertTrue(
+                validValues.contains(snapshot),
+                "currentUserId returned a torn/invalid value: \(String(describing: snapshot))"
+              )
+            }
+          }
+        }
+      }
+      // All child tasks must complete without trapping.
+      for await _ in group {}
+    }
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260721-rewind-currentuserid-race.json
+++ b/desktop/macos/changelog/unreleased/20260721-rewind-currentuserid-race.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a rare crash caused by a data race on Rewind's per-user database identifier during app termination or account switching"
+}


### PR DESCRIPTION
## Summary

Fixes a critical data race on `RewindDatabase.currentUserId` (SCA-8).

`currentUserId` was declared `nonisolated(unsafe) static var String?`. It was written from the `RewindDatabase` actor (`retargetEffectiveOwner`/`configure`) and read from `nonisolated static func markCleanShutdown()` — called synchronously from `OmiApp` during termination on the main thread — and from `AgentVMService` inside a `MainActor.run { … }` on a different executor. `String?` is a non-atomic, reference-counted type, so a concurrent write + read is a genuine data race that can crash via use-after-free on the string's heap storage (not a benign Bool flag).

## Change

- Replace the stored `nonisolated(unsafe) static var currentUserId: String?` with a private `OSAllocatedUnfairLock<String?>` plus a computed `static var currentUserId` whose `get`/`set` funnel through the lock.
- `OSAllocatedUnfairLock` is `Sendable` and its critical section is synchronous (no actor hop, no suspension), so reads/writes from any executor (the `RewindDatabase` actor, `MainActor`, and the `nonisolated` shutdown path) are atomic.
- The call-site API is unchanged, so no production callers (`RewindDatabase.swift`, `RewindStorage.swift`, `AgentVMService.swift`, `OmiApp.swift`) or any tests need edits.
- This matches the existing in-repo pattern (`RewindVideoDirectoryMutation`, `QueryTracer`) which already use `OSAllocatedUnfairLock` for cross-executor mutable state.

## Test

New `RewindDatabaseCurrentUserIdConcurrencyTests`:
- `testCurrentUserIdRoundTripsThroughLock` — get/set round-trip including `nil`.
- `testConcurrentReadWriteIsRaceFree` — 8 writers (distinct IDs) × 4 readers, 5k iterations each, in a task group; asserts every read returns a coherent written value (one of the writer IDs or `nil`), never a torn/garbage pointer. Under the prior `nonisolated(unsafe)` storage this would surface as a torn value or a use-after-free trap; with the lock it completes cleanly.

## Verification

- `xcrun swift build -c debug --package-path Desktop` — **Build complete**.
- `xcrun swift test --package-path Desktop --filter RewindDatabaseCurrentUserIdConcurrencyTests` — 2 passed.
- `xcrun swift test --package-path Desktop --filter RewindDatabaseLifecycleTests` — 4 passed (exercises `configure` + `currentUserId` set/read).
- `xcrun swift test --package-path Desktop --filter RewindRetentionCleanupTests` — 1 passed (exercises `RewindStorage.initialize()` read path).
- `xcrun swift test --package-path Desktop --filter ActionItemsFTSRepairTests` — 2 passed (exercises `ActionItemStorage` read path).
- `swift-format-wrapper.sh lint` on both changed files — clean.

Refs SCA-8.

## Product invariants affected

- INV-AUTH-1 — the `currentUserId` lock-gating strengthens the effective-owner boundary (race-free per-owner `RewindDatabase` retargeting/configure described in INV-AUTH-1); no change to session invalidation, 401 handling, or owner-transition policy.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



Failure-Class: none
