### PR TITLE
SCA-30: use schema-valid production reservation smoke tag

### DIFF
--- a/.github/scripts/check-gcp-backend-production-boundary.py
+++ b/.github/scripts/check-gcp-backend-production-boundary.py
@@ -43,7 +43,7 @@ def validate(root: Path) -> list[str]:
             errors.append("production serving smoke must follow exact serving release-vector verification")
     for required in (
         "https://api.omi.me/v2/desktop/beta/candidates/reserve",
-        '--data \'{"tag":"macos-unauthenticated-smoke"}\'',
+        '--data \'{"tag":"v0.0.0+1-macos"}\'',
         "schema-valid inert tag reaches the authorization wall",
         "--candidate-api-url https://api.omi.me",
         "umask 077",

--- a/.github/scripts/test_check_gcp_backend_production_boundary.py
+++ b/.github/scripts/test_check_gcp_backend_production_boundary.py
@@ -3,12 +3,20 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 from pathlib import Path
+import re
+import sys
 import tempfile
 import unittest
 
+from fastapi import HTTPException
+
 ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend"))
+from routers.updates import QualifiedBetaPromotionRequest, reserve_beta_candidate_endpoint
+
 MODULE_PATH = ROOT / ".github/scripts/check-gcp-backend-production-boundary.py"
 SPEC = importlib.util.spec_from_file_location("check_gcp_backend_production_boundary", MODULE_PATH)
 assert SPEC and SPEC.loader
@@ -19,6 +27,16 @@ SPEC.loader.exec_module(CHECKER)
 class GcpBackendProductionBoundaryTests(unittest.TestCase):
     def test_current_workflow_preserves_the_rollback_first_cloud_run_only_boundary(self) -> None:
         self.assertEqual(CHECKER.validate(ROOT), [])
+
+    def test_production_reservation_smoke_uses_a_schema_valid_inert_tag(self) -> None:
+        workflow = (ROOT / ".github/workflows/gcp_backend.yml").read_text(encoding="utf-8")
+        smoke = workflow[workflow.index(CHECKER.PROD_SMOKE) :]
+        match = re.search(r'''--data '\{"tag":"(?P<tag>[^"]+)"\}'\)''', smoke)
+        self.assertIsNotNone(match, "production reservation smoke must send an exact tag body")
+        request = QualifiedBetaPromotionRequest(tag=match.group("tag"))
+        with self.assertRaises(HTTPException) as denied:
+            asyncio.run(reserve_beta_candidate_endpoint(request, authorization=None))
+        self.assertEqual(denied.exception.status_code, 401)
 
     def test_rejects_production_boundary_regressions(self) -> None:
         original = (ROOT / ".github/workflows/gcp_backend.yml").read_text(encoding="utf-8")
@@ -32,7 +50,7 @@ class GcpBackendProductionBoundaryTests(unittest.TestCase):
                 "unexpected response",
             ),
             "uses_invalid_empty_reservation_body": (
-                '--data \'{"tag":"macos-unauthenticated-smoke"}\'',
+                '--data \'{"tag":"v0.0.0+1-macos"}\'',
                 "--data '{}')",
             ),
             "omits_smoke_rollback": (CHECKER.ROLLBACK_CONDITION, "false"),

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -897,7 +897,7 @@ jobs:
             --token-output "$token_file"
           reservation_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
             --request POST https://api.omi.me/v2/desktop/beta/candidates/reserve \
-            --header 'Content-Type: application/json' --data '{"tag":"macos-unauthenticated-smoke"}')"
+            --header 'Content-Type: application/json' --data '{"tag":"v0.0.0+1-macos"}')"
           # A schema-valid inert tag reaches the authorization wall without reserving a real candidate.
           test "$reservation_status" = 401
           python3 "$DEPLOY_CONTROL_SCRIPTS/transcription_capability_probe.py" \

--- a/backend/tests/unit/test_verify_backend_release_vector.py
+++ b/backend/tests/unit/test_verify_backend_release_vector.py
@@ -1065,7 +1065,7 @@ def test_production_cloud_run_only_boundary_smokes_serving_after_promotion():
     assert 'https://api.omi.me/v2/desktop/beta/candidates/reserve' in workflow
     assert '--candidate-api-url https://api.omi.me' in workflow
     assert 'firebase-production-serving-token' in workflow
-    assert '--data \'{"tag":"macos-unauthenticated-smoke"}\'' in workflow
+    assert '--data \'{"tag":"v0.0.0+1-macos"}\'' in workflow
     assert "--data '{}')" not in workflow
     assert "steps.smoke-promoted-production-serving-api.outcome == 'failure'" in workflow
     assert 'CLOUD_RUN_ONLY="--cloud-run-only"' in workflow


### PR DESCRIPTION
## Summary

- Replace the production unauthenticated reservation smoke tag with `v0.0.0+1-macos`.
- Validate the exact workflow body through `QualifiedBetaPromotionRequest` and prove the unauthenticated route returns 401.

## Verification

- RED: `python3 .github/scripts/test_check_gcp_backend_production_boundary.py` failed against `macos-unauthenticated-smoke` with Pydantic `string_pattern_mismatch`.
- GREEN: `python3 .github/scripts/check-gcp-backend-production-boundary.py`
- GREEN: `python3 .github/scripts/test_check_gcp_backend_production_boundary.py`
- GREEN: `backend/.venv/bin/python -m pytest backend/tests/unit/test_verify_backend_release_vector.py -q` (42 passed)
- GREEN: `make preflight`

Closes SCA-30


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

