### PR TITLE
fix(app): stop the conversation detail page acting on the wrong conversation

### DIFF
--- a/app/lib/pages/conversation_detail/conversation_detail_provider.dart
+++ b/app/lib/pages/conversation_detail/conversation_detail_provider.dart
@@ -61,6 +61,11 @@ class ConversationDetailProvider extends ChangeNotifier with MessageNotifierMixi
   /// Non-throwing variant of [conversation]. Build paths must use this so a
   /// transient miss (conversation deleted under us, day-group emptied) returns
   /// null instead of throwing from inside a Consumer's builder.
+  ///
+  /// Once a conversation is selected this only ever resolves to that same id.
+  /// Substituting another conversation would silently retarget the page, and
+  /// destructive actions (delete, visibility, rename) act on whatever this
+  /// returns.
   ServerConversation? get conversationOrNull {
     final list = conversationProvider?.groupedConversations[selectedDate];
     final id = _cachedConversationId;
@@ -70,12 +75,14 @@ class ConversationDetailProvider extends ChangeNotifier with MessageNotifierMixi
     if (list != null && list.isNotEmpty) {
       if (id != null) {
         result = list.firstWhereOrNull((c) => c.id == id);
+      } else {
+        result = list.first;
+        _cachedConversationId = result.id;
       }
-      result ??= list.first;
-      _cachedConversationId = result.id;
     }
 
     result ??= _cachedConversation;
+    if (result != null && id != null && result.id != id) return null;
     if (result != null) {
       // Validate against the same effective date used to group conversations
       // (startedAt ?? createdAt). Using createdAt alone breaks for

--- a/app/test/providers/conversation_detail_provider_selection_test.dart
+++ b/app/test/providers/conversation_detail_provider_selection_test.dart
@@ -49,4 +49,75 @@ void main() {
     expect(detailProvider.conversation.id, 'c1');
     expect(detailProvider.conversation.structured.title, 'Title');
   });
+
+  test('selected conversation is never replaced by another one in the day group', () {
+    // The detail page drives delete, visibility and rename off this getter, so
+    // resolving to a different conversation destroys or publicly shares the
+    // wrong one. When the selected conversation leaves the group (deleted on
+    // another device, merged away, or filtered out by the discarded/short
+    // toggles) the getter must report a miss rather than substitute a sibling.
+    final selected = _conversationAt('selected', DateTime.utc(2026, 7, 18, 9));
+    final sibling = _conversationAt('sibling', DateTime.utc(2026, 7, 18, 11));
+
+    final conversationProvider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      isSignedIn: () => true,
+    );
+    addTearDown(conversationProvider.dispose);
+    conversationProvider.conversations = [selected, sibling];
+    conversationProvider.groupConversationsByDate();
+
+    final groupDate = conversationProvider.groupedConversations.keys.single;
+
+    final detailProvider = ConversationDetailProvider();
+    addTearDown(detailProvider.dispose);
+    detailProvider.conversationProvider = conversationProvider;
+    detailProvider.updateConversation(selected.id, groupDate);
+
+    expect(detailProvider.conversation.id, 'selected');
+
+    conversationProvider.conversations = [sibling];
+    conversationProvider.groupConversationsByDate();
+
+    // Previously this resolved to the surviving sibling and rebound the tracked
+    // id to it, so a delete or visibility change hit the wrong conversation.
+    expect(detailProvider.conversationOrNull?.id, 'selected');
+    expect(detailProvider.conversationOrNull?.id, 'selected');
+  });
+
+  test('selected conversation survives a transient empty day group', () {
+    // A refresh can momentarily empty the group; the page must keep showing the
+    // conversation it was opened with instead of blanking or retargeting.
+    final selected = _conversationAt('selected', DateTime.utc(2026, 7, 18, 9));
+
+    final conversationProvider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      isSignedIn: () => true,
+    );
+    addTearDown(conversationProvider.dispose);
+    conversationProvider.conversations = [selected];
+    conversationProvider.groupConversationsByDate();
+
+    final groupDate = conversationProvider.groupedConversations.keys.single;
+
+    final detailProvider = ConversationDetailProvider();
+    addTearDown(detailProvider.dispose);
+    detailProvider.conversationProvider = conversationProvider;
+    detailProvider.updateConversation(selected.id, groupDate);
+
+    conversationProvider.conversations = [];
+    conversationProvider.groupConversationsByDate();
+
+    expect(detailProvider.conversationOrNull?.id, 'selected');
+  });
+}
+
+ServerConversation _conversationAt(String id, DateTime startedAt) {
+  return ServerConversation(
+    id: id,
+    startedAt: startedAt,
+    createdAt: startedAt,
+    structured: Structured(id, 'Overview'),
+    status: ConversationStatus.completed,
+  );
 }


### PR DESCRIPTION
## Problem

`ConversationDetailProvider.conversationOrNull` resolved to the **first
conversation in the day group** whenever the selected one was not found, and
permanently rebound `_cachedConversationId` to that substitute:

```dart
result = list.firstWhereOrNull((c) => c.id == id);
result ??= list.first;
_cachedConversationId = result.id;
```

The selected conversation leaves its group in ordinary use: deleted on another
device, merged away by sync, or filtered out when the show-discarded /
show-short toggles change.

The detail page drives its destructive actions off this getter —
`deleteConversation(provider.conversation)`, `setConversationVisibility(provider.conversation.id)`
(public share), and `updateConversationTitle(conversation.id, …)`. So the open
page silently switched targets and those actions hit a conversation the user
never opened: the wrong one deleted, or the wrong one made public. Because the
tracked id was rebound, there was no recovery.

The getter's own doc comment claimed it returned null on a transient miss. It
did not.

## Change

The head of the group is now taken only when nothing has been selected yet.
Once an id is bound, the getter resolves to that id or reports a miss, and a
guard rejects a cached conversation whose id no longer matches.

A transient miss still falls back to the cached conversation, so a refresh that
momentarily empties the group keeps the page on what the user opened rather than
blanking it.

## Tests

`test/providers/conversation_detail_provider_selection_test.dart`:

- the selected conversation is never replaced by a sibling when it leaves the
  group — **verified to fail on the previous code** with
  `Expected: selected / Actual: sibling`
- it survives a transient empty day group
- the existing midnight-spanning `startedAt`/`createdAt` case still passes

3/3 pass. `scripts/analyze_ratchet.sh` passes (`prefer_const_constructors`
improved, 451 vs baseline 465). `dart format --line-length 120` clean.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

