### PR TITLE
feat(backend): windows.omi.me download landing pages with channel fallback

### DIFF
--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -6,7 +6,7 @@ import logging
 import os
 import random
 import re
-from typing import Any, Optional, List, Dict, Literal
+from typing import Any, Optional, List, Dict, Literal, Tuple
 from xml.sax.saxutils import escape as xml_escape
 
 from fastapi import APIRouter, HTTPException, Header, Query
@@ -501,10 +501,24 @@ async def _get_live_desktop_releases(platform: str) -> List[Dict]:
     return resolved
 
 
-def _download_landing_html(dmg_url: str, channel: str = "stable", version: str = "", platform: str = "macos") -> str:
+def _pick_installer_entry(desktop_releases: List[Dict], platform: str, channel: str) -> Optional[Tuple[Dict, str]]:
+    """Newest entry in one channel that carries a resolvable installer asset."""
+    for entry in desktop_releases:
+        if entry["channel"] != channel:
+            continue
+        installer_url = _get_installer_download_url(entry["release"], platform)
+        if installer_url:
+            return entry, installer_url
+    return None
+
+
+def _download_landing_html(
+    dmg_url: str, channel: str = "stable", version: str = "", platform: str = "macos", notice: str = ""
+) -> str:
     """Generate an HTML landing page that auto-triggers the installer download."""
     channel_label = "Beta " if channel == "beta" else ""
     version_display = f"v{version}" if version else ""
