### PR TITLE
fix(release): unblock automatic nightly beta handoff

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -257,7 +257,7 @@ checks:
     command: ["python3", ".github/scripts/test_plan_desktop_release.py"]
     triggers: [".github/scripts/plan-desktop-release.py", ".github/scripts/test_plan_desktop_release.py", ".github/workflows/desktop_auto_release.yml"]
     lanes: ["local", "ci"]
-    reason: "candidate tags require a successful Desktop Swift Build & Tests check for their exact source SHA"
+    reason: "candidate tags require successful Release Eligibility for the exact current main SHA they contain"
   - id: desktop-manifest-routes
     command: ["python3", ".github/scripts/test_desktop_manifest_routes.py"]
     triggers: [".github/workflows/desktop-swift-ci.yml", ".github/checks-manifest.yaml", ".github/scripts/run_checks.py", ".github/scripts/test_desktop_manifest_routes.py"]

--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -624,6 +624,8 @@ def check_desktop_codemagic_release() -> list[str]:
         errors.append("Codemagic must not write release-body dispatch state outside the trusted workflow serialiser")
     if "candidate remains non-live" not in desktop_workflow_body:
         errors.append("desktop qualification handoff must state that a failed dispatch cannot publish beta")
+    if "ERROR: qualification dispatch was not confirmed after bounded retry" not in dispatch_body or "exit 1" not in dispatch_body:
+        errors.append("desktop qualification handoff must fail closed after bounded dispatch retries")
     if "gh release delete \"$CM_TAG\"" in desktop_workflow_body:
         errors.append("desktop candidate retries must not delete immutable qualification evidence")
     if "docker info" in desktop_workflow_body:

--- a/.github/scripts/fixtures/codemagic_workflow_contract/v1.json
+++ b/.github/scripts/fixtures/codemagic_workflow_contract/v1.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
-  "codemagic_raw_sha256": "e2da89eeb3e08e537ab8c38cba3dd5c5937dd86edc863285f058fd85b98dcb98",
-  "codemagic_semantic_sha256": "fd8b1bb76367c32089c1073a90df8e575edae01a1394d0469252672d1459998d",
+  "codemagic_raw_sha256": "e479473b506d15a6929f4a8394694583d69a4a91d52b81caaa7b4b4b472bf239",
+  "codemagic_semantic_sha256": "2608717738c45a57faa8d4f0aee268242ded474c6e82a6a3b7efaf554c2c9695",
   "omi-desktop-swift-preview": {
-    "semantic_sha256": "e5ee696a29e3318962c5310212d332f9a2919a693b07919455c96f2f29664795"
+    "semantic_sha256": "b0113ade783f57dbe36473376f9f7c64110ebeb9c21445deb2c6935f1e2030f1"
   },
   "omi-desktop-swift-release": {
     "publication_script": "if [[ \"${PREVIEW_MODE:-false}\" == \"true\" ]]; then\n  echo \"External previews do not create GitHub releases.\"\n  exit 0\nfi\nset -euo pipefail\nCHANGELOG_MD=$(python3 ../../.github/scripts/desktop-changelog.py latest-release --format markdown || echo \"- Bug fixes and improvements\")\n\n# Build changelog as pipe-separated string for KEY_VALUE_START\nCHANGELOG_PIPE=$(echo \"$CHANGELOG_MD\" | sed 's/^- //' | tr '\\n' '|' | sed 's/|$//')\n\nRELEASE_NOTES=\"## OMI Desktop v${VERSION}\n\n### What's New\n${CHANGELOG_MD}\n\n### Downloads\n- **DMG Installer**: For fresh installs, download the DMG below\n- **Auto-Update**: Existing users will receive this update automatically via Sparkle\n\n<!-- KEY_VALUE_START\nisLive: false\nchannel: candidate\nedSignature: ${ED_SIGNATURE}\nchangelog: ${CHANGELOG_PIPE}\nKEY_VALUE_END -->\"\n\n# A candidate is the evidence container. Once published, preserve its\n# signed artifacts and every qualification observation; retries only\n# resume the dispatch handoff below.\nif gh release view \"$CM_TAG\" --repo \"$GITHUB_REPO\" >/dev/null 2>&1; then\n  echo \"GitHub release candidate already exists; preserving immutable evidence for $CM_TAG\"\nelse\n  # The backend reservation is the authoritative Beta fence. It runs\n  # only after package, signature, notarization, and signed smoke pass,\n  # immediately before this workflow creates the immutable candidate.\n  set -euo pipefail\n  test -n \"${BETA_PROMOTION_TOKEN:-}\" || {\n    echo \"ERROR: BETA_PROMOTION_TOKEN is required to reserve a canonical candidate\" >&2\n    exit 1\n  }\n  curl --fail-with-body --silent --show-error \\\n    --request POST \"${OMI_PYTHON_API_URL%/}/v2/desktop/beta/candidates/reserve\" \\\n    --header \"Authorization: Bearer ${BETA_PROMOTION_TOKEN}\" \\\n    --header 'Content-Type: application/json' \\\n    --data \"{\\\"tag\\\":\\\"${CM_TAG}\\\"}\"\n  gh release create \"$CM_TAG\" \\\n    --repo \"$GITHUB_REPO\" \\\n    --title \"Omi Desktop v${VERSION} (candidate)\" \\\n    --notes \"$RELEASE_NOTES\" \\\n    \"$SPARKLE_ZIP_PATH\" \\\n    \"$DMG_PATH\" \\\n    \"$BUILD_DIR/desktop-smoke-result.json\"\n  echo \"GitHub release candidate created: $CM_TAG\"\nfi\n",
     "publication_script_sha256": "a8dfe376273b076fab7164ad84e48a3fab759ff97f4979ec8658629c8c837b40",
-    "semantic_sha256": "f8374ec86440562e1f38f471225d651255e7ad6b2b1565a00d242bb6960d62e1"
+    "semantic_sha256": "efb8950be295fd0daf0cde06abce2bf204c7be0714181b59b0d2a2f7d9c78ad0"
   }
 }

