### PR TITLE
fix(desktop): halt rewind flow on stale readiness

### DIFF
--- a/desktop/macos/changelog/unreleased/20260722-rewind-settings-qualification-gating.json
+++ b/desktop/macos/changelog/unreleased/20260722-rewind-settings-qualification-gating.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved reliability of macOS Beta qualification when Rewind settings are busy."
+}

--- a/desktop/macos/e2e/flows/rewind-settings.yaml
+++ b/desktop/macos/e2e/flows/rewind-settings.yaml
@@ -20,6 +20,7 @@ steps:
       state.selectedSettingsSection: Rewind
       state.snapshotStale: false
     timeout_seconds: 30
+    halt_on_failure: true
 
   - id: S2
     name: Rewind settings snapshot

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -842,7 +842,11 @@ def run_flow_once(args: argparse.Namespace) -> tuple[int, Path, dict[str, typing
 
     step_results = []
     if not setup_errors:
-        step_results = [execute_step(ctx, index, step) for index, step in enumerate(flow.get("steps", []), 1)]
+        for index, step in enumerate(flow.get("steps", []), 1):
+            result = execute_step(ctx, index, step)
+            step_results.append(result)
+            if not result["ok"] and step.get("halt_on_failure") is True:
+                break
     logs = collect_logs(ctx)
     final_state = request_json(ctx.base_url, "GET", "/state")
     traces = recent_traces(ctx)

--- a/desktop/macos/tests/test-omi-harness.sh
+++ b/desktop/macos/tests/test-omi-harness.sh
@@ -40,8 +40,10 @@ export PYTHONPATH="$TMPDIR${PYTHONPATH:+:$PYTHONPATH}"
 python3 - "$HARNESS" <<'PY'
 import importlib.machinery
 import importlib.util
+import argparse
 import json
 import os
+import tempfile
 from pathlib import Path
 import re
 import sys
@@ -122,11 +124,90 @@ module.state_snapshot = original_state_snapshot
 assert wait_ok and wait_state["snapshotStale"] is False, (wait_ok, wait_state, wait_expectations, state_calls)
 assert len(state_calls) == 2, "rewind flow must not start its MainActor action from a stale cached state"
 assert "timeout_seconds: 30" in s1_block, "rewind freshness wait must remain bounded"
+assert "halt_on_failure: true" in s1_block, "failed rewind readiness must halt before the action"
 
 module.state_snapshot = lambda _ctx: {"selectedSettingsSection": "Rewind", "snapshotStale": True}
 stale_ok, stale_state = module.wait_for_state(wait_context, wait_expectations, timeout=0.001)
 module.state_snapshot = original_state_snapshot
 assert not stale_ok and stale_state["snapshotStale"] is True, "persistent MainActor contention must still fail closed"
+
+
+def run_flow_case(s1_ok, s2_ok):
+    flow = {
+        "version": 2,
+        "name": "rewind-settings-gating-contract",
+        "steps": [
+            {"id": "S1", "name": "readiness", "halt_on_failure": True},
+            {"id": "S2", "name": "snapshot action"},
+            {"id": "S3", "name": "logs clean"},
+        ],
+    }
+    originals = {
+        name: getattr(module, name)
+        for name in (
+            "read_yaml",
+            "validate_flow_schema",
+            "create_context",
+            "request_json",
+            "execute_step",
+            "collect_logs",
+            "recent_traces",
+        )
+    }
+    executed = []
+
+    def fake_request_json(_base_url, method, route, payload=None, timeout=20.0):
+        del payload, timeout
+        if method == "POST" and route == "/traces/clear":
+            return {"ok": True}
+        if method == "GET" and route == "/capabilities":
+            return {"ok": True, "result": {}}
+        if method == "GET" and route == "/state":
+            return {"ok": True, "result": {}}
+        raise AssertionError((method, route))
+
+    def fake_execute_step(_ctx, _index, step):
+        step_id = step["id"]
+        executed.append(step_id)
+        ok = s1_ok if step_id == "S1" else s2_ok if step_id == "S2" else True
+        return {"id": step_id, "name": step["name"], "ok": ok, "duration_ms": 0.0}
+
+    try:
+        module.read_yaml = lambda _path: flow
+        module.validate_flow_schema = lambda _flow, _args: 2
+        module.create_context = lambda *_args: wait_context
+        module.request_json = fake_request_json
+        module.execute_step = fake_execute_step
+        module.collect_logs = lambda _ctx: {"error_count": 0}
+        module.recent_traces = lambda _ctx: []
+        with tempfile.TemporaryDirectory() as out:
+            args = argparse.Namespace(
+                flow=str(flow_path),
+                out=out,
+                lane="bridge",
+                port=59999,
+                bundle_id=None,
+                process_match=None,
+            )
+            code, _run_dir, metrics = module.run_flow_once(args)
+    finally:
+        for name, value in originals.items():
+            setattr(module, name, value)
+    return code, executed, metrics
+
+
+failed_readiness_code, failed_readiness_steps, _ = run_flow_case(False, True)
+assert failed_readiness_code == 1
+assert failed_readiness_steps == ["S1"], "failed readiness must execute zero subsequent actions"
+
+fresh_code, fresh_steps, _ = run_flow_case(True, True)
+assert fresh_code == 0
+assert fresh_steps.count("S2") == 1, "fresh readiness must execute the action exactly once"
+
+action_failure_code, action_failure_steps, _ = run_flow_case(True, False)
+assert action_failure_code == 1
+assert action_failure_steps == ["S1", "S2", "S3"]
+assert action_failure_steps.count("S2") == 1, "action failure must be terminal and never retried"
 
 
 class FakeResponse:


### PR DESCRIPTION
## Summary

- make the Rewind readiness step explicitly halt the flow when fresh bridge state cannot be obtained
- guarantee the snapshot action is never invoked after persistent stale-state contention
- retain log collection after an action-level failure and never retry the mutating action
- add full-flow regression coverage for success, readiness failure, and action failure
- add the required unreleased macOS changelog fragment so post-merge Release Eligibility remains green

## Incident evidence

Independent review of #10290 proved that `run_flow_once` executed every step unconditionally. A persistently stale S1 therefore failed the flow but still invoked S2. This follow-up adds a narrow step-level `halt_on_failure` contract only to Rewind S1.

## Verification

- `bash desktop/macos/tests/test-omi-harness.sh`
- `cd desktop/macos && ./scripts/desktop-core-harness.sh --self-check --skip-backend-contracts`
- `bash desktop/macos/tests/test-e2e-flow-coverage.sh`
- full-flow contract: failed S1 executes only S1 and zero snapshot actions
- full-flow contract: successful S1 executes S2 exactly once
- full-flow contract: failed S2 is not retried and S3 log collection still runs
- `git diff --check origin/main...HEAD`

## Product invariants affected

none

## Failure class

Failure-Class: none

## Release urgency

This is the fail-closed completion and release-eligibility repair required before creating the next immutable macOS Beta candidate. It does not modify signing, promotion, Stable, backend, schemas, credentials, IAM, or release authority.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

