### PR TITLE
fix(app): stop a failing reconcile from blocking all recording uploads

### DIFF
--- a/app/lib/services/wals/recording_transfer_coordinator.dart
+++ b/app/lib/services/wals/recording_transfer_coordinator.dart
@@ -220,12 +220,17 @@ class RecordingTransferCoordinator {
     try {
       // Uploaded jobs are resolved before a whole-WAL drain can offer any
       // retryable bytes. `syncAll` only uploads `miss`, preserving job ids.
-      await _reconcile();
+      // Reconciling only resolves work already on the server, so a failure here
+      // must not stop new recordings from uploading — it is retried instead.
+      var reconcileFailed = !await _tryReconcile();
       await _discover();
       await _refreshPending();
 
       final mayUpload = trigger == WakeTrigger.userRetry || _autoUploadEnabled();
-      if (!mayUpload) return;
+      if (!mayUpload) {
+        if (reconcileFailed) _scheduleRetry('reconcile pass failed');
+        return;
+      }
 
       final result = await _drain();
       await _refreshPending();
@@ -233,7 +238,7 @@ class RecordingTransferCoordinator {
       // Partial upload success still leaves `uploaded` WALs that need the
       // reconciler before any failure/contention retry path runs.
       if (result.needsReconciliation) {
-        await _reconcile();
+        reconcileFailed = !await _tryReconcile() || reconcileFailed;
         await _refreshPending();
       }
 
@@ -245,10 +250,25 @@ class RecordingTransferCoordinator {
         _scheduleRetry('eligible WAL drain was contended');
         return;
       }
+      if (reconcileFailed) {
+        _scheduleRetry('reconcile pass failed');
+        return;
+      }
       _failureStreak = 0;
     } catch (error, stackTrace) {
       Logger.debug('RecordingTransferCoordinator: $trigger pass failed: $error\n$stackTrace');
       _scheduleRetry('pass threw while recovering recording transfers');
+    }
+  }
+
+  /// Runs a reconcile pass, reporting failure instead of propagating it.
+  Future<bool> _tryReconcile() async {
+    try {
+      await _reconcile();
+      return true;
+    } catch (error, stackTrace) {
+      Logger.debug('RecordingTransferCoordinator: reconcile failed, continuing to drain: $error\n$stackTrace');
+      return false;
     }
   }
 

--- a/app/lib/services/wals/sync_reconciler.dart
+++ b/app/lib/services/wals/sync_reconciler.dart
@@ -65,8 +65,15 @@ class SyncReconciler {
       rethrow;
     } finally {
       _running = false;
+      // Re-arm on every outcome. Leaving the timer disarmed after a failed pass
+      // stranded uploaded WALs until something else happened to wake the
+      // coordinator.
+      try {
+        await _reschedule();
+      } catch (e) {
+        Logger.debug('SyncReconciler: reschedule failed: $e');
+      }
     }
-    await _reschedule();
   }
 
   Future<bool> _hasUploaded() async {

--- a/app/test/services/wals/recording_transfer_coordinator_test.dart
+++ b/app/test/services/wals/recording_transfer_coordinator_test.dart
@@ -48,6 +48,42 @@ void main() {
       expect(harness.maximumConcurrentDrains, 1);
     });
 
