### PR TITLE
feat(release): add trusted-M1 pre-tag readiness gate

### DIFF
--- a/.github/scripts/verify-pre-tag-readiness.py
+++ b/.github/scripts/verify-pre-tag-readiness.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Verify trusted-M1 pre-tag readiness evidence before an immutable tag is created.
+
+The desktop auto-release tag job runs this against the readiness evidence
+artifact produced on the trusted self-hosted M1. It never trusts that the
+readiness *job* merely succeeded: it loads the evidence and proves it covers the
+EXACT source SHA the tag job is about to tag, that it ran offline, and that it
+carries no production-pointer authority.
+
+Readiness is deliberately distinct from signed-artifact qualification: this
+verifier accepts only readiness evidence and rejects qualification evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+KIND = "omi-desktop-pre-tag-readiness-v1"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+LANES = frozenset({"local", "ci"})
+REQUIRED_CHECKS = (
+    "source_resolved_from_origin",
+    "exact_sha_checkout_verified",
+    "swift_cache_prepared",
+    "self_check",
+    "offline_stack_ready",
+)
+# Readiness must never carry production authority; qualification/promotion own
+# those decisions separately.
+FORBIDDEN_FIELDS = frozenset(
+    {
+        "beta_pointer",
+        "stable_pointer",
+        "is_live",
+        "promoted",
+        "production",
+        "qualified_beta",
+        "qualifiedbeta",
+    }
+)
+
+
+class EvidenceError(ValueError):
+    """Pre-tag readiness evidence violates the fail-closed contract."""
+
+
+def _fail(message: str) -> None:
+    raise EvidenceError(message)
+
+
+def verify(evidence: object, expected_sha: str) -> dict:
+    if not isinstance(evidence, dict):
+        _fail("evidence must be a JSON object")
+    unexpected = sorted(evidence.keys() & FORBIDDEN_FIELDS)
+    if unexpected:
+        _fail(f"readiness evidence must not carry production/qualification fields: {', '.join(unexpected)}")
+    if evidence.get("kind") != KIND:
+        _fail(f"evidence kind must be {KIND!r}, got {evidence.get('kind')!r}")
+    if evidence.get("passed") is not True:
+        _fail(f"readiness did not pass: {evidence.get('passed')!r}")
+    source_sha = evidence.get("source_sha")
+    if not isinstance(source_sha, str) or not SHA_RE.fullmatch(source_sha):
+        _fail(f"evidence source_sha must be 40 lowercase hex, got {source_sha!r}")
+    # The load-bearing check: the evidence must cover the EXACT SHA about to be
+    # tagged. A stale or mismatched evidence record must never authorize a tag.
+    if source_sha != expected_sha:
+        _fail(f"evidence source_sha {source_sha!r} != tag source {expected_sha!r}")
+    provider_mode = evidence.get("provider_mode")
+    if provider_mode != "offline":
+        _fail(f"evidence provider_mode must be 'offline', got {provider_mode!r}")
+    lane = evidence.get("lane")
+    if lane not in LANES:
+        _fail(f"evidence lane must be one of {sorted(LANES)}, got {lane!r}")
+    checks = evidence.get("checks")
+    if not isinstance(checks, dict):
+        _fail("evidence checks must be an object")
+    missing = sorted(set(REQUIRED_CHECKS) - checks.keys())
+    if missing:
+        _fail(f"evidence missing required checks: {', '.join(missing)}")
+    failed = sorted(name for name in REQUIRED_CHECKS if checks.get(name) is not True)
+    if failed:
+        _fail(f"evidence has failed checks: {', '.join(failed)}")
+    return evidence
+
+
+def _self_test() -> int:
+    failures: list[str] = []
+
+    def ok(name: str) -> None:
+        print(f"ok: {name}")
+
+    def expect_fail(name: str, evidence: object, expected_sha: str, needle: str) -> None:
+        try:
+            verify(evidence, expected_sha)
+        except EvidenceError as exc:
+            if needle in str(exc):
+                ok(name)
+            else:
+                failures.append(f"{name}: expected {needle!r} in error, got {exc}")
+        else:
+            failures.append(f"{name}: expected EvidenceError, verify accepted bad evidence")
+
+    def expect_ok(name: str, evidence: object, expected_sha: str) -> None:
+        try:
+            verify(evidence, expected_sha)
+        except EvidenceError as exc:
+            failures.append(f"{name}: unexpected EvidenceError: {exc}")
+        else:
+            ok(name)
+
+    base = {
+        "kind": KIND,
+        "passed": True,
+        "source_sha": "a" * 40,
+        "lane": "ci",
+        "provider_mode": "offline",
+        "checks": {name: True for name in REQUIRED_CHECKS},
+    }
+
+    expect_ok("valid evidence passes", dict(base), "a" * 40)
+    expect_ok("local lane accepted", {**base, "lane": "local"}, "a" * 40)
+
+    expect_fail("wrong kind", {**base, "kind": "qualification-evidence-v1"}, "a" * 40, "kind")
+    expect_fail("passed false", {**base, "passed": False}, "a" * 40, "did not pass")
+    expect_fail("sha mismatch — the load-bearing check", base, "b" * 40, "!=")
+    expect_fail("malformed sha", {**base, "source_sha": "deadbeef"}, "deadbeef", "40 lowercase hex")
+    expect_fail("non-offline provider", {**base, "provider_mode": "production"}, "a" * 40, "offline")
+    expect_fail("bad lane", {**base, "lane": "staging"}, "a" * 40, "lane")
+    expect_fail("missing check", {**base, "checks": {n: True for n in REQUIRED_CHECKS if n != "self_check"}}, "a" * 40, "missing")
+    expect_fail("failed check", {**base, "checks": {**base["checks"], "self_check": False}}, "a" * 40, "failed")
+    expect_fail("forbidden production field", {**base, "is_live": True}, "a" * 40, "production/qualification")
+    expect_fail("forbidden qualification field", {**base, "qualified_beta": True}, "a" * 40, "production/qualification")
+    expect_fail("not an object", ["nope"], "a" * 40, "JSON object")
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}", file=sys.stderr)
+        print(f"\n{len(failures)} self-test failure(s)", file=sys.stderr)
+        return 1
+    print("verify-pre-tag-readiness self-test passed")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    verify_parser = sub.add_parser("verify", help="Verify readiness evidence against an exact source SHA")
+    verify_parser.add_argument("--evidence", required=True)
+    verify_parser.add_argument("--source-sha", required=True)
+    sub.add_parser("self-test", help="Run built-in fixture tests")
+    args = parser.parse_args(argv)
+    if args.command == "self-test":
+        return _self_test()
+    evidence = json.loads(Path(args.evidence).read_text(encoding="utf-8"))
+    verify(evidence, args.source_sha)
+    print(f"pre-tag readiness evidence verified for {args.source_sha}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -44,8 +44,54 @@ jobs:
       - name: Show release plan
         run: echo "${{ steps.plan.outputs.reason }}"
 
-  tag-release:
+  pre-tag-readiness:
     needs: [plan-release]
+    if: needs.plan-release.outputs.should_release == 'true'
+    # Trusted self-hosted M1 — the same runner qualification uses. The runner's
+    # single-job capacity plus the dev-harness ownership sentinel serialize use
+    # with in-flight qualification; no prod environment or pointer secrets here.
+    runs-on: [self-hosted, macos, omi-desktop-qualification]
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    concurrency:
+      group: desktop-pre-tag-readiness
+      cancel-in-progress: false
+    steps:
+      - name: Fail-closed dispatch boundary
+        run: |
+          set -euo pipefail
+          # Readiness only: contents:read, no prod environment, no release or
+          # Beta/Stable pointer authority, no new secrets/environments/IAM. The
+          # gate validates source + an OFFLINE stack and must never mutate prod.
+          test -n "${{ needs.plan-release.outputs.source_sha }}"
+
+      - name: Checkout exact source (persisted actions/checkout lifecycle)
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.plan-release.outputs.source_sha }}
+          fetch-depth: 0
+
+      - name: Run trusted-M1 pre-tag readiness gate
+        env:
+          SOURCE_SHA: ${{ needs.plan-release.outputs.source_sha }}
+          OMI_READINESS_LANE: ci
+        run: |
+          set -euo pipefail
+          desktop/macos/scripts/pre-tag-readiness.sh \
+            --evidence /tmp/pre-tag-readiness-evidence.json \
+            "$SOURCE_SHA"
+
+      - name: Upload readiness evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: desktop-pre-tag-readiness-evidence
+          path: /tmp/pre-tag-readiness-evidence.json
+          if-no-files-found: warn
+
+  tag-release:
+    needs: [plan-release, pre-tag-readiness]
     if: needs.plan-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     concurrency:
