### PR TITLE
SCA-29: bind deploy controls to workflow source

### DIFF
--- a/.github/actions/sync-backfill-lifecycle/action.yml
+++ b/.github/actions/sync-backfill-lifecycle/action.yml
@@ -96,11 +96,12 @@ runs:
         SECRET_OVERLAY: ${{ inputs.backfill_secrets }}
         REMOVE_ENV_VARS: HOSTED_PUSHER_API_URL
       run: |
+        DEPLOY_CONTROL_SCRIPT_DIR="${DEPLOY_CONTROL_SCRIPTS:-backend/scripts}"
         gcloud run services describe backend-sync \
           --region=${{ inputs.region }} \
           --project=${{ inputs.project_id }} \
           --format=json > /tmp/backend-sync-live.json
-        python3 backend/scripts/render_cloud_run_clone_env.py \
+        python3 "$DEPLOY_CONTROL_SCRIPT_DIR/render_cloud_run_clone_env.py" \
           --source-json /tmp/backend-sync-live.json >> "$GITHUB_OUTPUT"
 
     - name: Render optional candidate tag

--- a/.github/actions/transcription-release-candidate-probe/action.yml
+++ b/.github/actions/transcription-release-candidate-probe/action.yml
@@ -28,9 +28,10 @@ runs:
         FIREBASE_AUTH_PROJECT_ID: ${{ inputs.firebase_auth_project_id }}
       run: |
         set -euo pipefail
+        DEPLOY_CONTROL_SCRIPT_DIR="${DEPLOY_CONTROL_SCRIPTS:-backend/scripts}"
         token_file="$(mktemp "$RUNNER_TEMP/omi-transcription-probe.XXXXXX")"
         trap 'rm -f "$token_file"' EXIT
-        python3 backend/scripts/firebase_release_probe_token.py \
+        python3 "$DEPLOY_CONTROL_SCRIPT_DIR/firebase_release_probe_token.py" \
           --secret-project "$PROBE_SECRET_PROJECT" \
           --firebase-project "$FIREBASE_AUTH_PROJECT_ID" \
           --token-output "$token_file"
@@ -40,7 +41,7 @@ runs:
           --json-only
         )
         if [[ -n "$EVIDENCE_PATH" ]]; then
-          python3 backend/scripts/transcription_capability_probe.py "${probe_args[@]}" > "$EVIDENCE_PATH"
+          python3 "$DEPLOY_CONTROL_SCRIPT_DIR/transcription_capability_probe.py" "${probe_args[@]}" > "$EVIDENCE_PATH"
         else
-          python3 backend/scripts/transcription_capability_probe.py "${probe_args[@]}"
+          python3 "$DEPLOY_CONTROL_SCRIPT_DIR/transcription_capability_probe.py" "${probe_args[@]}"
         fi

--- a/.github/failure-classes/FC-workflow-control-source-identity.json
+++ b/.github/failure-classes/FC-workflow-control-source-identity.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-workflow-control-source-identity",
+  "violated_contract": "A deployment workflow's control-plane scripts must execute from the immutable workflow revision that selected their behavior, while application and image inputs remain pinned to the admitted runtime release revision.",
+  "canonical_prevention": "Stage the workflow revision's deployment-control scripts before checking out the admitted runtime source, execute every workflow-owned control-script invocation from that staging directory, and cover the ordering and source boundary with a deployment contract test.",
+  "evidence_prs": [
+    10254
+  ],
+  "scope_hints": [
+    ".github/workflows/**",
+    ".github/actions/**",
+    "backend/scripts/**",
+    "backend/tests/unit/test_*release_vector.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/check-deployment-concurrency.py
+++ b/.github/scripts/check-deployment-concurrency.py
@@ -236,7 +236,10 @@ def validate_serving_release_vector(name: str, text: str) -> list[str]:
         [],
     )
     verifier_text = "\n".join(verifier_step)
-    if "backend/scripts/verify_backend_release_vector.py" not in verifier_text:
+    if not any(
+        marker in verifier_text
+        for marker in ("backend/scripts/verify_backend_release_vector.py", "$DEPLOY_CONTROL_SCRIPTS/verify_backend_release_vector.py")
+    ):
         errors.append(f"{name}: release-vector verification must use the canonical verifier")
     if "--environment" not in verifier_text:
         errors.append(f"{name}: release-vector verification must bind an environment")
@@ -275,9 +278,14 @@ def validate_phase_aware_backend_promotion(name: str, text: str) -> list[str]:
 
     candidate_step = steps[candidate_index] if candidate_index >= 0 else []
     candidate_text = "\n".join(candidate_step)
-    for marker in ("backend/scripts/verify_backend_release_vector.py", "--candidate", "--cloud-run-only"):
+    for marker in ("--candidate", "--cloud-run-only"):
         if marker not in candidate_text:
             errors.append(f"{name}: candidate acceptance must include {marker!r}")
