### PR TITLE
feat(desktop): add OpenAI Codex as a local agent runtime via the codex-acp bridge

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2209,
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4314
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4337
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": "per-turn reasoningEffort threaded through both query variants",
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "reasoningEffort added to the query wire message"
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "Codex adapter-command seeding (OMI_CODEX_ADAPTER_COMMAND) and codexAdapterCommand helper"
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -1,13 +1,13 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2375,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2383,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2853,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4842,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2423,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1621
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": "Agent completion presentation now follows the canonical terminal lifecycle used by PTT and chat.",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": "Codex case added to the DirectedProvider enum (display name, harness mode, executable, command env).",
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": "Onboarding bar glow, the reach-error card (Retry/Skip), and the notch hover/voice surface-state boundary render on the shared bar surface.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": "Reach-error state lives with the owning manager; savePreChatCenterIfNeeded snaps to the full stored restore frame so the pill no longer drifts per re-open cycle.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior.",

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
@@ -1,10 +1,10 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6214,
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6215,
     "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2861
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": "ChatTurnOwner reasoning-effort lane derivation",
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": "Codex added to the BridgeMode enum",
     "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": "Already-granted permissions no longer reopen System Settings: screen-recording and full-disk-access requests gate their Settings/drag-card opens behind the granted result."
   },
   "threshold": 1500

