### PR TITLE
fix(sync): fence post-merge audio finalization

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -5,12 +5,12 @@
     "backend/utils/memory_ingestion/pipeline.py": 1711,
     "backend/utils/other/storage.py": 1584,
     "backend/utils/retrieval/tools/calendar_tools.py": 1513,
-    "backend/utils/sync/pipeline.py": 2466
+    "backend/utils/sync/pipeline.py": 2467
   },
   "raise_justifications": {
     "backend/utils/apps.py": "get_available_app_model_by_id: the set-preferred-app availability authority as a validated App model, so the summary path honors what the setter admitted instead of re-deciding with the installed slice (#10074).",
     "backend/utils/other/storage.py": "delete_app_logo now requires an exact app-logo bucket prefix (startswith) so a foreign URL embedding the prefix later cannot delete an unrelated object on this deletion path (David review on #9873).",
-    "backend/utils/sync/pipeline.py": "Plan-aware soft-cap evaluation and its default-tier fallback remain in a small helper beside Sync's idempotent fresh-speech metering rather than overgrowing the durable worker coordinator. A lifecycle-fenced deferred reprocess must durably tombstone its conversation before audio side effects; retry hydration must preserve that ownership boundary."
+    "backend/utils/sync/pipeline.py": "Plan-aware soft-cap evaluation and its default-tier fallback remain in a small helper beside Sync's idempotent fresh-speech metering rather than overgrowing the durable worker coordinator. A lifecycle-fenced deferred reprocess must durably tombstone its conversation before audio side effects; retry hydration must preserve that ownership boundary. Fenced IDs are now discarded from new_memories too, because a conversation created in an earlier segment can be merged into by a later segment."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -5,12 +5,12 @@
     "backend/utils/memory_ingestion/pipeline.py": 1711,
     "backend/utils/other/storage.py": 1584,
     "backend/utils/retrieval/tools/calendar_tools.py": 1513,
-    "backend/utils/sync/pipeline.py": 2389
+    "backend/utils/sync/pipeline.py": 2466
   },
   "raise_justifications": {
     "backend/utils/apps.py": "get_available_app_model_by_id: the set-preferred-app availability authority as a validated App model, so the summary path honors what the setter admitted instead of re-deciding with the installed slice (#10074).",
     "backend/utils/other/storage.py": "delete_app_logo now requires an exact app-logo bucket prefix (startswith) so a foreign URL embedding the prefix later cannot delete an unrelated object on this deletion path (David review on #9873).",
-    "backend/utils/sync/pipeline.py": "Plan-aware soft-cap evaluation and its default-tier fallback remain in a small helper beside Sync's idempotent fresh-speech metering rather than overgrowing the durable worker coordinator. The same coordinator owns lifecycle-fence detection and the run-token-fenced superseded finalizer that prevents stale WAL retries."
+    "backend/utils/sync/pipeline.py": "Plan-aware soft-cap evaluation and its default-tier fallback remain in a small helper beside Sync's idempotent fresh-speech metering rather than overgrowing the durable worker coordinator. A lifecycle-fenced deferred reprocess must durably tombstone its conversation before audio side effects; retry hydration must preserve that ownership boundary."
   },
   "threshold": 1500
 }

