### PR TITLE
fix(sync): isolate fenced merged-conversation reprocessing

### DIFF
--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -1514,6 +1514,34 @@ class TestAsyncCoordinatorBehavioral:
         finally:
             self._cleanup(stubs['saved_modules'])
 
+    def test_merged_reprocess_fence_isolated_to_its_conversation(self, fenced_worker_module):
+        """One replaced merge target must not supersede its sibling conversations."""
+        _module, stubs = fenced_worker_module
+        pipeline = stubs['pipeline']
+
+        class ConversationPersistenceFenced(RuntimeError):
+            pass
+
+        pipeline.SyncConversationPersistenceFenced = ConversationPersistenceFenced
+        pipeline.logger = MagicMock()
+        pipeline._reprocess_conversation_after_update = MagicMock(
+            side_effect=[ConversationPersistenceFenced('conversation replaced'), None]
+        )
+        response = {'_merged': {'replaced-conversation': 'en', 'current-conversation': 'fr'}}
+
+        pipeline._reprocess_merged_conversations('uid', response)
+
+        assert response == {}
+        assert pipeline._reprocess_conversation_after_update.call_args_list == [
+            unittest.mock.call('uid', 'replaced-conversation', 'en'),
+            unittest.mock.call('uid', 'current-conversation', 'fr'),
+        ]
+        pipeline.logger.info.assert_called_once_with(
+            'event=sync_conversation_reprocess outcome=fenced conversation_id=%s',
+            'replaced-conversation',
+        )
+        pipeline.logger.error.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_durable_completion_offloads_epoch_and_terminal_metric(self, fenced_worker_module):
         """Redis-backed fencing and telemetry never run on the async coordinator loop."""

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -1288,7 +1288,7 @@ def _reprocess_merged_conversations(uid: str, response: dict):
         try:
             _reprocess_conversation_after_update(uid, conversation_id, language)
         except SyncConversationPersistenceFenced:
-            raise
+            logger.info('event=sync_conversation_reprocess outcome=fenced conversation_id=%s', conversation_id)
         except Exception as e:
             logger.error(f'sync: failed to reprocess merged conversation {conversation_id}: {e}')
 


### PR DESCRIPTION
## Summary

- Isolate a lifecycle fence raised while reprocessing one merged offline-sync conversation.
- Continue reprocessing sibling conversations so a valid current sync job can complete rather than being turned into a stale-worker `superseded` outcome.
- Preserve the lifecycle fence: the fenced conversation emits no stale completion side effects and is not retried or recreated by this worker.

## Root cause and durable guard

`_reprocess_merged_conversations` runs after segment persistence. Before this change, a `SyncConversationPersistenceFenced` from one conversation escaped the whole merged-conversation loop. That made an otherwise-current sync job look like a stale worker and could prevent its unaffected sibling conversations from receiving their post-merge reprocessing.

The loop now treats that fence as scoped to the replaced/discarded conversation, emits a bounded event, and continues to siblings. A regression test exercises a fenced first conversation followed by a successfully reprocessed sibling.

## Verification

- `VIRTUAL_ENV="$PWD/backend/.venv" PATH="$VIRTUAL_ENV/bin:$PATH" BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-10234-focused-tests.txt bash backend/test.sh -- -k merged_reprocess_fence_isolated_to_its_conversation -vv` — 164 passed.
- Full preflight and PR metadata preflight: pending at PR creation time.

## Scope limits

- No stale-worker side effects, client retry protocol, scheduler, or unbounded data scan is introduced.
- Existing historical backfill continues through the `backend-sync-backfill` lane and retains #10235's `completed/superseded` finalization semantics.

Closes #10234

Failure-Class: FC-split-mutation-authority


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

