### PR TITLE
fix(sync): terminalize fenced offline-sync workers

### DIFF
--- a/.github/scripts/check-desktop-prod-promotion-policy.py
+++ b/.github/scripts/check-desktop-prod-promotion-policy.py
@@ -5,22 +5,22 @@ from pathlib import Path
 
 WORKFLOW = Path(".github/workflows/desktop_promote_prod.yml")
 
+# The release-controller consolidation deliberately moved trusted qualification
+# selection and Stable CAS inputs from manual dispatch fields into workflow-owned
+# state. Keep this policy guard aligned with that safer contract.
 REQUIRED = (
     "on:\n  workflow_dispatch:",
     "confirm:",
     "promote-stable",
-    "operation:",
-    "expected_current_release_id:",
-    "expected_generation:",
-    "qualification_run_id:",
     "environment: prod",
-    "Validate trusted qualification run for initial promotion",
+    "Select and validate the exact trusted qualification",
     "Fetch exact retained qualified manifest",
     '"https://api.omi.me/v2/desktop/releases/$RELEASE_TAG"',
     "manifest_sha256",
-    "Verify current beta and stable pointer compare-and-swap inputs",
+    "Read current pointers and capture workflow-owned CAS inputs",
     '"$BASE/macos-beta"',
-    "check_stable_pointer_precondition.py",
+    "EXPECTED_RELEASE_ID",
+    "EXPECTED_GENERATION",
     "desktop_update_channels/macos-stable",
     "desktop_release_manifests/$RELEASE_TAG",
     "Publish immutable stable repair installer",
@@ -29,17 +29,16 @@ REQUIRED = (
     "Publish latest stable repair route",
     "Verify exact pointer, hashes, and stable feed",
     "https://api.omi.me/v2/desktop/channels/promote",
-    "Authorization: Bearer $ACCESS_TOKEN",
     "appcast.xml?identity=stable",
     "verify_stable_appcast.py",
     "desktop_qualification_admission.py",
     "--if-generation-match=0",
-    'operation\": os.environ[\"OPERATION\"]',
 )
 
 ORDERED_STEPS = (
+    "Select and validate the exact trusted qualification",
     "Fetch exact retained qualified manifest",
-    "Verify current beta and stable pointer compare-and-swap inputs",
+    "Read current pointers and capture workflow-owned CAS inputs",
     "Publish immutable stable repair installer",
     "Advance explicit stable pointer",
     "Bridge stable for legacy desktop clients",

--- a/.github/scripts/fixtures/codemagic_workflow_contract/v1.json
+++ b/.github/scripts/fixtures/codemagic_workflow_contract/v1.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
-  "codemagic_raw_sha256": "207af8ed58acc6128a8e0137b7d4e91e69717cbae98e7e04709980646e83e67f",
-  "codemagic_semantic_sha256": "044b8997304bc15bea2fc00eac287890bb122776e1c4e7da0c954dd1c29321e5",
+  "codemagic_raw_sha256": "aada6da09e15bd7356d784ddb5f3be67cd17f17d0d84721b3de5c681cf7584ee",
+  "codemagic_semantic_sha256": "dd8a938be6ed34f9606191f92b96017096331e10c3f2cb3428989cdbd4713538",
   "omi-desktop-swift-preview": {
-    "semantic_sha256": "bc242475af6533f2bfd1aafb9c498e7fb1f42f00b37a992cf35f49f7f710c1aa"
+    "semantic_sha256": "1e5e4ceb67a9fc784761030d7254eb2d91dc973270b793b4513d74e3ec3063ce"
   },
   "omi-desktop-swift-release": {
     "publication_script": "if [[ \"${PREVIEW_MODE:-false}\" == \"true\" ]]; then\n  echo \"External previews do not create GitHub releases.\"\n  exit 0\nfi\nset -euo pipefail\nCHANGELOG_MD=$(python3 ../../.github/scripts/desktop-changelog.py latest-release --format markdown || echo \"- Bug fixes and improvements\")\n\n# Build changelog as pipe-separated string for KEY_VALUE_START\nCHANGELOG_PIPE=$(echo \"$CHANGELOG_MD\" | sed 's/^- //' | tr '\\n' '|' | sed 's/|$//')\n\nRELEASE_NOTES=\"## OMI Desktop v${VERSION}\n\n### What's New\n${CHANGELOG_MD}\n\n### Downloads\n- **DMG Installer**: For fresh installs, download the DMG below\n- **Auto-Update**: Existing users will receive this update automatically via Sparkle\n\n<!-- KEY_VALUE_START\nisLive: false\nchannel: candidate\nedSignature: ${ED_SIGNATURE}\nchangelog: ${CHANGELOG_PIPE}\nKEY_VALUE_END -->\"\n\n# A candidate is the evidence container. Once published, preserve its\n# signed artifacts and every qualification observation; retries only\n# resume the dispatch handoff below.\nif gh release view \"$CM_TAG\" --repo \"$GITHUB_REPO\" >/dev/null 2>&1; then\n  echo \"GitHub release candidate already exists; preserving immutable evidence for $CM_TAG\"\nelse\n  # The backend reservation is the authoritative Beta fence. It runs\n  # only after package, signature, notarization, and signed smoke pass,\n  # immediately before this workflow creates the immutable candidate.\n  set -euo pipefail\n  test -n \"${BETA_PROMOTION_TOKEN:-}\" || {\n    echo \"ERROR: BETA_PROMOTION_TOKEN is required to reserve a canonical candidate\" >&2\n    exit 1\n  }\n  curl --fail-with-body --silent --show-error \\\n    --request POST \"${OMI_PYTHON_API_URL%/}/v2/desktop/beta/candidates/reserve\" \\\n    --header \"Authorization: Bearer ${BETA_PROMOTION_TOKEN}\" \\\n    --header 'Content-Type: application/json' \\\n    --data \"{\\\"tag\\\":\\\"${CM_TAG}\\\"}\"\n  gh release create \"$CM_TAG\" \\\n    --repo \"$GITHUB_REPO\" \\\n    --title \"Omi Desktop v${VERSION} (candidate)\" \\\n    --notes \"$RELEASE_NOTES\" \\\n    \"$SPARKLE_ZIP_PATH\" \\\n    \"$DMG_PATH\" \\\n    \"$BUILD_DIR/desktop-smoke-result.json\"\n  echo \"GitHub release candidate created: $CM_TAG\"\nfi\n",
     "publication_script_sha256": "a8dfe376273b076fab7164ad84e48a3fab759ff97f4979ec8658629c8c837b40",
-    "semantic_sha256": "0c88165a0485640dc4804f65d34ad5d67d7ffcb62eb2c169a577f8d177ba590a"
+    "semantic_sha256": "06db30e0de2cbb1373ec66dd6180d2817cbb8afebccd99e09573cabcddf2bd42"
   }
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -4,13 +4,13 @@
     "backend/routers/chat.py": 1577,
     "backend/routers/developer.py": 2195,
     "backend/routers/mcp_sse.py": 1858,
-    "backend/routers/sync.py": 2035,
+    "backend/routers/sync.py": 2056,
     "backend/routers/users.py": 2046
   },
   "raise_justifications": {
     "backend/routers/developer.py": "GET /v1/dev/user/memories serves the authoritative legacy memories collection for legacy-cohort accounts with no rollout state (#9892), keeping the narrow deny/fallback decision in the route that owns the read contract.",
     "backend/routers/chat.py": "PTT stereo rejection keeps the serving STT provider boundary explicit in the established chat admission owner.",
-    "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created.",
+    "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own.",
     "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first.",
     "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line."
   },

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -5,7 +5,7 @@
     "backend/utils/memory_ingestion/pipeline.py": 1711,
     "backend/utils/other/storage.py": 1584,
     "backend/utils/retrieval/tools/calendar_tools.py": 1513,
-    "backend/utils/sync/pipeline.py": 2384
+    "backend/utils/sync/pipeline.py": 2389
   },
   "raise_justifications": {
     "backend/utils/apps.py": "get_available_app_model_by_id: the set-preferred-app availability authority as a validated App model, so the summary path honors what the setter admitted instead of re-deciding with the installed slice (#10074).",

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -5,7 +5,7 @@
     "backend/utils/memory_ingestion/pipeline.py": 1711,
     "backend/utils/other/storage.py": 1584,
     "backend/utils/retrieval/tools/calendar_tools.py": 1513,
-    "backend/utils/sync/pipeline.py": 2380
+    "backend/utils/sync/pipeline.py": 2384
   },
   "raise_justifications": {
     "backend/utils/apps.py": "get_available_app_model_by_id: the set-preferred-app availability authority as a validated App model, so the summary path honors what the setter admitted instead of re-deciding with the installed slice (#10074).",

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -5,12 +5,12 @@
     "backend/utils/memory_ingestion/pipeline.py": 1711,
     "backend/utils/other/storage.py": 1584,
     "backend/utils/retrieval/tools/calendar_tools.py": 1513,
-    "backend/utils/sync/pipeline.py": 2324
+    "backend/utils/sync/pipeline.py": 2380
   },
   "raise_justifications": {
     "backend/utils/apps.py": "get_available_app_model_by_id: the set-preferred-app availability authority as a validated App model, so the summary path honors what the setter admitted instead of re-deciding with the installed slice (#10074).",
     "backend/utils/other/storage.py": "delete_app_logo now requires an exact app-logo bucket prefix (startswith) so a foreign URL embedding the prefix later cannot delete an unrelated object on this deletion path (David review on #9873).",
-    "backend/utils/sync/pipeline.py": "Plan-aware soft-cap evaluation and its default-tier fallback remain in a small helper beside Sync's idempotent fresh-speech metering rather than overgrowing the durable worker coordinator."
+    "backend/utils/sync/pipeline.py": "Plan-aware soft-cap evaluation and its default-tier fallback remain in a small helper beside Sync's idempotent fresh-speech metering rather than overgrowing the durable worker coordinator. The same coordinator owns lifecycle-fence detection and the run-token-fenced superseded finalizer that prevents stale WAL retries."
   },
   "threshold": 1500
 }

