### PR TITLE
release(desktop): bounded auto-retry of transient failed Beta qualification

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -414,6 +414,12 @@ checks:
     platforms: ["macos"]
     reason: "Exact-source retries must keep stable absolute SwiftPM paths while rejecting stale provenance, symlinks, collisions, and incomplete entries"
 
+  - id: desktop-beta-qualification-retry
+    command: ["python3", ".github/scripts/test_desktop_beta_qualification_retry.py"]
+    triggers: [".github/workflows/desktop_retry_beta_qualification.yml", ".github/scripts/desktop_beta_qualification_retry.py", ".github/scripts/test_desktop_beta_qualification_retry.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-49 bounded automatic retry of transient failed/cancelled Beta qualification must stay tag-bound, exact-SHA, bounded, and never re-dispatch in-progress/successful runs"
+
 exempt:
   - path: ".github/scripts/check-desktop-auto-beta-candidate.py"
     reason: "release pipeline check requires published candidate artifacts and workflow inputs"

--- a/.github/scripts/desktop_beta_qualification_retry.py
+++ b/.github/scripts/desktop_beta_qualification_retry.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Decide whether to retry the newest desktop Beta candidate qualification.
+
+The retry only recovers a *transient* failed/cancelled qualification of the
+newest valid immutable published candidate. It never trusts a caller claim: the
+candidate identity, qualification run set, and conclusion are all re-derived
+from server-provided JSON (a GitHub release view and the qualification workflow
+run list). On schedule the workflow supplies no tag at all.
+
+Safety properties enforced here:
+- tag-bound and exact-SHA: only the exact newest tag at its exact SHA is retried;
+- newest valid candidate only: a published, non-draft, non-prerelease candidate
+  carrying the canonical three assets and an isLive:false candidate body;
+- bounded candidate age and bounded attempts;
+- never retry an in-progress or already-successful run;
+- bounded attempts keep a deterministic product failure from looping forever.
+  (We do not classify transient vs deterministic from logs: a failed
+  qualification step can be either, and the attempt bound is the safe loop guard.
+  Mis-classifying a transient failure as deterministic would strand the newest
+  candidate; bounded retries cannot.)
+- promotion stays a separate completed-success authority: this only re-dispatches
+  qualification, never the promote endpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+QUALIFICATION_WORKFLOW = ".github/workflows/desktop_qualify_beta.yml"
+# The three immutable assets Codemagic attaches to every canonical candidate.
+CANONICAL_ASSETS = ("Omi.zip", "omi.dmg", "desktop-smoke-result.json")
+# A terminal qualification conclusion a transient retry may recover. "neutral"
+# and "skipped" are excluded: they are operator/policy outcomes, not transient.
+RETRYABLE_CONCLUSIONS = frozenset({"failure", "cancelled", "timed_out", "startup_failure"})
+DEFAULT_MAX_ATTEMPTS = 3
+DEFAULT_MAX_AGE_HOURS = 24
+TRUE_VALUES = {"true", "1", "yes"}
+
+
+def _load(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _parse_metadata(body: str) -> dict[str, str]:
+    """Read the KEY_VALUE block Codemagic writes into the release body.
+
+    Mirrors desktop_release_metadata.parse_metadata but denies (returns {})
+    instead of exiting when the block is absent: a retry decision is never a
+    hard failure, only a "no" with a reason.
+    """
+    result: dict[str, str] = {}
+    if "KEY_VALUE_START" not in body or "KEY_VALUE_END" not in body:
+        return result
+    block = body.split("KEY_VALUE_START", 1)[1].split("KEY_VALUE_END", 1)[0]
+    for line in block.strip().splitlines():
+        line = line.strip()
+        if line.startswith("<!--"):
+            line = line[4:].strip()
+        if line.endswith("-->"):
+            line = line[:-3].strip()
+        if ":" in line:
+            key, _, value = line.partition(":")
+            result[key.strip()] = value.strip()
+    return result
+
+
+def _valid_candidate(release: Any, release_tag: str) -> tuple[bool, str]:
+    """Validate the newest published candidate carries the canonical assets."""
+    if not isinstance(release, dict) or not release:
+        return False, "no published GitHub release for the newest tag"
+    if release.get("tagName") != release_tag:
+        return False, "release tag does not match the newest candidate tag"
+    if release.get("isDraft") or release.get("isPrerelease"):
+        return False, "newest candidate is a draft or prerelease"
+    if not release.get("publishedAt"):
+        return False, "newest candidate is not published"
+    metadata = _parse_metadata(release.get("body") or "")
+    if metadata.get("channel") != "candidate":
+        return False, "newest candidate is not channel: candidate"
+    if metadata.get("isLive", "").lower() not in {"false", "0", "no"}:
+        return False, "newest candidate is not isLive: false"
+    asset_names = {a.get("name") for a in release.get("assets", []) if isinstance(a, dict)}
+    missing = [name for name in CANONICAL_ASSETS if name not in asset_names]
+    if missing:
+        return False, f"newest candidate is missing canonical assets: {', '.join(missing)}"
+    return True, "newest candidate carries the canonical three assets"
+
+
+def _candidate_age_hours(release: Any) -> int | None:
+    published = release.get("publishedAt") if isinstance(release, dict) else None
+    if not isinstance(published, str) or not published:
+        return None
+    try:
+        published_at = datetime.fromisoformat(published.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return max(0, int((datetime.now(timezone.utc) - published_at).total_seconds() // 3600))
+
+
+def _runs_for_tag(runs: Any, release_tag: str, tag_sha: str) -> list[dict[str, Any]]:
+    """Select qualification runs bound to the exact candidate tag and SHA."""
+    selected: list[dict[str, Any]] = []
+    if not isinstance(runs, list):
+        return selected
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        if run.get("path") != QUALIFICATION_WORKFLOW:
+            continue
+        if run.get("event") != "workflow_dispatch":
+            continue
+        if run.get("head_branch") != release_tag:
+            continue
+        if tag_sha and run.get("head_sha") != tag_sha:
+            continue
+        selected.append(run)
+    return selected
+
+
+def _newest(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not runs:
+        return None
+    return max(runs, key=lambda r: r.get("updated_at") or r.get("created_at") or "")
+
+
+def _count_terminal(selected: list[dict[str, Any]]) -> int:
+    return sum(
+        1
+        for r in selected
+        if r.get("status") == "completed" and r.get("conclusion") in RETRYABLE_CONCLUSIONS
+    )
+
+
+def _decision(
+    *,
+    release_tag: str,
+    should_retry: bool,
+    reason: str,
+    attempts: int,
+    newest: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "should_retry": should_retry,
+        "release_tag": release_tag,
+        "reason": reason,
+        "attempts_so_far": attempts,
+        "newest_run_status": newest.get("status") if newest else None,
+        "newest_run_conclusion": newest.get("conclusion") if newest else None,
+        "newest_run_id": newest.get("id") if newest else None,
+    }
+
+
+def decide(
+    release: Any,
+    runs: Any,
+    *,
+    release_tag: str,
+    tag_sha: str,
+    max_attempts: int,
+    max_age_hours: int,
+) -> dict[str, Any]:
+    valid, candidate_reason = _valid_candidate(release, release_tag)
+    selected = _runs_for_tag(runs, release_tag, tag_sha) if valid else []
+    attempts = _count_terminal(selected)
+
+    if not valid:
+        return _decision(
+            release_tag=release_tag, should_retry=False, reason=candidate_reason, attempts=attempts, newest=None
+        )
+
+    age = _candidate_age_hours(release)
+    if age is not None and age > max_age_hours:
+        return _decision(
+            release_tag=release_tag,
+            should_retry=False,
+            reason=f"candidate age {age}h exceeds {max_age_hours}h bound",
+            attempts=attempts,
+            newest=_newest(selected),
+        )
+
+    newest = _newest(selected)
+    if newest is None:
+        return _decision(
+            release_tag=release_tag,
+            should_retry=False,
+            reason="no prior qualification attempt; not retrying an unattempted candidate",
+            attempts=attempts,
+            newest=None,
+        )
+
+    status = newest.get("status")
+    conclusion = newest.get("conclusion")
+    if status != "completed":
+        return _decision(
+            release_tag=release_tag,
+            should_retry=False,
+            reason=f"qualification is {status}; never retry an in-progress run",
+            attempts=attempts,
+            newest=newest,
+        )
+    if conclusion == "success":
+        return _decision(
+            release_tag=release_tag,
+            should_retry=False,
+            reason="qualification already succeeded; promotion is a separate completed-success authority",
+            attempts=attempts,
+            newest=newest,
+        )
+    if attempts >= max_attempts:
+        return _decision(
+            release_tag=release_tag,
+            should_retry=False,
+            reason=(
+                f"{attempts} failed attempts reached the {max_attempts} bound; "
+                "deterministic or persistent failure, not retrying"
+            ),
+            attempts=attempts,
+            newest=newest,
+        )
+    if conclusion not in RETRYABLE_CONCLUSIONS:
+        return _decision(
+            release_tag=release_tag,
+            should_retry=False,
+            reason=f"conclusion {conclusion!r} is not a transient retryable state",
+            attempts=attempts,
+            newest=newest,
+        )
+
+    return _decision(
+        release_tag=release_tag,
+        should_retry=True,
+        reason=f"retrying transient {conclusion} qualification (attempt {attempts + 1} of {max_attempts})",
+        attempts=attempts,
+        newest=newest,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=["decide"])
+    parser.add_argument("--release-json", type=Path, required=True)
+    parser.add_argument("--runs-json", type=Path, required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--tag-sha", required=True)
+    parser.add_argument("--max-attempts", type=int, default=DEFAULT_MAX_ATTEMPTS)
+    parser.add_argument("--max-age-hours", type=int, default=DEFAULT_MAX_AGE_HOURS)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    decision = decide(
+        _load(args.release_json),
+        _load(args.runs_json),
+        release_tag=args.release_tag,
+        tag_sha=args.tag_sha,
+        max_attempts=args.max_attempts,
+        max_age_hours=args.max_age_hours,
+    )
+    args.output.write_text(json.dumps(decision, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(decision["reason"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_desktop_beta_qualification_retry.py
+++ b/.github/scripts/test_desktop_beta_qualification_retry.py
@@ -13,14 +13,22 @@ from __future__ import annotations
 import copy
 import json
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import desktop_beta_qualification_retry as retry
 
 TAG = "v1.2.3+1234-macos"
 SHA = "a" * 40
-NOW_ISO = "2026-07-22T12:00:00Z"
-RECENT_ISO = "2026-07-22T11:30:00Z"
+
+
+def _utc_iso(dt: datetime) -> str:
+    return dt.replace(microsecond=0).astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+_NOW = datetime.now(timezone.utc)
+NOW_ISO = _utc_iso(_NOW)
+RECENT_ISO = _utc_iso(_NOW - timedelta(hours=1))
 
 
 def _release(*, tag: str = TAG, channel: str = "candidate", is_live: str = "false",
@@ -103,7 +111,7 @@ class RetryDecisionTests(unittest.TestCase):
     # --- age bound ---
 
     def test_candidate_too_old_denies(self):
-        old = "2026-07-01T00:00:00Z"
+        old = _utc_iso(_NOW - timedelta(hours=48))
         d = _decide(_release(published=old), [_run(conclusion="failure")], max_age_hours=24)
         self.assertFalse(d["should_retry"])
         self.assertIn("exceeds", d["reason"])
@@ -147,7 +155,10 @@ class RetryDecisionTests(unittest.TestCase):
         self.assertTrue(d["should_retry"])
 
     def test_second_failure_still_retries(self):
-        runs = [_run(conclusion="failure", run_id=1), _run(conclusion="failure", run_id=2, updated="2026-07-22T12:05:00Z")]
+        runs = [
+            _run(conclusion="failure", run_id=1),
+            _run(conclusion="failure", run_id=2, updated=_utc_iso(_NOW + timedelta(minutes=5))),
+        ]
         d = _decide(_release(), runs)
         self.assertTrue(d["should_retry"])
         self.assertEqual(d["attempts_so_far"], 2)
@@ -157,7 +168,7 @@ class RetryDecisionTests(unittest.TestCase):
 
     def test_at_max_attempts_denies(self):
         runs = [
-            _run(conclusion="failure", run_id=i, updated=f"2026-07-22T12:0{i}:00Z")
+            _run(conclusion="failure", run_id=i, updated=_utc_iso(_NOW + timedelta(minutes=i)))
             for i in (1, 2, 3)
         ]
         d = _decide(_release(), runs)
@@ -186,7 +197,7 @@ class RetryDecisionTests(unittest.TestCase):
     def test_newest_run_governs_in_progress_check(self):
         # Older failure present, but newest run is in_progress -> do not retry.
         runs = [
-            _run(conclusion="failure", run_id=1, updated="2026-07-22T11:00:00Z"),
+            _run(conclusion="failure", run_id=1, updated=_utc_iso(_NOW - timedelta(hours=1))),
             _run(status="in_progress", conclusion=None, run_id=2, updated=NOW_ISO),
         ]
         d = _decide(_release(), runs)
@@ -196,7 +207,7 @@ class RetryDecisionTests(unittest.TestCase):
     def test_success_after_failure_denies(self):
         # A later successful run supersedes an earlier failure.
         runs = [
-            _run(conclusion="failure", run_id=1, updated="2026-07-22T11:00:00Z"),
+            _run(conclusion="failure", run_id=1, updated=_utc_iso(_NOW - timedelta(hours=1))),
             _run(conclusion="success", run_id=2, updated=NOW_ISO),
         ]
         d = _decide(_release(), runs)

--- a/.github/scripts/test_desktop_beta_qualification_retry.py
+++ b/.github/scripts/test_desktop_beta_qualification_retry.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Fault tests for the bounded desktop Beta qualification retry decision.
+
+These exercise every safety property of the retry decision against fabricated
+server JSON: invalid candidate, age bound, no prior attempt, in-progress and
+successful runs, transient retry under the attempt bound, the deterministic
+loop guard at the bound, exact-SHA/tag binding, and non-retryable conclusions.
+"""
+
+# omi-test-quality: source-inspection -- the decision script is pure JSON logic.
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+
+import desktop_beta_qualification_retry as retry
+
+TAG = "v1.2.3+1234-macos"
+SHA = "a" * 40
+NOW_ISO = "2026-07-22T12:00:00Z"
+RECENT_ISO = "2026-07-22T11:30:00Z"
+
+
+def _release(*, tag: str = TAG, channel: str = "candidate", is_live: str = "false",
+             draft: bool = False, prerelease: bool = False, published: str = RECENT_ISO,
+             assets=retry.CANONICAL_ASSETS) -> dict:
+    body = (
+        "<!-- KEY_VALUE_START\n"
+        f"channel: {channel}\nisLive: {is_live}\n"
+        "<!-- KEY_VALUE_END -->"
+    )
+    return {
+        "tagName": tag,
+        "body": body,
+        "isDraft": draft,
+        "isPrerelease": prerelease,
+        "publishedAt": published,
+        "assets": [{"name": name} for name in assets],
+    }
+
+
+def _run(*, status="completed", conclusion="failure", branch=TAG, sha=SHA,
+         updated=NOW_ISO, run_id=1) -> dict:
+    return {
+        "id": run_id,
+        "status": status,
+        "conclusion": conclusion,
+        "event": "workflow_dispatch",
+        "path": retry.QUALIFICATION_WORKFLOW,
+        "head_branch": branch,
+        "head_sha": sha,
+        "name": "Qualify Desktop Beta Candidate",
+        "updated_at": updated,
+        "created_at": updated,
+    }
+
+
+def _decide(release, runs, **overrides):
+    kwargs = dict(release_tag=TAG, tag_sha=SHA, max_attempts=3, max_age_hours=24)
+    kwargs.update(overrides)
+    return retry.decide(release, runs, **kwargs)
+
+
+class RetryDecisionTests(unittest.TestCase):
+    # --- candidate validity (no retry) ---
+
+    def test_missing_release_denies(self):
+        d = _decide({}, [])
+        self.assertFalse(d["should_retry"])
+        self.assertIn("no published GitHub release", d["reason"])
+
+    def test_release_tag_mismatch_denies(self):
+        release = _release(tag="v9.9.9+9999-macos")
+        d = _decide(release, [])
+        self.assertFalse(d["should_retry"])
+        self.assertIn("does not match", d["reason"])
+
+    def test_draft_or_prerelease_denies(self):
+        for kw in ({"draft": True}, {"prerelease": True}):
+            with self.subTest(**kw):
+                d = _decide(_release(**kw), [_run(conclusion="failure")])
+                self.assertFalse(d["should_retry"])
+
+    def test_missing_canonical_asset_denies(self):
+        release = _release(assets=("Omi.zip", "omi.dmg"))  # no smoke result
+        d = _decide(release, [_run(conclusion="failure")])
+        self.assertFalse(d["should_retry"])
+        self.assertIn("missing canonical assets", d["reason"])
+
+    def test_promoted_candidate_denies(self):
+        # isLive:true means the candidate already advanced; never re-qualify.
+        d = _decide(_release(is_live="true"), [_run(conclusion="failure")])
+        self.assertFalse(d["should_retry"])
+        self.assertIn("isLive", d["reason"])
+
+    def test_wrong_channel_denies(self):
+        d = _decide(_release(channel="stable"), [_run(conclusion="failure")])
+        self.assertFalse(d["should_retry"])
+        self.assertIn("channel", d["reason"])
+
+    # --- age bound ---
+
+    def test_candidate_too_old_denies(self):
+        old = "2026-07-01T00:00:00Z"
+        d = _decide(_release(published=old), [_run(conclusion="failure")], max_age_hours=24)
+        self.assertFalse(d["should_retry"])
+        self.assertIn("exceeds", d["reason"])
+
+    # --- run state (never retry in-progress / successful / unattempted) ---
+
+    def test_no_prior_attempt_denies(self):
+        # The retry never owns the initial dispatch; Codemagic does.
+        d = _decide(_release(), [])
+        self.assertFalse(d["should_retry"])
+        self.assertIn("unattempted", d["reason"])
+
+    def test_in_progress_denies(self):
+        for status in ("in_progress", "queued", "waiting"):
+            with self.subTest(status=status):
+                d = _decide(_release(), [_run(status=status)])
+                self.assertFalse(d["should_retry"])
+                self.assertIn("in-progress", d["reason"])
+
+    def test_successful_run_denies(self):
+        d = _decide(_release(), [_run(conclusion="success")])
+        self.assertFalse(d["should_retry"])
+        self.assertIn("already succeeded", d["reason"])
+
+    def test_non_retryable_conclusion_denies(self):
+        for conclusion in ("neutral", "skipped", "action_required"):
+            with self.subTest(conclusion=conclusion):
+                d = _decide(_release(), [_run(conclusion=conclusion)])
+                self.assertFalse(d["should_retry"])
+
+    # --- transient retry under the bound ---
+
+    def test_failed_run_under_bound_retries(self):
+        d = _decide(_release(), [_run(conclusion="failure")])
+        self.assertTrue(d["should_retry"])
+        self.assertEqual(d["attempts_so_far"], 1)
+        self.assertIn("attempt 2 of 3", d["reason"])
+
+    def test_cancelled_run_retries(self):
+        d = _decide(_release(), [_run(conclusion="cancelled")])
+        self.assertTrue(d["should_retry"])
+
+    def test_second_failure_still_retries(self):
+        runs = [_run(conclusion="failure", run_id=1), _run(conclusion="failure", run_id=2, updated="2026-07-22T12:05:00Z")]
+        d = _decide(_release(), runs)
+        self.assertTrue(d["should_retry"])
+        self.assertEqual(d["attempts_so_far"], 2)
+        self.assertIn("attempt 3 of 3", d["reason"])
+
+    # --- deterministic / persistent loop guard ---
+
+    def test_at_max_attempts_denies(self):
+        runs = [
+            _run(conclusion="failure", run_id=i, updated=f"2026-07-22T12:0{i}:00Z")
+            for i in (1, 2, 3)
+        ]
+        d = _decide(_release(), runs)
+        self.assertFalse(d["should_retry"])
+        self.assertEqual(d["attempts_so_far"], 3)
+        self.assertIn("bound", d["reason"])
+
+    def test_custom_lower_bound_caps_earlier(self):
+        runs = [_run(conclusion="failure", run_id=1), _run(conclusion="failure", run_id=2)]
+        d = _decide(_release(), runs, max_attempts=2)
+        self.assertFalse(d["should_retry"])
+        self.assertIn("bound", d["reason"])
+
+    # --- exact tag + SHA binding (ignore other candidates' runs) ---
+
+    def test_runs_for_other_tags_are_ignored(self):
+        # A failed run for a different tag must not count toward this tag.
+        runs = [
+            _run(branch="v9.9.9+9999-macos", conclusion="failure", run_id=1),
+            _run(branch="v8.8.8+8888-macos", sha="b" * 40, conclusion="failure", run_id=2),
+        ]
+        d = _decide(_release(), runs)
+        self.assertFalse(d["should_retry"])
+        self.assertIn("unattempted", d["reason"])
+
+    def test_newest_run_governs_in_progress_check(self):
+        # Older failure present, but newest run is in_progress -> do not retry.
+        runs = [
+            _run(conclusion="failure", run_id=1, updated="2026-07-22T11:00:00Z"),
+            _run(status="in_progress", conclusion=None, run_id=2, updated=NOW_ISO),
+        ]
+        d = _decide(_release(), runs)
+        self.assertFalse(d["should_retry"])
+        self.assertIn("in-progress", d["reason"])
+
+    def test_success_after_failure_denies(self):
+        # A later successful run supersedes an earlier failure.
+        runs = [
+            _run(conclusion="failure", run_id=1, updated="2026-07-22T11:00:00Z"),
+            _run(conclusion="success", run_id=2, updated=NOW_ISO),
+        ]
+        d = _decide(_release(), runs)
+        self.assertFalse(d["should_retry"])
+        self.assertIn("already succeeded", d["reason"])
+
+    def test_non_workflow_dispatch_runs_ignored(self):
+        # Only workflow_dispatch qualification runs are authoritative.
+        run = _run()
+        run["event"] = "workflow_run"
+        d = _decide(_release(), [run])
+        self.assertFalse(d["should_retry"])
+
+    # --- never reaches promotion / stable ---
+
+    def test_decision_never_carries_promotion_authority(self):
+        d = _decide(_release(), [_run(conclusion="failure")])
+        self.assertTrue(d["should_retry"])
+        self.assertNotIn("promote-qualified", json.dumps(d))
+        self.assertNotIn("stable", json.dumps(d).lower())
+
+
+class CliOutputContractTests(unittest.TestCase):
+    """The CLI emits the decision file the workflow reads into GITHUB_OUTPUT."""
+
+    def test_decide_writes_json_with_should_retry(self):
+        import tempfile
+
+        script = Path(retry.__file__).resolve()
+        root = script.parent
+        release_path = root / "_tmp_retry_release.json"
+        runs_path = root / "_tmp_retry_runs.json"
+        out_path = root / "_tmp_retry_decision.json"
+        try:
+            release_path.write_text(json.dumps(_release()), encoding="utf-8")
+            runs_path.write_text(json.dumps([_run(conclusion="failure")]), encoding="utf-8")
+            import subprocess
+
+            result = subprocess.run(
+                ["python3", str(script), "decide",
+                 "--release-json", str(release_path),
+                 "--runs-json", str(runs_path),
+                 "--release-tag", TAG, "--tag-sha", SHA,
+                 "--output", str(out_path)],
+                check=True, text=True, capture_output=True,
+            )
+            decision = json.loads(out_path.read_text(encoding="utf-8"))
+            self.assertTrue(decision["should_retry"])
+            self.assertEqual(decision["release_tag"], TAG)
+            self.assertIn("retrying", result.stdout)
+        finally:
+            for p in (release_path, runs_path, out_path):
+                p.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/desktop_retry_beta_qualification.yml
+++ b/.github/workflows/desktop_retry_beta_qualification.yml
@@ -1,0 +1,120 @@
+name: Retry Failed Desktop Beta Qualification
+
+# Recover a *transient* failed/cancelled qualification of the newest immutable
+# published macOS candidate. This re-dispatches ONLY the trusted qualification
+# workflow; it never creates a build, never promotes, and never reaches Stable.
+# Promotion stays the single completed-success authority
+# (desktop_promote_beta.yml). The decision script re-derives the candidate and
+# run state from server data; on schedule the workflow supplies no tag, so no
+# caller claim is trusted.
+on:
+  schedule:
+    # Twice hourly, offset from the :17 candidate build, so a transient
+    # failed/cancelled qualification of the newest candidate recovers within
+    # ~30 minutes without racing the hourly planner.
+    - cron: '13,43 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  # A single retry planner; the per-tag qualification concurrency in
+  # desktop_qualify_beta.yml serializes the actual qualification runs.
+  group: desktop-beta-qualification-retry
+  cancel-in-progress: false
+
+jobs:
+  retry:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should_retry: ${{ steps.decide.outputs.should_retry }}
+      release_tag: ${{ steps.decide.outputs.release_tag }}
+      reason: ${{ steps.decide.outputs.reason }}
+    steps:
+      - name: Checkout retry controls
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Generate Omi Bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.OMI_BOT_APP_ID }}
+          private-key: ${{ secrets.OMI_BOT_PRIVATE_KEY }}
+
+      - name: Gather server-derived candidate and qualification state
+        id: gather
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/desktop-beta-retry
+          git fetch --force origin 'refs/tags/v*-macos:refs/tags/v*-macos'
+          LATEST_TAG=$(git for-each-ref --count=1 --sort=-v:refname \
+            --format='%(refname:strip=2)' 'refs/tags/v*-macos')
+          test -n "$LATEST_TAG"
+          TAG_SHA=$(git rev-list -n1 "$LATEST_TAG")
+          # Read-only production state: a release view plus the qualification
+          # run list. Transient API errors degrade to empty JSON, which the
+          # decision script turns into a safe "no" rather than a failed job.
+          gh release view "$LATEST_TAG" --repo "$REPO" \
+            --json tagName,body,isDraft,isPrerelease,publishedAt,assets \
+            > /tmp/desktop-beta-retry/release.json 2>/dev/null \
+            || echo '{}' > /tmp/desktop-beta-retry/release.json
+          gh api "repos/$REPO/actions/workflows/desktop_qualify_beta.yml/runs?event=workflow_dispatch&per_page=100" \
+            --jq '.workflow_runs' > /tmp/desktop-beta-retry/runs.json 2>/dev/null \
+            || echo '[]' > /tmp/desktop-beta-retry/runs.json
+          {
+            echo "latest_tag=$LATEST_TAG"
+            echo "tag_sha=$TAG_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Decide whether to retry the newest candidate
+        id: decide
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/desktop_beta_qualification_retry.py decide \
+            --release-json /tmp/desktop-beta-retry/release.json \
+            --runs-json /tmp/desktop-beta-retry/runs.json \
+            --release-tag "${{ steps.gather.outputs.latest_tag }}" \
+            --tag-sha "${{ steps.gather.outputs.tag_sha }}" \
+            --output /tmp/desktop-beta-retry/decision.json
+          python3 - <<'PY'
+          import json, os
+          decision = json.load(open('/tmp/desktop-beta-retry/decision.json'))
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              fh.write(f"should_retry={'true' if decision['should_retry'] else 'false'}\n")
+              for key in ('release_tag', 'reason'):
+                  fh.write(f"{key}={decision.get(key, '')}\n")
+          PY
+          {
+            echo '### Desktop Beta qualification retry'
+            echo
+            echo '```json'
+            cat /tmp/desktop-beta-retry/decision.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Re-dispatch trusted macOS qualification for the newest candidate
+        if: steps.decide.outputs.should_retry == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ steps.decide.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          # Per-tag GitHub concurrency and immutable qualification evidence own
+          # duplicate dispatches; this handoff only recovers a transient
+          # failed/cancelled qualification of the exact newest candidate.
+          # The Omi Bot app token (not the default GITHUB_TOKEN) is required:
+          # a run dispatched by GITHUB_TOKEN does not trigger the downstream
+          # workflow_run promotion in desktop_promote_beta.yml on success.
+          gh workflow run desktop_qualify_beta.yml --repo "$REPO" \
+            -f release_tag="$RELEASE_TAG" --ref "$RELEASE_TAG"
+          echo "Re-dispatched qualification for $RELEASE_TAG after a transient failed/cancelled run." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

Codemagic's qualification handoff already retries *dispatch I/O* (`for attempt in 1 2 3`), but nothing recovers a **transient failed or cancelled qualification outcome** on the newest candidate — it sits non-live until someone manually re-dispatches qualification. If there are no new releasable changes, the newest valid candidate can stay stranded indefinitely.

This adds a scheduled, fail-closed retry planner that re-dispatches the trusted macOS qualification workflow for the newest immutable published candidate, only after a transient failed/cancelled qualification.

## How

The retry decision lives entirely in a tested script (`.github/scripts/desktop_beta_qualification_retry.py`) that re-derives candidate identity and qualification state from **server JSON** — a `gh release view` and the qualification workflow run list. On schedule the workflow supplies **no tag**, so no caller claim is trusted.

The schedule runs twice hourly (`13,43 * * * *`), offset from the `:17` candidate build, so a transient failure recovers within ~30 min without racing the hourly planner.

### Safety properties (all enforced by the decision script)

- **Tag-bound and exact-SHA** — only the exact newest `v*-macos` tag at its exact SHA is retried.
- **Newest valid candidate only** — published, non-draft, non-prerelease, carrying the canonical three assets (`Omi.zip`, `omi.dmg`, `desktop-smoke-result.json`), `channel: candidate`, `isLive: false`.
- **Bounded candidate age** (24h) and **bounded attempts** (3 total).
- **Never retries an in-progress or already-successful run.**
- **Deterministic product failures can't loop forever** — the attempt bound is the loop guard. (We deliberately do not classify transient-vs-deterministic from logs: a failed qualification step can be either, and mis-classifying a transient failure as deterministic would strand the newest candidate. Bounded retries cannot loop.)
- **Re-dispatches qualification only.** Promotion stays the single completed-success authority (`desktop_promote_beta.yml`). No Stable reach, no new secrets/environments/IAM, production state read-only.

Dispatch uses the **Omi Bot app token** (not the default `GITHUB_TOKEN`) so the retried qualification's completion still triggers the `workflow_run` promotion — a `GITHUB_TOKEN`-dispatched run does not spawn downstream workflow runs.

## Tests

- `.github/scripts/test_desktop_beta_qualification_retry.py` — 22 fault tests covering every decision branch (invalid candidate, age bound, no prior attempt, in-progress/successful/non-retryable, transient retry under bound, the deterministic loop guard at the bound, exact tag+SHA binding, no promotion/stable authority).
- Registered as a `checks-manifest` lane (`desktop-beta-qualification-retry`).

## Verification

```
.github/scripts/test_desktop_beta_qualification_retry.py        → 22 tests OK
.github/scripts/test_desktop_release_flow_contract.py           → 13 tests OK
.github/scripts/check-release-process-guards.py                 → passed
YAML (workflow + manifest)                                      → valid
```

The one-path desktop release contract still passes unchanged — the retry adds no second promotion authority; it only re-enters the qualification step, which is per-tag serialized and idempotent via immutable evidence.

## Notes

- Backend unit tests (`test_desktop_release_scripts.py`, `test_qualified_beta_promotion.py`) reference only unmodified files (`desktop_promote_beta/prod.yml`, `desktop_qualify_beta.yml`, `codemagic.yaml`); they need `pytest` + the backend env which isn't in this checkout, and are unaffected by this change.
- If the Omi Bot app lacks the `Actions: write` repository permission, the dispatch step fails closed (candidate stays non-live — safe) and needs a one-time permission grant, not a new secret.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

