### PR TITLE
fix(backend): stop discarding chat answers that streamed before a bounded stop

### DIFF
--- a/backend/tests/unit/test_chat_async_offload.py
+++ b/backend/tests/unit/test_chat_async_offload.py
@@ -41,8 +41,10 @@ import utils.retrieval.agentic as agentic  # noqa: E402
 import utils.other.chat_file as chat_file  # noqa: E402
 
 
-async def _collect_agentic_chunks(producer):
+async def _collect_agentic_chunks(producer, callback_data=None):
     """Drive the real public stream with deterministic setup dependencies."""
+    if callback_data is None:
+        callback_data = {}
     with ExitStack() as stack:
         stack.enter_context(patch.object(agentic, 'get_user_timezone', lambda _uid: 'UTC'))
         stack.enter_context(patch.object(agentic, '_get_agentic_qa_prompt', lambda *_args, **_kwargs: 'SYSTEM'))
@@ -55,7 +57,7 @@ async def _collect_agentic_chunks(producer):
         return [
             chunk
             async for chunk in agentic.execute_agentic_chat_stream(
-                'uid1', [], app=None, callback_data={}, chat_session=None
+                'uid1', [], app=None, callback_data=callback_data, chat_session=None
             )
         ]
 
@@ -320,6 +322,63 @@ async def test_agentic_stream_cancels_a_silent_producer_before_the_proxy_deadlin
 
     assert chunks == [f'error: {agentic.AGENT_STREAM_TIMEOUT_MESSAGE}']
     assert cancelled.is_set()
+
+
+async def test_agentic_stream_keeps_an_answer_streamed_before_the_deadline():
+    """A bounded stop must persist what the user already watched arrive, not discard it."""
+    callback_data = {}
+
+    async def stalls_after_answering(*args, **_kwargs):
+        callback, full_response = args[4], args[5]
+        await callback.put_data('the answer so far')
+        full_response.append('the answer so far')
+        await asyncio.Event().wait()
+
+    with patch.object(agentic, 'AGENT_STREAM_PROGRESS_HEARTBEAT_SECONDS', 0.01), patch.object(
+        agentic, 'AGENT_STREAM_MAX_DURATION_SECONDS', 0.05
+    ), patch.object(agentic, 'AGENT_STREAM_CANCEL_GRACE_SECONDS', 0.05):
+        chunks = await _collect_agentic_chunks(stalls_after_answering, callback_data)
+
+    # The terminal None is what makes the router persist instead of writing a
+    # canned error over the streamed answer.
+    assert chunks[-1] is None
+    assert f'error: {agentic.AGENT_STREAM_TIMEOUT_MESSAGE}' not in chunks
+    assert callback_data['answer'] == 'the answer so far'
+    assert callback_data['error'] == 'idle_timeout'
+
+
+async def test_agentic_stream_still_errors_when_nothing_was_streamed():
+    """With no partial answer there is nothing to keep, so the terminal error stands."""
+    callback_data = {}
+
+    async def stalled_producer(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    with patch.object(agentic, 'AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS', 0.01), patch.object(
+        agentic, 'AGENT_STREAM_CANCEL_GRACE_SECONDS', 0.05
+    ):
+        chunks = await _collect_agentic_chunks(stalled_producer, callback_data)
+
+    assert chunks == [f'error: {agentic.AGENT_STREAM_TIMEOUT_MESSAGE}']
+    assert 'answer' not in callback_data
+
+
+async def test_agentic_stream_keeps_an_answer_streamed_before_a_producer_crash():
+    """A provider failure mid-answer must not discard the tokens already delivered."""
+    callback_data = {}
+
+    async def crashes_after_answering(*args, **_kwargs):
+        callback, full_response = args[4], args[5]
+        await callback.put_data('partial before crash')
+        full_response.append('partial before crash')
+        raise RuntimeError('simulated provider failure')
+
+    chunks = await _collect_agentic_chunks(crashes_after_answering, callback_data)
+
+    assert chunks[-1] is None
+    assert f'error: {agentic.AGENT_STREAM_FAILURE_MESSAGE}' not in chunks
+    assert callback_data['answer'] == 'partial before crash'
+    assert callback_data['error'] == 'RuntimeError'
 
 
 async def test_agentic_stream_surfaces_a_producer_crash_without_waiting_for_idle_timeout():

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -799,6 +799,26 @@ You have fetch_url_tool available. When the user shares any URL (starting with h
         )
     )
 