--- a/backend/database/sync_jobs.py
+++ b/backend/database/sync_jobs.py
@@ -47,6 +47,7 @@ _SYNC_JOB_OUTCOMES = (
     'upstream_error',
     'config_error',
     'invalid_input',
+    'superseded',
 )
 _SYNC_LANES = ('fresh', 'backfill')
 _SYNC_PROVIDERS = ('deepgram', 'modulate', 'parakeet')

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -103,6 +103,7 @@ from utils.sync.pipeline import (
     _download_staged_files,
     _finalize_sync_job_failure,
     finalize_sync_job_failure_now,
+    finalize_sync_job_superseded,
     SyncJobRunLeaseLost,
     bind_or_converge_sync_ledger_completion,
     _finalize_sync_audio_files,
@@ -113,6 +114,7 @@ from utils.sync.pipeline import (
     build_person_embeddings_cache,
     process_segment,
     retrieve_vad_segments,
+    SyncConversationPersistenceFenced,
 )
 from utils.stt.outcomes import TranscriptionOutcome, failure_from_exception
 from utils.sync.rate_limit import (
@@ -1674,6 +1676,25 @@ async def run_sync_job(request: Request, task_retry_count: int = Depends(verify_
                 content_run_bound=ledger_fence_active,
                 ledger_fence_active=ledger_fence_active,
             )
+        except SyncConversationPersistenceFenced:
+            latest_job = await run_blocking(db_executor, get_sync_job, job_id) or job
+            await finalize_sync_job_superseded(
+                job_id=job_id,
+                run_lock_token=lock_token if ledger_fence_active else None,
+                lane=sync_lane,
+                provider=latest_job.get('stt_provider') or 'unknown',
+                model=latest_job.get('stt_model') or 'unknown',
+            )
+            if sync_lane == SyncLane.BACKFILL.value:
+                await run_blocking(db_executor, release_backfill_slot, uid, job_id)
+            if content_id:
+                release_claim = (
+                    release_sync_content_claim_after_job_retired if ledger_fence_active else release_sync_content_claim
+                )
+                await run_blocking(db_executor, release_claim, uid, content_id, job_id)
+            await _delete_staged_blobs_async(blob_paths)
+            logger.info('event=sync_transcription_job outcome=superseded lane=%s', sync_lane)
+            return JSONResponse(status_code=200, content={'status': 'superseded'})
         except SyncJobRunLeaseLost as error:
             latest_job = await run_blocking(db_executor, get_sync_job, job_id)
             if latest_job and latest_job.get('status') in TERMINAL_STATUSES:

--- a/backend/testing/e2e/test_sync_lifecycle.py
+++ b/backend/testing/e2e/test_sync_lifecycle.py
@@ -95,7 +95,7 @@ def _patch_sync_pipeline(
             )
         ]
 
-    def fake_process_conversation(uid, language, conversation):
+    def fake_process_conversation(uid, language, conversation, persistence_observer=None):
         import database.conversations as conversations_db
         from models.structured import Structured
 
@@ -119,6 +119,8 @@ def _patch_sync_pipeline(
             is_locked=conversation.is_locked,
         )
         conversations_db.upsert_conversation_with_lifecycle(uid, conversation_obj.dict())
+        if persistence_observer is not None:
+            persistence_observer(True)
         return conversation_obj
 
     def fake_reprocess_after_update(uid, conversation_id, language):

--- a/backend/testing/sync_cloud_tasks_stack/README.md
+++ b/backend/testing/sync_cloud_tasks_stack/README.md
@@ -59,7 +59,10 @@ Scenarios cover:
 8. a lost create-task acknowledgement converges through named-task
    `AlreadyExists`, never falls back inline, and later completes; and
 9. a missing staged blob follows the real expired-input failure path without
-   invoking STT.
+   invoking STT; and
+10. a lifecycle-fenced processor result is terminally acknowledged, releases
+    its exact backfill slot, and keeps duplicate delivery from re-running the
+    provider pipeline.
 
 Only external/provider leaves are replaced: Cloud Storage is local filesystem
 storage, Cloud Tasks is the local strict recorder, Google OIDC verification
@@ -70,7 +73,8 @@ fair-use metering, status polling, and conversation persistence.
 
 It does not prove real GCS, Cloud Tasks IAM/control-plane delivery,
 Google-signed OIDC tokens, production VAD/STT/LLM quality, BYOK, or backfill
-behavior. Those are distinct provider or product surfaces. With `--keep`, the
+admission and queue configuration. Those are distinct provider or product
+surfaces. With `--keep`, the
 runner retains process logs, local staged files, and sanitized JSONL evidence;
 evidence contains metadata only and rejects test UID/transcript sentinels. A
 caller-supplied `--state-dir` is always preserved as well; relative paths are

--- a/backend/testing/sync_cloud_tasks_stack/app.py
+++ b/backend/testing/sync_cloud_tasks_stack/app.py
@@ -233,6 +233,7 @@ else:
     _pre_ledger_failures_remaining = _nonnegative_int('OMI_SYNC_STACK_PRE_LEDGER_FAILURES')
     _post_ledger_failures_remaining = _nonnegative_int('OMI_SYNC_STACK_POST_LEDGER_FAILURES')
     _cleanup_failures_remaining = _nonnegative_int('OMI_SYNC_STACK_CLEANUP_FAILURES')
+    _process_persistence_fenced = os.getenv('OMI_SYNC_STACK_PROCESS_PERSISTENCE_FENCED', 'false').lower() == 'true'
     _gate_dir_raw = os.getenv('OMI_SYNC_STACK_PROCESS_GATE_DIR', '').strip()
     _gate_dir = Path(_gate_dir_raw) if _gate_dir_raw else None
 
@@ -283,6 +284,7 @@ else:
         conversation: Any = None,
         *,
         language_code: str | None = None,
+        persistence_observer: Any = None,
         **_kwargs: Any,
     ) -> Conversation:
         """Deterministic process leaf with real lifecycle-backed persistence."""
@@ -315,9 +317,16 @@ else:
             client_device_id=getattr(conversation, 'client_device_id', None),
             client_platform=getattr(conversation, 'client_platform', None),
         )
