### PR TITLE
fix(backend): stop one unreadable sync file from discarding its whole batch

### DIFF
--- a/backend/tests/unit/test_sync_opus_decode.py
+++ b/backend/tests/unit/test_sync_opus_decode.py
@@ -224,6 +224,7 @@ try:
         MAX_SYNC_FRAME_BYTES,
         decode_files_to_wav,
         decode_opus_file_to_wav,
+        get_wav_duration,
         retrieve_file_paths,
     )
 finally:
@@ -314,8 +315,8 @@ class TestDecodeOpusFileToWav:
 
     # --- Corrupt stream boundaries ---
 
-    def test_one_corrupt_frame_in_middle_rejects_whole_file(self):
-        """A valid prefix plus a corrupt frame must not become partial success."""
+    def test_corrupt_frame_in_middle_keeps_decoded_prefix(self):
+        """Decoding stops at the bad frame; the frames already written survive."""
         klass, _ = _failing_decoder(fail_on={2})
         with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'test.bin')
@@ -324,8 +325,8 @@ class TestDecodeOpusFileToWav:
 
             result = decode_opus_file_to_wav(bin_path, wav_path)
 
-            assert result is False
-            assert not os.path.exists(wav_path)
+            assert result is True
+            assert get_wav_duration(wav_path) > 0
 
     def test_first_frame_corrupt_rejects_file(self):
         """A corrupt first frame has no recoverable decoded result."""
@@ -340,8 +341,8 @@ class TestDecodeOpusFileToWav:
             assert result is False
             assert not os.path.exists(wav_path)
 
-    def test_corrupt_tail_rejects_valid_prefix(self):
-        """A valid prefix followed by a corrupt tail remains retryable input."""
+    def test_corrupt_tail_keeps_valid_prefix(self):
+        """An app kill truncates the tail; the recording before it is not lost."""
         klass, _ = _failing_decoder(fail_on={4})
         with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'test.bin')
@@ -350,12 +351,12 @@ class TestDecodeOpusFileToWav:
 
             result = decode_opus_file_to_wav(bin_path, wav_path)
 
-            assert result is False
-            assert not os.path.exists(wav_path)
+            assert result is True
+            assert get_wav_duration(wav_path) > 0
 
-    def test_multiple_corrupt_frames_reject_whole_file(self):
-        """Any malformed frame invalidates the complete transport stream."""
-        klass, _ = _failing_decoder(fail_on={1, 3})
+    def test_first_corrupt_frame_bounds_the_kept_prefix(self):
+        """Decoding stops at the first bad frame, so later frames never land."""
+        klass, instance = _failing_decoder(fail_on={1, 3})
         with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'test.bin')
             wav_path = os.path.join(d, 'test.wav')
@@ -363,8 +364,10 @@ class TestDecodeOpusFileToWav:
 
             result = decode_opus_file_to_wav(bin_path, wav_path)
 
-            assert result is False
-            assert not os.path.exists(wav_path)
+            assert result is True
+            assert instance.decode.call_count == 2
+            with wave.open(wav_path, 'rb') as wav_file:
+                assert wav_file.getnframes() == len(FAKE_PCM_FRAME) // 2
 
     # --- All-corrupt payload ---
 
@@ -420,8 +423,8 @@ class TestDecodeOpusFileToWav:
 
     # --- Corrupt / malformed length prefix ---
 
-    def test_truncated_frame_data_rejects_valid_prefix(self):
-        """Length prefix says N bytes but file ends early: retain client WAL."""
+    def test_truncated_frame_data_keeps_valid_prefix(self):
+        """Length prefix says N bytes but file ends early: keep what decoded."""
         klass, _ = _good_decoder()
         with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'truncated.bin')
@@ -436,8 +439,8 @@ class TestDecodeOpusFileToWav:
 
             result = decode_opus_file_to_wav(bin_path, wav_path)
 
-            assert result is False
-            assert not os.path.exists(wav_path)
+            assert result is True
+            assert get_wav_duration(wav_path) > 0
 
     def test_truncated_frame_as_first_entry_returns_false(self):
         """Truncated data with no prior valid frames → False."""
