### PR TITLE
fix(release): preserve post-launch qualification timeout

### DIFF
--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -1240,6 +1240,20 @@ fi
 
 fi # full bundle path
 
+signal_desktop_launch() {
+    local signal_file="${OMI_DESKTOP_LAUNCH_SIGNAL_FILE:-}"
+    local signal_dir signal_tmp
+    [ -n "$signal_file" ] || return 0
+    signal_dir="$(dirname "$signal_file")"
+    if [ ! -d "$signal_dir" ]; then
+        echo "ERROR: desktop launch signal directory does not exist: $signal_dir" >&2
+        return 1
+    fi
+    signal_tmp="${signal_file}.tmp.$$"
+    printf 'bundle_id=%s\napp_path=%s\n' "$BUNDLE_ID" "$APP_PATH" > "$signal_tmp"
+    mv -f "$signal_tmp" "$signal_file"
+}
+
 step "Starting app..."
 
 # Print summary
@@ -1281,10 +1295,15 @@ printf 'launch_mode=%s fast_reason=%s bundle_id=%s profile_root=%q\n' \
 
 auth_debug "BEFORE launch: $(defaults read "$BUNDLE_ID" auth_isSignedIn 2>&1 || true)"
 if [ "${#AUTOMATION_ARGS[@]}" -gt 0 ]; then
-    open "$APP_PATH" --args "${AUTOMATION_ARGS[@]}" || "$APP_PATH/Contents/MacOS/$BINARY_NAME" "${AUTOMATION_ARGS[@]}" &
+    if ! open "$APP_PATH" --args "${AUTOMATION_ARGS[@]}"; then
+        "$APP_PATH/Contents/MacOS/$BINARY_NAME" "${AUTOMATION_ARGS[@]}" &
+    fi
 else
-    open "$APP_PATH" || "$APP_PATH/Contents/MacOS/$BINARY_NAME" &
+    if ! open "$APP_PATH"; then
+        "$APP_PATH/Contents/MacOS/$BINARY_NAME" &
+    fi
 fi
+signal_desktop_launch
 
 # Launch finished — free this worktree's lock so other checkouts (and a later
 # rebuild here) are not blocked by the long-running wait below. Kept through

--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -116,8 +116,10 @@ VERSION="${VERSION%-macos}"
 BUNDLE="omi-qualification-${VERSION}"
 WORKTREE="$REPO_ROOT/.qualification-worktrees/$RELEASE_TAG"
 LAUNCH_LOG=""
+LAUNCH_SIGNAL_FILE=""
 DESKTOP_LAUNCH_PID=""
 QUALIFICATION_SUCCESS=0
+DESKTOP_PREPARE_WAIT_SECS=1800
 BRIDGE_WAIT_SECS=900
 
 gh release view "$RELEASE_TAG" --repo BasedHardware/omi --json tagName,isDraft,isPrerelease,publishedAt,assets,body \
@@ -210,6 +212,24 @@ terminate_qualification_desktop() {
   fi
 }
 