+    if not any(
+        marker in candidate_text
+        for marker in ("backend/scripts/verify_backend_release_vector.py", "$DEPLOY_CONTROL_SCRIPTS/verify_backend_release_vector.py")
+    ):
+        errors.append(f"{name}: candidate acceptance must include the canonical release-vector verifier")
 
     for marker in (
         "Apply non-secret backend runtime config",
@@ -303,7 +311,10 @@ def validate_phase_aware_backend_promotion(name: str, text: str) -> list[str]:
             errors.append(f"{name}: traffic snapshot restoration must follow production serving smoke")
 
     snapshot_step = "\n".join(steps[snapshot_index]) if snapshot_index >= 0 else ""
-    if "backend/scripts/cloud_run_traffic_snapshot.py capture" not in snapshot_step:
+    if not any(
+        marker in snapshot_step
+        for marker in ("backend/scripts/cloud_run_traffic_snapshot.py capture", 'cloud_run_traffic_snapshot.py" capture')
+    ):
         errors.append(f"{name}: pre-promotion snapshot must use the canonical Cloud Run snapshot helper")
     for service in ("backend", "backend-sync", "backend-sync-backfill", "backend-integration"):
         if f"--service {service}" not in snapshot_step:
@@ -326,7 +337,10 @@ def validate_phase_aware_backend_promotion(name: str, text: str) -> list[str]:
         errors.append(f"{name}: traffic restoration must run after a failed promotion when its snapshot exists")
     if name == "gcp_backend.yml" and "steps.smoke-promoted-production-serving-api.outcome == 'failure'" not in restore_step:
         errors.append(f"{name}: traffic restoration must include failed production serving smoke")
-    if "backend/scripts/cloud_run_traffic_snapshot.py restore" not in restore_step:
+    if not any(
+        marker in restore_step
+        for marker in ("backend/scripts/cloud_run_traffic_snapshot.py restore", 'cloud_run_traffic_snapshot.py" restore')
+    ):
         errors.append(f"{name}: traffic restoration must use the canonical Cloud Run snapshot helper")
     for artifact in ("cloud-run-pre-promotion-traffic-snapshot.json", "cloud-run-traffic-restore.json"):
         if artifact not in text:
@@ -581,7 +595,12 @@ def check_repository() -> list[str]:
     for name, text in workflow_text.items():
         errors.extend(validate_pusher_config_preflight(name, text))
     release_vector_workflows = sorted(
-        name for name, text in workflow_text.items() if "backend/scripts/verify_backend_release_vector.py" in text
+        name
+        for name, text in workflow_text.items()
+        if any(
+            marker in text
+            for marker in ("backend/scripts/verify_backend_release_vector.py", "$DEPLOY_CONTROL_SCRIPTS/verify_backend_release_vector.py")
+        )
     )
     # Release-ring deploys are admitted from an immutable record and bind the
     # verifier to that record's source SHA and this deployment run identity.

--- a/.github/scripts/check-gcp-backend-production-boundary.py
+++ b/.github/scripts/check-gcp-backend-production-boundary.py
@@ -43,7 +43,8 @@ def validate(root: Path) -> list[str]:
             errors.append("production serving smoke must follow exact serving release-vector verification")
     for required in (
         "https://api.omi.me/v2/desktop/beta/candidates/reserve",
-        "expected validation response",
+        '--data \'{"tag":"macos-unauthenticated-smoke"}\'',
+        "schema-valid inert tag reaches the authorization wall",
         "--candidate-api-url https://api.omi.me",
         "umask 077",
         "firebase-production-serving-token",
@@ -52,6 +53,8 @@ def validate(root: Path) -> list[str]:
     ):
         if required not in text:
             errors.append(f"gcp_backend.yml is missing production serving-smoke guard {required!r}")
+    if "--data '{}')" in text:
+        errors.append("gcp_backend.yml must not use an invalid empty reservation body for the 401 smoke")
     smoke_text = text[text.find(PROD_SMOKE) :] if PROD_SMOKE in text else ""
     if "$GITHUB_OUTPUT" in smoke_text and "firebase-production-serving-token" in smoke_text:
         errors.append("production smoke token must not be written to GITHUB_OUTPUT")

--- a/.github/scripts/check_backend_deploy_source_admission.py
+++ b/.github/scripts/check_backend_deploy_source_admission.py
@@ -406,8 +406,9 @@ def validate_manual_workflow(text: str) -> list[str]:
     )
     if "github.event.inputs.branch" in text or re.search(r"(?m)^      branch:\n", text):
         errors.append("manual backend deploy must not accept an arbitrary branch or ref")
-    if "github.sha" in text:
-        errors.append("manual backend deploy must not substitute the dispatch default SHA for admitted source")
+    control_source_ref = "ref: ${{ github.sha }}"
+    if text.count(control_source_ref) != 1 or "Checkout workflow-owned deploy-control source" not in text:
+        errors.append("manual backend deploy must stage workflow-owned control scripts from github.sha")
 
     repair_job = mapping_block(text, "repair-traffic", 2)
     if repair_job is None:

--- a/.github/scripts/check_release_rings.py
+++ b/.github/scripts/check_release_rings.py
@@ -38,6 +38,12 @@ def require(text: str, path: Path, fragments: tuple[str, ...]) -> list[str]:
     ]
 
 
+def require_one(text: str, path: Path, description: str, alternatives: tuple[str, ...]) -> list[str]:
+    if any(fragment in text for fragment in alternatives):
+        return []
+    return [f"{path}: missing required release-vector guard {description!r}"]
+
+
 def check() -> list[str]:
     paths = {relative: ROOT / relative for relative in BACKEND_RELEASE_SOURCES}
     errors = [f"{path}: canonical production deploy source is missing" for path in paths.values() if not path.exists()]
@@ -58,15 +64,44 @@ def check() -> list[str]:
                 "needs.firestore_readiness.outputs.admitted_sha",
                 "--check-only",
                 "no_traffic: true",
-                "backend/scripts/deploy-backend-secrets.sh",
-                "cloud_run_traffic_snapshot.py capture",
-                "cloud_run_traffic_snapshot.py restore",
                 "Verify serving backend release vector",
-                "backend/scripts/verify_backend_release_vector.py",
                 "github.event.inputs.environment == 'prod'",
                 "environment=prod, deploy_targets=all is unsupported",
                 "Smoke promoted production serving API",
             ),
