### PR TITLE
ci(beta): add break-glass credential preflight

### DIFF
--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -118,6 +118,19 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         self.assertNotIn("source_sha", rollout)
         self.assertNotIn("build_number", rollout)
 
+    def test_breakglass_credential_preflight_is_read_only_and_beta_scoped(self) -> None:
+        preflight = workflow("desktop_breakglass_credential_preflight.yml")
+        self.assertIn("workflow_dispatch:", preflight)
+        self.assertIn("environment: prod", preflight)
+        self.assertIn("permissions: {}", preflight)
+        self.assertIn("secrets.GCP_CREDENTIALS", preflight)
+        self.assertIn("gcloud secrets versions access latest --secret=ADMIN_KEY", preflight)
+        self.assertIn("/v2/desktop/releases/$RELEASE_TAG", preflight)
+        self.assertNotIn("--request POST", preflight)
+        self.assertNotIn("/v2/desktop/beta/breakglass", preflight)
+        self.assertNotIn("/v2/desktop/channels/promote", preflight)
+        self.assertNotIn("stable", preflight.lower())
+
     def test_backend_release_vector_verifies_after_prod_traffic_shift(self) -> None:
         backend = workflow("gcp_backend.yml")
         shift = backend.index("      - name: Shift Cloud Run traffic to validated revisions")

--- a/.github/workflows/desktop_breakglass_credential_preflight.yml
+++ b/.github/workflows/desktop_breakglass_credential_preflight.yml
@@ -1,0 +1,55 @@
+name: Preflight Emergency Desktop Beta Credentials
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Exact immutable vX.Y.Z+BUILD-macos candidate to authenticate read-only'
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: desktop-beta-breakglass-credential-preflight
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    environment: prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate immutable candidate input
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+-macos$ ]] || {
+            echo "ERROR: release_tag must be an immutable macOS candidate tag" >&2
+            exit 1
+          }
+
+      - name: Use the existing production Google identity
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Verify existing emergency credential chain read-only
+        env:
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          ADMIN_KEY="$(gcloud secrets versions access latest --secret=ADMIN_KEY --project "$PROJECT_ID")"
+          trap 'unset ADMIN_KEY' EXIT
+          echo "::add-mask::$ADMIN_KEY"
+          response="$(mktemp)"
+          trap 'rm -f "$response"; unset ADMIN_KEY' EXIT
+          curl --fail-with-body --silent --show-error \
+            --header "secret-key: $ADMIN_KEY" \
+            "https://api.omi.me/v2/desktop/releases/$RELEASE_TAG" \
+            --output "$response"
+          jq -e --arg release_tag "$RELEASE_TAG" \
+            '.manifest.release_id == $release_tag' "$response" >/dev/null
+          echo "Existing prod identity, ADMIN_KEY access, and read-only release API authentication are ready."


### PR DESCRIPTION
## Summary

- add a protected, manually dispatched credential preflight for the existing emergency macOS Beta path
- authenticate with the same `prod` `GCP_CREDENTIALS` identity used by break glass
- verify `ADMIN_KEY` Secret Manager access and authenticated read-only retrieval of an exact immutable desktop release manifest
- make no Beta pointer, admission, release, Firestore, backend, or Stable mutation
- add a static release-flow contract that forbids POST, break-glass, promotion, and Stable surfaces from this preflight

## Verification

- `actionlint .github/workflows/desktop_breakglass_credential_preflight.yml`
- `python3 .github/scripts/check-release-process-guards.py`
- `python3 .github/scripts/test_desktop_release_flow_contract.py` — 7 passed
- `git diff --check`

## Product invariants affected

none

## Failure class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