@@ -76,6 +122,26 @@ jobs:
 
           python3 .github/scripts/plan-desktop-release.py \
             --repository "${{ github.repository }}"
+
+      - name: Download pre-tag readiness evidence
+        if: steps.recheck.outputs.should_release == 'true'
+        uses: actions/download-artifact@v7
+        with:
+          name: desktop-pre-tag-readiness-evidence
+          path: /tmp/pre-tag-readiness
+
+      - name: Verify readiness evidence covers the exact source
+        if: steps.recheck.outputs.should_release == 'true'
+        run: |
+          set -euo pipefail
+          # Never trust caller claims: prove the trusted-M1 evidence covers the
+          # EXACT source SHA about to be tagged, ran offline, and carries no
+          # production authority. Mismatch aborts before the immutable tag.
+          EVIDENCE="$(find /tmp/pre-tag-readiness -name 'pre-tag-readiness-evidence.json' | head -1)"
+          test -n "$EVIDENCE" || { echo "no readiness evidence artifact found" >&2; exit 1; }
+          python3 .github/scripts/verify-pre-tag-readiness.py verify \
+            --evidence "$EVIDENCE" \
+            --source-sha "${{ steps.recheck.outputs.source_sha }}"
 
       - name: Checkout exact releasable desktop source
         if: steps.recheck.outputs.should_release == 'true'