@@ -454,8 +457,8 @@ class TestDecodeOpusFileToWav:
             assert result is False
             assert not os.path.exists(wav_path)
 
-    def test_incomplete_length_prefix_at_eof_rejects_valid_prefix(self):
-        """Only 2 bytes remain for a length prefix: do not commit partial audio."""
+    def test_incomplete_length_prefix_at_eof_keeps_valid_prefix(self):
+        """Only 2 bytes remain for a length prefix: commit what already decoded."""
         klass, _ = _good_decoder()
         with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'partial_prefix.bin')
@@ -467,11 +470,11 @@ class TestDecodeOpusFileToWav:
 
             result = decode_opus_file_to_wav(bin_path, wav_path)
 
-            assert result is False
-            assert not os.path.exists(wav_path)
+            assert result is True
+            assert get_wav_duration(wav_path) > 0
 
-    def test_gigantic_length_prefix_rejects_whole_file_before_read(self):
-        """0xFFFFFFFF frame length must not permit a valid prefix to commit."""
+    def test_gigantic_length_prefix_stops_before_read(self):
+        """0xFFFFFFFF frame length is refused without reading the claimed bytes."""
         klass, instance = _good_decoder()
         with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
             bin_path = os.path.join(d, 'giant_prefix.bin')
@@ -484,11 +487,11 @@ class TestDecodeOpusFileToWav:
 
             result = decode_opus_file_to_wav(bin_path, wav_path)
 
-            assert result is False
+            assert result is True
             assert instance.decode.call_count == 1
-            assert not os.path.exists(wav_path)
+            assert get_wav_duration(wav_path) > 0
 
-    def test_frame_length_above_cap_rejected_before_read(self):
+    def test_frame_length_above_cap_stops_before_read(self):
         """Malformed Opus frame lengths use the same cap as PCM decoding."""
         klass, instance = _good_decoder()
         with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
@@ -502,9 +505,9 @@ class TestDecodeOpusFileToWav:
 
             result = decode_opus_file_to_wav(bin_path, wav_path)
 
-            assert result is False
+            assert result is True
             assert instance.decode.call_count == 1
-            assert not os.path.exists(wav_path)
+            assert get_wav_duration(wav_path) > 0
 
 
 class TestRetrieveFilePaths:
@@ -645,9 +648,8 @@ class TestDecodeFilesToWavOpus:
 
     # --- Multiple files ---
 
-    def test_mixed_batch_valid_and_corrupt_is_rejected(self):
-        """One corrupt required file prevents a false completed batch."""
-        good_klass, _ = _good_decoder()
+    def test_unreadable_file_does_not_discard_its_batch(self):
+        """A file that decodes nothing is dropped; its siblings still sync."""
         with tempfile.TemporaryDirectory() as d:
             valid_bin = self._opus_filename(d, ts=1710000001)
             corrupt_bin = self._opus_filename(d, ts=1710000002)
@@ -668,12 +670,44 @@ class TestDecodeFilesToWavOpus:
                 self._write_valid_opus_bin(valid_bin)
                 _write_opus_bin(corrupt_bin, [FAKE_OPUS_FRAME] * 5)
 
-                with pytest.raises(HTTPException) as exc_info:
-                    decode_files_to_wav([valid_bin, corrupt_bin])
+                wav_files = decode_files_to_wav([valid_bin, corrupt_bin])
 
-            assert exc_info.value.status_code == 400
+            assert wav_files == [valid_bin.replace('.bin', '.wav')]
+            assert os.path.exists(valid_bin.replace('.bin', '.wav'))
+            assert not os.path.exists(corrupt_bin.replace('.bin', '.wav'))
             assert not os.path.exists(valid_bin)
             assert not os.path.exists(corrupt_bin)
