### PR TITLE
fix(ci): publish canonical lowercase desktop DMG

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -398,7 +398,7 @@ checks:
     reason: "#10163 mutation-sensitive Stable retry and default-channel feed fixtures"
   - id: desktop-release-one-path-contract
     command: ["python3", ".github/scripts/test_desktop_release_flow_contract.py"]
-    triggers: [".github/workflows/desktop_auto_release.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_beta.yml", ".github/workflows/desktop_recover_beta.yml", ".github/workflows/desktop_promote_prod.yml", ".github/workflows/gcp_backend.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", ".github/scripts/test_desktop_release_flow_contract.py", ".github/checks-manifest.yaml"]
+    triggers: ["codemagic.yaml", ".github/workflows/desktop_auto_release.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_beta.yml", ".github/workflows/desktop_recover_beta.yml", ".github/workflows/desktop_promote_prod.yml", ".github/workflows/gcp_backend.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", ".github/scripts/test_desktop_release_flow_contract.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-17 prevents duplicate desktop promotion authorities and requires post-traffic production release-vector verification"
 

--- a/.github/scripts/fixtures/codemagic_workflow_contract/v1.json
+++ b/.github/scripts/fixtures/codemagic_workflow_contract/v1.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
-  "codemagic_raw_sha256": "aada6da09e15bd7356d784ddb5f3be67cd17f17d0d84721b3de5c681cf7584ee",
-  "codemagic_semantic_sha256": "dd8a938be6ed34f9606191f92b96017096331e10c3f2cb3428989cdbd4713538",
+  "codemagic_raw_sha256": "e2da89eeb3e08e537ab8c38cba3dd5c5937dd86edc863285f058fd85b98dcb98",
+  "codemagic_semantic_sha256": "fd8b1bb76367c32089c1073a90df8e575edae01a1394d0469252672d1459998d",
   "omi-desktop-swift-preview": {
-    "semantic_sha256": "1e5e4ceb67a9fc784761030d7254eb2d91dc973270b793b4513d74e3ec3063ce"
+    "semantic_sha256": "e5ee696a29e3318962c5310212d332f9a2919a693b07919455c96f2f29664795"
   },
   "omi-desktop-swift-release": {
     "publication_script": "if [[ \"${PREVIEW_MODE:-false}\" == \"true\" ]]; then\n  echo \"External previews do not create GitHub releases.\"\n  exit 0\nfi\nset -euo pipefail\nCHANGELOG_MD=$(python3 ../../.github/scripts/desktop-changelog.py latest-release --format markdown || echo \"- Bug fixes and improvements\")\n\n# Build changelog as pipe-separated string for KEY_VALUE_START\nCHANGELOG_PIPE=$(echo \"$CHANGELOG_MD\" | sed 's/^- //' | tr '\\n' '|' | sed 's/|$//')\n\nRELEASE_NOTES=\"## OMI Desktop v${VERSION}\n\n### What's New\n${CHANGELOG_MD}\n\n### Downloads\n- **DMG Installer**: For fresh installs, download the DMG below\n- **Auto-Update**: Existing users will receive this update automatically via Sparkle\n\n<!-- KEY_VALUE_START\nisLive: false\nchannel: candidate\nedSignature: ${ED_SIGNATURE}\nchangelog: ${CHANGELOG_PIPE}\nKEY_VALUE_END -->\"\n\n# A candidate is the evidence container. Once published, preserve its\n# signed artifacts and every qualification observation; retries only\n# resume the dispatch handoff below.\nif gh release view \"$CM_TAG\" --repo \"$GITHUB_REPO\" >/dev/null 2>&1; then\n  echo \"GitHub release candidate already exists; preserving immutable evidence for $CM_TAG\"\nelse\n  # The backend reservation is the authoritative Beta fence. It runs\n  # only after package, signature, notarization, and signed smoke pass,\n  # immediately before this workflow creates the immutable candidate.\n  set -euo pipefail\n  test -n \"${BETA_PROMOTION_TOKEN:-}\" || {\n    echo \"ERROR: BETA_PROMOTION_TOKEN is required to reserve a canonical candidate\" >&2\n    exit 1\n  }\n  curl --fail-with-body --silent --show-error \\\n    --request POST \"${OMI_PYTHON_API_URL%/}/v2/desktop/beta/candidates/reserve\" \\\n    --header \"Authorization: Bearer ${BETA_PROMOTION_TOKEN}\" \\\n    --header 'Content-Type: application/json' \\\n    --data \"{\\\"tag\\\":\\\"${CM_TAG}\\\"}\"\n  gh release create \"$CM_TAG\" \\\n    --repo \"$GITHUB_REPO\" \\\n    --title \"Omi Desktop v${VERSION} (candidate)\" \\\n    --notes \"$RELEASE_NOTES\" \\\n    \"$SPARKLE_ZIP_PATH\" \\\n    \"$DMG_PATH\" \\\n    \"$BUILD_DIR/desktop-smoke-result.json\"\n  echo \"GitHub release candidate created: $CM_TAG\"\nfi\n",
     "publication_script_sha256": "a8dfe376273b076fab7164ad84e48a3fab759ff97f4979ec8658629c8c837b40",
-    "semantic_sha256": "06db30e0de2cbb1373ec66dd6180d2817cbb8afebccd99e09573cabcddf2bd42"
+    "semantic_sha256": "f8374ec86440562e1f38f471225d651255e7ad6b2b1565a00d242bb6960d62e1"
   }
 }

--- a/.github/scripts/test_check_gcp_backend_production_boundary.py
+++ b/.github/scripts/test_check_gcp_backend_production_boundary.py
@@ -3,19 +3,14 @@
 
 from __future__ import annotations
 
