### PR TITLE
chore(devex): provision pre-push environment in setup

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -9,6 +9,11 @@ checks:
     triggers: ["scripts/pre-push", "scripts/pre-push-diff-base", "scripts/test-pre-push-diff-base.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "pre-push check selection must use the final PR diff rather than a stale remote feature tip"
+  - id: setup-pre-push-prerequisites
+    command: ["bash", "scripts/test-make-setup.sh"]
+    triggers: ["Makefile", "backend/scripts/sync-python-deps.sh", "scripts/pre-push", "scripts/test-make-setup.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "make setup must provision the minimal, rerunnable backend environment required by selected pre-push checks"
   - id: check-manifest-contract
     command: ["python3", ".github/scripts/test_run_checks.py"]
     triggers: ["all"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ The unit of work is the violated contract, not only the line where the symptom a
 
 ## Git
 
-- **Setup (required before first commit):** `make setup` — fetches `origin/main`, fast-forwards when safe, installs repo Git hooks (including the auto-formatting pre-commit hook) with linked-worktree-safe paths.
+- **Setup (required before first commit):** `make setup` — fetches `origin/main`, fast-forwards when safe, installs linked-worktree-safe Git hooks (including auto-formatting pre-commit), and syncs the pinned `backend/.venv` required by selected backend pre-push checks. It does not install app or desktop runtime environments.
 - Before starting work: `git fetch origin && git pull --ff-only` on `main` — don't branch off stale state.
 - Always work in a git worktree for code changes (`git worktree add`); commit to the current branch and never switch branches mid-task.
 - Make individual commits per feature or testable surface, not per file or unrelated bulk changes.

--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,21 @@ export PYTHON
 DESKTOP_USER ?= alice
 DESKTOP_APP_NAME ?=
 
-.PHONY: setup setup-main setup-hooks preflight runtime-image-source-closure runtime-image-smoke dev-check dev-up dev-status dev-summary dev-reset dev-down dev-logs dev dev-desktop dev-init dev-verify list-memory-scenarios seed-memory-scenario reset-memory-scenario desktop-run-local run-canonical-promotion
+.PHONY: setup setup-main setup-hooks setup-backend preflight runtime-image-source-closure runtime-image-smoke dev-check dev-up dev-status dev-summary dev-reset dev-down dev-logs dev dev-desktop dev-init dev-verify list-memory-scenarios seed-memory-scenario reset-memory-scenario desktop-run-local run-canonical-promotion
 
-setup: setup-main setup-hooks
-	@echo "Worktree setup complete."
+# Baseline setup is deliberately limited to prerequisites that the default
+# pre-push gate may require; app and desktop runtime environments stay opt-in.
+setup: setup-main setup-hooks setup-backend
+	@echo "Worktree setup complete: hooks installed and backend pre-push environment ready."
 
 setup-main:
 	@bash scripts/setup-refresh-main.sh
 
 setup-hooks:
 	@bash scripts/install-git-hooks.sh
+
+setup-backend:
+	@bash backend/scripts/sync-python-deps.sh
 
 preflight:
 	python3 .github/scripts/pr_preflight.py --lane local --base origin/main

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Starts the Windows desktop app from source using the public config in `.env.exam
 
 > **Requirements:** [Node.js](https://nodejs.org/)
 
-For development worktrees, run the cheap local setup once:
+For development worktrees, run the baseline local setup once. It installs the Git hooks and syncs the pinned backend Python environment used by selected pre-push checks; mobile and desktop runtime environments remain opt-in.
 
 ```bash
 make setup

--- a/backend/scripts/sync-python-deps.sh
+++ b/backend/scripts/sync-python-deps.sh
@@ -34,7 +34,7 @@ if ! command -v uv >/dev/null 2>&1; then
 fi
 
 uv python install "$PYTHON_VERSION"
-uv venv --python "$PYTHON_VERSION" "$VENV_PATH"
+uv venv --allow-existing --python "$PYTHON_VERSION" "$VENV_PATH"
 uv pip sync "$LOCK_FILE" --python "$PYTHON_BIN"
 
 echo "Backend dependencies synced from $LOCK_FILE into $ROOT_DIR/$VENV_PATH"

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -87,7 +87,7 @@ require_backend_python() {
     return 0
   fi
   echo "FAIL: a selected backend check requires backend/.venv/bin/python, but it was not found." >&2
-  echo "      Create it with: cd backend && bash scripts/sync-python-deps.sh" >&2
+  echo "      Create it with: make setup" >&2
   return 1
 }
 

--- a/scripts/test-make-setup.sh
+++ b/scripts/test-make-setup.sh
@@ -52,7 +52,13 @@ echo "make setup baseline prerequisites test passed."
 mkdir -p "$TMPDIR/sync/backend/scripts" "$TMPDIR/sync/bin"
 cp "$ROOT/backend/scripts/sync-python-deps.sh" "$TMPDIR/sync/backend/scripts/sync-python-deps.sh"
 printf '3.11\n' >"$TMPDIR/sync/backend/.python-version"
-touch "$TMPDIR/sync/backend/pylock.macos.toml"
+# The sync script selects a different checked-in lock by host platform.
+# Keep this fixture runnable in macOS, Linux, Windows, and Intel-macOS CI.
+touch \
+  "$TMPDIR/sync/backend/pylock.toml" \
+  "$TMPDIR/sync/backend/pylock.macos.toml" \
+  "$TMPDIR/sync/backend/pylock.macos-x86_64.toml" \
+  "$TMPDIR/sync/backend/pylock.windows.toml"
 cat >"$TMPDIR/sync/bin/uv" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail

--- a/scripts/test-make-setup.sh
+++ b/scripts/test-make-setup.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/omi-make-setup.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/repo/scripts/dev-harness" "$TMPDIR/repo/backend/scripts"
+git init --initial-branch=main "$TMPDIR/repo" >/dev/null
+cp "$ROOT/Makefile" "$TMPDIR/repo/Makefile"
+
+cat >"$TMPDIR/repo/scripts/dev-harness/_resolve_python.sh" <<'EOF'
+dev_harness_python() {
+  printf '%s\n' python3
+}
+EOF
+
+for script in setup-refresh-main.sh install-git-hooks.sh; do
+  cat >"$TMPDIR/repo/scripts/$script" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$(basename "$0")" >> setup-order.txt
+EOF
+  chmod +x "$TMPDIR/repo/scripts/$script"
+done
+
+cat >"$TMPDIR/repo/backend/scripts/sync-python-deps.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "backend-sync" >> setup-order.txt
+EOF
+chmod +x "$TMPDIR/repo/backend/scripts/sync-python-deps.sh"
+
+(
+  cd "$TMPDIR/repo"
+  make setup >/dev/null
+)
+
+expected=$'setup-refresh-main.sh\ninstall-git-hooks.sh\nbackend-sync'
+actual="$(cat "$TMPDIR/repo/setup-order.txt")"
+if [ "$actual" != "$expected" ]; then
+  echo "FAIL: make setup did not provision baseline pre-push prerequisites in order." >&2
+  printf 'Expected:\n%s\nActual:\n%s\n' "$expected" "$actual" >&2
+  exit 1
+fi
+
+echo "make setup baseline prerequisites test passed."
+
+# The baseline target is intentionally safe to rerun: an agent should not have
+# to delete a healthy venv just to repeat setup after a branch change.
+mkdir -p "$TMPDIR/sync/backend/scripts" "$TMPDIR/sync/bin"
+cp "$ROOT/backend/scripts/sync-python-deps.sh" "$TMPDIR/sync/backend/scripts/sync-python-deps.sh"
+printf '3.11\n' >"$TMPDIR/sync/backend/.python-version"
+touch "$TMPDIR/sync/backend/pylock.macos.toml"
+cat >"$TMPDIR/sync/bin/uv" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "python" ]; then
+  exit 0
+fi
+if [ "$1" = "venv" ]; then
+  target="${!#}"
+  if [ -e "$target" ] && [[ " $* " != *" --allow-existing "* ]]; then
+    echo "refusing to replace existing venv" >&2
+    exit 42
+  fi
+  mkdir -p "$target/bin"
+  exit 0
+fi
+if [ "$1" = "pip" ] && [ "$2" = "sync" ]; then
+  exit 0
+fi
+echo "unexpected uv invocation: $*" >&2
+exit 1
+EOF
+chmod +x "$TMPDIR/sync/bin/uv"
+(
+  cd "$TMPDIR/sync/backend"
+  PATH="$TMPDIR/sync/bin:$PATH" bash scripts/sync-python-deps.sh >/dev/null
+  PATH="$TMPDIR/sync/bin:$PATH" bash scripts/sync-python-deps.sh >/dev/null
+)
+
+echo "backend dependency sync rerun test passed."


### PR DESCRIPTION
## Summary

- make `make setup` provision the pinned `backend/.venv` used by selected backend pre-push checks
- retain app and desktop runtime setup as opt-in, and expose `make setup-backend` for focused recovery
- make the hook remediation point to the documented setup command and protect the wiring with a hermetic Makefile test

## Root cause and durable guard

`make setup` claimed to prepare a worktree for its first push but installed only hook dispatchers. A later backend-selected pre-push check could fail solely because its required `backend/.venv/bin/python` had never been created. The setup target now creates that baseline environment, and `scripts/test-make-setup.sh` verifies both the full setup wiring and repeatable backend dependency sync in isolated repositories.

## Verification

- `bash scripts/test-make-setup.sh`
- ad-hoc temporary verifier: setup wiring, repeatable `make setup-backend`, locked Python environment, and whitespace check
- `bash scripts/test-setup-refresh-main.sh`
- `bash scripts/test-pre-push-diff-base.sh`
- `make preflight`
- pre-push-equivalent check passed with `PRE_PUSH_SKIP_DESKTOP_SWIFT=1`; the unskipped prior run reached the desktop Swift dependency build but exceeded the 10-minute local limit while SwiftPM downloaded binary artifacts. This DevEx-only change does not modify desktop code; CI will run the normal branch checks.

## Scope

Baseline setup only: Git hooks plus the locked backend Python environment. It deliberately does not install Flutter/mobile or desktop runtime dependencies.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

