### PR TITLE
fix(ci): exempt internal desktop release controls

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -52,9 +52,9 @@ checks:
     reason: "real Firestore transaction serialization must fence stale qualified Beta admissions after reservation, pause, and generation transitions"
   - id: desktop-changelog-io-tests
     command: ["python3", ".github/scripts/test_desktop_changelog.py"]
-    triggers: [".github/scripts/desktop-changelog.py", ".github/scripts/test_desktop_changelog.py", ".github/checks-manifest.yaml"]
+    triggers: [".github/scripts/check-desktop-changelog.py", ".github/scripts/desktop-changelog.py", ".github/scripts/test_desktop_changelog.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "#9717: changelog JSON I/O must decode/encode as UTF-8 regardless of contributor host locale"
+    reason: "#9717: changelog tooling must preserve UTF-8 I/O and exempt only internal desktop release controls"
   - id: agents-md-lean
     command: ["python3", ".github/scripts/check_agents_md_lean.py"]
     triggers: ["AGENTS.md", ".github/scripts/check_agents_md_lean.py"]

--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -15,6 +15,8 @@ DESKTOP_PREFIX = "desktop/macos/"
 EXEMPT_DESKTOP_PATHS = {
     "desktop/macos/CHANGELOG.json",
     "desktop/macos/AGENTS.md",
+    "desktop/macos/docs/release.md",
+    "desktop/macos/scripts/qualify-desktop-beta.sh",
 }
 # Server-side Rust backend changes are internal reliability work, not user-facing app notes.
 EXEMPT_DESKTOP_PATH_PREFIXES = (

--- a/.github/scripts/test_desktop_changelog.py
+++ b/.github/scripts/test_desktop_changelog.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unit tests for desktop-changelog.py I/O encoding (stdlib unittest).
+"""Unit tests for desktop changelog tooling (stdlib unittest).
 
 Regression coverage for #9717: read_json/write_json must always use UTF-8 so a
 contributor on a non-UTF-8 host locale (e.g. GBK on native Windows Python) does
@@ -21,6 +21,12 @@ _SPEC = importlib.util.spec_from_file_location(
 )
 changelog = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(changelog)
+
+_CHECK_SPEC = importlib.util.spec_from_file_location(
+    "check_desktop_changelog", Path(__file__).with_name("check-desktop-changelog.py")
+)
+checker = importlib.util.module_from_spec(_CHECK_SPEC)
+_CHECK_SPEC.loader.exec_module(checker)
 
 
 class EncodingTests(unittest.TestCase):
@@ -59,6 +65,22 @@ class EncodingTests(unittest.TestCase):
             payload = {"note": "“curly” — café"}
             changelog.write_json(path, payload)
             self.assertEqual(changelog.read_json(path), payload)
+
+
+class ChangelogRequirementTests(unittest.TestCase):
+    def test_internal_release_controls_are_exempt_but_product_source_is_not(self) -> None:
+        for path in (
+            "desktop/macos/docs/release.md",
+            "desktop/macos/scripts/qualify-desktop-beta.sh",
+        ):
+            with self.subTest(path=path):
+                self.assertFalse(checker.is_desktop_change_requiring_changelog(path))
+
+        self.assertTrue(
+            checker.is_desktop_change_requiring_changelog(
+                "desktop/macos/Desktop/Sources/AppDelegate.swift"
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed and why

Exempt only `desktop/macos/docs/release.md` and `desktop/macos/scripts/qualify-desktop-beta.sh` from the desktop changelog gate. These are internal release-control paths, so they should not block post-merge Release Eligibility with a user-facing desktop changelog requirement. The focused test keeps a normal desktop product-source path gated, and the manifest now selects that test when the checker changes.

Failed mainline run: https://github.com/BasedHardware/omi/actions/runs/29874708482

Current `origin/main` base: `59d81ee28a398cb7a6febca3c44255504e3a3933`.

## Product invariants affected

none

## How it was verified

- RED: `python3 .github/scripts/test_desktop_changelog.py` failed for both exact internal paths before the exemption.
- GREEN: `python3 .github/scripts/test_desktop_changelog.py` passed all 4 tests after the exemption; it verifies both exact paths are exempt while `desktop/macos/Desktop/Sources/AppDelegate.swift` still requires a changelog.
- `python3 .github/scripts/test_run_checks.py` passed.
- `OMI_PR_BODY_FILE=.pr-body.md make preflight` passed the selected deterministic checks.
- `git diff --check origin/main...HEAD` passed.
- `scripts/pr-preflight --suggest` selected the Release Eligibility-equivalent manifest checks for this diff.

No deploy, workflow dispatch, production/cloud/Firestore write, or release-pointer mutation occurred.

## Tests

`ChangelogRequirementTests.test_internal_release_controls_are_exempt_but_product_source_is_not` is the regression coverage.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

