### PR TITLE
fix(backend): include surface flag in OpenAPI stale-contract hint

### DIFF
--- a/backend/scripts/export_openapi.py
+++ b/backend/scripts/export_openapi.py
@@ -985,12 +985,29 @@ def write_spec(path: Path, generated: str) -> None:
     path.write_text(generated)
 
 
-def check_spec(path: Path, generated: str) -> None:
+def surface_flag(surface: str) -> str:
+    """CLI flag that selects `surface`, empty for the default public surface.
+
+    Surface selection is a separate flag from the output path, so a hint that
+    omits it silently exports the public surface into another surface's file
+    (issue #10217).
+    """
+    if surface == 'public':
+        return ''
+    if surface == 'app-client':
+        return '--app-client '
+    if surface == 'integration-public':
+        return '--surface integration-public '
+    raise OpenAPIContractError(f'unknown OpenAPI surface: {surface}')
+
+
+def check_spec(path: Path, generated: str, surface: str = 'public') -> None:
+    flag = surface_flag(surface)
     if not path.exists():
-        raise OpenAPIContractError(f'{path} does not exist; run export_openapi.py --write {path}')
+        raise OpenAPIContractError(f'{path} does not exist; run backend/scripts/export_openapi.py {flag}--write {path}')
     current = path.read_text()
     if current != generated:
-        raise OpenAPIContractError(f'{path} is stale; run backend/scripts/export_openapi.py --write {path}')
+        raise OpenAPIContractError(f'{path} is stale; run backend/scripts/export_openapi.py {flag}--write {path}')
 
 
 def parse_args() -> argparse.Namespace:
@@ -1043,7 +1060,7 @@ def main() -> int:
             print(f'wrote {path}')
         elif args.check is not None:
             path = resolve_spec_path(args.surface, args.check)
-            check_spec(path, generated)
+            check_spec(path, generated, args.surface)
             print(f'{path} is up to date')
         return 0
     except OpenAPIContractError as e:

--- a/backend/tests/unit/test_openapi_contract.py
+++ b/backend/tests/unit/test_openapi_contract.py
@@ -162,6 +162,23 @@ def test_check_spec_detects_stale_file(tmp_path):
         export_openapi.check_spec(spec_path, json.dumps({'fresh': True}) + '\n')
 
 
+def test_stale_hint_includes_surface_flag_for_non_public_surfaces(tmp_path):
+    # Regression for #10217: following the hint verbatim must not silently
+    # export the default public surface into a non-public surface's file.
+    spec_path = tmp_path / 'spec.json'
+    spec_path.write_text(json.dumps({'stale': True}) + '\n')
+    generated = json.dumps({'fresh': True}) + '\n'
+
+    with pytest.raises(export_openapi.OpenAPIContractError, match=r'--app-client --write'):
+        export_openapi.check_spec(spec_path, generated, 'app-client')
+    with pytest.raises(export_openapi.OpenAPIContractError, match=r'--surface integration-public --write'):
+        export_openapi.check_spec(spec_path, generated, 'integration-public')
+
+    # Public surface stays flag-free so the default invocation is unchanged.
+    with pytest.raises(export_openapi.OpenAPIContractError, match=r'export_openapi\.py --write'):
+        export_openapi.check_spec(spec_path, generated, 'public')
+
+
 def test_network_recorder_fails_even_when_blocked_attempt_is_swallowed():
     with export_openapi.record_and_block_outbound_network() as attempts:
         try:


### PR DESCRIPTION
## What
The `--check` failure hint in `backend/scripts/export_openapi.py` now includes the surface-selection flag, so following it verbatim regenerates the correct surface.

## Why
From #10217:

> Following that command verbatim silently exports the **public** surface (surface defaults to `public`) into the app-client file — 53k lines deleted, wrong contract — because surface selection is a separate flag, not inferred from the output path. The correct command is `backend/scripts/export_openapi.py --app-client --write`.
>
> Evidence: hit while preparing #10215 today; the wrong invocation produced a 17-path public spec in place of the 309-path app-client spec and `--check` (also without the flag) then validated the wrong surface as 'up to date'.

`check_spec` had no knowledge of which surface was being checked, so its `is stale` / `does not exist` hints always emitted the bare `--write <path>` command, which defaults to the public surface.

## Change
- `check_spec(path, generated, surface='public')` now prefixes the correct selector via a new `surface_flag()` helper: `--app-client ` for app-client, `--surface integration-public ` for integration-public, empty for public (default invocation unchanged).
- `main()` passes `args.surface` into `check_spec`.
- Regression test `test_stale_hint_includes_surface_flag_for_non_public_surfaces` asserts each surface's hint carries its selector and that public stays flag-free.

## Verified
- Exercised the real `check_spec` code path for all three surfaces plus the does-not-exist branch (via the pinned openapi runner venv): every hint carries the right flag; the public hint is byte-for-byte the previous default.
  - app-client → `... run backend/scripts/export_openapi.py --app-client --write <path>`
  - integration-public → `... --surface integration-public --write <path>`
  - public → `... export_openapi.py --write <path>` (unchanged)
- `tests/unit/test_openapi_contract.py` — 15 passed (including the new regression test).
- `black --line-length 120 --skip-string-normalization` clean on both files.

Auto-generated from issue feedback by the mini issues-improver. Review before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