+
+    def test_batch_fails_only_when_nothing_decodes(self):
+        """Every file unreadable → 400, so the job is not marked complete."""
+        klass, _ = _failing_decoder(fail_on=set(range(self.ENOUGH_FRAMES)))
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
+            first = self._opus_filename(d, ts=1710000001)
+            second = self._opus_filename(d, ts=1710000002)
+            self._write_valid_opus_bin(first)
+            self._write_valid_opus_bin(second)
+
+            with pytest.raises(HTTPException) as exc_info:
+                decode_files_to_wav([first, second])
+
+            assert exc_info.value.status_code == 400
+
+    def test_truncated_tail_keeps_the_decodable_prefix(self):
+        """An interrupted writer leaves a partial frame; earlier audio survives."""
+        klass, _ = _good_decoder()
+        with tempfile.TemporaryDirectory() as d, patch('utils.sync.files.Decoder', klass):
+            bin_path = self._opus_filename(d)
+            with open(bin_path, 'wb') as f:
+                for _ in range(self.ENOUGH_FRAMES):
+                    f.write(struct.pack('<I', len(FAKE_OPUS_FRAME)))
+                    f.write(FAKE_OPUS_FRAME)
+                f.write(struct.pack('<I', len(FAKE_OPUS_FRAME)))
+                f.write(FAKE_OPUS_FRAME[:-1])
+
+            wav_files = decode_files_to_wav([bin_path])
+
+            assert wav_files == [bin_path.replace('.bin', '.wav')]
+            assert get_wav_duration(wav_files[0]) > 0
 
 
 class TestMergeAndCapVadSegments:

--- a/backend/tests/unit/test_sync_pcm_decode.py
+++ b/backend/tests/unit/test_sync_pcm_decode.py
@@ -201,7 +201,7 @@ if not hasattr(sys.modules.setdefault('google.cloud', MagicMock()), 'tasks_v2'):
 
 _remove_python_multipart_stub = _install_python_multipart_stub()
 try:
-    from utils.sync.files import _is_pcm_codec, decode_pcm_file_to_wav, decode_files_to_wav
+    from utils.sync.files import _is_pcm_codec, decode_pcm_file_to_wav, decode_files_to_wav, get_wav_duration
 finally:
     if _remove_python_multipart_stub:
         sys.modules.pop('python_multipart', None)
@@ -280,7 +280,7 @@ class TestDecodePcmFileToWav:
             result = decode_pcm_file_to_wav(bin_path, wav_path)
             assert result is False
 
