### PR TITLE
fix(desktop): qualify universal macOS artifacts

### DIFF
--- a/backend/tests/unit/test_desktop_release_scripts.py
+++ b/backend/tests/unit/test_desktop_release_scripts.py
@@ -239,6 +239,29 @@ def test_qualification_workflow_binds_immutable_controls_and_candidate_identity(
     assert "gh release upload" in qualification
 
 
+def test_codemagic_produces_canonical_app_and_strictly_verifiable_dmg():
+    workflow = CODEMAGIC_CONFIG.read_text(encoding="utf-8")
+    smoke = (REPO_ROOT / "desktop/macos/scripts/smoke-signed-desktop-artifact.sh").read_text(encoding="utf-8")
+    assert workflow.count('APP_NAME: "Omi"') == 1
+    assert 'APP_NAME: "omi"' not in workflow
+    assert "xattr -d com.apple.FinderInfo" in workflow
+    assert "xattr -d com.apple.ResourceFork" in workflow
+    assert 'codesign --verify --deep --strict --verbose=2 "$STAGING_DIR/$APP_NAME.app"' in workflow
+    assert 'dmg_app="$DMG_MOUNTPOINT/Omi.app"' in smoke
+    assert "DMG-contained Omi.app failed deep strict codesign verification" in smoke
+
+
+def test_universal_release_stages_and_smokes_both_sharp_architectures():
+    prepare = (REPO_ROOT / "desktop/macos/scripts/prepare-agent-runtime.sh").read_text(encoding="utf-8")
+    smoke = (REPO_ROOT / "desktop/macos/scripts/smoke-signed-desktop-artifact.sh").read_text(encoding="utf-8")
+    assert "stage_darwin_sharp_arches" in prepare
+    assert "for package_arch in arm64 x64" in prepare
+    assert "@img/sharp-darwin-$package_arch@$sharp_version" in prepare
+    assert "@img/sharp-libvips-darwin-$package_arch@$libvips_version" in prepare
+    assert "for sharp_arch in arm64 x64" in prepare
+    assert "agent runtime missing Sharp/libvips darwin-$sharp_arch pair" in smoke
+
+
 def test_prepare_manifest_rejects_caller_hashes_that_do_not_match_trusted_evidence():
     """Promotion can only bind bytes independently recorded by qualification."""
     evidence = {

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1884,7 +1884,7 @@ workflows:
         - desktop_secrets
       vars:
         BINARY_NAME: "Omi Computer"
-        APP_NAME: "omi"
+        APP_NAME: "Omi"
         BUNDLE_ID: "com.omi.computer-macos"
         BUILD_DIR: "build"
         GITHUB_REPO: "BasedHardware/omi"
@@ -2583,7 +2583,7 @@ workflows:
 
       - name: Create DMG installer
         script: |
-          set -e
+          set -euo pipefail
           pip3 install --break-system-packages "dmgbuild==$DMGBUILD_VERSION"
 
           STAGING_DIR="/tmp/omi-dmg-staging-$$"
@@ -2593,6 +2593,16 @@ workflows:
           # Re-staple in staging dir if needed
           xcrun stapler validate "$STAGING_DIR/$APP_NAME.app" 2>/dev/null || \
             xcrun stapler staple "$STAGING_DIR/$APP_NAME.app"
+
+          # Finder metadata is not signed application content and makes strict
+          # codesign verification fail after the app is copied out of the DMG.
+          # Remove only these forbidden metadata forks so the staple remains.
+          while IFS= read -r path; do
+            xattr -d com.apple.FinderInfo "$path" 2>/dev/null || true
+            xattr -d com.apple.ResourceFork "$path" 2>/dev/null || true
+          done < <(find "$STAGING_DIR/$APP_NAME.app" -print)
+          codesign --verify --deep --strict --verbose=2 "$STAGING_DIR/$APP_NAME.app"
+          xcrun stapler validate "$STAGING_DIR/$APP_NAME.app"
 
           # Use dmgbuild instead of create-dmg — writes .DS_Store directly
           # without Finder/AppleScript (which hangs in CI with --skip-jenkins)

--- a/desktop/macos/changelog/unreleased/universal-artifact-qualification.json
+++ b/desktop/macos/changelog/unreleased/universal-artifact-qualification.json
@@ -1,0 +1,1 @@
+{"change":"Improved macOS update reliability across both Apple silicon and Intel Macs."}

--- a/desktop/macos/scripts/prepare-agent-runtime.sh
+++ b/desktop/macos/scripts/prepare-agent-runtime.sh
@@ -193,11 +193,58 @@ stage_production_node_modules() {
     npm ci --omit=dev --no-fund --no-audit
   )
 
+  stage_darwin_sharp_arches "$package_dir" "$temp_dir"
   prune_non_macos_node_packages "$temp_dir"
   prune_packaged_node_modules "$temp_dir"
   rm -rf "$output_dir"
   mv "$temp_dir/node_modules" "$output_dir"
   rm -rf "$temp_dir"
+}
+
+stage_darwin_sharp_arches() {
+  local package_dir="$1"
+  local output_dir="$2"
+  local lock_path="$package_dir/package-lock.json"
+  local package_arch sharp_version libvips_version overlay
+
+  # npm installs optional native packages only for the builder architecture.
+  # The release app is universal, so overlay both Darwin pairs pinned by lock.
+  for package_arch in arm64 x64; do
+    sharp_version="$(node -e '
+      const lock = require(process.argv[1]);
+      const pkg = lock.packages?.[`node_modules/@img/sharp-darwin-${process.argv[2]}`];
+      if (pkg?.version) process.stdout.write(pkg.version);
+    ' "$lock_path" "$package_arch")"
+    libvips_version="$(node -e '
+      const lock = require(process.argv[1]);
+      const pkg = lock.packages?.[`node_modules/@img/sharp-libvips-darwin-${process.argv[2]}`];
+      if (pkg?.version) process.stdout.write(pkg.version);
+    ' "$lock_path" "$package_arch")"
+
+    if [ -z "$sharp_version" ] && [ -z "$libvips_version" ]; then
+      return 0
+    fi
+    [ -n "$sharp_version" ] && [ -n "$libvips_version" ] || {
+      echo "ERROR: package lock must pin Sharp and libvips for darwin-$package_arch" >&2
+      exit 1
+    }
+
+    overlay="$(mktemp -d "$PACKAGED_RUNTIME_DIR/sharp-$package_arch.XXXXXX")"
+    npm_config_platform=darwin npm_config_arch="$package_arch" \
+      npm install --prefix "$overlay" --ignore-scripts --no-save --package-lock=false \
+        --no-fund --no-audit \
+        "@img/sharp-darwin-$package_arch@$sharp_version" \
+        "@img/sharp-libvips-darwin-$package_arch@$libvips_version"
+    mkdir -p "$output_dir/node_modules/@img"
+    rm -rf \
+      "$output_dir/node_modules/@img/sharp-darwin-$package_arch" \
+      "$output_dir/node_modules/@img/sharp-libvips-darwin-$package_arch"
+    cp -R "$overlay/node_modules/@img/sharp-darwin-$package_arch" \
+      "$output_dir/node_modules/@img/"
+    cp -R "$overlay/node_modules/@img/sharp-libvips-darwin-$package_arch" \
+      "$output_dir/node_modules/@img/"
+    rm -rf "$overlay"
+  done
 }
 
 prune_non_macos_node_packages() {
@@ -605,6 +652,17 @@ validate_runtime_tree() {
 
   [ -d "$PI_MONO_PACKAGED_NODE_MODULES" ] || return 1
   validate_packaged_symlinks || return 1
+
+  local sharp_arch expected_arch sharp_native libvips_native
+  for sharp_arch in arm64 x64; do
+    expected_arch="$sharp_arch"
+    [ "$sharp_arch" = "x64" ] && expected_arch="x86_64"
+    sharp_native="$AGENT_PACKAGED_NODE_MODULES/@img/sharp-darwin-$sharp_arch/lib/sharp-darwin-$sharp_arch.node"
+    libvips_native="$AGENT_PACKAGED_NODE_MODULES/@img/sharp-libvips-darwin-$sharp_arch/lib/libvips-cpp.42.dylib"
+    [ -f "$sharp_native" ] && [ -f "$libvips_native" ] || return 1
+    file "$sharp_native" | grep -q "$expected_arch" || return 1
+    file "$libvips_native" | grep -q "$expected_arch" || return 1
+  done
 
   local staged_version
   staged_version="$("$NODE_RESOURCE" --version 2>/dev/null)" || return 1

--- a/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
+++ b/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
@@ -487,8 +487,10 @@ assert_sparkle_and_artifacts() {
     hdiutil attach "$DMG_PATH" -nobrowse -readonly -mountpoint "$DMG_MOUNTPOINT" -quiet \
       || fail "DMG attach failed"
     local dmg_app
-    dmg_app="$(find "$DMG_MOUNTPOINT" -maxdepth 2 -type d -name "*.app" | head -1)"
-    [[ -n "$dmg_app" ]] || fail "DMG does not contain an app bundle"
+    dmg_app="$DMG_MOUNTPOINT/Omi.app"
+    [[ -d "$dmg_app/Contents" ]] || fail "DMG must contain canonical Omi.app"
+    codesign --verify --deep --strict --verbose=2 "$dmg_app" >/dev/null 2>&1 \
+      || fail "DMG-contained Omi.app failed deep strict codesign verification"
     assert_bundle_matches_current "$dmg_app" "DMG"
     record_artifact "dmg" "$DMG_PATH"
   fi
@@ -511,6 +513,19 @@ assert_helper_runtime_integrity() {
   [[ -f "$resources/agent/src/runtime/omi-tool-manifest.ts" ]] || fail "agent tool manifest missing"
   [[ -d "$resources/pi-mono-extension" ]] || fail "pi-mono-extension missing"
   [[ -x "$resources/Omi Computer_Omi Computer.bundle/node" ]] || fail "bundled node missing"
+  local sharp_arch expected_arch sharp_native libvips_native
+  for sharp_arch in arm64 x64; do
+    expected_arch="$sharp_arch"
+    [[ "$sharp_arch" == "x64" ]] && expected_arch="x86_64"
+    sharp_native="$resources/agent/node_modules/@img/sharp-darwin-$sharp_arch/lib/sharp-darwin-$sharp_arch.node"
+    libvips_native="$resources/agent/node_modules/@img/sharp-libvips-darwin-$sharp_arch/lib/libvips-cpp.42.dylib"
+    [[ -f "$sharp_native" && -f "$libvips_native" ]] \
+      || fail "agent runtime missing Sharp/libvips darwin-$sharp_arch pair"
+    file "$sharp_native" | grep -q "$expected_arch" \
+      || fail "Sharp darwin-$sharp_arch binary has the wrong architecture"
+    file "$libvips_native" | grep -q "$expected_arch" \
+      || fail "libvips darwin-$sharp_arch binary has the wrong architecture"
+  done
   strings "$APP_BUNDLE/Contents/MacOS/$(plist_read CFBundleExecutable)" 2>/dev/null | grep -q "LocalAgentAPIServer" \
     || warn "could not find LocalAgentAPIServer marker in executable; release builds may strip Swift symbols"
 


### PR DESCRIPTION
## Summary

- restore canonical `Omi.app` casing while retaining `Omi.zip` and `omi.dmg`
- remove forbidden Finder metadata from the staged DMG app and require deep strict verification
- stage and verify both arm64 and x86_64 Sharp/libvips native runtime pairs
- add focused release contracts so all three `.93` regressions fail before publication

## Fast blocking verification

- `bash -n desktop/macos/scripts/prepare-agent-runtime.sh desktop/macos/scripts/smoke-signed-desktop-artifact.sh` — PASS
- focused pytest contracts — `2 passed`
- `git diff --check` — PASS

## Intentionally deferred for release speed

- full Swift/build suites
- real signed/notarized DMG production
- full `make preflight`

The next immutable Codemagic candidate is the authoritative end-to-end verification. Candidate `.93` remains failed/abandoned and must not be retagged or modified.

## Product invariants affected

- INV-AUTH-1
- INV-DATA-1

## Scope

Beta packaging only. No deployment, pointer mutation, Stable operation, or production app change.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