+wait_for_desktop_launch() {
+  local signal_file="$1"
+  local deadline=$((SECONDS + DESKTOP_PREPARE_WAIT_SECS))
+  while (( SECONDS < deadline )); do
+    if [[ -f "$signal_file" ]]; then
+      echo "desktop launch dispatched after bounded preparation"
+      return 0
+    fi
+    if [[ -n "$DESKTOP_LAUNCH_PID" ]] && ! kill -0 "$DESKTOP_LAUNCH_PID" 2>/dev/null; then
+      echo "qualification failed: desktop launch process exited during preparation" >&2
+      return 1
+    fi
+    sleep 5
+  done
+  echo "qualification failed: desktop launch not dispatched within ${DESKTOP_PREPARE_WAIT_SECS}s" >&2
+  return 1
+}
+
 wait_for_bridge() {
   local port="$1"
   local deadline=$((SECONDS + BRIDGE_WAIT_SECS))
@@ -265,14 +285,26 @@ trap cleanup EXIT
 
 terminate_qualification_desktop "$BUNDLE"
 "$SCRIPT_DIR/prepare-qualification-profile.sh" "$BUNDLE"
+LAUNCH_SIGNAL_FILE="$WORKTREE/.qualification-desktop-launched"
+rm -f "$LAUNCH_SIGNAL_FILE"
 
 (
   cd "$WORKTREE"
   PROVIDER_MODE=offline make dev-up
-  OMI_SKIP_SETTINGS_SEED=1 make desktop-run-local DESKTOP_APP_NAME="$BUNDLE" DESKTOP_USER=alice
+  OMI_DESKTOP_LAUNCH_SIGNAL_FILE="$LAUNCH_SIGNAL_FILE" OMI_SKIP_SETTINGS_SEED=1 \
+    make desktop-run-local DESKTOP_APP_NAME="$BUNDLE" DESKTOP_USER=alice
 ) >"$LAUNCH_LOG" 2>&1 &
 DESKTOP_LAUNCH_PID=$!
-# Build time must not consume the desktop-launch readiness allowance.
+
+if ! wait_for_desktop_launch "$LAUNCH_SIGNAL_FILE"; then
+  echo "--- last 80 lines of $LAUNCH_LOG ---" >&2
+  tail -n 80 "$LAUNCH_LOG" >&2 || true
+  exit 1
+fi
+
+# The bridge gets its complete post-launch readiness allowance; cold Rust,
+# agent-runtime, SwiftPM, packaging, and signing work consumed only the separate
+# bounded preparation phase above.
 SECONDS=0
 
 if ! wait_for_bridge "$AUTOMATION_PORT"; then

--- a/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
+++ b/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
@@ -6,6 +6,7 @@ QUALIFIER="$SCRIPT_DIR/../scripts/qualify-desktop-beta.sh"
 CORE_HARNESS="$SCRIPT_DIR/../scripts/desktop-core-harness.sh"
 PROFILE_PREP="$SCRIPT_DIR/../scripts/prepare-qualification-profile.sh"
 APP_CONFIG="$SCRIPT_DIR/../scripts/app-config.sh"
+RUN_SH="$SCRIPT_DIR/../run.sh"
 
 require_text() {
   local pattern="$1"
@@ -16,6 +17,25 @@ require_text() {
   }
 }
 
+require_order() {
+  local file="$1"
+  shift
+  python3 - "$file" "$@" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+needles = sys.argv[2:]
+text = path.read_text(encoding="utf-8")
+position = -1
+for needle in needles:
+    next_position = text.find(needle, position + 1)
+    if next_position < 0:
+        raise SystemExit(f"FAIL: {path} missing ordered launch-phase fragment: {needle}")
+    position = next_position
+PY
+}
+
 require_text 'defaults delete "$BUNDLE_ID"' "$PROFILE_PREP"
 require_text '^omi-qualification-' "$PROFILE_PREP"
 require_text 'Application Support/$BUNDLE_NAME' "$PROFILE_PREP"
@@ -24,7 +44,8 @@ require_text 'defaults write "$BUNDLE_ID" devLazyPermissionsEnabled -bool true' 
 require_text 'defaults write "$BUNDLE_ID" screenAnalysisEnabled -bool false' "$PROFILE_PREP"
 require_text 'defaults write "$BUNDLE_ID" transcriptionEnabled -bool false' "$PROFILE_PREP"
 require_text '"$SCRIPT_DIR/prepare-qualification-profile.sh" "$BUNDLE"' "$QUALIFIER"
-require_text 'OMI_SKIP_SETTINGS_SEED=1 make desktop-run-local'
+require_text 'OMI_SKIP_SETTINGS_SEED=1'
+require_text 'make desktop-run-local DESKTOP_APP_NAME="$BUNDLE" DESKTOP_USER=alice'
 require_text 'terminate_qualification_desktop "$BUNDLE"'
 require_text '--json tagName,isDraft,isPrerelease,publishedAt,assets,body'
 require_text 'worktree list --porcelain | grep -Fxq "worktree $WORKTREE"'
@@ -39,6 +60,25 @@ if grep -Fq 'rm -rf "$WORKTREE"' "$QUALIFIER"; then
 fi
 require_text 'derive_omi_app_config "$BUNDLE"' "$CORE_HARNESS"
 require_text 'wrong bundle on port' "$CORE_HARNESS"
+
+# Static timing contract: cold preparation has its own bounded phase and run.sh
+# explicitly signals successful launch dispatch before the 900-second bridge
+# readiness budget starts. This guards the trusted-runner failure from attempts
+# 1 and 2 of https://github.com/BasedHardware/omi/actions/runs/29896814913.
+require_text 'DESKTOP_PREPARE_WAIT_SECS=1800'
+require_text 'BRIDGE_WAIT_SECS=900'
+require_text 'OMI_DESKTOP_LAUNCH_SIGNAL_FILE="$LAUNCH_SIGNAL_FILE"'
+require_text 'signal_desktop_launch' "$RUN_SH"
+require_order "$QUALIFIER" \
+  'rm -f "$LAUNCH_SIGNAL_FILE"' \
+  'DESKTOP_LAUNCH_PID=$!' \
+  'wait_for_desktop_launch "$LAUNCH_SIGNAL_FILE"' \
+  'SECONDS=0' \
+  'wait_for_bridge "$AUTOMATION_PORT"'
+require_order "$RUN_SH" \
+  'step "Starting app..."' \
+  'open "$APP_PATH"' \
+  'signal_desktop_launch'
 
 if [[ ! -x "$PROFILE_PREP" ]]; then
   echo "FAIL: missing executable qualification profile preparation helper" >&2


### PR DESCRIPTION
## Summary

- give cold desktop preparation its own bounded 1,800-second phase before bridge readiness begins
- have `run.sh` atomically signal successful app launch dispatch, then preserve the existing 900-second post-launch bridge allowance
- retain fail-closed launcher-process exit detection and a bounded 2,700-second combined preparation/readiness budget

## Failure evidence

Trusted qualification run https://github.com/BasedHardware/omi/actions/runs/29896814913 failed identically on attempts 1 and 2 in `Qualify exact candidate on hermetic stack`:

```text
qualification failed: automation bridge not healthy within 900s (port 47778)
```

Both retained launch logs showed the cold Rust backend build, local stack startup, agent-runtime preparation, and SwiftPM dependency resolution/build still consuming the same 900-second clock. The existing comment said build time must not consume bridge readiness, but `SECONDS=0` ran immediately after backgrounding the combined build-and-launch process.

## Fix

`qualify-desktop-beta.sh` now waits up to 1,800 seconds for an explicit launch-dispatch file written atomically by `run.sh`. Only after that phase signal does it reset `SECONDS` and begin the existing 900-second bridge health wait. Either phase still fails immediately if the launcher process exits.

## Test evidence

- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh`
- all `desktop/macos/tests/test-*.sh`
- `desktop/macos/scripts/test-tool-surfaces.sh` (48 Vitest files / 577 tests and 107 Node TAP tests passed on the final run)
- `shellcheck -S error desktop/macos/scripts/qualify-desktop-beta.sh desktop/macos/run.sh desktop/macos/tests/test-qualify-desktop-beta-contract.sh`
- `python3 .github/scripts/check-release-process-guards.py`
- `backend/.venv/bin/python -m pytest -q .github/scripts/test_check_release_process_guards.py` (87 passed)
- `actionlint -shellcheck= .github/workflows/desktop_qualify_beta.yml`
- `git diff --check`

The exact trusted qualification was intentionally not rerun; this PR performs no qualification, promotion, deployment, admission, tag, Codemagic, Beta-channel, or Stable-channel mutation.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

