### PR TITLE
fix(backend): include surface flag in OpenAPI stale-contract hint (#10217)

### DIFF
--- a/backend/scripts/export_openapi.py
+++ b/backend/scripts/export_openapi.py
@@ -985,12 +985,26 @@ def write_spec(path: Path, generated: str) -> None:
     path.write_text(generated)
 
 
-def check_spec(path: Path, generated: str) -> None:
+def surface_flag(surface: str) -> str:
+    """Return the CLI flag that selects `surface`, so error hints regenerate the right contract.
+
+    Surface selection is a separate flag from `--write`/`--check`; omitting it silently defaults to
+    the public surface and would overwrite a non-public spec with the wrong contract (#10217).
+    """
+    if surface == 'app-client':
+        return '--app-client '
+    if surface == 'integration-public':
+        return '--surface integration-public '
+    return ''
+
+
+def check_spec(path: Path, generated: str, surface: str = 'public') -> None:
+    flag = surface_flag(surface)
     if not path.exists():
-        raise OpenAPIContractError(f'{path} does not exist; run export_openapi.py --write {path}')
+        raise OpenAPIContractError(f'{path} does not exist; run backend/scripts/export_openapi.py {flag}--write {path}')
     current = path.read_text()
     if current != generated:
-        raise OpenAPIContractError(f'{path} is stale; run backend/scripts/export_openapi.py --write {path}')
+        raise OpenAPIContractError(f'{path} is stale; run backend/scripts/export_openapi.py {flag}--write {path}')
 
 
 def parse_args() -> argparse.Namespace:
@@ -1043,7 +1057,7 @@ def main() -> int:
             print(f'wrote {path}')
         elif args.check is not None:
             path = resolve_spec_path(args.surface, args.check)
-            check_spec(path, generated)
+            check_spec(path, generated, args.surface)
             print(f'{path} is up to date')
         return 0
     except OpenAPIContractError as e:

--- a/backend/tests/unit/test_openapi_contract.py
+++ b/backend/tests/unit/test_openapi_contract.py
@@ -162,6 +162,28 @@ def test_check_spec_detects_stale_file(tmp_path):
         export_openapi.check_spec(spec_path, json.dumps({'fresh': True}) + '\n')
 
 
+def test_check_spec_hint_includes_surface_flag(tmp_path):
+    # Regression for #10217: following the stale/missing hint verbatim must regenerate the same
+    # surface, not silently overwrite a non-public spec with the default public contract.
+    spec_path = tmp_path / 'openapi.json'
+    spec_path.write_text(json.dumps({'stale': True}) + '\n')
+    fresh = json.dumps({'fresh': True}) + '\n'
+
+    with pytest.raises(export_openapi.OpenAPIContractError, match=r'--app-client --write'):
+        export_openapi.check_spec(spec_path, fresh, 'app-client')
+
+    with pytest.raises(export_openapi.OpenAPIContractError, match=r'--surface integration-public --write'):
+        export_openapi.check_spec(spec_path, fresh, 'integration-public')
+
+    missing = tmp_path / 'absent.json'
+    with pytest.raises(export_openapi.OpenAPIContractError, match=r'--app-client --write'):
+        export_openapi.check_spec(missing, fresh, 'app-client')
+
+    # Public surface needs no flag — the default command stays correct.
+    with pytest.raises(export_openapi.OpenAPIContractError, match=r'export_openapi\.py --write'):
+        export_openapi.check_spec(spec_path, fresh)
+
+
 def test_network_recorder_fails_even_when_blocked_attempt_is_swallowed():
     with export_openapi.record_and_block_outbound_network() as attempts:
         try:


### PR DESCRIPTION
Closes #10217

## Bug
`backend/scripts/export_openapi.py`'s contract check prints a fix-it hint on a stale or missing spec:

```
... is stale; run backend/scripts/export_openapi.py --write <path>
```

The surface (`public` / `app-client` / `integration-public`) is selected by a **separate flag** that defaults to `public` and is **not** inferred from the output path. So following the hint verbatim for the app-client or integration-public spec regenerates the *public* surface and overwrites the wrong contract — the reporter saw a 17-path public spec written over the 309-path app-client spec (~53k lines deleted) — and a subsequent `--check` (also missing the flag) then validated the wrong surface as "up to date".

## Fix
`check_spec` now receives the surface and prepends the selecting flag to both the stale and does-not-exist hints via a small `surface_flag()` helper:
- `app-client` → `--app-client --write <path>`
- `integration-public` → `--surface integration-public --write <path>`
- `public` → unchanged (`--write <path>`)

The `main()` `--check` call passes `args.surface` through. No behavior change for the public surface; existing callers/test remain valid.

## Verification
Exercised the real `check_spec`/`surface_flag` functions from source over a temp spec for all three surfaces plus the missing-file path — each hint now names the flag that actually regenerates that surface. Added `test_check_spec_hint_includes_surface_flag` as the regression test (extends `tests/unit/test_openapi_contract.py`). Backend Python env is not installable in the watchdog sandbox, so the full pytest suite runs in CI.

🤖 automated by hourly watchdog; opened for review, not merged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

