### PR TITLE
fix(app): recover Ray-Ban glasses hidden by the legacy device id

### DIFF
--- a/app/lib/services/devices/discovery/rayban_meta_discoverer.dart
+++ b/app/lib/services/devices/discovery/rayban_meta_discoverer.dart
@@ -24,6 +24,12 @@ class RayBanMetaDiscoverer extends DeviceDiscoverer {
   /// start registration from the device list; never connectable directly.
   static const String setupPlaceholderId = 'rayban-meta-setup';
 
+  /// Synthetic id persisted by the audio-only fallback before selections were
+  /// keyed by the stable HFP UID. It never matches a real input, so a stored
+  /// selection carrying it is treated as no selection at all rather than as a
+  /// UID that failed to match.
+  static const String legacyAudioOnlyId = 'rayban-meta-audio';
+
   @override
   String get name => 'Ray-Ban Meta';
 
@@ -68,7 +74,8 @@ class RayBanMetaDiscoverer extends DeviceDiscoverer {
         final storedDevice = SharedPreferencesUtil().btDevice;
         final hasStoredAudioSelection = storedDevice.type == DeviceType.raybanMeta &&
             storedDevice.locator?.extras[audioOnlyExtraKey] == true &&
-            storedDevice.id.isNotEmpty;
+            storedDevice.id.isNotEmpty &&
+            storedDevice.id != legacyAudioOnlyId;
 
         if (hasStoredAudioSelection) {
           final selected = inputs.where((input) => input.uid == storedDevice.id).firstOrNull;

--- a/app/test/unit/rayban_meta_device_test.dart
+++ b/app/test/unit/rayban_meta_device_test.dart
@@ -263,6 +263,61 @@ void main() {
       expect(result.devices.single.locator?.extras[RayBanMetaDiscoverer.audioOnlyExtraKey], isTrue);
     });
 
+    test('recovers glasses stored under the legacy synthetic id', () async {
+      // Installs that paired during the audio-only fallback persisted the
+      // synthetic 'rayban-meta-audio' id. It can never match a real HFP UID, so
+      // treating it as a failed UID match hid the glasses permanently.
+      final legacy = BtDevice(
+        name: 'Ray-Ban Meta',
+        id: RayBanMetaDiscoverer.legacyAudioOnlyId,
+        type: DeviceType.raybanMeta,
+        rssi: 0,
+        locator: DeviceLocator.metaDat(extras: {RayBanMetaDiscoverer.audioOnlyExtraKey: true}),
+      );
+      SharedPreferences.setMockInitialValues({'btDevice': jsonEncode(legacy.toJson())});
+      await SharedPreferencesUtil.init();
+
+      setRayBanMetaHostApiHandler('getAvailabilityMode', (_) async => <Object?>['audio_only']);
+      setRayBanMetaHostApiHandler(
+        'getBluetoothHfpInputs',
+        (_) async => <Object?>[
+          <BluetoothHfpInput>[
+            BluetoothHfpInput(uid: 'other-headset', name: 'AirPods Pro'),
+            BluetoothHfpInput(uid: 'real-hfp-uid', name: 'Ray-Ban Meta'),
+          ],
+        ],
+      );
+
+      final result = await RayBanMetaDiscoverer().discover();
+
+      expect(result.devices, hasLength(1));
+      expect(result.devices.single.id, 'real-hfp-uid');
+      expect(result.devices.single.locator?.extras[RayBanMetaDiscoverer.audioOnlyExtraKey], isTrue);
+    });
+
+    test('a stored real UID that is absent is never substituted', () async {
+      // Guards the migration above from widening into "match anything by name":
+      // a genuine selection that is simply not connected must report nothing
+      // rather than bind to someone else's headset.
+      final stored = RayBanMetaDiscoverer.audioOnlyDeviceForInput(
+        BluetoothHfpInput(uid: 'stable-hfp-uid', name: 'Ray-Ban Meta'),
+      );
+      SharedPreferences.setMockInitialValues({'btDevice': jsonEncode(stored.toJson())});
+      await SharedPreferencesUtil.init();
+
+      setRayBanMetaHostApiHandler('getAvailabilityMode', (_) async => <Object?>['audio_only']);
+      setRayBanMetaHostApiHandler(
+        'getBluetoothHfpInputs',
+        (_) async => <Object?>[
+          <BluetoothHfpInput>[BluetoothHfpInput(uid: 'someone-elses-uid', name: 'Ray-Ban Meta')],
+        ],
+      );
+
+      final result = await RayBanMetaDiscoverer().discover();
+
+      expect(result.devices, isEmpty);
+    });
+
     test('uses a name match only as a first-selection convenience and keeps the real UID', () async {
       setRayBanMetaHostApiHandler('getAvailabilityMode', (_) async => <Object?>['audio_only']);
       setRayBanMetaHostApiHandler(


### PR DESCRIPTION
## Problem

The audio-only Ray-Ban fallback originally persisted a **synthetic** device id,
`'rayban-meta-audio'`, for every user. Selections were later re-keyed to the
stable iOS HFP UID — correctly, since the UID survives renames — but nothing
migrated the installs already holding the synthetic id.

That id can never equal a real HFP input UID, so discovery took the
"stored selection whose device is absent" branch:

```dart
if (hasStoredAudioSelection) {
  final selected = inputs.where((i) => i.uid == storedDevice.id).firstOrNull;
  if (selected != null) return DeviceDiscoveryResult(devices: [audioOnlyDeviceForInput(selected)]);
  return const DeviceDiscoveryResult(devices: []);   // early return
}
```

The early return skips the name-match fallback directly below it, so for anyone
who paired in that window the glasses **disappeared from the device list
permanently** — no error, no prompt, and no recovery path, since the only way
back is a picker that is not surfaced from the empty state. Background reconnect
fails the same way in `RayBanMetaTransport`.

## Change

A stored selection carrying the legacy synthetic id is treated as *no* selection
rather than as a UID that failed to match, so the name-match convenience path
runs and the glasses reappear. Connecting then persists the real UID, which
heals the stored value.

The id is named as a constant (`legacyAudioOnlyId`) so the intent is explicit
rather than a bare string comparison.

## What this deliberately does not do

It does not fall back to name matching when a stored **real** UID is absent.
That case means the glasses are merely disconnected, or were re-paired, and
matching by name there could bind the user to a different headset. The existing
invariant is preserved and now has its own test.

## Tests

`test/unit/rayban_meta_device_test.dart`:

- **recovers glasses stored under the legacy synthetic id** — verified to fail on
  the current code with `Expected: an object with length of <1> / Actual: []`,
  which is exactly the reported symptom.
- **a stored real UID that is absent is never substituted** — locks the
  no-substitution invariant so this migration cannot later be widened into
  "match anything by name". Passes both before and after.

19/19 in the file pass, including the pre-existing rename, first-selection and
product-name cases. `scripts/analyze_ratchet.sh` passes. `dart format` clean.

## Follow-up (not in this PR)

`rayban_meta_input_picker_sheet.dart` disconnects the currently connected device
before trying the new one and, on failure, rolls back only the persisted
preference — leaving the previous device disconnected. Worth a separate fix.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

