### PR TITLE
fix(release): bind beta smoke evidence to the candidate source SHA

### DIFF
--- a/.github/scripts/check-desktop-auto-beta-candidate.py
+++ b/.github/scripts/check-desktop-auto-beta-candidate.py
@@ -60,6 +60,7 @@ def _validate_smoke_contract(
     release_tag: str,
     expected_version: str,
     expected_build: str,
+    expected_source_sha: str,
     label: str,
 ) -> set[str]:
     """Enforce the shared success/tag/version/build/team/channel contract on a
@@ -77,6 +78,12 @@ def _validate_smoke_contract(
     for field, value in expected.items():
         if smoke.get(field) != value:
             fail(f"{label} smoke result {field} mismatch: expected {value!r}, got {smoke.get(field)!r}")
+
+    smoke_source_sha = smoke.get("source_sha")
+    if not isinstance(smoke_source_sha, str) or not re.fullmatch(r"[0-9a-f]{40}", smoke_source_sha):
+        fail(f"{label} smoke result is missing an exact source SHA")
+    if smoke_source_sha != expected_source_sha:
+        fail(f"{label} smoke source SHA does not match the candidate tag")
 
     checks = set(smoke.get("checks") or [])
     missing_checks = sorted(REQUIRED_SMOKE_CHECKS - checks)
@@ -144,6 +151,7 @@ def validate(args: argparse.Namespace) -> dict:
         release_tag=args.release_tag,
         expected_version=expected_version,
         expected_build=expected_build,
+        expected_source_sha=args.tag_sha,
         label="signed",
     )
 
@@ -176,6 +184,7 @@ def validate(args: argparse.Namespace) -> dict:
             release_tag=args.release_tag,
             expected_version=expected_version,
             expected_build=expected_build,
+            expected_source_sha=args.tag_sha,
             label="beta",
         )
         beta_zip_release = asset_by_name(release, {"Omi.Beta.zip"})

--- a/.github/scripts/test_check_desktop_auto_beta_candidate.py
+++ b/.github/scripts/test_check_desktop_auto_beta_candidate.py
@@ -95,6 +95,7 @@ def beta_fixtures(root: Path) -> argparse.Namespace:
     beta_smoke = {
         "ok": True,
         "release_tag": TAG,
+        "source_sha": SHA,
         "expected_channel": "beta",
         "bundle_id": "com.omi.computer-macos.beta",
         "version": "0.12.99",
@@ -208,6 +209,11 @@ def main() -> int:
         del beta_smoke["notification_callback_canary"]
         beta_smoke_path.write_text(json.dumps(beta_smoke))
         expect_failure(args, "beta smoke result is missing UserNotifications callback canary")
+
+        beta_smoke = json.loads(original)
+        beta_smoke["source_sha"] = "d" * 40
+        beta_smoke_path.write_text(json.dumps(beta_smoke))
+        expect_failure(args, "beta smoke source SHA does not match the candidate tag")
 
         beta_smoke = json.loads(original)
         beta_smoke["notification_callback_canary"]["bundle_id"] = "com.omi.computer-macos"


### PR DESCRIPTION
Round-3 review finding on the INV-BETA-1 re-land: `_validate_smoke_contract` bound `source_sha` only for the stable smoke; a beta smoke with a different 40-char SHA passed `validate()`, so stale Omi Beta evidence could green-light qualification. Both smokes now bind to the candidate tag SHA inside the shared contract; regression test mutates the beta `source_sha` and asserts failure.

## Product invariants affected

- INV-BETA-1

## Failure class

Failure-Class: none

Gate hardening for the just-merged re-land; never shipped. Verified: `.github/scripts/test_check_desktop_auto_beta_candidate.py` green (incl. new mismatched-SHA case).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

