### PR TITLE
Make LLM gateway dev-auto, prod-manual, and safely composable

### DIFF
--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -547,6 +547,16 @@ jobs:
         if: ${{ github.event.inputs.deploy_gateway == 'true' }}
         uses: azure/setup-helm@v5
 
+      - name: Build, smoke, and push combined LLM Gateway image
+        if: ${{ github.event.inputs.deploy_gateway == 'true' }}
+        run: |
+          gateway_image="gcr.io/${{ vars.GCP_PROJECT_ID }}/llm-gateway:${{ steps.image-tag.outputs.short_sha }}"
+          docker build -t "$gateway_image" -f backend/Dockerfile .
+          python3 "$DEPLOY_CONTROL_SCRIPTS/runtime_image_contracts.py" smoke \
+            --dockerfile backend/Dockerfile \
+            --image "$gateway_image"
+          docker push "$gateway_image"
+
       - name: Deploy LLM Gateway with backend stack
         if: ${{ github.event.inputs.deploy_gateway == 'true' }}
         env:

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -31,6 +31,11 @@ on:
         options:
           - all
           - cloud-run-only
+      deploy_gateway:
+        description: 'Development only: deploy the LLM gateway binary with the backend stack (requires deploy_targets=all)'
+        required: true
+        default: false
+        type: boolean
       # Break-glass: the eligibility proof requires a *successful* Release
       # Eligibility push-run on this exact SHA. A flaky or red check therefore
       # poisons that SHA permanently -- rerunning does not retroactively make
@@ -89,6 +94,14 @@ jobs:
           fi
           if [[ "$DEPLOY_ENVIRONMENT" == "prod" && "$DEPLOY_TARGETS" == "all" ]]; then
             echo "environment=prod, deploy_targets=all is unsupported; use cloud-run-only." >&2
+            exit 1
+          fi
+          if [[ "${{ github.event.inputs.deploy_gateway }}" == "true" && "$DEPLOY_ENVIRONMENT" == "prod" ]]; then
+            echo "environment=prod, deploy_gateway=true is unsupported; use the standalone manual LLM gateway workflow." >&2
+            exit 1
+          fi
+          if [[ "${{ github.event.inputs.deploy_gateway }}" == "true" && "$DEPLOY_TARGETS" != "all" ]]; then
+            echo "deploy_gateway=true requires deploy_targets=all." >&2
             exit 1
           fi
 
@@ -337,6 +350,14 @@ jobs:
             echo "Invalid deploy_targets: ${{ github.event.inputs.deploy_targets }}. Must be 'all' or 'cloud-run-only'."
             exit 1
           fi
+          if [[ "${{ github.event.inputs.deploy_gateway }}" == "true" && "${{ github.event.inputs.environment }}" == "prod" ]]; then
+            echo "environment=prod, deploy_gateway=true is unsupported; use the standalone manual LLM gateway workflow." >&2
+            exit 1
+          fi
+          if [[ "${{ github.event.inputs.deploy_gateway }}" == "true" && "${{ github.event.inputs.deploy_targets }}" != "all" ]]; then
+            echo "deploy_gateway=true requires deploy_targets=all." >&2
+            exit 1
+          fi
 
       # To workaround "no space left on device" issue of GitHub-hosted runner
       - name: Delete huge unnecessary tools folder
@@ -448,7 +469,6 @@ jobs:
 
       - name: Determine whether this deploy requests gateway-first serving
         id: gateway-intent
-        if: ${{ github.event.inputs.deploy_targets == 'all' }}
         run: |
           python3 "$DEPLOY_CONTROL_SCRIPTS/verify-llm-gateway-serving.py" \
             --environment="${{ vars.ENV }}" \
@@ -458,7 +478,7 @@ jobs:
             --intent-only >> "$GITHUB_OUTPUT"
 
       - name: Get GKE credentials for gateway serving gate
-        if: ${{ github.event.inputs.deploy_targets == 'all' && steps.gateway-intent.outputs.enabled == 'true' }}
+        if: ${{ github.event.inputs.deploy_targets == 'all' || steps.gateway-intent.outputs.enabled == 'true' }}
         uses: google-github-actions/get-gke-credentials@v3
         with:
           cluster_name: ${{ vars.GKE_CLUSTER }}
