### PR TITLE
fix(release): peel qualification tag identities

### DIFF
--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -4,7 +4,10 @@
 # omi-test-quality: source-inspection -- static contract: GitHub workflow authority is YAML-only.
 from __future__ import annotations
 
+import os
 import re
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -21,6 +24,51 @@ def codemagic() -> str:
 
 
 class DesktopReleaseFlowContractTests(unittest.TestCase):
+    def _qualification_identity_expressions(self) -> tuple[str, str]:
+        qualification = workflow("desktop_qualify_beta.yml")
+        candidate_step = qualification.split("      - name: Download and validate newest candidate evidence", 1)[1]
+        candidate_step = candidate_step.split("\n      - name:", 1)[0]
+        target = re.search(r"^\s*TARGET_SHA=\$\((.+)\)$", candidate_step, re.MULTILINE)
+        checkout = re.search(r"^\s*CHECKOUT_SHA=\$\((.+)\)$", candidate_step, re.MULTILINE)
+        self.assertIsNotNone(target)
+        self.assertIsNotNone(checkout)
+        return target.group(1), checkout.group(1)
+
+    def _assert_qualification_tag_identity(self, *, annotated: bool) -> None:
+        target_expression, checkout_expression = self._qualification_identity_expressions()
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            git_env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+            def run_git(*args: str) -> None:
+                subprocess.run(["git", *args], cwd=repo, env=git_env, check=True)
+
+            run_git("init", "-q")
+            run_git("config", "user.name", "Contract Test")
+            run_git("config", "user.email", "contract@example.com")
+            (repo / "candidate.txt").write_text("immutable candidate\n", encoding="utf-8")
+            run_git("add", "candidate.txt")
+            run_git("-c", "core.hooksPath=/dev/null", "commit", "-qm", "candidate")
+            release_tag = "v0.12.105+12105-macos"
+            tag_args = ["git", "tag"]
+            if annotated:
+                tag_args.extend(["-a", "-m", "candidate"])
+            tag_args.append(release_tag)
+            subprocess.run(tag_args, cwd=repo, env=git_env, check=True)
+            run_git("checkout", "-q", release_tag)
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    f'TARGET_SHA=$({target_expression}); CHECKOUT_SHA=$({checkout_expression}); '
+                    'test "$TARGET_SHA" = "$CHECKOUT_SHA"',
+                ],
+                cwd=repo,
+                env={"PATH": "/usr/bin:/bin", "RELEASE_TAG": release_tag},
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0)
+
     def test_canonical_release_and_qualification_use_lowercase_dmg_asset(self) -> None:
         build_identity = codemagic().split("- name: Resolve trusted source and build identity", 1)[1]
         build_identity = build_identity.split("- name: ", 1)[0]
@@ -69,6 +117,21 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         )
         self.assertTrue(set(invoked_options).issubset(supported_options))
         self.assertNotIn("--no-promote", qualify_step)
+
+    def test_beta_qualification_peels_every_compared_identity_to_a_commit(self) -> None:
+        target_expression, checkout_expression = self._qualification_identity_expressions()
+        self.assertEqual(target_expression, 'git rev-parse "$RELEASE_TAG^{commit}"')
+        self.assertEqual(checkout_expression, 'git rev-parse "HEAD^{commit}"')
+        self.assertEqual(
+            workflow("desktop_qualify_beta.yml").count('TARGET_SHA=$(git rev-parse "$RELEASE_TAG^{commit}")'),
+            2,
+        )
+
+    def test_beta_qualification_accepts_annotated_tag_at_exact_checkout_commit(self) -> None:
+        self._assert_qualification_tag_identity(annotated=True)
+
+    def test_beta_qualification_accepts_lightweight_tag_at_exact_checkout_commit(self) -> None:
+        self._assert_qualification_tag_identity(annotated=False)
 
     def test_stable_is_manual_and_uses_one_explicit_confirmation(self) -> None:
         stable = workflow("desktop_promote_prod.yml")

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -69,8 +69,8 @@ jobs:
           git fetch --force origin "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
           LATEST_TAG=$(git for-each-ref --count=1 --sort=-v:refname --format='%(refname:strip=2)' 'refs/tags/v*-macos')
           test -n "$LATEST_TAG"
-          TARGET_SHA=$(git rev-list -n1 "$RELEASE_TAG")
-          CHECKOUT_SHA=$(git rev-parse "$RELEASE_TAG")
+          TARGET_SHA=$(git rev-parse "$RELEASE_TAG^{commit}")
+          CHECKOUT_SHA=$(git rev-parse "HEAD^{commit}")
           rm -rf /tmp/desktop-beta-qualification
           mkdir -p /tmp/desktop-beta-qualification
           gh release view "$RELEASE_TAG" --repo "$REPO" \
@@ -113,7 +113,7 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
-          TARGET_SHA=$(git rev-list -n1 "$RELEASE_TAG")
+          TARGET_SHA=$(git rev-parse "$RELEASE_TAG^{commit}")
           STABLE_DMG=/tmp/desktop-beta-qualification/assets/omi.dmg
           test -n "$STABLE_DMG"
           python3 .github/scripts/desktop_qualification_evidence.py build \


### PR DESCRIPTION
## Summary

- peel the requested macOS Beta candidate tag with `^{commit}` before all immutable identity and evidence comparisons
- compare the checked-out `HEAD^{commit}` with that peeled candidate commit, preserving the exact-source fail-closed gate
- add regressions that exercise the workflow's real identity expressions with both annotated and lightweight tags

## Why

Qualification run 29934177852 for immutable candidate `v0.12.105+12105-macos` failed before qualification because `TARGET_SHA` resolved the tag's commit while `CHECKOUT_SHA` resolved the annotated tag object. Both identities referred to the same candidate source but had different object IDs.

This change compares commit identity to commit identity. A checkout at any other commit still fails closed, and all existing newest-candidate, signed-artifact, static, Tier-2, fault-suite, and immutable-evidence gates remain unchanged.

## Verification

- `python3 .github/scripts/test_desktop_release_flow_contract.py -v` — 10 passed, including annotated-tag and lightweight-tag identity regressions
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh` — passed
- `python3 .github/scripts/check-release-process-guards.py` — passed
- `actionlint .github/workflows/desktop_qualify_beta.yml` — passed
- `git diff --check origin/main...HEAD` — passed

No release, tag, build, qualification, deployment, promotion, or Stable operation was run.

## Product invariants

None. This repairs immutable qualification identity normalization without changing product behavior or release admission gates.

## Failure class

Failure-Class: none

## Changelog

Internal qualification-controller fix only; `no-changelog-needed`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

