### PR TITLE
fix(beta): accept canonical GitHub candidate evidence

### DIFF
--- a/backend/tests/unit/test_qualified_beta_promotion.py
+++ b/backend/tests/unit/test_qualified_beta_promotion.py
@@ -16,6 +16,7 @@ from utils.qualified_beta_promotion import (
     REPOSITORY,
     GitHubQualifiedBetaReader,
     QualifiedBetaAdmissionError,
+    _asset_url,
     _current_time,
     _timestamp,
     build_qualified_beta_manifest,
@@ -100,6 +101,109 @@ class FakeQualifiedBetaReader:
     async def download(self, url):
         self.download_calls.append(url)
         return self.downloaded[url]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("github_status", "expected"),
+    (("ahead", True), ("identical", True), ("behind", False), ("diverged", False)),
+)
+async def test_github_merged_source_uses_head_relative_to_base_direction(monkeypatch, github_status, expected):
+    reader = GitHubQualifiedBetaReader()
+
+    async def fake_api(path):
+        assert path == f"compare/{SHA}...main"
+        return {"status": github_status}
+
+    monkeypatch.setattr(reader, "_api", fake_api)
+    assert await reader.is_merged_source(SHA) is expected
+
+
+@pytest.mark.parametrize(
+    "tag_path",
+    (TAG, TAG.replace("+", "%2B")),
+)
+def test_asset_url_accepts_only_literal_or_github_canonical_plus_encoding(tag_path):
+    url = f"https://github.com/{REPOSITORY}/releases/download/{tag_path}/Omi.zip"
+    assert _asset_url({"browser_download_url": url}, TAG, "Omi.zip") == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        f"https://github.com/{REPOSITORY}/releases/download/{TAG.replace('+', '%2b')}/Omi.zip",
+        f"https://github.com/attacker/omi/releases/download/{TAG}/Omi.zip",
+        f"https://github.com/{REPOSITORY}/releases/download/{TAG}/other.zip",
+    ),
+)
+def test_asset_url_rejects_noncanonical_or_wrong_identity(url):
+    with pytest.raises(QualifiedBetaAdmissionError, match="asset identity"):
+        _asset_url({"browser_download_url": url}, TAG, "Omi.zip")
+
+
+class FakeHTTPResponse:
+    def __init__(self, status_code, *, headers=None, content=b""):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.content = content
+
+
+class FakeHTTPClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    async def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return self.responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_github_asset_download_follows_one_exact_asset_host_redirect_without_auth(monkeypatch):
+    redirect = "https://release-assets.githubusercontent.com/github-production-release-asset/123/file?sig=abc"
+    client = FakeHTTPClient(
+        [FakeHTTPResponse(302, headers={"location": redirect}), FakeHTTPResponse(200, content=b"artifact")]
+    )
+    monkeypatch.setattr("utils.qualified_beta_promotion.get_web_fetch_client", lambda: client)
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+
+    reader = GitHubQualifiedBetaReader()
+    assert await reader.download("https://github.com/BasedHardware/omi/releases/download/tag/Omi.zip") == b"artifact"
+    assert client.calls[0][1]["headers"]["Authorization"] == "Bearer test-token"
+    assert client.calls[1] == (redirect, {})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "redirect",
+    (
+        "http://release-assets.githubusercontent.com/file",
+        "https://attacker.example/file",
+        "https://user@release-assets.githubusercontent.com/file",
+        "https://release-assets.githubusercontent.com:444/file",
+    ),
+)
+async def test_github_asset_download_rejects_untrusted_redirects(monkeypatch, redirect):
+    client = FakeHTTPClient([FakeHTTPResponse(302, headers={"location": redirect})])
+    monkeypatch.setattr("utils.qualified_beta_promotion.get_web_fetch_client", lambda: client)
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+
+    with pytest.raises(QualifiedBetaAdmissionError, match="asset is unavailable"):
+        await GitHubQualifiedBetaReader().download("https://github.com/BasedHardware/omi/releases/download/tag/Omi.zip")
+    assert len(client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_github_asset_download_rejects_a_second_redirect(monkeypatch):
+    redirect = "https://release-assets.githubusercontent.com/file"
+    client = FakeHTTPClient(
+        [FakeHTTPResponse(302, headers={"location": redirect}), FakeHTTPResponse(302, headers={"location": redirect})]
+    )
+    monkeypatch.setattr("utils.qualified_beta_promotion.get_web_fetch_client", lambda: client)
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+
+    with pytest.raises(QualifiedBetaAdmissionError, match="asset is unavailable"):
+        await GitHubQualifiedBetaReader().download("https://github.com/BasedHardware/omi/releases/download/tag/Omi.zip")
 
 
 def _digest(value):

--- a/backend/utils/qualified_beta_promotion.py
+++ b/backend/utils/qualified_beta_promotion.py
@@ -10,6 +10,7 @@ import os
 import re
 from collections.abc import Awaitable
 from typing import Any, NoReturn, TypeGuard
+from urllib.parse import urlsplit
 import zipfile
 import zlib
 
@@ -195,7 +196,8 @@ def _qualification_artifacts(value: object) -> list[dict[str, Any]]:
 def _asset_url(asset: dict[str, Any], tag: str, name: str) -> str:
     url = asset.get("browser_download_url")
     expected = f"https://github.com/{REPOSITORY}/releases/download/{tag}/{name}"
-    if not isinstance(url, str) or url != expected:
+    encoded = f"https://github.com/{REPOSITORY}/releases/download/{tag.replace('+', '%2B')}/{name}"
+    if not isinstance(url, str) or url not in {expected, encoded}:
         _fail("candidate asset identity does not match its immutable release")
     return url
 
@@ -362,7 +364,10 @@ class GitHubQualifiedBetaReader:
 
     async def is_merged_source(self, source_sha: str) -> bool:
         comparison = await self._api(f"compare/{source_sha}...main")
-        return comparison.get("status") in {"behind", "identical"}
+        # GitHub reports the HEAD (`main`) relative to the base (`source_sha`).
+        # A candidate already merged into main therefore yields `ahead` (or
+        # `identical`), while `behind` means the candidate is ahead of main.
+        return comparison.get("status") in {"ahead", "identical"}
 
     async def runs(self) -> list[dict[str, Any]]:
         response = await self._api(
@@ -377,7 +382,23 @@ class GitHubQualifiedBetaReader:
         return _github_objects(artifacts, "candidate qualification artifacts are invalid")
 
     async def download(self, url: str) -> bytes:
-        response = await get_web_fetch_client().get(url, headers=self._headers())
+        client = get_web_fetch_client()
+        response = await client.get(url, headers=self._headers())
+        if response.status_code in {301, 302, 303, 307, 308}:
+            location = response.headers.get("location")
+            if not isinstance(location, str):
+                _fail("candidate GitHub asset is unavailable")
+            redirect = urlsplit(location)
+            if (
+                redirect.scheme != "https"
+                or redirect.hostname != "release-assets.githubusercontent.com"
+                or redirect.port is not None
+                or redirect.username is not None
+                or redirect.password is not None
+            ):
+                _fail("candidate GitHub asset is unavailable")
+            # Never forward the GitHub API credential to the signed asset URL.
+            response = await client.get(location)
         if response.status_code != 200:
             _fail("candidate GitHub asset is unavailable")
         return response.content


### PR DESCRIPTION
## Summary

Repair two GitHub canonical-semantics mismatches that caused the protected emergency macOS Beta endpoint to reject every valid immutable candidate before mutation:

- interpret `compare/{candidate}...main` correctly: GitHub reports `ahead` when `main` contains the candidate
- accept GitHub's canonical `%2B` release-tag URL spelling while retaining exact repository/tag/filename checks
- follow exactly one HTTPS asset redirect to `release-assets.githubusercontent.com`, without forwarding the GitHub credential
- reject wrong hosts, userinfo, non-HTTPS, non-default ports, and second redirects

No backend policy, credential, environment, database transaction, channel scope, qualification truth, or Stable behavior changes.

## Verification

- `pytest -q backend/tests/unit/test_qualified_beta_promotion.py` — **177 passed**
- `py_compile` for changed source/tests — passed
- `git diff --check` — passed
- Real `build_emergency_beta_manifest('v0.12.103+12103-macos')` against GitHub — passed:
  - exact source `0e804a569142e93448049ac8f54cd4484c0ea883`
  - `qualification_tier=emergency`
  - `qualification_passed=false`
  - ZIP `sha256:e0cf5a4dc40201b852330db5cdf9afad711cf2c1c35aee535db371380a745861`
  - DMG `sha256:f66bade408b8fdfcef112ab3e3fd477837003d12aa12012a79691b1859760a61`

## Product invariants affected

- Beta release admission remains exact-identity, immutable, fail-closed, generation-fenced, and Beta-only.
- Stable remains unreachable from the emergency endpoint.

## Failure class

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

