### PR TITLE
ci: bound and retire obsolete Swift PR runs

### DIFF
--- a/.github/scripts/test_desktop_swift_ci_contract.py
+++ b/.github/scripts/test_desktop_swift_ci_contract.py
@@ -99,6 +99,22 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
         release_job = self.jobs["desktop-swift-release-compile"]
         self.assertIn("fetch-depth: 1", release_job)
 
+    def test_macos_jobs_have_a_bounded_runner_budget(self):
+        """A stuck Swift invocation must not consume hosted macOS capacity forever."""
+        for job_id in MACOS_JOBS:
+            with self.subTest(job=job_id):
+                self.assertIn("timeout-minutes: 60", self.jobs[job_id])
+
+    def test_closed_prs_release_the_same_pr_concurrency_group_without_allocating_a_runner(self):
+        """A close event supersedes its PR run before any macOS job can start."""
+        workflow = _workflow_text()
+        changes = self.jobs["changes"]
+
+        self.assertRegex(workflow, r"types:\s*\[[^]]*closed[^]]*\]")
+        self.assertIn("github.event.pull_request.number || github.sha", workflow)
+        self.assertIn("cancel-in-progress: ${{ github.event_name == 'pull_request' }}", workflow)
+        self.assertIn("github.event.action != 'closed'", changes)
+
     def test_notification_boundary_runs_targeted_release_regression(self):
         changes = self.jobs["changes"]
         job = self.jobs["desktop-swift-tests"]

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -5,6 +5,7 @@ on:
     branches: main
   pull_request:
     branches: main
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   # Supersede stale revisions of the same PR, but never let a later main push
@@ -15,6 +16,7 @@ concurrency:
 jobs:
   changes:
     name: Detect Desktop Swift Changes
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     outputs:
       diff_base: ${{ steps.changed.outputs.diff_base }}
@@ -107,6 +109,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: macos-15
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -148,6 +151,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: macos-15
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -231,6 +235,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should_release_compile == 'true'
     runs-on: macos-15
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

- trigger the existing per-PR `Desktop Swift CI` concurrency group when a PR closes, so GitHub cancels that PR's queued/running macOS work without a second workflow, token, or runner allocation
- skip all jobs on the close-triggered run; `main` evidence remains in its distinct SHA-scoped group
- cap every macOS Swift job at 60 minutes so a wedged toolchain/test invocation cannot hold hosted capacity indefinitely
- pin both properties in the existing Desktop Swift CI contract test

## Why this is deliberately small

The existing workflow already scopes PR concurrency by PR number and uses `cancel-in-progress` for pull-request events. It did not subscribe to `pull_request.closed`, so merged/closed PR runs could keep consuming limited GitHub-hosted macOS capacity. Adding `closed` lets that existing concurrency mechanism retire precisely the obsolete PR run. No global lock is introduced, so unrelated current PRs keep their own independent CI lanes; `main` remains SHA-scoped for the release source gate.

## Validation

- `python3 .github/scripts/test_desktop_swift_ci_contract.py` — 20 passed
- `actionlint .github/workflows/desktop-swift-ci.yml` — passed
- `git diff --check` — passed
- `make preflight` — pending below

## Not exercised locally

GitHub Actions scheduler behavior cannot be exercised locally. The contract test verifies the required close event, preserves the existing PR-number/SHA concurrency partition, requires `cancel-in-progress` for PR events, and proves the close event skips all jobs. CI will exercise the workflow syntax and normal PR path.

## Out of scope

- buying/provisioning more macOS capacity or changing the privileged qualification runner trust boundary
- global concurrency, which would replace valid queued PR work rather than eliminate only obsolete work
- per-suite timeout diagnostics/artifact collection; this PR first establishes a bounded failure mode


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

