### PR TITLE
android: target API level 36

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -98,7 +98,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.friend.ios"
         minSdkVersion 29
-        targetSdkVersion 35
+        targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Why

Google Play requires apps to target Android 16 (API level 36).

## Change

`app/android/app/build.gradle`: `targetSdkVersion 35` → `36`.

`compileSdkVersion` is already `36`, so this raises the target only — one line.
`minSdkVersion 29` is unchanged.

## Behavior changes that apply when targeting API 36

Assessed each against this codebase:

**1. Edge-to-edge is enforced.** `android:windowOptOutEdgeToEdgeEnforcement` is
ignored on Android 16 for apps targeting 36. The app sets it in 8 style files
(added in #2873 as a temporary Android 15 workaround, *"until flutter implements
it"*). Those entries go inert on Android 16, so the app becomes edge-to-edge
there.

I deliberately **kept** the attribute rather than deleting it: it is still
honored on Android 15 devices, so keeping it confines the edge-to-edge change to
Android 16 — where it is unavoidable — instead of also changing Android 15.
Foundation is in place (`SafeArea` in 61 files, Flutter 3.41.9).

**2. Orientation/resizability ignored on large screens (≥600dp).** No exposure —
the app sets no `screenOrientation`, no `resizableActivity`, and no
`SystemChrome.setPreferredOrientations`.

**3. Predictive back on by default; `onBackPressed()` not called.** No exposure —
back handling already uses `PopScope` (15 files), with zero remaining
`WillPopScope`.

## Verification

- SDK platform `android-36` and build-tools `36.0.0` are installed; `compileSdk`
  was already 36.
- `targetSdkVersion` does not affect compilation (that is `compileSdk`), so its
  risk is runtime behavior only.

**Not verified on-device:** I could not run this on an Android 16 device or
emulator (none available on this machine), so the edge-to-edge rendering change
is reasoned about statically, not observed. Worth a smoke test on an Android 16
device before release — mainly checking that screens are not drawn under the
status/navigation bars.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

