### PR TITLE
fix(ci): tolerate shared-runner agent test contention

### DIFF
--- a/desktop/macos/agent/tests/vitest-runtime-budget.test.ts
+++ b/desktop/macos/agent/tests/vitest-runtime-budget.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import config from "../vitest.config";
+
+describe("Vitest runtime budget", () => {
+  it("keeps contention-sensitive agent tests bounded without using Vitest defaults", () => {
+    expect(config.test?.testTimeout).toBe(15_000);
+    expect(config.test?.hookTimeout).toBe(20_000);
+  });
+});

--- a/desktop/macos/agent/vitest.config.ts
+++ b/desktop/macos/agent/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Codemagic's shared M2 runner can briefly starve CPU, subprocess, and Unix
+// socket tests while Vitest runs the full agent suite in parallel. Keep hangs
+// bounded while allowing the measured contention-sensitive tests to complete.
+export default defineConfig({
+  test: {
+    testTimeout: 15_000,
+    hookTimeout: 20_000,
+  },
+});

--- a/desktop/macos/changelog/unreleased/20260722-agent-vitest-timeout-budget.json
+++ b/desktop/macos/changelog/unreleased/20260722-agent-vitest-timeout-budget.json
@@ -1,0 +1,3 @@
+{
+  "change": "Prevent transient shared-runner contention from timing out the macOS agent release test suite."
+}


### PR DESCRIPTION
## Summary
- give the macOS agent Vitest suite a bounded 15-second test and 20-second hook budget
- preserve hang detection while tolerating the measured shared-M2 contention that timed out three unrelated `.107` tests
- add an executable config contract and desktop changelog fragment

## Failure class
Failure-Class: none

This is CI infrastructure contention rather than a semantic product-state failure class. The macOS agent suite implicitly used Vitest's 5-second test and 10-second hook defaults. A shared Codemagic M2 slowdown caused a synchronous source scan, a generator subprocess, and a Unix-socket test to expire together even though all pass in isolation and the full suite passes on an adequately resourced host.

## Product invariants
None affected.

## Verification
- `npm ci`
- `npm run build`
- `npm test` — 49 files, 578 tests passed; exit 0
- `python3 .github/scripts/desktop-changelog.py validate`
- `make preflight`

## Release safety
- no production or release workflow authority changes
- does not rewrite or alter immutable `.107`
- no Beta or Stable pointer operations


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

