### PR TITLE
fix(desktop): preserve strict codesign in DMG

### DIFF
--- a/backend/tests/unit/test_desktop_release_scripts.py
+++ b/backend/tests/unit/test_desktop_release_scripts.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 from pathlib import Path
+import runpy
 import tempfile
 
 import pytest
@@ -12,6 +13,7 @@ PROMOTE_BETA_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "desktop_promote_b
 PROMOTE_PROD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "desktop_promote_prod.yml"
 QUALIFY_BETA_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "desktop_qualify_beta.yml"
 CODEMAGIC_CONFIG = REPO_ROOT / "codemagic.yaml"
+DMGBUILD_SETTINGS = REPO_ROOT / "desktop" / "macos" / "dmg-assets" / "dmgbuild_settings.py"
 QUALIFICATION_ADMISSION = SCRIPTS / "desktop_qualification_admission.py"
 
 
@@ -250,6 +252,15 @@ def test_codemagic_produces_canonical_app_and_strictly_verifiable_dmg():
     assert 'codesign --verify --deep --strict --verbose=2 "$STAGING_DIR/$APP_NAME.app"' in workflow
     assert 'dmg_app="$DMG_MOUNTPOINT/Omi.app"' in smoke
     assert "DMG-contained Omi.app failed deep strict codesign verification" in smoke
+
+
+def test_dmgbuild_does_not_attach_finder_info_to_the_signed_app():
+    settings = runpy.run_path(
+        str(DMGBUILD_SETTINGS),
+        init_globals={"defines": {"app_name": "Omi", "app_path": "/tmp/Omi.app"}},
+    )
+
+    assert settings.get("hide_extensions", []) == []
 
 
 def test_universal_release_stages_and_smokes_both_sharp_architectures():

--- a/desktop/macos/dmg-assets/dmgbuild_settings.py
+++ b/desktop/macos/dmg-assets/dmgbuild_settings.py
@@ -43,8 +43,9 @@ icon_locations = {
     "Applications": (455, 175),
 }
 
-# Hide extension for the app
-hide_extensions = [app_name + ".app"]
+# Hiding the extension attaches com.apple.FinderInfo to the signed app bundle,
+# which makes codesign --deep --strict reject the app copied into the DMG.
+hide_extensions = []
 
 # Volume icon
 if icon_path:


### PR DESCRIPTION
## Summary

- stop `dmgbuild` from hiding the `.app` extension, which attaches `com.apple.FinderInfo` after staging verification
- preserve the signed app unchanged inside the generated DMG
- add a focused regression contract for the production DMG settings

## Root cause

`hide_extensions = [app_name + ".app"]` makes `dmgbuild` run `SetFile -a E` on the mounted-image app. That adds a 32-byte `com.apple.FinderInfo` xattr, causing:

```text
resource fork, Finder information, or similar detritus not allowed
file with invalid attached data: Disallowed xattr com.apple.FinderInfo found on …/Omi.app
```

## Verification

- focused release-script tests: `28 passed`
- signed-artifact smoke script tests: passed
- real dmgbuild regression fixture:
  - old settings: FinderInfo present; strict codesign failed
  - fixed settings: FinderInfo absent; `codesign --verify --deep --strict` passed
- exact `.95` ZIP app passed strict codesign; exact `.95` DMG app reproduced the forbidden FinderInfo failure
- `git diff --check`: passed

## Product invariants affected

none

## Failure class

Failure-Class: none

## Release impact

Required before creating the next immutable macOS Beta candidate. No Stable action.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