--- a/desktop/macos/changelog/unreleased/20260722-pre-tag-readiness-gate.json
+++ b/desktop/macos/changelog/unreleased/20260722-pre-tag-readiness-gate.json
@@ -1,0 +1,3 @@
+{
+  "change": "Beta nightly tags now pass a fail-closed trusted-M1 pre-tag readiness gate (exact-source checkout, Swift cache prep, offline backend stack) before the immutable tag is created, so checkout and Firebase readiness failures surface before signed publication rather than after."
+}

--- a/desktop/macos/scripts/desktop-core-harness.sh
+++ b/desktop/macos/scripts/desktop-core-harness.sh
@@ -7,6 +7,7 @@
 #   ./scripts/desktop-core-harness.sh --tier 0
 #   ./scripts/desktop-core-harness.sh --tier 1 --bundle omi-core-e2e
 #   ./scripts/desktop-core-harness.sh --tier 2 --bundle omi-core-e2e --keep-stack
+#   ./scripts/desktop-core-harness.sh --readiness
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -20,6 +21,7 @@ FAULT_SUITE=0
 FAULT_BUNDLE="omi-fault"
 KEEP_STACK=0
 SELF_CHECK=0
+READINESS=0
 SKIP_BACKEND_CONTRACTS=0
 PORT="${OMI_AUTOMATION_PORT:-47777}"
 DEV_STACK_PROVIDER_MODE=""
@@ -29,12 +31,13 @@ usage() {
 Desktop core E2E harness.
 
 Options:
-  --tier N                    Run tier N checks (0-3). Required unless --self-check.
+  --tier N                    Run tier N checks (0-3). Required unless --self-check or --readiness.
   --bundle NAME               Named test bundle for T1+ (default: omi-core-e2e)
   --port PORT                 Automation bridge port (default: OMI_AUTOMATION_PORT or 47777)
   --keep-stack                On T2+, leave dev-up running after the run
   --fault-suite               Start omi-fault-inject + omi-fault bundle; run chat-fault-5xx flow
   --self-check                Static checks (flow lint + gauntlet self-check; backend contracts locally)
+  --readiness                 Pre-tag readiness: self-check + offline dev-stack probe (no app launch, no E2E flows)
   --skip-backend-contracts    With --self-check, skip backend preflight + pytest contracts (CI desktop gate)
   --help                      Show this help
 USAGE
@@ -62,6 +65,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     --self-check)
       SELF_CHECK=1
+      ;;
+    --readiness)
+      READINESS=1
       ;;
     --skip-backend-contracts)
       SKIP_BACKEND_CONTRACTS=1
