### PR TITLE
fix(desktop): wait for fresh rewind bridge state

### DIFF
--- a/desktop/macos/e2e/flows/rewind-settings.yaml
+++ b/desktop/macos/e2e/flows/rewind-settings.yaml
@@ -18,6 +18,8 @@ steps:
       activateApp: false
     wait:
       state.selectedSettingsSection: Rewind
+      state.snapshotStale: false
+    timeout_seconds: 30
 
   - id: S2
     name: Rewind settings snapshot

--- a/desktop/macos/tests/test-omi-harness.sh
+++ b/desktop/macos/tests/test-omi-harness.sh
@@ -42,6 +42,8 @@ import importlib.machinery
 import importlib.util
 import json
 import os
+from pathlib import Path
+import re
 import sys
 
 path = sys.argv[1]
@@ -88,6 +90,43 @@ except RuntimeError:
     pass
 else:
     raise AssertionError("relative health log path must fail loudly")
+
+flow_path = Path(path).parent.parent / "e2e/flows/rewind-settings.yaml"
+flow_text = flow_path.read_text(encoding="utf-8")
+s1_block = flow_text.split("  - id: S1", 1)[1].split("  - id: S2", 1)[0]
+wait_expectations = {"state.selectedSettingsSection": "Rewind"}
+freshness_match = re.search(r"state\.snapshotStale:\s*(true|false)", s1_block)
+if freshness_match:
+    wait_expectations["state.snapshotStale"] = freshness_match.group(1) == "true"
+
+state_sequence = [
+    {"selectedSettingsSection": "Rewind", "snapshotStale": True},
+    {"selectedSettingsSection": "Rewind", "snapshotStale": False},
+]
+state_calls = []
+original_state_snapshot = module.state_snapshot
+wait_context = module.HarnessContext(
+    base_url="http://127.0.0.1:59999",
+    flow_path=flow_path,
+    run_dir=Path("runs"),
+    steps_dir=Path("runs/steps"),
+    lane="bridge",
+    log_path=Path("/private/tmp/omi/harness-test.log"),
+    log_start=0,
+    bundle_id=None,
+    process_match=None,
+)
+module.state_snapshot = lambda _ctx: state_calls.append(len(state_calls)) or state_sequence[min(len(state_calls) - 1, 1)]
+wait_ok, wait_state = module.wait_for_state(wait_context, wait_expectations, timeout=1.0)
+module.state_snapshot = original_state_snapshot
+assert wait_ok and wait_state["snapshotStale"] is False, (wait_ok, wait_state, wait_expectations, state_calls)
+assert len(state_calls) == 2, "rewind flow must not start its MainActor action from a stale cached state"
+assert "timeout_seconds: 30" in s1_block, "rewind freshness wait must remain bounded"
+
+module.state_snapshot = lambda _ctx: {"selectedSettingsSection": "Rewind", "snapshotStale": True}
+stale_ok, stale_state = module.wait_for_state(wait_context, wait_expectations, timeout=0.001)
+module.state_snapshot = original_state_snapshot
+assert not stale_ok and stale_state["snapshotStale"] is True, "persistent MainActor contention must still fail closed"
 
 
 class FakeResponse:


### PR DESCRIPTION
## Summary

- wait for a fresh, non-stale Rewind settings state before invoking the mutating snapshot action
- keep the readiness wait bounded at 30 seconds and fail closed if MainActor contention persists
- never retry the action after a client timeout, avoiding ambiguous duplicate mutation
- add harness regression coverage for transient stale-state recovery and persistent stale-state failure

## Incident evidence

`.102` attempt 1 and `.103` attempt 1 both reached Rewind settings, then timed out the S2 action at the fixed 20-second client deadline while the app logged that its live `/state` refresh was blocked on the main thread and a cached snapshot was served. The bridge recovered immediately and app logs were otherwise clean.

The flake begins because S1 accepted that cached snapshot as navigation readiness. This change makes S1 require `snapshotStale: false` before S2 starts. It does not retry S2.

## Verification

- `bash desktop/macos/tests/test-omi-harness.sh`
- `cd desktop/macos && ./scripts/desktop-core-harness.sh --self-check --skip-backend-contracts`
- `bash desktop/macos/tests/test-e2e-flow-coverage.sh`
- ad-hoc actual `omi-harness.wait_for_state` verification: transient stale snapshot followed by fresh snapshot passes; persistent stale snapshots fail closed; wait remains bounded at 30 seconds
- `git diff --check origin/main...HEAD`

## Product invariants affected

none

## Failure class

Failure-Class: none

## Release urgency

This is a narrow qualification-harness false-negative repair intended for the next immutable macOS Beta candidate. It changes no application product source, signing, publication, promotion, Stable, backend, schema, credentials, or release-control authority.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