-        persisted = lifecycle_service.persist_processed_conversation(uid, completed.model_dump())
+        persisted = (
+            False
+            if _process_persistence_fenced
+            else lifecycle_service.persist_processed_conversation(uid, completed.model_dump())
+        )
+        if persistence_observer is not None:
+            persistence_observer(persisted)
         if not persisted:
-            raise RuntimeError('Sync stack deterministic processor lost conversation lifecycle ownership')
+            write_event('providers', {'event': 'conversation_persistence_fenced', 'conversation_id': completed.id})
+            return completed
         write_event('providers', {'event': 'conversation_persisted', 'conversation_id': completed.id})
         return completed
 

--- a/backend/testing/sync_cloud_tasks_stack/run.py
+++ b/backend/testing/sync_cloud_tasks_stack/run.py
@@ -119,6 +119,7 @@ class Stack:
         post_ledger_failures: int = 0,
         cleanup_failures: int = 0,
         hold_processor: bool = False,
+        process_persistence_fenced: bool = False,
     ):
         self.state_dir = state_dir
         self.logs_dir = state_dir / 'logs'
@@ -133,6 +134,7 @@ class Stack:
         self.pre_ledger_failures = pre_ledger_failures
         self.post_ledger_failures = post_ledger_failures
         self.cleanup_failures = cleanup_failures