@@ -96,6 +102,7 @@ finalize_run() {
   local flows_json="$6"
   python3 - "$run_dir/manifest.json" "$passed" "$tier_value" "$started_at" "$duration_s" "$flows_json" "$BUNDLE" "$(git_sha)" "$DEV_STACK_PROVIDER_MODE" <<'PY'
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -111,6 +118,9 @@ manifest = {
 }
 if provider_mode:
     manifest["provider_mode"] = provider_mode
+lane = os.environ.get("OMI_READINESS_LANE")
+if lane:
+    manifest["lane"] = lane
 Path(path).write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 PY
   if [[ "$passed" == "true" ]]; then
@@ -183,7 +193,7 @@ refuse_prod_bundle() {
 }
 
 maybe_teardown_dev_stack() {
-  if [[ "$KEEP_STACK" -eq 0 && "${TIER:-0}" -ge 2 ]]; then
+  if [[ "$KEEP_STACK" -eq 0 && ( "${TIER:-0}" -ge 2 || "${READINESS:-0}" -eq 1 ) ]]; then
     make -C "$REPO_ROOT" dev-down >/dev/null 2>&1 || true
   fi
 }
@@ -667,9 +677,31 @@ if [[ "$FAULT_SUITE" -eq 1 ]]; then
   echo "desktop-core-harness fault-suite failed (evidence: $RUN_DIR)" >&2
   exit 1
 fi
+if [[ "$READINESS" -eq 1 ]]; then
+  # Pre-tag readiness gate: validate the exact desktop source + bounded offline
+  # dev stack on the trusted self-hosted M1 BEFORE an immutable tag is created.
+  # Distinct from post-tag qualification: no app launch, no E2E flows, no signed
+  # artifacts. provider_mode=offline is enforced by ensure_dev_stack (no prod).
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "desktop-core-harness: --readiness requires macOS (trusted self-hosted M1)" >&2
+    exit 1
+  fi
+  RUN_DIR="$HARNESS_ROOT/$(run_id)-readiness"
+  mkdir -p "$RUN_DIR"
+  STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  START_SEC=$(date +%s)
+  FLOW_RESULTS="[]"
+  run_self_check
+  ensure_dev_stack
+  maybe_teardown_dev_stack
+  DURATION=$(( $(date +%s) - START_SEC ))
+  finalize_run "$RUN_DIR" true "readiness" "$STARTED_AT" "$DURATION" "$FLOW_RESULTS"
+  echo "desktop-core-harness readiness passed (evidence: $RUN_DIR)"
+  exit 0
+fi
 
 if [[ -z "$TIER" ]]; then
-  echo "--tier is required unless --self-check or --fault-suite" >&2
+  echo "--tier is required unless --self-check, --readiness, or --fault-suite" >&2
   usage >&2
   exit 2
 fi

--- a/desktop/macos/scripts/pre-tag-readiness.sh
+++ b/desktop/macos/scripts/pre-tag-readiness.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Fail-closed trusted-M1 pre-tag readiness gate.
+#
+# Validates the EXACT planned desktop release source on the trusted self-hosted
+# M1 BEFORE an immutable version tag is created. This is readiness, not
+# qualification: it checks the source + bounded OFFLINE backend stack only — no
+# app launch, no E2E flows, no signed artifacts, no Beta/Stable pointer
+# authority, no production interaction, no new secrets/environments/IAM.
+#
+# It never trusts caller claims about the source:
+#   - the requested SHA is independently resolved and reachability-checked
+#     against origin/main;
+#   - the exact-SHA persistent checkout (from qualification-swift-cache) is
+#     re-verified to HEAD == requested SHA;
+#   - the harness readiness manifest is re-checked for passed + provider_mode
+#     offline + git_sha == requested SHA;
+#   - passed evidence is emitted only after every bounded check succeeds.
+#
+# The tag-creation job consumes the emitted evidence and re-verifies it against
+# the SHA it is about to tag (verify-pre-tag-readiness.py), so a tag is never
+# created on caller-asserted success.
+#
+# Usage:
+#   pre-tag-readiness.sh [--keep-stack] [--evidence PATH] [--source-repository PATH] <source-sha>
+#
+# OMI_READINESS_LANE selects the manifest lane recorded in evidence (default:
+# local; the CI workflow sets ci).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DESKTOP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$DESKTOP_DIR/../.." && pwd)"
+
+KEEP_STACK=0
+EVIDENCE=""
+SOURCE_REPOSITORY="$REPO_ROOT"
+SOURCE_SHA=""
+LANE="${OMI_READINESS_LANE:-local}"
+SHA_RE='^[0-9a-f]{40}$'
+
+usage() {
+  cat <<'USAGE'
+Fail-closed trusted-M1 pre-tag readiness gate.
+
+Usage:
+  pre-tag-readiness.sh [--keep-stack] [--evidence PATH] \
+    [--source-repository PATH] <source-sha>
+
+Options:
+  --keep-stack               Leave the offline dev-harness stack running on exit
+  --evidence PATH            Write readiness evidence JSON to PATH (default stdout)
+  --source-repository PATH   Git repo to resolve/clone the exact source from
+                             (default: this checkout)
+  <source-sha>               40-hex source commit to validate (must be on origin/main)
+
+Environment:
+  OMI_READINESS_LANE         Manifest lane recorded in evidence (local|ci)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep-stack)
+      KEEP_STACK=1
+      shift
+      ;;
+    --evidence)
+      [[ $# -ge 2 && -n "${2:-}" && "${2:-}" != -* ]] || { echo "--evidence requires a path" >&2; exit 2; }
+      EVIDENCE="$2"
+      shift 2
+      ;;
+    --source-repository)
+      [[ $# -ge 2 && -n "${2:-}" && "${2:-}" != -* ]] || { echo "--source-repository requires a path" >&2; exit 2; }
+      SOURCE_REPOSITORY="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "$SOURCE_SHA" ]]; then
+        echo "unexpected extra argument: $1" >&2
+        usage >&2
+        exit 2
+      fi
+      SOURCE_SHA="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$SOURCE_SHA" ]]; then
+  echo "pre-tag-readiness: <source-sha> is required" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "pre-tag-readiness: requires macOS (trusted self-hosted M1)" >&2
+  exit 1
+fi
+
+if ! [[ "$SOURCE_SHA" =~ $SHA_RE ]]; then
+  echo "pre-tag-readiness: source-sha must be 40 lowercase hex: $SOURCE_SHA" >&2
+  exit 1
+fi
+
+git -C "$SOURCE_REPOSITORY" rev-parse --git-dir >/dev/null 2>&1 || {
+  echo "pre-tag-readiness: --source-repository is not a git repo: $SOURCE_REPOSITORY" >&2
+  exit 1
+}
+
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+START_SEC=$(date +%s)
+GATE_OK=0
+HARNESS_EVIDENCE=""
+
+# Deterministic fail-closed evidence. On any abort (set -e) the EXIT trap still
+# emits passed=false evidence so the tag job and operators get structured
+# diagnostics instead of a bare exit code.
+emit_evidence() {
+  local passed="$1"
+  local duration_s="$2"
+  local err="${3:-}"
+  python3 - "$EVIDENCE" "$passed" "$SOURCE_SHA" "$LANE" "$duration_s" "$STARTED_AT" "$HARNESS_EVIDENCE" "$err" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+out_path, passed, source_sha, lane, duration_s, started_at, harness_ev, err = sys.argv[1:9]
+evidence = {
+    "kind": "omi-desktop-pre-tag-readiness-v1",
+    "passed": passed == "true",
+    "source_sha": source_sha,
+    "lane": lane,
+    "provider_mode": "offline" if passed == "true" else None,
+    "started_at": started_at,
+    "duration_s": float(duration_s) if duration_s.isdigit() else 0.0,
+    "checks": {
+        "source_resolved_from_origin": passed == "true",
+        "exact_sha_checkout_verified": passed == "true",
+        "swift_cache_prepared": passed == "true",
+        "self_check": passed == "true",
+        "offline_stack_ready": passed == "true",
+    },
+    "harness_evidence": harness_ev or None,
+}
+if err:
+    evidence["error"] = err
+if out_path:
+    Path(out_path).write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+else:
+    print(json.dumps(evidence, indent=2, sort_keys=True))
+PY
+}
+
+on_abort() {
+  local rc=$?
+  if [[ "$GATE_OK" -eq 0 ]]; then
+    local duration_s=$(( $(date +%s) - START_SEC ))
+    emit_evidence false "$duration_s" "pre-tag-readiness aborted before completing all checks (rc=$rc)"
+  fi
+}
+trap on_abort EXIT
+
+# 1. Independently resolve the requested SHA from origin and confirm it is on
+#    main. Never trust the caller's claim that this is the planned source.
+git -C "$SOURCE_REPOSITORY" fetch --quiet --force origin main
+git -C "$SOURCE_REPOSITORY" rev-parse --verify --quiet "${SOURCE_SHA}^{commit}" >/dev/null || {
+  echo "pre-tag-readiness: source SHA $SOURCE_SHA does not resolve to a commit in $SOURCE_REPOSITORY" >&2
+  exit 1
+}
+git -C "$SOURCE_REPOSITORY" merge-base --is-ancestor "$SOURCE_SHA" origin/main || {
+  echo "pre-tag-readiness: source SHA $SOURCE_SHA is not reachable from origin/main" >&2
+  exit 1
+}
+
+# 2. Prepare the exact-SHA Swift cache + persistent exact-source checkout. This
+#    exercises the persisted checkout lifecycle (clean clone + detach + clean)
+#    outside the Actions checkout and validates Package.swift/Package.resolved.
+WORKTREE="$(bash "$SCRIPT_DIR/qualification-swift-cache.sh" prepare "$SOURCE_SHA" "$SOURCE_REPOSITORY")"
+
+# 3. Re-verify the persistent checkout HEAD matches the requested SHA exactly.
+CHECKOUT_SHA="$(git -C "$WORKTREE" rev-parse HEAD)"
+if [[ "$CHECKOUT_SHA" != "$SOURCE_SHA" ]]; then
+  echo "pre-tag-readiness: persistent checkout HEAD $CHECKOUT_SHA != requested $SOURCE_SHA" >&2
+  exit 1
+fi
+
+# 4. Run source + offline-stack readiness in the exact-source checkout. The
+#    harness enforces provider_mode=offline (no production interaction) and
+#    probes Firebase Auth/Firestore, Redis, Typesense, backend and Rust desktop
+#    backend. Fails closed on any check.
+KEEP_FLAG=()
+[[ "$KEEP_STACK" -eq 1 ]] && KEEP_FLAG=(--keep-stack)
+(
+  cd "$WORKTREE/desktop/macos"
+  OMI_READINESS_LANE="$LANE" ./scripts/desktop-core-harness.sh --readiness "${KEEP_FLAG[@]}"
+)
+
+# 5. Locate and validate the harness readiness manifest. Re-check passed,
+#    provider_mode and git_sha against the requested source — the tag job will
+#    do this again, but the gate never emits success it did not observe.
+HARNESS_ROOT="$WORKTREE/desktop/macos/.harness/desktop-core"
+HARNESS_DIR="$(ls -td "$HARNESS_ROOT"/*-readiness 2>/dev/null | head -1)"
+if [[ -z "$HARNESS_DIR" || ! -f "$HARNESS_DIR/manifest.json" ]]; then
+  echo "pre-tag-readiness: no readiness manifest produced under $HARNESS_ROOT" >&2
+  exit 1
+fi
+HARNESS_EVIDENCE="$HARNESS_DIR/manifest.json"
+
+python3 - "$HARNESS_EVIDENCE" "$SOURCE_SHA" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path, requested_sha = sys.argv[1], sys.argv[2]
+m = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+if m.get("tier") != "readiness":
+    raise SystemExit(f"readiness manifest tier must be 'readiness', got {m.get('tier')!r}")
+if m.get("passed") is not True:
+    raise SystemExit(f"readiness manifest did not pass: {m.get('passed')!r}")
+if m.get("provider_mode") != "offline":
+    raise SystemExit(f"readiness manifest provider_mode must be 'offline', got {m.get('provider_mode')!r}")
+if m.get("git_sha") != requested_sha:
+    raise SystemExit(f"readiness manifest git_sha {m.get('git_sha')!r} != requested {requested_sha!r}")
+PY
+
+DURATION=$(( $(date +%s) - START_SEC ))
+GATE_OK=1
+trap - EXIT
+emit_evidence true "$DURATION"
+echo "pre-tag-readiness: passed for $SOURCE_SHA (lane=$LANE, evidence: ${EVIDENCE:-stdout})" >&2


### PR DESCRIPTION
## Summary

Adds a **fail-closed trusted-M1 pre-tag readiness gate** so the exact planned desktop release source is validated on the trusted self-hosted M1 *before* the immutable version tag is created. Closes the gap that let **v0.12.107** embed a checkout workflow bug and only catch Firebase readiness failure *after* signed publication.

## Problem

Today the flow is `plan-release` (ubuntu) → `tag-release` (ubuntu, creates immutable tag) → Codemagic (build/sign) → qualification (trusted M1). Source validation on the trusted M1 happens only in qualification, **after** the tag is signed and published. The planner's required source checks run on ubuntu CI, so they cannot catch M1/trusted-runner-specific checkout-lifecycle, Swift-cache, or offline-backend-stack failures.

## Change

New flow: `plan-release` → **`pre-tag-readiness`** (trusted M1) → `tag-release`.

The tag job **never trusts caller claims** — it downloads the readiness evidence artifact and proves it covers the *exact* SHA it is about to tag, ran offline, and carries no production/qualification authority. Any mismatch aborts before the immutable tag.

| File | Change |
|---|---|
| `desktop/macos/scripts/desktop-core-harness.sh` | New `--readiness` mode: composes existing `run_self_check` + `ensure_dev_stack` (offline-enforced Firebase Auth/Firestore, Redis, Typesense, backend, Rust desktop backend) + deterministic teardown. Adds `OMI_READINESS_LANE` (local\|ci) manifest field. |
| `desktop/macos/scripts/pre-tag-readiness.sh` *(new)* | Fail-closed gate. Independently resolves the SHA from `origin/main`, prepares the exact-SHA Swift cache + persistent checkout (`qualification-swift-cache.sh`), re-verifies checkout HEAD, runs `--readiness`, validates the manifest, emits structured evidence. |
| `.github/scripts/verify-pre-tag-readiness.py` *(new)* | Tag-side verifier (with self-test) — the load-bearing exact-SHA + offline + no-prod-authority check. |
| `.github/workflows/desktop_auto_release.yml` | `pre-tag-readiness` job on `[self-hosted, macos, omi-desktop-qualification]` + tag-job evidence verification step. |

## Constraints honored

- **Fail-closed**: any check failure aborts; tag creation requires completed-success exact-source evidence.
- **Never trusts caller claims**: SHA independently resolved from origin + re-verified at checkout + re-verified against the manifest + re-verified by the tag job against the exact SHA it's about to tag.
- **Persisted actions/checkout lifecycle incl. post cleanup**: the CI job's own `actions/checkout@v7` on the exact source exercises setup + post-cleanup; the gate additionally validates the independent exact-SHA persistent checkout (clean clone + detach + clean).
- **Bounded offline readiness**: `provider_mode=offline` enforced by `ensure_dev_stack` — Firebase Auth/Firestore emulator, Redis, Typesense, backend, Rust desktop backend. No production app interaction.
- **Deterministic cleanup**: stack torn down via `make dev-down` unless `--keep-stack`.
- **No Beta/Stable pointer authority, no new secrets/environments/IAM**: job uses `contents: read` only, no prod environment, no release/pointer secrets. Reuses the existing offline dev-harness.
- **Readiness ≠ qualification**: signed-artifact qualification (`desktop_qualify_beta.yml` / `qualify-desktop-beta.sh`) is untouched and remains the post-tag authority.

## Verification

- `verify-pre-tag-readiness.py self-test` — 13 fixtures pass (valid evidence, wrong kind, passed=false, **SHA mismatch**, malformed SHA, non-offline provider, bad lane, missing/failed checks, forbidden production/qualification fields, non-object).
- Evidence round-trip: matching SHA verifies (rc 0), mismatched SHA aborts (rc 1).
- `bash -n` clean on both shell scripts; workflow YAML parses with correct DAG (`plan-release → pre-tag-readiness → tag-release`).
- Harness function definitions precede the `--readiness` dispatch branch; `--help` lists the new mode.

Note: the gate runs only on a release candidate (planner `should_release == true`), so it adds a trusted-M1 job to the hourly cron only when there is something to release. Full M1 execution is exercised by the workflow on the trusted runner, not in this PR's CI.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

