### PR TITLE
fix(desktop): preserve explicit Home hub collapse

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -224,7 +224,7 @@ struct DashboardPage: View {
   @ObservedObject private var homeSuggestionsStore = HomeSuggestionsStore.shared
   @StateObject private var intelligenceStore = DashboardIntelligenceStore()
   @State private var dismissedKnowsTaskIDs: Set<String> = []
-  @State private var didAutoOpenChatForHistory = false
+  @State private var homeHistoryAutoOpenPolicy = HomeStageHistoryAutoOpenPolicy()
   @Binding var selectedIndex: Int
   @State private var citedConversation: ServerConversation? = nil
   @State private var selectedCatalogApp: OmiApp?
@@ -1150,12 +1150,16 @@ struct DashboardPage: View {
   }
 
   /// Chat with history is the default Home surface: whenever prior messages
-  /// exist, the hub greeting yields to the chat panel. Runs once per page
-  /// visit so an explicit Esc back to the hub is respected afterwards.
+  /// exist, the hub greeting yields to the chat panel. Runs once per page;
+  /// an explicit automation hub close consumes the one-shot so a late async
+  /// history update cannot immediately undo that deterministic bridge action.
   private func autoOpenChatForExistingHistoryIfNeeded() {
-    guard !didAutoOpenChatForHistory else { return }
-    guard !useLegacyHomeDesign, homeMode == .hub, !chatProvider.messages.isEmpty else { return }
-    didAutoOpenChatForHistory = true
+    guard
+      homeHistoryAutoOpenPolicy.shouldAutoOpen(
+        isLegacy: useLegacyHomeDesign,
+        mode: homeMode,
+        hasMessages: !chatProvider.messages.isEmpty)
+    else { return }
     homeMode = .chat
     reportHomeAutomationMode()
   }
@@ -1208,6 +1212,7 @@ struct DashboardPage: View {
 
   private func closeHomeStagePanel() {
     homeAskFieldFocused = false
+    homeHistoryAutoOpenPolicy.suppressAutoOpenForExplicitHubClose()
     OmiMotion.withGated(Self.homeStageAnimation) {
       homeMode = .hub
     }
@@ -2123,7 +2128,7 @@ private enum HomeDestinationProminence {
   case quiet
 }
 
-private enum HomeStageMode: Equatable {
+enum HomeStageMode: Equatable {
   case hub
   case chat
   case connect
@@ -2134,6 +2139,20 @@ private enum HomeStageMode: Equatable {
     case .chat: return "chat"
     case .connect: return "connect"
     }
+  }
+}
+
+struct HomeStageHistoryAutoOpenPolicy: Equatable {
+  private var didAutoOpen = false
+
+  mutating func shouldAutoOpen(isLegacy: Bool, mode: HomeStageMode, hasMessages: Bool) -> Bool {
+    guard !didAutoOpen, !isLegacy, mode == .hub, hasMessages else { return false }
+    didAutoOpen = true
+    return true
+  }
+
+  mutating func suppressAutoOpenForExplicitHubClose() {
+    didAutoOpen = true
   }
 }
 

--- a/desktop/macos/Desktop/Tests/HomeStageHistoryAutoOpenPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeStageHistoryAutoOpenPolicyTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class HomeStageHistoryAutoOpenPolicyTests: XCTestCase {
+  func testExplicitAutomationHubCloseSurvivesLateMessageCountChange() {
+    var policy = HomeStageHistoryAutoOpenPolicy()
+
+    XCTAssertFalse(
+      policy.shouldAutoOpen(isLegacy: false, mode: .chat, hasMessages: true),
+      "A message arriving while chat is already open must leave the one-shot auto-open pending")
+
+    policy.suppressAutoOpenForExplicitHubClose()
+
+    XCTAssertFalse(
+      policy.shouldAutoOpen(isLegacy: false, mode: .hub, hasMessages: true),
+      "A late message-count change must not undo an explicit automation hub close")
+  }
+
+  func testInitialHistoryStillAutoOpensChatOnce() {
+    var policy = HomeStageHistoryAutoOpenPolicy()
+
+    XCTAssertTrue(policy.shouldAutoOpen(isLegacy: false, mode: .hub, hasMessages: true))
+    XCTAssertFalse(policy.shouldAutoOpen(isLegacy: false, mode: .hub, hasMessages: true))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260722-home-hub-collapse-race.json
+++ b/desktop/macos/changelog/unreleased/20260722-home-hub-collapse-race.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a timing issue that could reopen Home chat after explicitly returning to the hub."
+}


### PR DESCRIPTION
## Summary
- preserve an explicit Home hub collapse against a late chat-history update
- model the one-shot history auto-open policy explicitly
- add regression coverage and a macOS changelog fragment

## Failure evidence
Trusted macOS Beta qualification run `29913227011` attempt 1 returned `ok: true` for `home_close_panel`, but `state.homeMode` was already `chat`; chat completion and orphan terminalization overlapped the action. The pending history auto-open one-shot reopened chat after the explicit hub close.

## Verification
- `xcrun swift test --package-path desktop/macos/Desktop --filter HomeStageHistoryAutoOpenPolicyTests` — 2 passed
- `xcrun swift build -c debug --package-path desktop/macos/Desktop` — passed
- `./scripts/desktop-core-harness.sh --self-check --skip-backend-contracts` — passed
- `python3 scripts/check-e2e-flow-coverage.py --strict` — passed
- `python3 scripts/check_desktop_test_quality.py` — passed
- `git diff --check` — passed
- changelog JSON syntax — passed

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

