### PR TITLE
SCA-57: fail-close Beta qualification retry guards

### DIFF
--- a/.github/scripts/desktop_beta_qualification_retry.py
+++ b/.github/scripts/desktop_beta_qualification_retry.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -90,15 +90,20 @@ def _valid_candidate(release: Any, release_tag: str) -> tuple[bool, str]:
     return True, "newest candidate carries the canonical three assets"
 
 
-def _candidate_age_hours(release: Any) -> int | None:
+def _candidate_age(release: Any) -> tuple[timedelta | None, str | None]:
     published = release.get("publishedAt") if isinstance(release, dict) else None
     if not isinstance(published, str) or not published:
-        return None
+        return None, "candidate publication timestamp is missing"
     try:
         published_at = datetime.fromisoformat(published.replace("Z", "+00:00"))
     except ValueError:
-        return None
-    return max(0, int((datetime.now(timezone.utc) - published_at).total_seconds() // 3600))
+        return None, "candidate publication timestamp is malformed"
+    if published_at.tzinfo is None or published_at.utcoffset() is None:
+        return None, "candidate publication timestamp is malformed"
+    age = datetime.now(timezone.utc) - published_at.astimezone(timezone.utc)
+    if age < timedelta(0):
+        return None, "candidate publication timestamp is in the future"
+    return age, None
 
 
 def _runs_for_tag(runs: Any, release_tag: str, tag_sha: str) -> list[dict[str, Any]]:
@@ -127,12 +132,18 @@ def _newest(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
     return max(runs, key=lambda r: r.get("updated_at") or r.get("created_at") or "")
 
 
-def _count_terminal(selected: list[dict[str, Any]]) -> int:
-    return sum(
-        1
-        for r in selected
-        if r.get("status") == "completed" and r.get("conclusion") in RETRYABLE_CONCLUSIONS
-    )
+def _count_attempts(selected: list[dict[str, Any]]) -> int:
+    """Count every unique exact-candidate qualification run as an attempt."""
+    identities: set[tuple[str, Any]] = set()
+    for index, run in enumerate(selected):
+        run_id = run.get("id")
+        if isinstance(run_id, int) and not isinstance(run_id, bool) and run_id > 0:
+            identities.add(("id", run_id))
+        else:
+            # GitHub run IDs are positive integers. A malformed/missing ID must
+            # not make the retry bound fail open by collapsing distinct records.
+            identities.add(("record", index))
+    return len(identities)
 
 
 def _decision(
@@ -165,19 +176,27 @@ def decide(
 ) -> dict[str, Any]:
     valid, candidate_reason = _valid_candidate(release, release_tag)
     selected = _runs_for_tag(runs, release_tag, tag_sha) if valid else []
-    attempts = _count_terminal(selected)
+    attempts = _count_attempts(selected)
 
     if not valid:
         return _decision(
             release_tag=release_tag, should_retry=False, reason=candidate_reason, attempts=attempts, newest=None
         )
 
-    age = _candidate_age_hours(release)
-    if age is not None and age > max_age_hours:
+    age, age_error = _candidate_age(release)
+    if age_error is not None:
         return _decision(
             release_tag=release_tag,
             should_retry=False,
-            reason=f"candidate age {age}h exceeds {max_age_hours}h bound",
+            reason=age_error,
+            attempts=attempts,
+            newest=_newest(selected),
+        )
+    if age is not None and age > timedelta(hours=max_age_hours):
+        return _decision(
+            release_tag=release_tag,
+            should_retry=False,
+            reason=f"candidate age exceeds exact {max_age_hours}h bound",
             attempts=attempts,
             newest=_newest(selected),
         )
@@ -192,24 +211,31 @@ def decide(
             newest=None,
         )
 
-    status = newest.get("status")
+    non_completed = next((run for run in selected if run.get("status") != "completed"), None)
+    if non_completed is not None:
+        return _decision(
+            release_tag=release_tag,
+            should_retry=False,
+            reason=(
+                f"qualification run {non_completed.get('id')} is {non_completed.get('status')}; "
+                "never retry while any exact-candidate run is in-progress"
+            ),
+            attempts=attempts,
+            newest=newest,
+        )
+    successful = next((run for run in selected if run.get("conclusion") == "success"), None)
+    if successful is not None:
+        return _decision(
+            release_tag=release_tag,
+            should_retry=False,
+            reason=(
+                f"qualification run {successful.get('id')} already succeeded; "
+                "promotion is a separate completed-success authority"
+            ),
+            attempts=attempts,
+            newest=newest,
+        )
     conclusion = newest.get("conclusion")
-    if status != "completed":
-        return _decision(
-            release_tag=release_tag,
-            should_retry=False,
-            reason=f"qualification is {status}; never retry an in-progress run",
-            attempts=attempts,
-            newest=newest,
-        )
-    if conclusion == "success":
-        return _decision(
-            release_tag=release_tag,
-            should_retry=False,
-            reason="qualification already succeeded; promotion is a separate completed-success authority",
-            attempts=attempts,
-            newest=newest,
-        )
     if attempts >= max_attempts:
         return _decision(
             release_tag=release_tag,

--- a/.github/scripts/test_desktop_beta_qualification_retry.py
+++ b/.github/scripts/test_desktop_beta_qualification_retry.py
@@ -116,6 +116,23 @@ class RetryDecisionTests(unittest.TestCase):
         self.assertFalse(d["should_retry"])
         self.assertIn("exceeds", d["reason"])
 
+    def test_candidate_24_hours_30_minutes_old_denies(self):
+        old = _utc_iso(_NOW - timedelta(hours=24, minutes=30))
+        d = _decide(_release(published=old), [_run(conclusion="failure")], max_age_hours=24)
+        self.assertFalse(d["should_retry"])
+        self.assertIn("exceeds", d["reason"])
+
+    def test_malformed_publication_timestamp_denies(self):
+        d = _decide(_release(published="not-a-timestamp"), [_run(conclusion="failure")])
+        self.assertFalse(d["should_retry"])
+        self.assertIn("malformed", d["reason"])
+
+    def test_future_publication_timestamp_denies(self):
+        future = _utc_iso(_NOW + timedelta(minutes=30))
+        d = _decide(_release(published=future), [_run(conclusion="failure")])
+        self.assertFalse(d["should_retry"])
+        self.assertIn("future", d["reason"])
+
     # --- run state (never retry in-progress / successful / unattempted) ---
 
     def test_no_prior_attempt_denies(self):
@@ -182,6 +199,23 @@ class RetryDecisionTests(unittest.TestCase):
         self.assertFalse(d["should_retry"])
         self.assertIn("bound", d["reason"])
 
+    def test_neutral_plus_two_failures_reaches_total_attempt_bound(self):
+        runs = [
+            _run(conclusion="neutral", run_id=1, updated=_utc_iso(_NOW - timedelta(minutes=2))),
+            _run(conclusion="failure", run_id=2, updated=_utc_iso(_NOW - timedelta(minutes=1))),
+            _run(conclusion="failure", run_id=3, updated=NOW_ISO),
+        ]
+        d = _decide(_release(), runs)
+        self.assertFalse(d["should_retry"])
+        self.assertEqual(d["attempts_so_far"], 3)
+        self.assertIn("bound", d["reason"])
+
+    def test_duplicate_run_records_count_as_one_attempt(self):
+        run = _run(conclusion="failure", run_id=7)
+        d = _decide(_release(), [run, copy.deepcopy(run)])
+        self.assertTrue(d["should_retry"])
+        self.assertEqual(d["attempts_so_far"], 1)
+
     # --- exact tag + SHA binding (ignore other candidates' runs) ---
 
     def test_runs_for_other_tags_are_ignored(self):
@@ -213,6 +247,25 @@ class RetryDecisionTests(unittest.TestCase):
         d = _decide(_release(), runs)
         self.assertFalse(d["should_retry"])
         self.assertIn("already succeeded", d["reason"])
+
+    def test_older_success_with_newer_failure_denies(self):
+        runs = [
+            _run(conclusion="success", run_id=1, updated=_utc_iso(_NOW - timedelta(hours=1))),
+            _run(conclusion="failure", run_id=2, updated=NOW_ISO),
+        ]
+        d = _decide(_release(), runs)
+        self.assertFalse(d["should_retry"])
+        self.assertIn("already succeeded", d["reason"])
+
+    def test_older_in_progress_with_newer_cancelled_denies(self):
+        runs = [
+            _run(status="in_progress", conclusion=None, run_id=1,
+                 updated=_utc_iso(_NOW - timedelta(hours=1))),
+            _run(conclusion="cancelled", run_id=2, updated=NOW_ISO),
+        ]
+        d = _decide(_release(), runs)
+        self.assertFalse(d["should_retry"])
+        self.assertIn("in-progress", d["reason"])
 
     def test_non_workflow_dispatch_runs_ignored(self):
         # Only workflow_dispatch qualification runs are authoritative.
@@ -261,6 +314,14 @@ class CliOutputContractTests(unittest.TestCase):
         finally:
             for p in (release_path, runs_path, out_path):
                 p.unlink(missing_ok=True)
+
+
+class WorkflowContractTests(unittest.TestCase):
+    def test_app_token_requests_only_required_permissions(self):
+        workflow = (Path(__file__).resolve().parents[1] / "workflows" /
+                    "desktop_retry_beta_qualification.yml").read_text(encoding="utf-8")
+        self.assertIn("          permission-actions: write\n", workflow)
+        self.assertIn("          permission-contents: read\n", workflow)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/desktop_retry_beta_qualification.yml
+++ b/.github/workflows/desktop_retry_beta_qualification.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           app-id: ${{ secrets.OMI_BOT_APP_ID }}
           private-key: ${{ secrets.OMI_BOT_PRIVATE_KEY }}
+          permission-actions: write
+          permission-contents: read
 
       - name: Gather server-derived candidate and qualification state
         id: gather


### PR DESCRIPTION
## Summary

- count all unique exact-tag/SHA qualification runs as total attempts, regardless of conclusion
- deny retry when any matching run is non-completed or successful
- fail closed on malformed, future, or older-than-24-hours `publishedAt` using an exact duration comparison
- restrict the Omi Bot token to `actions: write` and `contents: read`
- preserve qualification-only retry authority; promotion and Stable remain separate and untouched

## Regression coverage

Adds adversarial cases for:

- older success plus newer failure
- older in-progress plus newer cancelled
- neutral plus failure plus failure at the total-attempt bound
- duplicate run records counting once
- 24h30m-old, malformed, and future publication timestamps
- least-privilege GitHub App token inputs

## Verification

- `python3 .github/scripts/test_desktop_beta_qualification_retry.py` — 30 tests passed
- `python3 .github/scripts/test_desktop_release_flow_contract.py` — 18 tests passed
- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_desktop_release_scripts.py backend/tests/unit/test_qualified_beta_promotion.py` — 205 tests passed
- `uv run --with pyyaml python .github/scripts/check-release-process-guards.py` — passed
- `actionlint .github/workflows/desktop_retry_beta_qualification.yml` — passed
- independent Codex review — no blocking findings

Failure-Class: none

Closes SCA-57


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