--- a/desktop/macos/Desktop/Sources/Chat/AgentFailureTranscriptFormatter.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentFailureTranscriptFormatter.swift
@@ -44,6 +44,7 @@ enum AgentFailureTranscriptFormatter {
         switch harnessMode {
         case .openclaw: return AgentPillsManager.DirectedProvider.openclaw.setupNeededStatus
         case .hermes: return AgentPillsManager.DirectedProvider.hermes.setupNeededStatus
+        case .codex: return AgentPillsManager.DirectedProvider.codex.setupNeededStatus
         default: break
         }
       }

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -653,7 +653,7 @@ actor AgentRuntimeProcess {
   /// The Node registry is the authority for adapter activation. Swift must not
   /// re-run local executable detection before advertising a realtime provider.
   func registeredDirectedProviderIDs() -> [String] {
-    runtimeAdapterIDs.intersection(["hermes", "openclaw"]).sorted()
+    runtimeAdapterIDs.intersection(["hermes", "openclaw", "codex"]).sorted()
   }
 
   static func adapterId(forHarnessMode harnessMode: String) -> String? {
@@ -2785,6 +2785,16 @@ actor AgentRuntimeProcess {
     {
       env["OMI_OPENCLAW_ADAPTER_COMMAND"] = Self.openClawAdapterCommand(openClawPath: openClaw)
     }
+
+    if env["OMI_CODEX_ADAPTER_COMMAND"]?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true,
+      case .available(command: let codex) = LocalAgentProviderDetector.availability(
+        for: .codex,
+        environment: env,
+        homeDirectory: home
+      ).status
+    {
+      env["OMI_CODEX_ADAPTER_COMMAND"] = Self.codexAdapterCommand(codexAdapterPath: codex)
+    }
   }
 
   static func byokEnvironmentKey(for provider: BYOKProvider) -> String {
@@ -2827,6 +2837,19 @@ actor AgentRuntimeProcess {
       return "\(shellQuote(nodePath)) \(shellQuote(openClawPath)) acp"
     }
     return "\(shellQuote(openClawPath)) acp"
+  }
+
+  /// The `codex-acp` bridge speaks ACP over stdio directly, so — unlike the
+  /// `<cli> acp` adapters — it takes no subcommand. A directly launched app
+  /// bundle may not have `node` on PATH for the bin's shebang, so prefer a
+  /// `node` sitting next to the adapter when present (mirrors OpenClaw).
+  static func codexAdapterCommand(codexAdapterPath: String, fileManager: FileManager = .default) -> String {
+    let nodePath =
+      ((codexAdapterPath as NSString).deletingLastPathComponent as NSString).appendingPathComponent("node")
+    if fileManager.isExecutableFile(atPath: nodePath) {
+      return "\(shellQuote(nodePath)) \(shellQuote(codexAdapterPath))"
+    }
+    return shellQuote(codexAdapterPath)
   }
 
   /// Directly launched app bundles do not inherit the shell's FNM multishell

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -401,11 +401,13 @@ final class AgentPillsManager: ObservableObject {
   enum DirectedProvider: String, Equatable {
     case hermes
     case openclaw
+    case codex
 
     var displayName: String {
       switch self {
       case .hermes: return "Hermes"
       case .openclaw: return "OpenClaw"
+      case .codex: return "Codex"
       }
     }
 
@@ -413,6 +415,7 @@ final class AgentPillsManager: ObservableObject {
       switch self {
       case .hermes: return .hermes
       case .openclaw: return .openclaw
+      case .codex: return .codex
       }
     }
 
@@ -420,6 +423,10 @@ final class AgentPillsManager: ObservableObject {
       switch self {
       case .hermes: return "hermes"
       case .openclaw: return "openclaw"
+      // Codex reaches Omi's ACP bridge through the `codex-acp` adapter
+      // (`@zed-industries/codex-acp`); that binary is what proves the Codex
+      // runtime is installed, since the OpenAI `codex` CLI has no native ACP.
+      case .codex: return "codex-acp"
       }
     }
 
@@ -427,6 +434,7 @@ final class AgentPillsManager: ObservableObject {
       switch self {
       case .hermes: return "OMI_HERMES_ADAPTER_COMMAND"
       case .openclaw: return "OMI_OPENCLAW_ADAPTER_COMMAND"
+      case .codex: return "OMI_CODEX_ADAPTER_COMMAND"
       }
     }
 

--- a/desktop/macos/Desktop/Sources/Providers/AIProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/AIProvider.swift
@@ -61,7 +61,17 @@ struct AIProvider: Identifiable {
     bridgeModeRawValue: "openclaw"
   )
 
-  static let all: [AIProvider] = [.piMono, .claude, .hermes, .openClaw]
+  static let codex = AIProvider(
+    id: "codex",
+    displayName: "Codex",
+    tagline: "Local OpenAI Codex via the codex-acp bridge",
+    attributionURL: URL(string: "https://github.com/openai/codex"),
+    sfSymbol: "",
+    logoResource: nil,
+    bridgeModeRawValue: "codex"
+  )
+
+  static let all: [AIProvider] = [.piMono, .claude, .hermes, .openClaw, .codex]
 
   /// Look up a provider by its `chatBridgeMode` raw value.
   static func from(bridgeMode: String) -> AIProvider? {

--- a/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
+++ b/desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
@@ -5,6 +5,7 @@ enum AgentHarnessMode: String {
   case acp = "acp"
   case hermes = "hermes"
   case openclaw = "openclaw"
+  case codex = "codex"
 }
 
 extension Optional where Wrapped == AgentHarnessMode {
@@ -19,6 +20,7 @@ enum AgentAdapterId: String {
   case acp = "acp"
   case hermes = "hermes"
   case openclaw = "openclaw"
+  case codex = "codex"
 }
 
 enum AgentRuntimeRouting {
@@ -32,6 +34,8 @@ enum AgentRuntimeRouting {
       return .hermes
     case .openClaw:
       return .openclaw
+    case .codex:
+      return .codex
     }
   }
 
@@ -45,6 +49,8 @@ enum AgentRuntimeRouting {
       return .hermes
     case AgentHarnessMode.openclaw.rawValue, "openClaw":
       return .openclaw
+    case AgentHarnessMode.codex.rawValue:
+      return .codex
     default:
       return nil
     }
@@ -60,6 +66,8 @@ enum AgentRuntimeRouting {
       return .hermes
     case .openclaw:
       return .openclaw
+    case .codex:
+      return .codex
     }
   }
 }
@@ -84,6 +92,9 @@ struct LocalAgentProviderAvailability: Equatable {
       return "I don't see Hermes installed. Make sure Hermes is installed first, then try again."
     case .openclaw:
       return "I don't see OpenClaw installed. Make sure OpenClaw is installed first, then try again."
+    case .codex:
+      return
+        "I don't see the Codex ACP adapter installed. Install `@zed-industries/codex-acp` (the `codex-acp` binary) first, then try again."
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1232,6 +1232,7 @@ class ChatProvider: ObservableObject {
     case piMono = "piMono"
     case hermes = "hermes"
     case openClaw = "openclaw"
+    case codex = "codex"
   }
   @AppStorage("chatBridgeMode") var bridgeMode: String = BridgeMode.piMono.rawValue
 

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -1055,6 +1055,41 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertEqual(command, "'\(openClawPath)' acp")
   }
 
+  func testCodexAdapterCommandUsesSiblingNodeWithoutAcpSubcommand() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("codex-command-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let nodePath = tempDir.appendingPathComponent("node").path
+    let codexPath = tempDir.appendingPathComponent("codex-acp").path
+    FileManager.default.createFile(atPath: nodePath, contents: Data("#!/bin/sh\n".utf8))
+    FileManager.default.createFile(atPath: codexPath, contents: Data("#!/usr/bin/env node\n".utf8))
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: nodePath)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: codexPath)
+
+    // The codex-acp bridge speaks ACP directly, so — unlike `<cli> acp` adapters
+    // — the command must NOT append an `acp` subcommand.
+    let command = AgentRuntimeProcess.codexAdapterCommand(codexAdapterPath: codexPath)
+
+    XCTAssertEqual(command, "'\(nodePath)' '\(codexPath)'")
+  }
+
+  func testCodexAdapterCommandFallsBackToBridgeBinaryWithoutSiblingNode() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("codex-command-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let codexPath = tempDir.appendingPathComponent("codex-acp").path
+    FileManager.default.createFile(atPath: codexPath, contents: Data("#!/usr/bin/env node\n".utf8))
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: codexPath)
+
+    let command = AgentRuntimeProcess.codexAdapterCommand(codexAdapterPath: codexPath)
+
+    XCTAssertEqual(command, "'\(codexPath)'")
+  }
+
   func testOpenClawDiscoveryFindsXDGFnmInstall() throws {
     let home = FileManager.default.temporaryDirectory
       .appendingPathComponent("openclaw-fnm-home-\(UUID().uuidString)", isDirectory: true)

--- a/desktop/macos/Desktop/Tests/PiMonoWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/PiMonoWiringTests.swift
@@ -32,6 +32,10 @@ final class PiMonoWiringTests: XCTestCase {
     XCTAssertEqual(ChatProvider.harnessMode(for: .openClaw), "openclaw")
   }
 
+  func testTaskChatModeMappingCodex() {
+    XCTAssertEqual(ChatProvider.harnessMode(for: .codex), "codex")
+  }
+
   func testTaskChatModeMappingAgentSDK() {
     XCTAssertEqual(ChatProvider.harnessMode(for: .omiAI), "piMono")
   }
@@ -41,6 +45,8 @@ final class PiMonoWiringTests: XCTestCase {
     XCTAssertEqual(AgentRuntimeRouting.adapterId(for: .acp).rawValue, "acp")
     XCTAssertEqual(AgentRuntimeRouting.adapterId(for: .hermes).rawValue, "hermes")
     XCTAssertEqual(AgentRuntimeRouting.adapterId(for: .openclaw).rawValue, "openclaw")
+    XCTAssertEqual(AgentRuntimeRouting.adapterId(for: .codex).rawValue, "codex")
+    XCTAssertEqual(AgentRuntimeRouting.harnessMode(from: "codex"), .codex)
     XCTAssertNil(AgentRuntimeRouting.harnessMode(from: "unknown"))
   }
 
@@ -237,7 +243,7 @@ final class PiMonoWiringTests: XCTestCase {
   }
 
   func testAIProviderAllContainsSupportedProviders() {
-    XCTAssertEqual(AIProvider.all.map(\.id), ["piMono", "claude", "hermes", "openclaw"])
+    XCTAssertEqual(AIProvider.all.map(\.id), ["piMono", "claude", "hermes", "openclaw", "codex"])
   }
 
   func testAIProviderFromBridgeModeReturnsCorrectProvider() {
@@ -245,6 +251,7 @@ final class PiMonoWiringTests: XCTestCase {
     XCTAssertEqual(AIProvider.from(bridgeMode: "claudeCode")?.id, "claude")
     XCTAssertEqual(AIProvider.from(bridgeMode: "hermes")?.id, "hermes")
     XCTAssertEqual(AIProvider.from(bridgeMode: "openclaw")?.id, "openclaw")
+    XCTAssertEqual(AIProvider.from(bridgeMode: "codex")?.id, "codex")
     XCTAssertNil(AIProvider.from(bridgeMode: "unknown"))
     XCTAssertNil(AIProvider.from(bridgeMode: "agentSDK"))
   }

--- a/desktop/macos/agent/src/adapters/codex.ts
+++ b/desktop/macos/agent/src/adapters/codex.ts
@@ -1,0 +1,26 @@
+import { AcpRuntimeAdapter } from "./acp.js";
+
+export interface CodexRuntimeAdapterOptions {
+  command?: string;
+  log?: (message: string) => void;
+}
+
+/**
+ * OpenAI Codex, bridged onto Omi's ACP transport through the
+ * `@zed-industries/codex-acp` adapter (the `codex-acp` binary). The `codex` CLI
+ * itself has no native ACP mode, so the bridge is what actually speaks ACP over
+ * stdio. Like OpenClaw it does not accept per-session MCP servers and does not
+ * expose session/set_model.
+ */
+export class CodexRuntimeAdapter extends AcpRuntimeAdapter {
+  constructor(options: CodexRuntimeAdapterOptions = {}) {
+    super({
+      adapterId: "codex",
+      envCommandName: "OMI_CODEX_ADAPTER_COMMAND",
+      command: options.command,
+      sessionMcpServersMode: "empty",
+      supportsSessionSetModel: false,
+      log: options.log,
+    });
+  }
+}

--- a/desktop/macos/agent/src/adapters/interface.ts
+++ b/desktop/macos/agent/src/adapters/interface.ts
@@ -269,6 +269,25 @@ export const ADAPTER_CAPABILITY_MATRIX = {
       restartOrphanSemantics: required("Startup reconciliation orphans active attempts while preserving native-resumable OpenClaw bindings."),
     },
   },
+  codex: {
+    adapterId: "codex",
+    productionAdapter: true,
+    credentialScope: "local_user",
+    expectations: {
+      // Codex reaches Omi's ACP transport through the `@zed-industries/codex-acp`
+      // bridge process; the OpenAI `codex` CLI has no native ACP mode. Bridge
+      // sessions live in that process and are stale after it restarts, so
+      // bindings are treated as process-local rather than native-resumable.
+      nativeResume: unsupported("Codex ACP sessions live in the codex-acp bridge process and are stale after adapter process restart."),
+      cancellationDispatch: required("Codex ACP accepts cancellation through the shared ACP interrupt path."),
+      cancellationAck: knownLimitation("Codex cancellation resolves locally without an independent adapter ack.", "TICKET-03-follow-up-cancel-ack"),
+      pinnedWorker: required("Codex keeps session state in the codex-acp bridge process and must stay worker-pinned while active."),
+      modelSwitching: unsupported("Codex ACP does not expose session/set_model; model selection is configured in the codex CLI."),
+      artifactEmission: unsupported("Codex ACP adapter does not emit artifact references yet."),
+      toolSupport: unsupported("Codex ACP rejects per-session MCP servers; Omi tools are unavailable until configured in the codex CLI."),
+      restartOrphanSemantics: required("Startup reconciliation orphans active attempts and marks process-local Codex bindings stale."),
+    },
+  },
   a2a: {
     adapterId: "a2a",
     productionAdapter: false,
@@ -278,10 +297,10 @@ export const ADAPTER_CAPABILITY_MATRIX = {
 } as const satisfies Record<string, AdapterCapabilityMatrixEntry>;
 
 export type KnownAdapterId = keyof typeof ADAPTER_CAPABILITY_MATRIX;
-export type ProductionAdapterId = "acp" | "pi-mono" | "hermes" | "openclaw";
+export type ProductionAdapterId = "acp" | "pi-mono" | "hermes" | "openclaw" | "codex";
 export type PlaceholderAdapterId = Exclude<KnownAdapterId, ProductionAdapterId>;
 
-export const PRODUCTION_ADAPTER_IDS = ["acp", "pi-mono", "hermes", "openclaw"] as const satisfies readonly ProductionAdapterId[];
+export const PRODUCTION_ADAPTER_IDS = ["acp", "pi-mono", "hermes", "openclaw", "codex"] as const satisfies readonly ProductionAdapterId[];
 export const PLACEHOLDER_ADAPTER_IDS = ["a2a"] as const satisfies readonly PlaceholderAdapterId[];
 
 export function isKnownAdapterId(adapterId: string): adapterId is KnownAdapterId {

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -1306,8 +1306,16 @@ async function main(): Promise<void> {
       onCreate: (adapter) => localAcpAdapters.add(adapter),
     });
   };
+  const ensureCodexAdapter = async (): Promise<boolean> => {
+    return ensureRegisteredAdapter(registry, "codex", {
+      log: logErr,
+      maxWorkers: 1,
+      onCreate: (adapter) => localAcpAdapters.add(adapter),
+    });
+  };
   const hermesAvailable = await ensureHermesAdapter();
   const openClawAvailable = await ensureOpenClawAdapter();
+  const codexAvailable = await ensureCodexAdapter();
   if (!piMonoAvailable && defaultAdapterId === "pi-mono" && process.env.OMI_AGENT_ALLOW_CONTROL_ONLY !== "1") {
     const msg = "pi-mono mode requires OMI_AUTH_TOKEN (Firebase ID token); refusing to start";
     logErr(msg);
@@ -1324,6 +1332,12 @@ async function main(): Promise<void> {
   }
   if (!openClawAvailable && defaultAdapterId === "openclaw") {
     const msg = adapterActivationError("openclaw") ?? "OpenClaw adapter is unavailable.";
+    logErr(msg);
+    send({ type: "error", message: msg });
+    process.exit(1);
+  }
+  if (!codexAvailable && defaultAdapterId === "codex") {
+    const msg = adapterActivationError("codex") ?? "Codex adapter is unavailable.";
     logErr(msg);
     send({ type: "error", message: msg });
     process.exit(1);
@@ -1556,6 +1570,10 @@ async function main(): Promise<void> {
           } else if (adapterId === "openclaw") {
             if (!(await ensureOpenClawAdapter())) {
               throw new Error(adapterActivationError("openclaw"));
+            }
+          } else if (adapterId === "codex") {
+            if (!(await ensureCodexAdapter())) {
+              throw new Error(adapterActivationError("codex"));
             }
           }
           await transport.handleQuery(query);

--- a/desktop/macos/agent/src/runtime/adapter-selection.ts
+++ b/desktop/macos/agent/src/runtime/adapter-selection.ts
@@ -1,6 +1,7 @@
 import { AcpRuntimeAdapter } from "../adapters/acp.js";
 import { HermesRuntimeAdapter } from "../adapters/hermes.js";
 import { OpenClawRuntimeAdapter } from "../adapters/openclaw.js";
+import { CodexRuntimeAdapter } from "../adapters/codex.js";
 import { adapterCapabilitiesFor, type AdapterCapabilities, type ProductionAdapterId, type RuntimeAdapter } from "../adapters/interface.js";
 import type { AdapterRegistry } from "./adapter-registry.js";
 
@@ -9,6 +10,7 @@ export const ADAPTER_ACTIVATION_ENV = {
   "pi-mono": "OMI_AUTH_TOKEN",
   hermes: "OMI_HERMES_ADAPTER_COMMAND",
   openclaw: "OMI_OPENCLAW_ADAPTER_COMMAND",
+  codex: "OMI_CODEX_ADAPTER_COMMAND",
 } as const;
 
 export type SelectableAdapterId = keyof typeof ADAPTER_ACTIVATION_ENV;
@@ -52,6 +54,13 @@ export const ADAPTER_PROFILES: Record<ProductionAdapterId, AdapterProfile> = {
     capabilities: adapterCapabilitiesFor("openclaw"),
     createAdapter: ({ log }) => new OpenClawRuntimeAdapter({ log }),
   },
+  codex: {
+    adapterId: "codex",
+    activationEnv: ADAPTER_ACTIVATION_ENV.codex,
+    maxWorkers: 1,
+    capabilities: adapterCapabilitiesFor("codex"),
+    createAdapter: ({ log }) => new CodexRuntimeAdapter({ log }),
+  },
 };
 
 export function adapterIdForHarnessMode(harnessMode: string | undefined): SelectableAdapterId {
@@ -65,6 +74,8 @@ export function adapterIdForHarnessMode(harnessMode: string | undefined): Select
     case "openclaw":
     case "openClaw":
       return "openclaw";
+    case "codex":
+      return "codex";
     case "acp":
       return "acp";
     default:
@@ -91,6 +102,9 @@ export function adapterProfile(adapterId: ProductionAdapterId): AdapterProfile {
 export function adapterActivationError(adapterId: ProductionAdapterId): string | undefined {
   const envName = adapterActivationEnv(adapterId);
   if (!envName) return undefined;
+  if (adapterId === "codex") {
+    return "Codex is not available. Install the codex-acp adapter (@zed-industries/codex-acp) first, then try again.";
+  }
   const label = adapterId === "pi-mono" ? "pi-mono" : adapterId === "openclaw" ? "OpenClaw" : "Hermes";
   if (adapterId === "hermes" || adapterId === "openclaw") {
     return `${label} is not available. Make sure ${label} is installed first, then try again.`;

--- a/desktop/macos/agent/src/runtime/external-surface-tool-policy.ts
+++ b/desktop/macos/agent/src/runtime/external-surface-tool-policy.ts
@@ -75,6 +75,7 @@ const PERMISSION_CAPABILITY_SUBJECTS = new Set([
 const DIRECTED_PROVIDER_TARGETS = [
   { provider: "openclaw" as const, pattern: "(?:open\\s*claw|open\\s*cloud)" },
   { provider: "hermes" as const, pattern: "hermes" },
+  { provider: "codex" as const, pattern: "codex" },
 ] as const;
 const DIRECTED_PROVIDER_ACTION = "(?:ask|tell|ping|message|use|run|try|start|spawn|delegate(?:\\s+to)?|have|let|send|make)";
 
@@ -204,13 +205,13 @@ function constrainSpawnProviderToCurrentUserIntent(
   if (selectedProvider) return { ...toolInput, provider: selectedProvider };
 
   const suppliedProvider = textField(toolInput, "provider");
-  if (suppliedProvider !== "openclaw" && suppliedProvider !== "hermes") return toolInput;
+  if (suppliedProvider !== "openclaw" && suppliedProvider !== "hermes" && suppliedProvider !== "codex") return toolInput;
 
   const { provider: _, ...defaultOmiInput } = toolInput;
   return defaultOmiInput;
 }
 
-function directedProviderSelectedByUser(prompt: string): "openclaw" | "hermes" | null {
+function directedProviderSelectedByUser(prompt: string): "openclaw" | "hermes" | "codex" | null {
   const normalized = prompt.toLowerCase();
   const selected = DIRECTED_PROVIDER_TARGETS.flatMap(({ provider, pattern }) => {
     const target = `(?:the\\s+)?${pattern}(?:\\s+agent)?`;

--- a/desktop/macos/agent/src/runtime/failures.ts
+++ b/desktop/macos/agent/src/runtime/failures.ts
@@ -208,6 +208,8 @@ function adapterFailureLabel(adapterId: ProductionAdapterId, provider?: string):
       return "OpenClaw";
     case "hermes":
       return "Hermes";
+    case "codex":
+      return "Codex";
     case "pi-mono":
       return "pi-mono";
     case "acp":

--- a/desktop/macos/agent/src/runtime/run-tool-capability.ts
+++ b/desktop/macos/agent/src/runtime/run-tool-capability.ts
@@ -185,6 +185,7 @@ function relayAdapterId(adapterId: string): OmiToolAdapterId {
     case "acp":
     case "hermes":
     case "openclaw":
+    case "codex":
       return "omi-tools-stdio";
     default:
       throw new Error(`Unknown canonical session adapter ${adapterId}`);

--- a/desktop/macos/agent/tests/runtime-adapter.test.ts
+++ b/desktop/macos/agent/tests/runtime-adapter.test.ts
@@ -558,7 +558,7 @@ describe("adapter capability matrix", () => {
     expect(Object.keys(ADAPTER_CAPABILITY_MATRIX).sort()).toEqual(
       [...PRODUCTION_ADAPTER_IDS, ...PLACEHOLDER_ADAPTER_IDS].sort()
     );
-    expect(PRODUCTION_ADAPTER_IDS).toEqual(["acp", "pi-mono", "hermes", "openclaw"]);
+    expect(PRODUCTION_ADAPTER_IDS).toEqual(["acp", "pi-mono", "hermes", "openclaw", "codex"]);
     expect(PLACEHOLDER_ADAPTER_IDS).toEqual(["a2a"]);
     expect(Object.fromEntries(PRODUCTION_ADAPTER_IDS.map((adapterId) => [
       adapterId,
@@ -568,6 +568,7 @@ describe("adapter capability matrix", () => {
       "pi-mono": "managed_cloud",
       hermes: "local_user",
       openclaw: "local_user",
+      codex: "local_user",
     });
 
     expect(ADAPTER_CAPABILITY_MATRIX.acp.expectations).toMatchObject({
@@ -605,6 +606,16 @@ describe("adapter capability matrix", () => {
       cancellationDispatch: { status: "required" },
       cancellationAck: { status: "known_limitation", followUpTicket: "TICKET-03-follow-up-cancel-ack" },
       pinnedWorker: { status: "unsupported" },
+      modelSwitching: { status: "unsupported" },
+      artifactEmission: { status: "unsupported" },
+      toolSupport: { status: "unsupported" },
+      restartOrphanSemantics: { status: "required" },
+    });
+    expect(ADAPTER_CAPABILITY_MATRIX.codex.expectations).toMatchObject({
+      nativeResume: { status: "unsupported" },
+      cancellationDispatch: { status: "required" },
+      cancellationAck: { status: "known_limitation", followUpTicket: "TICKET-03-follow-up-cancel-ack" },
+      pinnedWorker: { status: "required" },
       modelSwitching: { status: "unsupported" },
       artifactEmission: { status: "unsupported" },
       toolSupport: { status: "unsupported" },

--- a/desktop/macos/changelog/unreleased/20260721-codex-agent-provider.json
+++ b/desktop/macos/changelog/unreleased/20260721-codex-agent-provider.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added OpenAI Codex as a selectable AI provider for local agents, bridged through the codex-acp adapter"
+}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -23,6 +23,7 @@ covers:
   - desktop/macos/Desktop/Sources/Providers/ChatSkillCatalog.swift
   - desktop/macos/Desktop/Sources/Providers/ChatProvider+HarnessReset.swift
   - desktop/macos/Desktop/Sources/Providers/AgentRuntimeRouting.swift
+  - desktop/macos/Desktop/Sources/Providers/AIProvider.swift
   - desktop/macos/Desktop/Sources/AnalyticsManager.swift
   - desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeBridgeLifecycle.swift


### PR DESCRIPTION
## What

Adds **OpenAI Codex** as a selectable local agent runtime in the desktop macOS agent control plane, bridged onto Omi's existing ACP transport through the `@zed-industries/codex-acp` adapter (the `codex-acp` binary). It sits beside the existing Hermes and OpenClaw local adapters and reuses the shared `AcpRuntimeAdapter` — no new transport, no new identity/lifecycle surface.

The OpenAI `codex` CLI has no native ACP mode, so `codex-acp` is the process that actually speaks ACP over stdio and drives Codex underneath. Detecting that binary (or an explicit `OMI_CODEX_ADAPTER_COMMAND`) is what proves the runtime is installed.

## Product invariants affected

- INV-AGENT-*
- INV-AUTH-1
- INV-CHAT-1

**INV-AGENT-*** (agent control-plane) is the one this change substantively touches: Codex is bound as an adapter *under* the kernel — no new session/run/attempt identity or authority. The change edits `desktop/macos/agent/src/runtime/**`, so this PR names it and updates the matching guard test (`tests/runtime-adapter.test.ts` — the adapter capability-matrix guard now covers Codex).

**INV-AUTH-1** and **INV-CHAT-1** are named because the diff touches files under their path globs (`ChatProvider.swift`, `AgentRuntimeProcess.swift`, `AgentPill.swift`, `AgentFailureTranscriptFormatter.swift`, the runtime adapter files), but the edits are purely additive — a new Codex provider case alongside the existing ones. No existing auth-session or chat-continuity behavior changes, so their guard tests are unchanged (and still pass).

## Runtime authority (Node — `desktop/macos/agent/src/runtime`, `src/adapters`)

- `adapters/codex.ts`: new thin `AcpRuntimeAdapter` subclass (`adapterId: "codex"`, `OMI_CODEX_ADAPTER_COMMAND`, `sessionMcpServersMode: "empty"`, `supportsSessionSetModel: false`).
- `adapters/interface.ts`: `codex` added to `ProductionAdapterId` / `PRODUCTION_ADAPTER_IDS` and the capability matrix (`local_user` scope; process-local sessions → non-native-resumable + worker-pinned; no per-session MCP / model-switch, mirroring the OpenClaw ACP limitations).
- `runtime/adapter-selection.ts`: activation env, adapter profile, harness-mode routing, and a Codex-specific activation-error message.
- `index.ts`: `ensureCodexAdapter` registration + the default-adapter activation guard and per-query activation, mirroring OpenClaw.
- `runtime/failures.ts`, `runtime/run-tool-capability.ts`: Codex failure label + `omi-tools-stdio` relay mapping (the id-exhaustive switches).
- `runtime/external-surface-tool-policy.ts`: "use/via/with codex …" directed-provider routing.

## Swift projection (`desktop/macos/Desktop/Sources`)

- `.codex` across `AIProvider` (+`.all`), `ChatProvider.BridgeMode`, `AgentHarnessMode`/`AgentAdapterId` routing, and `AgentPillsManager.DirectedProvider`.
- `AgentRuntimeProcess`: seeds `OMI_CODEX_ADAPTER_COMMAND` from the detected `codex-acp` binary via a new `codexAdapterCommand(...)`. Unlike the `<cli> acp` adapters, the `codex-acp` bridge speaks ACP directly, so the command carries **no** `acp` subcommand (prefers a sibling `node` for directly-launched bundles, mirroring OpenClaw).

## Verification

- Node: `npx tsc --noEmit` clean; `npx vitest run` — **577/577 passing** (incl. the updated capability-matrix guard test).
- Swift: `xcrun swift build -c debug --package-path Desktop` — clean; `<swift test filter>` — Codex routing + `codexAdapterCommand` tests passing.
- Line-count ratchet: raised the three touched oversized files to their exact new counts with one-line justifications in the owning shards.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

