### PR TITLE
fix(release): align trusted qualification CLI contract

### DIFF
--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -4,6 +4,7 @@
 # omi-test-quality: source-inspection -- static contract: GitHub workflow authority is YAML-only.
 from __future__ import annotations
 
+import re
 import unittest
 from pathlib import Path
 
@@ -43,6 +44,31 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         self.assertIn("workflow_call:", beta)
         self.assertNotIn("workflow_dispatch:", beta)
         self.assertEqual(beta.count("/v2/desktop/beta/promote-qualified"), 1)
+
+    def test_beta_qualification_workflow_uses_supported_exact_cli(self) -> None:
+        qualification = workflow("desktop_qualify_beta.yml")
+        qualification_script = (ROOT / "desktop/macos/scripts/qualify-desktop-beta.sh").read_text(
+            encoding="utf-8"
+        )
+        qualify_step_name = "      - name: Qualify exact candidate on hermetic stack"
+        qualify_step = qualification.split(qualify_step_name, 1)[1]
+        qualify_step = qualify_step.split("\n      - name:", 1)[0]
+        invoked_options = tuple(
+            re.findall(r"^\s+(--[a-z0-9-]+)(?:\s+[^\\]+)? \\$", qualify_step, re.MULTILINE)
+        )
+        supported_options = set(re.findall(r"^    (--[a-z0-9-]+)\)$", qualification_script, re.MULTILINE))
+
+        self.assertEqual(
+            invoked_options,
+            (
+                "--automatic",
+                "--github-actions-artifact",
+                "--signed-smoke-result",
+                "--candidate-gate-result",
+            ),
+        )
+        self.assertTrue(set(invoked_options).issubset(supported_options))
+        self.assertNotIn("--no-promote", qualify_step)
 
     def test_stable_is_manual_and_uses_one_explicit_confirmation(self) -> None:
         stable = workflow("desktop_promote_prod.yml")

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -101,7 +101,6 @@ jobs:
           set -euo pipefail
           desktop/macos/scripts/qualify-desktop-beta.sh \
             --automatic \
-            --no-promote \
             --github-actions-artifact \
             --signed-smoke-result /tmp/desktop-beta-qualification/desktop-smoke-result.json \
             --candidate-gate-result /tmp/desktop-beta-qualification/candidate-gate.json \


### PR DESCRIPTION
## Summary

- remove the stale unsupported `--no-promote` argument from the trusted desktop Beta qualification workflow
- add a focused release-flow contract that locks the exact qualification invocation and verifies every workflow option is accepted by `qualify-desktop-beta.sh`
- keep evidence publication in the qualification workflow and downstream Beta promotion in the existing reusable workflow

Failure-Class: FC-workflow-script-input-contract

## Failure mechanism

The trusted qualification workflow invoked `qualify-desktop-beta.sh` with `--no-promote`, but that script's declared CLI rejects the option before qualification begins. The script already has no promotion authority when `--github-actions-artifact` is used; it qualifies the candidate and leaves evidence publication and the reusable promotion handoff to the workflow.

## Verification

- `python3 .github/scripts/test_desktop_release_flow_contract.py -v` — 6 passed
- `actionlint -shellcheck '' .github/workflows/desktop_qualify_beta.yml` — passed
- `make preflight` — 12 selected checks passed

## Safety

- Beta-only architecture is unchanged
- no candidate assets, tags, release metadata, admission state, or appcast pointers are modified
- Stable nomination and promotion remain untouched
- this PR does not build, release, deploy, qualify, promote, or enable admission


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

