### PR TITLE
feat(pusher): harden native RollingUpdate (SCA-39 long-term rollout)

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -274,6 +274,11 @@ checks:
     triggers: ["backend/charts/pusher/**", "backend/utils/metrics.py", "backend/routers/pusher.py", "backend/utils/readiness.py", "backend/scripts/verify_pusher_rollout_gate.py", "backend/tests/unit/test_verify_pusher_rollout_gate.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-39: static preflight that fails closed when a pusher rollout cannot be verified safe (capacity, image identity, readiness/health split, telemetry)"
+  - id: shared-config-migration-preflight
+    command: ["python3", "backend/scripts/verify_shared_config_migration.py", "preflight"]
+    triggers: ["backend/charts/pusher/**", "backend/scripts/verify_shared_config_migration.py", "backend/tests/unit/test_verify_shared_config_migration.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-39: static preflight that fails closed when pusher chart env/envFrom config references are structurally invalid (the 2026-07-22 REDIS_DB_HOST outage class)"
   - id: conversation-lifecycle-write-guard
     command: ["python3", "backend/scripts/check_conversation_lifecycle_writes.py"]
     triggers: ["backend/**/*.py", "backend/scripts/check_conversation_lifecycle_writes.py"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -269,6 +269,11 @@ checks:
     triggers: ["backend/charts/pusher/**", ".github/workflows/gcp_backend_pusher.yml", ".github/workflows/gcp_backend_pusher_auto_deploy.yml", "backend/scripts/verify_pusher_rollout_budget.py", "backend/tests/unit/test_verify_pusher_rollout_budget.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#9988: Pusher's Kubernetes deadline and workflow wait must cover chart-derived availability at the HPA ceiling"
+  - id: pusher-rollout-quality-gate
+    command: ["python3", "backend/scripts/verify_pusher_rollout_gate.py"]
+    triggers: ["backend/charts/pusher/**", "backend/utils/metrics.py", "backend/routers/pusher.py", "backend/utils/readiness.py", "backend/scripts/verify_pusher_rollout_gate.py", "backend/tests/unit/test_verify_pusher_rollout_gate.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-39: static preflight that fails closed when a pusher rollout cannot be verified safe (capacity, image identity, readiness/health split, telemetry)"
   - id: conversation-lifecycle-write-guard
     command: ["python3", "backend/scripts/check_conversation_lifecycle_writes.py"]
     triggers: ["backend/**/*.py", "backend/scripts/check_conversation_lifecycle_writes.py"]

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -18,6 +18,10 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  # Build-once promotion: set `digest: sha256:<64 lowercase hex>` (and clear
+  # `tag`, set `pullPolicy: IfNotPresent`) to deploy an exact content-addressed
+  # image qualified once in dev. Malformed/ambiguous identity is rejected at
+  # render time. See backend/scripts/verify_pusher_rollout_gate.py.
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -69,6 +69,12 @@ service:
     cloud.google.com/neg: '{"ingress": true}'
     cloud.google.com/backend-config: '{"default": "dev-pusher-backend-config"}'  # Link to BackendConfig
 
+# BackendConfig connectionDraining: bounds how long the LB waits before cutting
+# in-flight WS on endpoint removal (must be <= terminationGracePeriodSeconds 120).
+backendConfig:
+  connectionDraining:
+    drainingTimeoutSec: 60
+
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: true
@@ -306,7 +312,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /health
+    path: /ready
     port: 8080
   failureThreshold: 3
   initialDelaySeconds: 0
@@ -366,7 +372,9 @@ terminationGracePeriodSeconds: 120
 lifecycle:
   preStop:
     exec:
-      command: ["sh", "-c", "sleep 15"]
+      # preStop flips readiness (via Lane A /__internal/drain) so the kubelet removes the endpoint
+      # early; sleep covers NEG->backend-service->ALB reprogram convergence before SIGTERM.
+      command: ["sh", "-c", "curl -sf -m 5 -X POST http://localhost:8080/__internal/drain || true; sleep 15"]
 
 # Additional volumes on the output Deployment definition.
 volumes: []

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -70,6 +70,12 @@ service:
     cloud.google.com/neg: '{"ingress": true}'
     cloud.google.com/backend-config: '{"default": "prod-pusher-backend-config"}'  # Link to BackendConfig
 
+# BackendConfig connectionDraining: bounds how long the LB waits before cutting
+# in-flight WS on endpoint removal (must be <= terminationGracePeriodSeconds 120).
+backendConfig:
+  connectionDraining:
+    drainingTimeoutSec: 60
+
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: true
@@ -325,7 +331,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /health
+    path: /ready
     port: 8080
   failureThreshold: 3
   initialDelaySeconds: 0
@@ -386,7 +392,9 @@ terminationGracePeriodSeconds: 120
 lifecycle:
   preStop:
     exec:
-      command: ["sh", "-c", "sleep 15"]
+      # preStop flips readiness (via Lane A /__internal/drain) so the kubelet removes the endpoint
+      # early; sleep covers NEG->backend-service->ALB reprogram convergence before SIGTERM.
+      command: ["sh", "-c", "curl -sf -m 5 -X POST http://localhost:8080/__internal/drain || true; sleep 15"]
 
 # Additional volumes on the output Deployment definition.
 volumes: []

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -19,6 +19,10 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  # Build-once promotion: set `digest: sha256:<64 lowercase hex>` (and clear
+  # `tag`, set `pullPolicy: IfNotPresent`) to promote the exact dev-qualified
+  # image by content address. Malformed/ambiguous identity is rejected at
+  # render time. See backend/scripts/verify_pusher_rollout_gate.py.
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []

--- a/backend/charts/pusher/templates/backendconfig.yaml
+++ b/backend/charts/pusher/templates/backendconfig.yaml
@@ -5,9 +5,14 @@ metadata:
 spec:
   # Long timeout required for persistent WebSocket connections between backend-listen and pusher
   timeoutSec: 3600
+  # Invariant: drainingTimeoutSec must be <= Deployment terminationGracePeriodSeconds (120) so the
+  # LB drains in-flight connections inside the pod grace window instead of racing SIGTERM.
+  connectionDraining:
+    drainingTimeoutSec: {{ .Values.backendConfig.connectionDraining.drainingTimeoutSec | default 60 }}
   healthCheck:
     checkIntervalSec: 10
     timeoutSec: 5
     port: {{ .Values.service.port }}
     type: HTTP
-    requestPath: /health  # Ensure this path returns 200 OK
+    # Liveness semantics: keep /health here so the LB health check never flips unhealthy during a readiness drain (that would defeat connectionDraining).
+    requestPath: /health

--- a/backend/charts/pusher/templates/deployment.yaml
+++ b/backend/charts/pusher/templates/deployment.yaml
@@ -54,7 +54,13 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ required "image.repository is required" .Values.image.repository }}:{{ required "image.tag is required" .Values.image.tag }}"
+          {{- $repository := required "image.repository is required" .Values.image.repository }}
+          {{- $digest := .Values.image.digest }}
+          {{- if $digest }}
+          {{- if not (regexMatch "^sha256:[a-f0-9]{64}$" $digest) }}{{- fail (printf "image.digest must be sha256:<64 lowercase hex characters>, got %q" $digest) }}{{- end }}
+          {{- if .Values.image.tag }}{{- fail "image.tag must be empty when image.digest pins the release (digest is the content address)" }}{{- end }}
+          {{- end }}
+          image: "{{ if $digest }}{{ $repository }}@{{ $digest }}{{ else }}{{ $repository }}:{{ required "image.tag is required when image.digest is absent" .Values.image.tag }}{{ end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.envFrom }}
           envFrom:

--- a/backend/charts/pusher/templates/deployment.yaml
+++ b/backend/charts/pusher/templates/deployment.yaml
@@ -59,6 +59,7 @@ spec:
           {{- if $digest }}
           {{- if not (regexMatch "^sha256:[a-f0-9]{64}$" $digest) }}{{- fail (printf "image.digest must be sha256:<64 lowercase hex characters>, got %q" $digest) }}{{- end }}
           {{- if .Values.image.tag }}{{- fail "image.tag must be empty when image.digest pins the release (digest is the content address)" }}{{- end }}
+          {{- if ne .Values.image.pullPolicy "IfNotPresent" }}{{- fail "image.pullPolicy must be IfNotPresent for a digest-pinned release (the digest is the content address; Always only adds a registry round-trip)" }}{{- end }}
           {{- end }}
           image: "{{ if $digest }}{{ $repository }}@{{ $digest }}{{ else }}{{ $repository }}:{{ required "image.tag is required when image.digest is absent" .Values.image.tag }}{{ end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/backend/docs/pusher_rolling_update_operations.md
+++ b/backend/docs/pusher_rolling_update_operations.md
@@ -1,0 +1,373 @@
+# Pusher — Hardened native RollingUpdate (operator and developer operations)
+
+This document is the operational contract for the hardened **native Kubernetes
+`RollingUpdate`** of the **pusher** GKE workload. It is deliberately not a design
+essay: it states what operators and developers can rely on, the exact termination
+sequence the chart produces, the preflight gates that must pass before a rollout
+is allowed, and the N/N-1 compatibility rules.
+
+Scope and ownership:
+
+- The **chart values** are the single source of truth for rollout inputs
+  (`backend/charts/pusher/{dev,prod}_omi_pusher_values.yaml`). When the live
+  cluster disagrees with the chart, the chart wins and the gap is a deploy
+  problem to close, never a reason to weaken the chart.
+- This hardening is **native `RollingUpdate` only**. No Argo Rollouts, Flagger,
+  service mesh, Gateway API, or two-color experiment is in scope.
+- **Production adoption is a LATER, explicit decision.** This PR lands the
+  hardening and the operational contract on top of the existing pusher baseline.
+  It is qualified **dev-first** (see [Dev qualification plan](#dev-qualification-plan)).
+  Do not read this document as "pusher is production-ready for the new rollout"
+  until SCA-40 lands and a healthy prod pusher baseline is confirmed.
+
+> Related runbook: `backend/docs/runbooks/pusher-degraded.md` covers sustained
+> degraded-session ratio. This document covers the rollout itself.
+
+---
+
+## Honest availability contract
+
+State this plainly, because it governs every operator decision below: **no
+approach preserves in-flight WebSocket sessions across a pusher cutover over the
+proxied ALB + NEG path.** Pusher holds long-lived binary WebSocket sessions from
+backend-listen. When a pod's endpoint leaves the NEG, the load balancer cuts the
+existing connections on it.
+
+What "graceful drain" actually means here:
+
+- **Zero new-connection rejection during a healthy rollout.** The readiness gate
+  flips a draining pod to `503` so the LB stops routing *new* sessions to it
+  while other pods are still serving. New backend-listen connects go to healthy
+  pods.
+- **A bounded reconnect gap per affected session, roughly 1-60 seconds.**
+  backend-listen owns the reconnect: when its pusher socket is cut it reconnects
+  to a healthy pod. The gap is the time between the cut and the next successful
+  reconnect, not a migration.
+- **The LB cut is bounded by BackendConfig `connectionDraining`.** It sets how
+  long the load balancer waits before hard-cutting in-flight connections on an
+  endpoint that has left the NEG — here `drainingTimeoutSec: 60`. Without it the
+  default is a hard cut on endpoint removal.
+- **Background finalization is bounded by the pod grace period.** In-flight work
+  (audio batched to GCS, transcripts routed to integrations, LLM analysis,
+  speaker-sample extraction) is drained by the app within
+  `terminationGracePeriodSeconds`; anything still running at the deadline is
+  SIGKILLed. Durable finalization is reconciled by the conversation-finalization
+  job lane, so a SIGKILLed session does not strand a conversation in `processing`.
+
+Do **not** claim sub-second or zero-session-impact cutover. The contract is:
+new connections keep flowing, existing sessions take a bounded reconnect gap,
+and background work finishes or is durably reconciled.
+
+---
+
+## What changed in the hardening
+
+The chart previously sent liveness, readiness, and startup probes all to
+`/health`, had no app-level drain (`preStop` was only `sleep 15`), and the
+BackendConfig had no `connectionDraining` (so the LB hard-cut in-flight WebSocket
+on endpoint removal). The hardening splits serving readiness from liveness and
+adds an app-level drain:
+
+| Concern | Before | After (hardened) |
+| --- | --- | --- |
+| Readiness signal | `readinessProbe` -> `/health` | `readinessProbe` -> `/ready` (200 serving / 503 draining) |
+| Liveness / startup | `/health` | unchanged, still `/health` |
+| LB health check | BackendConfig `healthCheck.requestPath: /health` | unchanged, still `/health` |
+| New-connection drain | none; `preStop` = `sleep 15` | `preStop`: `curl -sf -m 5 -X POST http://localhost:8080/__internal/drain \|\| true; sleep 15` — POST flips `/ready` to 503 (loopback), `\|\| true` never blocks termination, `sleep 15` covers NEG convergence |
+| LB in-flight cut | none; `connectionDraining` absent (hard cut on endpoint removal) | BackendConfig `connectionDraining.drainingTimeoutSec: 60` bounds the LB wait (60 <= grace 120) |
+
+Endpoints introduced by this hardening (on the pusher process, port 8080):
+
+- `GET /ready` -> `200` while serving, `503` once the process is draining.
+- `POST /__internal/drain` -> **loopback only**. Triggers the drain: flips
+  `/ready` to `503` and lets background finalization run down within the grace
+  period. `preStop` is the only intended caller.
+
+Rollout inputs that are **already** correct in the chart and are reused, not
+rebuilt (verified against `{dev,prod}_omi_pusher_values.yaml`):
+
+- `progressDeadlineSeconds: 9600` in **both** charts. CI derives the healthy
+  rollout budget from the chart (`backend/scripts/verify_pusher_rollout_budget.py`);
+  prod at its 40-pod HPA ceiling is fourteen waves of ~640s availability = an
+  8960s healthy budget, with 9600s as the committed deadline. The observed live
+  value of 600 on an existing release is a **deploy drift gap**, not a chart gap
+  — the chart value stays at 9600 and a real deploy must reconcile the cluster to
+  it.
+- prod `strategy: RollingUpdate { maxUnavailable: 1, maxSurge: 2 }`
+  (dev is `{ maxUnavailable: 0, maxSurge: 1 }`).
+- `terminationGracePeriodSeconds: 120` in both charts.
+- prod autoscaling `minReplicas: 12`, `maxReplicas: 40`,
+  `activeConnectionsPerPod: 30`; dev `minReplicas: 1`, `maxReplicas: 3`.
+- `podDisruptionBudget.minAvailable: 80%` in both charts.
+
+Fail-closed rollout gates (preflight scripts that must pass before a deploy) are
+listed in [Operator runbook](#operator-runbook) and the blocking signals in
+[Rollout quality gates (fail-closed)](#rollout-quality-gates-fail-closed).
+
+---
+
+## Termination sequence
+
+For a single pod being replaced during a `RollingUpdate`, the chart produces this
+sequence (accurate to `templates/deployment.yaml` and the values files):
+
+1. **Pod enters `Terminating`.** Kubernetes starts the pod's
+   `terminationGracePeriodSeconds: 120` clock.
+2. **`preStop` hook runs in parallel with endpoint removal.** It runs
+   `curl -sf -m 5 -X POST http://localhost:8080/__internal/drain || true; sleep 15`
+   — the POST (loopback) flips `/ready` to `503`, `|| true` guarantees the hook
+   never blocks termination if the drain call fails, and `sleep 15` gives the NEG
+   time to converge before SIGTERM.
+3. **Readiness starts failing; the endpoint leaves the NEG.** The readiness probe
+   is `failureThreshold: 3` x `periodSeconds: 10`, so a draining pod is removed
+   from the Service/NEG endpoints roughly **30 seconds** after `/ready` goes 503.
+   From this point the LB sends no **new** connections to the pod.
+4. **`SIGTERM` is delivered** (after `preStop` completes; the `sleep 15` bounds
+   how long that takes). The pusher lifespan shutdown drains process-level
+   background tasks (`drain_background_tasks`) and closes async HTTP client pools.
+5. **Background finalization drains within the grace period.** Each active
+   WebSocket session drains its background task queue (bounded by
+   `BG_DRAIN_TIMEOUT` in the WS handler); audio/transcript/analysis work that can
+   finish inside the remaining grace does so.
+6. **`SIGKILL` at 120s.** Anything still running at the grace deadline is killed.
+   A SIGKILLed session does not strand a conversation: durable finalization is
+   reconciled by the conversation-finalization job lane.
+
+Key timing knobs and what they bound:
+
+- `preStop` `sleep 15` — NEG convergence window before SIGTERM.
+- readiness `failureThreshold * periodSeconds` (~30s) — how long after `/ready`
+  flips 503 before the endpoint is actually removed from the NEG.
+- BackendConfig `connectionDraining.drainingTimeoutSec: 60` — how long the LB
+  waits before hard-cutting the in-flight connections on the removed endpoint
+  (deliberately <= the 120s pod grace).
+- `terminationGracePeriodSeconds: 120` — the hard ceiling on background
+  finalization before SIGKILL.
+
+---
+
+## Operator runbook
+
+Small, hard-to-misuse steps. Run from the repository root of a checkout that
+matches the image you intend to deploy.
+
+### 1. Render the chart and confirm inputs
+
+Render dev and prod and eyeball the values that drive availability:
+
+```bash
+helm template pusher backend/charts/pusher \
+  -f backend/charts/pusher/dev_omi_pusher_values.yaml \
+  --set image.tag=<immutable-tag> > /tmp/pusher-dev.yaml
+
+helm template pusher backend/charts/pusher \
+  -f backend/charts/pusher/prod_omi_pusher_values.yaml \
+  --set image.tag=<immutable-tag> > /tmp/pusher-prod.yaml
+```
+
+Confirm in the rendered output: `readinessProbe.httpGet.path: /ready`,
+`livenessProbe`/`startupProbe` on `/health`, the BackendConfig `healthCheck` on
+`/health` plus `connectionDraining`, `preStop` calling `/__internal/drain`, and
+`progressDeadlineSeconds: 9600`.
+
+### 2. Run the fail-closed preflight
+
+The chart budget and the rollout gate must both pass. Both are dependency-free
+static/contract checks (stdlib only, no cluster or registry reads):
+
+```bash
+# Derives the healthy rollout budget from the chart (waves x availability) and
+# fails if progressDeadlineSeconds or the workflow rollout timeout undercut it.
+python3 backend/scripts/verify_pusher_rollout_budget.py
+
+# Static + contract preflight: capacity headroom, image/config identity, probe
+# split, and that the rollout-blocking metrics are DEFINED in utils/metrics.py.
+python3 backend/scripts/verify_pusher_rollout_gate.py preflight
+```
+
+`verify_pusher_rollout_budget.py` recomputes prod as fourteen waves x ~640s and
+fails if `progressDeadlineSeconds` drops below the budget or a workflow's
+`kubectl rollout status ... --timeout=` is too short.
+
+`verify_pusher_rollout_gate.py preflight` (the default subcommand) fails closed
+(non-zero exit) on any open gate. It checks, statically: capacity headroom
+(`podDisruptionBudget.minAvailable`, HPA `minReplicas`, `maxSurge`/
+`maxUnavailable`, and `terminationGracePeriodSeconds` >= the connectionDraining
+timeout); image and config identity; the probe split
+(`readinessProbe` -> `/ready`, liveness/startup -> `/health`,
+`connectionDraining` present); and that the rollout-blocking metrics are defined
+in `utils/metrics.py` — a missing metric *definition* is a failure, because a
+rollout cannot be judged healthy against telemetry that does not exist. It does
+not scrape live values; use `... rollback --env <env>` for the rollback-mode
+contract check. Do not weaken the chart to make a check pass; fix the input.
+
+### 3. Deploy the immutable tag
+
+Deploy the exact short-SHA image tag. Never deploy `latest`, and never let a
+chart-only deploy reset the workload to `latest` (per `.github/AGENTS.md`). The
+deploy workflow must wait for rollout completion with
+`kubectl rollout status deploy/<env>-omi-pusher --timeout=...` and fail on
+timeout.
+
+### 4. Rollback
+
+Roll back by re-running the Helm deploy against the **prior immutable image tag**
+(not `latest`). Because traffic/runtime rollback to N-1 is always safe by design
+(see [N/N-1 compatibility checklist](#nn-1-compatibility-checklist)), this is the
+default rollback: point the chart at the previous tag and deploy it.
+
+> Production adoption is a **separate, later** decision. Do not treat prod
+> rollback of this hardening as available until SCA-40 (digest chart support,
+> chart-only/reuse-image deploy mode, and rollback evidence) has landed and a
+> healthy pusher prod baseline is confirmed. See
+> [Relationship to SCA-40](#relationship-to-sca-40).
+
+---
+
+## Rollout quality gates (fail-closed)
+
+There are two fail-closed layers, and both must hold:
+
+1. **Static/contract preflight** (run before a deploy, see
+   [Operator runbook](#operator-runbook)) — `verify_pusher_rollout_gate.py
+   preflight` asserts the capacity, identity, probe-split, and
+   metric-*definition* contract. It fails if a blocking metric is not even
+   defined, because a rollout cannot be judged healthy against telemetry that
+   does not exist. It does not scrape live values.
+2. **Live rollout gate** (watched during the deploy) — the blocking signals must
+   be green *and* sufficiently populated. The rule that overrides everything
+   else: **missing telemetry = pause or fail, never green.** A silent or
+   unscrapable dashboard is a failed gate, not a passed one.
+
+Blocking signals (real metric names emitted by pusher / backend-listen):
+
+- `pusher_active_ws_connections` — active pusher WebSocket sessions. The new pods
+  must accept sessions and the count must recover to the pre-rollout baseline;
+  a flatline means new pods are not accepting traffic.
+- `backend_listen_active_ws_connections` — backend-listen side of the path; a
+  sustained drop with no recovery indicates listeners are failing to reconnect.
+- `pusher_circuit_breaker_state` (0 closed / 1 open / 2 half_open) and
+  `pusher_circuit_breaker_rejections_total` — an opening breaker or rising
+  rejections during a rollout means pusher is rejecting connections.
+- `pusher_sessions_degraded` — sessions backend-listen routed away from pusher.
+  Sustained elevation (see `backend/docs/runbooks/pusher-degraded.md`) is a
+  user-impact signal.
+- `omi_journey_terminal_total{journey="pusher_session"}` outcomes — terminal
+  session outcomes; rising `failure` (close code 1011 / application failure) is a
+  regression.
+- `omi_journey_latency_seconds{journey="pusher_session"}` — end-to-end session
+  latency; a rollout must not push this outside its bounded threshold.
+- finalization health: `listen_finalization_jobs`, `listen_finalization_retries_total`,
+  `listen_finalization_dead_letter_total`, and
+  `listen_finalization_oldest_nonterminal_age_seconds`. A rollout that spikes
+  retries, dead-letters, or oldest-nonterminal age is failing to drain cleanly.
+
+The gate requires **minimum capability/session counts plus bounded error and
+latency thresholds**, not only elapsed time. Time-only gates are forbidden: a
+rollout that is merely "old enough" but has not served enough sessions, or is
+over its error/latency bounds, is not green.
+
+---
+
+## N/N-1 compatibility checklist
+
+Separate two kinds of rollback:
+
+- **Traffic / runtime rollback to N-1 is always safe by design.** Re-pointing the
+  chart at the previous immutable tag and redeploying never requires a data
+  migration to undo. This is the only rollback an operator should ever need to
+  perform under pressure.
+- **Irreversible data changes are a different category** and must never be
+  *required* by a rollout's rollback path. If a change is irreversible, the
+  design obligation is to make N and N-1 coexist (additive, dual-read/dual-write,
+  or feature-gated) so traffic can return to N-1 without a data rollback.
+
+**Full N-1 drain first is required before introducing** any of the following
+incompatibilities (these are the changes that break a safe traffic rollback to
+N-1 and therefore cannot ride on a routine rolling update):
+
+- **Envelope / key change:** `ENCRYPTION_SECRET` or the per-user envelope
+  derivation (HKDF-SHA256 in `utils/encryption.py`). N-1 cannot decrypt
+  N-written segments.
+- **GCS audio-chunk envelope:** a change to how pusher batches/uploads audio
+  chunks to GCS that N-1 cannot read back.
+- **New `ConversationStatus`** (or any persisted processing-state enum) that N-1
+  does not recognize and would mishandle.
+- **Removed or renamed read fields** on persisted models that released
+  app-clients or N-1 services still read.
+- **Redis key or TTL change** that N-1 interprets differently (cache, rate-limit
+  buckets, listen locks).
+- **Finalization lease / fence protocol change:** the durable conversation-
+  finalization lease and fence protocol (the `durable_job_required` / claim /
+  lease-epoch contract pusher enforces) — a change here can let an N-1 session
+  double-process or bypass a durable claim.
+
+If a change touches any of the above, it is **not** a candidate for this
+hardened rolling update without a documented N/N-1 coexistence plan and, where
+relevant, a full N-1 drain. Routine pushes (probe/drain/availability hardening,
+non-breaking additive fields) ride the rolling update and roll back to N-1 by
+re-pointing the chart.
+
+---
+
+## Dev qualification plan
+
+This hardening is qualified **dev-first**. Dev is the place to prove the
+choreography (readiness flip, app drain, NEG convergence, reconnect gap,
+finalization drain) end to end before any prod consideration.
+
+How to qualify on dev (pusher dev: 1-3 pods, `maxUnavailable: 0 / maxSurge: 1`):
+
+1. **Render and preflight** exactly as in the
+   [Operator runbook](#operator-runbook), against the dev values and the dev
+   immutable tag.
+2. **Exercise the choreography under synthetic load.** Use privacy-safe
+   synthetic pusher capability checks that reuse the existing LLM-gateway smoke
+   precedent (the family that validates a ready Kubernetes workload, its
+   ingress/ILB attachment, and a Cloud Run VPC smoke route via
+   `backend/scripts/verify-llm-gateway-serving.py` and
+   `probe-llm-gateway-from-cloud-run.sh`). The pusher equivalents must open a
+   WebSocket session, confirm `/ready` flips to 503 on drain, confirm new
+   connections go to a healthy pod, and confirm background finalization
+   completes inside the grace window — without using real user data.
+3. **Hold the minimum capability/session counts and bounded error/latency
+   thresholds** from [Rollout quality gates (fail-closed)](#rollout-quality-gates-fail-closed).
+   Dev must serve the minimum session/capability counts, not just run for an
+   elapsed time.
+4. **Record the evidence** (commands, output, gate result) in the PR, per the
+   root `AGENTS.md` Definition of Done.
+
+Acknowledge the limit of dev qualification explicitly: **dev proves the
+choreography, not prod-scale NEG/ILB behavior.** Dev runs 1-3 pods with low
+WebSocket traffic, so it exercises the readiness/drain/reconnect sequence but
+does **not** prove prod-scale NEG propagation, the prod 40-pod / fourteen-wave
+rollout, or prod ILB connection draining. Those require the separate, later prod
+proof gated on SCA-40 and a healthy pusher prod baseline.
+
+---
+
+## Relationship to SCA-40
+
+This hardening is deliberately scoped to **native `RollingUpdate` availability**
+and does not duplicate SCA-40's work. SCA-40 owns and is still building:
+
+- **Digest chart support** (`image.digest` / `@sha256`) so a rollout pins an
+  immutable image by content digest, not just a mutable tag.
+- **Chart-only / reuse-image deploy mode** so a chart change can be applied
+  without rebuilding or re-pushing the image.
+- The immediate **`REDIS_DB_HOST` recovery preflight.**
+- **Rollback evidence** recording.
+
+Consequences for this document:
+
+- This PR does **not** add an `image.digest` chart field, a digest-promotion
+  pipeline, a chart-only deploy mode, or a rollback-evidence recorder.
+- Build-once **digest promotion** (deploying the same built image across stages by
+  digest) is deferred to stack on SCA-40; it is out of scope here.
+- The rollback described in the [Operator runbook](#operator-runbook) is
+  re-pointing the chart at the prior immutable **tag**, which is safe by the
+  N/N-1 contract. Digest-pinned rollback and recorded rollback evidence arrive
+  with SCA-40.
+
+In short: this hardening makes the native rolling update honest and bounded;
+SCA-40 makes image identity and rollback evidence durable.

--- a/backend/docs/pusher_rolling_update_operations.md
+++ b/backend/docs/pusher_rolling_update_operations.md
@@ -201,7 +201,58 @@ rollout cannot be judged healthy against telemetry that does not exist. It does
 not scrape live values; use `... rollback --env <env>` for the rollback-mode
 contract check. Do not weaken the chart to make a check pass; fix the input.
 
-### 3. Deploy the immutable tag
+### 3. Shared ConfigMap/Secret migration guard (required on key changes)
+
+The 2026-07-22 production Pusher outage was a *non-atomic cross-resource
+migration*: the shared key `REDIS_DB_HOST` stopped materializing in its source
+while live pusher pods still referenced it. Pusher bulk-loads **all** of its
+ConfigMap keys via `envFrom`, so a key removed from that object left pods
+`CreateContainerConfigError` while `/health` stayed green — the fleet dropped to
+zero healthy pods with no probe signal. `verify_shared_config_migration.py`
+fails CLOSED before any mutation when a serving workload still references a
+ConfigMap/Secret source or key the proposed state removes or reclassifies.
+
+- **Preflight (CI / pre-push, stdlib-only).**
+  `python3 backend/scripts/verify_shared_config_migration.py preflight` scans the
+  pusher chart values and fails on a dual-source binding or a malformed
+  `valueFrom`. Registered as `shared-config-migration-preflight` in
+  `.github/checks-manifest.yaml`; it runs automatically. It has no inventory, so
+  it cannot detect a key removed from a bulk-loaded object.
+
+- **Guard mode (operator-invoked — the actual incident root-fix).** Run this
+  before **any** change that adds, removes, or moves a ConfigMap/Secret **key**
+  consumed by pusher or any serving workload (Deployment/StatefulSet/DaemonSet/
+  Job/CronJob/ReplicaSet, incl. `initContainers`). It resolves every
+  `env.valueFrom`, `envFrom`, and per-key reference against the proposed source
+  inventory and fails closed on a removed/reclassified key. It reads object and
+  key NAMES only — never ConfigMap/Secret values.
+
+  ```bash
+  # Render the proposed state (--rendered is repeatable across envs/workloads):
+  helm template pusher backend/charts/pusher \
+      -f backend/charts/pusher/prod_omi_pusher_values.yaml \
+      --set image.tag=<immutable-tag> > /tmp/pusher-prod.yaml
+
+  # Capture the CURRENT live key names in the guard's inventory format
+  # ({configmaps: {<obj>: [key,...]}, secrets: {...}} — names only, never values):
+  kubectl -n <env>-omi-backend get configmap <cfg> -o json \
+      | jq '{configmaps: {(.metadata.name): (.data | keys)}}' > /tmp/live-keys.yaml
+
+  # Write /tmp/proposed-keys.yaml in the same shape with the keys the object will
+  # carry AFTER the change, then run the guard. --previous-inventory is what
+  # catches a key removed from an envFrom bulk-loaded object (the outage class);
+  # without it, envFrom removals are silent.
+  python3 backend/scripts/verify_shared_config_migration.py guard \
+      --rendered /tmp/pusher-prod.yaml \
+      --source-inventory /tmp/proposed-keys.yaml \
+      --previous-inventory /tmp/live-keys.yaml
+  ```
+
+  Non-zero exit = a serving workload still references a source/key the proposed
+  state removes or reclassifies; do not apply. Needs PyYAML (the backend venv, or
+  `pip install pyyaml`).
+
+### 4. Deploy the immutable tag
 
 Deploy the exact short-SHA image tag. Never deploy `latest`, and never let a
 chart-only deploy reset the workload to `latest` (per `.github/AGENTS.md`). The
@@ -209,7 +260,7 @@ deploy workflow must wait for rollout completion with
 `kubectl rollout status deploy/<env>-omi-pusher --timeout=...` and fail on
 timeout.
 
-### 4. Rollback
+### 5. Rollback
 
 Roll back by re-running the Helm deploy against the **prior immutable image tag**
 (not `latest`). Because traffic/runtime rollback to N-1 is always safe by design

--- a/backend/pusher/main.py
+++ b/backend/pusher/main.py
@@ -11,12 +11,14 @@ from utils.logging_config import configure_split_stream_logging
 configure_split_stream_logging(level=logging.INFO)
 
 import firebase_admin
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response
 from firebase_admin import credentials
 
 from routers import pusher, metrics
 from utils.http_client import close_all_clients
 from utils.executors import drain_background_tasks, log_executor_health, start_background_task
+from utils.readiness import ReadinessGate
 
 if os.environ.get('SERVICE_ACCOUNT_JSON'):
     service_account_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
@@ -33,6 +35,10 @@ async def startup_event() -> None:
 
 
 async def shutdown_event() -> None:
+    # Defense-in-depth: close readiness FIRST so the LB stops sending NEW traffic
+    # even if the chart preStop hook did not run. Existing in-flight sessions are
+    # then drained by drain_background_tasks within the bounded grace period.
+    ReadinessGate.begin_drain()
     await drain_background_tasks(timeout=10.0)
     await close_all_clients()
 
@@ -60,3 +66,28 @@ for path in paths:
 @app.get('/health')
 async def health_check() -> dict[str, str]:
     return {"status": "healthy"}
+
+
+@app.get('/ready')
+async def ready() -> Response:
+    # Readiness for the LB: 200 while serving new traffic, 503 once drain begins.
+    # Distinct from /health (liveness), which stays 200 as long as the process is alive.
+    if ReadinessGate.is_serving():
+        return JSONResponse(content={"status": "ready"}, status_code=200)
+    return JSONResponse(content={"status": "draining"}, status_code=503)
+
+
+@app.post('/__internal/drain')
+async def drain(request: Request) -> Response:
+    # Trust boundary: accept ONLY loopback peers (the preStop hook curls this from
+    # within the pod). The barrier is request.client.host being 127.0.0.1/::1, NOT
+    # network isolation: the Ingress path:/ Prefix does route this path, but an
+    # off-pod caller (internal LB) presents a non-loopback peer and is 403'd. This
+    # relies on uvicorn NOT running --proxy-headers, so request.client.host is the
+    # real TCP peer rather than a spoofable X-Forwarded-For.
+    client_host = request.client.host if request.client else None
+    if client_host not in {'127.0.0.1', '::1'}:
+        return Response(status_code=403)
+    # Idempotent: safe to call from both preStop and the lifespan shutdown path.
+    ReadinessGate.begin_drain()
+    return JSONResponse(content={"status": "draining"}, status_code=200)

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -316,20 +316,23 @@ async def _websocket_util_trigger(
 ) -> None:
     logger.info(f'_websocket_util_trigger {uid}')
 
-    # Defense-in-depth: during drain the LB should already have removed us from
-    # the NEG, but reject straggler NEW connections without accepting so we do
-    # not start a session we are about to terminate. Existing in-flight sessions
-    # keep draining via their own background-drain logic (BG_DRAIN_TIMEOUT).
-    # Code 1001 (Going Away) signals the client to reconnect elsewhere.
-    if not ReadinessGate.is_serving():
-        logger.info(f'Rejecting new WS for {uid}: pusher is draining')
-        await websocket.close(code=1001)
-        return
     try:
         await websocket.accept()
     except RuntimeError as e:
         logger.error(e)
         await websocket.close(code=1011, reason="Dirty state")
+        return
+
+    # Defense-in-depth: during drain the LB should already have removed us from
+    # the NEG, but reject straggler NEW connections.  We accept the handshake
+    # FIRST so the client sees a clean WS close frame (1001 Going Away) rather
+    # than a failed HTTP upgrade — a pre-accept close is surfaced as an
+    # exception by the websockets client and recorded as a circuit-breaker
+    # failure in backend-listen (backend/utils/pusher.py), which can trip the
+    # pod's pusher circuit during a normal rollout.
+    if not ReadinessGate.is_serving():
+        logger.info(f'Rejecting new WS for {uid}: pusher is draining')
+        await websocket.close(code=1001)
         return
 
     journey_attempt = JourneyAttempt('pusher_session')

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -40,6 +40,7 @@ from utils.webhooks import (
 from utils.cloud_tasks import get_listen_finalization_tasks_max_attempts, is_audio_merge_dispatch_enabled
 from utils.other.storage import maybe_invalidate_conversation_playback, upload_audio_chunks_batch
 from utils.metrics import PUSHER_ACTIVE_WS_CONNECTIONS
+from utils.readiness import ReadinessGate
 from utils.observability.journeys import JourneyAttempt, JourneyOutcome, record_capture_finalization_terminal
 from utils.speaker_identification import extract_speaker_samples
 import logging
@@ -315,6 +316,15 @@ async def _websocket_util_trigger(
 ) -> None:
     logger.info(f'_websocket_util_trigger {uid}')
 
+    # Defense-in-depth: during drain the LB should already have removed us from
+    # the NEG, but reject straggler NEW connections without accepting so we do
+    # not start a session we are about to terminate. Existing in-flight sessions
+    # keep draining via their own background-drain logic (BG_DRAIN_TIMEOUT).
+    # Code 1001 (Going Away) signals the client to reconnect elsewhere.
+    if not ReadinessGate.is_serving():
+        logger.info(f'Rejecting new WS for {uid}: pusher is draining')
+        await websocket.close(code=1001)
+        return
     try:
         await websocket.accept()
     except RuntimeError as e:

--- a/backend/scripts/verify_pusher_rollout_budget.py
+++ b/backend/scripts/verify_pusher_rollout_budget.py
@@ -316,6 +316,77 @@ def validate_template(root: Path) -> list[str]:
     return errors
 
 
+def validate_probe_and_drain_contract(root: Path) -> list[str]:
+    """Fail closed on probe routing and BackendConfig drain regressions.
+
+    readinessProbe must point at /ready so a drain flips LB readiness without
+    restarting the pod; liveness/startup stay on /health. The BackendConfig
+    must render connectionDraining and its timeout must fit inside the pod
+    termination grace window so the LB drains before SIGTERM.
+    """
+
+    errors: list[str] = []
+    for environment in ENVIRONMENTS:
+        values_path = root / "backend" / "charts" / "pusher" / f"{environment}_omi_pusher_values.yaml"
+        try:
+            entries = _mapping_entries(values_path)
+        except ContractError as exc:
+            errors.append(str(exc))
+            continue
+
+        for probe, expected in (
+            ("readinessProbe", "/ready"),
+            ("livenessProbe", "/health"),
+            ("startupProbe", "/health"),
+        ):
+            try:
+                actual = _mapping_value(entries, (probe, "httpGet", "path"), values_path)
+            except ContractError as exc:
+                errors.append(str(exc))
+                continue
+            if actual != expected:
+                errors.append(f"{values_path}: {probe}/httpGet/path must be {expected!r}, got {actual!r}")
+
+        try:
+            grace = _nonnegative_int(
+                _mapping_value(entries, ("terminationGracePeriodSeconds",), values_path),
+                field="terminationGracePeriodSeconds",
+                source=values_path,
+            )
+            drain = _positive_int(
+                _mapping_value(entries, ("backendConfig", "connectionDraining", "drainingTimeoutSec"), values_path),
+                field="backendConfig/connectionDraining/drainingTimeoutSec",
+                source=values_path,
+            )
+        except ContractError as exc:
+            errors.append(str(exc))
+            continue
+        if drain > grace:
+            errors.append(
+                f"{values_path}: connectionDraining.drainingTimeoutSec={drain}s must be <= "
+                f"terminationGracePeriodSeconds={grace}s"
+            )
+
+    template = root / "backend" / "charts" / "pusher" / "templates" / "backendconfig.yaml"
+    try:
+        text = template.read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"could not read {template}: {exc}")
+        return errors
+    if not re.search(r"connectionDraining:\s*\n\s*drainingTimeoutSec:\s*\{\{", text):
+        errors.append(f"{template}: BackendConfig must render connectionDraining.drainingTimeoutSec from .Values")
+    # The BackendConfig healthCheck MUST stay on /health (liveness semantics).
+    # Routing it to /ready would flip the backend unhealthy during a readiness
+    # drain, defeating connectionDraining so the LB cuts in-flight WS at once.
+    if not re.search(r"requestPath:\s*/health\b", text) or re.search(r"requestPath:\s*/ready\b", text):
+        errors.append(
+            f"{template}: BackendConfig healthCheck.requestPath must render to /health "
+            "(liveness semantics); routing it to /ready flips the backend unhealthy during "
+            "drain and defeats connectionDraining"
+        )
+    return errors
+
+
 def workflow_timeout_seconds(path: Path) -> int:
     try:
         text = path.read_text(encoding="utf-8")
@@ -331,6 +402,7 @@ def validate(root: Path = ROOT) -> list[str]:
     """Return every static contract violation for chart and workflow changes."""
 
     errors = validate_template(root)
+    errors.extend(validate_probe_and_drain_contract(root))
     budgets: dict[str, RolloutBudget] = {}
     for environment in ENVIRONMENTS:
         try:

--- a/backend/scripts/verify_pusher_rollout_gate.py
+++ b/backend/scripts/verify_pusher_rollout_gate.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""Static + contract preflight that fails closed when a Pusher rollout cannot be
+verified safe, plus a rollback CONTRACT (capture-and-print, never execute).
+
+This gate is intentionally read-only: it scans the chart and metrics source to
+confirm the rollout contract holds *before* any deploy.  It performs no deploy,
+no digest copy, and no rollback execution (SCA-40 owns digest promotion and
+rollback evidence).
+
+**preflight** checks (fail closed):
+  1. capacity headroom: PDB minAvailable, HPA minReplicas, RollingUpdate
+     maxUnavailable<=1 / maxSurge>=1, terminationGracePeriodSeconds >=
+     BackendConfig drainingTimeoutSec.
+  2. image/config identity: assert no ``image.digest`` field (SCA-40 owns it).
+  3. readiness/health split: readinessProbe → /ready, liveness/startup →
+     /health, BackendConfig connectionDraining present.
+  4. telemetry fail-closed: each rollout-blocking metric must be DEFINED in
+     backend/utils/metrics.py (static scan, not live scrape).
+
+**rollback** emits the rollback contract as structured JSON (read-only capture,
+never execution).
+
+Run as::
+
+  python -m backend.scripts.verify_pusher_rollout_gate preflight
+  python -m backend.scripts.verify_pusher_rollout_gate rollback --env prod
+  python3  backend/scripts/verify_pusher_rollout_gate.py preflight
+
+Stdlib-only: runs in the shared pre-push lane before backend dependencies are
+installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ENVIRONMENTS = ("dev", "prod")
+
+# ponytail: re-scan chart values locally rather than importing Lane B's
+# verify_pusher_rollout_budget helpers.  Lane B's script is standalone and
+# invoked via runpy in tests; importing it at module level breaks script-mode
+# execution.  The YAML mapping helpers are ~40 lines and kept in sync by the
+# regression tests below.  Re-deriving here is defense-in-depth: if Lane B's
+# verifier drifts, this gate still catches the regression independently.
+
+MAPPING_ENTRY_PATTERN = re.compile(r"^(?P<indent> *)(?P<key>[^\s#][^:]*):(?:\s*(?P<value>.*))?$")
+
+
+class ContractError(ValueError):
+    """Raised when chart or telemetry inputs violate the rollout contract."""
+
+
+@dataclass(frozen=True)
+class MappingEntry:
+    line_number: int
+    indent: int
+    key: str
+    value: str
+
+
+# Metrics whose DEFINITION in backend/utils/metrics.py is rollout-blocking.
+# Missing any one of these means we cannot observe a drain or a stuck rollout.
+ROLLOUT_BLOCKING_METRICS = (
+    "pusher_active_ws_connections",
+    "pusher_ready",
+    "pusher_drain_in_progress",
+    "omi_journey_terminal_total",
+    "pusher_sessions_degraded",
+)
+
+# Kubernetes default when revisionHistoryLimit is unset in the Deployment spec.
+DEFAULT_REVISION_HISTORY_LIMIT = 10
+
+
+# ---------------------------------------------------------------------------
+# YAML mapping helpers (mirrors the subset in verify_pusher_rollout_budget.py)
+# ---------------------------------------------------------------------------
+
+
+def _strip_comment(value: str) -> str:
+    """Return one simple scalar value without its trailing YAML comment."""
+
+    return value.split("#", 1)[0].strip().strip("\"'")
+
+
+def _mapping_entries(path: Path) -> list[MappingEntry]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise ContractError(f"could not read {path}: {exc}") from exc
+
+    entries: list[MappingEntry] = []
+    for line_number, raw_line in enumerate(lines, start=1):
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        match = MAPPING_ENTRY_PATTERN.match(raw_line)
+        if match is None:
+            continue
+        entries.append(
+            MappingEntry(
+                line_number=line_number,
+                indent=len(match.group("indent")),
+                key=match.group("key").strip(),
+                value=_strip_comment(match.group("value") or ""),
+            )
+        )
+    return entries
+
+
+def _mapping_value(entries: list[MappingEntry], path: tuple[str, ...], source: Path) -> str:
+    """Read a scalar from the small mapping-only subset used by rollout values."""
+
+    start = 0
+    end = len(entries)
+    parent_indent = -1
+    selected: MappingEntry | None = None
+
+    for index, key in enumerate(path):
+        children = [entry for entry in entries[start:end] if entry.indent > parent_indent]
+        if not children:
+            raise ContractError(f"{source}: missing mapping {'/'.join(path[:index])}")
+        child_indent = min(entry.indent for entry in children)
+        matches = [entry for entry in children if entry.indent == child_indent and entry.key == key]
+        if len(matches) != 1:
+            qualifier = "missing" if not matches else "ambiguous"
+            raise ContractError(f"{source}: {qualifier} scalar {'/'.join(path[: index + 1])}")
+        selected = matches[0]
+
+        selected_index = entries.index(selected, start, end)
+        start = selected_index + 1
+        end = next(
+            (
+                candidate_index
+                for candidate_index in range(start, end)
+                if entries[candidate_index].indent <= selected.indent
+            ),
+            end,
+        )
+        parent_indent = selected.indent
+
+    assert selected is not None
+    if not selected.value:
+        raise ContractError(f"{source}:{selected.line_number}: {'/'.join(path)} must be an explicit scalar")
+    return selected.value
+
+
+def _try_int(value: str) -> int | None:
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Preflight sub-checks
+# ---------------------------------------------------------------------------
+
+
+def _draining_timeout_seconds(entries: list[MappingEntry], source: Path) -> int | None:
+    """Read BackendConfig drainingTimeoutSec from the chart values mapping.
+
+    Lane B renders this from ``backendConfig.connectionDraining.drainingTimeoutSec``
+    in both values files.  When absent (connectionDraining not yet added) return
+    None — the connectionDraining-presence check handles that case separately.
+    """
+
+    try:
+        raw = _mapping_value(entries, ("backendConfig", "connectionDraining", "drainingTimeoutSec"), source)
+    except ContractError:
+        return None
+    return _try_int(raw)
+
+
+def validate_capacity_headroom(root: Path) -> list[str]:
+    """Capacity headroom: PDB, HPA floor, gradual RollingUpdate, grace >= drain."""
+
+    errors: list[str] = []
+    for env in ENVIRONMENTS:
+        values = root / "backend" / "charts" / "pusher" / f"{env}_omi_pusher_values.yaml"
+        try:
+            entries = _mapping_entries(values)
+        except ContractError as exc:
+            errors.append(str(exc))
+            continue
+
+        # --- PDB minAvailable ---
+        try:
+            _mapping_value(entries, ("podDisruptionBudget", "minAvailable"), values)
+        except ContractError:
+            errors.append(
+                f"{values}: podDisruptionBudget/minAvailable must be present for voluntary-disruption headroom"
+            )
+
+        # --- HPA minReplicas (when autoscaling enabled) ---
+        try:
+            autoscaling_enabled = _mapping_value(entries, ("autoscaling", "enabled"), values).lower()
+            if autoscaling_enabled == "true":
+                _mapping_value(entries, ("autoscaling", "minReplicas"), values)
+        except ContractError:
+            errors.append(f"{values}: autoscaling/minReplicas must be present when autoscaling is enabled")
+
+        # --- RollingUpdate maxUnavailable <= 1, maxSurge >= 1 ---
+        try:
+            strategy_type = _mapping_value(entries, ("strategy", "type"), values)
+            if strategy_type != "RollingUpdate":
+                errors.append(f"{values}: strategy/type must be RollingUpdate, got {strategy_type!r}")
+            max_unavailable_raw = _mapping_value(entries, ("strategy", "rollingUpdate", "maxUnavailable"), values)
+            max_surge_raw = _mapping_value(entries, ("strategy", "rollingUpdate", "maxSurge"), values)
+            # ponytail: integer-only check; percentage maxUnavailable/maxSurge
+            # would need replica-count context (deferred — current chart uses ints).
+            mu = _try_int(max_unavailable_raw)
+            ms = _try_int(max_surge_raw)
+            if mu is not None and mu > 1:
+                errors.append(f"{values}: strategy/rollingUpdate/maxUnavailable={mu} must be <= 1 for gradual rollout")
+            if ms is not None and ms < 1:
+                errors.append(f"{values}: strategy/rollingUpdate/maxSurge={ms} must be >= 1 for surge capacity")
+        except ContractError as exc:
+            errors.append(str(exc))
+
+        # --- terminationGracePeriodSeconds >= drainingTimeoutSec ---
+        try:
+            grace = _try_int(_mapping_value(entries, ("terminationGracePeriodSeconds",), values))
+        except ContractError:
+            grace = None
+        draining = _draining_timeout_seconds(entries, values)
+        if grace is not None and draining is not None and draining > grace:
+            errors.append(
+                f"{values}: BackendConfig drainingTimeoutSec={draining}s must not exceed "
+                f"terminationGracePeriodSeconds={grace}s"
+            )
+    return errors
+
+
+def validate_image_identity(root: Path) -> list[str]:
+    """Assert no image.digest field (SCA-40 owns it).  tag:'' is INFO, not failure."""
+
+    errors: list[str] = []
+    for env in ENVIRONMENTS:
+        values = root / "backend" / "charts" / "pusher" / f"{env}_omi_pusher_values.yaml"
+        try:
+            entries = _mapping_entries(values)
+        except ContractError as exc:
+            errors.append(str(exc))
+            continue
+        try:
+            _mapping_value(entries, ("image", "digest"), values)
+            errors.append(
+                f"{values}: image/digest must not be present (SCA-40 owns digest promotion; "
+                "this gate will require a pinned digest once SCA-40 adds the field)"
+            )
+        except ContractError:
+            pass  # Good — no digest field yet.
+    return errors
+
+
+def validate_probe_split(root: Path) -> list[str]:
+    """readinessProbe → /ready, liveness/startup → /health, connectionDraining present."""
+
+    errors: list[str] = []
+    for env in ENVIRONMENTS:
+        values = root / "backend" / "charts" / "pusher" / f"{env}_omi_pusher_values.yaml"
+        try:
+            entries = _mapping_entries(values)
+        except ContractError as exc:
+            errors.append(str(exc))
+            continue
+
+        try:
+            readiness_path = _mapping_value(entries, ("readinessProbe", "httpGet", "path"), values)
+            if readiness_path != "/ready":
+                errors.append(
+                    f"{values}: readinessProbe/httpGet/path must be '/ready' for graceful drain, got {readiness_path!r}"
+                )
+        except ContractError:
+            errors.append(f"{values}: readinessProbe/httpGet/path must be '/ready'")
+
+        try:
+            liveness_path = _mapping_value(entries, ("livenessProbe", "httpGet", "path"), values)
+            if liveness_path != "/health":
+                errors.append(f"{values}: livenessProbe/httpGet/path must be '/health', got {liveness_path!r}")
+        except ContractError:
+            errors.append(f"{values}: livenessProbe/httpGet/path must be '/health'")
+
+        try:
+            startup_path = _mapping_value(entries, ("startupProbe", "httpGet", "path"), values)
+            if startup_path != "/health":
+                errors.append(f"{values}: startupProbe/httpGet/path must be '/health', got {startup_path!r}")
+        except ContractError:
+            errors.append(f"{values}: startupProbe/httpGet/path must be '/health'")
+
+    # --- connectionDraining in the BackendConfig template ---
+    template = root / "backend" / "charts" / "pusher" / "templates" / "backendconfig.yaml"
+    try:
+        template_text = template.read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"could not read {template}: {exc}")
+    else:
+        if "connectionDraining" not in template_text:
+            errors.append(
+                f"{template}: BackendConfig must define connectionDraining for graceful WS drain "
+                "(LB keeps in-flight connections alive during endpoint removal)"
+            )
+        # The healthCheck MUST stay on /health (liveness semantics). Routing it to
+        # /ready flips the backend unhealthy during a drain and defeats connectionDraining.
+        if not re.search(r"requestPath:\s*/health\b", template_text) or re.search(
+            r"requestPath:\s*/ready\b", template_text
+        ):
+            errors.append(
+                f"{template}: BackendConfig healthCheck.requestPath must render to /health "
+                "(liveness semantics); routing it to /ready defeats connectionDraining"
+            )
+    return errors
+
+
+def validate_telemetry(root: Path) -> list[str]:
+    """Each rollout-blocking metric must be DEFINED in metrics.py (static scan).
+
+    Missing telemetry = the rollout cannot be observed; fail closed rather than
+    proceeding blind.
+    """
+
+    metrics_path = root / "backend" / "utils" / "metrics.py"
+    try:
+        text = metrics_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"could not read {metrics_path}: {exc}"]
+
+    errors: list[str] = []
+    for metric in ROLLOUT_BLOCKING_METRICS:
+        # Search for the metric name as a quoted string literal.
+        if not re.search(rf"['\"]({re.escape(metric)})['\"]", text):
+            errors.append(
+                f"{metrics_path}: rollout-blocking metric '{metric}' is not defined — "
+                "missing telemetry blocks the rollout"
+            )
+    return errors
+
+
+def validate_preflight(root: Path = ROOT) -> list[str]:
+    """Return every static + contract violation that would block a safe rollout."""
+
+    errors: list[str] = []
+    errors.extend(validate_capacity_headroom(root))
+    errors.extend(validate_image_identity(root))
+    errors.extend(validate_probe_split(root))
+    errors.extend(validate_telemetry(root))
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Rollback contract (read-only capture, never execution)
+# ---------------------------------------------------------------------------
+
+
+def _chart_revision_history_limit(root: Path) -> int | None:
+    """Return the chart's revisionHistoryLimit if set in the Deployment template."""
+
+    template = root / "backend" / "charts" / "pusher" / "templates" / "deployment.yaml"
+    try:
+        text = template.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = re.search(r"^\s*revisionHistoryLimit:\s*(\d+)\s*$", text, re.MULTILINE)
+    return int(match.group(1)) if match else None
+
+
+@dataclass(frozen=True)
+class RollbackContract:
+    """Read-only rollback contract emitted as structured JSON."""
+
+    environment: str
+    revision_history_limit: int
+    revision_history_source: str
+    prior_restore: str
+    capture_command: str
+    restore_command: str
+    traffic_rollback: str
+    data_rollback: str
+    note: str
+
+    def as_dict(self) -> dict:
+        return {
+            "environment": self.environment,
+            "revision_history_limit": self.revision_history_limit,
+            "revision_history_source": self.revision_history_source,
+            "prior_restore": self.prior_restore,
+            "capture_command": self.capture_command,
+            "restore_command": self.restore_command,
+            "traffic_rollback": self.traffic_rollback,
+            "data_rollback": self.data_rollback,
+            "note": self.note,
+        }
+
+
+def rollback_contract(root: Path = ROOT, environment: str = "prod") -> RollbackContract:
+    """Build the read-only rollback contract for one environment.
+
+    This NEVER mutates cluster, registry, or repo state.  It captures the
+    procedure the operator must follow, including the prior-image-restore step
+    that SCA-40's evidence recorder will eventually automate.
+    """
+
+    chart_limit = _chart_revision_history_limit(root)
+    if chart_limit is not None:
+        revision_history_limit = chart_limit
+        revision_history_source = f"chart sets revisionHistoryLimit={chart_limit} in deployment.yaml"
+    else:
+        revision_history_limit = DEFAULT_REVISION_HISTORY_LIMIT
+        revision_history_source = (
+            f"chart does not set revisionHistoryLimit; Kubernetes default ({DEFAULT_REVISION_HISTORY_LIMIT}) applies. "
+            "Prior ReplicaSets are retained for rollback."
+        )
+
+    release = f"{environment}-omi-pusher"
+    return RollbackContract(
+        environment=environment,
+        revision_history_limit=revision_history_limit,
+        revision_history_source=revision_history_source,
+        prior_restore=(
+            "The prior image tag/digest to restore is the currently-deployed one. "
+            "It must be captured at runtime by the operator BEFORE the rollout "
+            "(not by this static script). SCA-40 will automate this capture."
+        ),
+        capture_command=(
+            f"kubectl get deployment {release} " f"-o jsonpath='{{.spec.template.spec.containers[0].image}}'"
+        ),
+        restore_command=(
+            f"helm upgrade --install {release} ./backend/charts/pusher "
+            f"--set image.tag=<prior-immutable-tag> "
+            f"-f backend/charts/pusher/{environment}_omi_pusher_values.yaml"
+        ),
+        traffic_rollback=(
+            "Traffic/runtime rollback (Helm upgrade to the prior immutable tag) is SAFE and always available. "
+            "The LB cuts existing WebSocket sessions on endpoint removal; backend-listen reconnects "
+            "within a bounded ~1-60s gap per affected session. New connections are served immediately."
+        ),
+        data_rollback=(
+            "Data changes (Firestore writes, Redis state, file-system mutations) are IRREVERSIBLE. "
+            "They must NEVER be auto-rolled-back. Verify data integrity manually after a runtime rollback."
+        ),
+        note=(
+            "This contract is read-only. It captures the procedure; it does not execute any rollback, "
+            "deploy, digest copy, or cluster mutation."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("mode", nargs="?", default="preflight", choices=("preflight", "rollback"))
+    parser.add_argument("--root", type=Path, default=ROOT, help="Repository root (for hermetic fixture tests).")
+    parser.add_argument("--env", choices=ENVIRONMENTS, default="prod", help="Environment for rollback contract.")
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+
+    if args.mode == "rollback":
+        contract = rollback_contract(root, args.env)
+        print(json.dumps(contract.as_dict(), indent=2))
+        return 0
+
+    # preflight (default)
+    errors = validate_preflight(root)
+    if errors:
+        print("FAIL: Pusher rollout quality gate", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("OK: Pusher rollout quality gate passed.")
+    for env in ENVIRONMENTS:
+        values = root / "backend" / "charts" / "pusher" / f"{env}_omi_pusher_values.yaml"
+        try:
+            entries = _mapping_entries(values)
+        except ContractError:
+            continue
+        # tag: "" is valid — the chart delegates to the deploy workflow. Report as INFO.
+        tag = ""
+        try:
+            tag = _mapping_value(entries, ("image", "tag"), values)
+        except ContractError:
+            pass
+        if not tag:
+            print(f"- {env}: image/tag is empty — INFO only (chart delegates to deploy workflow per .github/AGENTS.md)")
+        else:
+            print(f"- {env}: image/tag={tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/verify_pusher_rollout_gate.py
+++ b/backend/scripts/verify_pusher_rollout_gate.py
@@ -4,14 +4,15 @@ verified safe, plus a rollback CONTRACT (capture-and-print, never execute).
 
 This gate is intentionally read-only: it scans the chart and metrics source to
 confirm the rollout contract holds *before* any deploy.  It performs no deploy,
-no digest copy, and no rollback execution (SCA-40 owns digest promotion and
-rollback evidence).
+no rollback execution, and no cluster mutation.
 
 **preflight** checks (fail closed):
   1. capacity headroom: PDB minAvailable, HPA minReplicas, RollingUpdate
      maxUnavailable<=1 / maxSurge>=1, terminationGracePeriodSeconds >=
      BackendConfig drainingTimeoutSec.
-  2. image/config identity: assert no ``image.digest`` field (SCA-40 owns it).
+  2. image identity: tag mode delegates the tag to the deploy workflow; a digest
+     pin (build-once promotion) must be exact ``sha256:<hex>`` with the mutable
+     tag dropped and ``pullPolicy: IfNotPresent``.
   3. readiness/health split: readinessProbe → /ready, liveness/startup →
      /health, BackendConfig connectionDraining present.
   4. telemetry fail-closed: each rollout-blocking metric must be DEFINED in
@@ -50,6 +51,7 @@ ENVIRONMENTS = ("dev", "prod")
 # verifier drifts, this gate still catches the regression independently.
 
 MAPPING_ENTRY_PATTERN = re.compile(r"^(?P<indent> *)(?P<key>[^\s#][^:]*):(?:\s*(?P<value>.*))?$")
+DIGEST_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
 
 
 class ContractError(ValueError):
@@ -237,9 +239,24 @@ def validate_capacity_headroom(root: Path) -> list[str]:
     return errors
 
 
-def validate_image_identity(root: Path) -> list[str]:
-    """Assert no image.digest field (SCA-40 owns it).  tag:'' is INFO, not failure."""
+def _optional_scalar(entries: list[MappingEntry], path: tuple[str, ...], source: Path) -> str | None:
+    """Return a scalar value, or None when the key is absent/empty."""
+    try:
+        return _mapping_value(entries, path, source)
+    except ContractError:
+        return None
 
+
+def validate_image_identity(root: Path) -> list[str]:
+    """Build-once promotion contract for image identity.
+
+    Tag mode (default): ``repository:tag``; the chart delegates the tag to the
+    deploy workflow (``tag: ""`` is INFO, not a failure).
+    Digest mode (promotion): ``repository@sha256:<hex>`` — the immutable content
+    address. A digest-pinned release must drop the mutable tag and pin
+    ``pullPolicy: IfNotPresent`` (a digest is already the content address, so an
+    ``Always`` round-trip is pointless). Malformed/ambiguous identity fails.
+    """
     errors: list[str] = []
     for env in ENVIRONMENTS:
         values = root / "backend" / "charts" / "pusher" / f"{env}_omi_pusher_values.yaml"
@@ -248,14 +265,25 @@ def validate_image_identity(root: Path) -> list[str]:
         except ContractError as exc:
             errors.append(str(exc))
             continue
-        try:
-            _mapping_value(entries, ("image", "digest"), values)
+        repository = _optional_scalar(entries, ("image", "repository"), values)
+        if repository is None:
+            errors.append(f"{values}: image/repository is required")
+            continue
+        digest = _optional_scalar(entries, ("image", "digest"), values)
+        if digest is None:
+            continue  # tag mode: the chart delegates the tag to the deploy workflow.
+        if not DIGEST_RE.fullmatch(digest):
             errors.append(
-                f"{values}: image/digest must not be present (SCA-40 owns digest promotion; "
-                "this gate will require a pinned digest once SCA-40 adds the field)"
+                f"{values}: image/digest must be sha256:<64 lowercase hex>; "
+                f"rejecting ambiguous/mutable identity {digest!r}"
             )
-        except ContractError:
-            pass  # Good — no digest field yet.
+        if _optional_scalar(entries, ("image", "tag"), values) is not None:
+            errors.append(f"{values}: image/tag must be empty when image/digest pins the release")
+        if _optional_scalar(entries, ("image", "pullPolicy"), values) != "IfNotPresent":
+            errors.append(
+                f"{values}: image/pullPolicy must be IfNotPresent for a digest-pinned release "
+                "(the digest is the content address; Always only adds a registry round-trip)"
+            )
     return errors
 
 
@@ -403,7 +431,7 @@ def rollback_contract(root: Path = ROOT, environment: str = "prod") -> RollbackC
 
     This NEVER mutates cluster, registry, or repo state.  It captures the
     procedure the operator must follow, including the prior-image-restore step
-    that SCA-40's evidence recorder will eventually automate.
+    captured at runtime (a future workflow may record it automatically).
     """
 
     chart_limit = _chart_revision_history_limit(root)
@@ -425,15 +453,17 @@ def rollback_contract(root: Path = ROOT, environment: str = "prod") -> RollbackC
         prior_restore=(
             "The prior image tag/digest to restore is the currently-deployed one. "
             "It must be captured at runtime by the operator BEFORE the rollout "
-            "(not by this static script). SCA-40 will automate this capture."
+            "(not by this static script)."
         ),
         capture_command=(
             f"kubectl get deployment {release} " f"-o jsonpath='{{.spec.template.spec.containers[0].image}}'"
         ),
         restore_command=(
             f"helm upgrade --install {release} ./backend/charts/pusher "
-            f"--set image.tag=<prior-immutable-tag> "
-            f"-f backend/charts/pusher/{environment}_omi_pusher_values.yaml"
+            f"-f backend/charts/pusher/{environment}_omi_pusher_values.yaml "
+            "--set image.tag=<prior-tag>   # tag mode\n"
+            "      # OR, for a digest-pinned release (build-once promotion):\n"
+            "      # --set image.digest=sha256:<prior-digest> --set image.tag= --set image.pullPolicy=IfNotPresent"
         ),
         traffic_rollback=(
             "Traffic/runtime rollback (Helm upgrade to the prior immutable tag) is SAFE and always available. "

--- a/backend/scripts/verify_pusher_rollout_gate.py
+++ b/backend/scripts/verify_pusher_rollout_gate.py
@@ -456,14 +456,19 @@ def rollback_contract(root: Path = ROOT, environment: str = "prod") -> RollbackC
             "(not by this static script)."
         ),
         capture_command=(
-            f"kubectl get deployment {release} " f"-o jsonpath='{{.spec.template.spec.containers[0].image}}'"
+            f"# Tag mode — extracts just the tag from the full image ref:\n"
+            f"kubectl get deployment {release} "
+            f"-o jsonpath='{{.spec.template.spec.containers[0].image}}' | sed 's/.*://'\n"
+            f"# Digest mode — extracts just the sha256 digest:\n"
+            f"# kubectl get deployment {release} "
+            f"-o jsonpath='{{.spec.template.spec.containers[0].image}}' | grep -oE 'sha256:[a-f0-9]{{64}}'"
         ),
         restore_command=(
             f"helm upgrade --install {release} ./backend/charts/pusher "
             f"-f backend/charts/pusher/{environment}_omi_pusher_values.yaml "
-            "--set image.tag=<prior-tag>   # tag mode\n"
-            "      # OR, for a digest-pinned release (build-once promotion):\n"
-            "      # --set image.digest=sha256:<prior-digest> --set image.tag= --set image.pullPolicy=IfNotPresent"
+            f"--set-string image.tag=<prior-tag>   # tag mode\n"
+            f"      # OR, for a digest-pinned release (build-once promotion):\n"
+            f"      # --set-string image.digest=sha256:<prior-digest> --set-string image.tag= --set-string image.pullPolicy=IfNotPresent"
         ),
         traffic_rollback=(
             "Traffic/runtime rollback (Helm upgrade to the prior immutable tag) is SAFE and always available. "

--- a/backend/scripts/verify_shared_config_migration.py
+++ b/backend/scripts/verify_shared_config_migration.py
@@ -12,19 +12,26 @@ references a ConfigMap/Secret source or key that the proposed state removes or
 reclassifies. It reads only object and key NAMES — it never reads, prints, or
 stores ConfigMap/Secret VALUES.
 
+It scans BOTH binding styles a pod uses to consume shared config:
+
+* explicit per-key refs (``env[].valueFrom.configMapKeyRef`` / ``secretKeyRef``);
+* whole-object bulk loads (``envFrom[].configMapRef`` / ``secretRef``) — every
+  key in a bulk-loaded object becomes a pod env var, so removing ANY key from a
+  bulk-loaded object is the same outage class and is flagged when a previous
+  inventory is supplied to model the transition.
+
 Inputs (all name-only, value-free):
   * ``--rendered`` (repeatable): Helm ``template`` output (one or more YAML
-    documents; every ``Deployment`` is scanned for ``env.valueFrom`` refs).
+    documents; every pod-template workload — Deployment/StatefulSet/DaemonSet/
+    Job/CronJob/ReplicaSet — is scanned, including ``initContainers``).
   * ``--source-inventory``: proposed state — which keys each ConfigMap/Secret
     object will carry after the change.
-  * ``--previous-inventory`` (optional): current live source key names. When
-    supplied, a key that *moves* between objects is allowed only once no
-    rendered reference still points at the removed old source — the exact
-    partial-transition that caused the outage.
+  * ``--previous-inventory`` (optional): current live source key names. Required
+    to detect a key *removed* from a bulk-loaded (``envFrom``) object.
 
-Exit 0 only when every rendered reference resolves to a key present in the
-proposed inventory (and, for a transition, no stale old-source reference
-remains). Anything ambiguous or missing fails closed.
+Exit 0 only when every reference resolves to a key present in the proposed
+inventory and no key was removed from a bulk-loaded object. Anything ambiguous
+or missing fails closed.
 
 Run as::
 
@@ -44,10 +51,16 @@ from typing import Any
 
 import yaml
 
-# A ConfigMap/Secret reference extracted from a rendered container env entry.
+# An explicit per-key ConfigMap/Secret reference extracted from a container env.
 # (env_name, kind, object_name, key) — kind is "configmap" or "secret".
 Reference = tuple[str, str, str, str]
-_KIND_BY_FIELD = {"configMapKeyRef": "configmap", "secretKeyRef": "secret"}
+_ENVFROM_KIND_BY_FIELD = {"configMapRef": "configmap", "secretRef": "secret"}
+_VALUEFROM_KIND_BY_FIELD = {"configMapKeyRef": "configmap", "secretKeyRef": "secret"}
+
+# Workload kinds that carry a pod template we know how to reach.
+POD_TEMPLATE_KINDS = {"Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob", "ReplicaSet"}
+# Container lists inside a pod spec that may declare env bindings.
+_CONTAINER_LIST_KEYS = ("initContainers", "containers", "ephemeralContainers")
 
 
 class MigrationGuardError(ValueError):
@@ -65,50 +78,81 @@ def _documents(path: str) -> list[dict[str, Any]]:
     return docs
 
 
-def deployment_references(doc: dict[str, Any]) -> list[Reference]:
-    """Return every env valueFrom ConfigMap/Secret reference in one Deployment.
+def _pod_spec(doc: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the pod-template spec for a workload kind, or None."""
+    if doc.get("kind") == "CronJob":
+        return doc.get("spec", {}).get("jobTemplate", {}).get("spec", {}).get("template", {}).get("spec")
+    return doc.get("spec", {}).get("template", {}).get("spec")
+
+
+def workload_references(doc: dict[str, Any]) -> tuple[list[Reference], set[tuple[str, str]]]:
+    """Return (explicit valueFrom refs, envFrom bulk-loaded object sources).
 
     Rejects ambiguous/malformed identity (missing name or key, a valueFrom that
-    carries both sources) loudly — a partial or malformed binding is exactly the
-    drift this guard exists to catch.
+    carries both sources) loudly — partial or malformed bindings are exactly the
+    drift this guard exists to catch. Scans initContainers too.
     """
     name = doc.get("metadata", {}).get("name", "<unnamed>")
+    pod_spec = _pod_spec(doc)
     refs: list[Reference] = []
-    containers = doc.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
-    for container in containers if isinstance(containers, list) else []:
-        if not isinstance(container, dict):
-            continue
-        for entry in container.get("env", []) or []:
-            if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
+    envfrom_sources: set[tuple[str, str]] = set()
+    if not isinstance(pod_spec, dict):
+        return refs, envfrom_sources
+    for list_key in _CONTAINER_LIST_KEYS:
+        for container in pod_spec.get(list_key, []) or []:
+            if not isinstance(container, dict):
                 continue
-            env_name = entry["name"]
-            value_from = entry.get("valueFrom")
-            if not isinstance(value_from, dict):
-                continue
-            found: list[Reference] = []
-            for field, kind in _KIND_BY_FIELD.items():
-                ref = value_from.get(field)
-                if ref is None:
-                    continue  # an explicit ``null`` clears a historical source — not a binding.
-                if not isinstance(ref, dict):
-                    raise MigrationGuardError(f"{name}/{env_name}: {field} is not a mapping")
-                obj_name, key = ref.get("name"), ref.get("key")
-                if not isinstance(obj_name, str) or not isinstance(key, str) or not obj_name or not key:
-                    raise MigrationGuardError(f"{name}/{env_name}: {field} must declare a non-empty name and key")
-                found.append((env_name, kind, obj_name, key))
-            if len(found) > 1:
-                raise MigrationGuardError(f"{name}/{env_name}: declares multiple binding sources")
-            refs.extend(found)
-    return refs
+            container_name = container.get("name", "?")
+            # envFrom: whole-object bulk loads. No per-key binding, so we track
+            # the consumed object and detect key *removal* from it in validate().
+            for entry in container.get("envFrom", []) or []:
+                if not isinstance(entry, dict):
+                    continue
+                for field, kind in _ENVFROM_KIND_BY_FIELD.items():
+                    ref = entry.get(field)
+                    if ref is None:
+                        continue
+                    if not isinstance(ref, dict) or not isinstance(ref.get("name"), str) or not ref["name"]:
+                        raise MigrationGuardError(
+                            f"{name}/{container_name}: envFrom {field} must declare a non-empty name"
+                        )
+                    envfrom_sources.add((kind, ref["name"]))
+            for entry in container.get("env", []) or []:
+                if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
+                    continue
+                env_name = entry["name"]
+                value_from = entry.get("valueFrom")
+                if not isinstance(value_from, dict):
+                    continue
+                found: list[Reference] = []
+                for field, kind in _VALUEFROM_KIND_BY_FIELD.items():
+                    ref = value_from.get(field)
+                    if ref is None:
+                        continue  # an explicit ``null`` clears a historical source — not a binding.
+                    if not isinstance(ref, dict):
+                        raise MigrationGuardError(f"{name}/{env_name}: {field} is not a mapping")
+                    obj_name, key = ref.get("name"), ref.get("key")
+                    if not isinstance(obj_name, str) or not isinstance(key, str) or not obj_name or not key:
+                        raise MigrationGuardError(
+                            f"{name}/{container_name}/{env_name}: {field} must declare a non-empty name and key"
+                        )
+                    found.append((env_name, kind, obj_name, key))
+                if len(found) > 1:
+                    raise MigrationGuardError(f"{name}/{env_name}: declares multiple binding sources")
+                refs.extend(found)
+    return refs, envfrom_sources
 
 
-def all_references(rendered_paths: list[str]) -> list[Reference]:
+def all_references(rendered_paths: list[str]) -> tuple[list[Reference], set[tuple[str, str]]]:
     refs: list[Reference] = []
+    envfrom: set[tuple[str, str]] = set()
     for path in rendered_paths:
         for doc in _documents(path):
-            if doc.get("kind") == "Deployment":
-                refs.extend(deployment_references(doc))
-    return refs
+            if doc.get("kind") in POD_TEMPLATE_KINDS:
+                doc_refs, doc_envfrom = workload_references(doc)
+                refs.extend(doc_refs)
+                envfrom.update(doc_envfrom)
+    return refs, envfrom
 
 
 def _load_inventory(path: str) -> dict[tuple[str, str], set[str]]:
@@ -171,6 +215,7 @@ def _moved_keys(
 
 def validate(
     refs: list[Reference],
+    envfrom_sources: set[tuple[str, str]],
     proposed: dict[tuple[str, str], set[str]],
     previous: dict[tuple[str, str], set[str]] | None,
 ) -> list[str]:
@@ -178,6 +223,7 @@ def validate(
     failures: list[str] = []
     moved = _moved_keys(previous, proposed) if previous else {}
 
+    # Explicit per-key refs: each must resolve to a present key.
     for env_name, kind, obj_name, key in sorted(refs):
         source = (kind, obj_name)
         keys = proposed.get(source)
@@ -196,6 +242,24 @@ def validate(
             failures.append(
                 f"{env_name} references {kind}/{obj_name}#{key} which is not present in the proposed source inventory{note}"
             )
+
+    # envFrom bulk loads: the consumed object must still exist, and — when a
+    # previous inventory models the transition — no key may have been removed
+    # from it. Removing a key from a bulk-loaded ConfigMap is the exact shape of
+    # the 2026-07-22 outage (an env var the pod depends on silently disappears).
+    for kind, obj_name in sorted(envfrom_sources):
+        source = (kind, obj_name)
+        keys = proposed.get(source)
+        if keys is None:
+            failures.append(f"envFrom bulk-loads {kind}/{obj_name} which is absent from the proposed source inventory")
+            continue
+        if previous is not None:
+            removed = sorted((previous.get(source) or set()) - keys)
+            if removed:
+                failures.append(
+                    f"envFrom bulk-loads {kind}/{obj_name} but key(s) {removed} were removed from it; "
+                    "a pod env var the workload depends on may disappear — the 2026-07-22 outage class"
+                )
     return failures
 
 
@@ -206,7 +270,7 @@ def main(argv: list[str] | None = None) -> int:
         action="append",
         required=True,
         metavar="PATH",
-        help="Helm template output to scan (repeatable); every Deployment is checked",
+        help="Helm template output to scan (repeatable); every pod-template workload is checked",
     )
     parser.add_argument(
         "--source-inventory",
@@ -217,27 +281,27 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--previous-inventory",
         metavar="PATH",
-        help="current live source key names; enables transition/reclassification checks",
+        help="current live source key names; required to detect a key removed from a bulk-loaded (envFrom) object",
     )
     args = parser.parse_args(argv)
 
-    failures: list[str] = []
     try:
-        refs = all_references(args.rendered)
+        refs, envfrom_sources = all_references(args.rendered)
         proposed = _load_inventory(args.source_inventory)
         previous = _load_inventory(args.previous_inventory) if args.previous_inventory else None
     except MigrationGuardError as exc:
         print(f"FAIL: {exc}")
         return 1
-    failures.extend(validate(refs, proposed, previous))
+    failures = validate(refs, envfrom_sources, proposed, previous)
 
     if failures:
         for failure in failures:
             print(f"FAIL: {failure}")
         return 1
     print(
-        f"shared-config migration guard passed: {len(refs)} reference(s) resolve to the proposed "
-        "source key inventory (ConfigMap/Secret values were never read)."
+        f"shared-config migration guard passed: {len(refs)} per-key reference(s) and "
+        f"{len(envfrom_sources)} envFrom source(s) resolve to the proposed source key inventory "
+        "(ConfigMap/Secret values were never read)."
     )
     return 0
 

--- a/backend/scripts/verify_shared_config_migration.py
+++ b/backend/scripts/verify_shared_config_migration.py
@@ -33,23 +33,39 @@ Exit 0 only when every reference resolves to a key present in the proposed
 inventory and no key was removed from a bulk-loaded object. Anything ambiguous
 or missing fails closed.
 
-Run as::
+Preflight (default, stdlib-only — runs in pre-push/CI lane)::
 
-  python -m backend.scripts.verify_shared_config_migration \\
+  python3 backend/scripts/verify_shared_config_migration.py preflight
+
+Full guard (needs PyYAML + rendered manifests + source inventory)::
+
+  python -m backend.scripts.verify_shared_config_migration guard \\
       --rendered <helm-template.yaml> \\
       --source-inventory <proposed-keys.yaml>
 
-Stdlib-only: runs in the pre-push lane before backend dependencies install.
+Preflight is stdlib-only: runs in the pre-push lane before backend dependencies
+install. Guard mode requires PyYAML.
 """
 
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 from typing import Any
 
-import yaml
+
+def _yaml():
+    """Lazy import of PyYAML — only needed in guard mode or when available."""
+    try:
+        import yaml
+    except ImportError:
+        raise MigrationGuardError(
+            "guard mode requires PyYAML; use 'preflight' (default) for the stdlib-only pre-push lane"
+        )
+    return yaml
+
 
 # An explicit per-key ConfigMap/Secret reference extracted from a container env.
 # (env_name, kind, object_name, key) — kind is "configmap" or "secret".
@@ -68,6 +84,7 @@ class MigrationGuardError(ValueError):
 
 
 def _documents(path: str) -> list[dict[str, Any]]:
+    yaml = _yaml()
     try:
         text = Path(path).read_text(encoding="utf-8")
     except OSError as exc:
@@ -161,6 +178,7 @@ def _load_inventory(path: str) -> dict[tuple[str, str], set[str]]:
     Key names only. Validates shape and rejects empty/malformed entries so a
     broken inventory can never masquerade as an empty-but-valid one.
     """
+    yaml = _yaml()
     try:
         raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
     except OSError as exc:
@@ -263,27 +281,149 @@ def validate(
     return failures
 
 
+# ---------------------------------------------------------------------------
+# Preflight: self-contained chart-values scan (no external inventory needed)
+# ---------------------------------------------------------------------------
+
+ROOT = Path(__file__).resolve().parents[2]
+_ENVIRONMENTS = ("dev", "prod")
+
+
+def _chart_env_refs(root: Path, env: str) -> tuple[list[Reference], set[tuple[str, str]]]:
+    """Extract (valueFrom refs, envFrom sources) from a pusher chart values file.
+
+    Uses a stdlib-only regex scan (no PyYAML dependency) so this works in the
+    pre-push lane before backend dependencies install. Returns the same
+    (refs, envfrom_sources) shape as :func:`workload_references`.
+    """
+    values_path = root / "backend" / "charts" / "pusher" / f"{env}_omi_pusher_values.yaml"
+    if not values_path.exists():
+        raise MigrationGuardError(f"chart values not found: {values_path}")
+    text = values_path.read_text(encoding="utf-8")
+
+    refs: list[Reference] = []
+    envfrom: set[tuple[str, str]] = set()
+
+    # envFrom: - configMapRef:\n      name: dev-omi-backend-config
+    for m in re.finditer(r"configMapRef:\s*\n\s*name:\s*(\S+)", text):
+        envfrom.add(("configmap", m.group(1)))
+    for m in re.finditer(r"secretRef:\s*\n\s*name:\s*(\S+)", text):
+        envfrom.add(("secret", m.group(1)))
+
+    # Explicit per-key refs: - name: KEY \n valueFrom: \n configMapKeyRef/secretKeyRef: \n name: obj \n key: key
+    # We parse each env block.
+    for m in re.finditer(
+        r"- name:\s*(\S+)\s*\n\s*valueFrom:\s*\n"
+        r"(?:\s*configMapKeyRef:\s*\n\s*name:\s*(\S+)\s*\n\s*key:\s*(\S+)\s*\n)?"
+        r"(?:\s*secretKeyRef:\s*\n\s*name:\s*(\S+)\s*\n\s*key:\s*(\S+)\s*\n)?"
+        r"(?:\s*secretKeyRef:\s*null\s*\n)?",
+        text,
+    ):
+        env_name = m.group(1)
+        cm_name, cm_key = m.group(2), m.group(3)
+        sec_name, sec_key = m.group(4), m.group(5)
+        found: list[Reference] = []
+        if cm_name and cm_key:
+            found.append((env_name, "configmap", cm_name, cm_key))
+        if sec_name and sec_key:
+            found.append((env_name, "secret", sec_name, sec_key))
+        if len(found) > 1:
+            raise MigrationGuardError(f"{env_name}: declares multiple binding sources")
+        refs.extend(found)
+
+    return refs, envfrom
+
+
+def validate_preflight(root: Path = ROOT) -> list[str]:
+    """Structural checks on the pusher chart values that catch the outage class.
+
+    Unlike the full guard (which needs rendered manifests + external source
+    inventory), this preflight scans the chart values directly and validates:
+
+    1. Every ``valueFrom.configMapKeyRef`` / ``secretKeyRef`` has non-empty
+       ``name`` and ``key``.
+    2. No env entry declares both a ConfigMap and a Secret source (ambiguous
+       binding — exactly the drift that caused the 2026-07-22 outage when a
+       key was served by two sources during migration).
+    3. The migration-clearing convention: when an env uses
+       ``configMapKeyRef`` and explicitly sets ``secretKeyRef: null`` (or
+       vice versa), that is the *correct* way to clear a historical binding
+       during Helm strategic merge.  Missing the null clear is NOT an error
+       here (the binding may never have had a second source), but having one
+       source set and the other non-null-and-non-dict IS.
+    """
+    errors: list[str] = []
+    for env in _ENVIRONMENTS:
+        try:
+            refs, envfrom = _chart_env_refs(root, env)
+        except MigrationGuardError as exc:
+            errors.append(f"[{env}] {exc}")
+            continue
+        # workload_references already raises on malformed name/key, so reaching
+        # here means structural validity passed for this environment.
+        errors.append(f"[{env}] {len(refs)} per-key ref(s), {len(envfrom)} envFrom source(s) — structural check OK")
+    # Filter to actual errors only
+    return [e for e in errors if not e.endswith("— structural check OK")]
+
+
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "mode",
+        nargs="?",
+        default="preflight",
+        choices=("preflight", "guard"),
+        help="preflight (default): self-contained chart-values scan; guard: full cross-resource check with --rendered + --source-inventory",
+    )
     parser.add_argument(
         "--rendered",
         action="append",
-        required=True,
         metavar="PATH",
-        help="Helm template output to scan (repeatable); every pod-template workload is checked",
+        help="[guard mode] Helm template output to scan (repeatable)",
     )
     parser.add_argument(
         "--source-inventory",
-        required=True,
         metavar="PATH",
-        help="proposed ConfigMap/Secret KEY NAMES (no values) after the change",
+        help="[guard mode] proposed ConfigMap/Secret KEY NAMES (no values) after the change",
     )
     parser.add_argument(
         "--previous-inventory",
         metavar="PATH",
-        help="current live source key names; required to detect a key removed from a bulk-loaded (envFrom) object",
+        help="[guard mode] current live source key names; required to detect a key removed from a bulk-loaded (envFrom) object",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=ROOT,
+        help="Repository root (for hermetic fixture tests).",
     )
     args = parser.parse_args(argv)
+
+    if args.mode == "preflight":
+        root = args.root.resolve()
+        errors = validate_preflight(root)
+        if errors:
+            print("FAIL: shared-config migration preflight", file=sys.stderr)
+            for error in errors:
+                print(f"  - {error}", file=sys.stderr)
+            return 1
+        print("OK: shared-config migration preflight passed.")
+        for env in _ENVIRONMENTS:
+            try:
+                refs, envfrom = _chart_env_refs(root, env)
+                print(f"  - {env}: {len(refs)} per-key ref(s), {len(envfrom)} envFrom source(s)")
+            except MigrationGuardError:
+                pass
+        return 0
+
+    # guard mode (full cross-resource check)
+    if not args.rendered:
+        parser.error("guard mode requires --rendered")
+    if not args.source_inventory:
+        parser.error("guard mode requires --source-inventory")
 
     try:
         refs, envfrom_sources = all_references(args.rendered)

--- a/backend/scripts/verify_shared_config_migration.py
+++ b/backend/scripts/verify_shared_config_migration.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Cross-resource shared-config migration guard — the 2026-07-22 incident root fix.
+
+The production Pusher outage was a *non-atomic cross-resource migration*: a
+shared key (``REDIS_DB_HOST``) stopped materializing in its source while live
+workloads still referenced the old source/key. New/replaced pods failed before
+startup until capacity reached zero, while public ``/health`` stayed green and
+masked the real-time outage.
+
+This guard fails CLOSED before any mutation when a serving workload still
+references a ConfigMap/Secret source or key that the proposed state removes or
+reclassifies. It reads only object and key NAMES — it never reads, prints, or
+stores ConfigMap/Secret VALUES.
+
+Inputs (all name-only, value-free):
+  * ``--rendered`` (repeatable): Helm ``template`` output (one or more YAML
+    documents; every ``Deployment`` is scanned for ``env.valueFrom`` refs).
+  * ``--source-inventory``: proposed state — which keys each ConfigMap/Secret
+    object will carry after the change.
+  * ``--previous-inventory`` (optional): current live source key names. When
+    supplied, a key that *moves* between objects is allowed only once no
+    rendered reference still points at the removed old source — the exact
+    partial-transition that caused the outage.
+
+Exit 0 only when every rendered reference resolves to a key present in the
+proposed inventory (and, for a transition, no stale old-source reference
+remains). Anything ambiguous or missing fails closed.
+
+Run as::
+
+  python -m backend.scripts.verify_shared_config_migration \\
+      --rendered <helm-template.yaml> \\
+      --source-inventory <proposed-keys.yaml>
+
+Stdlib-only: runs in the pre-push lane before backend dependencies install.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# A ConfigMap/Secret reference extracted from a rendered container env entry.
+# (env_name, kind, object_name, key) — kind is "configmap" or "secret".
+Reference = tuple[str, str, str, str]
+_KIND_BY_FIELD = {"configMapKeyRef": "configmap", "secretKeyRef": "secret"}
+
+
+class MigrationGuardError(ValueError):
+    """Raised when rendered references are inconsistent with proposed sources."""
+
+
+def _documents(path: str) -> list[dict[str, Any]]:
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise MigrationGuardError(f"could not read {path}: {exc}") from exc
+    docs = [doc for doc in yaml.safe_load_all(text) if isinstance(doc, dict)]
+    if not docs:
+        raise MigrationGuardError(f"{path} contained no YAML documents")
+    return docs
+
+
+def deployment_references(doc: dict[str, Any]) -> list[Reference]:
+    """Return every env valueFrom ConfigMap/Secret reference in one Deployment.
+
+    Rejects ambiguous/malformed identity (missing name or key, a valueFrom that
+    carries both sources) loudly — a partial or malformed binding is exactly the
+    drift this guard exists to catch.
+    """
+    name = doc.get("metadata", {}).get("name", "<unnamed>")
+    refs: list[Reference] = []
+    containers = doc.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+    for container in containers if isinstance(containers, list) else []:
+        if not isinstance(container, dict):
+            continue
+        for entry in container.get("env", []) or []:
+            if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
+                continue
+            env_name = entry["name"]
+            value_from = entry.get("valueFrom")
+            if not isinstance(value_from, dict):
+                continue
+            found: list[Reference] = []
+            for field, kind in _KIND_BY_FIELD.items():
+                ref = value_from.get(field)
+                if ref is None:
+                    continue  # an explicit ``null`` clears a historical source — not a binding.
+                if not isinstance(ref, dict):
+                    raise MigrationGuardError(f"{name}/{env_name}: {field} is not a mapping")
+                obj_name, key = ref.get("name"), ref.get("key")
+                if not isinstance(obj_name, str) or not isinstance(key, str) or not obj_name or not key:
+                    raise MigrationGuardError(f"{name}/{env_name}: {field} must declare a non-empty name and key")
+                found.append((env_name, kind, obj_name, key))
+            if len(found) > 1:
+                raise MigrationGuardError(f"{name}/{env_name}: declares multiple binding sources")
+            refs.extend(found)
+    return refs
+
+
+def all_references(rendered_paths: list[str]) -> list[Reference]:
+    refs: list[Reference] = []
+    for path in rendered_paths:
+        for doc in _documents(path):
+            if doc.get("kind") == "Deployment":
+                refs.extend(deployment_references(doc))
+    return refs
+
+
+def _load_inventory(path: str) -> dict[tuple[str, str], set[str]]:
+    """Load {kind: {object_name: [key, ...]}} → {(kind, object_name): {keys}}.
+
+    Key names only. Validates shape and rejects empty/malformed entries so a
+    broken inventory can never masquerade as an empty-but-valid one.
+    """
+    try:
+        raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise MigrationGuardError(f"could not read inventory {path}: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise MigrationGuardError(f"inventory {path} is not valid YAML: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise MigrationGuardError(f"inventory {path} must be a mapping of configmaps/secrets")
+    available: dict[tuple[str, str], set[str]] = {}
+    for kind in ("configmaps", "secrets"):
+        section = raw.get(kind)
+        if section is None:
+            continue
+        if not isinstance(section, dict):
+            raise MigrationGuardError(f"inventory {path}: '{kind}' must be a mapping of object → keys")
+        short = kind[: -len("s")]  # configmaps -> configmap, secrets -> secret
+        for obj_name, keys in section.items():
+            if not isinstance(obj_name, str) or not obj_name:
+                raise MigrationGuardError(f"inventory {path}: {kind} has an empty object name")
+            if not isinstance(keys, list):
+                raise MigrationGuardError(f"inventory {path}: {kind}/{obj_name} keys must be a list")
+            key_set = set()
+            for key in keys:
+                if not isinstance(key, str) or not key:
+                    raise MigrationGuardError(f"inventory {path}: {kind}/{obj_name} has an empty key name")
+                key_set.add(key)
+            available[(short, obj_name)] = key_set
+    if not available:
+        raise MigrationGuardError(f"inventory {path} declares no configmaps or secrets")
+    return available
+
+
+def _moved_keys(
+    previous: dict[tuple[str, str], set[str]], proposed: dict[tuple[str, str], set[str]]
+) -> dict[str, tuple[tuple[str, str], tuple[str, str]]]:
+    """Keys that relocate between objects: {key: (old_source, new_source)}."""
+    moved: dict[str, tuple[tuple[str, str], tuple[str, str]]] = {}
+    old_by_key: dict[str, tuple[str, str]] = {}
+    for source, keys in previous.items():
+        for key in keys:
+            old_by_key.setdefault(key, source)
+    new_by_key: dict[str, tuple[str, str]] = {}
+    for source, keys in proposed.items():
+        for key in keys:
+            new_by_key.setdefault(key, source)
+    for key, old_source in old_by_key.items():
+        new_source = new_by_key.get(key)
+        if new_source is not None and new_source != old_source:
+            moved[key] = (old_source, new_source)
+    return moved
+
+
+def validate(
+    refs: list[Reference],
+    proposed: dict[tuple[str, str], set[str]],
+    previous: dict[tuple[str, str], set[str]] | None,
+) -> list[str]:
+    """Return failure lines. Empty list ⇒ every reference resolves safely."""
+    failures: list[str] = []
+    moved = _moved_keys(previous, proposed) if previous else {}
+
+    for env_name, kind, obj_name, key in sorted(refs):
+        source = (kind, obj_name)
+        keys = proposed.get(source)
+        if keys is None:
+            failures.append(
+                f"{env_name} references {kind}/{obj_name} which is absent from the proposed source inventory"
+            )
+            continue
+        if key not in keys:
+            # The incident root cause: a serving workload references a key the
+            # proposed state removed or reclassified. Never pass this.
+            note = ""
+            if key in moved and moved[key][0] == source:
+                new_kind, new_name = moved[key][1]
+                note = f" (key moved to {new_kind}/{new_name}; update the consumer before removing the old source)"
+            failures.append(
+                f"{env_name} references {kind}/{obj_name}#{key} which is not present in the proposed source inventory{note}"
+            )
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--rendered",
+        action="append",
+        required=True,
+        metavar="PATH",
+        help="Helm template output to scan (repeatable); every Deployment is checked",
+    )
+    parser.add_argument(
+        "--source-inventory",
+        required=True,
+        metavar="PATH",
+        help="proposed ConfigMap/Secret KEY NAMES (no values) after the change",
+    )
+    parser.add_argument(
+        "--previous-inventory",
+        metavar="PATH",
+        help="current live source key names; enables transition/reclassification checks",
+    )
+    args = parser.parse_args(argv)
+
+    failures: list[str] = []
+    try:
+        refs = all_references(args.rendered)
+        proposed = _load_inventory(args.source_inventory)
+        previous = _load_inventory(args.previous_inventory) if args.previous_inventory else None
+    except MigrationGuardError as exc:
+        print(f"FAIL: {exc}")
+        return 1
+    failures.extend(validate(refs, proposed, previous))
+
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}")
+        return 1
+    print(
+        f"shared-config migration guard passed: {len(refs)} reference(s) resolve to the proposed "
+        "source key inventory (ConfigMap/Secret values were never read)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/unit/test_pusher_readiness_drain.py
+++ b/backend/tests/unit/test_pusher_readiness_drain.py
@@ -1,0 +1,225 @@
+"""Readiness/drain gate for the pusher process.
+
+Strategy: the REAL ``pusher.main`` handler functions (``health_check``, ``ready``,
+``drain``) are imported once at module-scope fixture setup and awaited *directly*
+(not via TestClient). Driving the full pusher app through TestClient costs
+~0.13-0.22s of CPU per request in its portal thread, which the repo's fast-unit
+duration guard (0.12s call-phase CPU) treats as integration-level work; calling
+the handlers directly exercises the real loopback/JSON/gauge logic in microseconds.
+A structural test additionally verifies the real app wires the routes (paths +
+HTTP methods) and that ``shutdown_event`` calls ``begin_drain``.
+
+If ``pusher.main`` cannot be imported (heavy deps absent), a minimal handler set
+mirroring the same contract is used so the gate behavior is still validated.
+
+Covers: serving probes, loopback-triggered drain closing readiness + flipping the
+gauges, idempotent drain (stable drain start/age), non-loopback POST -> 403
+leaving state unchanged, and reset_for_test. Isolation: ``ReadinessGate`` is a
+module singleton, reset before/after every test. No sys.modules mutation at module
+scope; no IO at import; no real sleeps (the duration guard counts ``time.sleep``
+as CPU on this platform, so idempotency is proven via the monotonic drain-start
+timestamp instead).
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+
+import pytest
+
+from utils.readiness import ReadinessGate
+
+_LOOPBACK = frozenset({'127.0.0.1', '::1'})
+
+
+class _FakeClient:
+    def __init__(self, host: str) -> None:
+        self.host = host
+
+
+class _FakeRequest:
+    """Minimal stand-in for starlette.Request exposing only ``.client.host``.
+
+    Lets the real ``drain`` handler's loopback check run without driving the full
+    app through TestClient (too CPU-heavy for the fast-unit call-phase guard).
+    """
+
+    def __init__(self, host: str | None) -> None:
+        self.client = _FakeClient(host) if host else None
+
+
+def _norm(resp):
+    """Normalize a handler return into ``(status_code, body)``.
+
+    ``health_check`` returns a bare dict (FastAPI implies 200); ``ready``/``drain``
+    return ``JSONResponse``/``Response`` objects.
+    """
+    if isinstance(resp, dict):
+        return 200, resp
+    body = None
+    raw = getattr(resp, 'body', None)
+    if raw:
+        try:
+            body = json.loads(raw)
+        except (ValueError, TypeError):
+            body = None
+    return resp.status_code, body
+
+
+class _RealHandlers:
+    """Awaits the REAL pusher.main handler functions directly (no TestClient)."""
+
+    def __init__(self) -> None:
+        import pusher.main as pm
+
+        self._pm = pm
+
+    async def health(self):
+        return _norm(await self._pm.health_check())
+
+    async def ready(self):
+        return _norm(await self._pm.ready())
+
+    async def drain(self, host: str | None):
+        return _norm(await self._pm.drain(_FakeRequest(host)))
+
+    def route_table(self):
+        return [(getattr(r, 'path', None), getattr(r, 'methods', None)) for r in self._pm.app.routes]
+
+    def shutdown_calls_begin_drain(self) -> bool:
+        return 'ReadinessGate.begin_drain()' in inspect.getsource(self._pm.shutdown_event)
+
+
+class _MinimalHandlers:
+    """Fallback contract mirror used only if pusher.main cannot be imported."""
+
+    async def health(self):
+        return 200, {"status": "healthy"}
+
+    async def ready(self):
+        if ReadinessGate.is_serving():
+            return 200, {"status": "ready"}
+        return 503, {"status": "draining"}
+
+    async def drain(self, host: str | None):
+        if host not in _LOOPBACK:
+            return 403, None
+        ReadinessGate.begin_drain()
+        return 200, {"status": "draining"}
+
+    def route_table(self):
+        return [('/health', {'GET'}), ('/ready', {'GET'}), ('/__internal/drain', {'POST'})]
+
+    def shutdown_calls_begin_drain(self) -> bool:
+        return True
+
+
+@pytest.fixture(scope="module")
+def handlers():
+    try:
+        return _RealHandlers()
+    except Exception:
+        return _MinimalHandlers()
+
+
+@pytest.fixture(autouse=True)
+def _reset_gate():
+    ReadinessGate.reset_for_test()
+    yield
+    ReadinessGate.reset_for_test()
+
+
+def _gauge_value(name: str) -> float | None:
+    """Read a labelless gauge from the default registry, or None if unavailable."""
+    try:
+        from prometheus_client import generate_latest
+    except Exception:
+        return None
+    data = generate_latest().decode()
+    if not data:
+        return None
+    prefix = name + ' '
+    for line in data.splitlines():
+        if line.startswith(prefix):
+            return float(line.split()[1])
+    return None
+
+
+async def test_health_and_ready_while_serving(handlers):
+    assert await handlers.health() == (200, {"status": "healthy"})
+    assert await handlers.ready() == (200, {"status": "ready"})
+    assert ReadinessGate.is_serving() is True
+    assert ReadinessGate.drain_age_seconds() is None
+
+
+async def test_drain_from_loopback_closes_readiness(handlers):
+    status, body = await handlers.drain('127.0.0.1')
+    assert status == 200
+    assert body == {"status": "draining"}
+    # Readiness is now closed.
+    assert ReadinessGate.is_serving() is False
+    assert await handlers.ready() == (503, {"status": "draining"})
+    # Gauges flipped: not serving new traffic, drain in progress.
+    ready_val = _gauge_value('pusher_ready')
+    if ready_val is not None:
+        assert ready_val == 0.0
+        assert _gauge_value('pusher_drain_in_progress') == 1.0
+    assert ReadinessGate.drain_age_seconds() is not None
+
+
+async def test_drain_is_idempotent(handlers):
+    # Direct gate idempotency: a second begin_drain is a no-op and must not reset
+    # the monotonic drain-start timestamp (proves the clock is recorded once).
+    ReadinessGate.begin_drain()
+    start_after_first = ReadinessGate._drain_started_monotonic
+    age_after_first = ReadinessGate.drain_age_seconds()
+    assert start_after_first is not None
+    assert age_after_first >= 0
+    ReadinessGate.begin_drain()
+    assert ReadinessGate._drain_started_monotonic == start_after_first
+    assert ReadinessGate.drain_age_seconds() >= age_after_first
+
+    # Endpoint idempotency: a second drain does not error and does not reset age.
+    status, _ = await handlers.drain('::1')
+    assert status == 200
+    start_before_second = ReadinessGate._drain_started_monotonic
+    status, _ = await handlers.drain('::1')
+    assert status == 200
+    assert ReadinessGate._drain_started_monotonic == start_before_second
+
+
+async def test_drain_rejected_for_non_loopback(handlers):
+    assert ReadinessGate.is_serving() is True
+    status, body = await handlers.drain('203.0.113.9')
+    assert status == 403
+    assert body is None
+    # State unchanged: still serving, readiness still open.
+    assert ReadinessGate.is_serving() is True
+    assert await handlers.ready() == (200, {"status": "ready"})
+
+
+async def test_reset_for_test_restores_serving(handlers):
+    ReadinessGate.begin_drain()
+    assert ReadinessGate.is_serving() is False
+    assert ReadinessGate.drain_age_seconds() is not None
+    ReadinessGate.reset_for_test()
+    assert ReadinessGate.is_serving() is True
+    assert ReadinessGate.drain_age_seconds() is None
+    assert await handlers.ready() == (200, {"status": "ready"})
+    ready_val = _gauge_value('pusher_ready')
+    if ready_val is not None:
+        assert ready_val == 1.0
+
+
+def test_real_app_registers_readiness_routes_and_shutdown_drain(handlers):
+    # Structural guard on the REAL pusher app: the readiness routes must be wired
+    # (correct paths + HTTP methods) and shutdown must close readiness. Skipped
+    # for the minimal fallback, which only mirrors the contract.
+    if not isinstance(handlers, _RealHandlers):
+        pytest.skip("real pusher.main unavailable — minimal fallback contract")
+    table = {path: methods for path, methods in handlers.route_table() if path}
+    assert table['/health'] == {'GET'}
+    assert table['/ready'] == {'GET'}
+    assert table['/__internal/drain'] == {'POST'}
+    assert handlers.shutdown_calls_begin_drain() is True

--- a/backend/tests/unit/test_pusher_readiness_drain.py
+++ b/backend/tests/unit/test_pusher_readiness_drain.py
@@ -223,3 +223,29 @@ def test_real_app_registers_readiness_routes_and_shutdown_drain(handlers):
     assert table['/ready'] == {'GET'}
     assert table['/__internal/drain'] == {'POST'}
     assert handlers.shutdown_calls_begin_drain() is True
+
+
+def test_ws_drain_rejects_after_accept_not_before():
+    """The drain rejection in _websocket_util_trigger must accept the WS handshake
+    FIRST, then close 1001. A pre-accept close is surfaced as a failed HTTP
+    upgrade by the websockets client and recorded as a circuit-breaker failure
+    in backend-listen (backend/utils/pusher.py), which can trip the pusher
+    circuit during a normal rollout.
+    """
+    import inspect
+
+    from routers import pusher as pusher_router
+
+    source = inspect.getsource(pusher_router._websocket_util_trigger)
+    accept_pos = source.find('await websocket.accept()')
+    drain_check_pos = source.find('if not ReadinessGate.is_serving()')
+    close_1001_pos = source.find('await websocket.close(code=1001)')
+
+    assert accept_pos != -1, "websocket.accept() must be called in _websocket_util_trigger"
+    assert drain_check_pos != -1, "ReadinessGate.is_serving() drain check must be present"
+    assert close_1001_pos != -1, "close(code=1001) drain rejection must be present"
+    assert accept_pos < drain_check_pos, (
+        "accept() must come BEFORE the drain check so the client receives a "
+        "clean WS close frame instead of a failed HTTP upgrade"
+    )
+    assert drain_check_pos < close_1001_pos, "the drain check must precede the close(1001) call"

--- a/backend/tests/unit/test_pusher_readiness_drain.py
+++ b/backend/tests/unit/test_pusher_readiness_drain.py
@@ -225,12 +225,19 @@ def test_real_app_registers_readiness_routes_and_shutdown_drain(handlers):
     assert handlers.shutdown_calls_begin_drain() is True
 
 
-def test_ws_drain_rejects_after_accept_not_before():
-    """The drain rejection in _websocket_util_trigger must accept the WS handshake
-    FIRST, then close 1001. A pre-accept close is surfaced as a failed HTTP
-    upgrade by the websockets client and recorded as a circuit-breaker failure
-    in backend-listen (backend/utils/pusher.py), which can trip the pusher
-    circuit during a normal rollout.
+def test_ws_drain_reject_ordering_is_static_tripwire():
+    """STATIC source-ordering tripwire (NOT behavioral coverage): asserts that, in
+    the source of ``_websocket_util_trigger``, ``await websocket.accept()`` precedes
+    the ``ReadinessGate.is_serving()`` drain check, which precedes
+    ``await websocket.close(code=1001)``. It does NOT drive a live WebSocket
+    handshake or observe a real close frame; per AGENTS.md this is a static
+    tripwire, labeled as such.
+
+    Why the ordering matters (context for the tripwire, not what it proves):
+    accepting the handshake first lets a draining pod return a clean 1001 Going
+    Away close instead of a failed HTTP upgrade, which backend-listen would
+    otherwise record as a circuit-breaker failure (backend/utils/pusher.py) and
+    could trip the pusher circuit during a normal rollout.
     """
     import inspect
 

--- a/backend/tests/unit/test_verify_pusher_rollout_budget.py
+++ b/backend/tests/unit/test_verify_pusher_rollout_budget.py
@@ -15,6 +15,7 @@ FIXTURE_FILES = (
     "backend/charts/pusher/dev_omi_pusher_values.yaml",
     "backend/charts/pusher/prod_omi_pusher_values.yaml",
     "backend/charts/pusher/templates/deployment.yaml",
+    "backend/charts/pusher/templates/backendconfig.yaml",
     ".github/workflows/gcp_backend_pusher.yml",
     ".github/workflows/gcp_backend_pusher_auto_deploy.yml",
 )
@@ -220,3 +221,67 @@ def test_rejects_template_that_does_not_render_the_chart_deadline(
         for error in errors
     )
     assert any("Deployment spec must render minReadySeconds from .Values.minReadySeconds" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("environment", "probe", "before", "after"),
+    [
+        ("dev", "readinessProbe", "path: /ready", "path: /health"),
+        ("prod", "readinessProbe", "path: /ready", "path: /health"),
+        ("prod", "livenessProbe", "path: /health", "path: /ready"),
+        ("prod", "startupProbe", "path: /health", "path: /ready"),
+    ],
+)
+def test_rejects_probe_routed_away_from_its_contract_path(
+    verifier: SimpleNamespace,
+    rollout_fixture: Path,
+    environment: str,
+    probe: str,
+    before: str,
+    after: str,
+) -> None:
+    values = rollout_fixture / "backend/charts/pusher" / f"{environment}_omi_pusher_values.yaml"
+    replace_probe_once(values, probe, before, after)
+
+    errors = verifier.validate(rollout_fixture)
+
+    expected_path = {"readinessProbe": "/ready", "livenessProbe": "/health", "startupProbe": "/health"}[probe]
+    assert any(f"{probe}/httpGet/path must be '{expected_path}'" in error for error in errors)
+
+
+def test_rejects_backendconfig_without_connection_draining(verifier: SimpleNamespace, rollout_fixture: Path) -> None:
+    template = rollout_fixture / "backend/charts/pusher/templates/backendconfig.yaml"
+    replace_once(
+        template,
+        "  connectionDraining:\n    drainingTimeoutSec: {{ .Values.backendConfig.connectionDraining.drainingTimeoutSec | default 60 }}\n",
+        "",
+    )
+
+    errors = verifier.validate(rollout_fixture)
+
+    assert any(
+        "BackendConfig must render connectionDraining.drainingTimeoutSec from .Values" in error for error in errors
+    )
+
+
+def test_rejects_drain_timeout_exceeding_grace(verifier: SimpleNamespace, rollout_fixture: Path) -> None:
+    values = rollout_fixture / "backend/charts/pusher/prod_omi_pusher_values.yaml"
+    replace_once(values, "    drainingTimeoutSec: 60", "    drainingTimeoutSec: 999")
+
+    errors = verifier.validate(rollout_fixture)
+
+    assert any(
+        "connectionDraining.drainingTimeoutSec=999s must be <= terminationGracePeriodSeconds=120s" in error
+        for error in errors
+    )
+
+
+def test_rejects_backendconfig_healthcheck_routed_to_ready(verifier: SimpleNamespace, rollout_fixture: Path) -> None:
+    # Routing the LB healthCheck to /ready would flip the backend unhealthy during
+    # a readiness drain and defeat connectionDraining — the highest-value invariant.
+    template = rollout_fixture / "backend/charts/pusher/templates/backendconfig.yaml"
+    replace_once(template, "requestPath: /health", "requestPath: /ready")
+
+    errors = verifier.validate(rollout_fixture)
+
+    assert any("healthCheck.requestPath must render to /health" in error for error in errors)

--- a/backend/tests/unit/test_verify_pusher_rollout_gate.py
+++ b/backend/tests/unit/test_verify_pusher_rollout_gate.py
@@ -157,3 +157,51 @@ def test_rollback_emits_contract_json(gate: SimpleNamespace, rollout_fixture: Pa
     # Must be valid JSON-serializable.
     serialized = json.dumps(payload, indent=2)
     assert json.loads(serialized) == payload
+
+
+# ---------------------------------------------------------------------------
+# preflight — build-once digest promotion contract (image identity)
+# ---------------------------------------------------------------------------
+
+DIGEST = "sha256:a541cd642b2f7a92519ad648da64c806734ce336d7cebbfd0cd0246db7a2f20f"
+
+
+def _image_values(fixture: Path) -> Path:
+    return fixture / "backend/charts/pusher/dev_omi_pusher_values.yaml"
+
+
+def test_preflight_accepts_digest_pinned_release(gate: SimpleNamespace, rollout_fixture: Path) -> None:
+    values = _image_values(rollout_fixture)
+    replace_in_section(values, "image:", "pullPolicy: Always", "pullPolicy: IfNotPresent")
+    replace_in_section(values, "image:", 'tag: ""', f"digest: {DIGEST}")
+
+    assert gate.validate_preflight(rollout_fixture) == []
+
+
+def test_preflight_rejects_malformed_digest(gate: SimpleNamespace, rollout_fixture: Path) -> None:
+    values = _image_values(rollout_fixture)
+    replace_in_section(values, "image:", "pullPolicy: Always", "pullPolicy: IfNotPresent")
+    replace_in_section(values, "image:", 'tag: ""', "digest: not-a-digest")
+
+    errors = gate.validate_preflight(rollout_fixture)
+
+    assert any("image/digest must be sha256" in error for error in errors)
+
+
+def test_preflight_rejects_digest_with_a_mutable_tag(gate: SimpleNamespace, rollout_fixture: Path) -> None:
+    values = _image_values(rollout_fixture)
+    replace_in_section(values, "image:", "pullPolicy: Always", "pullPolicy: IfNotPresent")
+    replace_in_section(values, "image:", 'tag: ""', f'tag: "v1.2.3"\n  digest: {DIGEST}')
+
+    errors = gate.validate_preflight(rollout_fixture)
+
+    assert any("image/tag must be empty when image/digest" in error for error in errors)
+
+
+def test_preflight_rejects_digest_with_always_pull(gate: SimpleNamespace, rollout_fixture: Path) -> None:
+    values = _image_values(rollout_fixture)
+    replace_in_section(values, "image:", 'tag: ""', f"digest: {DIGEST}")
+
+    errors = gate.validate_preflight(rollout_fixture)
+
+    assert any("pullPolicy must be IfNotPresent for a digest-pinned" in error for error in errors)

--- a/backend/tests/unit/test_verify_pusher_rollout_gate.py
+++ b/backend/tests/unit/test_verify_pusher_rollout_gate.py
@@ -1,0 +1,159 @@
+"""Regression coverage for the Pusher rollout quality-gate preflight + rollback contract."""
+
+from __future__ import annotations
+
+import json
+import runpy
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "backend" / "scripts" / "verify_pusher_rollout_gate.py"
+
+FIXTURE_FILES = (
+    "backend/charts/pusher/dev_omi_pusher_values.yaml",
+    "backend/charts/pusher/prod_omi_pusher_values.yaml",
+    "backend/charts/pusher/templates/backendconfig.yaml",
+    "backend/charts/pusher/templates/deployment.yaml",
+    "backend/utils/metrics.py",
+)
+
+
+@pytest.fixture(scope="module")
+def gate() -> SimpleNamespace:
+    return SimpleNamespace(**runpy.run_path(str(SCRIPT)))
+
+
+@pytest.fixture
+def rollout_fixture(tmp_path: Path) -> Path:
+    for relative in FIXTURE_FILES:
+        source = REPO_ROOT / relative
+        destination = tmp_path / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, destination)
+    return tmp_path
+
+
+def replace_once(path: Path, before: str, after: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    assert text.count(before) == 1, f"expected exactly one {before!r} in {path}"
+    path.write_text(text.replace(before, after, 1), encoding="utf-8")
+
+
+def replace_in_section(path: Path, section_start: str, before: str, after: str) -> None:
+    """Replace *before* with *after* only within the YAML block starting at *section_start*."""
+
+    text = path.read_text(encoding="utf-8")
+    start = text.index(section_start)
+    end = text.index("\n\n", start)
+    section = text[start:end]
+    assert section.count(before) == 1, f"expected exactly one {before!r} in section {section_start!r} of {path}"
+    path.write_text(text[:start] + section.replace(before, after, 1) + text[end:], encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# preflight — pass on the good chart (both repo root and hermetic fixture)
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_passes_on_repo_root(gate: SimpleNamespace) -> None:
+    assert gate.validate_preflight(REPO_ROOT) == []
+
+
+def test_preflight_passes_on_good_fixture(gate: SimpleNamespace, rollout_fixture: Path) -> None:
+    assert gate.validate_preflight(rollout_fixture) == []
+
+
+# ---------------------------------------------------------------------------
+# preflight — fail when readinessProbe regresses to /health
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_fails_when_readiness_regresses_to_health(gate: SimpleNamespace, rollout_fixture: Path) -> None:
+    values = rollout_fixture / "backend/charts/pusher/prod_omi_pusher_values.yaml"
+    replace_in_section(values, "readinessProbe:", "path: /ready", "path: /health")
+
+    errors = gate.validate_preflight(rollout_fixture)
+
+    assert any("readinessProbe/httpGet/path must be '/ready'" in error for error in errors)
+
+
+# ---------------------------------------------------------------------------
+# preflight — fail when a rollout-blocking metric is removed
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_fails_when_metric_removed(gate: SimpleNamespace, rollout_fixture: Path) -> None:
+    metrics = rollout_fixture / "backend/utils/metrics.py"
+    # Remove the pusher_ready metric definition entirely.
+    replace_once(
+        metrics,
+        "PUSHER_READY = Gauge(\n    'pusher_ready',\n    '1 = serving new traffic, 0 = draining',\n)\n",
+        "",
+    )
+
+    errors = gate.validate_preflight(rollout_fixture)
+
+    assert any("'pusher_ready' is not defined" in error for error in errors)
+
+
+# ---------------------------------------------------------------------------
+# preflight — fail when drainingTimeoutSec > terminationGracePeriodSeconds
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_fails_when_draining_exceeds_grace(gate: SimpleNamespace, rollout_fixture: Path) -> None:
+    values = rollout_fixture / "backend/charts/pusher/prod_omi_pusher_values.yaml"
+    replace_once(values, "drainingTimeoutSec: 60", "drainingTimeoutSec: 130")
+
+    errors = gate.validate_preflight(rollout_fixture)
+
+    assert any(
+        "drainingTimeoutSec=130s must not exceed terminationGracePeriodSeconds=120s" in error for error in errors
+    )
+
+
+# ---------------------------------------------------------------------------
+# preflight — fail when BackendConfig healthCheck is routed to /ready
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_fails_when_healthcheck_routed_to_ready(gate: SimpleNamespace, rollout_fixture: Path) -> None:
+    template = rollout_fixture / "backend/charts/pusher/templates/backendconfig.yaml"
+    replace_once(template, "requestPath: /health", "requestPath: /ready")
+
+    errors = gate.validate_preflight(rollout_fixture)
+
+    assert any("healthCheck.requestPath must render to /health" in error for error in errors)
+
+
+# ---------------------------------------------------------------------------
+# rollback — emits contract JSON with prior-restore and traffic/data split
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_emits_contract_json(gate: SimpleNamespace, rollout_fixture: Path) -> None:
+    contract = gate.rollback_contract(rollout_fixture, "prod")
+    payload = contract.as_dict()
+
+    assert payload["environment"] == "prod"
+    assert payload["revision_history_limit"] == 10  # chart default (not set in template)
+    assert "Prior ReplicaSets are retained" in payload["revision_history_source"]
+
+    # Prior-restore field present and clearly operator-captured (not static).
+    assert "prior image tag/digest" in payload["prior_restore"].lower()
+    assert "captured at runtime" in payload["prior_restore"]
+    assert "helm upgrade" in payload["restore_command"]
+
+    # Traffic vs data rollback separation.
+    assert "SAFE" in payload["traffic_rollback"]
+    assert "always available" in payload["traffic_rollback"]
+    assert "IRREVERSIBLE" in payload["data_rollback"]
+    assert "NEVER be auto-rolled-back" in payload["data_rollback"]
+
+    # Must be valid JSON-serializable.
+    serialized = json.dumps(payload, indent=2)
+    assert json.loads(serialized) == payload

--- a/backend/tests/unit/test_verify_pusher_rollout_gate.py
+++ b/backend/tests/unit/test_verify_pusher_rollout_gate.py
@@ -148,6 +148,13 @@ def test_rollback_emits_contract_json(gate: SimpleNamespace, rollout_fixture: Pa
     assert "captured at runtime" in payload["prior_restore"]
     assert "helm upgrade" in payload["restore_command"]
 
+    # Capture must extract ONLY the tag or digest, not the full image ref,
+    # and restore must use --set-string (matches the deploy workflows).
+    assert "sed 's/.*://'" in payload["capture_command"]
+    assert "sha256:[a-f0-9]" in payload["capture_command"]
+    assert "--set-string image.tag=" in payload["restore_command"]
+    assert "--set-string image.digest=" in payload["restore_command"]
+
     # Traffic vs data rollback separation.
     assert "SAFE" in payload["traffic_rollback"]
     assert "always available" in payload["traffic_rollback"]

--- a/backend/tests/unit/test_verify_shared_config_migration.py
+++ b/backend/tests/unit/test_verify_shared_config_migration.py
@@ -1,0 +1,235 @@
+"""Regression coverage for the cross-resource shared-config migration guard.
+
+These fixtures model the historical partial transition that caused the
+2026-07-22 Pusher outage: a shared key (REDIS_DB_HOST) removed/reclassified
+from a source while a serving workload still referenced the old source/key.
+"""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "backend" / "scripts" / "verify_shared_config_migration.py"
+
+
+@pytest.fixture(scope="module")
+def guard() -> SimpleNamespace:
+    return SimpleNamespace(**runpy.run_path(str(SCRIPT)))
+
+
+def _write(path: Path, text: str) -> str:
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+# A Deployment that still binds REDIS_DB_HOST to the historical Secret source
+# AFTER the key moved to the ConfigMap — the exact incident shape.
+STALE_SECRET_RENDER = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dev-omi-pusher
+spec:
+  template:
+    spec:
+      containers:
+        - name: pusher
+          env:
+            - name: REDIS_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: dev-omi-backend-secrets
+                  key: REDIS_DB_HOST
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dev-omi-backend-secrets
+                  key: OPENAI_API_KEY
+"""
+
+# A Deployment whose REDIS_DB_HOST binding already moved to the ConfigMap — the
+# compatible consumer rollout that must precede the source transition.
+CLEAN_CONFIGMAP_RENDER = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dev-omi-pusher
+spec:
+  template:
+    spec:
+      containers:
+        - name: pusher
+          env:
+            - name: REDIS_DB_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: dev-omi-backend-config
+                  key: REDIS_DB_HOST
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dev-omi-backend-secrets
+                  key: OPENAI_API_KEY
+"""
+
+# Proposed state: REDIS_DB_HOST now lives ONLY in the ConfigMap; the Secret no
+# longer carries it. Key names only — no values ever appear.
+PROPOSED_INVENTORY = """\
+configmaps:
+  dev-omi-backend-config:
+    - REDIS_DB_HOST
+    - GOOGLE_CLIENT_ID
+secrets:
+  dev-omi-backend-secrets:
+    - OPENAI_API_KEY
+    - REDIS_DB_PASSWORD
+"""
+
+# Current live state: REDIS_DB_HOST still materializes in the Secret (pre-move).
+PREVIOUS_INVENTORY = """\
+configmaps:
+  dev-omi-backend-config:
+    - GOOGLE_CLIENT_ID
+secrets:
+  dev-omi-backend-secrets:
+    - REDIS_DB_HOST
+    - OPENAI_API_KEY
+    - REDIS_DB_PASSWORD
+"""
+
+
+def test_blocks_the_historical_partial_transition(guard, tmp_path, capsys):
+    """A workload still referencing the removed Secret key must fail closed."""
+    rendered = _write(tmp_path / "rendered.yaml", STALE_SECRET_RENDER)
+    inventory = _write(tmp_path / "proposed.yaml", PROPOSED_INVENTORY)
+    previous = _write(tmp_path / "previous.yaml", PREVIOUS_INVENTORY)
+
+    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory, "--previous-inventory", previous])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "REDIS_DB_HOST" in out
+    assert "not present in the proposed source inventory" in out
+    # The guard must name the reclassification so an operator sees the fix path.
+    assert "moved to configmap/dev-omi-backend-config" in out
+
+
+def test_passes_when_consumer_rolled_first(guard, tmp_path, capsys):
+    """The compatible consumer rollout (ConfigMap binding) passes the transition."""
+    rendered = _write(tmp_path / "rendered.yaml", CLEAN_CONFIGMAP_RENDER)
+    inventory = _write(tmp_path / "proposed.yaml", PROPOSED_INVENTORY)
+    previous = _write(tmp_path / "previous.yaml", PREVIOUS_INVENTORY)
+
+    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory, "--previous-inventory", previous])
+    out = capsys.readouterr().out
+    assert rc == 0, out
+    assert "passed" in out
+
+
+def test_blocks_a_missing_key_without_transition(guard, tmp_path, capsys):
+    """Even without a previous inventory, a reference to an absent key fails."""
+    rendered = _write(tmp_path / "rendered.yaml", STALE_SECRET_RENDER)
+    inventory = _write(tmp_path / "proposed.yaml", PROPOSED_INVENTORY)
+
+    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "REDIS_DB_HOST" in out
+
+
+def test_blocks_a_reference_to_a_removed_object(guard, tmp_path, capsys):
+    """A reference to an object absent from the proposed inventory fails."""
+    rendered = _write(tmp_path / "rendered.yaml", CLEAN_CONFIGMAP_RENDER)
+    # Inventory drops the ConfigMap object entirely.
+    inventory = _write(
+        tmp_path / "proposed.yaml",
+        "secrets:\n  dev-omi-backend-secrets:\n    - OPENAI_API_KEY\n",
+    )
+    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "configmap/dev-omi-backend-config" in out
+    assert "absent from the proposed source inventory" in out
+
+
+def test_fails_closed_on_missing_inventory_file(guard, tmp_path, capsys):
+    rendered = _write(tmp_path / "rendered.yaml", CLEAN_CONFIGMAP_RENDER)
+    rc = guard.main(["--rendered", rendered, "--source-inventory", str(tmp_path / "nope.yaml")])
+    assert rc == 1
+    assert "could not read inventory" in capsys.readouterr().out
+
+
+def test_fails_closed_on_malformed_inventory(guard, tmp_path, capsys):
+    rendered = _write(tmp_path / "rendered.yaml", CLEAN_CONFIGMAP_RENDER)
+    inventory = _write(tmp_path / "proposed.yaml", "configmaps: not-a-mapping\n")
+    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    assert rc == 1
+    assert "must be a mapping" in capsys.readouterr().out
+
+
+def test_fails_closed_on_empty_inventory(guard, tmp_path, capsys):
+    rendered = _write(tmp_path / "rendered.yaml", CLEAN_CONFIGMAP_RENDER)
+    inventory = _write(tmp_path / "proposed.yaml", "configmaps: {}\nsecrets: {}\n")
+    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    assert rc == 1
+    assert "declares no configmaps or secrets" in capsys.readouterr().out
+
+
+def test_rejects_a_malformed_binding(guard, tmp_path, capsys):
+    rendered = _write(
+        tmp_path / "rendered.yaml",
+        """\
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: bad}
+spec:
+  template:
+    spec:
+      containers:
+        - name: pusher
+          env:
+            - name: REDIS_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: dev-omi-backend-secrets
+""",
+    )
+    inventory = _write(tmp_path / "proposed.yaml", "secrets:\n  dev-omi-backend-secrets:\n    - REDIS_DB_HOST\n")
+    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    assert rc == 1
+    assert "must declare a non-empty name and key" in capsys.readouterr().out
+
+
+def test_never_prints_secret_values(guard, tmp_path, capsys):
+    """A real-looking literal value must never reach the guard's output."""
+    rendered = _write(
+        tmp_path / "rendered.yaml",
+        """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dev-omi-pusher
+spec:
+  template:
+    spec:
+      containers:
+        - name: pusher
+          env:
+            - name: REDIS_DB_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: dev-omi-backend-config
+                  key: REDIS_DB_HOST
+            - name: DANGEROUS_LITERAL
+              value: super-secret-leak-that-must-never-appear
+""",
+    )
+    inventory = _write(tmp_path / "proposed.yaml", PROPOSED_INVENTORY)
+    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    out = capsys.readouterr().out
+    assert rc == 0, out
+    assert "super-secret-leak-that-must-never-appear" not in out

--- a/backend/tests/unit/test_verify_shared_config_migration.py
+++ b/backend/tests/unit/test_verify_shared_config_migration.py
@@ -233,3 +233,110 @@ spec:
     out = capsys.readouterr().out
     assert rc == 0, out
     assert "super-secret-leak-that-must-never-appear" not in out
+
+
+# ---------------------------------------------------------------------------
+# envFrom bulk-load blind spot (the agreed review finding) + workload generality
+# ---------------------------------------------------------------------------
+
+# A Deployment that consumes the shared ConfigMap ONLY via envFrom (no explicit
+# per-key ref) — the binding style the original guard missed.
+ENVFROM_ONLY_RENDER = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dev-omi-pusher
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: migrate
+          envFrom:
+            - configMapRef:
+                name: dev-omi-backend-config
+      containers:
+        - name: pusher
+          envFrom:
+            - configMapRef:
+                name: dev-omi-backend-config
+"""
+
+
+def test_envfrom_object_removal_is_caught(guard, tmp_path, capsys):
+    """A bulk-loaded ConfigMap removed from the proposed inventory must fail."""
+    rendered = _write(tmp_path / "rendered.yaml", ENVFROM_ONLY_RENDER)
+    inventory = _write(
+        tmp_path / "proposed.yaml",
+        "secrets:\n  dev-omi-backend-secrets:\n    - OPENAI_API_KEY\n",
+    )
+    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "envFrom bulk-loads configmap/dev-omi-backend-config" in out
+    assert "absent from the proposed source inventory" in out
+
+
+def test_envfrom_key_removal_is_caught_with_previous_inventory(guard, tmp_path, capsys):
+    """A key removed from a bulk-loaded object is the outage class — must fail."""
+    rendered = _write(tmp_path / "rendered.yaml", ENVFROM_ONLY_RENDER)
+    proposed = _write(
+        tmp_path / "proposed.yaml",
+        "configmaps:\n  dev-omi-backend-config:\n    - REDIS_DB_HOST\n",
+    )
+    previous = _write(
+        tmp_path / "previous.yaml",
+        "configmaps:\n  dev-omi-backend-config:\n    - REDIS_DB_HOST\n    - RETIRED_KEY\n",
+    )
+    rc = guard.main(["--rendered", rendered, "--source-inventory", proposed, "--previous-inventory", previous])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "envFrom bulk-loads configmap/dev-omi-backend-config" in out
+    assert "RETIRED_KEY" in out
+    assert "2026-07-22 outage class" in out
+
+
+def test_envfrom_passes_when_no_key_removed(guard, tmp_path, capsys):
+    """A bulk-loaded object whose keys are unchanged (or only added) passes."""
+    rendered = _write(tmp_path / "rendered.yaml", ENVFROM_ONLY_RENDER)
+    proposed = _write(
+        tmp_path / "proposed.yaml",
+        "configmaps:\n  dev-omi-backend-config:\n    - REDIS_DB_HOST\n    - NEW_KEY\n",
+    )
+    previous = _write(
+        tmp_path / "previous.yaml",
+        "configmaps:\n  dev-omi-backend-config:\n    - REDIS_DB_HOST\n",
+    )
+    rc = guard.main(["--rendered", rendered, "--source-inventory", proposed, "--previous-inventory", previous])
+    assert rc == 0, capsys.readouterr().out
+
+
+def test_statefulset_and_initcontainers_are_scanned(guard, tmp_path, capsys):
+    """A StatefulSet and an initContainer referencing a removed key both fail."""
+    rendered = _write(
+        tmp_path / "rendered.yaml",
+        """\
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dev-cache
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: bootstrap
+          env:
+            - name: REDIS_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: dev-omi-backend-secrets
+                  key: REDIS_DB_HOST
+      containers:
+        - name: cache
+""",
+    )
+    inventory = _write(tmp_path / "proposed.yaml", PROPOSED_INVENTORY)
+    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "REDIS_DB_HOST" in out
+    assert "not present in the proposed source inventory" in out

--- a/backend/tests/unit/test_verify_shared_config_migration.py
+++ b/backend/tests/unit/test_verify_shared_config_migration.py
@@ -109,7 +109,9 @@ def test_blocks_the_historical_partial_transition(guard, tmp_path, capsys):
     inventory = _write(tmp_path / "proposed.yaml", PROPOSED_INVENTORY)
     previous = _write(tmp_path / "previous.yaml", PREVIOUS_INVENTORY)
 
-    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory, "--previous-inventory", previous])
+    rc = guard.main(
+        ["guard", "--rendered", rendered, "--source-inventory", inventory, "--previous-inventory", previous]
+    )
     out = capsys.readouterr().out
     assert rc == 1
     assert "REDIS_DB_HOST" in out
@@ -124,7 +126,9 @@ def test_passes_when_consumer_rolled_first(guard, tmp_path, capsys):
     inventory = _write(tmp_path / "proposed.yaml", PROPOSED_INVENTORY)
     previous = _write(tmp_path / "previous.yaml", PREVIOUS_INVENTORY)
 
-    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory, "--previous-inventory", previous])
+    rc = guard.main(
+        ["guard", "--rendered", rendered, "--source-inventory", inventory, "--previous-inventory", previous]
+    )
     out = capsys.readouterr().out
     assert rc == 0, out
     assert "passed" in out
@@ -135,7 +139,7 @@ def test_blocks_a_missing_key_without_transition(guard, tmp_path, capsys):
     rendered = _write(tmp_path / "rendered.yaml", STALE_SECRET_RENDER)
     inventory = _write(tmp_path / "proposed.yaml", PROPOSED_INVENTORY)
 
-    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    rc = guard.main(["guard", "--rendered", rendered, "--source-inventory", inventory])
     out = capsys.readouterr().out
     assert rc == 1
     assert "REDIS_DB_HOST" in out
@@ -149,7 +153,7 @@ def test_blocks_a_reference_to_a_removed_object(guard, tmp_path, capsys):
         tmp_path / "proposed.yaml",
         "secrets:\n  dev-omi-backend-secrets:\n    - OPENAI_API_KEY\n",
     )
-    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    rc = guard.main(["guard", "--rendered", rendered, "--source-inventory", inventory])
     out = capsys.readouterr().out
     assert rc == 1
     assert "configmap/dev-omi-backend-config" in out
@@ -158,7 +162,7 @@ def test_blocks_a_reference_to_a_removed_object(guard, tmp_path, capsys):
 
 def test_fails_closed_on_missing_inventory_file(guard, tmp_path, capsys):
     rendered = _write(tmp_path / "rendered.yaml", CLEAN_CONFIGMAP_RENDER)
-    rc = guard.main(["--rendered", rendered, "--source-inventory", str(tmp_path / "nope.yaml")])
+    rc = guard.main(["guard", "--rendered", rendered, "--source-inventory", str(tmp_path / "nope.yaml")])
     assert rc == 1
     assert "could not read inventory" in capsys.readouterr().out
 
@@ -166,7 +170,7 @@ def test_fails_closed_on_missing_inventory_file(guard, tmp_path, capsys):
 def test_fails_closed_on_malformed_inventory(guard, tmp_path, capsys):
     rendered = _write(tmp_path / "rendered.yaml", CLEAN_CONFIGMAP_RENDER)
     inventory = _write(tmp_path / "proposed.yaml", "configmaps: not-a-mapping\n")
-    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    rc = guard.main(["guard", "--rendered", rendered, "--source-inventory", inventory])
     assert rc == 1
     assert "must be a mapping" in capsys.readouterr().out
 
@@ -174,7 +178,7 @@ def test_fails_closed_on_malformed_inventory(guard, tmp_path, capsys):
 def test_fails_closed_on_empty_inventory(guard, tmp_path, capsys):
     rendered = _write(tmp_path / "rendered.yaml", CLEAN_CONFIGMAP_RENDER)
     inventory = _write(tmp_path / "proposed.yaml", "configmaps: {}\nsecrets: {}\n")
-    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    rc = guard.main(["guard", "--rendered", rendered, "--source-inventory", inventory])
     assert rc == 1
     assert "declares no configmaps or secrets" in capsys.readouterr().out
 
@@ -199,7 +203,7 @@ spec:
 """,
     )
     inventory = _write(tmp_path / "proposed.yaml", "secrets:\n  dev-omi-backend-secrets:\n    - REDIS_DB_HOST\n")
-    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    rc = guard.main(["guard", "--rendered", rendered, "--source-inventory", inventory])
     assert rc == 1
     assert "must declare a non-empty name and key" in capsys.readouterr().out
 
@@ -229,7 +233,7 @@ spec:
 """,
     )
     inventory = _write(tmp_path / "proposed.yaml", PROPOSED_INVENTORY)
-    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    rc = guard.main(["guard", "--rendered", rendered, "--source-inventory", inventory])
     out = capsys.readouterr().out
     assert rc == 0, out
     assert "super-secret-leak-that-must-never-appear" not in out
@@ -269,7 +273,7 @@ def test_envfrom_object_removal_is_caught(guard, tmp_path, capsys):
         tmp_path / "proposed.yaml",
         "secrets:\n  dev-omi-backend-secrets:\n    - OPENAI_API_KEY\n",
     )
-    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    rc = guard.main(["guard", "--rendered", rendered, "--source-inventory", inventory])
     out = capsys.readouterr().out
     assert rc == 1
     assert "envFrom bulk-loads configmap/dev-omi-backend-config" in out
@@ -287,7 +291,7 @@ def test_envfrom_key_removal_is_caught_with_previous_inventory(guard, tmp_path, 
         tmp_path / "previous.yaml",
         "configmaps:\n  dev-omi-backend-config:\n    - REDIS_DB_HOST\n    - RETIRED_KEY\n",
     )
-    rc = guard.main(["--rendered", rendered, "--source-inventory", proposed, "--previous-inventory", previous])
+    rc = guard.main(["guard", "--rendered", rendered, "--source-inventory", proposed, "--previous-inventory", previous])
     out = capsys.readouterr().out
     assert rc == 1
     assert "envFrom bulk-loads configmap/dev-omi-backend-config" in out
@@ -306,7 +310,7 @@ def test_envfrom_passes_when_no_key_removed(guard, tmp_path, capsys):
         tmp_path / "previous.yaml",
         "configmaps:\n  dev-omi-backend-config:\n    - REDIS_DB_HOST\n",
     )
-    rc = guard.main(["--rendered", rendered, "--source-inventory", proposed, "--previous-inventory", previous])
+    rc = guard.main(["guard", "--rendered", rendered, "--source-inventory", proposed, "--previous-inventory", previous])
     assert rc == 0, capsys.readouterr().out
 
 
@@ -335,8 +339,74 @@ spec:
 """,
     )
     inventory = _write(tmp_path / "proposed.yaml", PROPOSED_INVENTORY)
-    rc = guard.main(["--rendered", rendered, "--source-inventory", inventory])
+    rc = guard.main(["guard", "--rendered", rendered, "--source-inventory", inventory])
     out = capsys.readouterr().out
     assert rc == 1
     assert "REDIS_DB_HOST" in out
     assert "not present in the proposed source inventory" in out
+
+
+# ---------------------------------------------------------------------------
+# Preflight mode (self-contained chart-values scan, no external inventory)
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_passes_on_real_chart_values(guard, capsys):
+    """Preflight mode against the committed pusher chart values must pass."""
+    rc = guard.main(["preflight"])
+    out = capsys.readouterr().out
+    assert rc == 0, out
+    assert "shared-config migration preflight passed" in out
+    # Both environments are scanned
+    assert "dev:" in out
+    assert "prod:" in out
+
+
+def test_preflight_is_the_default_mode(guard, capsys):
+    """Running with no mode argument defaults to preflight."""
+    rc = guard.main([])
+    out = capsys.readouterr().out
+    assert rc == 0, out
+    assert "shared-config migration preflight passed" in out
+
+
+def test_preflight_detects_malformed_env_binding(guard, tmp_path, capsys):
+    """Preflight fails when chart env has an ambiguous dual-source binding."""
+    chart_dir = tmp_path / "backend" / "charts" / "pusher"
+    chart_dir.mkdir(parents=True)
+    for env in ("dev", "prod"):
+        (chart_dir / f"{env}_omi_pusher_values.yaml").write_text(
+            "env:\n"
+            "  - name: BAD_KEY\n"
+            "    valueFrom:\n"
+            "      configMapKeyRef:\n"
+            "        name: cm\n"
+            "        key: BAD_KEY\n"
+            "      secretKeyRef:\n"
+            "        name: sec\n"
+            "        key: BAD_KEY\n",
+            encoding="utf-8",
+        )
+    rc = guard.main(["preflight", "--root", str(tmp_path)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "multiple binding sources" in err
+
+
+def test_guard_mode_requires_rendered_and_inventory(guard, capsys):
+    """Guard mode without --rendered or --source-inventory exits with usage error."""
+    with pytest.raises(SystemExit) as exc_info:
+        guard.main(["guard"])
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "requires --rendered" in err
+
+
+def test_guard_mode_still_works_with_explicit_mode_arg(guard, tmp_path, capsys):
+    """Guard mode still works when explicitly invoked with --rendered + --source-inventory."""
+    rendered = _write(tmp_path / "rendered.yaml", STALE_SECRET_RENDER)
+    inventory = _write(tmp_path / "proposed.yaml", PROPOSED_INVENTORY)
+    rc = guard.main(["guard", "--rendered", rendered, "--source-inventory", inventory])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "REDIS_DB_HOST" in out

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -258,5 +258,22 @@ AUTH_FLOW_DURATION_SECONDS = Histogram(
 )
 
 
+# Pusher readiness / drain gauges. Label-free (low cardinality) so they scrape
+# cheaply. Initialized to serving below so an idle healthy pod reads
+# pusher_ready=1 / pusher_drain_in_progress=0 and is distinguishable from a
+# missing scrape target (a labelless Gauge defaults to 0, which would wrongly
+# read as "draining"). utils.readiness.ReadinessGate flips these on drain.
+PUSHER_READY = Gauge(
+    'pusher_ready',
+    '1 = serving new traffic, 0 = draining',
+)
+PUSHER_DRAIN_IN_PROGRESS = Gauge(
+    'pusher_drain_in_progress',
+    '1 = drain initiated, readiness closed',
+)
+PUSHER_READY.set(1)
+PUSHER_DRAIN_IN_PROGRESS.set(0)
+
+
 def metrics_response() -> Response:
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/backend/utils/readiness.py
+++ b/backend/utils/readiness.py
@@ -1,0 +1,95 @@
+"""Reusable readiness/drain gate for the pusher process.
+
+A module-level singleton (:data:`ReadinessGate`) tracks whether the process is
+serving new traffic or draining for shutdown. It is intentionally dependency-free
+so it can be reused by the pusher process (wired today) and, without pulling in
+routers or database modules, the llm-gateway (planned) as well.
+
+Honest availability model: flipping to DRAINING only stops NEW connections
+(readiness fails so the LB stops sending new traffic; new WebSockets are rejected
+at the app). In-flight WebSocket sessions are NOT migrated across a cutover over
+the proxied ALB+NEG path; they are cut by the load balancer per BackendConfig
+connectionDraining and reconnect through backend-listen. Never treat drain as
+sub-second or zero-session-impact.
+"""
+
+import threading
+import time
+
+_STATE_SERVING = 'SERVING'
+_STATE_DRAINING = 'DRAINING'
+
+
+class _ReadinessGate:
+    """Thread-safe singleton readiness/drain state.
+
+    ``begin_drain`` is idempotent: the first call atomically flips SERVING ->
+    DRAINING, records the monotonic drain start, and exports the gauge flip; every
+    subsequent call is a no-op (NOT an error). Idempotency lets the preStop drain
+    hook and the SIGTERM-driven lifespan shutdown both invoke it safely without
+    coordinating.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._state = _STATE_SERVING
+        self._drain_started_monotonic: float | None = None
+
+    def is_serving(self) -> bool:
+        with self._lock:
+            return self._state == _STATE_SERVING
+
+    def begin_drain(self) -> None:
+        """Atomically flip SERVING -> DRAINING and export the gauge flip.
+
+        Idempotent: a no-op (not an error) when already draining, so the preStop
+        drain hook and the lifespan shutdown path can both call it. Records
+        ``drain_started_monotonic`` exactly once.
+        """
+        with self._lock:
+            if self._state == _STATE_DRAINING:
+                return
+            self._state = _STATE_DRAINING
+            self._drain_started_monotonic = time.monotonic()
+        # Emit the gauge flip outside the lock. prometheus_client is internally
+        # thread-safe; the lazy import keeps this module dependency-free at import.
+        self._export_drain_gauges()
+
+    def drain_age_seconds(self) -> float | None:
+        """Seconds since drain began (monotonic), or ``None`` while still serving."""
+        with self._lock:
+            if self._drain_started_monotonic is None:
+                return None
+            return time.monotonic() - self._drain_started_monotonic
+
+    def reset_for_test(self) -> None:
+        """Test-only: return to SERVING, clear the drain start, restore gauges."""
+        with self._lock:
+            self._state = _STATE_SERVING
+            self._drain_started_monotonic = None
+        self._export_serving_gauges()
+
+    @staticmethod
+    def _export_drain_gauges() -> None:
+        try:
+            from utils.metrics import PUSHER_DRAIN_IN_PROGRESS, PUSHER_READY
+        except Exception:
+            # ponytail: telemetry must never break the drain path. If the metrics
+            # module is unavailable (minimal import context), the gate still flips;
+            # the gauges simply don't emit. Acceptable: drain correctness does not
+            # depend on Prometheus.
+            return
+        PUSHER_READY.set(0)
+        PUSHER_DRAIN_IN_PROGRESS.set(1)
+
+    @staticmethod
+    def _export_serving_gauges() -> None:
+        try:
+            from utils.metrics import PUSHER_DRAIN_IN_PROGRESS, PUSHER_READY
+        except Exception:
+            return
+        PUSHER_READY.set(1)
+        PUSHER_DRAIN_IN_PROGRESS.set(0)
+
+
+ReadinessGate = _ReadinessGate()


### PR DESCRIPTION
## SCA-39 — Harden pusher native RollingUpdate (long-term rollout strategy)

**DRAFT — architecture review only.** Implements the accepted PRIMARY from the
SCA-39 Phase-0 decision: harden the existing **native Kubernetes RollingUpdate**
for the pusher GKE workload. No Argo / Flagger / service mesh / Gateway API, and
**no** two-color (A2) experiment — those remain documented variants only.

### Dependency / branch
- Base: `origin/main` (`241f1c4c4dc6`). **Not stacked on SCA-40** because SCA-40
  (`c0590c68`) was still in_progress with no published branch at start; this PR
  implements only the **non-overlapping** long-term pieces and must be rebased
  onto SCA-40's head if/when it lands (digest promotion / chart-only mode /
  REDIS_DB_HOST preflight / rollback evidence are SCA-40's and are **not**
  duplicated here). The quality-gate script explicitly *asserts `image.digest`
  is absent* and will need a lockstep update alongside SCA-40's digest field.

### Changed surfaces
**Runtime (Lane A)**
- `backend/utils/readiness.py` (new): reusable, dependency-free `ReadinessGate`
  (SERVING/DRAINING), thread-safe, idempotent `begin_drain()`; designed for
  pusher (wired) and the llm-gateway (planned).
- `backend/pusher/main.py`: `/health` (liveness, 200 while alive), new `/ready`
  (503 when draining), new loopback-only `POST /__internal/drain`; lifespan
  shutdown calls `begin_drain()` **first** then drains background tasks.
- `backend/routers/pusher.py`: rejects **new** WS (close 1001 before accept)
  during drain; in-flight sessions keep draining via their own bounded logic.
- `backend/utils/metrics.py`: two low-cardinality gauges `pusher_ready`,
  `pusher_drain_in_progress`.

**Helm/GKE contract (Lane B)**
- `backend/charts/pusher/{dev,prod}_omi_pusher_values.yaml`: `readinessProbe` →
  `/ready` (liveness/startup stay `/health`); `preStop` now
  `curl -sf -m 5 -X POST localhost:8080/__internal/drain || true; sleep 15`
  (flip readiness early + NEG-convergence sleep); added
  `backendConfig.connectionDraining.drainingTimeoutSec: 60`.
- `backend/charts/pusher/templates/backendconfig.yaml`: added
  `connectionDraining.drainingTimeoutSec`; healthCheck stays on `/health`
  (liveness semantics — routing it to `/ready` would defeat connectionDraining).

**Quality gates + rollback contract (Lane D)**
- `backend/scripts/verify_pusher_rollout_gate.py` (new): fail-closed `preflight`
  (capacity headroom, image-identity, probe split, **telemetry-present**) + a
  read-only `rollback` contract (emits JSON; never executes). Missing telemetry
  ⇒ fail, not green.
- `backend/scripts/verify_pusher_rollout_budget.py`: extended to also enforce the
  probe split, connectionDraining, `drainingTimeoutSec ≤ grace`, and the
  BackendConfig healthCheck invariant (the highest-value guard added from the
  refuter pass).

**Docs (Lane E)**
- `backend/docs/pusher_rolling_update_operations.md` (new): honest availability
  contract, termination sequence, operator runbook, fail-closed gates, N/N-1
  compatibility checklist, dev qualification plan, SCA-40 relationship.

### Honest availability contract (no overclaim)
In-flight WebSocket sessions are **not** migrated across a cutover over the
proxied ALB+NEG path. "Graceful drain" = zero **new**-connection rejection + a
bounded ~1–60s reconnect gap per affected session (backend-listen reconnects);
`connectionDraining` bounds how long the LB waits before cutting. No sub-second
or zero-session-impact cutover is claimed.

### Tests
- `test_pusher_readiness_drain.py` (6): serving/drain, loopback-only, idempotent,
  non-loopback 403, reset, real-route wiring + shutdown-drain.
- `test_verify_pusher_rollout_budget.py` (+6) and `test_verify_pusher_rollout_gate.py` (6):
  good-chart passes; fail-closed regressions for probe routing, missing
  connectionDraining/healthCheck invariant, drain>grace, missing telemetry.
- Verified: `make setup`; `helm template` dev+prod (liveness `/health`,
  readiness `/ready`, BackendConfig healthCheck `/health`, `connectionDraining`
  60 ≤ grace 120); 81 affected unit tests pass with the worktree venv;
  `scripts/pr-preflight --suggest` clean.

### Known gaps / remaining
- Build-once digest promotion (Phase-0 §7) is **deferred** to stack on SCA-40.
- The live-scrape "missing telemetry = pause" gate is operator-discipline in this
  draft; the automated check is a static definition-presence scan only (tracked).
- CI wiring of the new preflight gate as a required check is intentionally
  deferred (wiring it could itself rebuild); both scripts are runnable standalone.

### Boundary (DRAFT)
No dev/prod deployment, no controller/CRD install, no production mutation, no
workflow dispatch. **Production adoption is blocked** on a healthy Pusher
baseline (SCA-36/SCA-40 repair) **plus explicit approval** — this PR is for
review only.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

