### PR TITLE
fix(conversations): stop the public shared endpoint leaking owner-internal fields

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -1118,7 +1118,14 @@ def get_shared_conversation_by_id(conversation_id: str):
     if not visibility or visibility == ConversationVisibility.private:
         raise HTTPException(status_code=404, detail="Conversation is private")
     conversation = deserialize_conversation(conversation)
+    # This endpoint is public and unauthenticated. Strip fields that are internal
+    # to the owner and never part of the shared transcript/summary the user chose
+    # to publish: precise geolocation, the server-side encryption tier, and
+    # external_data (which carries merge provenance — other conversation ids — and
+    # integration metadata).
     conversation.geolocation = None
+    conversation.data_protection_level = None
+    conversation.external_data = None
 
     # Fetch people data for speaker names
     person_ids = conversation.get_person_ids()

--- a/backend/tests/unit/test_shared_conversation_field_exposure.py
+++ b/backend/tests/unit/test_shared_conversation_field_exposure.py
@@ -1,0 +1,44 @@
+"""The public /v1/conversations/{id}/shared endpoint must not expose owner-internal fields.
+
+The endpoint returns a conversation to anyone with the link (no auth). It is
+meant to publish the transcript/summary the owner shared, not internal fields:
+precise geolocation (already stripped), the server-side encryption tier
+(`data_protection_level`), or `external_data` (merge provenance — other
+conversation ids — and integration metadata).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import routers.conversations as conv_router
+
+
+def test_shared_endpoint_strips_internal_fields_before_serialising():
+    conv = SimpleNamespace(
+        geolocation='here',
+        data_protection_level='enhanced',
+        external_data={'merge_metadata': {'source_ids': ['other-conv']}},
+    )
+    conv.get_person_ids = lambda: []
+
+    captured = {}
+
+    def fake_to_dict(c):
+        captured['geolocation'] = c.geolocation
+        captured['data_protection_level'] = c.data_protection_level
+        captured['external_data'] = c.external_data
+        return {'id': 'c1'}
+
+    with patch.object(conv_router.redis_db, 'get_conversation_uid', return_value='owner-uid'), patch.object(
+        conv_router, '_get_valid_conversation_by_id', return_value={'visibility': 'public'}
+    ), patch.object(conv_router, 'deserialize_conversation', return_value=conv), patch.object(
+        conv_router, 'conversation_to_dict', side_effect=fake_to_dict
+    ), patch.object(
+        conv_router.users_db, 'get_people_by_ids', return_value=[]
+    ):
+        conv_router.get_shared_conversation_by_id('c1')
+
+    # All three owner-internal fields must be cleared before serialization.
+    assert captured['geolocation'] is None
+    assert captured['data_protection_level'] is None
+    assert captured['external_data'] is None


### PR DESCRIPTION
## What

`GET /v1/conversations/{id}/shared` is **public and unauthenticated** — anyone with the link gets the response. It is meant to publish the transcript/summary the owner shared, but it returned the **full `Conversation` model** with only `geolocation` stripped, also exposing:

- **`data_protection_level`** — the owner's server-side encryption tier (internal).
- **`external_data`** — merge provenance (**other conversation ids** the owner merged) and integration metadata.

The endpoint already nulls `geolocation`, which shows the intent was a curated public view — the other internal fields were just missed.

## Fix

Strip `data_protection_level` and `external_data` alongside `geolocation` before serializing — same pattern, same spot. Scope is deliberately narrow: only the unambiguously-internal fields. The transcript, summary, structured data, people and audio the owner chose to publish are unchanged, so the response schema (and its generated clients) is unchanged.

## Tests (hermetic)

- `test_shared_conversation_field_exposure.py` — the endpoint clears `geolocation` / `data_protection_level` / `external_data` before serialization. **1 passed.**

## Product invariants affected

none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

