### PR TITLE
chore(desktop): add qualification changelog fragment

### DIFF
--- a/desktop/macos/changelog/unreleased/20260722-beta-qualification-readiness.json
+++ b/desktop/macos/changelog/unreleased/20260722-beta-qualification-readiness.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved reliability of macOS Beta release qualification."
+}


### PR DESCRIPTION
## Summary

- add the missing unreleased macOS changelog fragment for the merged qualification-timeout repair
- restore exact-main release eligibility without changing runtime behavior

## Verification

- `make preflight`
- `python3 .github/scripts/run_checks.py --lane ci --base origin/main --head HEAD --skip-pr-body-checks`
- `git diff --check origin/main...HEAD`

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