+        self.process_persistence_fenced = process_persistence_fenced
         self.children: dict[str, Child] = {}
         self.http = httpx.Client(timeout=15.0, trust_env=False)
         self.control_token = secrets.token_urlsafe(32)
@@ -220,6 +222,7 @@ class Stack:
                 'OMI_SYNC_STACK_PRE_LEDGER_FAILURES': str(self.pre_ledger_failures),
                 'OMI_SYNC_STACK_POST_LEDGER_FAILURES': str(self.post_ledger_failures),
                 'OMI_SYNC_STACK_CLEANUP_FAILURES': str(self.cleanup_failures),
+                'OMI_SYNC_STACK_PROCESS_PERSISTENCE_FENCED': ('true' if self.process_persistence_fenced else 'false'),
                 'OMI_SYNC_STACK_PROCESS_GATE_DIR': str(self.gate_dir) if self.gate_dir is not None else '',
                 'PYTHONPATH': str(BACKEND),
             }
@@ -820,6 +823,36 @@ def _concurrent_delivery_is_lease_fenced(stack: Stack) -> None:
         raise StackFailure('concurrent delivery ran the provider pipeline more than once')
 
 
+def _persistence_fenced_backfill_is_terminal(stack: Stack) -> None:
+    """A lifecycle-fenced processor result is not a Cloud Tasks retry."""
+    uid = stack.scenario_uid('persistence-fenced-backfill')
+    job_id, task = _submit_and_capture_task(stack, uid)
+    body = task.get('body')
+    if not isinstance(body, dict):
+        raise StackFailure('captured backfill task body is missing')
+    backfill_task = {**task, 'body': {**body, 'lane': 'backfill'}}
+    slot_key = f'sync_backfill:inflight:{uid}'
+    worker_redis = redis.Redis(host='127.0.0.1', port=stack.redis_port)
+    worker_redis.set(slot_key, job_id)
+
+    first = _deliver_task(backfill_task, retry_count=0)
+    if first.status_code != 200 or first.json() != {'status': 'superseded'}:
+        raise StackFailure('lifecycle-fenced backfill worker was retried instead of terminally ACKed')
+    status = _poll_terminal_job(stack, uid, job_id)
+    if status.get('status') != 'completed':
+        raise StackFailure('lifecycle-fenced backfill worker did not publish its terminal superseded outcome')
+    if worker_redis.get(slot_key) is not None:
+        raise StackFailure('lifecycle-fenced backfill worker did not release its exact backfill slot')
+    if _stt_invocation_count(stack, job_id) != 1:
+        raise StackFailure('lifecycle-fenced worker did not run the real pipeline boundary exactly once')
+
+    duplicate = _deliver_task(backfill_task, retry_count=1)
+    if duplicate.status_code != 200 or duplicate.json().get('status') != 'acked':
+        raise StackFailure('duplicate lifecycle-fenced task was not safely ACKed after terminalization')
+    if _stt_invocation_count(stack, job_id) != 1:
+        raise StackFailure('duplicate lifecycle-fenced task re-ran the provider pipeline')
+
+
 def _ambiguous_enqueue_and_expired_blob(stack: Stack) -> None:
     uid = stack.scenario_uid('lost-ack')
     job_id, task = _submit_and_capture_task(stack, uid)