-    def test_truncated_frame_rejects_valid_prefix(self):
+    def test_truncated_frame_keeps_valid_prefix(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bin_path = os.path.join(tmpdir, 'test.bin')
             wav_path = os.path.join(tmpdir, 'test.wav')
@@ -293,10 +293,10 @@ class TestDecodePcmFileToWav:
                 f.write(bytes([0] * 100))  # But only 100 bytes
 
             result = decode_pcm_file_to_wav(bin_path, wav_path)
-            assert result is False
-            assert not os.path.exists(wav_path)
+            assert result is True
+            assert get_wav_duration(wav_path) > 0
 
-    def test_suspicious_frame_length_rejects_valid_prefix(self):
+    def test_suspicious_frame_length_keeps_valid_prefix(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bin_path = os.path.join(tmpdir, 'test.bin')
             wav_path = os.path.join(tmpdir, 'test.wav')
@@ -308,8 +308,8 @@ class TestDecodePcmFileToWav:
                 f.write(struct.pack('<I', 999999))  # Suspicious length > 65536
 
             result = decode_pcm_file_to_wav(bin_path, wav_path)
-            assert result is False
-            assert not os.path.exists(wav_path)
+            assert result is True
+            assert get_wav_duration(wav_path) > 0
 
     def test_frame_length_boundary_65536_accepted(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -327,7 +327,7 @@ class TestDecodePcmFileToWav:
             with wave.open(wav_path, 'rb') as wf:
                 assert wf.getnframes() == 65536 // 2  # 16-bit samples = 2 bytes each
 
-    def test_frame_length_boundary_65537_rejected(self):
+    def test_frame_length_boundary_65537_stops_before_read(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bin_path = os.path.join(tmpdir, 'test.bin')
             wav_path = os.path.join(tmpdir, 'test.wav')
@@ -339,10 +339,10 @@ class TestDecodePcmFileToWav:
                 f.write(struct.pack('<I', 65537))  # Just over 65536 limit
 
             result = decode_pcm_file_to_wav(bin_path, wav_path)
-            assert result is False
-            assert not os.path.exists(wav_path)
+            assert result is True
+            assert get_wav_duration(wav_path) > 0
 
-    def test_zero_length_frame_stops(self):
+    def test_zero_length_frame_keeps_valid_prefix(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bin_path = os.path.join(tmpdir, 'test.bin')
             wav_path = os.path.join(tmpdir, 'test.wav')
@@ -354,10 +354,10 @@ class TestDecodePcmFileToWav:
                 f.write(struct.pack('<I', 0))  # Zero-length frame
 
             result = decode_pcm_file_to_wav(bin_path, wav_path)
-            assert result is False
-            assert not os.path.exists(wav_path)
+            assert result is True
+            assert get_wav_duration(wav_path) > 0
 
-    def test_truncated_length_header_handled(self):
+    def test_truncated_length_header_keeps_valid_prefix(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bin_path = os.path.join(tmpdir, 'test.bin')
             wav_path = os.path.join(tmpdir, 'test.wav')
@@ -369,8 +369,8 @@ class TestDecodePcmFileToWav:
                 f.write(bytes([0x40, 0x01]))  # Truncated length header
 
             result = decode_pcm_file_to_wav(bin_path, wav_path)
-            assert result is False
-            assert not os.path.exists(wav_path)
+            assert result is True
+            assert get_wav_duration(wav_path) > 0
 
     def test_nonexistent_file_returns_false(self):
         result = decode_pcm_file_to_wav('/nonexistent/path.bin', '/nonexistent/out.wav')

--- a/backend/utils/sync/files.py
+++ b/backend/utils/sync/files.py
@@ -84,7 +84,11 @@ def decode_opus_file_to_wav(
                     corrupt_stream = True
                     break
 
-        if frame_count > 0 and not corrupt_stream:
+        if frame_count > 0:
+            if corrupt_stream:
+                logger.warning(
+                    'Opus decode: keeping %d frames decoded before the stream became unreadable', frame_count
+                )
             logger.info(f"Decoded audio saved to {sanitize(wav_file_path)}")
             return True
 
@@ -183,12 +187,14 @@ def decode_pcm_file_to_wav(
                     break
                 pcm_data.extend(frame_data)
 
-        if not pcm_data or corrupt_stream:
+        if not pcm_data:
             logger.info('PCM decode: stream is empty or malformed')
-            pcm_data.clear()
             if os.path.exists(wav_file_path):
                 os.remove(wav_file_path)
             return False
+
+        if corrupt_stream:
+            logger.warning('PCM decode: keeping %d bytes decoded before the stream became unreadable', len(pcm_data))
 
         wav_data = sync_playback.pcm_to_wav(
             bytes(pcm_data), sample_rate=sample_rate, channels=channels, sample_width=sample_width
@@ -229,7 +235,15 @@ def detect_source_from_filenames(filenames: List[Optional[str]]) -> Conversation
 
 
 def decode_files_to_wav(files_path: List[str]) -> List[str]:
+    """Decode each uploaded sync file, isolating unreadable files from their batch.
+
+    A batch shares one sync job, so failing the whole batch on a single bad file
+    discards every sibling recording and leaves the client retrying the same
+    doomed set forever. Unreadable files are dropped individually; the request
+    only fails when nothing in the batch decoded.
+    """
     wav_files: List[str] = []
+    unreadable: List[str] = []
     for path in files_path:
         wav_path = path.replace('.bin', '.wav')
         filename = os.path.basename(path)
@@ -252,27 +266,26 @@ def decode_files_to_wav(files_path: List[str]) -> List[str]:
         else:
             success = decode_opus_file_to_wav(path, wav_path, frame_size=frame_size)
 
-        if not success:
-            for decoded_wav in wav_files:
-                if os.path.exists(decoded_wav):
-                    os.remove(decoded_wav)
-            if os.path.exists(path):
-                os.remove(path)
-            raise HTTPException(status_code=400, detail='Audio decode failed')
-
         if os.path.exists(path):
             os.remove(path)
 
-        duration = get_wav_duration(wav_path)
-        if duration == 0:
+        if success and get_wav_duration(wav_path) == 0:
+            success = False
+
+        if not success:
+            unreadable.append(filename)
             if os.path.exists(wav_path):
                 os.remove(wav_path)
-            for decoded_wav in wav_files:
-                if os.path.exists(decoded_wav):
-                    os.remove(decoded_wav)
-            raise HTTPException(status_code=400, detail='Invalid audio input')
+            continue
 
         # Short, successfully decoded audio is not proof of silence. Preserve it
         # for the authoritative VAD stage instead of silently acknowledging it.
         wav_files.append(wav_path)
+
+    if unreadable:
+        logger.warning('Sync decode dropped %d of %d unreadable files', len(unreadable), len(files_path))
+
+    if not wav_files:
+        raise HTTPException(status_code=400, detail='Audio decode failed')
+
     return wav_files


### PR DESCRIPTION
## Problem

A sync batch uploads up to 20 recordings under a single job
(`nextSyncUploadBatch`, `batchLimit = 20` on the fresh lane). Two defects
combined to make one bad file destroy all of them:

1. `decode_files_to_wav` deleted **every already-decoded WAV in the batch** and
   raised `400` as soon as one file failed.
2. Both decoders threw away a perfectly good decoded prefix whenever the stream
   ended early — `decode_opus_file_to_wav` required `frame_count > 0 and not
   corrupt_stream`, and `decode_pcm_file_to_wav` required `not corrupt_stream`.

A WAL truncated by an app kill or battery death — the normal shape of an
interrupted `[len][opus]` writer — therefore failed the entire batch. The job
finalized as `sync_invalid_audio`, the client reverted all 20 recordings to
`miss`, and since the candidate filter has no `retryCount` gate it re-uploaded
the identical batch on every pass, deterministically failing each time until all
20 rendered as failed. Up to 19 intact recordings were never transcribed.

## Change

- **Per-file isolation.** An unreadable file is dropped on its own and the loop
  continues; the request only fails when *nothing* in the batch decoded. The
  `duration == 0` case is folded into the same path instead of discarding
  siblings.
- **Keep what decoded.** Both decoders now succeed when any audio was decoded,
  logging how much was kept. This is safe by construction: each decoder `break`s
  at the first bad frame and only ever writes frames that decoded cleanly, so
  the retained WAV contains no corrupt audio.

The DoS guard is unchanged — an implausible length prefix (4 GB, or above
`MAX_SYNC_FRAME_BYTES`) still stops *before* the claimed bytes are read, and the
tests assert `decode.call_count == 1` to lock that in.

## On the changed tests

12 existing tests asserted the previous "reject the whole file" behavior, so I
checked whether that was long-standing intent. `git log -S` shows `corrupt_stream`
and every `*_rejects_valid_prefix` test were introduced by the **same commit**
that introduced this bug (`d4252a6738`) — they codify that change rather than
prior intent, and discarding a decodable prefix contradicts that commit's own
"retain failed audio" goal. They are rewritten to assert the corrected contract
rather than removed.

New coverage: an unreadable file dropped while its siblings still sync, a batch
that fails only when nothing decodes, and a genuinely truncated tail file.

## Tests

- `test_sync_opus_decode.py` + `test_sync_pcm_decode.py`: 58 passed.
- `test_sync_v2.py`, `test_sync_record_usage.py`, `test_chat_quota_counting_router.py`,
  `test_optional_audio_codecs.py`: 193 passed.
- `scripts/scan_async_blockers.py`: 0 findings. `black --line-length 120` clean.

`bash test.sh` reports unrelated pre-existing failures in this environment
(`ImportError: google.cloud.translate_v3`, and `ENCRYPTION_SECRET` collection
errors). None of those files reference `utils/sync/files` or any decode function.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