--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -10,7 +10,7 @@ import time
 from pathlib import Path
 
 CODEMAGIC_CHECK_NAME = "Release OMI Desktop (Swift)"
-DESKTOP_SWIFT_CHECK_NAME = "Desktop Swift Build & Tests"
+RELEASE_ELIGIBILITY_CHECK_NAME = "Release Eligibility"
 RECENT_TAG_WITHOUT_CHECK_SECONDS = 10 * 60
 AUTO_RELEASE_QUIET_SECONDS = 10 * 60
 
@@ -84,19 +84,6 @@ def latest_change_age_seconds(paths: list[str]) -> int | None:
         return None
 
 
-def latest_releasable_source_sha(ref: str | None, paths: list[str]) -> str | None:
-    """Return the newest queued desktop-content commit, not an unrelated HEAD commit."""
-    if not paths:
-        return None
-
-    revision = f"{ref}..HEAD" if ref else "HEAD"
-    try:
-        source_sha = git(["log", "-1", "--format=%H", revision, "--", *paths])
-    except subprocess.CalledProcessError:
-        return None
-    return source_sha or None
-
-
 def github_check_status(repository: str, sha: str, check_name: str) -> tuple[str | None, str | None, str | None]:
     result = subprocess.run(
         [
@@ -128,17 +115,17 @@ def codemagic_check_status(repository: str, sha: str) -> tuple[str | None, str |
     return github_check_status(repository, sha, CODEMAGIC_CHECK_NAME)
 
 
-def required_desktop_swift_check_reason(repository: str, sha: str) -> str | None:
-    status, conclusion, error = github_check_status(repository, sha, DESKTOP_SWIFT_CHECK_NAME)
+def required_release_eligibility_reason(repository: str, sha: str) -> str | None:
+    status, conclusion, error = github_check_status(repository, sha, RELEASE_ELIGIBILITY_CHECK_NAME)
     if error:
         return f"could not read required check for source SHA {sha}: {error}"
     if status is None:
-        return f"required check {DESKTOP_SWIFT_CHECK_NAME} is missing for source SHA {sha}"
+        return f"required check {RELEASE_ELIGIBILITY_CHECK_NAME} is missing for exact main SHA {sha}"
     if status != "completed":
-        return f"required check {DESKTOP_SWIFT_CHECK_NAME} for source SHA {sha} is {status}"
+        return f"required check {RELEASE_ELIGIBILITY_CHECK_NAME} for exact main SHA {sha} is {status}"
     if conclusion != "success":
         return (
-            f"required check {DESKTOP_SWIFT_CHECK_NAME} for source SHA {sha} "
+            f"required check {RELEASE_ELIGIBILITY_CHECK_NAME} for exact main SHA {sha} "
             f"completed with {conclusion or 'no conclusion'}"
         )
     return None
@@ -184,7 +171,11 @@ def main() -> int:
 
     latest_tag = latest_desktop_tag()
     changes = releasable_desktop_changes_since(latest_tag)
-    source_sha = latest_releasable_source_sha(latest_tag, changes) or git(["rev-parse", "HEAD"])
+    # The tag is created from this checkout (plus its deterministic changelog
+    # commit), so exact current main is the release source authority. Gating an
+    # older path-touching commit strands the queue when a later metadata-only
+    # repair makes current main eligible without rerunning component CI.
+    source_sha = git(["rev-parse", "HEAD"])
     set_output("latest_tag", latest_tag or "")
     set_output("source_sha", source_sha)
 
@@ -213,7 +204,7 @@ def main() -> int:
         )
         return 0
 
-    source_check_reason = required_desktop_swift_check_reason(args.repository, source_sha)
+    source_check_reason = required_release_eligibility_reason(args.repository, source_sha)
     if source_check_reason:
         set_output("should_release", "false")
         set_output("reason", f"Desktop candidate source gate blocked: {source_check_reason}.")

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -27,21 +27,19 @@ RELEASABLE_PATH = "desktop/macos/Desktop/Sources/AppDelegate.swift"
 class DesktopCandidateSourceCheckTests(unittest.TestCase):
     def test_exact_source_sha_success_passes_the_gate(self) -> None:
         with patch.object(planner, "github_check_status", return_value=("completed", "success", None)):
-            self.assertIsNone(planner.required_desktop_swift_check_reason(REPOSITORY, SOURCE_SHA))
+            self.assertIsNone(planner.required_release_eligibility_reason(REPOSITORY, SOURCE_SHA))
 
     def test_missing_or_failed_source_check_blocks_the_gate(self) -> None:
         with patch.object(planner, "github_check_status", return_value=(None, None, None)):
-            self.assertIn("missing", planner.required_desktop_swift_check_reason(REPOSITORY, SOURCE_SHA) or "")
+            self.assertIn("missing", planner.required_release_eligibility_reason(REPOSITORY, SOURCE_SHA) or "")
         with patch.object(planner, "github_check_status", return_value=("completed", "failure", None)):
-            self.assertIn("failure", planner.required_desktop_swift_check_reason(REPOSITORY, SOURCE_SHA) or "")
+            self.assertIn("failure", planner.required_release_eligibility_reason(REPOSITORY, SOURCE_SHA) or "")
 
-    def test_automatic_planner_uses_the_latest_releasable_source(self) -> None:
+    def test_automatic_planner_gates_exact_head_release_eligibility(self) -> None:
         checked_shas: list[str] = []
 
         def fake_git(args: list[str], *, check: bool = True) -> str:
             if args == ["rev-parse", "HEAD"]:
-                return "b" * 40
-            if args == ["log", "-1", "--format=%H", f"{LATEST_TAG}..HEAD", "--", RELEASABLE_PATH]:
                 return SOURCE_SHA
             self.fail(f"unexpected git invocation: {args}")
 
@@ -52,7 +50,7 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
                 patch.object(planner, "releasable_desktop_changes_since", return_value=[RELEASABLE_PATH]),
                 patch.object(planner, "latest_change_age_seconds", return_value=601),
                 patch.object(planner, "git", side_effect=fake_git),
-                patch.object(planner, "required_desktop_swift_check_reason", side_effect=lambda _, sha: checked_shas.append(sha)),
+                patch.object(planner, "required_release_eligibility_reason", side_effect=lambda _, sha: checked_shas.append(sha)),
                 patch.object(planner, "active_release_reason", return_value=None),
                 patch.object(sys, "argv", [str(SCRIPT), "--repository", REPOSITORY]),
                 patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_path)}, clear=False),