+    notice_html = f'<p class="notice">{notice}</p>' if notice else ""
     os_name = "Windows" if platform == "windows" else "macOS"
     if platform == "windows":
         install_steps = (
@@ -542,6 +556,7 @@ def _download_landing_html(dmg_url: str, channel: str = "stable", version: str =
         .done .checkmark {{ display: block; }}
         .done .subtitle {{ color: #4ade80; }}
         @keyframes spin {{ to {{ transform: rotate(360deg); }} }}
+        .notice {{ color: #fbbf24; font-size: 14px; margin-bottom: 24px; }}
         .download-link {{ color: #6C8FFF; text-decoration: none; font-size: 15px; }}
         .download-link:hover {{ text-decoration: underline; }}
         .video-container {{ margin-top: 32px; border-radius: 12px; overflow: hidden;
@@ -560,6 +575,7 @@ def _download_landing_html(dmg_url: str, channel: str = "stable", version: str =
     <div class="container">
         <h1>Downloading Omi {channel_label}for {os_name}</h1>
         <p class="version">{version_display}</p>
+        {notice_html}
         <p class="subtitle" id="status-text">Your download should start automatically&hellip;</p>
         <div class="status" id="status-icon">
             <div class="spinner"></div>
@@ -790,27 +806,24 @@ async def download_latest_desktop_release(
     channel: str = Query(default="stable", pattern="^(beta|stable)$"),
 ):
     """
-    Redirect to the latest desktop release DMG installer.
+    Serve the latest desktop release installer as an auto-download landing page.
     Both channels resolve only from their explicit channel pointer or the same
-    channel in the legacy release metadata.
+    channel in the legacy release metadata; the requested channel is strict
+    (404 when empty — QA/tooling contract).
     Defaults to stable channel (for macos.omi.me). Use channel=beta for QA.
     """
     desktop_releases = await _get_live_desktop_releases(platform)
     if not desktop_releases:
         raise HTTPException(status_code=404, detail=f"No live desktop releases found for platform: {platform}")
 
-    # Find latest release matching the requested channel
-    for entry in desktop_releases:
-        if entry["channel"] != channel:
-            continue
-        installer_url = _get_installer_download_url(entry["release"], platform)
-        if installer_url:
-            version = entry["version_info"]["version"]
-            return HTMLResponse(
-                content=_download_landing_html(installer_url, channel=channel, version=version, platform=platform)
-            )
-
-    raise HTTPException(status_code=404, detail=f"No installer found for platform {platform}, channel: {channel}")
+    picked = _pick_installer_entry(desktop_releases, platform, channel)
+    if picked is None:
+        raise HTTPException(status_code=404, detail=f"No installer found for platform {platform}, channel: {channel}")
+    entry, installer_url = picked
+    version = entry["version_info"]["version"]
+    return HTMLResponse(
+        content=_download_landing_html(installer_url, channel=channel, version=version, platform=platform)
+    )
 
 
 @router.get("/v2/desktop/download/beta")
@@ -818,8 +831,10 @@ async def download_beta_desktop_release(
     platform: str = Query(default="macos", pattern="^(macos|windows|linux)$"),
 ):
     """
-    Redirect to the latest beta desktop release DMG installer.
-    Convenience endpoint for macos.omi.me/beta (URL map can't add query params).
+    Serve the latest beta release as an auto-download landing page.
+    Legacy convenience route: macos.omi.me/beta now redirects straight to
+    /v2/desktop/download/latest?channel=beta (URL-map urlRedirect.pathRedirect
+    does carry query params); kept for old shared links.
     """
     return await download_latest_desktop_release(platform=platform, channel="beta")
 
@@ -829,10 +844,53 @@ async def download_windows_desktop_release(
     channel: str = Query(default="stable", pattern="^(beta|stable)$"),
 ):
     """
-    Redirect to the latest Windows desktop release installer.
-    Convenience endpoint for windows.omi.me (URL map can't add query params).
+    Serve the latest Windows release as an auto-download landing page.
+
+    Public-link endpoint behind windows.omi.me (stable) and windows.omi.me/beta
+    (channel=beta). Unlike /v2/desktop/download/latest, an empty requested
+    channel falls back to the other one: the Windows beta slot empties every
+    time a prerelease is promoted to stable (channel = GitHub release state),
+    and a shared public link must keep serving an installer through that
+    window. The landing page always shows the channel actually served.
     """
-    return await download_latest_desktop_release(platform="windows", channel=channel)
+    desktop_releases = await _get_live_desktop_releases("windows")
+    if not desktop_releases:
+        raise HTTPException(status_code=404, detail="No live desktop releases found for platform: windows")
+
+    served_channel = channel
+    picked = _pick_installer_entry(desktop_releases, "windows", channel)
+    if picked is None:
+        fallback_channel = "beta" if channel == "stable" else "stable"
+        picked = _pick_installer_entry(desktop_releases, "windows", fallback_channel)
+        if picked is not None:
+            served_channel = fallback_channel
+            record_fallback(
+                component='other',
+                from_mode=f'desktop_download_{channel}',
+                to_mode=f'desktop_download_{fallback_channel}',
+                reason='other',
+                # beta->stable hands out the same-or-newer qualified build;
+                # stable->beta puts the public stable audience on a prerelease.
+                outcome='recovered' if fallback_channel == 'stable' else 'degraded',
+                log=logger,
+            )
+    if picked is None:
+        raise HTTPException(status_code=404, detail=f"No installer found for platform windows, channel: {channel}")
+    entry, installer_url = picked
+    notice = ""
+    if served_channel != channel:
+        notice = (
+            f"No {channel} build is published right now &mdash; serving the latest {served_channel} release instead."
+        )
+    return HTMLResponse(
+        content=_download_landing_html(
+            installer_url,
+            channel=served_channel,
+            version=entry["version_info"]["version"],
+            platform="windows",
+            notice=notice,
+        )
+    )
 
 
 def _preview_landing_response(result: Dict[str, Any]) -> HTMLResponse:

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -922,6 +922,97 @@ class TestDownloadEndpoint:
         assert resp.status_code == 200
         assert "https://example.com/omi-setup.exe" in resp.text
 
+    @pytest.mark.asyncio
+    async def test_windows_beta_falls_back_to_stable_when_beta_empty(self):
+        # After a prerelease is promoted, the beta slot is empty until the next
+        # cut; the public windows.omi.me/beta link must keep serving stable.
+        mock_releases = [
+            {
+                "channel": "stable",
+                "version_info": {"version": "1.0.1", "build": "0"},
+                "release": {"assets": [_exe_asset("https://example.com/omi-setup.exe")]},
+            },
+        ]
+        with (
+            patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases),
+            patch("routers.updates.record_fallback") as mock_fallback,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/download/windows?channel=beta")
+        assert resp.status_code == 200
+        assert "https://example.com/omi-setup.exe" in resp.text
+        # Landing page reflects the channel actually served, not the requested
+        # one, and says why out loud (the download auto-starts, so the title
+        # alone is easy to miss).
+        assert "Omi Beta" not in resp.text
+        assert "serving the latest stable release instead" in resp.text
+        mock_fallback.assert_called_once()
+        assert mock_fallback.call_args.kwargs["outcome"] == "recovered"
+
+    @pytest.mark.asyncio
+    async def test_windows_stable_falls_back_to_beta_when_no_stable(self):
+        # Launch-day shape: only prereleases exist, windows.omi.me must still serve.
+        mock_releases = [
+            {
+                "channel": "beta",
+                "version_info": {"version": "1.0.2", "build": "0"},
+                "release": {"assets": [_exe_asset("https://example.com/beta-setup.exe")]},
+            },
+        ]
+        with (
+            patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases),
+            patch("routers.updates.record_fallback") as mock_fallback,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/download/windows")
+        assert resp.status_code == 200
+        assert "https://example.com/beta-setup.exe" in resp.text
+        assert "Omi Beta for Windows" in resp.text
+        mock_fallback.assert_called_once()
+        # Serving a prerelease to the public stable link is a hit, not a heal.
+        assert mock_fallback.call_args.kwargs["outcome"] == "degraded"
+
+    @pytest.mark.asyncio
+    async def test_windows_beta_prefers_beta_when_present(self):
+        mock_releases = [
+            {
+                "channel": "stable",
+                "version_info": {"version": "1.0.1", "build": "0"},
+                "release": {"assets": [_exe_asset("https://example.com/omi-setup.exe")]},
+            },
+            {
+                "channel": "beta",
+                "version_info": {"version": "1.0.2", "build": "0"},
+                "release": {"assets": [_exe_asset("https://example.com/beta-setup.exe")]},
+            },
+        ]
+        with (
+            patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases),
+            patch("routers.updates.record_fallback") as mock_fallback,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/download/windows?channel=beta")
+        assert resp.status_code == 200
+        assert "https://example.com/beta-setup.exe" in resp.text
+        mock_fallback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_windows_404_when_both_channels_empty(self):
+        # Releases exist but neither channel has a resolvable installer asset;
+        # the 404 must name the channel the caller asked for, not the fallback.
+        mock_releases = [
+            {
+                "channel": "stable",
+                "version_info": {"version": "1.0.1", "build": "0"},
+                "release": {"assets": [_dmg_asset()]},
+            },
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/download/windows?channel=beta")
+        assert resp.status_code == 404
+        assert "channel: beta" in resp.json()["detail"]
+
 
 # --- Clear cache endpoint ---
 

--- a/desktop/windows/docs/release-pipeline.md
+++ b/desktop/windows/docs/release-pipeline.md
@@ -166,26 +166,39 @@ Every release also uploads a canonical `omi-setup.exe` asset (exact lowercase
 name — the Windows analog of macOS's `omi.dmg`). The backend resolves it:
 
 - `https://api.omi.me/v2/desktop/download/windows` — latest **stable** Windows
-  release, served as an auto-download landing page
-- `…/v2/desktop/download/windows?channel=beta` — latest beta
-- `…/v2/desktop/download/latest?platform=windows` — same, query-param form
+  release (or beta when no stable exists — see fallback below), served as an
+  auto-download landing page
+- `…/v2/desktop/download/windows?channel=beta` — latest beta (or stable when
+  the beta slot is empty)
+- `…/v2/desktop/download/latest?platform=windows` — same, but strict (404s
+  when the exact channel is empty; QA/tooling contract)
 
 Channel mapping is GitHub's own release state (`backend/routers/updates.py`):
 the auto-cut **prerelease is the beta channel**; clearing the prerelease flag
 (`gh release edit v<version>-windows --prerelease=false`) **promotes it to
 stable** — no KEY_VALUE block needed. Releases marked draft are never served.
 
-### windows.omi.me (one-time infra setup)
+Because promotion empties the beta slot until the next cut (and before the
+first promotion there is no stable at all), the `/v2/desktop/download/windows`
+public-link route falls back to the other channel instead of 404ing, records
+it via `record_fallback`, and the landing page shows the channel actually
+served. `/v2/desktop/download/latest` keeps strict channel semantics.
 
-`macos.omi.me` is a Namecheap A record (`registrar-servers.com` DNS) pointing
-at the GCP global load balancer in front of the backend, with a URL-map host
-rule that rewrites `/` to the download endpoint. To stand up `windows.omi.me`:
+### windows.omi.me (live infra)
 
-1. Namecheap: add an A record for `windows` → the existing LB IP (same as
-   `macos.omi.me`, currently `34.54.223.100`).
-2. GCP LB: add `windows.omi.me` to the managed certificate, and add a URL-map
-   host rule routing `/` to the backend service with path rewrite
-   `/v2/desktop/download/windows` (URL maps can't add query params — that's why
-   the dedicated route exists).
+Both `macos.omi.me` and `windows.omi.me` are Namecheap A records
+(`registrar-servers.com` DNS) pointing at the GCP global load balancer
+(`34.54.223.100`, project `based-hardware`), covered by its managed
+certificate. URL map `custom-domains-49a4` holds one `routeRules` matcher per
+host issuing 301 `urlRedirect`s (`pathRedirect` **can** carry a query string):
 
-Until then, the `api.omi.me` links above are the canonical distributable URLs.
+- `windows.omi.me/` → `api.omi.me/v2/desktop/download/windows`
+- `windows.omi.me/beta` → `api.omi.me/v2/desktop/download/windows?channel=beta`
+- (`macos.omi.me` mirrors this shape onto `/v2/desktop/download/latest`)
+
+Emergency pin: to serve a known-good installer while the backend or a release
+is broken, edit the matcher to redirect to the immutable GitHub asset
+(`hostRedirect: github.com`, `pathRedirect:
+/BasedHardware/omi/releases/download/v<version>-windows/omi-setup.exe`) — the
+shape the links launched with. `gcloud compute url-maps export/import
+custom-domains-49a4 --global` is the edit loop; export a backup first.


### PR DESCRIPTION
## Summary

`windows.omi.me` and `windows.omi.me/beta` currently 301 straight to a version-pinned GitHub `.exe` — no thank-you/landing page, and the pinned URL goes stale every release. This makes the backend public-link route robust so the LB can redirect both links to the same auto-download landing page `macos.omi.me` uses, adapted per platform and channel:

- `/v2/desktop/download/windows` (+ `?channel=beta`) resolves releases once and falls back to the other channel when the requested one has no live installer — the Windows beta slot empties on every prerelease→stable promotion (channel = GitHub release state), and before the first promotion there is no stable at all. A shared public link must keep serving an installer through those windows.
- Fallback is recorded via the shared `record_fallback` helper with a direction-aware outcome (beta→stable = `recovered`; stable→beta = `degraded`, since that puts the public stable audience on a prerelease). The landing page shows the channel actually served **plus an explicit notice** — the download auto-starts, so the title alone is easy to miss. On double-miss, the 404 names the requested channel.
- `/v2/desktop/download/latest` keeps strict channel semantics (QA/tooling contract) — existing strict-channel tests unchanged.
- Docs: corrected the stale "URL maps can't add query params" claim (the deployed `macos.omi.me/beta` redirect carries `?channel=beta`), documented the live `windows.omi.me` URL-map shape and the emergency-pin procedure in `desktop/windows/docs/release-pipeline.md`.

After merge + prod deploy, the `custom-domains-49a4` URL map `windows-omi-me` matcher flips from the pinned GitHub asset to:

- `/` → `api.omi.me/v2/desktop/download/windows`
- `/beta` → `api.omi.me/v2/desktop/download/windows?channel=beta`

## Accepted tradeoffs (from independent agent review — APPROVE, no blocking findings)

- stable→beta fallback can serve a prerelease where the old code 404ed. Accepted: the primary motivation is the launch-day no-stable state where the alternative is a dead public link; the serve is `outcome=degraded` in telemetry, visibly labeled on the page, documented, and pinned by a test.
- Hand-shared `/v2/desktop/download/latest?platform=windows` links keep strict 404 semantics during promotion windows (QA contract, unchanged behavior); the canonical public links route through the fallback-capable `/windows` form.

## Product invariants affected

none

## Verification

- `backend/tests/unit/test_desktop_updates.py` — 112 passed (4 new: beta→stable fallback with notice + `recovered` outcome, stable→beta fallback with `degraded` outcome, beta preferred when present, requested-channel 404 detail).
- Real path exercised via local uvicorn against live release data:
  - `GET /v2/desktop/download/windows` → 200 `<title>Download Omi for Windows</title>`, v1.0.1, linking the real `omi-setup.exe`, no notice
  - `GET /v2/desktop/download/windows?channel=beta` (404 in prod today) → 200 stable landing page with visible notice "No beta build is published right now — serving the latest stable release instead."; server log: `omi_fallback_event component=other from=desktop_download_beta to=desktop_download_stable reason=other outcome=recovered`
  - `GET /v2/desktop/download/latest` (macOS) → unchanged, 200 `<title>Download Omi for macOS</title>`
- `make preflight` — 19 checks passed locally.
- Independent agent review (3 finder angles + verify pass): APPROVE, zero blocking findings; all confirmed findings fixed in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

