### PR TITLE
fix(release): guarantee pre-tag readiness failure cleanup

### DIFF
--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 SCRIPT = Path(__file__).with_name("plan-desktop-release.py")
 WORKFLOW = Path(__file__).parents[1] / "workflows" / "desktop_auto_release.yml"
+ROOT = Path(__file__).resolve().parents[2]
 SPEC = importlib.util.spec_from_file_location("plan_desktop_release", SCRIPT)
 assert SPEC and SPEC.loader
 planner = importlib.util.module_from_spec(SPEC)
@@ -101,6 +102,17 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertIn("source_sha: ${{ steps.plan.outputs.source_sha }}", workflow)
         self.assertIn("ref: ${{ steps.recheck.outputs.source_sha }}", workflow)
         self.assertLess(workflow.index('git commit -m "chore: consolidate changelog for v${VERSION}"'), workflow.index('git tag "$RELEASE_TAG"'))
+
+    def test_pre_tag_readiness_workflow_contract(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        readiness_script = (ROOT / "desktop/macos/scripts/pre-tag-readiness.sh").read_text(encoding="utf-8")
+        upload_step = workflow.split("      - name: Upload readiness evidence", 1)[1]
+        upload_step = upload_step.split("\n      - name:", 1)[0]
+        self.assertIn("if-no-files-found: error", upload_step)
+        self.assertIn("+refs/heads/main:refs/remotes/origin/main", readiness_script)
+        self.assertNotIn("fetch --quiet --force origin main", readiness_script)
+        self.assertIn("pre-tag-readiness:", workflow)
+        self.assertIn("verify-pre-tag-readiness.py verify", workflow)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           name: desktop-pre-tag-readiness-evidence
           path: /tmp/pre-tag-readiness-evidence.json
-          if-no-files-found: warn
+          if-no-files-found: error
 
   tag-release:
     needs: [plan-release, pre-tag-readiness]

--- a/desktop/macos/scripts/desktop-core-harness.sh
+++ b/desktop/macos/scripts/desktop-core-harness.sh
@@ -192,8 +192,14 @@ refuse_prod_bundle() {
   fi
 }
 
+DEV_STACK_TEARDOWN_DONE=0
+
 maybe_teardown_dev_stack() {
+  if [[ "$DEV_STACK_TEARDOWN_DONE" -eq 1 ]]; then
+    return 0
+  fi
   if [[ "$KEEP_STACK" -eq 0 && ( "${TIER:-0}" -ge 2 || "${READINESS:-0}" -eq 1 ) ]]; then
+    DEV_STACK_TEARDOWN_DONE=1
     make -C "$REPO_ROOT" dev-down >/dev/null 2>&1 || true
   fi
 }
@@ -691,9 +697,11 @@ if [[ "$READINESS" -eq 1 ]]; then
   STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   START_SEC=$(date +%s)
   FLOW_RESULTS="[]"
+  trap maybe_teardown_dev_stack EXIT
   run_self_check
   ensure_dev_stack
   maybe_teardown_dev_stack
+  trap - EXIT
   DURATION=$(( $(date +%s) - START_SEC ))
   finalize_run "$RUN_DIR" true "readiness" "$STARTED_AT" "$DURATION" "$FLOW_RESULTS"
   echo "desktop-core-harness readiness passed (evidence: $RUN_DIR)"

--- a/desktop/macos/scripts/pre-tag-readiness.sh
+++ b/desktop/macos/scripts/pre-tag-readiness.sh
@@ -172,7 +172,7 @@ trap on_abort EXIT
 
 # 1. Independently resolve the requested SHA from origin and confirm it is on
 #    main. Never trust the caller's claim that this is the planned source.
-git -C "$SOURCE_REPOSITORY" fetch --quiet --force origin main
+git -C "$SOURCE_REPOSITORY" fetch --quiet --no-tags origin +refs/heads/main:refs/remotes/origin/main
 git -C "$SOURCE_REPOSITORY" rev-parse --verify --quiet "${SOURCE_SHA}^{commit}" >/dev/null || {
   echo "pre-tag-readiness: source SHA $SOURCE_SHA does not resolve to a commit in $SOURCE_REPOSITORY" >&2
   exit 1

--- a/desktop/macos/tests/test-desktop-core-harness-readiness-teardown.sh
+++ b/desktop/macos/tests/test-desktop-core-harness-readiness-teardown.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$MACOS_DIR/../.." && pwd)"
+CORE_HARNESS="$MACOS_DIR/scripts/desktop-core-harness.sh"
+
+TMP_ROOT="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+write_stub_binaries() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+
+  cat >"$bin_dir/uname" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-s" ]]; then
+  printf 'Darwin\n'
+  exit 0
+fi
+exec /usr/bin/uname "$@"
+SH
+
+  cat >"$bin_dir/git" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-C" && "${3:-}" == "rev-parse" && "${4:-}" == "HEAD" ]]; then
+  printf 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n'
+  exit 0
+fi
+exec /usr/bin/git "$@"
+SH
+
+  cat >"$bin_dir/make" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+log="${OMI_TEST_MAKE_LOG:?}"
+case "$*" in
+  *dev-up*)
+    : >"${OMI_TEST_DEV_UP_MARKER:?}"
+    printf 'dev-up\n' >>"$log"
+    ;;
+  *dev-down*)
+    printf 'dev-down\n' >>"$log"
+    ;;
+esac
+exit 0
+SH
+
+  cat >"$bin_dir/python3" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+scenario="${OMI_TEST_SCENARIO:?}"
+
+if [[ "${1:-}" == "-" ]]; then
+  script="$(cat)"
+  if [[ "$script" == *"REQUIRED_SERVICES"* ]]; then
+    if [[ "$scenario" == "ensure_dev_stack_fail" && -f "${OMI_TEST_DEV_UP_MARKER:-}" ]]; then
+      printf '%s\n' '{"healthy":false,"reason":"injected_probe_failure"}'
+      exit 1
+    fi
+    if [[ -f "${OMI_TEST_DEV_UP_MARKER:-}" || "$scenario" == "success" || "$scenario" == "keep_stack_fail" ]]; then
+      printf '%s\n' '{"healthy":true,"provider_mode":"offline","config_digest_path":"/tmp/digest.json","instance":"default","state_root":"/tmp/state"}'
+      exit 0
+    fi
+    printf '%s\n' '{"healthy":false,"reason":"stack_not_started"}'
+    exit 1
+  fi
+  if [[ "$script" == *"manifest"* ]]; then
+    exit 0
+  fi
+  exit 0
+fi
+
+script_path="${2:-${1:-}}"
+case "$(basename "$script_path")" in
+  desktop-flow-lint.py|agent-continuity-gauntlet-lib.py)
+    if [[ "$scenario" == "self_check_fail" || "$scenario" == "keep_stack_fail" ]]; then
+      exit 1
+    fi
+  ;;
+esac
+if [[ "$script_path" == *"/backend/testing/contracts"* ]]; then
+  exit 0
+fi
+if [[ "$script_path" == *"-c"* ]]; then
+  exit 0
+fi
+exit 0
+SH
+
+  chmod +x "$bin_dir/uname" "$bin_dir/git" "$bin_dir/make" "$bin_dir/python3"
+}
+
+prepare_fixture_repo() {
+  local fixture="$1"
+  mkdir -p "$fixture/desktop/macos/scripts" "$fixture/backend/testing/contracts"
+  ln -s "$CORE_HARNESS" "$fixture/desktop/macos/scripts/desktop-core-harness.sh"
+  printf '# stub\n' >"$fixture/desktop/macos/scripts/desktop-flow-lint.py"
+  printf '# stub\n' >"$fixture/desktop/macos/scripts/agent-continuity-gauntlet-lib.py"
+  cat >"$fixture/backend/test-preflight.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fixture/backend/test-preflight.sh"
+}
+
+run_readiness_case() {
+  local scenario="$1"
+  local keep_stack="${2:-0}"
+  local fixture="$TMP_ROOT/$scenario"
+  local bin_dir="$TMP_ROOT/${scenario}-bin"
+  local make_log="$fixture/make.log"
+  local dev_up_marker="$fixture/dev-up.marker"
+  local output="$fixture/output.txt"
+  local status=0
+  local args=(--readiness)
+
+  rm -rf "$fixture"
+  prepare_fixture_repo "$fixture"
+  write_stub_binaries "$bin_dir"
+  : >"$make_log"
+  rm -f "$dev_up_marker"
+
+  if [[ "$keep_stack" -eq 1 ]]; then
+    args+=(--keep-stack)
+  fi
+
+  set +e
+  PATH="$bin_dir:$PATH" \
+    OMI_TEST_SCENARIO="$scenario" \
+    OMI_TEST_MAKE_LOG="$make_log" \
+    OMI_TEST_DEV_UP_MARKER="$dev_up_marker" \
+    bash "$fixture/desktop/macos/scripts/desktop-core-harness.sh" "${args[@]}" >"$output" 2>&1
+  status=$?
+  set -e
+
+  printf '%s\n' "$status" "$make_log"
+}
+
+count_make_target() {
+  local log="$1"
+  local target="$2"
+  grep -c "^${target}$" "$log" || true
+}
+
+assert_self_check_failure_triggers_dev_down() {
+  local parsed status make_log
+  parsed="$(run_readiness_case self_check_fail)"
+  status="$(printf '%s\n' "$parsed" | sed -n '1p')"
+  make_log="$(printf '%s\n' "$parsed" | sed -n '2p')"
+  [[ "$status" -ne 0 ]] || fail "self_check failure should exit non-zero"
+  [[ "$(count_make_target "$make_log" dev-down)" -eq 1 ]] || fail "self_check failure must run dev-down once (got: $(cat "$make_log"))"
+  [[ "$(count_make_target "$make_log" dev-up)" -eq 0 ]] || fail "self_check failure must not start dev-up"
+}
+
+assert_ensure_dev_stack_failure_triggers_dev_down() {
+  local parsed status make_log
+  parsed="$(run_readiness_case ensure_dev_stack_fail)"
+  status="$(printf '%s\n' "$parsed" | sed -n '1p')"
+  make_log="$(printf '%s\n' "$parsed" | sed -n '2p')"
+  [[ "$status" -ne 0 ]] || fail "ensure_dev_stack failure should exit non-zero"
+  [[ "$(count_make_target "$make_log" dev-up)" -eq 1 ]] || fail "ensure_dev_stack failure must start dev-up before failing"
+  [[ "$(count_make_target "$make_log" dev-down)" -eq 1 ]] || fail "ensure_dev_stack failure must run dev-down once (got: $(cat "$make_log"))"
+}
+
+assert_keep_stack_skips_dev_down_on_failure() {
+  local parsed status make_log
+  parsed="$(run_readiness_case keep_stack_fail 1)"
+  status="$(printf '%s\n' "$parsed" | sed -n '1p')"
+  make_log="$(printf '%s\n' "$parsed" | sed -n '2p')"
+  [[ "$status" -ne 0 ]] || fail "keep-stack failure should exit non-zero"
+  [[ "$(count_make_target "$make_log" dev-down)" -eq 0 ]] || fail "--keep-stack must skip dev-down on failure (got: $(cat "$make_log"))"
+}
+
+assert_success_teardowns_once() {
+  local parsed status make_log
+  parsed="$(run_readiness_case success)"
+  status="$(printf '%s\n' "$parsed" | sed -n '1p')"
+  make_log="$(printf '%s\n' "$parsed" | sed -n '2p')"
+  [[ "$status" -eq 0 ]] || fail "readiness success should exit zero"
+  [[ "$(count_make_target "$make_log" dev-down)" -eq 1 ]] || fail "readiness success must run dev-down exactly once (got: $(cat "$make_log"))"
+}
+
+assert_self_check_failure_triggers_dev_down
+assert_ensure_dev_stack_failure_triggers_dev_down
+assert_keep_stack_skips_dev_down_on_failure
+assert_success_teardowns_once
+
+echo "desktop-core-harness readiness teardown tests passed"


### PR DESCRIPTION
## Summary
- Install `trap maybe_teardown_dev_stack EXIT` in `desktop-core-harness.sh --readiness` so `dev-down` runs when self-check or dev-stack startup fails under `set -e`; clear the trap after successful teardown and guard with `DEV_STACK_TEARDOWN_DONE` to prevent double teardown.
- Add `test-desktop-core-harness-readiness-teardown.sh` with controllable-seam failure injection proving dev-down on self-check/readiness failures and `--keep-stack` skipping it.
- Apply low-risk reviewer follow-ups: explicit `origin/main` fetch refspec in `pre-tag-readiness.sh`, `upload-artifact` `if-no-files-found: error`, and a checked-in workflow contract in `test_plan_desktop_release.py`.

## Test plan
- [x] `bash desktop/macos/tests/test-desktop-core-harness-readiness-teardown.sh`
- [x] `python3 .github/scripts/test_plan_desktop_release.py`
- [x] `python3 .github/scripts/verify-pre-tag-readiness.py self-test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



Failure-Class: none