@@ -61,6 +59,7 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
             outputs = output_path.read_text(encoding="utf-8")
 
         self.assertEqual(checked_shas, [SOURCE_SHA])
+        self.assertIn(f"source_sha={SOURCE_SHA}", outputs)
         self.assertIn("should_release=true", outputs)
 
     def test_workflow_is_schedule_only_and_tags_the_changelog_commit(self) -> None:

--- a/backend/tests/unit/test_desktop_release_scripts.py
+++ b/backend/tests/unit/test_desktop_release_scripts.py
@@ -482,6 +482,10 @@ def test_qualification_is_serialized_by_tag_and_retried_without_release_body_sta
     assert "group: desktop-beta-qualification-${{ inputs.release_tag }}" in qualification
     assert "cancel-in-progress: false" in qualification
     assert "for attempt in 1 2 3" in dispatch
+    assert "ERROR: qualification dispatch was not confirmed after bounded retry" in dispatch
+    assert dispatch.index("ERROR: qualification dispatch was not confirmed after bounded retry") < dispatch.index(
+        "exit 1"
+    )
     assert "desktop_qualification_dispatch.py" not in qualification
     assert "steps.candidate.outcome == 'success' && steps.qualify.outcome == 'success'" in qualification
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2856,7 +2856,8 @@ workflows:
               sleep "$((attempt * 2))"
             fi
           done