@@ -467,7 +487,7 @@ jobs:
 
       - name: Verify LLM gateway control plane before promotion
         id: gateway-serving
-        if: ${{ github.event.inputs.deploy_targets == 'all' && steps.gateway-intent.outputs.enabled == 'true' }}
+        if: ${{ github.event.inputs.deploy_gateway != 'true' && steps.gateway-intent.outputs.enabled == 'true' }}
         run: |
           python3 "$DEPLOY_CONTROL_SCRIPTS/verify-llm-gateway-serving.py" \
             --environment="${{ vars.ENV }}" \
@@ -518,19 +538,64 @@ jobs:
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:latest
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
 
+      # Development can compose the gateway binary with a full backend deploy.
+      # Production remains Cloud Run-only; use gcp_llm_gateway.yml for its
+      # separate manual gateway deployment. This helm release changes no caller
+      # traffic flags, and the source-controlled caller mode still has to pass
+      # the serving and VPC gates below before a Cloud Run revision is created.
+      - name: Install Helm for combined LLM Gateway deployment
+        if: ${{ github.event.inputs.deploy_gateway == 'true' }}
+        uses: azure/setup-helm@v5
+
+      - name: Deploy LLM Gateway with backend stack
+        if: ${{ github.event.inputs.deploy_gateway == 'true' }}
+        env:
+          LLM_GATEWAY_GSA: ${{ vars.LLM_GATEWAY_GSA }}
+          ENVIRONMENT: ${{ vars.ENV }}
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          GKE_CLUSTER: ${{ vars.GKE_CLUSTER }}
+          REGION: ${{ env.REGION }}
+        run: |
+          test -n "$LLM_GATEWAY_GSA"
+          python3 "$DEPLOY_CONTROL_SCRIPTS/validate-llm-gateway-env.py" \
+            backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml \
+            backend/charts/llm-gateway/${{ vars.ENV }}_omi_llm_gateway_values.yaml
+          IMAGE_TAG="${{ steps.image-tag.outputs.short_sha }}" "$DEPLOY_CONTROL_SCRIPTS/deploy-llm-gateway.sh"
+
+      - name: Verify combined LLM gateway serving data plane
+        id: combined-gateway-serving
+        if: ${{ github.event.inputs.deploy_gateway == 'true' && steps.gateway-intent.outputs.enabled == 'true' }}
+        run: |
+          python3 "$DEPLOY_CONTROL_SCRIPTS/verify-llm-gateway-serving.py" \
+            --environment="${{ vars.ENV }}" \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ env.REGION }}" \
+            --github-output "$GITHUB_OUTPUT"
+
       - name: Probe LLM gateway from the Cloud Run VPC before promotion
-        if: ${{ github.event.inputs.deploy_targets == 'all' && steps.gateway-intent.outputs.enabled == 'true' }}
+        if: ${{ steps.gateway-intent.outputs.enabled == 'true' }}
         run: |
           bash "$DEPLOY_CONTROL_SCRIPTS/probe-llm-gateway-from-cloud-run.sh" \
             --project "${{ vars.GCP_PROJECT_ID }}" \
             --region "${{ env.REGION }}" \
             --image "gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}" \
-            --gateway-url "${{ steps.gateway-serving.outputs.gateway_url }}" \
+            --gateway-url "${{ steps.combined-gateway-serving.outputs.gateway_url || steps.gateway-serving.outputs.gateway_url }}" \
             --network "${{ vars.CLOUD_RUN_VPC_NETWORK }}" \
             --subnet "${{ vars.CLOUD_RUN_VPC_SUBNET }}" \
             --vpc-egress private-ranges-only \
             --lane omi:auto:public-shared-conversation-chat \
             --name-suffix "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Reject an inert gateway endpoint when source-controlled gateway mode is requested