+        )
+    )
+    workflow_path = paths[Path(".github/workflows/gcp_backend.yml")]
+    errors.extend(
+        require_one(
+            workflow,
+            workflow_path,
+            "canonical deploy-backend-secrets helper",
+            ("backend/scripts/deploy-backend-secrets.sh", "$DEPLOY_CONTROL_SCRIPTS/deploy-backend-secrets.sh"),
+        )
+    )
+    errors.extend(
+        require_one(
+            workflow,
+            workflow_path,
+            "canonical Cloud Run snapshot helper capture",
+            ("cloud_run_traffic_snapshot.py capture", 'cloud_run_traffic_snapshot.py" capture'),
+        )
+    )
+    errors.extend(
+        require_one(
+            workflow,
+            workflow_path,
+            "canonical Cloud Run snapshot helper restore",
+            ("cloud_run_traffic_snapshot.py restore", 'cloud_run_traffic_snapshot.py" restore'),
+        )
+    )
+    errors.extend(
+        require_one(
+            workflow,
+            workflow_path,
+            "canonical release-vector verifier",
+            ("backend/scripts/verify_backend_release_vector.py", "$DEPLOY_CONTROL_SCRIPTS/verify_backend_release_vector.py"),
         )
     )
     promotion = workflow.find("Shift Cloud Run traffic to validated revisions")

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-other.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-other.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "backend/scripts/validate-backend-runtime-env.py": 1825
+    "backend/scripts/validate-backend-runtime-env.py": 1843
   },
   "raise_justifications": {
-    "backend/scripts/validate-backend-runtime-env.py": "Serving STT retirement and shared forbidden-env guard keep provider/runtime validation in the authoritative deployment contract validator."
+    "backend/scripts/validate-backend-runtime-env.py": "Serving STT retirement, shared forbidden-env validation, and the SCA-29 admitted-runtime/workflow-control source boundary remain one authoritative deployment contract."
   },
   "threshold": 1500
 }

--- a/.github/scripts/test_check_backend_deploy_source_admission.py
+++ b/.github/scripts/test_check_backend_deploy_source_admission.py
@@ -572,6 +572,18 @@ class WorkflowContractTests(unittest.TestCase):
         )
         self.assertIn("manual deployment must bind every release vector to the admitted SHA", CHECKER.validate(root))
 
