### PR TITLE
feat(release): allow no-input desktop candidate dispatch

### DIFF
--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -113,7 +113,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         qualification = workflow("desktop_qualify_beta.yml")
         beta = workflow("desktop_promote_beta.yml")
         self.assertIn("schedule:", candidate)
-        self.assertNotIn("workflow_dispatch:", candidate)
+        self.assertIn("workflow_dispatch:\n  schedule:", candidate)
         self.assertNotIn("uses: ./.github/workflows/desktop_promote_beta.yml", qualification)
         self.assertNotIn("promote-qualified-beta:", qualification)
         self.assertIn('workflows: ["Qualify Desktop Beta Candidate"]', beta)

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -94,10 +94,10 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertNotIn(f"source_sha={LATER_NON_DESKTOP_SHA}", outputs)
         self.assertIn("should_release=true", outputs)
 
-    def test_workflow_is_schedule_only_and_tags_the_changelog_commit(self) -> None:
+    def test_workflow_has_no_input_manual_trigger_and_tags_the_changelog_commit(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("workflow_dispatch:\n  schedule:", workflow)
         self.assertIn("- cron: '17 * * * *'", workflow)
-        self.assertNotIn("workflow_dispatch:", workflow)
         self.assertNotIn("break_glass", workflow)
         self.assertIn("source_sha: ${{ steps.plan.outputs.source_sha }}", workflow)
         self.assertIn("ref: ${{ steps.recheck.outputs.source_sha }}", workflow)

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -1,6 +1,7 @@
 name: Build Desktop Release Candidate
 
 on:
+  workflow_dispatch:
   schedule:
     # Retry hourly; planner quiet-window, exact-SHA checks, and active-release
     # fences still admit at most one eligible candidate at a time.


### PR DESCRIPTION
## Summary

Adds a no-input `workflow_dispatch` trigger to the existing fail-closed desktop candidate planner so maintainers can start the same automatic path immediately instead of waiting for the hourly schedule.

The trigger accepts no source, tag, version, break-glass, or promotion inputs. The planner still derives the newest releasable exact SHA server-side, requires trusted-M1 pre-tag readiness evidence, and keeps qualification and promotion separate.

## Verification

- `.github/scripts/test_plan_desktop_release.py` — 5 passed
- `.github/scripts/test_desktop_release_flow_contract.py` — 18 passed
- selected manifest/preflight — 13 checks passed
- `actionlint .github/workflows/desktop_auto_release.yml` — passed
- bounded pre-push gate — passed

## Authority

No new release, Beta, Stable, credential, or promotion authority is introduced. Manual and scheduled invocations execute the same planner and exact-source gates.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

