### PR TITLE
SCA-33: split workflow and runtime validation roots

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-other.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-other.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "backend/scripts/validate-backend-runtime-env.py": 1843
+    "backend/scripts/validate-backend-runtime-env.py": 1859
   },
   "raise_justifications": {
-    "backend/scripts/validate-backend-runtime-env.py": "Serving STT retirement, shared forbidden-env validation, and the SCA-29 admitted-runtime/workflow-control source boundary remain one authoritative deployment contract."
+    "backend/scripts/validate-backend-runtime-env.py": "Serving STT retirement, shared forbidden-env validation, and SCA-29/SCA-33 runtime-versus-workflow source boundaries remain one authoritative deployment contract."
   },
   "threshold": 1500
 }

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -351,11 +351,15 @@ jobs:
           ref: ${{ github.sha }}
           path: .workflow-source
 
-      - name: Stage workflow-owned deployment-control scripts
+      - name: Stage immutable workflow validation source and deploy-control scripts
         run: |
           set -euo pipefail
+          workflow_source="$RUNNER_TEMP/backend-deploy-workflow-source"
           control_scripts="$RUNNER_TEMP/backend-deploy-control-scripts"
+          rm -rf "$workflow_source"
           rm -rf "$control_scripts"
+          mkdir -p "$workflow_source"
+          cp -a .workflow-source/.github "$workflow_source/.github"
           cp -a .workflow-source/backend/scripts "$control_scripts"
           rm -rf .workflow-source
 
@@ -364,15 +368,21 @@ jobs:
         with:
           ref: ${{ needs.firestore_readiness.outputs.admitted_sha }}
 
-      - name: Install workflow-owned deployment-control scripts in admitted workspace
+      - name: Install immutable workflow validation source and deploy-control scripts
         run: |
           set -euo pipefail
+          workflow_root="$GITHUB_WORKSPACE/.deploy-workflow-source"
           control_scripts="$GITHUB_WORKSPACE/.deploy-control/scripts"
+          rm -rf "$workflow_root"
           rm -rf "$GITHUB_WORKSPACE/.deploy-control"
+          mkdir -p "$workflow_root"
           mkdir -p "$(dirname "$control_scripts")"
+          cp -a "$RUNNER_TEMP/backend-deploy-workflow-source/.github" "$workflow_root/.github"
           cp -a "$RUNNER_TEMP/backend-deploy-control-scripts" "$control_scripts"
+          rm -rf "$RUNNER_TEMP/backend-deploy-workflow-source"
           rm -rf "$RUNNER_TEMP/backend-deploy-control-scripts"
           printf 'DEPLOY_CONTROL_SCRIPTS=%s\n' "$control_scripts" >> "$GITHUB_ENV"
+          printf 'DEPLOY_WORKFLOW_ROOT=%s\n' "$workflow_root" >> "$GITHUB_ENV"
 
       - name: Google Auth
         id: auth
@@ -483,7 +493,7 @@ jobs:
         env:
           SYNC_LEDGER_FENCE_MODE: ${{ vars.SYNC_LEDGER_FENCE_MODE || 'legacy' }}
         run: |
-          python3 "$DEPLOY_CONTROL_SCRIPTS/validate-backend-runtime-env.py" --env ${{ vars.ENV }} --check-workflows --check-rendered-cloud-run
+          python3 "$DEPLOY_CONTROL_SCRIPTS/validate-backend-runtime-env.py" --env ${{ vars.ENV }} --check-workflows --workflow-root "$DEPLOY_WORKFLOW_ROOT" --check-rendered-cloud-run
 
       - name: Build runtime image
         uses: docker/build-push-action@v7
@@ -695,7 +705,7 @@ jobs:
         env:
           SYNC_LEDGER_FENCE_MODE: ${{ vars.SYNC_LEDGER_FENCE_MODE || 'legacy' }}
         run: |