+        root = self.fixture_root()
+        self.mutate(
+            root,
+            CHECKER.MANUAL_WORKFLOW_PATH,
+            "ref: ${{ github.sha }}",
+            "ref: ${{ github.event.inputs.release_sha }}",
+        )
+        self.assertIn(
+            "manual backend deploy must stage workflow-owned control scripts from github.sha",
+            CHECKER.validate(root),
+        )
+
     def test_traffic_only_repair_remains_separate_from_source_admission(self) -> None:
         root = self.fixture_root()
         self.mutate(

--- a/.github/scripts/test_check_gcp_backend_production_boundary.py
+++ b/.github/scripts/test_check_gcp_backend_production_boundary.py
@@ -27,7 +27,14 @@ class GcpBackendProductionBoundaryTests(unittest.TestCase):
             "permits_prod_all": (CHECKER.PROD_ALL_REJECTION, "if false; then"),
             "reintroduces_tagged_url": ("Production has no tagged candidate URL", "Production has no tagged candidate URL\n# resolve_cloud_run_tagged_url.py"),
             "moves_smoke_before_serving_verification": (CHECKER.PROD_SMOKE, "Smoke production candidate API"),
-            "omits_route_presence_smoke": ("expected validation response", "unexpected response"),
+            "omits_schema_valid_unauthenticated_smoke": (
+                "schema-valid inert tag reaches the authorization wall",
+                "unexpected response",
+            ),
+            "uses_invalid_empty_reservation_body": (
+                '--data \'{"tag":"macos-unauthenticated-smoke"}\'',
+                "--data '{}')",
+            ),
             "omits_smoke_rollback": (CHECKER.ROLLBACK_CONDITION, "false"),
             "leaks_smoke_token_to_output": (
                 "trap 'rm -f \"$token_file\"' EXIT",

--- a/.github/scripts/test_check_release_rings.py
+++ b/.github/scripts/test_check_release_rings.py
@@ -74,3 +74,21 @@ def test_serving_release_vector_must_follow_traffic_promotion(tmp_path: Path, mo
     monkeypatch.setattr(checker, "ROOT", tmp_path)
 
     assert any("serving release-vector verification must follow traffic promotion" in error for error in checker.check())
+
+
+def test_staged_workflow_control_verifier_remains_required(tmp_path: Path, monkeypatch) -> None:
+    for relative in checker.BACKEND_RELEASE_SOURCES:
+        destination = tmp_path / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(checker.ROOT / relative, destination)
+    deploy_path = tmp_path / ".github/workflows/gcp_backend.yml"
+    deploy_path.write_text(
+        deploy_path.read_text(encoding="utf-8").replace(
+            "$DEPLOY_CONTROL_SCRIPTS/verify_backend_release_vector.py",
+            "$DEPLOY_CONTROL_SCRIPTS/not-the-release-vector-verifier.py",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(checker, "ROOT", tmp_path)
+
+    assert any("canonical release-vector verifier" in error for error in checker.check())

--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -59,7 +59,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         self.assertLess(shift, verify)
         self.assertLess(verify, status)
         evidence = backend[verify:status]
-        self.assertIn("backend/scripts/verify_backend_release_vector.py", evidence)
+        self.assertIn("$DEPLOY_CONTROL_SCRIPTS/verify_backend_release_vector.py", evidence)
         self.assertIn("--deploy-run-id \"${{ github.run_id }}\"", evidence)
         self.assertIn("--deploy-run-attempt \"${{ github.run_attempt }}\"", evidence)
 

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -342,7 +342,25 @@ jobs:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache
 
-      - name: Checkout
+      - name: Checkout workflow-owned deploy-control source
+        uses: actions/checkout@v7
+        with:
+          # The workflow owns deployment-control behavior. Pin this source to
+          # the immutable workflow revision before the admitted runtime source
+          # replaces the normal workspace.
+          ref: ${{ github.sha }}
+          path: .workflow-source
+
+      - name: Stage workflow-owned deployment-control scripts
+        run: |
+          set -euo pipefail
+          control_scripts="$RUNNER_TEMP/backend-deploy-control-scripts"
+          rm -rf "$control_scripts"
+          cp -a .workflow-source/backend/scripts "$control_scripts"
+          rm -rf .workflow-source
+          printf 'DEPLOY_CONTROL_SCRIPTS=%s\n' "$control_scripts" >> "$GITHUB_ENV"
+
+      - name: Checkout admitted runtime source
         uses: actions/checkout@v7
         with:
           ref: ${{ needs.firestore_readiness.outputs.admitted_sha }}
@@ -360,7 +378,7 @@ jobs:
         env:
           SYNC_LEDGER_FENCE_MODE: ${{ vars.SYNC_LEDGER_FENCE_MODE || 'legacy' }}
         run: |
-          python3 backend/scripts/verify_sync_ledger_fence_transition.py \
+          python3 "$DEPLOY_CONTROL_SCRIPTS/verify_sync_ledger_fence_transition.py" \
             --project=${{ vars.GCP_PROJECT_ID }} \
             --region=${{ env.REGION }} \
             --desired-mode="$SYNC_LEDGER_FENCE_MODE"
@@ -413,7 +431,7 @@ jobs:
         id: gateway-intent
         if: ${{ github.event.inputs.deploy_targets == 'all' }}
         run: |
-          python3 backend/scripts/verify-llm-gateway-serving.py \
+          python3 "$DEPLOY_CONTROL_SCRIPTS/verify-llm-gateway-serving.py" \
             --environment="${{ vars.ENV }}" \
             --project="${{ vars.GCP_PROJECT_ID }}" \
             --region="${{ env.REGION }}" \
@@ -432,7 +450,7 @@ jobs:
         id: gateway-serving
         if: ${{ github.event.inputs.deploy_targets == 'all' && steps.gateway-intent.outputs.enabled == 'true' }}
         run: |
-          python3 backend/scripts/verify-llm-gateway-serving.py \
+          python3 "$DEPLOY_CONTROL_SCRIPTS/verify-llm-gateway-serving.py" \
             --environment="${{ vars.ENV }}" \
             --project="${{ vars.GCP_PROJECT_ID }}" \
             --region="${{ env.REGION }}" \
@@ -450,13 +468,13 @@ jobs:
           if [[ "${{ github.event.inputs.environment }}" == "prod" || "${{ github.event.inputs.environment }}" == "development" ]]; then
             PREFLIGHT_ARGS+=(--repair-traffic)
           fi
-          python3 backend/scripts/preflight-cloud-run-deploy.py "${PREFLIGHT_ARGS[@]}"
+          python3 "$DEPLOY_CONTROL_SCRIPTS/preflight-cloud-run-deploy.py" "${PREFLIGHT_ARGS[@]}"
 
       - name: Validate backend runtime env before deploy
         env:
           SYNC_LEDGER_FENCE_MODE: ${{ vars.SYNC_LEDGER_FENCE_MODE || 'legacy' }}
         run: |
-          python3 backend/scripts/validate-backend-runtime-env.py --env ${{ vars.ENV }} --check-workflows --check-rendered-cloud-run
+          python3 "$DEPLOY_CONTROL_SCRIPTS/validate-backend-runtime-env.py" --env ${{ vars.ENV }} --check-workflows --check-rendered-cloud-run
 
       - name: Build runtime image
         uses: docker/build-push-action@v7
@@ -474,7 +492,7 @@ jobs:
       - name: Verify built runtime image before publish
         run: |
           image=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
-          python3 backend/scripts/runtime_image_contracts.py smoke --dockerfile backend/Dockerfile --image "$image"
+          python3 "$DEPLOY_CONTROL_SCRIPTS/runtime_image_contracts.py" smoke --dockerfile backend/Dockerfile --image "$image"
 
       - name: Push verified runtime image
         run: |
@@ -484,7 +502,7 @@ jobs:
       - name: Probe LLM gateway from the Cloud Run VPC before promotion
         if: ${{ github.event.inputs.deploy_targets == 'all' && steps.gateway-intent.outputs.enabled == 'true' }}
         run: |
-          bash backend/scripts/probe-llm-gateway-from-cloud-run.sh \
+          bash "$DEPLOY_CONTROL_SCRIPTS/probe-llm-gateway-from-cloud-run.sh" \
             --project "${{ vars.GCP_PROJECT_ID }}" \
             --region "${{ env.REGION }}" \
             --image "gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}" \
@@ -517,14 +535,14 @@ jobs:
           SYNC_TASKS_HANDLER_URL: ${{ steps.account-deletion-target.outputs.sync_tasks_handler_url }}
           SYNC_TASKS_INVOKER_SA: ${{ steps.account-deletion-target.outputs.sync_tasks_invoker_sa }}
         run: |
-          python3 backend/scripts/render_backend_runtime_env.py --env ${{ vars.ENV }} >> "$GITHUB_OUTPUT"
+          python3 "$DEPLOY_CONTROL_SCRIPTS/render_backend_runtime_env.py" --env ${{ vars.ENV }} >> "$GITHUB_OUTPUT"
 
       # Strips Secret Manager bindings left on services for settings the manifest
       # now declares as public literals; gcloud cannot flip a binding's type in
       # place. No-ops once a service carries no legacy binding.
       - name: Migrate legacy public Cloud Run bindings
         run: >-
-          python3 backend/scripts/preflight-cloud-run-deploy.py
+          python3 "$DEPLOY_CONTROL_SCRIPTS/preflight-cloud-run-deploy.py"
           --env ${{ vars.ENV }}
           --project="${{ vars.GCP_PROJECT_ID }}"
           --region="${{ env.REGION }}"
@@ -655,7 +673,7 @@ jobs:
 
       - name: Wait for Cloud Run revisions to become ready
         run: |
-          python3 backend/scripts/preflight-cloud-run-deploy.py \
+          python3 "$DEPLOY_CONTROL_SCRIPTS/preflight-cloud-run-deploy.py" \
             --env ${{ vars.ENV }} \
             --project ${{ vars.GCP_PROJECT_ID }} \
             --region ${{ env.REGION }} \
@@ -668,7 +686,7 @@ jobs:
         env:
           SYNC_LEDGER_FENCE_MODE: ${{ vars.SYNC_LEDGER_FENCE_MODE || 'legacy' }}
         run: |
-          python3 backend/scripts/validate-backend-runtime-env.py --env ${{ vars.ENV }} --check-workflows --check-live-cloud-run
+          python3 "$DEPLOY_CONTROL_SCRIPTS/validate-backend-runtime-env.py" --env ${{ vars.ENV }} --check-workflows --check-live-cloud-run
 
       # Development probes the no-traffic tagged revision directly from the
       # runner. Production has no tagged candidate URL or private probe job.
@@ -676,7 +694,7 @@ jobs:
         id: transcription-candidate
         if: ${{ github.event.inputs.environment == 'development' }}
         run: |
-          candidate_url="$(python3 backend/scripts/resolve_cloud_run_tagged_url.py \
+          candidate_url="$(python3 "$DEPLOY_CONTROL_SCRIPTS/resolve_cloud_run_tagged_url.py" \
             --project=${{ vars.GCP_PROJECT_ID }} \
             --region=${{ env.REGION }} \
             --service=${{ env.SERVICE }} \
@@ -696,7 +714,7 @@ jobs:
       - name: Accept no-traffic Cloud Run candidate
         id: verify-cloud-run-candidate
         run: |
-          python3 backend/scripts/verify_backend_release_vector.py \
+          python3 "$DEPLOY_CONTROL_SCRIPTS/verify_backend_release_vector.py" \
             --candidate \
             --cloud-run-only \
             --commit-sha "${{ needs.firestore_readiness.outputs.admitted_sha }}" \
@@ -768,7 +786,7 @@ jobs:
           TWILIO_TWIML_APP_SID: ${{ vars.TWILIO_TWIML_APP_SID }}
           X_OAUTH_CLIENT_ID: ${{ vars.X_OAUTH_CLIENT_ID }}
           X_OAUTH_REDIRECT_URI: ${{ vars.X_OAUTH_REDIRECT_URI }}
-        run: backend/scripts/deploy-backend-config.sh
+        run: bash "$DEPLOY_CONTROL_SCRIPTS/deploy-backend-config.sh"
 
       - name: Deploy backend-secrets to GKE using Helm
         if: ${{ github.event.inputs.deploy_targets == 'all' }}
@@ -777,7 +795,7 @@ jobs:
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
           GKE_CLUSTER: ${{ vars.GKE_CLUSTER }}
           REGION: ${{ env.REGION }}
-        run: backend/scripts/deploy-backend-secrets.sh
+        run: bash "$DEPLOY_CONTROL_SCRIPTS/deploy-backend-secrets.sh"
 
       - name: Deploy ${{ env.SERVICE }}-listen to GKE using Helm
         if: ${{ github.event.inputs.deploy_targets == 'all' }}
@@ -795,15 +813,15 @@ jobs:
           # still fails fast on the deployment's 600s progressDeadlineSeconds, which
           # kubectl reports as ProgressDeadlineExceeded regardless of this value.
           if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=1800s; then
-            python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service backend-listen || true
+            python3 "$DEPLOY_CONTROL_SCRIPTS/deploy_status_report.py" --env ${{ vars.ENV }} --include-gke --gke-service backend-listen || true
             exit 1
           fi
-          python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service backend-listen
+          python3 "$DEPLOY_CONTROL_SCRIPTS/deploy_status_report.py" --env ${{ vars.ENV }} --include-gke --gke-service backend-listen
 
       - name: Verify exact candidate composition
         if: ${{ github.event.inputs.deploy_targets == 'all' }}
         run: |
-          python3 backend/scripts/verify_backend_release_vector.py \
+          python3 "$DEPLOY_CONTROL_SCRIPTS/verify_backend_release_vector.py" \
             --candidate \
             --commit-sha "${{ needs.firestore_readiness.outputs.admitted_sha }}" \
             --short-sha "${{ steps.image-tag.outputs.short_sha }}" \
@@ -817,7 +835,7 @@ jobs:
       - name: Capture Cloud Run pre-promotion traffic snapshot
         id: cloud-run-traffic-snapshot
         run: |
-          python3 backend/scripts/cloud_run_traffic_snapshot.py capture \
+          python3 "$DEPLOY_CONTROL_SCRIPTS/cloud_run_traffic_snapshot.py" capture \
             --project "${{ vars.GCP_PROJECT_ID }}" \
             --region "${{ env.REGION }}" \
             --service backend \
@@ -851,7 +869,7 @@ jobs:
           if [[ "${{ github.event.inputs.deploy_targets }}" == "cloud-run-only" ]]; then
             CLOUD_RUN_ONLY="--cloud-run-only"
           fi
-          python3 backend/scripts/verify_backend_release_vector.py \
+          python3 "$DEPLOY_CONTROL_SCRIPTS/verify_backend_release_vector.py" \
             --commit-sha "${{ needs.firestore_readiness.outputs.admitted_sha }}" \
             --short-sha "${{ steps.image-tag.outputs.short_sha }}" \
             --deploy-run-id "${{ github.run_id }}" \
@@ -873,23 +891,23 @@ jobs:
           umask 077
           token_file="$RUNNER_TEMP/firebase-production-serving-token"
           trap 'rm -f "$token_file"' EXIT
-          python3 backend/scripts/firebase_release_probe_token.py \
+          python3 "$DEPLOY_CONTROL_SCRIPTS/firebase_release_probe_token.py" \
             --secret-project "$PROBE_SECRET_PROJECT" \
             --firebase-project "$FIREBASE_AUTH_PROJECT_ID" \
             --token-output "$token_file"
           reservation_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
             --request POST https://api.omi.me/v2/desktop/beta/candidates/reserve \
-            --header 'Content-Type: application/json' --data '{}')"
-          # An expected validation response proves the route is present without a reservation mutation.
+            --header 'Content-Type: application/json' --data '{"tag":"macos-unauthenticated-smoke"}')"
+          # A schema-valid inert tag reaches the authorization wall without reserving a real candidate.
           test "$reservation_status" = 401
-          python3 backend/scripts/transcription_capability_probe.py \
+          python3 "$DEPLOY_CONTROL_SCRIPTS/transcription_capability_probe.py" \
             --candidate-api-url https://api.omi.me \
             --bearer-token-file "$token_file" --json-only
 
       - name: Restore Cloud Run traffic snapshot after failed promotion
         if: ${{ failure() && steps.cloud-run-traffic-snapshot.outcome == 'success' && (steps.shift-cloud-run-traffic.outcome == 'failure' || steps.verify-serving-release-vector.outcome == 'failure' || steps.smoke-promoted-production-serving-api.outcome == 'failure') }}
         run: |
-          python3 backend/scripts/cloud_run_traffic_snapshot.py restore \
+          python3 "$DEPLOY_CONTROL_SCRIPTS/cloud_run_traffic_snapshot.py" restore \
             --snapshot artifacts/backend-cloud-run-pre-promotion-traffic-snapshot.json \
             --evidence-path artifacts/backend-cloud-run-traffic-restore.json
 
@@ -902,7 +920,7 @@ jobs:
           ADMIN_KEY="$(gcloud secrets versions access latest --secret=ADMIN_KEY --project="$PROJECT_ID")"
           export ADMIN_KEY
           trap 'unset ADMIN_KEY' EXIT
-          python3 backend/scripts/smoke_what_matters_now.py --base-url https://api.omi.dev
+          python3 "$DEPLOY_CONTROL_SCRIPTS/smoke_what_matters_now.py" --base-url https://api.omi.dev
 
       - name: Cloud Run deploy status report
         if: always()
@@ -922,7 +940,7 @@ jobs:
               --expect-cloud-run-traffic backend-integration=${{ steps.capture-backend-integration-revision.outputs.revision }}
             )
           fi
-          python3 backend/scripts/deploy_status_report.py \
+          python3 "$DEPLOY_CONTROL_SCRIPTS/deploy_status_report.py" \
             --env ${{ vars.ENV }} \
             --project ${{ vars.GCP_PROJECT_ID }} \
             --region ${{ env.REGION }} \

--- a/backend/scripts/runtime_image_contracts.py
+++ b/backend/scripts/runtime_image_contracts.py
@@ -385,7 +385,10 @@ def workflow_contract_errors(contracts: Iterable[ImageContract]) -> list[str]:
         for workflow in contract.deployment_workflows:
             workflow_text = workflow.read_text(encoding="utf-8")
             workflow_name = _repository_relative(workflow)
-            if "runtime_image_contracts.py smoke" not in workflow_text:
+            if not any(
+                marker in workflow_text
+                for marker in ("runtime_image_contracts.py smoke", 'runtime_image_contracts.py" smoke')
+            ):
                 errors.append(f"{contract.name}: {workflow_name} does not smoke its registered runtime image")
             if dockerfile not in workflow_text:
                 errors.append(

--- a/backend/scripts/validate-backend-runtime-env.py
+++ b/backend/scripts/validate-backend-runtime-env.py
@@ -991,10 +991,28 @@ def _validate_firestore_readiness_workflow_contract(workflow_file: str, workflow
         errors.append(ValidationError(scope, admission_error))
     deploy_steps = [_as_config_dict(step) or {} for step in (_as_config_list(deploy_job.get('steps')) or [])]
     deploy_checkout = [step for step in deploy_steps if step.get('uses') == 'actions/checkout@v7']
+    runtime_checkout = [
+        step
+        for step in deploy_checkout
+        if (_as_config_dict(step.get('with')) or {}).get('ref')
+        == '${{ needs.firestore_readiness.outputs.admitted_sha }}'
+    ]
+    workflow_control_checkout = next(
+        (step for step in deploy_checkout if step.get('name') == 'Checkout workflow-owned deploy-control source'),
+        None,
+    )
+    workflow_control_with = _as_config_dict((workflow_control_checkout or {}).get('with')) or {}
+    expected_checkout_count = 2 if is_manual_deploy else 1
     if (
-        len(deploy_checkout) != 1
-        or (_as_config_dict(deploy_checkout[0].get('with')) or {}).get('ref')
-        != '${{ needs.firestore_readiness.outputs.admitted_sha }}'
+        len(deploy_checkout) != expected_checkout_count
+        or len(runtime_checkout) != 1
+        or (
+            is_manual_deploy
+            and (
+                workflow_control_with.get('ref') != '${{ github.sha }}'
+                or workflow_control_with.get('path') != '.workflow-source'
+            )
+        )
     ):
         errors.append(
             ValidationError(scope, 'backend deploy checkout must remain bound to the readiness-approved commit')

--- a/backend/scripts/verify_backend_release_vector.py
+++ b/backend/scripts/verify_backend_release_vector.py
@@ -460,7 +460,7 @@ def main() -> int:
     parser.add_argument(
         '--cloud-run-only',
         action='store_true',
-        help='verify only the no-traffic Cloud Run candidate before GKE serving mutations',
+        help='verify only Cloud Run; candidate mode accepts no traffic and serving mode requires 100% traffic',
     )
     parser.add_argument('--evidence-path', type=Path)
     args = parser.parse_args()
@@ -475,8 +475,6 @@ def main() -> int:
             environment=args.environment,
             expected_image=args.expected_image,
         )
-        if args.cloud_run_only and not args.candidate:
-            raise ValueError('--cloud-run-only is valid only for a no-traffic candidate')
         commands = build_read_only_commands(
             expectation,
             include_listener=not args.cloud_run_only,

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -472,6 +472,29 @@ def test_automatic_firestore_readiness_contract_requires_readiness_admitted_sha_
     )
 
 
+def test_manual_firestore_readiness_contract_allows_one_staged_workflow_control_checkout():
+    validator = load_validator()
+    workflow_path = ROOT.parent / '.github/workflows/gcp_backend.yml'
+    workflow = validator._load_yaml(workflow_path)
+
+    assert validator._validate_firestore_readiness_workflow_contract(str(workflow_path), workflow) == []
+
+    workflow['jobs']['deploy']['steps'] = [
+        step
+        for step in workflow['jobs']['deploy']['steps']
+        if step.get('name') != 'Checkout workflow-owned deploy-control source'
+    ]
+    errors = validator._validate_firestore_readiness_workflow_contract(str(workflow_path), workflow)
+
+    assert (
+        validator.ValidationError(
+            f'cloud_run_workflow/{workflow_path}',
+            'backend deploy checkout must remain bound to the readiness-approved commit',
+        )
+        in errors
+    )
+
+
 @pytest.mark.parametrize('workflow_name', ['gcp_backend.yml', 'gcp_backend_auto_dev.yml'])
 def test_firestore_readiness_contract_requires_validation_before_artifact_upload(workflow_name):
     validator = load_validator()

--- a/backend/tests/unit/test_verify_backend_release_vector.py
+++ b/backend/tests/unit/test_verify_backend_release_vector.py
@@ -360,7 +360,7 @@ def test_prod_deploy_invokes_legacy_binding_migration_before_deploy() -> None:
     workflow = BACKEND_DIR.parent / '.github/workflows/gcp_backend.yml'
     text = workflow.read_text(encoding='utf-8')
 
-    assert 'backend/scripts/preflight-cloud-run-deploy.py' in text
+    assert 'preflight-cloud-run-deploy.py' in text
     assert text.count('--migrate-legacy-public-binding') == 4
     for service in ('backend', 'backend-sync', 'backend-sync-backfill', 'backend-integration'):
         assert f'--migrate-legacy-public-binding {service}' in text
@@ -504,7 +504,7 @@ def test_static_release_vector_verify_binds_the_workflow_short_sha() -> None:
         text = workflow.read_text(encoding='utf-8')
         assert 'verify_backend_release_vector.py' in text, f'{workflow.name} must invoke the release-vector verifier'
         # Count verify invocations and the --short-sha wiring; require a 1:1 match.
-        invocations = text.count('verify_backend_release_vector.py \\\n')
+        invocations = text.count('verify_backend_release_vector.py')
         wired = text.count('--short-sha "${{ steps.image-tag.outputs.short_sha }}"')
         assert invocations == wired, (
             f'{workflow.name}: {invocations} release-vector verify call(s) but '
@@ -857,6 +857,93 @@ def test_candidate_cloud_run_only_verification_does_not_require_listener_mutatio
     assert 'gke_listener' not in report
 
 
+def test_candidate_verification_accepts_a_ready_retired_zero_traffic_revision() -> None:
+    expectation = _expectation()
+    documents = _documents(expectation)
+    for service in expectation.revisions:
+        documents[f'cloud_run/{service}']['status']['traffic'] = [
+            {'revisionName': f'{service}-serving', 'percent': 100},
+            {'revisionName': expectation.revisions[service], 'percent': 0},
+        ]
+        documents[f'cloud_run_revision/{service}']['status']['conditions'][0]['reason'] = 'Retired'
+
+    cloud_run_only = {key: value for key, value in documents.items() if key.startswith('cloud_run')}
+
+    assert (
+        verifier.evaluate(
+            expectation,
+            cloud_run_only,
+            require_serving_traffic=False,
+            include_listener=False,
+        )
+        == []
+    )
+
+
+def test_serving_cloud_run_only_verification_is_allowed_and_requires_exact_traffic(monkeypatch) -> None:
+    expectation = _expectation()
+    documents = _documents(expectation)
+    monkeypatch.setattr(verifier, 'collect_documents', lambda _commands: documents)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'verify_backend_release_vector.py',
+            '--commit-sha',
+            expectation.commit_sha,
+            '--deploy-run-id',
+            expectation.deploy_run_id,
+            '--deploy-run-attempt',
+            expectation.deploy_run_attempt,
+            '--project',
+            expectation.project,
+            '--environment',
+            expectation.environment,
+            '--cloud-run-only',
+        ],
+    )
+
+    assert verifier.main() == 0
+
+    documents['cloud_run/backend']['status']['traffic'] = [{'revisionName': 'backend-old', 'percent': 100}]
+    assert verifier.evaluate(expectation, documents, include_listener=False) == [
+        'cloud_run/backend: expected revision does not receive 100% traffic'
+    ]
+
+
+def test_deploy_stages_workflow_owned_control_scripts_before_release_checkout() -> None:
+    workflow = (BACKEND_DIR.parent / '.github/workflows/gcp_backend.yml').read_text(encoding='utf-8')
+    deploy = workflow.split('\n  deploy:\n', 1)[1]
+
+    control_checkout = 'Checkout workflow-owned deploy-control source'
+    staging = 'Stage workflow-owned deployment-control scripts'
+    release_checkout = 'Checkout admitted runtime source'
+    assert control_checkout in deploy
+    assert staging in deploy
+    assert release_checkout in deploy
+    assert deploy.index(control_checkout) < deploy.index(staging) < deploy.index(release_checkout)
+    checkout_step = deploy[
+        deploy.index(control_checkout) : deploy.index('\n      - name:', deploy.index(control_checkout) + 1)
+    ]
+    stage_step = deploy[deploy.index(staging) : deploy.index('\n      - name:', deploy.index(staging) + 1)]
+    assert 'ref: ${{ github.sha }}' in checkout_step
+    assert 'control_scripts="$RUNNER_TEMP/backend-deploy-control-scripts"' in stage_step
+    assert 'cp -a .workflow-source/backend/scripts "$control_scripts"' in stage_step
+    assert 'DEPLOY_CONTROL_SCRIPTS=%s' in stage_step
+    assert '>> "$GITHUB_ENV"' in stage_step
+    assert 'python3 backend/scripts/' not in deploy
+    assert 'bash backend/scripts/' not in deploy
+    assert 'run: backend/scripts/' not in deploy
+
+    for action in (
+        BACKEND_DIR.parent / '.github/actions/sync-backfill-lifecycle/action.yml',
+        BACKEND_DIR.parent / '.github/actions/transcription-release-candidate-probe/action.yml',
+    ):
+        action_text = action.read_text(encoding='utf-8')
+        assert 'DEPLOY_CONTROL_SCRIPTS' in action_text
+        assert 'python3 backend/scripts/' not in action_text
+
+
 def test_candidate_failure_status_report_uses_candidate_evidence_before_promotion() -> None:
     workflow = (BACKEND_DIR.parent / '.github/workflows/gcp_backend.yml').read_text(encoding='utf-8')
     candidate = workflow[
@@ -886,7 +973,7 @@ def test_full_backend_deploys_verify_the_serving_release_vector_after_promotion(
         verification = text.index('Verify serving backend release vector')
         assert promotion < verification
         release_vector_step = text[verification : text.index('\n      - name:', verification + 1)]
-        assert 'backend/scripts/verify_backend_release_vector.py' in release_vector_step
+        assert 'verify_backend_release_vector.py' in release_vector_step
         assert commit_marker in release_vector_step
         assert '--environment' in release_vector_step
 
@@ -924,7 +1011,8 @@ def test_backend_promotions_are_phase_aware_and_restore_the_recorded_traffic_sna
         assert candidate_acceptance < snapshot < promotion < serving_vector < restore, relative
 
         snapshot_step = text[snapshot : text.index('\n      - name:', snapshot + 1)]
-        assert 'backend/scripts/cloud_run_traffic_snapshot.py capture' in snapshot_step
+        assert 'cloud_run_traffic_snapshot.py' in snapshot_step
+        assert ' capture' in snapshot_step
         for service in ('backend', 'backend-sync', 'backend-sync-backfill', 'backend-integration'):
             assert f'--service {service}' in snapshot_step
 
@@ -944,7 +1032,8 @@ def test_backend_promotions_are_phase_aware_and_restore_the_recorded_traffic_sna
                 "|| steps.smoke-promoted-production-serving-api.outcome == 'failure') }}"
             )
         assert expected_restore_condition in restore_step
-        assert 'backend/scripts/cloud_run_traffic_snapshot.py restore' in restore_step
+        assert 'cloud_run_traffic_snapshot.py' in restore_step
+        assert ' restore' in restore_step
 
         evidence_upload = text[text.index('Upload ') :]
         assert 'cloud-run-pre-promotion-traffic-snapshot.json' in evidence_upload
@@ -976,6 +1065,8 @@ def test_production_cloud_run_only_boundary_smokes_serving_after_promotion():
     assert 'https://api.omi.me/v2/desktop/beta/candidates/reserve' in workflow
     assert '--candidate-api-url https://api.omi.me' in workflow
     assert 'firebase-production-serving-token' in workflow
+    assert '--data \'{"tag":"macos-unauthenticated-smoke"}\'' in workflow
+    assert "--data '{}')" not in workflow
     assert "steps.smoke-promoted-production-serving-api.outcome == 'failure'" in workflow
     assert 'CLOUD_RUN_ONLY="--cloud-run-only"' in workflow
     assert 'probe-transcription-candidate-from-cloud-run.sh' not in workflow


### PR DESCRIPTION
Closes SCA-29

## Summary

- Fix the failure class where the workflow YAML revision and executed helper-script revision diverged: stage deployment-control scripts from the exact workflow SHA before checking out the admitted runtime release SHA.
- Keep application source, Docker context, runtime configuration, and image identity pinned to the admitted release SHA; route direct workflow and local-action control scripts through the staged source.
- Allow Cloud Run-only release-vector verification in both no-traffic candidate and post-promotion serving modes, preserving Ready/Retired candidate and strict 100% serving checks.
- Make the production reservation smoke send a schema-valid inert tag without authorization, so it reaches and proves the expected 401 authorization wall without reserving a real candidate.

## Validation

- RED: `cd backend && pytest -q tests/unit/test_verify_backend_release_vector.py -k 'candidate_verification_accepts or serving_cloud_run_only_verification_is_allowed or deploy_stages_workflow_owned'` → 2 failed as expected: serving `--cloud-run-only` was rejected and deploy-control staging was absent.
- GREEN: `cd backend && pytest -q tests/unit/test_verify_backend_release_vector.py` → `42 passed`.
- YAML parse: `python3` with `yaml.safe_load` over the workflow and changed composite actions → `YAML parse: ok`.
- Required PR preflight: `make preflight`.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