+        if: ${{ steps.gateway-intent.outputs.enabled == 'true' }}
+        env:
+          GATEWAY_URL: ${{ steps.combined-gateway-serving.outputs.gateway_url || steps.gateway-serving.outputs.gateway_url }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$GATEWAY_URL" || "$GATEWAY_URL" == "http://127.0.0.1:9" ]]; then
+            echo "Gateway mode requires a verified non-sentinel endpoint." >&2
+            exit 1
+          fi
 
       # The endpoint is rendered only after the deployment gate derived it
       # from the provisioned ingress address. Direct mode gets the inert
@@ -547,7 +612,7 @@ jobs:
           MCP_OAUTH_CLAUDE_CLIENT_ID: ${{ vars.MCP_OAUTH_CLAUDE_CLIENT_ID }}
           MCP_OAUTH_CLAUDE_CLIENT_NAME: ${{ vars.MCP_OAUTH_CLAUDE_CLIENT_NAME }}
           MCP_OAUTH_CLAUDE_REDIRECT_URIS: ${{ vars.MCP_OAUTH_CLAUDE_REDIRECT_URIS }}
-          OMI_LLM_GATEWAY_URL: ${{ steps.gateway-serving.outputs.gateway_url || 'http://127.0.0.1:9' }}
+          OMI_LLM_GATEWAY_URL: ${{ steps.combined-gateway-serving.outputs.gateway_url || steps.gateway-serving.outputs.gateway_url || 'http://127.0.0.1:9' }}
           PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_AUDIENCE: ${{ vars.PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_AUDIENCE }}
           PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_INVOKER_SA: ${{ vars.PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_INVOKER_SA }}
           SYNC_LEDGER_FENCE_MODE: ${{ vars.SYNC_LEDGER_FENCE_MODE || 'legacy' }}
@@ -764,14 +829,6 @@ jobs:
             --region=${{ env.REGION }} \
             --remove-tags="$TRANSCRIPTION_CANDIDATE_TAG" \
             --quiet
-
-      - name: Get GKE credentials
-        if: ${{ github.event.inputs.deploy_targets == 'all' }}
-        uses: google-github-actions/get-gke-credentials@v3
-        with:
-          cluster_name: ${{ vars.GKE_CLUSTER }}
-          location: ${{ env.REGION }}
-          project_id: ${{ vars.GCP_PROJECT_ID }}
 
       - name: Install Helm
         if: ${{ github.event.inputs.deploy_targets == 'all' }}

--- a/.github/workflows/gcp_llm_gateway_auto_dev.yml
+++ b/.github/workflows/gcp_llm_gateway_auto_dev.yml
@@ -41,6 +41,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Bind gateway image identity to the triggering main SHA
+        id: image-tag
+        run: |
+          CHECKED_OUT_SHA="$(git rev-parse HEAD)"
+          if [[ "$CHECKED_OUT_SHA" != "${GITHUB_SHA}" ]]; then
+            echo "Checked-out gateway source must equal the triggering main SHA." >&2
+            exit 1
+          fi
+          echo "short_sha=$(git rev-parse --short=7 "$CHECKED_OUT_SHA")" >> "$GITHUB_OUTPUT"
+
       - name: Google Auth
         id: auth
         uses: 'google-github-actions/auth@v3'
@@ -72,11 +82,11 @@ jobs:
 
       - name: Build and Push Docker image
         run: |
-          docker build -t gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7} -f backend/Dockerfile .
+          docker build -t gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }} -f backend/Dockerfile .
           python3 backend/scripts/runtime_image_contracts.py smoke \
             --dockerfile backend/Dockerfile \
-            --image gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}
-          docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}
+            --image gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
+          docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}
 
       - name: Get GKE credentials
         uses: google-github-actions/get-gke-credentials@v3
@@ -93,7 +103,7 @@ jobs:
           GKE_CLUSTER: ${{ vars.GKE_CLUSTER }}
           REGION: ${{ env.REGION }}
         run: |
-          IMAGE_TAG="${GITHUB_SHA::7}" backend/scripts/deploy-llm-gateway.sh
+          IMAGE_TAG="${{ steps.image-tag.outputs.short_sha }}" backend/scripts/deploy-llm-gateway.sh
 
       - name: Verify LLM Gateway serving data plane
         id: gateway-serving
@@ -109,7 +119,7 @@ jobs:
           bash backend/scripts/probe-llm-gateway-from-cloud-run.sh \
             --project "${{ vars.GCP_PROJECT_ID }}" \
             --region "${{ env.REGION }}" \
-            --image "gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}" \
+            --image "gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}" \
             --gateway-url "${{ steps.gateway-serving.outputs.gateway_url }}" \
             --network "${{ vars.CLOUD_RUN_VPC_NETWORK }}" \
             --subnet "${{ vars.CLOUD_RUN_VPC_SUBNET }}" \
