### PR TITLE
fix(desktop): repair Tier-2 qualification contracts

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/AuthService.swift": 3294,
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
-    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4239,
+    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4238,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1578,
     "desktop/macos/Desktop/Sources/OmiApp.swift": 1638
   },

--- a/desktop/macos/Desktop/Sources/AppleNotesReaderService.swift
+++ b/desktop/macos/Desktop/Sources/AppleNotesReaderService.swift
@@ -89,6 +89,23 @@ enum AppleNotesReadOutcome: Equatable {
   }
 }
 
+enum AppleNotesReadProbe {
+  nonisolated static func resolveRequestedFolder(
+    path: String?,
+    fileManager: FileManager = .default,
+    homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+  ) throws -> URL? {
+    guard let path = path?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
+      return nil
+    }
+    return try AppleNotesReaderService.resolveSelectedFolder(
+      URL(fileURLWithPath: path),
+      fileManager: fileManager,
+      homeDirectory: homeDirectory
+    )
+  }
+}
+
 actor AppleNotesReaderService {
   static let shared = AppleNotesReaderService()
   private static let classifierNoise = [

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -2030,14 +2030,13 @@ final class DesktopAutomationActionRegistry {
       params: ["folderPath", "maxResults", "remember"]
     ) { params in
       let maxResults = min(max(intParam(params["maxResults"], default: 20), 1), 250)
-      let folderPath = params["folderPath"]?.trimmingCharacters(in: .whitespacesAndNewlines)
       let remember = boolParam(params["remember"], default: false)
 
       do {
         let selectedFolderPath: String?
-        if let folderPath, !folderPath.isEmpty {
+        if let requestedFolder = try AppleNotesReadProbe.resolveRequestedFolder(path: params["folderPath"]) {
           let resolved = try await AppleNotesReaderService.shared.validateSelectedFolder(
-            path: folderPath,
+            path: requestedFolder.path,
             remember: remember
           )
           selectedFolderPath = resolved.path

--- a/desktop/macos/Desktop/Tests/AppleNotesReaderServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/AppleNotesReaderServiceTests.swift
@@ -101,6 +101,25 @@ final class AppleNotesReaderServiceTests: XCTestCase {
     }
   }
 
+  func testReadProbeRejectsInvalidFolderBeforeEnteringReaderActor() throws {
+    let root = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let invalidPath = root.appendingPathComponent("not-apple-notes", isDirectory: true).path
+
+    XCTAssertThrowsError(
+      try AppleNotesReadProbe.resolveRequestedFolder(
+        path: invalidPath,
+        homeDirectory: root
+      )
+    ) { error in
+      guard case .invalidSelectedFolder(let path) = error as? AppleNotesReaderError else {
+        return XCTFail("Expected invalidSelectedFolder, got \(error)")
+      }
+      XCTAssertEqual(path, invalidPath)
+    }
+  }
+
   func testReadRecentNotesFromSelectedFolderFixture() async throws {
     let root = try makeTemporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }

--- a/desktop/macos/Desktop/Tests/FeedbackPayloadDryRunTests.swift
+++ b/desktop/macos/Desktop/Tests/FeedbackPayloadDryRunTests.swift
@@ -90,6 +90,18 @@ import XCTest
       XCTAssertEqual(feedbackReportTitle(for: "mic dropped"), "User Report")
     }
 
+    func testTier2FlowExpectsPrivacySafeReportTitle() throws {
+      // omi-test-quality: source-inspection -- static contract: the checked-in Tier-2
+      // expectation must match the privacy-safe product title used by the shared builder.
+      let flow = try String(contentsOf: feedbackPayloadFlowURL(), encoding: .utf8)
+      let expectedTitle = feedbackReportTitle(for: "[[MARKER:set02-dryrun]]")
+      XCTAssertTrue(
+        flow.contains("result.detail.sentry_message: \"\(expectedTitle)\""),
+        "Tier-2 must expect the shared privacy-safe Sentry title")
+      XCTAssertFalse(flow.contains("User Report: [[MARKER:set02-dryrun]]"))
+      XCTAssertFalse(flow.contains("User Report (logs only)"))
+    }
+
     func testDiagnosticsPayloadIsParseableAndCarriesPrivacyMarker() throws {
       DesktopDiagnosticsManager.shared.resetForTests()
       defer { DesktopDiagnosticsManager.shared.resetForTests() }
@@ -116,6 +128,14 @@ import XCTest
     }
 
     // MARK: - Helpers
+
+    private func feedbackPayloadFlowURL() -> URL {
+      URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("e2e/flows/feedback-payload-dryrun.yaml")
+    }
 
     private func dryRunActionBlock() throws -> String {
       let source = try bridgeSource()

--- a/desktop/macos/e2e/flows/feedback-payload-dryrun.yaml
+++ b/desktop/macos/e2e/flows/feedback-payload-dryrun.yaml
@@ -11,23 +11,23 @@ preconditions:
 
 steps:
   - id: S1
-    name: Dry-run builds the report title from a message, no Sentry capture
+    name: Dry-run uses the privacy-safe report title, no Sentry capture
     bridge.action:
       name: dump_feedback_payload_dryrun
       params:
         message: "[[MARKER:set02-dryrun]]"
     expect:
-      result.detail.sentry_message: "User Report: [[MARKER:set02-dryrun]]"
+      result.detail.sentry_message: "User Report"
       result.detail.sentry_capture_invoked: "false"
       result.detail.would_submit_to_sentry: "false"
       result.detail.diagnostics_filename: "desktop_diagnostics.json"
 
   - id: S2
-    name: Empty message yields the logs-only title
+    name: Empty message uses the same privacy-safe report title
     bridge.action:
       name: dump_feedback_payload_dryrun
     expect:
-      result.detail.sentry_message: "User Report (logs only)"
+      result.detail.sentry_message: "User Report"
       result.detail.sentry_capture_invoked: "false"
 
   - id: S3


### PR DESCRIPTION
## Summary

- reject immutable invalid Apple Notes probe input before entering the shared reader actor
- align feedback dry-run qualification expectations with the privacy-safe fixed `User Report` title
- add focused regression coverage for both qualification contracts

## Root causes

- Apple Notes Tier-2 could spend its full 20-second bridge timeout waiting on unrelated shared-actor work before rejecting a known-invalid folder.
- Feedback Tier-2 retained pre-privacy title expectations after product hardening intentionally fixed all Sentry report titles to `User Report`.

## Focused verification

- AppleNotesReaderServiceTests: 1 passed
- exact apple-notes-read probe: PASS in 36.52 ms; S1 in 1.86 ms
- FeedbackPayloadDryRunTests: 8 passed
- desktop-flow-lint: 57 flows and 134 actions validated

No broad suite or release build was run. Codemagic `.95` continues independently for artifact pre-qualification.

## Product invariants affected

- INV-AUTH-1
- INV-DATA-1
- INV-INT-1

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