--- a/backend/testing/e2e/test_core_flow_expansion.py
+++ b/backend/testing/e2e/test_core_flow_expansion.py
@@ -221,7 +221,7 @@ def test_sync_v2_job_runs_pipeline_and_polls_completed_result(client, auth_heade
     monkeypatch.setattr(sync_pipeline, "retrieve_vad_segments", fake_retrieve_vad_segments)
     monkeypatch.setattr(sync_pipeline, "get_wav_duration", lambda path: 2.0)
     monkeypatch.setattr(sync_pipeline, "process_segment", fake_process_segment)
-    monkeypatch.setattr(sync_pipeline, "_reprocess_merged_conversations", lambda uid, response: None)
+    monkeypatch.setattr(sync_pipeline, "_reprocess_merged_conversations", lambda uid, response, on_fenced=None: None)
     monkeypatch.setattr(sync_pipeline, "build_person_embeddings_cache", lambda uid: {})
     monkeypatch.setattr(sync_router, "get_hard_restriction_status", lambda uid: (False, None))
     monkeypatch.setattr(sync_router, "has_transcription_credits", lambda uid: True)

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -1531,6 +1531,10 @@ class TestAsyncCoordinatorBehavioral:
         response = {
             '_merged': {'replaced-conversation': 'en', 'current-conversation': 'fr'},
             'updated_memories': {'replaced-conversation', 'current-conversation'},
+            # A conversation can appear in both new_memories (created in an
+            # earlier segment) and updated_memories (merged into by a later
+            # segment).  The fence must discard it from both.
+            'new_memories': {'replaced-conversation'},
         }
         checkpointed_fences = []
 
@@ -1548,6 +1552,7 @@ class TestAsyncCoordinatorBehavioral:
         assert response == {
             '_fenced_conversation_ids': {'replaced-conversation'},
             'updated_memories': {'current-conversation'},
+            'new_memories': set(),
         }
         assert checkpointed_fences == [{'fenced': {'replaced-conversation'}, 'updated': {'current-conversation'}}]
         assert pipeline._reprocess_conversation_after_update.call_args_list == [
@@ -2629,7 +2634,12 @@ class TestAsyncCoordinatorBehavioral:
             pipeline.users_db.get_data_protection_level = MagicMock(return_value=None)
             pipeline.build_person_embeddings_cache = MagicMock(return_value={})
             pipeline.get_sync_job = MagicMock(
-                return_value={'partial_result': {'updated_memories': ['fenced-conversation', 'current-conversation']}}
+                return_value={
+                    'partial_result': {
+                        'updated_memories': ['fenced-conversation', 'current-conversation'],
+                        'new_memories': ['fenced-conversation'],
+                    }
+                }
             )
             pipeline.get_sync_content_partial_result = MagicMock(
                 return_value={'fenced_conversation_ids': ['fenced-conversation']}
@@ -2658,6 +2668,7 @@ class TestAsyncCoordinatorBehavioral:
             finalized_response = pipeline._finalize_sync_audio_files.call_args.args[1]
             assert finalized_response['updated_memories'] == {'current-conversation'}
             assert 'fenced-conversation' not in finalized_response['updated_memories']
+            assert 'fenced-conversation' not in finalized_response['new_memories']
         finally:
             self._cleanup(stubs['saved_modules'])
 

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -1006,10 +1006,11 @@ class TestAsyncCoordinatorStructure:
         assert 'build_person_embeddings_cache' in _get_pipeline_async_function_body('_load_sync_segment_context')
 
     def test_no_thread_pool_slot_held_for_coordinator(self):
-        """Async coordinator must NOT use submit_with_context or hold a thread pool slot."""
+        """Async coordinator must not submit itself to a thread pool slot."""
         body = self._get_bg_func_body()
         assert 'submit_with_context' not in body, "Async coordinator must not use submit_with_context"
-        assert '.result(' not in body, "Async coordinator must not call future.result()"
+        assert body.count('.result(') == 1, "Only the sync-worker fence callback may synchronously await a future"
+        assert 'asyncio.run_coroutine_threadsafe(' in body
 
 
 # ---------------------------------------------------------------------------
@@ -1527,11 +1528,28 @@ class TestAsyncCoordinatorBehavioral:
         pipeline._reprocess_conversation_after_update = MagicMock(
             side_effect=[ConversationPersistenceFenced('conversation replaced'), None]
         )
-        response = {'_merged': {'replaced-conversation': 'en', 'current-conversation': 'fr'}}
+        response = {
+            '_merged': {'replaced-conversation': 'en', 'current-conversation': 'fr'},
+            'updated_memories': {'replaced-conversation', 'current-conversation'},
+        }
+        checkpointed_fences = []
 
-        pipeline._reprocess_merged_conversations('uid', response)
+        pipeline._reprocess_merged_conversations(
+            'uid',
+            response,
+            on_fenced=lambda: checkpointed_fences.append(
+                {
+                    'fenced': set(response['_fenced_conversation_ids']),
+                    'updated': set(response['updated_memories']),
+                }
+            ),
+        )
 
-        assert response == {}
+        assert response == {
+            '_fenced_conversation_ids': {'replaced-conversation'},
+            'updated_memories': {'current-conversation'},
+        }
+        assert checkpointed_fences == [{'fenced': {'replaced-conversation'}, 'updated': {'current-conversation'}}]
         assert pipeline._reprocess_conversation_after_update.call_args_list == [
             unittest.mock.call('uid', 'replaced-conversation', 'en'),
             unittest.mock.call('uid', 'current-conversation', 'fr'),
@@ -1541,6 +1559,20 @@ class TestAsyncCoordinatorBehavioral:
             'replaced-conversation',
         )
         pipeline.logger.error.assert_not_called()
+
+        audio_file = MagicMock()
+        audio_file.model_dump.return_value = {'path': 'current.opus'}
+        pipeline.conversations_db = MagicMock()
+        pipeline.conversations_db.create_audio_files_from_chunks.return_value = [audio_file]
+        pipeline.precache_conversation_audio = MagicMock()
+        pipeline.is_audio_merge_dispatch_enabled = MagicMock(return_value=False)
+
+        pipeline._finalize_sync_audio_files('uid', response)
+
+        pipeline.conversations_db.create_audio_files_from_chunks.assert_called_once_with('uid', 'current-conversation')
+        pipeline.conversations_db.update_conversation.assert_called_once_with(
+            'uid', 'current-conversation', {'audio_files': [{'path': 'current.opus'}]}
+        )
 
     @pytest.mark.asyncio
     async def test_durable_completion_offloads_epoch_and_terminal_metric(self, fenced_worker_module):
@@ -2579,6 +2611,183 @@ class TestAsyncCoordinatorBehavioral:
             assert result['failed_segments'] == 0
             assert result['total_segments'] == 1
         finally:
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_retry_hydration_excludes_durably_fenced_conversation_from_audio_finalization(self):
+        """A fence recorded before a retry cannot let its stale checkpoint finalize audio."""
+        module, stubs = self._load_sync_module()
+        try:
+            segment_path = '/tmp/seg_1700000001.wav'
+            pipeline = stubs['pipeline']
+            pipeline.decode_files_to_wav = MagicMock(return_value=['/tmp/w.wav'])
+            pipeline._cleanup_files = MagicMock()
+            pipeline.retrieve_vad_segments = lambda _path, paths, _errors: paths.add(segment_path)
+            pipeline.get_wav_duration = MagicMock(return_value=5.0)
+            pipeline.users_db.get_user_transcription_preferences = MagicMock(return_value={})
+            pipeline.users_db.get_user_private_cloud_sync_enabled = MagicMock(return_value=True)
+            pipeline.users_db.get_data_protection_level = MagicMock(return_value=None)
+            pipeline.build_person_embeddings_cache = MagicMock(return_value={})
+            pipeline.get_sync_job = MagicMock(
+                return_value={'partial_result': {'updated_memories': ['fenced-conversation', 'current-conversation']}}
+            )
+            pipeline.get_sync_content_partial_result = MagicMock(
+                return_value={'fenced_conversation_ids': ['fenced-conversation']}
+            )
+            pipeline.get_processed_sync_segment_ids = MagicMock(return_value={'segment-1'})
+            pipeline.compute_sync_segment_id = MagicMock(return_value='segment-1')
+            pipeline.process_segment = MagicMock()
+            pipeline._reprocess_merged_conversations = MagicMock()
+            pipeline._finalize_sync_audio_files = MagicMock()
+
+            await module._run_full_pipeline_background_async(
+                'job-retry-fenced',
+                'uid',
+                ['/tmp/f.opus'],
+                'omi',
+                False,
+                '/tmp/job-retry-fenced',
+                task_mode=True,
+                content_id='content-retry-fenced',
+                content_run_bound=True,
+                ledger_fence_active=False,
+            )
+
+            pipeline.process_segment.assert_not_called()
+            pipeline._finalize_sync_audio_files.assert_called_once()
+            finalized_response = pipeline._finalize_sync_audio_files.call_args.args[1]
+            assert finalized_response['updated_memories'] == {'current-conversation'}
+            assert 'fenced-conversation' not in finalized_response['updated_memories']
+        finally:
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_fence_checkpoint_handoffs_to_db_executor_before_audio_finalization(self):
+        """A sync-worker fence persists ledger then job state through the coordinator loop."""
+        module, stubs = self._load_sync_module()
+        sync_worker = ThreadPoolExecutor(max_workers=1)
+        try:
+            segment_path = '/tmp/seg_1700000001.wav'
+            pipeline = stubs['pipeline']
+            checkpoint_events = []
+            db_offload_calls = []
+            pipeline.decode_files_to_wav = MagicMock(return_value=['/tmp/w.wav'])
+            pipeline._cleanup_files = MagicMock()
+            pipeline.retrieve_vad_segments = lambda _path, paths, _errors: paths.add(segment_path)
+            pipeline.get_wav_duration = MagicMock(return_value=5.0)
+            pipeline.users_db.get_user_transcription_preferences = MagicMock(return_value={})
+            pipeline.users_db.get_user_private_cloud_sync_enabled = MagicMock(return_value=True)
+            pipeline.users_db.get_data_protection_level = MagicMock(return_value=None)
+            pipeline.build_person_embeddings_cache = MagicMock(return_value={})
+            pipeline.get_sync_job = MagicMock(return_value={'partial_result': {}})
+            pipeline.get_sync_content_partial_result = MagicMock(return_value={})
+            pipeline.get_processed_sync_segment_ids = MagicMock(return_value=set())
+            pipeline.compute_sync_segment_id = MagicMock(return_value='segment-1')
+            pipeline.process_segment = MagicMock(return_value=False)
+            pipeline.checkpoint_sync_content_partial_result = MagicMock(
+                side_effect=lambda *_args, **_kwargs: checkpoint_events.append('durable') or True
+            )
+
+            def _record_job_partial(*args):
+                if 'partial_result' in args[2]:
+                    checkpoint_events.append('job')
+
+            pipeline._update_sync_job_for_run = MagicMock(side_effect=_record_job_partial)
+
+            def _fence_in_sync_worker(_uid, response, on_fenced):
+                response['_fenced_conversation_ids'].add('fenced-conversation')
+                on_fenced()
+
+            pipeline._reprocess_merged_conversations = _fence_in_sync_worker
+            pipeline._finalize_sync_audio_files = MagicMock()
+
+            async def _threaded_run_blocking(executor, fn, *args, **kwargs):
+                if executor is pipeline.sync_executor:
+                    return await _production_run_blocking(sync_worker, fn, *args, **kwargs)
+                if executor is pipeline.db_executor and (
+                    fn is pipeline.checkpoint_sync_content_partial_result
+                    or (fn is pipeline._update_sync_job_for_run and 'partial_result' in args[2])
+                ):
+                    db_offload_calls.append(fn)
+                return fn(*args, **kwargs)
+
+            pipeline.run_blocking = _threaded_run_blocking
+
+            await module._run_full_pipeline_background_async(
+                'job-fence-checkpoint',
+                'uid',
+                ['/tmp/f.opus'],
+                'omi',
+                False,
+                '/tmp/job-fence-checkpoint',
+                task_mode=True,
+                content_id='content-fence-checkpoint',
+                content_run_bound=True,
+            )
+
+            assert db_offload_calls == [
+                pipeline.checkpoint_sync_content_partial_result,
+                pipeline._update_sync_job_for_run,
+            ]
+            assert checkpoint_events == ['durable', 'job']
+            pipeline._finalize_sync_audio_files.assert_called_once()
+        finally:
+            sync_worker.shutdown(wait=True)
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_fence_checkpoint_lease_loss_stops_audio_finalization(self):
+        """A durable fence checkpoint failure reaches the sync callback before side effects."""
+        module, stubs = self._load_sync_module()
+        sync_worker = ThreadPoolExecutor(max_workers=1)
+        try:
+            segment_path = '/tmp/seg_1700000001.wav'
+            pipeline = stubs['pipeline']
+            pipeline.decode_files_to_wav = MagicMock(return_value=['/tmp/w.wav'])
+            pipeline._cleanup_files = MagicMock()
+            pipeline.retrieve_vad_segments = lambda _path, paths, _errors: paths.add(segment_path)
+            pipeline.get_wav_duration = MagicMock(return_value=5.0)
+            pipeline.users_db.get_user_transcription_preferences = MagicMock(return_value={})
+            pipeline.users_db.get_user_private_cloud_sync_enabled = MagicMock(return_value=True)
+            pipeline.users_db.get_data_protection_level = MagicMock(return_value=None)
+            pipeline.build_person_embeddings_cache = MagicMock(return_value={})
+            pipeline.get_sync_job = MagicMock(return_value={'partial_result': {}})
+            pipeline.get_sync_content_partial_result = MagicMock(return_value={})
+            pipeline.get_processed_sync_segment_ids = MagicMock(return_value=set())
+            pipeline.compute_sync_segment_id = MagicMock(return_value='segment-1')
+            pipeline.process_segment = MagicMock(return_value=False)
+            pipeline.checkpoint_sync_content_partial_result = MagicMock(return_value=False)
+
+            def _fence_in_sync_worker(_uid, response, on_fenced):
+                response['_fenced_conversation_ids'].add('fenced-conversation')
+                on_fenced()
+
+            pipeline._reprocess_merged_conversations = _fence_in_sync_worker
+            pipeline._finalize_sync_audio_files = MagicMock()
+
+            async def _threaded_run_blocking(executor, fn, *args, **kwargs):
+                if executor is pipeline.sync_executor:
+                    return await _production_run_blocking(sync_worker, fn, *args, **kwargs)
+                return fn(*args, **kwargs)
+
+            pipeline.run_blocking = _threaded_run_blocking
+
+            with pytest.raises(pipeline.SyncJobRunLeaseLost):
+                await module._run_full_pipeline_background_async(
+                    'job-fence-lease-lost',
+                    'uid',
+                    ['/tmp/f.opus'],
+                    'omi',
+                    False,
+                    '/tmp/job-fence-lease-lost',
+                    task_mode=True,
+                    content_id='content-fence-lease-lost',
+                    content_run_bound=True,
+                )
+
+            pipeline._finalize_sync_audio_files.assert_not_called()
+        finally:
+            sync_worker.shutdown(wait=True)
             self._cleanup(stubs['saved_modules'])
 
     @pytest.mark.asyncio

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -1294,6 +1294,7 @@ def _reprocess_merged_conversations(uid: str, response: dict, on_fenced=None):
         except SyncConversationPersistenceFenced:
             response.setdefault(_RESPONSE_FENCED_CONVERSATION_IDS, set()).add(conversation_id)
             response.get('updated_memories', set()).discard(conversation_id)
+            response.get('new_memories', set()).discard(conversation_id)
             if on_fenced:
                 on_fenced()
             logger.info('event=sync_conversation_reprocess outcome=fenced conversation_id=%s', conversation_id)
@@ -2014,7 +2015,7 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
             fenced_conversation_ids = set(partial_result.get(_PARTIAL_RESULT_FENCED_CONVERSATION_IDS) or [])
             response = {
                 'updated_memories': set(partial_result.get('updated_memories') or []) - fenced_conversation_ids,
-                'new_memories': set(partial_result.get('new_memories') or []),
+                'new_memories': set(partial_result.get('new_memories') or []) - fenced_conversation_ids,
                 _RESPONSE_FENCED_CONVERSATION_IDS: fenced_conversation_ids,
             }
             segment_errors = []

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -3,7 +3,7 @@
 Extracted from routers/sync.py so the router stays thin and utils never imports routers.
 """
 
-# pyright: reportPrivateUsage=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUnnecessaryComparison=false, reportAssignmentType=false, reportIndexIssue=false, reportArgumentType=false
+# pyright: reportPrivateUsage=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUnusedImport=false, reportUnnecessaryComparison=false, reportAssignmentType=false, reportIndexIssue=false, reportArgumentType=false
 
 from __future__ import annotations
 
@@ -123,6 +123,8 @@ logger = logging.getLogger(__name__)
 
 MAX_VAD_SEGMENT_SECONDS = int(os.getenv('SYNC_MAX_VAD_SEGMENT_SECONDS', '300'))
 _SYNC_STT_MODELS = {'nova-3', 'velma-2', 'parakeet'}
+_PARTIAL_RESULT_FENCED_CONVERSATION_IDS = 'fenced_conversation_ids'
+_RESPONSE_FENCED_CONVERSATION_IDS = '_fenced_conversation_ids'
 _SYNC_FAILURE_REASON_CODES = {
     'backfill_capacity',
     'backfill_paced',
@@ -1277,20 +1279,62 @@ def process_segment(
             turnstile.complete(path)
 
 
-def _reprocess_merged_conversations(uid: str, response: dict):
+def _reprocess_merged_conversations(uid: str, response: dict, on_fenced=None):
     """Regenerate summary/structured data for conversations that gained segments this batch.
 
     The merge path in process_segment only appends transcript segments; without this the
-    conversation keeps the summary generated from its first chunk only.
+    enriched fields (summary, structured, speakers) remain stale.  Fences are isolated
+    per conversation: a replaced/reopened conversation must not block siblings in the
+    same batch.
     """
     merged = response.pop('_merged', {})
     for conversation_id, language in merged.items():
         try:
             _reprocess_conversation_after_update(uid, conversation_id, language)
         except SyncConversationPersistenceFenced:
+            response.setdefault(_RESPONSE_FENCED_CONVERSATION_IDS, set()).add(conversation_id)
+            response.get('updated_memories', set()).discard(conversation_id)
+            if on_fenced:
+                on_fenced()
             logger.info('event=sync_conversation_reprocess outcome=fenced conversation_id=%s', conversation_id)
         except Exception as e:
             logger.error(f'sync: failed to reprocess merged conversation {conversation_id}: {e}')
+
+
+async def _checkpoint_fenced_conversations_for_run(
+    uid: str,
+    response: dict,
+    content_id: str | None,
+    job_id: str,
+    active_run_lock_token: str,
+    active_run_lock_epoch: int | None,
+):
+    """Persist a fence tombstone before the losing worker can finalize audio."""
+    partial = {
+        'new_memories': sorted(response['new_memories']),
+        'updated_memories': sorted(response['updated_memories']),
+        _PARTIAL_RESULT_FENCED_CONVERSATION_IDS: sorted(response[_RESPONSE_FENCED_CONVERSATION_IDS]),
+    }
+    if content_id:
+        checkpointed = await run_blocking(
+            db_executor,
+            checkpoint_sync_content_partial_result,
+            uid,
+            content_id,
+            job_id,
+            partial,
+            run_token=active_run_lock_token,
+            run_epoch=active_run_lock_epoch,
+        )
+        if not checkpointed:
+            raise SyncJobRunLeaseLost(f'sync content ledger owner lost: job={job_id}')
+    await run_blocking(
+        db_executor,
+        _update_sync_job_for_run,
+        job_id,
+        active_run_lock_token,
+        {'partial_result': partial},
+    )
 
 
 def _wav_bytes_to_pcm16_16k(audio_bytes: Optional[bytes]) -> Optional[bytes]:
@@ -1962,10 +2006,16 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
                         set(partial_result.get('updated_memories') or [])
                         | set(durable_partial.get('updated_memories') or [])
                     ),
+                    _PARTIAL_RESULT_FENCED_CONVERSATION_IDS: sorted(
+                        set(partial_result.get(_PARTIAL_RESULT_FENCED_CONVERSATION_IDS) or [])
+                        | set(durable_partial.get(_PARTIAL_RESULT_FENCED_CONVERSATION_IDS) or [])
+                    ),
                 }
+            fenced_conversation_ids = set(partial_result.get(_PARTIAL_RESULT_FENCED_CONVERSATION_IDS) or [])
             response = {
-                'updated_memories': set(partial_result.get('updated_memories') or []),
+                'updated_memories': set(partial_result.get('updated_memories') or []) - fenced_conversation_ids,
                 'new_memories': set(partial_result.get('new_memories') or []),
+                _RESPONSE_FENCED_CONVERSATION_IDS: fenced_conversation_ids,
             }
             segment_errors = []
             segment_lock = threading.Lock()
@@ -2031,6 +2081,9 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
                         partial = {
                             'new_memories': sorted(response['new_memories']),
                             'updated_memories': sorted(response['updated_memories']),
+                            _PARTIAL_RESULT_FENCED_CONVERSATION_IDS: sorted(
+                                response[_RESPONSE_FENCED_CONVERSATION_IDS]
+                            ),
                         }
                         _update_sync_job_for_run(job_id, active_run_lock_token, {'partial_result': partial})
                         if content_id:
@@ -2132,7 +2185,31 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
                 except Exception:
                     pass
 
-            await run_blocking(sync_executor, _reprocess_merged_conversations, uid, response)
+            coordinator_loop = asyncio.get_running_loop()
+
+            def _checkpoint_fenced_conversations():
+                # This callback runs in sync_executor. Waiting here keeps the fence
+                # durable before audio finalization, while the coordinator loop stays
+                # available to dispatch the writes through db_executor.
+                asyncio.run_coroutine_threadsafe(
+                    _checkpoint_fenced_conversations_for_run(
+                        uid,
+                        response,
+                        content_id,
+                        job_id,
+                        active_run_lock_token,
+                        active_run_lock_epoch,
+                    ),
+                    coordinator_loop,
+                ).result()
+
+            await run_blocking(
+                sync_executor,
+                _reprocess_merged_conversations,
+                uid,
+                response,
+                on_fenced=_checkpoint_fenced_conversations,
+            )
 
             # Persist conversation audio (private-cloud chunks → audio_files) so synced
             # conversations play exactly like realtime ones. Gated on the user's setting.


### PR DESCRIPTION
## Summary

- Exclude a lifecycle-fenced merged conversation from `updated_memories` after deferred reprocessing loses ownership.
- Preserve processing and audio finalization for unaffected sibling conversations.
- Prevent the later private-cloud audio finalizer from writing `audio_files`, precache state, or an artifact job for a fenced conversation.

## Failure class

Failure-Class: FC-split-mutation-authority

## Verification

- `BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-10234-fenced-finalization-tests.txt bash backend/test.sh -- -k merged_reprocess_fence_isolated_to_its_conversation -vv` — 164 passed.
- The regression first failed before the production change: the fenced ID remained in `updated_memories`; after the fix it proves only the current sibling reaches audio finalization.

## Risk

Low. The change removes post-fence side effects only for the conversation whose lifecycle ownership was explicitly lost. It does not change the fence itself, retry/terminal semantics, or the sibling-success path.

Closes #10234


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