-          echo "WARNING: qualification dispatch was not confirmed after bounded retry; candidate remains non-live."
+          echo "ERROR: qualification dispatch was not confirmed after bounded retry; candidate remains non-live." >&2
+          exit 1
 
     artifacts:
       - build/*.app


### PR DESCRIPTION
## Summary
- gate scheduled macOS candidate creation on successful `Release Eligibility` for the exact current `main` SHA that is tagged
- prevent metadata-only repair commits from leaving the nightly queue pinned to a stale failed path-touching commit
- make exhausted Codemagic qualification-dispatch retries fail closed instead of reporting a successful build with a stranded non-live candidate
- preserve the existing immutable candidate, trusted M1 qualification, evidence, narrow Beta promotion, and manual-only Stable paths

## Incident evidence
- scheduled run 29824363988 skipped candidate creation because it checked a stale desktop component result rather than exact-main Release Eligibility
- qualification run 29896814913 spent the readiness budget compiling before failing; PR #10275 already repaired that phase boundary
- the Codemagic dispatch block ended with a warning and exit status 0 after all retries, which could strand a published candidate without surfacing a failed handoff

## Verification
- `python3 .github/scripts/test_plan_desktop_release.py`
- `python3 .github/scripts/test_desktop_release_flow_contract.py`
- `python3 .github/scripts/check-release-process-guards.py`
- `backend/.venv/bin/pytest -q backend/tests/unit/test_desktop_release_scripts.py` — 28 passed
- `actionlint .github/workflows/desktop_auto_release.yml .github/workflows/desktop_qualify_beta.yml .github/workflows/desktop_promote_beta.yml .github/workflows/desktop_recover_beta.yml`
- live read-only planner check against current main selected `cadf6f74ca2bc8567918a3b273630683ea08e518` and correctly found no changes after `v0.12.101+12101-macos`

## Product invariants affected

- INV-AUTH-1 — the Codemagic release-control edit does not change the mandatory signed-app Keychain canary or session behavior
- INV-DATA-1 — canonical production endpoints, bundle identity, Firebase project, and Beta/Stable channel separation are unchanged

## Failure class (fixes)

Failure-Class: none

## Safety
- no tag, release, workflow dispatch, qualification, promotion, deploy, pointer mutation, or credential/config mutation was performed
- `.github/workflows/desktop_promote_prod.yml` and every Stable path are unchanged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

