### PR TITLE
fix(release): extend cold qualification preparation bound

### DIFF
--- a/desktop/macos/changelog/unreleased/20260722-beta-qualification-cold-build-timeout.json
+++ b/desktop/macos/changelog/unreleased/20260722-beta-qualification-cold-build-timeout.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved macOS Beta qualification reliability for cold builds."
+}

--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -119,7 +119,7 @@ LAUNCH_LOG=""
 LAUNCH_SIGNAL_FILE=""
 DESKTOP_LAUNCH_PID=""
 QUALIFICATION_SUCCESS=0
-DESKTOP_PREPARE_WAIT_SECS=1800
+DESKTOP_PREPARE_WAIT_SECS=3600
 BRIDGE_WAIT_SECS=900
 
 gh release view "$RELEASE_TAG" --repo BasedHardware/omi --json tagName,isDraft,isPrerelease,publishedAt,assets,body \

--- a/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
+++ b/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
@@ -61,12 +61,21 @@ fi
 require_text 'derive_omi_app_config "$BUNDLE"' "$CORE_HARNESS"
 require_text 'wrong bundle on port' "$CORE_HARNESS"
 
-# Static timing contract: cold preparation has its own bounded phase and run.sh
-# explicitly signals successful launch dispatch before the 900-second bridge
-# readiness budget starts. This guards the trusted-runner failure from attempts
-# 1 and 2 of https://github.com/BasedHardware/omi/actions/runs/29896814913.
-require_text 'DESKTOP_PREPARE_WAIT_SECS=1800'
+# Static timing contract: cold preparation has its own bounded 3600-second phase
+# and run.sh explicitly signals successful launch dispatch before the separate
+# 900-second bridge readiness phase starts. The combined bound remains 4500
+# seconds. This guards https://github.com/BasedHardware/omi/actions/runs/29904736566,
+# where Swift was still compiling at 1107/1182 units when the 1800-second
+# preparation phase expired.
+require_text 'DESKTOP_PREPARE_WAIT_SECS=3600'
 require_text 'BRIDGE_WAIT_SECS=900'
+prepare_wait_secs="$(sed -n 's/^DESKTOP_PREPARE_WAIT_SECS=//p' "$QUALIFIER")"
+bridge_wait_secs="$(sed -n 's/^BRIDGE_WAIT_SECS=//p' "$QUALIFIER")"
+if [[ "$prepare_wait_secs" -ne 3600 || "$bridge_wait_secs" -ne 900 \
+  || $((prepare_wait_secs + bridge_wait_secs)) -ne 4500 ]]; then
+  echo "FAIL: qualification timing bounds must remain 3600s preparation + 900s bridge = 4500s total" >&2
+  exit 1
+fi
 require_text 'OMI_DESKTOP_LAUNCH_SIGNAL_FILE="$LAUNCH_SIGNAL_FILE"'
 require_text 'signal_desktop_launch' "$RUN_SH"
 require_order "$QUALIFIER" \


### PR DESCRIPTION
## Summary
- Increase the trusted macOS qualification cold-preparation bound from 1800 to 3600 seconds.
- Preserve the separate 900-second post-launch bridge bound and fail-closed launcher-exit detection.
- Lock the two-phase 3600/900 contract and 4500-second total in the static regression test.

## Failure evidence
Trusted qualification run https://github.com/BasedHardware/omi/actions/runs/29904736566 reached the 1800-second preparation deadline while a cold Swift compile was still active at 1107/1182 units. Candidate-gate and signed-artifact checks had already passed; launch had not yet been dispatched, so this is a deterministic preparation-bound defect rather than a bridge-readiness failure.

## Product invariants affected
none

## Failure class
Failure-Class: none

## Tests
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh`
- `bash -n desktop/macos/scripts/qualify-desktop-beta.sh desktop/macos/tests/test-qualify-desktop-beta-contract.sh`
- `python3 .github/scripts/check-release-process-guards.py`
- `python3 .github/scripts/desktop-changelog.py validate`
- `python3 .github/scripts/check-desktop-changelog.py --base origin/main --head HEAD`
- `git diff --check origin/main...HEAD`
- `OMI_PR_BODY_FILE=/tmp/omi-macos-beta-timeout-pr.md make preflight`
- `scripts/pr-preflight --pr-body-file /tmp/omi-macos-beta-timeout-pr.md`

No candidate build, qualification, deployment, promotion, or Stable operation was dispatched by this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

