### PR TITLE
fix(desktop): install cross-architecture Sharp payloads

### DIFF
--- a/backend/tests/unit/test_desktop_release_scripts.py
+++ b/backend/tests/unit/test_desktop_release_scripts.py
@@ -256,6 +256,7 @@ def test_universal_release_stages_and_smokes_both_sharp_architectures():
     smoke = (REPO_ROOT / "desktop/macos/scripts/smoke-signed-desktop-artifact.sh").read_text(encoding="utf-8")
     assert "stage_darwin_sharp_arches" in prepare
     assert "for package_arch in arm64 x64" in prepare
+    assert 'npm install --prefix "$overlay" --force' in prepare
     assert "@img/sharp-darwin-$package_arch@$sharp_version" in prepare
     assert "@img/sharp-libvips-darwin-$package_arch@$libvips_version" in prepare
     assert "for sharp_arch in arm64 x64" in prepare

--- a/desktop/macos/scripts/prepare-agent-runtime.sh
+++ b/desktop/macos/scripts/prepare-agent-runtime.sh
@@ -230,8 +230,7 @@ stage_darwin_sharp_arches() {
     }
 
     overlay="$(mktemp -d "$PACKAGED_RUNTIME_DIR/sharp-$package_arch.XXXXXX")"
-    npm_config_platform=darwin npm_config_arch="$package_arch" \
-      npm install --prefix "$overlay" --ignore-scripts --no-save --package-lock=false \
+    npm install --prefix "$overlay" --force --ignore-scripts --no-save --package-lock=false \
         --no-fund --no-audit \
         "@img/sharp-darwin-$package_arch@$sharp_version" \
         "@img/sharp-libvips-darwin-$package_arch@$libvips_version"


### PR DESCRIPTION
## Summary

- force-install the exact lock-pinned cross-architecture Sharp/libvips overlays on arm64 Codemagic builders
- retain fail-closed filesystem and Mach-O architecture validation for both arm64 and x86_64
- add a focused release contract for the forced overlay

## Root cause

Codemagic build `6a5ff4f9997989ee566da88a` failed in `Prepare agent runtime`: npm ignored the attempted architecture environment override and rejected `@img/sharp-darwin-x64` with `EBADPLATFORM`.

## Fast verification

- isolated arm64-host npm overlay with `--force`: PASS
- x86_64 Sharp Mach-O verification: PASS
- x86_64 libvips Mach-O verification: PASS
- focused pytest contract: `1 passed`
- shell syntax and `git diff --check`: PASS

## Deferred

The next Codemagic candidate is the authoritative full release build. No broad suite or local signed build was run.

## Product invariants affected

- INV-AUTH-1

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