-          python3 "$DEPLOY_CONTROL_SCRIPTS/validate-backend-runtime-env.py" --env ${{ vars.ENV }} --check-workflows --check-live-cloud-run
+          python3 "$DEPLOY_CONTROL_SCRIPTS/validate-backend-runtime-env.py" --env ${{ vars.ENV }} --check-workflows --workflow-root "$DEPLOY_WORKFLOW_ROOT" --check-live-cloud-run
 
       # Development probes the no-traffic tagged revision directly from the
       # runner. Production has no tagged candidate URL or private probe job.

--- a/backend/scripts/validate-backend-runtime-env.py
+++ b/backend/scripts/validate-backend-runtime-env.py
@@ -87,6 +87,11 @@ def main() -> int:
         help='Validate checked-in Cloud Run workflow env_vars blocks against the manifest.',
     )
     parser.add_argument(
+        '--workflow-root',
+        type=Path,
+        help='Immutable source root for workflow YAML and local composite actions; defaults to the runtime root.',
+    )
+    parser.add_argument(
         '--check-rendered-cloud-run',
         action='store_true',
         help='Validate manifest Cloud Run env/secrets against an offline rendered revision shape.',
@@ -105,6 +110,7 @@ def main() -> int:
         check_live_cloud_run=args.check_live_cloud_run,
         check_rendered_cloud_run=args.check_rendered_cloud_run,
         check_workflows=args.check_workflows,
+        workflow_root=args.workflow_root,
         strict_provisional=args.strict_provisional,
     )
     for error in errors:
@@ -123,6 +129,7 @@ def validate_runtime_env(
     check_live_cloud_run: bool = False,
     check_rendered_cloud_run: bool = False,
     check_workflows: bool = False,
+    workflow_root: Path | None = None,
     strict_provisional: bool = False,
 ) -> list[ValidationError]:
     manifest = _load_yaml(manifest_path)
@@ -146,6 +153,7 @@ def validate_runtime_env(
                 strict_provisional=strict_provisional,
                 manifest_path=manifest_path,
                 manifest=manifest,
+                workflow_root=workflow_root,
             )
         )
 
@@ -806,6 +814,7 @@ def _validate_cloud_run_workflows(
     strict_provisional: bool,
     manifest_path: Path,
     manifest: ConfigDict | None = None,
+    workflow_root: Path | None = None,
 ) -> list[ValidationError]:
     errors: list[ValidationError] = []
     cloud_run = _as_config_dict(env_config.get('cloud_run')) or {}