@@ -123,7 +133,7 @@ jobs:
           METRICS_TOKEN="$(kubectl -n "$NAMESPACE" get secret ${{ vars.ENV }}-omi-backend-secrets -o jsonpath='{.data.METRICS_SECRET}' | base64 -d)"
           kubectl -n "$NAMESPACE" run "llm-gateway-smoke-${GITHUB_RUN_ID}" \
             --rm -i --restart=Never \
-            --image "gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}" \
+            --image "gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ steps.image-tag.outputs.short_sha }}" \
             --env "SMOKE_URL=http://${{ vars.ENV }}-omi-llm-gateway.${{ vars.ENV }}-omi-backend.svc.cluster.local:8080" \
             --env "SMOKE_TOKEN=$TOKEN" \
             --env "METRICS_SECRET=$METRICS_TOKEN" \

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -226,7 +226,10 @@ def test_backend_deploy_requires_serving_and_cloud_run_vpc_gates_before_gateway_
     assert "github.event.inputs.deploy_targets == 'all'" not in intent_step
     assert 'Reject an inert gateway endpoint when source-controlled gateway mode is requested' in workflow
     assert 'Gateway mode requires a verified non-sentinel endpoint.' in workflow
-    assert 'steps.combined-gateway-serving.outputs.gateway_url || steps.gateway-serving.outputs.gateway_url || \'http://127.0.0.1:9\'' in workflow
+    assert (
+        'steps.combined-gateway-serving.outputs.gateway_url || steps.gateway-serving.outputs.gateway_url || \'http://127.0.0.1:9\''
+        in workflow
+    )
     assert 'Verify LLM gateway control plane before promotion' in auto_dev
     assert 'Probe LLM gateway from the Cloud Run VPC before promotion' in auto_dev
     assert 'OMI_LLM_GATEWAY_URL: ${{ steps.gateway-serving.outputs.gateway_url }}' in auto_dev
@@ -240,17 +243,26 @@ def test_backend_can_compose_dev_gateway_with_immutable_backend_image_but_prod_s
 
     assert 'deploy_gateway:' in workflow
     assert "default: false\n        type: boolean" in workflow
-    assert 'environment=prod, deploy_gateway=true is unsupported; use the standalone manual LLM gateway workflow.' in workflow
+    assert (
+        'environment=prod, deploy_gateway=true is unsupported; use the standalone manual LLM gateway workflow.'
+        in workflow
+    )
     assert 'deploy_gateway=true requires deploy_targets=all.' in workflow
     gateway_publish = workflow.index('      - name: Build, smoke, and push combined LLM Gateway image')
     gateway_deploy = workflow.index('      - name: Deploy LLM Gateway with backend stack')
     assert gateway_publish < gateway_deploy
     combined_publish_step = workflow[gateway_publish:gateway_deploy]
-    assert 'gateway_image="gcr.io/${{ vars.GCP_PROJECT_ID }}/llm-gateway:${{ steps.image-tag.outputs.short_sha }}"' in combined_publish_step
+    assert (
+        'gateway_image="gcr.io/${{ vars.GCP_PROJECT_ID }}/llm-gateway:${{ steps.image-tag.outputs.short_sha }}"'
+        in combined_publish_step
+    )
     assert 'runtime_image_contracts.py" smoke' in combined_publish_step
     assert 'docker push "$gateway_image"' in combined_publish_step
     assert 'Deploy LLM Gateway with backend stack' in workflow
-    assert 'IMAGE_TAG="${{ steps.image-tag.outputs.short_sha }}" "$DEPLOY_CONTROL_SCRIPTS/deploy-llm-gateway.sh"' in workflow
+    assert (
+        'IMAGE_TAG="${{ steps.image-tag.outputs.short_sha }}" "$DEPLOY_CONTROL_SCRIPTS/deploy-llm-gateway.sh"'
+        in workflow
+    )
     assert 'deploy-backend-stack-${{ github.event.inputs.environment }}' in workflow
     assert 'deploy-backend-stack-${{ github.event.inputs.environment }}' in standalone
     assert 'IMAGE_TAG=$(git rev-parse --short=7 "$CHECKED_OUT_SHA")' in standalone

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -242,6 +242,13 @@ def test_backend_can_compose_dev_gateway_with_immutable_backend_image_but_prod_s
     assert "default: false\n        type: boolean" in workflow
     assert 'environment=prod, deploy_gateway=true is unsupported; use the standalone manual LLM gateway workflow.' in workflow
     assert 'deploy_gateway=true requires deploy_targets=all.' in workflow
