### PR TITLE
ci(mobile): cut duplicated build_runner work across mobile checks

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -69,7 +69,10 @@ runs:
         fi
 
         FILES=$(scripts/changed-files "$DIFF_BASE"...HEAD)
-        APP_COMPILE_FILES="$FILES"
+        # Translation-only changes cannot break the Android build: the ARBs and
+        # their generated localization classes still go through Dart Analyze and
+        # Flutter Tests, so the expensive Gradle APK build adds no signal.
+        APP_COMPILE_FILES=$(echo "$FILES" | grep -vE '^app/lib/l10n/app_[A-Za-z_]+\.arb$|^app/lib/l10n/app_localizations(_[A-Za-z_]+)?\.dart$' || true)
         echo "$FILES"
         echo "diff_base=$DIFF_BASE" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/mobile-app-checks.yml
+++ b/.github/workflows/mobile-app-checks.yml
@@ -47,6 +47,17 @@ jobs:
           channel: stable
           cache: true
 
+      # flutter-action already caches the SDK and ~/.pub-cache. build_runner's
+      # incremental state is not covered by it and is what makes codegen slow.
+      - name: Cache build_runner state
+        uses: actions/cache@v6
+        with:
+          path: app/.dart_tool/build
+          key: ${{ runner.os }}-flutter-buildrunner-${{ hashFiles('app/pubspec.lock', 'app/build.yaml') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-buildrunner-${{ hashFiles('app/pubspec.lock', 'app/build.yaml') }}-
+            ${{ runner.os }}-flutter-buildrunner-
+
       - name: Resolve Flutter dependencies
         working-directory: app
         run: flutter pub get
@@ -81,11 +92,12 @@ jobs:
             exit 1
           fi
 
-  analyze:
-    name: Dart Analyze (ratchet)
+  analyze-and-test:
+    name: Dart Analyze & Tests
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.has_app_dart == 'true'
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -96,10 +108,21 @@ jobs:
           channel: stable
           cache: true
 
+      - name: Cache build_runner state
+        uses: actions/cache@v6
+        with:
+          path: app/.dart_tool/build
+          key: ${{ runner.os }}-flutter-buildrunner-${{ hashFiles('app/pubspec.lock', 'app/build.yaml') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-buildrunner-${{ hashFiles('app/pubspec.lock', 'app/build.yaml') }}-
+            ${{ runner.os }}-flutter-buildrunner-
+
       - name: Resolve Flutter dependencies
         working-directory: app
         run: flutter pub get
 
+      # Also satisfies test.sh's generated-file prerequisites, so it skips its
+      # own pub get and build_runner run.
       - name: Prepare Flutter dev compile inputs
         working-directory: app
         run: |
@@ -120,22 +143,6 @@ jobs:
       - name: Run analyzer ratchet
         working-directory: app
         run: bash scripts/analyze_ratchet.sh
-
-  flutter-test:
-    name: Flutter Tests
-    runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.has_app_dart == 'true'
-    timeout-minutes: 30
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-          cache: true
 
       - name: Run Flutter tests
         id: flutter_tests
@@ -237,6 +244,15 @@ jobs:
         with:
           channel: stable
           cache: true
+
+      - name: Cache build_runner state
+        uses: actions/cache@v6
+        with:
+          path: app/.dart_tool/build
+          key: ${{ runner.os }}-flutter-buildrunner-${{ hashFiles('app/pubspec.lock', 'app/build.yaml') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-buildrunner-${{ hashFiles('app/pubspec.lock', 'app/build.yaml') }}-
+            ${{ runner.os }}-flutter-buildrunner-
 
       - name: Resolve Flutter dependencies
         working-directory: app


### PR DESCRIPTION
## Problem

Four mobile jobs ran per PR, and each rebuilt the same state from scratch:

| Step | Generated Files | Analyze | Flutter Tests | Android Smoke |
|---|:--:|:--:|:--:|:--:|
| checkout | ✓ | ✓ | ✓ | ✓ |
| Setup Flutter | ✓ | ✓ | ✓ | ✓ |
| `flutter pub get` | ✓ | ✓ | ✓ *(via test.sh)* | ✓ |
| **`build_runner build`** | ✓ | ✓ | ✓ *(via test.sh)* | ✓ |

`build_runner` ran four times and produced identical output each time. It takes
roughly 3 minutes on this repo, so that is ~9 minutes of duplicated codegen per
PR touching `app/lib`.

## Changes

**1. Cache build_runner's incremental state.** `subosito/flutter-action` already
caches the Flutter SDK and `~/.pub-cache` (`pub-cache` defaults to the `cache`
value), so those were already covered — `.dart_tool/build` was not, and it is
what makes codegen slow. It is 36 MB, keyed on `pubspec.lock` + `build.yaml`
with a rolling run id and prefix restore-keys.

**2. Skip the Android APK build for translation-only changes.** `app/lib/l10n`
ARBs and their generated localization classes matched the compile-smoke filter,
so a translations-only PR triggered a full Gradle APK build — the most expensive
job here, which needs a disk-cleanup step to fit on the runner. Those files still
go through Dart Analyze and Flutter Tests, which is where a broken localization
class would actually surface. `l10n.yaml`, `app_en.arb` plus real code changes,
Android, and iOS changes all still trigger it.

**3. Merge Dart Analyze into the Flutter Tests job.** Both needed the same
checkout, SDK, `pub get` and codegen. They now share one setup. Analyze runs
first so a lint failure stops before the longer test run. Preparing the dev
compile inputs also satisfies `test.sh`'s generated-file prerequisites
(`firebase_options_*.dart`, `lib/env/*_env.g.dart`), so it skips its own
`pub get` and `build_runner` instead of repeating them.

## Verification

- Both YAML files parse; jobs resolve to `changes`, `generated-files`,
  `analyze-and-test`, `android-compile-smoke`.
- Compile-smoke filter tested against representative file sets:

  | Change | APK build |
  |---|---|
  | translation-only (47 ARBs + generated classes) | skipped |
  | any `app/lib/**.dart` code change | runs |
  | new key in `app_en.arb` + code using it | runs |
  | `app/l10n.yaml` | runs |
  | `app/android/**` | runs |

- `main` has no `required_status_checks` and no rulesets, so renaming the two
  merged checks does not block PRs. The old job names are not referenced in
  `checks-manifest.yaml` or any script.
- Test failure diagnostics and the `flutter-test-diagnostics` artifact upload are
  preserved unchanged.

## Note

`has_app_codegen` still matches `^app/lib/`, so a translations-only PR runs
`build_runner` inside Generated Files even though only `gen-l10n` matters there.
Left alone deliberately to keep this reviewable — worth a follow-up.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