+    test('a failing reconcile still drains pending recordings', () async {
+      // Reconcile only resolves jobs already on the server. When it threw, it
+      // aborted the pass before the drain, so brand-new recordings stopped
+      // uploading entirely for as long as the failure persisted.
+      final harness = _TransferHarness()..reconcileFails = true;
+      addTearDown(harness.dispose);
+
+      await harness.coordinator.wake(WakeTrigger.startup);
+
+      expect(harness.reconcilePasses, 1);
+      expect(harness.drainPasses, 1);
+      // Uploaded, not still waiting to be offered: the bytes left the device
+      // even though reconcile could not resolve the job yet.
+      expect(harness.walState, 'uploaded');
+      expect(harness.walState, isNot('miss'));
+    });
+
+    test('a failing reconcile is retried on cooldown', () async {
+      final harness = _TransferHarness()..reconcileFails = true;
+      addTearDown(harness.dispose);
+
+      await harness.coordinator.wake(WakeTrigger.startup);
+
+      expect(harness.scheduledCooldowns, hasLength(1));
+    });
+
+    test('a failing reconcile still drains when uploads are disabled', () async {
+      final harness = _TransferHarness(autoUploadEnabled: false)..reconcileFails = true;
+      addTearDown(harness.dispose);
+
+      await harness.coordinator.wake(WakeTrigger.startup);
+
+      expect(harness.discoveryPasses, 1);
+      expect(harness.scheduledCooldowns, hasLength(1));
+    });
+
     test('a retryable drain failure never presents synced and schedules cooldown', () async {
       final harness = _TransferHarness()..drainFails = true;
       addTearDown(harness.dispose);
@@ -197,6 +233,7 @@ class _TransferHarness {
   late final RecordingTransferCoordinator coordinator;
 
   Completer<void>? reconcileGate;
+  bool reconcileFails = false;
   bool drainFails = false;
   bool drainNeedsReconciliation = false;
   bool drainContended = false;
@@ -213,6 +250,9 @@ class _TransferHarness {
 
   Future<void> _reconcile() async {
     reconcilePasses++;
+    if (reconcileFails) {
+      throw StateError('reconcile pass failed');
+    }
     if (uploadedWalAwaitingReconcile) {
       uploadedWalAwaitingReconcile = false;
       reconciledUploadedWal = true;


### PR DESCRIPTION
## Problem

`_runPass` reconciles before it drains:

```dart
await _reconcile();     // first statement
await _discover();
await _refreshPending();
...
final result = await _drain();   // never reached if reconcile throws
```

`SyncReconciler.poke()` rethrows on failure, so any throw from
`reconcileUploadedWals` aborts the pass at the first line. Discovery, the pending
refresh and — critically — the **drain** are all skipped.

Reconciling only resolves jobs that are *already on the server*. Blocking the
drain on it means that while the failure persists, **brand-new recordings never
upload at all**. Every retry re-enters `_runPass` and aborts at the same point,
so the backlog grows with no user-visible cause.

Second, smaller defect in the same path: `poke()` calls `_reschedule()` *after*
its try block, so the rethrow skipped it and left the reconciler's own poll timer
disarmed. Only the coordinator's backoff remained to wake it.

## Change

- **Reconcile is now best effort relative to the drain.** It runs through
  `_tryReconcile()`, which reports failure instead of propagating it. The pass
  continues to discovery, the pending refresh and the drain, then schedules a
  retry so reconcile is attempted again. A failed reconcile schedules that retry
  on every exit path, including the uploads-disabled early return, so the failure
  is never silently dropped. The post-drain reconcile is treated the same way.
- **The poll timer is re-armed on every outcome** — `_reschedule()` moved into
  `finally` and guarded, so a reschedule failure cannot mask the original error.

Nothing about WAL state transitions changes. A recording that uploads while
reconcile is failing lands in `uploaded` and is resolved to `synced` by a later
successful reconcile, exactly as before.

## Tests

`test/services/wals/recording_transfer_coordinator_test.dart` — new
`reconcileFails` harness flag plus:

- **a failing reconcile still drains pending recordings** — verified to fail on
  the current code with `drainPasses: Expected <1>, Actual <0>`, i.e. the drain
  genuinely never ran.
- **a failing reconcile still drains when uploads are disabled** — fails on
  current code with `discoveryPasses: Expected <1>, Actual <0>`.
- **a failing reconcile is retried on cooldown** — documents that the failure is
  still surfaced as a scheduled retry rather than swallowed.

14/14 in that file pass; 149/149 across `test/services/` and `test/providers/`.
`scripts/analyze_ratchet.sh` passes. `dart format` clean.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

