### PR TITLE
fix(listen): latch a clean STT upstream close and terminate the zombie session (#10028)

### DIFF
--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -69,6 +69,10 @@ from utils.listen_audio import ChannelConfig, mix_n_channel_buffers, resample_pc
 
 logger = logging.getLogger(__name__)
 
+# Cadence for the frame-independent provider-death monitor (#10028). Short enough
+# to terminate a zombie "Listening" session promptly, far below ws_receive_timeout.
+STT_DEATH_POLL_INTERVAL_SECONDS = 1.0
+
 
 def _get_opuslib() -> Any:
     if opuslib is None:
@@ -237,6 +241,7 @@ class ListenReceiver:
             self.stt_socket = (
                 GatedSTTSocket(raw, gate=self.vad_gate, passthrough_audio=passthrough) if self.vad_gate else raw
             )
+            self.host.spawn(self._monitor_stt_death(provider), name='stt_death_monitor')
             return True
         except Exception as error:
             await self._drain_stt_sockets()
@@ -248,6 +253,32 @@ class ListenReceiver:
                 platform=self.host.client_device_context.platform,
             )
             return False
+
+    async def _monitor_stt_death(self, provider: str) -> None:
+        """Terminate the client session promptly when the provider STT socket dies.
+
+        The receive loop only observes provider death while flushing a client
+        audio buffer (``_flush_stt_buffer`` → ``live_stt_socket_is_dead``), so a
+        clean upstream close with no further client audio could hold the mobile
+        socket in the "Listening" state until the 300s ``ws_receive_timeout``.
+        This frame-independent poll drives the same idempotent terminal path
+        (``stt_failed`` + WebSocket 1011) as soon as the death latch flips (#10028).
+        """
+        while self.host.state.active and not self.host.state.stt_terminal_failure:
+            socket = self.stt_socket
+            if socket is not None and live_stt_socket_is_dead(socket):
+                await terminate_live_stt_session(
+                    self.host.request.websocket,
+                    self.host.state,
+                    failure=live_stt_upstream_failure(provider),
+                    reason='connection_lost',
+                    platform=self.host.client_device_context.platform,
+                )
+                return
+            # Shutdown-aware sleep: wakes immediately on session shutdown, in
+            # which case normal teardown owns termination and we simply exit.
+            if await self.host.wait(STT_DEATH_POLL_INTERVAL_SECONDS):
+                return
 
     def _cleanup_expired_image_chunks(self) -> None:
         now = time.time()