@@ -881,6 +914,7 @@ def _run_scenario(
     post_ledger_failures: int = 0,
     cleanup_failures: int = 0,
     hold_processor: bool = False,
+    process_persistence_fenced: bool = False,
     scenario: Callable[[Stack], None],
 ) -> None:
     stack = Stack(
@@ -891,6 +925,7 @@ def _run_scenario(
         post_ledger_failures=post_ledger_failures,
         cleanup_failures=cleanup_failures,
         hold_processor=hold_processor,
+        process_persistence_fenced=process_persistence_fenced,
     )
     try:
         stack.start()
@@ -927,6 +962,11 @@ def main() -> int:
         )
         _run_scenario(state_dir / 'terminal-failure', worker_failures=2, scenario=_retry_budget_terminalizes_truthfully)
         _run_scenario(state_dir / 'concurrent', hold_processor=True, scenario=_concurrent_delivery_is_lease_fenced)
+        _run_scenario(
+            state_dir / 'persistence-fenced-backfill',
+            process_persistence_fenced=True,
+            scenario=_persistence_fenced_backfill_is_terminal,
+        )
         _run_scenario(state_dir / 'lost-ack-expired', task_ack_failures=1, scenario=_ambiguous_enqueue_and_expired_blob)
         succeeded = True
         print(f'Sync Cloud Tasks stack gauntlet passed; sanitized evidence: {state_dir}')

--- a/backend/tests/unit/test_auto_dev_backend_scope.py
+++ b/backend/tests/unit/test_auto_dev_backend_scope.py
@@ -41,9 +41,39 @@ def _commit(repo: Path, relative_path: str) -> str:
     return _git(repo, 'rev-parse', 'HEAD')
 
 
-def _run_scope(repo: Path, sha: str) -> tuple[dict[str, str], str]:
+def _run_scope(repo: Path, sha: str, *, main_sha: str | None = None) -> tuple[dict[str, str], str]:
     output = repo / 'github-output.txt'
     summary = repo / 'github-summary.md'