+    gateway_publish = workflow.index('      - name: Build, smoke, and push combined LLM Gateway image')
+    gateway_deploy = workflow.index('      - name: Deploy LLM Gateway with backend stack')
+    assert gateway_publish < gateway_deploy
+    combined_publish_step = workflow[gateway_publish:gateway_deploy]
+    assert 'gateway_image="gcr.io/${{ vars.GCP_PROJECT_ID }}/llm-gateway:${{ steps.image-tag.outputs.short_sha }}"' in combined_publish_step
+    assert 'runtime_image_contracts.py" smoke' in combined_publish_step
+    assert 'docker push "$gateway_image"' in combined_publish_step
     assert 'Deploy LLM Gateway with backend stack' in workflow
     assert 'IMAGE_TAG="${{ steps.image-tag.outputs.short_sha }}" "$DEPLOY_CONTROL_SCRIPTS/deploy-llm-gateway.sh"' in workflow
     assert 'deploy-backend-stack-${{ github.event.inputs.environment }}' in workflow

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -59,6 +59,7 @@ def _render_probe_workflow_run(run: str) -> str:
         '${{ env.SERVICE }}': 'llm-gateway',
         '${{ steps.image-tag.outputs.short_sha }}': 'abc1234',
         '${{ steps.gateway-serving.outputs.gateway_url }}': 'http://10.0.0.5',
+        '${{ steps.combined-gateway-serving.outputs.gateway_url || steps.gateway-serving.outputs.gateway_url }}': 'http://10.0.0.5',
         '${{ vars.CLOUD_RUN_VPC_NETWORK }}': 'test-network',
         '${{ vars.CLOUD_RUN_VPC_SUBNET }}': 'test-subnet',
     }
@@ -175,6 +176,35 @@ def test_gateway_deploy_workflow_and_helper_allow_explicit_prod_launches():
     assert 'Probe LLM Gateway from the Cloud Run VPC' in workflow
     assert 'verify-llm-gateway-serving.py' in workflow
     assert 'probe-llm-gateway-from-cloud-run.sh' in workflow
+    assert 'workflow_dispatch:' in workflow
+    assert 'push:' not in workflow
+    assert 'workflow_run:' not in workflow
+    assert 'schedule:' not in workflow
+    assert '--update-traffic' not in workflow
+    assert 'gcloud run services update-traffic' not in workflow
+
+
+def test_gateway_dev_auto_trigger_is_main_scoped_relevant_source_and_uses_checked_out_sha():
+    workflow = (BACKEND_ROOT.parent / '.github/workflows/gcp_llm_gateway_auto_dev.yml').read_text(encoding='utf-8')
+
+    assert 'push:' in workflow
+    assert 'branches: [ "main" ]' in workflow
+    for relevant_path in (
+        "'backend/llm_gateway/**'",
+        "'backend/charts/llm-gateway/**'",
+        "'backend/scripts/deploy-llm-gateway.sh'",
+        "'backend/scripts/verify-llm-gateway-serving.py'",
+        "'.github/workflows/gcp_llm_gateway*.yml'",
+    ):
+        assert relevant_path in workflow
+    assert 'workflow_dispatch:' not in workflow
+    assert 'workflow_run:' not in workflow
+    assert 'schedule:' not in workflow
+    assert 'CHECKED_OUT_SHA="$(git rev-parse HEAD)"' in workflow
+    assert 'if [[ "$CHECKED_OUT_SHA" != "${GITHUB_SHA}" ]]; then' in workflow
+    assert 'short_sha=$(git rev-parse --short=7 "$CHECKED_OUT_SHA")' in workflow
+    assert 'steps.image-tag.outputs.short_sha' in workflow
+    assert '${GITHUB_SHA::7}' not in workflow
 
 
 def test_backend_deploy_requires_serving_and_cloud_run_vpc_gates_before_gateway_promotion():