@@ -818,14 +827,20 @@ def _validate_cloud_run_workflows(
     workflow_services: dict[str, ConfigDict] = {}
     workflow_jobs: dict[str, ConfigDict] = {}
     manifest = manifest if manifest is not None else _load_yaml(manifest_path)
+    workflow_root = workflow_root or ROOT
     for workflow_file in workflow_files:
         if not isinstance(workflow_file, str):
             errors.append(ValidationError('cloud_run/workflows', 'workflow file paths must be strings'))
             continue
-        workflow_path = ROOT / workflow_file
+        workflow_path = workflow_root / workflow_file
         workflow = _load_yaml(workflow_path)
         errors.extend(_validate_firestore_index_reconciliation_boundary(workflow_file, workflow))
-        extracted = _extract_workflow_cloud_run_targets(workflow, env=env, manifest=manifest)
+        extracted = _extract_workflow_cloud_run_targets(
+            workflow,
+            env=env,
+            manifest=manifest,
+            workflow_root=workflow_root,
+        )
         errors.extend(_validate_sync_backfill_co_deploy(workflow_file, extracted['services']))
         workflow_services.update(extracted['services'])
         workflow_jobs.update(extracted['jobs'])
@@ -1363,6 +1378,7 @@ def _extract_workflow_cloud_run_targets(
     *,
     env: str,
     manifest: ConfigDict,
+    workflow_root: Path,
 ) -> dict[str, dict[str, ConfigDict]]:
     workflow_env = _as_config_dict(workflow.get('env')) or {}
     rendered_runtime_env = _rendered_runtime_env_outputs(workflow, env=env, manifest=manifest)
@@ -1379,7 +1395,7 @@ def _extract_workflow_cloud_run_targets(
         if steps is None:
             continue
         for step in steps:
-            for deploy_step in _expand_cloud_run_deploy_steps(step):
+            for deploy_step in _expand_cloud_run_deploy_steps(step, workflow_root=workflow_root):
                 step_dict = _as_config_dict(deploy_step) or {}
                 step_with = _as_config_dict(step_dict.get('with')) or {}
                 env_vars = _parse_workflow_env_vars(
@@ -1421,7 +1437,7 @@ def _validate_sync_backfill_co_deploy(workflow_file: str, services: dict[str, Co
     ]
 
 
-def _expand_cloud_run_deploy_steps(step: object) -> list[ConfigDict]:
+def _expand_cloud_run_deploy_steps(step: object, *, workflow_root: Path) -> list[ConfigDict]:
     step_dict = _as_config_dict(step)
     if step_dict is None:
         return []
@@ -1430,7 +1446,7 @@ def _expand_cloud_run_deploy_steps(step: object) -> list[ConfigDict]:
     uses = step_dict.get('uses')
     if not isinstance(uses, str) or not uses.startswith('./'):
         return []
-    action = _load_local_composite_action(uses)
+    action = _load_local_composite_action(uses, workflow_root=workflow_root)
     if action is None:
         return []
     runs = _as_config_dict(action.get('runs')) or {}
@@ -1470,8 +1486,8 @@ def _composite_step_active_for_caller(nested_step: ConfigDict, caller_with: Conf
     return True
 
 
-def _load_local_composite_action(uses: str) -> ConfigDict | None:
-    action_dir = ROOT / uses[2:]
+def _load_local_composite_action(uses: str, *, workflow_root: Path) -> ConfigDict | None:
+    action_dir = workflow_root / uses[2:]
     for name in ('action.yml', 'action.yaml'):
         path = action_dir / name
         if path.is_file():

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -114,7 +114,7 @@ def with_cloud_run_oauth_secrets(payload: str) -> str:
     )
 
 
-def validate_cloud_run_workflows_only(validator, *, env: str, manifest_path: Path):
+def validate_cloud_run_workflows_only(validator, *, env: str, manifest_path: Path, workflow_root: Path | None = None):
     """Exercise a workflow fixture without unrelated full-manifest rollout contracts."""
     manifest = validator._load_yaml(manifest_path)
     return validator._validate_cloud_run_workflows(
@@ -123,6 +123,7 @@ def validate_cloud_run_workflows_only(validator, *, env: str, manifest_path: Pat
         strict_provisional=False,
         manifest_path=manifest_path,
         manifest=manifest,
+        workflow_root=workflow_root,
     )
 
 
@@ -303,6 +304,80 @@ def test_repo_prod_cloud_run_workflows_match_manifest(monkeypatch):
     )
 
     assert errors == []
+
+
+def test_workflow_validation_uses_immutable_workflow_root_with_admitted_runtime_manifest(tmp_path):
+    validator = load_validator()
+    workflow_path = ROOT.parent / '.github/workflows/gcp_backend.yml'
+    admitted_workflow = validator._load_yaml(workflow_path)
+    old_admitted_workflow = copy.deepcopy(admitted_workflow)
+    old_admitted_workflow['jobs']['deploy']['steps'] = [
+        step
+        for step in old_admitted_workflow['jobs']['deploy']['steps']
+        if step.get('name') != 'Checkout workflow-owned deploy-control source'
+    ]
+    assert validator.ValidationError(
+        f'cloud_run_workflow/{workflow_path}',
+        'backend deploy checkout must remain bound to the readiness-approved commit',
+    ) in validator._validate_firestore_readiness_workflow_contract(str(workflow_path), old_admitted_workflow)
+
+    workflow_root = tmp_path / 'workflow-source'
+    staged_workflow_path = workflow_root / '.github/workflows/deploy.yml'
+    staged_workflow_path.parent.mkdir(parents=True)
+    write_yaml(staged_workflow_path, {'jobs': {}})
+    manifest_path = tmp_path / 'admitted-runtime-env.yaml'
+    write_yaml(
+        manifest_path,
+        {
+            'schema_version': 1,
+            'environments': {
+                'dev': {
+                    'gcp_project': 'deployment-project',
+                    'runtime_gcp_project': 'serving-project',
+                    'region': 'us-central1',
+                    'gke': {},
+                    'cloud_run': {'workflow_files': ['.github/workflows/deploy.yml'], 'services': {}, 'jobs': {}},
+                }
+            },
+        },
+    )
+
+    assert (
+        validate_cloud_run_workflows_only(
+            validator, env='dev', manifest_path=manifest_path, workflow_root=workflow_root
+        )
+        == []
+    )
+
+
+def test_local_composite_actions_resolve_from_workflow_root(tmp_path):
+    validator = load_validator()
+    workflow_root = tmp_path / 'workflow-source'
+    action_path = workflow_root / '.github/actions/workflow-root-only/action.yml'
+    action_path.parent.mkdir(parents=True)
+    write_yaml(
+        action_path,
+        {
+            'runs': {
+                'using': 'composite',
+                'steps': [
+                    {
+                        'uses': 'google-github-actions/deploy-cloudrun@v2',
+                        'with': {'service': 'backend', 'env_vars': 'RUNTIME_SOURCE=admitted\n'},
+                    }
+                ],
+            }
+        },
+    )
+
+    assert validator._expand_cloud_run_deploy_steps(
+        {'uses': './.github/actions/workflow-root-only'}, workflow_root=workflow_root
+    ) == [
+        {
+            'uses': 'google-github-actions/deploy-cloudrun@v2',
+            'with': {'service': 'backend', 'env_vars': 'RUNTIME_SOURCE=admitted\n'},
+        }
+    ]
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -226,6 +226,7 @@ def test_gateway_vpc_probe_workflows_execute_the_production_parser(tmp_path):
             'GITHUB_RUN_ATTEMPT': '1',
             'GITHUB_RUN_ID': '42',
             'GITHUB_SHA': 'abcdef0123456789',
+            'DEPLOY_CONTROL_SCRIPTS': str(BACKEND_ROOT / 'scripts'),
             'PATH': f'{tmp_path}{os.pathsep}{os.environ["PATH"]}',
         }
 

--- a/backend/tests/unit/test_verify_backend_release_vector.py
+++ b/backend/tests/unit/test_verify_backend_release_vector.py
@@ -911,14 +911,14 @@ def test_serving_cloud_run_only_verification_is_allowed_and_requires_exact_traff
     ]
 
 
-def test_deploy_stages_workflow_owned_control_scripts_inside_admitted_workspace(tmp_path: Path) -> None:
+def test_deploy_stages_workflow_owned_control_and_validation_sources_inside_admitted_workspace(tmp_path: Path) -> None:
     workflow = (BACKEND_DIR.parent / '.github/workflows/gcp_backend.yml').read_text(encoding='utf-8')
     deploy = workflow.split('\n  deploy:\n', 1)[1]
 
     control_checkout = 'Checkout workflow-owned deploy-control source'
-    staging = 'Stage workflow-owned deployment-control scripts'
+    staging = 'Stage immutable workflow validation source and deploy-control scripts'
     release_checkout = 'Checkout admitted runtime source'
-    install = 'Install workflow-owned deployment-control scripts in admitted workspace'
+    install = 'Install immutable workflow validation source and deploy-control scripts'
     assert control_checkout in deploy
     assert staging in deploy
     assert release_checkout in deploy
@@ -932,11 +932,16 @@ def test_deploy_stages_workflow_owned_control_scripts_inside_admitted_workspace(
     stage_step = deploy[deploy.index(staging) : deploy.index('\n      - name:', deploy.index(staging) + 1)]
     install_step = deploy[deploy.index(install) : deploy.index('\n      - name:', deploy.index(install) + 1)]
     assert 'ref: ${{ github.sha }}' in checkout_step
+    assert 'workflow_source="$RUNNER_TEMP/backend-deploy-workflow-source"' in stage_step
+    assert 'cp -a .workflow-source/.github "$workflow_source/.github"' in stage_step
     assert 'control_scripts="$RUNNER_TEMP/backend-deploy-control-scripts"' in stage_step
     assert 'cp -a .workflow-source/backend/scripts "$control_scripts"' in stage_step
+    assert 'workflow_root="$GITHUB_WORKSPACE/.deploy-workflow-source"' in install_step
+    assert 'cp -a "$RUNNER_TEMP/backend-deploy-workflow-source/.github" "$workflow_root/.github"' in install_step
     assert 'control_scripts="$GITHUB_WORKSPACE/.deploy-control/scripts"' in install_step
     assert 'cp -a "$RUNNER_TEMP/backend-deploy-control-scripts" "$control_scripts"' in install_step
     assert 'DEPLOY_CONTROL_SCRIPTS=%s' in install_step
+    assert 'DEPLOY_WORKFLOW_ROOT=%s' in install_step
     assert '>> "$GITHUB_ENV"' in install_step
 
     workspace = tmp_path / 'workspace'
@@ -955,9 +960,25 @@ def test_deploy_stages_workflow_owned_control_scripts_inside_admitted_workspace(
     assert control_script.resolve().parents[2] == workspace
     assert (control_script.resolve().parents[2] / 'backend' / 'deploy' / 'runtime_env.yaml') == manifest
 
+    workflow_file = workspace / '.deploy-workflow-source' / '.github' / 'workflows' / 'gcp_backend.yml'
+    workflow_file.parent.mkdir(parents=True)
+    workflow_file.touch()
+    assert workflow_file.resolve().parents[3] == workspace
+    assert workflow_file.resolve().parents[3] / 'backend' / 'deploy' / 'runtime_env.yaml' == manifest
+
     dockerfile = (BACKEND_DIR / 'Dockerfile').read_text(encoding='utf-8')
     assert 'COPY backend/ .' in dockerfile
     assert '.deploy-control' not in dockerfile
+    assert '.deploy-workflow-source' not in dockerfile
+    validation_steps = [
+        deploy[deploy.index('Validate backend runtime env before deploy') : deploy.index('Build runtime image')],
+        deploy[
+            deploy.index('Validate backend runtime env after deploy') : deploy.index(
+                'Resolve transcription candidate URL'
+            )
+        ],
+    ]
+    assert all('--workflow-root "$DEPLOY_WORKFLOW_ROOT"' in step for step in validation_steps)
     assert 'python3 backend/scripts/' not in deploy
     assert 'bash backend/scripts/' not in deploy
     assert 'run: backend/scripts/' not in deploy


### PR DESCRIPTION
## Summary

- Stage the immutable workflow revision .github tree separately from the admitted runtime checkout.
- Validate workflow YAML and local composite actions from that staged root while retaining admitted runtime/config inputs.
- Cover old-workflow regression, local action resolution, source pinning, and the image boundary.

## Verification

- python3 -m pytest backend/tests/unit/test_backend_runtime_env_validator.py -q
- python3 -m pytest backend/tests/unit/test_verify_backend_release_vector.py -q
- python3 .github/scripts/test_check_backend_deploy_source_admission.py
- python3 .github/scripts/check_backend_deploy_source_admission.py
- make preflight
- pre-push gate

Failure-Class: FC-workflow-control-source-identity

Fixes SCA-33

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