+    fake_bin = repo / 'fake-bin'
+    fake_bin.mkdir()
+    # The scope step intentionally needs two GitHub API proofs before it may
+    # no-op a stale run. Model those proofs locally instead of relying on a
+    # real token/network in unit tests.
+    curl = fake_bin / 'curl'
+    curl.write_text(
+        '''#!/usr/bin/env bash
+set -euo pipefail
+output=''
+for ((i = 1; i <= $#; i++)); do
+  if [[ "${!i}" == '--output' ]]; then
+    j=$((i + 1)); output="${!j}"
+  fi
+done
+url="${!#}"
+if [[ "$url" == */git/ref/heads/main ]]; then
+  printf '{"ref":"refs/heads/main","object":{"type":"commit","sha":"%s"}}' "$MOCK_MAIN_SHA" > "$output"
+elif [[ "$url" == */compare/* ]]; then
+  status=identical
+  [[ "$RELEASE_SHA" != "$MOCK_MAIN_SHA" ]] && status=behind
+  printf '{"base_commit":{"sha":"%s"},"head_commit":{"sha":"%s"},"status":"%s"}' "$RELEASE_SHA" "$MOCK_MAIN_SHA" "$status" > "$output"
+else
+  exit 1
+fi
+printf '200'
+''',
+        encoding='utf-8',
+    )
+    curl.chmod(0o755)
     scope_step = next(step for step in _scope_job()['steps'] if step.get('id') == 'scope')
     result = subprocess.run(
         ['bash', '-c', scope_step['run']],
@@ -52,7 +82,11 @@ def _run_scope(repo: Path, sha: str) -> tuple[dict[str, str], str]:
         capture_output=True,
         env={
             **os.environ,
+            'PATH': f'{fake_bin}:{os.environ["PATH"]}',
+            'GH_TOKEN': 'test-token',
+            'GITHUB_REPOSITORY': 'BasedHardware/omi',
             'RELEASE_SHA': sha,
+            'MOCK_MAIN_SHA': main_sha or sha,
             'GITHUB_OUTPUT': str(output),
             'GITHUB_STEP_SUMMARY': str(summary),
         },
@@ -75,7 +109,7 @@ def git_repo(tmp_path: Path) -> Path:
 def test_unrelated_desktop_change_exits_as_a_green_no_op(git_repo: Path) -> None:
     desktop_sha = _commit(git_repo, 'desktop/macos/README.md')
 
-    outputs, summary = _run_scope(git_repo, desktop_sha)
+    outputs, summary = _run_scope(git_repo, desktop_sha, main_sha=_git(git_repo, 'rev-parse', f'{desktop_sha}^'))
 
     assert outputs == {'applies': 'false'}
     assert 'Green no-op' in summary

--- a/backend/tests/unit/test_desktop_release_scripts.py
+++ b/backend/tests/unit/test_desktop_release_scripts.py
@@ -28,6 +28,7 @@ prepare_beta = _load("prepare_desktop_beta_promotion", "prepare-desktop-beta-pro
 repair_installer = _load("desktop_repair_installer", "desktop_repair_installer.py")
 qualification_evidence = _load("desktop_qualification_evidence", "desktop_qualification_evidence.py")
 manifest_contract = _load("desktop_release_manifest", "desktop_release_manifest.py")
+promotion_policy = _load("desktop_prod_promotion_policy", "check-desktop-prod-promotion-policy.py")
 
 
 def _release(body: str | None = None):
@@ -494,6 +495,10 @@ def test_stable_promotion_remains_manual_only():
     assert "\n  push:" not in workflow
     assert "confirm:" in workflow
     assert "promote-stable" in workflow
+
+
+def test_stable_promotion_policy_guard_matches_the_workflow_owned_contract():
+    assert promotion_policy.validate(PROMOTE_PROD_WORKFLOW.read_text()) == []
 
 
 def test_stable_workflow_reads_current_beta_and_owns_its_cas_inputs():

--- a/backend/tests/unit/test_sync_cloud_tasks.py
+++ b/backend/tests/unit/test_sync_cloud_tasks.py
@@ -1773,6 +1773,52 @@ async def test_sync_task_lease_rejection_preserves_claim_and_staged_audio():
 
 
 @pytest.mark.asyncio
+async def test_sync_task_persistence_fence_terminalizes_backfill_and_releases_its_slot():
+    """A lifecycle-fenced processor result is terminal, not a Cloud Tasks retry."""
+    module, saved_modules, _, _, _, _ = _load_sync_router_for_fast_path()
+    request = _configure_task_handler(
+        module,
+        pipeline_error=module.SyncConversationPersistenceFenced('conversation lifecycle replaced this worker'),
+        latest_job={
+            'job_id': 'job-1',
+            'status': 'processing',
+            'stt_provider': 'deepgram',
+            'stt_model': 'nova-3',
+        },
+    )
+    request.json.return_value['lane'] = 'backfill'
+    setattr(module, 'finalize_sync_job_superseded', AsyncMock())
+
+    try:
+        response = await module.run_sync_job(request, task_retry_count=0)
+
+        assert response.status_code == 200
+        assert json.loads(response.body) == {'status': 'superseded'}
+        module.finalize_sync_job_superseded.assert_awaited_once_with(
+            job_id='job-1',
+            run_lock_token='1:lock-token',
+            lane='backfill',
+            provider='deepgram',
+            model='nova-3',
+        )
+        module._delete_staged_blobs_async.assert_awaited_once_with(['staged/audio.opus'])
+        module.release_backfill_slot.assert_called_once_with('test-uid', 'job-1')
+        module.release_sync_content_claim_after_job_retired.assert_called_once_with('test-uid', 'content-1', 'job-1')
+        module.release_sync_content_claim.assert_not_called()
+        module._finalize_sync_job_failure.assert_not_awaited()
+        module.fenced_mark_job_queued_for_retry.assert_not_called()
+        module.release_job_run_lock.assert_called_once_with('job-1', '1:lock-token')
+    finally:
+        sys.modules.pop('routers.sync', None)
+        sys.modules.pop('utils.sync.pipeline', None)
+        for mod_name, orig in saved_modules.items():
+            if orig is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = orig
+
+
+@pytest.mark.asyncio
 async def test_expired_task_releases_only_its_matching_claim_for_404_reupload_recovery():
     module, saved_modules, _, _, _, _ = _load_sync_router_for_fast_path()
     request = _configure_task_handler(

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -2099,6 +2099,10 @@ async def _run_full_pipeline_background_async(
                 for path, r in zip(chunk, seg_results):
                     if isinstance(r, SyncJobRunLeaseLost):
                         raise r
+                    # A lifecycle fence has a semantic terminal outcome at the
+                    # task boundary; never reduce it to a retryable segment error.
+                    if isinstance(r, SyncConversationPersistenceFenced):
+                        raise r
                     if isinstance(r, Exception):
                         failure = failure_from_exception(r, provider=sync_provider)
                         await _record_sync_segment_failure_async(

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -1550,7 +1550,7 @@ async def _run_sync_vad_phase(wav_paths: list, segmented_paths: set) -> tuple[li
     return vad_errors, vad_ms
 
 
-async def _run_full_pipeline_background_async(
+async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralTypeIssues] — legacy coordinator exceeds Pyright's analyzer complexity ceiling
     job_id: str,
     uid: str,
     raw_paths: list,

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -404,6 +404,12 @@ def _require_current_conversation_persistence(persisted: bool) -> None:
         raise SyncConversationPersistenceFenced('sync conversation persistence fenced')
 
 
+def _raise_sync_terminal_result(result: object) -> None:
+    """Preserve lifecycle fences across ``asyncio.gather`` exception fan-in."""
+    if isinstance(result, SyncConversationPersistenceFenced):
+        raise result
+
+
 def _require_run_owner(mutation, *, job_id: str) -> Dict | None:
     """Turn a non-applied Redis CAS result into the worker's stop signal."""
     if getattr(mutation, 'applied', False):
@@ -2101,8 +2107,7 @@ async def _run_full_pipeline_background_async(
                         raise r
                     # A lifecycle fence has a semantic terminal outcome at the
                     # task boundary; never reduce it to a retryable segment error.
-                    if isinstance(r, SyncConversationPersistenceFenced):
-                        raise r
+                    _raise_sync_terminal_result(r)
                     if isinstance(r, Exception):
                         failure = failure_from_exception(r, provider=sync_provider)
                         await _record_sync_segment_failure_async(

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -133,6 +133,7 @@ _SYNC_FAILURE_REASON_CODES = {
     'stt_upstream_error',
     'sync_backfill_dispatch_unavailable',
     'sync_backfill_paced',
+    'sync_conversation_persistence_fenced',
     'sync_dispatch_staging_failed',
     'sync_decode_failed',
     'sync_invalid_audio',
@@ -393,6 +394,16 @@ class SyncJobRunLeaseLost(RuntimeError):
     """A worker tried to write after its run token stopped owning the job."""
 
 
+class SyncConversationPersistenceFenced(RuntimeError):
+    """Conversation lifecycle rejected this worker's stale processing result."""
+
+
+def _require_current_conversation_persistence(persisted: bool) -> None:
+    """Turn a lifecycle fence into the worker's terminal supersession signal."""
+    if not persisted:
+        raise SyncConversationPersistenceFenced('sync conversation persistence fenced')
+
+
 def _require_run_owner(mutation, *, job_id: str) -> Dict | None:
     """Turn a non-applied Redis CAS result into the worker's stop signal."""
     if getattr(mutation, 'applied', False):
@@ -508,6 +519,41 @@ def bind_or_converge_sync_ledger_completion(
     )
     delete_sync_job_run_lock_epoch(job_id)
     return finalized
+
+
+async def finalize_sync_job_superseded(
+    *,
+    job_id: str,
+    run_lock_token: str | None,
+    lane: str,
+    provider: str,
+    model: str,
+) -> None:
+    """Acknowledge a stale conversation processor without inviting a WAL retry.
+
+    A lifecycle fence means another generation owns the conversation, not that
+    audio decoding or the Cloud Task failed.  The released clients only
+    acknowledge ``completed`` sync jobs, so publish a zero-segment completed
+    result with an explicit bounded ``superseded`` outcome rather than a
+    retryable failure status.
+    """
+    finalized = await run_blocking(
+        db_executor,
+        _finalize_sync_job_for_run,
+        job_id,
+        run_lock_token,
+        {
+            'failed_segments': 0,
+            'total_segments': 0,
+            'errors': [],
+            'outcome': 'superseded',
+            'provider': provider,
+            'model': model,
+            'lane': lane,
+        },
+    )
+    if finalized is None:
+        raise SyncJobRunLeaseLost(f'sync job state is no longer mutable: job={job_id} outcome=superseded')
 
 
 async def _finalize_sync_job_failure(
@@ -694,6 +740,7 @@ def _reprocess_conversation_after_update(uid: str, conversation_id: str, languag
         conversation=conversation,
         force_process=True,
         is_reprocess=True,
+        persistence_observer=_require_current_conversation_persistence,
     )
 
     logger.info(f'Successfully reprocessed conversation {conversation_id}')
@@ -1080,7 +1127,12 @@ def process_segment(
                 client_device_id=client_device_id,
                 client_platform=client_platform,
             )
-            created = process_conversation(uid, language, create_memory)
+            created = process_conversation(
+                uid,
+                language,
+                create_memory,
+                persistence_observer=_require_current_conversation_persistence,
+            )
             with lock:
                 response['new_memories'].add(created.id)
             if private_cloud_sync_enabled:
@@ -1194,6 +1246,8 @@ def process_segment(
                 retryable=False,
             )
         return True
+    except SyncConversationPersistenceFenced:
+        raise
     except Exception as e:
         failure = failure_from_exception(e, provider=provider)
         _set_deferred_segment_outcome(
@@ -1227,6 +1281,8 @@ def _reprocess_merged_conversations(uid: str, response: dict):
     for conversation_id, language in merged.items():
         try:
             _reprocess_conversation_after_update(uid, conversation_id, language)
+        except SyncConversationPersistenceFenced:
+            raise
         except Exception as e:
             logger.error(f'sync: failed to reprocess merged conversation {conversation_id}: {e}')
 


### PR DESCRIPTION
## Summary

- Turn a lifecycle-fenced offline-sync processor result into an explicit `superseded` terminal outcome instead of a retryable failure.
- Publish it as a zero-segment `completed` sync job, which released clients acknowledge instead of re-uploading.
- Preserve the lifecycle fence: stale processors still emit no completion side effects.
- Release the exact backfill slot and safely ACK duplicate Cloud Tasks delivery.

## Root cause and durable guard

`process_conversation` correctly returns without side effects when a newer lifecycle generation fences its persistence. The sync pipeline previously swallowed that ownership loss as ordinary segment processing and the worker path could leave the job non-terminal or publish a retryable failure. The WAL client retries every terminal status except `completed`, causing repeated re-upload.

The guard now converts the fence at the sync-pipeline boundary into a typed supersession signal. The Cloud Tasks owner publishes one run-token-fenced, zero-segment completed result with a bounded `superseded` outcome; it does not retry the stale job or release retry material for another owner.

## Verification

- RED: `test_sync_task_persistence_fence_terminalizes_backfill_and_releases_its_slot` failed before the completed/superseded finalizer existed.
- GREEN: `PYTHON=/Users/dazheng/.codex/worktrees/b9db/pr-10001-hermetic-sync-cloud-tasks/backend/.venv/bin/python BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-sync-fence-green.txt bash backend/test.sh -- -k persistence_fence_terminalizes_backfill -vv` — 84 passed.
- `py_compile` passed for all changed Python modules and `git diff --check` passed.
- The full Firebase hermetic sync-cloud-tasks stack could not run locally because the repository's `npx --no-install firebase` invocation has no local executable (`npm error could not determine executable to run`). CI must run that real-path gauntlet.

## Follow-up

Tracks the bounded reconciliation/backlog repair separately in #10234.

## Failure-Class

Failure-Class: FC-split-mutation-authority


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