@@ -188,12 +218,35 @@ def test_backend_deploy_requires_serving_and_cloud_run_vpc_gates_before_gateway_
     assert (
         '--listener-values="backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml"' in workflow
     )
-    assert "steps.gateway-serving.outputs.gateway_url || 'http://127.0.0.1:9'" in workflow
+    intent_step = workflow[
+        workflow.index('      - name: Determine whether this deploy requests gateway-first serving') : workflow.index(
+            '      - name: Get GKE credentials for gateway serving gate'
+        )
+    ]
+    assert "github.event.inputs.deploy_targets == 'all'" not in intent_step
+    assert 'Reject an inert gateway endpoint when source-controlled gateway mode is requested' in workflow
+    assert 'Gateway mode requires a verified non-sentinel endpoint.' in workflow
+    assert 'steps.combined-gateway-serving.outputs.gateway_url || steps.gateway-serving.outputs.gateway_url || \'http://127.0.0.1:9\'' in workflow
     assert 'Verify LLM gateway control plane before promotion' in auto_dev
     assert 'Probe LLM gateway from the Cloud Run VPC before promotion' in auto_dev
     assert 'OMI_LLM_GATEWAY_URL: ${{ steps.gateway-serving.outputs.gateway_url }}' in auto_dev
     assert '--lane omi:auto:public-shared-conversation-chat' in workflow
     assert '--lane omi:auto:public-shared-conversation-chat' in auto_dev
+
+
+def test_backend_can_compose_dev_gateway_with_immutable_backend_image_but_prod_stays_separate():
+    workflow = (BACKEND_ROOT.parent / '.github/workflows/gcp_backend.yml').read_text(encoding='utf-8')
+    standalone = (BACKEND_ROOT.parent / '.github/workflows/gcp_llm_gateway.yml').read_text(encoding='utf-8')
+
+    assert 'deploy_gateway:' in workflow
+    assert "default: false\n        type: boolean" in workflow
+    assert 'environment=prod, deploy_gateway=true is unsupported; use the standalone manual LLM gateway workflow.' in workflow
+    assert 'deploy_gateway=true requires deploy_targets=all.' in workflow
+    assert 'Deploy LLM Gateway with backend stack' in workflow
+    assert 'IMAGE_TAG="${{ steps.image-tag.outputs.short_sha }}" "$DEPLOY_CONTROL_SCRIPTS/deploy-llm-gateway.sh"' in workflow
+    assert 'deploy-backend-stack-${{ github.event.inputs.environment }}' in workflow
+    assert 'deploy-backend-stack-${{ github.event.inputs.environment }}' in standalone
+    assert 'IMAGE_TAG=$(git rev-parse --short=7 "$CHECKED_OUT_SHA")' in standalone
 
 
 def test_gateway_deploy_workflows_bind_identity_and_gate_serving_static_contract():


### PR DESCRIPTION
## Summary

- keep development gateway deployment automatic and bind its image to the checked-out triggering `main` SHA
- add the explicit development-only `deploy_gateway` backend-stack option, sharing the existing environment lock and immutable backend image tag
- make source-controlled gateway intent, not `deploy_targets`, require serving/VPC gates and a verified non-sentinel endpoint before rendering caller configuration
- publish the exact `llm-gateway` repository image, after a runtime smoke, before combined Helm deployment

## Safety

- Production gateway deployment remains manual-only through `gcp_llm_gateway.yml`; `gcp_backend.yml` rejects `environment=prod, deploy_gateway=true` and retains the existing production Cloud Run-only boundary.
- Gateway deployment updates its GKE release only. It does not set or update caller traffic flags, and this PR does not enable any production gateway feature mode or traffic.

## Verification

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_llm_gateway_deploy_contract.py -q` — 13 passed
- `python3 .github/scripts/check-deployment-concurrency.py --self-test && python3 .github/scripts/check-deployment-concurrency.py` — passed
- `python3 .github/scripts/check-gcp-backend-production-boundary.py` and its fixture tests — passed
- `python3 .github/scripts/check-direct-backend-production-admission.py` and its fixture tests — passed
- `make preflight` — 27 selected checks passed

Failure-Class: FC-runtime-image-boundary