-import asyncio
 import importlib.util
 from pathlib import Path
 import re
-import sys
 import tempfile
 import unittest
 
-from fastapi import HTTPException
-
 ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT / "backend"))
-from routers.updates import QualifiedBetaPromotionRequest, reserve_beta_candidate_endpoint
+UPDATES_SOURCE = (ROOT / "backend/routers/updates.py").read_text(encoding="utf-8")
 
 MODULE_PATH = ROOT / ".github/scripts/check-gcp-backend-production-boundary.py"
 SPEC = importlib.util.spec_from_file_location("check_gcp_backend_production_boundary", MODULE_PATH)
@@ -32,11 +27,24 @@ class GcpBackendProductionBoundaryTests(unittest.TestCase):
         workflow = (ROOT / ".github/workflows/gcp_backend.yml").read_text(encoding="utf-8")
         smoke = workflow[workflow.index(CHECKER.PROD_SMOKE) :]
         match = re.search(r'''--data '\{"tag":"(?P<tag>[^"]+)"\}'\)''', smoke)
-        self.assertIsNotNone(match, "production reservation smoke must send an exact tag body")
-        request = QualifiedBetaPromotionRequest(tag=match.group("tag"))
-        with self.assertRaises(HTTPException) as denied:
-            asyncio.run(reserve_beta_candidate_endpoint(request, authorization=None))
-        self.assertEqual(denied.exception.status_code, 401)
+        if match is None:
+            self.fail("production reservation smoke must send an exact tag body")
+
+        schema = re.search(
+            r'class QualifiedBetaPromotionRequest\(BaseModel\):.*?tag: str = Field\(pattern=r"(?P<pattern>[^"]+)"\)',
+            UPDATES_SOURCE,
+            re.DOTALL,
+        )
+        if schema is None:
+            self.fail("qualified Beta tag schema must remain statically inspectable")
+        self.assertRegex(match.group("tag"), re.compile(schema.group("pattern")))
+
+        reserve = UPDATES_SOURCE[
+            UPDATES_SOURCE.index("async def reserve_beta_candidate_endpoint(") :
+            UPDATES_SOURCE.index('@router.put("/v2/desktop/beta/admission")')
+        ]
+        self.assertIn("if not _has_beta_promotion_authorization(authorization):", reserve)
+        self.assertIn('raise HTTPException(status_code=401, detail="Unauthorized")', reserve)
 
     def test_rejects_production_boundary_regressions(self) -> None:
         original = (ROOT / ".github/workflows/gcp_backend.yml").read_text(encoding="utf-8")

--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -15,7 +15,24 @@ def workflow(name: str) -> str:
     return (ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
 
 
+def codemagic() -> str:
+    return (ROOT / "codemagic.yaml").read_text(encoding="utf-8")
+
+
 class DesktopReleaseFlowContractTests(unittest.TestCase):
+    def test_canonical_release_and_qualification_use_lowercase_dmg_asset(self) -> None:
+        build_identity = codemagic().split("- name: Resolve trusted source and build identity", 1)[1]
+        build_identity = build_identity.split("- name: ", 1)[0]
+        preview_branch, canonical_branch = build_identity.split("          else\n", 1)
+        qualification = workflow("desktop_qualify_beta.yml")
+
+        self.assertIn('DMG_PATH="$BUILD_DIR/Omi-Preview.dmg"', preview_branch)
+        self.assertIn('DMG_PATH="$BUILD_DIR/omi.dmg"', canonical_branch)
+        self.assertNotIn('DMG_PATH="$BUILD_DIR/$APP_NAME.dmg"', canonical_branch)
+        self.assertIn("--pattern 'Omi.zip' --pattern 'omi.dmg'", qualification)
+        self.assertIn("STABLE_DMG=/tmp/desktop-beta-qualification/assets/omi.dmg", qualification)
+        self.assertIn('--asset "omi.dmg=$STABLE_DMG"', qualification)
+
     def test_has_one_automatic_candidate_to_beta_authority(self) -> None:
         candidate = workflow("desktop_auto_release.yml")
         qualification = workflow("desktop_qualify_beta.yml")

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1982,7 +1982,7 @@ workflows:
               exit 1
             fi
             URL_SCHEME="omi-computer"
-            DMG_PATH="$BUILD_DIR/$APP_NAME.dmg"
+            DMG_PATH="$BUILD_DIR/omi.dmg"
             SPARKLE_ZIP_PATH="$BUILD_DIR/Omi.zip"
           fi
           echo "VERSION=$VERSION" >> $CM_ENV


### PR DESCRIPTION
## Summary
- publish the canonical non-preview Codemagic desktop DMG as lowercase `omi.dmg`
- preserve `Omi.app`, `Omi.zip`, and preview `Omi-Preview.dmg` naming
- enforce exact case agreement between Codemagic publication and trusted macOS qualification in the existing desktop release-flow contract
- refresh the reviewed Codemagic workflow digests for this single approved change

## Urgency / scope
Emergency Beta-only release unblock: the cancelled `.98` candidate exposed that Codemagic would upload `Omi.dmg` while the trusted qualifier downloads only `omi.dmg`. This change does not tag, publish, promote, deploy, or alter Stable.

## Verification
- `python3 .github/scripts/test_desktop_release_flow_contract.py` — 5 tests passed
- `python3 .github/scripts/test_check_desktop_auto_beta_candidate.py` — passed
- `backend/.venv/bin/python -m pytest .github/scripts/test_check_release_process_guards.py -q` — 87 passed
- parsed `codemagic.yaml` with PyYAML — 10 workflows

## Failure-Class
Failure-Class: none

## Product invariants affected
- INV-AUTH-1
- INV-DATA-1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

