### PR TITLE
refactor(desktop): move Home auto-open policy out of Dashboard

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeStageHistoryAutoOpenPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeStageHistoryAutoOpenPolicy.swift
@@ -1,0 +1,13 @@
+struct HomeStageHistoryAutoOpenPolicy: Equatable {
+  private var didAutoOpen = false
+
+  mutating func shouldAutoOpen(isLegacy: Bool, mode: HomeStageMode, hasMessages: Bool) -> Bool {
+    guard !didAutoOpen, !isLegacy, mode == .hub, hasMessages else { return false }
+    didAutoOpen = true
+    return true
+  }
+
+  mutating func suppressAutoOpenForExplicitHubClose() {
+    didAutoOpen = true
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -1149,16 +1149,11 @@ struct DashboardPage: View {
     }
   }
 
-  /// Chat with history is the default Home surface: whenever prior messages
-  /// exist, the hub greeting yields to the chat panel. Runs once per page;
-  /// an explicit automation hub close consumes the one-shot so a late async
-  /// history update cannot immediately undo that deterministic bridge action.
+  /// Chat with history is the default Home surface. An explicit hub close consumes
+  /// the one-shot so a late history update cannot immediately undo that action.
   private func autoOpenChatForExistingHistoryIfNeeded() {
-    guard
-      homeHistoryAutoOpenPolicy.shouldAutoOpen(
-        isLegacy: useLegacyHomeDesign,
-        mode: homeMode,
-        hasMessages: !chatProvider.messages.isEmpty)
+    guard homeHistoryAutoOpenPolicy.shouldAutoOpen(
+      isLegacy: useLegacyHomeDesign, mode: homeMode, hasMessages: !chatProvider.messages.isEmpty)
     else { return }
     homeMode = .chat
     reportHomeAutomationMode()
@@ -2139,20 +2134,6 @@ enum HomeStageMode: Equatable {
     case .chat: return "chat"
     case .connect: return "connect"
     }
-  }
-}
-
-struct HomeStageHistoryAutoOpenPolicy: Equatable {
-  private var didAutoOpen = false
-
-  mutating func shouldAutoOpen(isLegacy: Bool, mode: HomeStageMode, hasMessages: Bool) -> Bool {
-    guard !didAutoOpen, !isLegacy, mode == .hub, hasMessages else { return false }
-    didAutoOpen = true
-    return true
-  }
-
-  mutating func suppressAutoOpenForExplicitHubClose() {
-    didAutoOpen = true
   }
 }
 


### PR DESCRIPTION
## Summary
- move `HomeStageHistoryAutoOpenPolicy` out of oversized `DashboardPage.swift`
- retain the verified Home-collapse race fix without increasing the frozen Dashboard line-count baseline

## Verification
- `HomeStageHistoryAutoOpenPolicyTests`: 2 passed
- `DashboardPage.swift`: exactly 4,543 lines (baseline)
- product file line-count ratchet: passed for both changed files
- `git diff --check`: passed

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