--- a/backend/tests/unit/test_listen_stt_death_monitor.py
+++ b/backend/tests/unit/test_listen_stt_death_monitor.py
@@ -1,0 +1,65 @@
+"""Regression (#10028): the listen receiver proactively terminates a session when
+the provider STT socket dies, without waiting for another client audio frame.
+
+``_flush_stt_buffer`` only observes provider death while flushing a client audio
+buffer, so a clean upstream close with no further audio could hold the mobile
+socket "Listening" until the 300s ``ws_receive_timeout``. ``_monitor_stt_death``
+polls the death latch independently and drives the idempotent terminal path.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from routers.listen import receiver as receiver_mod
+from routers.listen.receiver import ListenReceiver
+
+
+@pytest.fixture
+def anyio_backend():
+    return 'asyncio'
+
+
+def _monitor_self(*, dead: bool):
+    """Duck-typed receiver exposing only what `_monitor_stt_death` touches."""
+    state = SimpleNamespace(active=True, stt_terminal_failure=False)
+
+    async def wait(_seconds):
+        # Return True so the shutdown-aware sleep ends the loop after one pass;
+        # the assertion then reflects a single poll, not an infinite spin.
+        return True
+
+    host = SimpleNamespace(
+        state=state,
+        request=SimpleNamespace(websocket=object()),
+        client_device_context=SimpleNamespace(platform='ios'),
+        wait=wait,
+    )
+    return SimpleNamespace(host=host, stt_socket=SimpleNamespace(is_connection_dead=dead))
+
+
+@pytest.mark.anyio
+async def test_monitor_terminates_when_provider_socket_dead():
+    monitor_self = _monitor_self(dead=True)
+    with patch.object(receiver_mod, 'terminate_live_stt_session', new=AsyncMock()) as terminate:
+        await ListenReceiver._monitor_stt_death(monitor_self, provider='parakeet')
+    terminate.assert_awaited_once()
+    assert terminate.await_args.kwargs['reason'] == 'connection_lost'
+
+
+@pytest.mark.anyio
+async def test_monitor_does_not_terminate_a_live_socket():
+    monitor_self = _monitor_self(dead=False)
+    with patch.object(receiver_mod, 'terminate_live_stt_session', new=AsyncMock()) as terminate:
+        await ListenReceiver._monitor_stt_death(monitor_self, provider='parakeet')
+    terminate.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_monitor_exits_without_terminating_once_already_terminal():
+    monitor_self = _monitor_self(dead=True)
+    monitor_self.host.state.stt_terminal_failure = True  # another path already terminalized
+    with patch.object(receiver_mod, 'terminate_live_stt_session', new=AsyncMock()) as terminate:
+        await ListenReceiver._monitor_stt_death(monitor_self, provider='parakeet')
+    terminate.assert_not_awaited()

--- a/backend/tests/unit/test_modulate_stt.py
+++ b/backend/tests/unit/test_modulate_stt.py
@@ -530,8 +530,12 @@ class TestRecvLoop(unittest.TestCase):
 
     def test_invalid_json_skipped(self):
         sock = self._run_recv(['not json', '{{bad'])
-        self.assertFalse(sock.is_connection_dead)
+        # Invalid frames are skipped (no segments, no crash). The socket is then
+        # latched dead only by the subsequent clean upstream close — not by the
+        # bad frames — which the clean-close death reason proves (#10028).
         self.assertEqual(self.segments, [])
+        self.assertTrue(sock.is_connection_dead)
+        self.assertIn('closed cleanly', sock.death_reason)
 
     def test_error_message_marks_dead(self):
         msg = json.dumps({'type': 'error', 'error': 'rate limit'})

--- a/backend/tests/unit/test_stt_clean_close_latch.py
+++ b/backend/tests/unit/test_stt_clean_close_latch.py
@@ -1,0 +1,103 @@
+"""Regression (#10028): a clean upstream close must latch the provider socket dead.
+
+When a Parakeet or Modulate live upstream WebSocket ends *cleanly* — the
+``async for`` over the socket exhausts without raising ``ConnectionClosed`` — the
+wrapper previously fell through with ``_dead`` still ``False``. ``live_stt_socket_is_dead``
+then read that stale ``False``, so the listen loop kept the mobile socket in a
+"Listening" zombie state (up to the 300s ``ws_receive_timeout``) instead of
+terminating via the ``stt_failed`` / WebSocket 1011 path.
+
+An explicit local drain (``_closed``) or an expected provider ``done`` frame is
+finalization, not death, and must NOT latch dead.
+"""
+
+import asyncio
+import json
+
+from utils.stt.streaming import ParakeetWebSocketSocket, SafeModulateSocket
+
+
+class _FakeUpstreamWS:
+    """Async-iterable stand-in for a provider WebSocket that yields `messages`
+    then closes cleanly (StopAsyncIteration) — exactly a graceful upstream close."""
+
+    def __init__(self, messages):
+        self._messages = list(messages)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._messages:
+            return self._messages.pop(0)
+        raise StopAsyncIteration
+
+    async def send(self, _data):
+        return None
+
+    async def close(self):
+        return None
+
+
+# --------------------------------------------------------------------------
+# Modulate
+# --------------------------------------------------------------------------
+
+
+def _run_modulate_recv(messages):
+    loop = asyncio.new_event_loop()
+
+    async def run():
+        ws = _FakeUpstreamWS(messages)
+        sock = SafeModulateSocket(ws, lambda _segments: None, loop, preseconds=0)
+        sock.set_wav_header(b'')
+        sock._send_task.cancel()
+        await asyncio.wait_for(sock._recv_task, timeout=2)
+        return sock
+
+    try:
+        return loop.run_until_complete(run())
+    finally:
+        loop.close()
+
+
+def test_modulate_clean_upstream_close_latches_dead():
+    sock = _run_modulate_recv([])  # provider closes without any terminal frame
+    assert sock.is_connection_dead is True
+
+
+def test_modulate_done_frame_is_not_death():
+    sock = _run_modulate_recv([json.dumps({'type': 'done', 'duration_ms': 100})])
+    assert sock.is_connection_dead is False
+
+
+# --------------------------------------------------------------------------
+# Parakeet
+# --------------------------------------------------------------------------
+
+
+def _run_parakeet_recv(messages, *, closed=False):
+    loop = asyncio.new_event_loop()
+
+    async def run():
+        sock = ParakeetWebSocketSocket(lambda _segments: None, ws_url='ws://unused', sample_rate=16000)
+        if closed:
+            sock._closed = True
+        await asyncio.wait_for(sock._receive_loop(_FakeUpstreamWS(messages)), timeout=2)
+        return sock
+
+    try:
+        return loop.run_until_complete(run())
+    finally:
+        loop.close()
+
+
+def test_parakeet_clean_upstream_close_latches_dead():
+    sock = _run_parakeet_recv([])  # provider closes cleanly mid-stream
+    assert sock.is_connection_dead is True
+
+
+def test_parakeet_local_drain_close_is_not_death():
+    # A local drain/finalization sets _closed before the loop ends; not a failure.
+    sock = _run_parakeet_recv([], closed=True)
+    assert sock.is_connection_dead is False

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -851,6 +851,14 @@ class SafeModulateSocket(STTSocket):
                 elif msg_type == 'utterance':
                     utt = msg.get('utterance', msg)
                     self._handle_utterance(utt)
+            # A clean async-for exhaustion means the provider closed the upstream
+            # WebSocket without raising. A local drain (self._closed) or an
+            # explicit provider 'done' (self._done_event) is expected
+            # finalization; any other clean close is unexpected provider death and
+            # must latch terminal so the listen loop propagates it without waiting
+            # for another client audio frame (#10028).
+            if not self._closed and not self._done_event.is_set():
+                self._mark_dead('modulate ws closed cleanly without terminal frame')
         except websockets.exceptions.ConnectionClosed as e:
             self._mark_dead(f'ws recv closed: {e}')
         except Exception as e:
@@ -1376,6 +1384,13 @@ class ParakeetWebSocketSocket(STTSocket):
                                 self._stream_transcript([seg])
                     except json.JSONDecodeError:
                         pass
+            # A clean async-for exhaustion means the provider closed the upstream
+            # WebSocket without raising. Unless this is a local drain/finalization
+            # (self._closed, set by drain_and_close and the _run finally), it is an
+            # unexpected clean provider close and must latch terminal so the listen
+            # loop propagates it without waiting for another client audio frame (#10028).
+            if not self._closed:
+                self._mark_dead('parakeet ws closed cleanly by provider')
         except Exception as e:
             if not self._closed:
                 logger.error(f"Parakeet WS recv error: {e}")


### PR DESCRIPTION
## What

Fixes #10028 — the "Listening" zombie when a live STT upstream dies cleanly.

When a Parakeet or Modulate live upstream WebSocket ends **cleanly** (the `async for` over the socket exhausts without raising `ConnectionClosed`), the wrapper fell through with `_dead` still `False`. `live_stt_socket_is_dead` then read that stale `False`. Since the listen loop only observes provider death while flushing a client audio buffer (`_flush_stt_buffer`), the mobile socket stayed `ready` ("Listening") until the next audio frame's provider send happened to fail — or, with no further audio, up to the **300s `ws_receive_timeout`**.

## Fix

1. **Latch the clean close** in both wrappers (`SafeModulateSocket._recv_loop`, `ParakeetWebSocketSocket._receive_loop`): a clean `async for` exhaustion now marks the socket dead, **excluding** an explicit local drain (`_closed`) or an expected provider `done` finalization — those are not failures.
2. **Propagate without a client frame**: a frame-independent `_monitor_stt_death` poll on the receiver drives the existing **idempotent** `stt_failed` + WebSocket 1011 terminal path (`terminate_live_stt_session`) as soon as the death latch flips. It sleeps via the shutdown-aware `host.wait`, so normal teardown still owns clean termination and the task can't outlive the session.

## Tests (hermetic)

- `test_stt_clean_close_latch.py` — both providers: a clean upstream close latches dead; a `done` frame / local drain does **not**.
- `test_listen_stt_death_monitor.py` — the monitor terminates a dead socket (reason `connection_lost`), leaves a live one alone, and no-ops once another path already terminalized.
- Updated `test_modulate_stt.py::test_invalid_json_skipped` for the new clean-close latch — it now asserts the death reason is the clean close (not the skipped bad frames), preserving the original "invalid JSON is non-fatal" intent.
- **121 passed** across the STT / listen suites.

## Scope note

Wrapper- and monitor-level coverage is hermetic and covers both new behaviors. A full `/v4/listen` route test driving a loopback provider peer (as the issue suggests) is a heavier integration harness and a reasonable follow-up.

## Product invariants affected

none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

