### PR TITLE
fix(release): align release process guard contract

### DIFF
--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -805,7 +805,6 @@ def check_desktop_qualification_runner() -> list[str]:
         "docker info",
         "check-desktop-auto-beta-candidate.py",
         "--automatic",
-        "--no-promote",
         "desktop_promote_beta.yml",
         "actions/create-github-app-token@v3",
         "desktop-beta-qualification-${{ inputs.release_tag }}",


### PR DESCRIPTION
## Summary

- remove the stale `--no-promote` requirement from the broad release-process guard
- keep every other trusted desktop qualification guard unchanged
- restore contract coherence after #10269 removed the unsupported workflow argument

Failure-Class: FC-workflow-script-input-contract

## Failure mechanism

PR #10269 correctly removed the unsupported `--no-promote` workflow argument, but it was merged while its failing Hygiene run still showed `.github/scripts/check-release-process-guards.py` requiring that fragment. The broad guard therefore rejects the valid parser-supported invocation.

## Verification

- `python3 .github/scripts/check-release-process-guards.py` — passed
- `backend/.venv/bin/python -m pytest .github/scripts/test_check_release_process_guards.py -q` — 87 passed
- `python3 .github/scripts/test_desktop_release_flow_contract.py -v` — 6 passed
- `actionlint -shellcheck '' .github/workflows/desktop_qualify_beta.yml` — passed
- `make preflight` — 12 selected checks passed
- `scripts/failure-class validate --base origin/main --head HEAD --pr-body-file /tmp/omi-pr-10269-followup.md --format text` — passed
- `git diff --check origin/main...HEAD` — passed
- bounded pre-push gate — passed

## Safety

- Beta-only architecture is unchanged
- no candidate assets, tags, release metadata, admission state, or appcast pointers are modified
- Stable remains untouched
- this PR does not build, release, deploy, qualify, promote, or enable admission


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