+    def keep_streamed_answer() -> bool:
+        """Preserve what already reached the user when the stream stops early.
+
+        The bounded deadline and failure paths cancel the producer, but the
+        tokens yielded before that are a real answer the user watched arrive.
+        Returns whether there was anything to keep.
+        """
+        if callback_data is None:
+            return False
+        streamed = ''.join(full_response)
+        if not streamed:
+            return False
+        callback_data['answer'] = streamed
+        callback_data['memories_found'] = conversations_collected if conversations_collected else []
+        callback_data['ask_for_nps'] = tool_usage_count > 0
+        chart_data_from_config = configurable.get('chart_data')
+        if chart_data_from_config:
+            callback_data['chart_data'] = chart_data_from_config
+        return True
+
     # Stream from callback queue
     try:
         started_at = asyncio.get_running_loop().time()
@@ -852,6 +872,9 @@ You have fetch_url_tool available. When the user shares any URL (starting with h
         await cancel_stream_task(task)
         if callback_data is not None:
             callback_data['error'] = 'idle_timeout'
+        if keep_streamed_answer():
+            yield None
+            return
         yield f'error: {AGENT_STREAM_TIMEOUT_MESSAGE}'
         return
     except asyncio.CancelledError:
@@ -862,6 +885,9 @@ You have fetch_url_tool available. When the user shares any URL (starting with h
         await cancel_stream_task(task)
         if callback_data is not None:
             callback_data['error'] = type(error).__name__
+        if keep_streamed_answer():
+            yield None
+            return
         yield f'error: {AGENT_STREAM_FAILURE_MESSAGE}'
         return
     finally:


### PR DESCRIPTION
## Problem

`execute_agentic_chat_stream` persists its result in two steps: it sets
`callback_data['answer']`, then falls through to `yield None` — the terminal
sentinel the router waits for:

```python
        if callback_data is not None:
            callback_data['answer'] = ''.join(full_response)   # line 842
            ...
    except asyncio.TimeoutError:
        ...
        yield f'error: {AGENT_STREAM_TIMEOUT_MESSAGE}'
        return                                                 # skips both
    ...
    yield None  # Signal completion
```

Both early-exit paths `return` before either step. In `routers/chat.py`,
`answered` only becomes true when a falsy chunk arrives *and*
`callback_data['answer']` is set, so on a bounded stop `answered` stays false
and `emit_stream_error_fallback` writes a canned error in its place.

The result: a user watches a complete answer stream in, sees it replaced by
"The response took too long", and finds nothing in their chat history — while
`full_response` held the full text the entire time.

This is not a rare path. The code's own comment notes "some app tools allow
120s", so a two-tool answer can legitimately exceed the 150s cap — exactly the
long, expensive answers that hurt most to lose.

## Change

Both the deadline and failure paths now keep what was streamed and emit the
sentinel so the router persists it. Citation sources are carried over too, so
`[1]`-style references inside that text still resolve instead of being stripped
as out-of-range.

When nothing was streamed there is nothing to keep, so the terminal error still
stands and the fallback behaves exactly as before. `callback_data['error']` is
still recorded on both paths, so the failure remains observable server-side.

## Tests

`tests/unit/test_chat_async_offload.py` — the shared harness now exposes
`callback_data`:

- **keeps an answer streamed before the deadline** — verified to fail on current
  code with `assert 'error: The response took too long…' is None`, i.e. the
  answer was discarded.
- **keeps an answer streamed before a producer crash** — fails on current code
  with the equivalent failure-path assertion.
- **still errors when nothing was streamed** — passes before and after, pinning
  the no-partial-answer behaviour so this cannot widen into swallowing real
  failures.

13/13 in that file, 32/32 with the chat quota and vision stream suites.
`scripts/scan_async_blockers.py`: 0 findings. `black` clean.

## Follow-ups (not in this PR)

- The file and persona routes in `utils/retrieval/graph.py` drop partial answers
  the same way, but structurally differently — their answer comes from
  `await task` rather than an accumulated buffer, so it needs its own fix.
- `first_event_deadline` is computed *before* the 25s setup block, so a slow
  cold setup can leave ~1s for the first token and kill a healthy stream.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

