### PR TITLE
fix(desktop): harden beta auth and Rewind recovery

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1643,
-    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3516,
+    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3502,
     "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": 1856
   },
   "raise_justifications": {

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -1,16 +1,16 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/AuthService.swift": 3219,
+    "desktop/macos/Desktop/Sources/AuthService.swift": 3198,
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4238,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1578,
-    "desktop/macos/Desktop/Sources/OmiApp.swift": 1645
+    "desktop/macos/Desktop/Sources/OmiApp.swift": 1693
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/AuthService.swift": "Apple first-auth name capture signals observers (authNameDidUpdate) and persists the name to Firebase so it survives reinstalls.",
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": "Reach-error card gains a debug bridge action so the actionable failure surface is verifiable in-process.",
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
-    "desktop/macos/Desktop/Sources/OmiApp.swift": "shared openMainAppWindow helper for menu bar + Open Omi shortcut"
+    "desktop/macos/Desktop/Sources/OmiApp.swift": "Current main already contains 1693 lines after the menu-bar summon and chat-landing additions; this PR changes the Firebase-missing launch branch without increasing that count."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/AuthService.swift": 3294,
+    "desktop/macos/Desktop/Sources/AuthService.swift": 3219,
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4238,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1578,

--- a/desktop/macos/Desktop/Package.resolved
+++ b/desktop/macos/Desktop/Package.resolved
@@ -1,1 +1,212 @@
-{"pins":[]}
+{
+  "originHash" : "a71a71d21fa17d870fe706bdbc8d24164f43179ad6d21882d241f0e0e619fe64",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "3e33dd27dd4c69bd81c7c81fe61d8ccf58846902",
+        "version" : "11.3.1"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "fdc352fabaf5916e7faa1f96ad02b1957e93e5a5",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "fluidaudio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/FluidInference/FluidAudio.git",
+      "state" : {
+        "revision" : "19600a485baa4998812e4654b70d2bab8f2c9949"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "a2d0f1f1666de591eb1a811f40b1706f5c63a2ed",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "45ce435e9406d3c674dd249a042b932bee006f60",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
+        "version" : "8.1.2"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift.git",
+      "state" : {
+        "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
+        "version" : "6.29.3"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "c756a29784521063b6a1202907e2cc47f41b667c",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "3851d94a41890dea16dc3db34caf60e585cb4163",
+        "version" : "2.30910.1"
+      }
+    },
+    {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
+      }
+    },
+    {
+      "identity" : "onnxruntime-swift-package-manager",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/onnxruntime-swift-package-manager.git",
+      "state" : {
+        "revision" : "b7fb7f7dea8a2469e6335d95a61b8f36d0dc83b2",
+        "version" : "1.24.2"
+      }
+    },
+    {
+      "identity" : "posthog-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PostHog/posthog-ios.git",
+      "state" : {
+        "revision" : "33145b13ffa1135623e6a2624e29234288a52258",
+        "version" : "3.65.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
+        "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa.git",
+      "state" : {
+        "revision" : "16cd512711375fa73f25ae5e373f596bdf4251ae",
+        "version" : "8.58.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown-ui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
+      "state" : {
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
+        "version" : "1.38.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/desktop/macos/Desktop/Package.swift
+++ b/desktop/macos/Desktop/Package.swift
@@ -1,1 +1,166 @@
-// package-a
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+  name: "Omi Computer",
+  platforms: [
+    .macOS("14.0")
+  ],
+  dependencies: [
+    .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.0.0"),
+    .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
+    .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.58.0"),
+    .package(url: "https://github.com/groue/GRDB.swift.git", from: "6.24.0"),
+    .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
+    .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.0"),
+    .package(
+      url: "https://github.com/microsoft/onnxruntime-swift-package-manager.git", from: "1.20.0"),
+    // FluidAudio removed the v0.14.8+ tags that its semantic requirement used.
+    // Keep the audited Package.resolved source revision without re-resolving it
+    // against the now-truncated upstream tag set.
+    .package(
+      url: "https://github.com/FluidInference/FluidAudio.git",
+      revision: "19600a485baa4998812e4654b70d2bab8f2c9949"
+    ),
+  ],
+  targets: [
+    .target(
+      name: "ObjCExceptionCatcher",
+      path: "ObjCExceptionCatcher",
+      publicHeadersPath: "include"
+    ),
+    .systemLibrary(
+      name: "CWebP",
+      path: "CWebP",
+      pkgConfig: "libwebp",
+      providers: [
+        .brew(["webp"])
+      ]
+    ),
+    .target(
+      name: "OmiSupport",
+      path: "Sources/OmiSupport",
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .target(
+      name: "OmiTheme",
+      path: "Sources/Theme",
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .target(
+      name: "OmiWAL",
+      path: "Sources/OmiWAL",
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .target(
+      name: "VoiceTurnDomain",
+      path: "Sources/VoiceTurnDomain",
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .executableTarget(
+      name: "Omi Computer",
+      dependencies: [
+        "ObjCExceptionCatcher",
+        "CWebP",
+        "OmiSupport",
+        "OmiTheme",
+        "OmiWAL",
+        "VoiceTurnDomain",
+        .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
+        .product(name: "FirebaseAuth", package: "firebase-ios-sdk"),
+        .product(name: "PostHog", package: "posthog-ios"),
+        .product(name: "Sentry", package: "sentry-cocoa"),
+        .product(name: "GRDB", package: "GRDB.swift"),
+        .product(name: "Sparkle", package: "Sparkle"),
+        .product(name: "MarkdownUI", package: "swift-markdown-ui"),
+        .product(name: "onnxruntime", package: "onnxruntime-swift-package-manager"),
+        .product(name: "FluidAudio", package: "FluidAudio"),
+      ],
+      path: "Sources",
+      exclude: [
+        "GoogleService-Info-Dev.plist",
+        "GoogleService-Info-Local.plist",
+        "Theme",
+        "OmiSupport",
+        "OmiWAL",
+        "VoiceTurnDomain",
+        "Bluetooth/ARCHITECTURE.md",
+        "FloatingControlBar/ARCHITECTURE.md",
+      ],
+      resources: [
+        .process("GoogleService-Info.plist"),
+        // Bundles everything under Resources/ (incl. *_logo.png brand marks,
+        // signin_bg.png, and Resources/Fonts/*.ttf — Geist / Geist Mono fonts).
+        // NOTE: SwiftPM caches the resource manifest, so new files added to
+        // Resources/ are only picked up when the manifest regenerates — editing
+        // this file forces incremental builds to re-scan and include them.
+        .process("Resources"),
+      ],
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .testTarget(
+      name: "Omi ComputerTests",
+      dependencies: [
+        .target(name: "Omi Computer"),
+        "OmiSupport",
+        "OmiTheme",
+        "OmiWAL",
+        "VoiceTurnDomain",
+      ],
+      path: "Tests",
+      exclude: [
+        "fixtures",
+        "SemanticFeatureSentinels",
+        "OmiSupportTests",
+        "OmiWALTests",
+        "VoiceTurnDomainTests",
+      ],
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .testTarget(
+      name: "OmiSupportTests",
+      dependencies: ["OmiSupport"],
+      path: "Tests/OmiSupportTests",
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .testTarget(
+      name: "OmiWALTests",
+      dependencies: ["OmiWAL"],
+      path: "Tests/OmiWALTests",
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .testTarget(
+      name: "VoiceTurnDomainTests",
+      dependencies: [
+        .target(name: "Omi Computer"),
+        "VoiceTurnDomain",
+      ],
+      path: "Tests/VoiceTurnDomainTests"
+    ),
+    .testTarget(
+      name: "SemanticFeatureSentinels",
+      dependencies: [],
+      path: "Tests/SemanticFeatureSentinels",
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete"])
+      ]
+    ),
+  ],
+  swiftLanguageModes: [.v6]
+)

--- a/desktop/macos/Desktop/Sources/Auth/AuthOwnerTransition.swift
+++ b/desktop/macos/Desktop/Sources/Auth/AuthOwnerTransition.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Auth state publication fails closed when owner-bound physical storage could
+/// not be released before the defaults/token generation changes.
+@MainActor
+func performAuthOwnerTransition<T: Sendable>(
+  context: String,
+  plannedNextOwner: @escaping @Sendable (UserDefaults, String?) -> String?,
+  _ transition: @escaping @Sendable (UserDefaults) async throws -> T
+) async -> T? {
+  do {
+    return try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+      plannedNextOwner: plannedNextOwner,
+      transition)
+  } catch {
+    logError("AUTH: Could not prepare local storage for \(context) owner transition", error: error)
+    return nil
+  }
+}
+
+extension AuthService {
+  // MARK: - Auth Persistence (UserDefaults for dev builds)
+
+  @discardableResult
+  func saveAuthState(
+    isSignedIn: Bool,
+    email: String?,
+    userId: String?,
+    attempt: AuthSessionAttempt
+  ) async -> Bool {
+    let attemptFence = sessionAttemptFence
+    guard
+      let committed = await performAuthOwnerTransition(
+        context: "auth-state",
+        plannedNextOwner: { _, previousOwner in
+          attemptFence.isCurrent(attempt) ? userId : previousOwner
+        },
+        { defaults in
+          attemptFence.commitIfCurrent(attempt) {
+            defaults.set(isSignedIn, forKey: .authIsSignedIn)
+            defaults.set(email, forKey: .authUserEmail)
+            defaults.set(userId, forKey: .authUserId)
+            defaults.synchronize()
+            return true
+          } ?? false
+        })
+    else { return false }
+    guard committed, sessionAttemptFence.isCurrent(attempt) else { return false }
+    NSLog("OMI AUTH: Saved auth state - signedIn: %@, email: %@", isSignedIn ? "true" : "false", email ?? "nil")
+    return true
+  }
+
+  @discardableResult
+  func clearPersistedAuthState(attempt: AuthSessionAttempt) async -> Bool {
+    let attemptFence = sessionAttemptFence
+    guard
+      let committed = await performAuthOwnerTransition(
+        context: "sign-out",
+        plannedNextOwner: { _, previousOwner in
+          attemptFence.isCurrent(attempt) ? nil : previousOwner
+        },
+        { defaults in
+          attemptFence.commitIfCurrent(attempt) {
+            defaults.removeObject(forKey: .authIsSignedIn)
+            defaults.removeObject(forKey: .authUserEmail)
+            defaults.removeObject(forKey: .authUserId)
+            defaults.removeObject(forKey: .authIdToken)
+            defaults.removeObject(forKey: .authRefreshToken)
+            defaults.removeObject(forKey: .authTokenExpiry)
+            defaults.removeObject(forKey: .authTokenUserId)
+            return true
+          } ?? false
+        })
+    else { return false }
+    return committed && sessionAttemptFence.isCurrent(attempt)
+  }
+
+  /// The only production path for changing the persisted authenticated uid
+  /// outside the larger save/clear auth-state transactions above.
+  @discardableResult
+  func persistAuthenticatedOwner(
+    _ userId: String?,
+    attempt: AuthSessionAttempt
+  ) async -> Bool {
+    let attemptFence = sessionAttemptFence
+    guard
+      let committed = await performAuthOwnerTransition(
+        context: "authenticated-owner",
+        plannedNextOwner: { _, previousOwner in
+          attemptFence.isCurrent(attempt) ? userId : previousOwner
+        },
+        { defaults in
+          attemptFence.commitIfCurrent(attempt) {
+            if let userId {
+              defaults.set(userId, forKey: .authUserId)
+            } else {
+              defaults.removeObject(forKey: .authUserId)
+            }
+            return true
+          } ?? false
+        })
+    else { return false }
+    return committed && sessionAttemptFence.isCurrent(attempt)
+  }
+}

--- a/desktop/macos/Desktop/Sources/Auth/AuthOwnerTransition.swift
+++ b/desktop/macos/Desktop/Sources/Auth/AuthOwnerTransition.swift
@@ -21,6 +21,46 @@ func performAuthOwnerTransition<T: Sendable>(
 extension AuthService {
   // MARK: - Auth Persistence (UserDefaults for dev builds)
 
+  /// Revoke the remote session and publish the signed-out credential generation
+  /// only after owner-bound storage is safely prepared. A preparation failure
+  /// therefore leaves the previous session intact instead of exposing a signed-
+  /// out UI with the previous owner's local authority still active.
+  @discardableResult
+  func commitSignedOutSession(
+    attempt: AuthSessionAttempt,
+    phase: AuthSessionPhase,
+    beforeClearingCredentials: @escaping @MainActor @Sendable () throws -> Void = {},
+    prepareLocalStorageTransition:
+      @escaping @Sendable (_ previousOwner: String?, _ plannedNextOwner: String?) async throws -> Void = { _, _ in
+        RewindIndexer.shared.suspendForOwnerTransition()
+        try await RewindStorage.shared.resetForOwnerTransition()
+      }
+  ) async throws -> Bool {
+    let attemptFence = sessionAttemptFence
+    let committed = try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+      plannedNextOwner: { _, previousOwner in
+        attemptFence.isCurrent(attempt) ? nil : previousOwner
+      },
+      prepareLocalStorageTransition: prepareLocalStorageTransition,
+      { _ in
+        try await MainActor.run {
+          try attemptFence.commitIfCurrent(attempt) {
+            try beforeClearingCredentials()
+            self.clearTokens()
+            AuthState.shared.userEmail = nil
+            AuthState.shared.transition(to: phase)
+            let defaults = UserDefaults.standard
+            defaults.set(false, forKey: .authIsSignedIn)
+            defaults.removeObject(forKey: .authUserEmail)
+            defaults.removeObject(forKey: .authUserId)
+            defaults.synchronize()
+            return true
+          } ?? false
+        }
+      })
+    return committed && sessionAttemptFence.isCurrent(attempt)
+  }
+
   @discardableResult
   func saveAuthState(
     isSignedIn: Bool,

--- a/desktop/macos/Desktop/Sources/Auth/FirebaseAuthAvailability.swift
+++ b/desktop/macos/Desktop/Sources/Auth/FirebaseAuthAvailability.swift
@@ -1,0 +1,74 @@
+@preconcurrency import FirebaseAuth
+import FirebaseCore
+import Foundation
+
+/// The Firebase SDK is optional at runtime: local harnesses deliberately skip
+/// it and a damaged/missing bundled plist must leave REST-backed auth usable.
+/// `Auth.auth()` fatally traps without a configured default Firebase app, so
+/// callers obtain SDK access only through this seam.
+@MainActor
+struct FirebaseAuthAvailability {
+  var configuredAuth: () -> Auth?
+
+  static let live = FirebaseAuthAvailability(
+    configuredAuth: {
+      guard FirebaseApp.app() != nil else { return nil }
+      return Auth.auth()
+    })
+
+  func auth() -> Auth? {
+    configuredAuth()
+  }
+
+  struct NativeAppleSignInResult {
+    let tokens: AuthService.FirebaseTokenResult
+    let fallbackReason: String?
+  }
+
+  static func signInWithNativeApple(
+    auth: Auth?,
+    identityToken: String,
+    nonce: String,
+    isSessionCurrent: () -> Bool,
+    discardStaleFirebaseUser: (String) -> Void,
+    restFallback: () async throws -> AuthService.FirebaseTokenResult
+  ) async throws -> NativeAppleSignInResult {
+    guard let auth else {
+      let tokens = try await restFallback()
+      return .init(tokens: tokens, fallbackReason: "config_incomplete")
+    }
+
+    let credential = OAuthProvider.credential(providerID: .apple, idToken: identityToken, rawNonce: nonce)
+    do {
+      let authResult = try await auth.signIn(with: credential)
+      let tokenResult = try await authResult.user.getIDTokenResult()
+      guard isSessionCurrent() else {
+        discardStaleFirebaseUser(authResult.user.uid)
+        throw AuthError.cancelled
+      }
+      let tokens = AuthService.FirebaseTokenResult(
+        idToken: tokenResult.token,
+        refreshToken: authResult.user.refreshToken ?? "",
+        expiresIn: Int(tokenResult.expirationDate.timeIntervalSinceNow),
+        localId: authResult.user.uid)
+      return .init(tokens: tokens, fallbackReason: nil)
+    } catch {
+      guard isSessionCurrent() else { throw AuthError.cancelled }
+      let nsError = error as NSError
+      logError(
+        "AUTH: Firebase SDK Apple sign-in failed (domain=\(nsError.domain) code=\(nsError.code))", error: error)
+      let tokens = try await restFallback()
+      return .init(tokens: tokens, fallbackReason: "auth")
+    }
+  }
+
+  static func recordNativeAppleFallback(reason: String) {
+    DesktopDiagnosticsManager.shared.recordFallback(
+      area: "api_auth",
+      from: "firebase_sdk",
+      to: "firebase_rest",
+      reason: reason,
+      outcome: .recovered
+    )
+  }
+}

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -555,6 +555,22 @@ class AuthService {
 
   var tokenRefreshHooks = TokenRefreshHooks.live
 
+  // Firebase availability is injected for hermetic auth tests and resolves to
+  // nil when the default Firebase app was not configured at launch. Keeping
+  // this state separate from session ownership lets the REST-token flow remain
+  // authoritative while every direct SDK call stays safe.
+  // It deliberately does not alter AuthSessionAttempt fencing, token storage,
+  // or RuntimeOwnerIdentity; those remain the session owner's responsibility.
+  // The availability seam is intentionally narrow.
+  var firebaseAuthAvailability = FirebaseAuthAvailability.live
+
+  /// Returns the SDK only when its default Firebase app exists. Callers must
+  /// treat `nil` as an expected runtime mode, never as a reason to read the
+  /// Firebase SDK directly.
+  private func configuredFirebaseAuth() -> Auth? {
+    firebaseAuthAvailability.auth()
+  }
+
   // Firebase Web API key — fetched from backend via APIKeyService, set as env var.
   // No hardcoded fallback — if the key isn't available, auth operations will fail
   // with a clear error instead of silently using a potentially wrong key.
@@ -621,7 +637,7 @@ class AuthService {
   }
 
   private let sessionCoordinator = AuthSessionCoordinator.shared
-  private let sessionAttemptFence = AuthSessionAttemptFence()
+  let sessionAttemptFence = AuthSessionAttemptFence()
 
   init() {
     // Initialize without super
@@ -644,12 +660,12 @@ class AuthService {
   }
 
   private func discardStaleFirebaseUserIfNeeded(_ userID: String) {
-    guard FirebaseApp.app() != nil,
-      Auth.auth().currentUser?.uid == userID
+    guard let auth = configuredFirebaseAuth(),
+      auth.currentUser?.uid == userID
     else {
       return
     }
-    try? Auth.auth().signOut()
+    try? auth.signOut()
   }
 
   // MARK: - Session invalidation (light — not nuclear signOut)
@@ -667,11 +683,10 @@ class AuthService {
     // auth-state listener do not re-create the ghost session on the next
     // launch. Unlike signOut(), this does NOT tear down storage caches or
     // stop background services — it only clears the Firebase SDK user.
-    // Guard: tests/local harnesses can exercise invalidation without
-    // FirebaseApp.configure(); Auth.auth() traps fatally if called before
-    // Firebase is configured.
-    if FirebaseApp.app() != nil {
-      try? Auth.auth().signOut()
+    // The REST-backed session remains authoritative if the Firebase SDK was
+    // unavailable at launch. Only clear an SDK session when one exists.
+    if let auth = configuredFirebaseAuth() {
+      try? auth.signOut()
     }
     return await commitSignedOutSession(attempt: attempt, phase: .needsReauth)
   }
@@ -683,7 +698,14 @@ class AuthService {
     isConfigured = true
     let attempt = beginSessionAttempt()
     await restoreAuthState(attempt: attempt)
-    setupAuthStateListener()
+    // The listener enriches a configured SDK session, but a REST-backed
+    // session can still restore and validate without it. Do not make listener
+    // setup a prerequisite for the auth state machine.
+    if configuredFirebaseAuth() != nil {
+      setupAuthStateListener()
+    } else {
+      log("AuthService: Firebase SDK unavailable; continuing with REST-backed auth")
+    }
 
     // Timeout: if auth isn't restored within 5 seconds, stop showing loading
     DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
@@ -778,81 +800,6 @@ class AuthService {
     Self.localUserId(fromIDToken: idToken)
   }
 
-  // MARK: - Auth Persistence (UserDefaults for dev builds)
-
-  @discardableResult
-  private func saveAuthState(
-    isSignedIn: Bool,
-    email: String?,
-    userId: String?,
-    attempt: AuthSessionAttempt
-  ) async -> Bool {
-    let attemptFence = sessionAttemptFence
-    let committed = await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-      plannedNextOwner: { _, previousOwner in
-        attemptFence.isCurrent(attempt) ? userId : previousOwner
-      }
-    ) { defaults in
-      attemptFence.commitIfCurrent(attempt) {
-        defaults.set(isSignedIn, forKey: .authIsSignedIn)
-        defaults.set(email, forKey: .authUserEmail)
-        defaults.set(userId, forKey: .authUserId)
-        defaults.synchronize()  // Force flush before process can be killed
-        return true
-      } ?? false
-    }
-    guard committed, sessionAttemptFence.isCurrent(attempt) else { return false }
-    NSLog("OMI AUTH: Saved auth state - signedIn: %@, email: %@", isSignedIn ? "true" : "false", email ?? "nil")
-    return true
-  }
-
-  @discardableResult
-  private func clearPersistedAuthState(attempt: AuthSessionAttempt) async -> Bool {
-    let attemptFence = sessionAttemptFence
-    let committed = await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-      plannedNextOwner: { _, previousOwner in
-        attemptFence.isCurrent(attempt) ? nil : previousOwner
-      }
-    ) { defaults in
-      attemptFence.commitIfCurrent(attempt) {
-        defaults.removeObject(forKey: .authIsSignedIn)
-        defaults.removeObject(forKey: .authUserEmail)
-        defaults.removeObject(forKey: .authUserId)
-        defaults.removeObject(forKey: .authIdToken)
-        defaults.removeObject(forKey: .authRefreshToken)
-        defaults.removeObject(forKey: .authTokenExpiry)
-        defaults.removeObject(forKey: .authTokenUserId)
-        return true
-      } ?? false
-    }
-    return committed && sessionAttemptFence.isCurrent(attempt)
-  }
-
-  /// The only production path for changing the persisted authenticated uid
-  /// outside the larger save/clear auth-state transactions above.
-  @discardableResult
-  private func persistAuthenticatedOwner(
-    _ userId: String?,
-    attempt: AuthSessionAttempt
-  ) async -> Bool {
-    let attemptFence = sessionAttemptFence
-    let committed = await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-      plannedNextOwner: { _, previousOwner in
-        attemptFence.isCurrent(attempt) ? userId : previousOwner
-      }
-    ) { defaults in
-      attemptFence.commitIfCurrent(attempt) {
-        if let userId {
-          defaults.set(userId, forKey: .authUserId)
-        } else {
-          defaults.removeObject(forKey: .authUserId)
-        }
-        return true
-      } ?? false
-    }
-    return committed && sessionAttemptFence.isCurrent(attempt)
-  }
-
   /// Commit credentials and their owner as one generation-owned auth result.
   /// Token persistence is synchronous and generation-locked; the awaited owner
   /// transition re-checks the same attempt before changing defaults. A newer
@@ -875,24 +822,24 @@ class AuthService {
     let committed = try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
       plannedNextOwner: { _, previousOwner in
         attemptFence.isCurrent(attempt) ? tokens.localId : previousOwner
-      }
-    ) { _ in
-      try await MainActor.run {
-        try attemptFence.commitIfCurrent(attempt) {
-          try self.saveTokens(
-            idToken: tokens.idToken,
-            refreshToken: tokens.refreshToken,
-            expiresIn: tokens.expiresIn,
-            userId: tokens.localId)
-          let defaults = UserDefaults.standard
-          defaults.set(true, forKey: .authIsSignedIn)
-          defaults.set(email, forKey: .authUserEmail)
-          defaults.set(tokens.localId, forKey: .authUserId)
-          defaults.synchronize()
-          return true
-        } ?? false
-      }
-    }
+      },
+      { _ in
+        try await MainActor.run {
+          try attemptFence.commitIfCurrent(attempt) {
+            try self.saveTokens(
+              idToken: tokens.idToken,
+              refreshToken: tokens.refreshToken,
+              expiresIn: tokens.expiresIn,
+              userId: tokens.localId)
+            let defaults = UserDefaults.standard
+            defaults.set(true, forKey: .authIsSignedIn)
+            defaults.set(email, forKey: .authUserEmail)
+            defaults.set(tokens.localId, forKey: .authUserId)
+            defaults.synchronize()
+            return true
+          } ?? false
+        }
+      })
     guard committed else { return false }
     guard sessionAttemptFence.isCurrent(attempt) else { return false }
     NSLog("OMI AUTH: Atomically saved signed-in session for user %@", tokens.localId)
@@ -961,7 +908,7 @@ class AuthService {
     // with user=nil and flip isSignedIn to false before we restore it.
     if savedSignedIn {
       AuthState.shared.transition(to: .restoring)
-      AuthState.shared.userEmail = Auth.auth().currentUser?.email ?? savedEmail
+      AuthState.shared.userEmail = configuredFirebaseAuth()?.currentUser?.email ?? savedEmail
 
       // Migration: Fix empty userId by extracting from stored idToken.
       let savedUserId = UserDefaults.standard.string(forKey: .authUserId) ?? ""
@@ -1012,7 +959,7 @@ class AuthService {
 
   private func validateRestoredSessionNow(attempt: AuthSessionAttempt) async {
     guard sessionAttemptFence.isCurrent(attempt) else { return }
-    let hasFirebaseUser = !DesktopLocalProfile.isEnabled && Auth.auth().currentUser != nil
+    let hasFirebaseUser = !DesktopLocalProfile.isEnabled && configuredFirebaseAuth()?.currentUser != nil
 
     guard storedRefreshToken != nil || storedIdToken != nil || hasFirebaseUser else {
       NSLog("OMI AUTH: Restored session has no credentials — invalidating")
@@ -1024,7 +971,7 @@ class AuthService {
       _ = try await sessionCoordinator.refreshSingleFlight(auth: self)
       guard sessionAttemptFence.isCurrent(attempt) else { return }
       NSLog("OMI AUTH: Restored session validated via forced refresh")
-      let userId = storedTokenUserId ?? Auth.auth().currentUser?.uid
+      let userId = storedTokenUserId ?? configuredFirebaseAuth()?.currentUser?.uid
       guard
         await commitRestoredSession(
           userId: userId,
@@ -1057,7 +1004,8 @@ class AuthService {
   // MARK: - Auth State Listener
 
   private func setupAuthStateListener() {
-    authStateHandle = Auth.auth().addStateDidChangeListener { [weak self] _, user in
+    guard let auth = configuredFirebaseAuth() else { return }
+    authStateHandle = auth.addStateDidChangeListener { [weak self] _, user in
       Task { @MainActor in
         guard let self else { return }
         if let user {
@@ -1200,45 +1148,14 @@ class AuthService {
     // fall back to REST API (for web OAuth audience 'me.omi.web')
     NSLog("OMI AUTH: Signing in with Firebase using Apple identity token...")
 
-    let credential = OAuthProvider.credential(providerID: .apple, idToken: identityToken, rawNonce: nonce)
-    var userId = ""
-    let firebaseTokens: FirebaseTokenResult
-
-    do {
-      // Firebase SDK sign-in (works with native bundle ID as token audience)
-      let authResult = try await Auth.auth().signIn(with: credential)
-      NSLog("OMI AUTH: Firebase SDK sign-in SUCCESS - uid: %@", authResult.user.uid)
-      userId = authResult.user.uid
-
-      // Get ID token from Firebase SDK for API calls
-      let tokenResult = try await authResult.user.getIDTokenResult()
-      let idToken = tokenResult.token
-      let refreshToken = authResult.user.refreshToken ?? ""
-      let expiresIn = Int(tokenResult.expirationDate.timeIntervalSinceNow)
-      guard sessionAttemptFence.isCurrent(sessionAttempt) else {
-        discardStaleFirebaseUserIfNeeded(authResult.user.uid)
-        throw AuthError.cancelled
-      }
-      firebaseTokens = FirebaseTokenResult(
-        idToken: idToken,
-        refreshToken: refreshToken,
-        expiresIn: expiresIn,
-        localId: userId)
-    } catch {
-      if !sessionAttemptFence.isCurrent(sessionAttempt) {
-        throw AuthError.cancelled
-      }
-      // Fall back to REST API (works when Firebase SDK has keychain issues)
-      let nsError = error as NSError
-      NSLog(
-        "OMI AUTH: Firebase SDK Apple sign-in failed (domain=%@ code=%d): %@", nsError.domain, nsError.code,
-        error.localizedDescription)
-      logError("AUTH: Firebase SDK Apple sign-in failed (domain=\(nsError.domain) code=\(nsError.code))", error: error)
-      NSLog("OMI AUTH: Falling back to REST API for Apple sign-in...")
-      let fallbackTokens = try await signInWithAppleIdentityToken(identityToken: identityToken, nonce: nonce)
-      userId = fallbackTokens.localId
-      firebaseTokens = fallbackTokens
-    }
+    let nativeSignIn = try await FirebaseAuthAvailability.signInWithNativeApple(
+      auth: configuredFirebaseAuth(),
+      identityToken: identityToken,
+      nonce: nonce,
+      isSessionCurrent: { self.sessionAttemptFence.isCurrent(sessionAttempt) },
+      discardStaleFirebaseUser: { self.discardStaleFirebaseUserIfNeeded($0) },
+      restFallback: { try await self.signInWithAppleIdentityToken(identityToken: identityToken, nonce: nonce) }
+    )
 
     // Extract email from identity token if not provided by Apple
     if AuthState.shared.userEmail == nil {
@@ -1251,11 +1168,14 @@ class AuthService {
 
     guard
       try await commitSignedInSession(
-        tokens: firebaseTokens,
+        tokens: nativeSignIn.tokens,
         email: AuthState.shared.userEmail,
         attempt: sessionAttempt)
     else {
       throw AuthError.cancelled
+    }
+    if let fallbackReason = nativeSignIn.fallbackReason {
+      FirebaseAuthAvailability.recordNativeAppleFallback(reason: fallbackReason)
     }
 
     if givenName.isEmpty {
@@ -1284,7 +1204,7 @@ class AuthService {
     if !AnalyticsManager.isDevBuild {
       // Keep Sentry correlation opaque; PII remains in the application/backend,
       // not crash and error reports.
-      SentrySDK.setUser(User(userId: userId))
+      SentrySDK.setUser(User(userId: nativeSignIn.tokens.localId))
     }
 
     NSLog("OMI AUTH: Apple Sign in complete!")
@@ -1519,18 +1439,20 @@ class AuthService {
       guard sessionAttemptFence.isCurrent(sessionAttempt) else {
         throw AuthError.cancelled
       }
-      do {
-        let authResult = try await Auth.auth().signIn(withCustomToken: tokenResult.customToken)
-        guard sessionAttemptFence.isCurrent(sessionAttempt) else {
-          discardStaleFirebaseUserIfNeeded(authResult.user.uid)
+      if let auth = configuredFirebaseAuth() {
+        do {
+          let authResult = try await auth.signIn(withCustomToken: tokenResult.customToken)
+          guard sessionAttemptFence.isCurrent(sessionAttempt) else {
+            discardStaleFirebaseUserIfNeeded(authResult.user.uid)
+            throw AuthError.cancelled
+          }
+          NSLog("OMI AUTH: Firebase SDK sign-in SUCCESS - uid: %@", authResult.user.uid)
+        } catch AuthError.cancelled {
           throw AuthError.cancelled
+        } catch let firebaseError as NSError {
+          // Keychain errors are expected on dev builds - we have REST API tokens as fallback
+          NSLog("OMI AUTH: Firebase SDK sign-in failed (using REST API tokens): %@", firebaseError.localizedDescription)
         }
-        NSLog("OMI AUTH: Firebase SDK sign-in SUCCESS - uid: %@", authResult.user.uid)
-      } catch AuthError.cancelled {
-        throw AuthError.cancelled
-      } catch let firebaseError as NSError {
-        // Keychain errors are expected on dev builds - we have REST API tokens as fallback
-        NSLog("OMI AUTH: Firebase SDK sign-in failed (using REST API tokens): %@", firebaseError.localizedDescription)
       }
 
       // Save auth state immediately
@@ -2147,7 +2069,7 @@ class AuthService {
     let isImpersonating = UserDefaults.standard.bool(forKey: .authIsImpersonating)
     if isImpersonating {
       NSLog("OMI AUTH: Skipping Firebase displayName update (impersonation mode)")
-    } else if let user = Auth.auth().currentUser {
+    } else if let user = configuredFirebaseAuth()?.currentUser {
       do {
         let changeRequest = user.createProfileChangeRequest()
         changeRequest.displayName = trimmedName
@@ -2179,7 +2101,7 @@ class AuthService {
     guard isCurrentOwner(expectedOwnerID, authorizationSnapshot: authorizationSnapshot) else { return }
     let isImpersonating = UserDefaults.standard.bool(forKey: .authIsImpersonating)
 
-    if !isImpersonating, let user = Auth.auth().currentUser {
+    if !isImpersonating, let user = configuredFirebaseAuth()?.currentUser {
       guard user.uid == expectedOwnerID else { return }
       do {
         let changeRequest = user.createProfileChangeRequest()
@@ -2228,7 +2150,7 @@ class AuthService {
 
   /// Try to get name from Firebase user (after OAuth sign-in)
   func getNameFromFirebase() -> String? {
-    if let displayName = Auth.auth().currentUser?.displayName, !displayName.isEmpty {
+    if let displayName = configuredFirebaseAuth()?.currentUser?.displayName, !displayName.isEmpty {
       return displayName
     }
     return nil
@@ -2278,8 +2200,7 @@ class AuthService {
       guard self.givenName.isEmpty,
         self.isSessionAttemptCurrent(attempt),
         RuntimeOwnerIdentity.currentOwnerId() == expectedOwnerID,
-        FirebaseApp.app() != nil,
-        Auth.auth().currentUser?.uid == expectedOwnerID,
+        self.configuredFirebaseAuth()?.currentUser?.uid == expectedOwnerID,
         let firebaseName = self.getNameFromFirebase()
       else {
         return
@@ -2829,10 +2750,9 @@ class AuthService {
       }
     }
 
-    // Third try: Use Firebase SDK (only if user matches expected user)
-    // This prevents returning a stale user's token during sign-out race conditions
-    // Local harness skips FirebaseApp.configure(); Auth.auth() traps if called.
-    if !DesktopLocalProfile.isEnabled, FirebaseApp.app() != nil, let user = Auth.auth().currentUser {
+    // Third try: Use Firebase SDK (only if user matches expected user).
+    // This prevents returning a stale user's token during sign-out race conditions.
+    if !DesktopLocalProfile.isEnabled, let user = configuredFirebaseAuth()?.currentUser {
       if expectedUserId == nil || user.uid == expectedUserId {
         if expectedUserId == nil {
           // Backfill the missing userId
@@ -2957,11 +2877,16 @@ class AuthService {
     }
 
     let signingOutUserID = UserDefaults.standard.string(forKey: .authUserId)
-    try Auth.auth().signOut()
-    // Reset coordinator only after Firebase sign-out succeeds so the state
-    // transition is atomic — if signOut() throws (e.g. keychain error), the
-    // coordinator stays in its previous phase rather than falsely reporting
-    // .signedOut while local tokens remain intact.
+    if let auth = configuredFirebaseAuth() {
+      try auth.signOut()
+    } else {
+      // A REST-backed session has no SDK credential to revoke; continue with
+      // the same fenced local token and owner cleanup below.
+      log("AuthService: Firebase SDK unavailable; signing out the REST-backed session")
+    }
+    // Reset coordinator only after the Firebase sign-out succeeds when the SDK
+    // exists, so a keychain error cannot falsely report .signedOut while local
+    // tokens remain intact. A REST-backed session has no SDK state to clear.
     sessionCoordinator.resetAfterNuclearSignOut()
     CredentialHealthManager.shared.reset()
     APIKeyService.shared.clear()

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -685,10 +685,19 @@ class AuthService {
     // stop background services — it only clears the Firebase SDK user.
     // The REST-backed session remains authoritative if the Firebase SDK was
     // unavailable at launch. Only clear an SDK session when one exists.
-    if let auth = configuredFirebaseAuth() {
-      try? auth.signOut()
+    do {
+      return try await commitSignedOutSession(
+        attempt: attempt,
+        phase: .needsReauth,
+        beforeClearingCredentials: { [self] in
+          if let auth = configuredFirebaseAuth() {
+            try auth.signOut()
+          }
+        })
+    } catch {
+      logError("AUTH: Session invalidation could not release owner-bound storage", error: error)
+      return false
     }
-    return await commitSignedOutSession(attempt: attempt, phase: .needsReauth)
   }
 
   // MARK: - Configuration (call after FirebaseApp.configure())
@@ -868,29 +877,6 @@ class AuthService {
     AuthState.shared.userEmail = email
     sessionCoordinator.resetAfterSuccessfulSignIn()
     return true
-  }
-
-  /// Clear credentials before the awaited owner transition. This ordering is
-  /// deliberate: a newer sign-in can begin while SQLite is closing, but a stale
-  /// sign-out has no token-deletion step left to run after that suspension.
-  @discardableResult
-  func commitSignedOutSession(
-    attempt: AuthSessionAttempt,
-    phase: AuthSessionPhase
-  ) async -> Bool {
-    let cleared =
-      sessionAttemptFence.commitIfCurrent(attempt) {
-        clearTokens()
-        AuthState.shared.userEmail = nil
-        AuthState.shared.transition(to: phase)
-        return true
-      } ?? false
-    guard cleared else { return false }
-    return await saveAuthState(
-      isSignedIn: false,
-      email: nil,
-      userId: nil,
-      attempt: attempt)
   }
 
   private func restoreAuthState(attempt: AuthSessionAttempt) async {
@@ -2257,7 +2243,7 @@ class AuthService {
     NSLog("OMI AUTH: Saved tokens for user %@, expires at %@", userId, expiryTime.description)
   }
 
-  private func clearTokens() {
+  func clearTokens() {
     tokenStorageHooks.deleteKeychainString(authTokenKeychainService, authTokenKeychainAccount)
     clearUserDefaultsTokens()
     invalidateStoredTokensCache()
@@ -2867,37 +2853,18 @@ class AuthService {
 
   func signOut() async throws {
     let sessionAttempt = beginSessionAttempt()
-    // Track sign out and reset analytics
-    AnalyticsManager.shared.signedOut()
-    AnalyticsManager.shared.reset()
-
-    // Clear Sentry user context (skip in dev builds)
-    if !AnalyticsManager.isDevBuild {
-      SentrySDK.setUser(nil)
-    }
-
     let signingOutUserID = UserDefaults.standard.string(forKey: .authUserId)
-    if let auth = configuredFirebaseAuth() {
-      try auth.signOut()
-    } else {
-      // A REST-backed session has no SDK credential to revoke; continue with
-      // the same fenced local token and owner cleanup below.
-      log("AuthService: Firebase SDK unavailable; signing out the REST-backed session")
-    }
-    // Reset coordinator only after the Firebase sign-out succeeds when the SDK
-    // exists, so a keychain error cannot falsely report .signedOut while local
-    // tokens remain intact. A REST-backed session has no SDK state to clear.
-    sessionCoordinator.resetAfterNuclearSignOut()
-    CredentialHealthManager.shared.reset()
-    APIKeyService.shared.clear()
-    ChatDraftStore.shared.clearAll(ownerID: signingOutUserID)
-    // Clear credentials before the awaited owner/SQLite transition. If a
-    // newer sign-in starts while the old pool is closing, this stale
-    // sign-out has no later token deletion that could wipe the new session.
     guard
-      await commitSignedOutSession(
+      try await commitSignedOutSession(
         attempt: sessionAttempt,
-        phase: .signedOut)
+        phase: .signedOut,
+        beforeClearingCredentials: { [self] in
+          if let auth = configuredFirebaseAuth() {
+            try auth.signOut()
+          } else {
+            log("AuthService: Firebase SDK unavailable; signing out the REST-backed session")
+          }
+        })
     else {
       log("AuthService: stale sign-out completion ignored")
       return
@@ -2906,6 +2873,18 @@ class AuthService {
       log("AuthService: sign-out superseded by a newer session")
       return
     }
+
+    // Destructive session projections follow the committed owner revocation so
+    // a storage failure cannot leave a partially signed-out prior-owner session.
+    AnalyticsManager.shared.signedOut()
+    AnalyticsManager.shared.reset()
+    if !AnalyticsManager.isDevBuild {
+      SentrySDK.setUser(nil)
+    }
+    sessionCoordinator.resetAfterNuclearSignOut()
+    CredentialHealthManager.shared.reset()
+    APIKeyService.shared.clear()
+    ChatDraftStore.shared.clearAll(ownerID: signingOutUserID)
 
     // Stop trial polling and reset banner state for this user session
     if let state = AppState.current {

--- a/desktop/macos/Desktop/Sources/AuthSessionCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/AuthSessionCoordinator.swift
@@ -106,7 +106,7 @@ final class AuthSessionCoordinator {
   func invalidateSession(reason: InvalidateReason, auth: AuthService) async {
     NSLog("OMI AUTH: invalidateSession reason=%@", reason.rawValue)
     guard await auth.performLightSessionInvalidation() else {
-      NSLog("OMI AUTH: stale invalidateSession completion ignored")
+      NSLog("OMI AUTH: invalidateSession failed or was superseded; existing session remains authoritative")
       return
     }
     NotificationCenter.default.post(

--- a/desktop/macos/Desktop/Sources/Chat/RuntimeOwnerIdentity.swift
+++ b/desktop/macos/Desktop/Sources/Chat/RuntimeOwnerIdentity.swift
@@ -249,13 +249,20 @@ enum RuntimeOwnerIdentity {
           previousOwner: previousOwner,
           nextOwner: nextOwner)
       },
+    prepareLocalStorageTransition:
+      @escaping @Sendable (
+        _ previousOwner: String?, _ plannedNextOwner: String?
+      ) async throws -> Void = { _, _ in
+        RewindIndexer.shared.suspendForOwnerTransition()
+        try await RewindStorage.shared.resetForOwnerTransition()
+      },
     ownerDidChange: @escaping @Sendable () async -> Void = {
       await MainActor.run {
         NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
       }
     },
     _ transition: @escaping @Sendable (UserDefaults) async throws -> T
-  ) async rethrows -> T {
+  ) async throws -> T {
     let defaultsReference = RuntimeOwnerDefaultsReference(value: defaults)
     let cleanupCapabilitySlot = RuntimeOwnerTransitionCleanupCapabilitySlot()
     return try await EffectiveOwnerTransitionFence.shared.performEffectiveOwnerTransition(
@@ -308,6 +315,10 @@ enum RuntimeOwnerIdentity {
             cleanupCapability: cleanupCapability)
         }
       },
+      prepareLocalStorageTransition: prepareLocalStorageTransition,
+      finalizeLocalStorageTransition: {
+        await RewindIndexer.shared.resumeAfterOwnerTransition()
+      },
       transition: {
         try await transition(defaultsReference.value)
       },
@@ -350,9 +361,7 @@ enum RuntimeOwnerIdentity {
     // Wait for an active file scan to leave its actor before closing the pool
     // it captured. New-owner mutations remain parked by the fence.
     await FileIndexerService.shared.invalidateCache()
-    await RewindIndexer.shared.reset()
     await OCREmbeddingService.shared.reset()
-    await RewindStorage.shared.reset()
     await RewindDatabase.shared.retargetEffectiveOwner(to: nextOwner)
     await TranscriptionStorage.shared.invalidateCache()
     await MemoryStorage.shared.invalidateCache()
@@ -415,24 +424,29 @@ enum RuntimeOwnerIdentity {
   ) async -> String? {
     let trimmed = ownerBId.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return nil }
-    return await performEffectiveOwnerTransition(
-      defaults: defaults,
-      allowAutomationOverride: true,
-      plannedNextOwner: { _, _ in trimmed }
-    ) { defaults in
-      let ownerA = defaults.string(forKey: .authUserId)?
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-      defaults.set(trimmed, forKey: .automationOwnerOverride)
-      // Preserve an existing backup (nested/re-entrant swap). Only seed when absent
-      // so a second override cannot replace the real Firebase uid with owner B.
-      let existingBackup = defaults.string(forKey: .automationOwnerABackup)?
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-      if existingBackup == nil || existingBackup?.isEmpty == true,
-        let ownerA, !ownerA.isEmpty, ownerA != trimmed
-      {
-        defaults.set(ownerA, forKey: .automationOwnerABackup)
+    do {
+      return try await performEffectiveOwnerTransition(
+        defaults: defaults,
+        allowAutomationOverride: true,
+        plannedNextOwner: { _, _ in trimmed }
+      ) { defaults in
+        let ownerA = defaults.string(forKey: .authUserId)?
+          .trimmingCharacters(in: .whitespacesAndNewlines)
+        defaults.set(trimmed, forKey: .automationOwnerOverride)
+        // Preserve an existing backup (nested/re-entrant swap). Only seed when absent
+        // so a second override cannot replace the real Firebase uid with owner B.
+        let existingBackup = defaults.string(forKey: .automationOwnerABackup)?
+          .trimmingCharacters(in: .whitespacesAndNewlines)
+        if existingBackup == nil || existingBackup?.isEmpty == true,
+          let ownerA, !ownerA.isEmpty, ownerA != trimmed
+        {
+          defaults.set(ownerA, forKey: .automationOwnerABackup)
+        }
+        return ownerA
       }
-      return ownerA
+    } catch {
+      logError("RuntimeOwnerIdentity: Could not prepare local storage for automation owner", error: error)
+      return nil
     }
   }
 
@@ -446,16 +460,21 @@ enum RuntimeOwnerIdentity {
   ) async -> Bool {
     let trimmed = ownerID.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return false }
-    return await performEffectiveOwnerTransition(
-      defaults: defaults,
-      allowAutomationOverride: true,
-      plannedNextOwner: { _, previousOwner in previousOwner ?? trimmed }
-    ) { defaults in
-      guard persistedOwnerId(defaults: defaults, allowAutomationOverride: true) == nil else {
-        return false
+    do {
+      return try await performEffectiveOwnerTransition(
+        defaults: defaults,
+        allowAutomationOverride: true,
+        plannedNextOwner: { _, previousOwner in previousOwner ?? trimmed }
+      ) { defaults in
+        guard persistedOwnerId(defaults: defaults, allowAutomationOverride: true) == nil else {
+          return false
+        }
+        defaults.set(trimmed, forKey: .automationOwnerOverride)
+        return true
       }
-      defaults.set(trimmed, forKey: .automationOwnerOverride)
-      return true
+    } catch {
+      logError("RuntimeOwnerIdentity: Could not prepare local storage for temporary owner", error: error)
+      return false
     }
   }
 
@@ -493,44 +512,49 @@ enum RuntimeOwnerIdentity {
   static func clearAutomationOwnerOverride(
     defaults: UserDefaults = .standard
   ) async -> (restored: Bool, ownerId: String?) {
-    await performEffectiveOwnerTransition(
-      defaults: defaults,
-      allowAutomationOverride: true,
-      plannedNextOwner: { defaults, previousOwner in
-        plannedOwnerAfterClearingAutomationOverride(
-          defaults: defaults,
-          previousOwner: previousOwner)
-      }
-    ) { defaults in
-      let override = defaults.string(forKey: .automationOwnerOverride)?
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-      let hadOverride = !(override?.isEmpty ?? true)
-      let backup = defaults.string(forKey: .automationOwnerABackup)?
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-      defaults.removeObject(forKey: .automationOwnerOverride)
-
-      if let backup, !backup.isEmpty {
-        let currentAuthUserId = defaults.string(forKey: .authUserId)?
-          .trimmingCharacters(in: .whitespacesAndNewlines)
-        // Only rewrite auth_userId when it still looks like a synthetic overwrite
-        // (empty, equals the override we cleared, or legacy backup-only heal).
-        // Never clobber a legitimately updated auth uid from a mid-session sign-in.
-        let shouldHealAuthUserId =
-          currentAuthUserId == nil
-          || currentAuthUserId?.isEmpty == true
-          || (hadOverride && currentAuthUserId == override)
-          || (!hadOverride && currentAuthUserId != backup)
-        if shouldHealAuthUserId {
-          defaults.set(backup, forKey: .authUserId)
+    do {
+      return try await performEffectiveOwnerTransition(
+        defaults: defaults,
+        allowAutomationOverride: true,
+        plannedNextOwner: { defaults, previousOwner in
+          plannedOwnerAfterClearingAutomationOverride(
+            defaults: defaults,
+            previousOwner: previousOwner)
         }
-        defaults.removeObject(forKey: .automationOwnerABackup)
-        return (true, defaults.string(forKey: .authUserId) ?? backup)
-      }
+      ) { defaults in
+        let override = defaults.string(forKey: .automationOwnerOverride)?
+          .trimmingCharacters(in: .whitespacesAndNewlines)
+        let hadOverride = !(override?.isEmpty ?? true)
+        let backup = defaults.string(forKey: .automationOwnerABackup)?
+          .trimmingCharacters(in: .whitespacesAndNewlines)
+        defaults.removeObject(forKey: .automationOwnerOverride)
 
-      if hadOverride {
-        return (true, defaults.string(forKey: .authUserId))
+        if let backup, !backup.isEmpty {
+          let currentAuthUserId = defaults.string(forKey: .authUserId)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+          // Only rewrite auth_userId when it still looks like a synthetic overwrite
+          // (empty, equals the override we cleared, or legacy backup-only heal).
+          // Never clobber a legitimately updated auth uid from a mid-session sign-in.
+          let shouldHealAuthUserId =
+            currentAuthUserId == nil
+            || currentAuthUserId?.isEmpty == true
+            || (hadOverride && currentAuthUserId == override)
+            || (!hadOverride && currentAuthUserId != backup)
+          if shouldHealAuthUserId {
+            defaults.set(backup, forKey: .authUserId)
+          }
+          defaults.removeObject(forKey: .automationOwnerABackup)
+          return (true, defaults.string(forKey: .authUserId) ?? backup)
+        }
+
+        if hadOverride {
+          return (true, defaults.string(forKey: .authUserId))
+        }
+        return (false, nil)
       }
-      return (false, nil)
+    } catch {
+      logError("RuntimeOwnerIdentity: Could not prepare local storage while clearing automation owner", error: error)
+      return (false, currentOwnerId(defaults: defaults, allowAutomationOverride: true))
     }
   }
 

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -446,11 +446,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
       let options = FirebaseOptions(contentsOfFile: path)
     {
       FirebaseApp.configure(options: options)
-      Task { @MainActor in
-        await AuthService.shared.configure()
-      }
+      Task { @MainActor in await AuthService.shared.configure() }
     } else {
-      log("Firebase configure skipped (plistPath=\(plistPath ?? "nil"))")
+      // REST-backed token restoration does not require the Firebase SDK.
+      log("Firebase configure skipped (plistPath=\(plistPath ?? "nil")); using REST-backed auth")
+      Task { @MainActor in await AuthService.shared.configure() }
     }
 
     // Initialize analytics (PostHog)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -442,7 +442,7 @@ public class ProactiveAssistantsPlugin: NSObject {
 
         Task {
           do {
-            _ = try await VideoChunkEncoder.shared.flushCurrentChunk()
+            _ = try await RewindStorage.shared.flushCurrentVideoChunk()
           } catch {
             logError("ProactiveAssistantsPlugin: Failed to flush video chunk before power cadence switch", error: error)
           }

--- a/desktop/macos/Desktop/Sources/ResourceMonitor.swift
+++ b/desktop/macos/Desktop/Sources/ResourceMonitor.swift
@@ -371,7 +371,7 @@ class ResourceMonitor {
       // reset counters in component diagnostics so hang/memory Sentry events can
       // be correlated.
       do {
-        _ = try await VideoChunkEncoder.shared.flushCurrentChunk()
+        _ = try await RewindStorage.shared.flushCurrentVideoChunk()
       } catch {
         logError("ResourceMonitor: Failed to flush video chunk during memory remediation", error: error)
       }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindAbandonedVideoChunkRecovery.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindAbandonedVideoChunkRecovery.swift
@@ -1,0 +1,150 @@
+import Foundation
+@preconcurrency import GRDB
+
+/// A durable sidecar journal for chunks whose writer was cancelled before it
+/// could produce a playable MP4 trailer. Markers are intentionally stored
+/// beside the per-user Videos directory so the next startup can finish cleanup
+/// against the same user database.
+enum RewindAbandonedVideoChunkJournal {
+  private static let directoryName = ".abandoned-video-chunks"
+
+  private struct Marker: Codable {
+    let relativePath: String
+  }
+
+  struct MarkerFile: Sendable {
+    let relativePath: String
+    let url: URL
+  }
+
+  @discardableResult
+  static func record(reservation: RewindVideoChunkReservation, in videosDirectory: URL) throws -> MarkerFile {
+    let markerDirectory = videosDirectory.appendingPathComponent(directoryName, isDirectory: true)
+    try FileManager.default.createDirectory(at: markerDirectory, withIntermediateDirectories: true)
+
+    let markerURL = markerDirectory.appendingPathComponent("\(reservation.generation)-\(UUID().uuidString).json")
+    let data = try JSONEncoder().encode(Marker(relativePath: reservation.relativePath))
+    try data.write(to: markerURL, options: .atomic)
+    return MarkerFile(relativePath: reservation.relativePath, url: markerURL)
+  }
+
+  static func markers(in videosDirectory: URL) throws -> [MarkerFile] {
+    let markerDirectory = videosDirectory.appendingPathComponent(directoryName, isDirectory: true)
+    guard FileManager.default.fileExists(atPath: markerDirectory.path) else {
+      return []
+    }
+
+    return try FileManager.default.contentsOfDirectory(
+      at: markerDirectory,
+      includingPropertiesForKeys: nil,
+      options: [.skipsHiddenFiles]
+    ).compactMap { markerURL in
+      guard markerURL.pathExtension == "json" else { return nil }
+      let marker = try JSONDecoder().decode(Marker.self, from: Data(contentsOf: markerURL))
+      _ = try videoURL(relativePath: marker.relativePath, in: videosDirectory)
+      return MarkerFile(relativePath: marker.relativePath, url: markerURL)
+    }
+  }
+
+  static func remove(_ marker: MarkerFile) throws {
+    try FileManager.default.removeItem(at: marker.url)
+  }
+
+  static func videoURL(relativePath: String, in videosDirectory: URL) throws -> URL {
+    let trimmed = relativePath.trimmingCharacters(in: .whitespacesAndNewlines)
+    let components = trimmed.split(separator: "/", omittingEmptySubsequences: false)
+    guard components.count == 2,
+      components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }),
+      trimmed.hasSuffix(".mp4")
+    else {
+      throw RewindError.storageError("Invalid abandoned video chunk path")
+    }
+
+    let root = videosDirectory.standardizedFileURL
+    let candidate = root.appendingPathComponent(trimmed).standardizedFileURL
+    guard candidate.path.hasPrefix(root.path + "/") else {
+      throw RewindError.storageError("Abandoned video chunk path escapes storage")
+    }
+    return candidate
+  }
+}
+
+/// The tombstone is the database half of abandoned-chunk recovery. It rejects
+/// late OCR/indexing writes after file recovery has removed the chunk.
+enum RewindAbandonedVideoChunkQuarantine {
+  private static let tableName = "abandoned_video_chunks"
+
+  static func registerMigration(on migrator: inout DatabaseMigrator) {
+    migrator.registerMigration("quarantineAbandonedVideoChunks") { db in
+      try db.execute(
+        sql: """
+          CREATE TABLE \(tableName) (
+            videoChunkPath TEXT PRIMARY KEY NOT NULL
+          )
+          """
+      )
+    }
+  }
+
+  static func requireAvailable(_ db: Database, videoChunkPath: String) throws {
+    let isAbandoned =
+      try Int.fetchOne(
+        db,
+        sql: "SELECT EXISTS(SELECT 1 FROM \(tableName) WHERE videoChunkPath = ?)",
+        arguments: [videoChunkPath]
+      ) ?? 0
+    guard isAbandoned == 0 else {
+      throw RewindAbandonedVideoChunkError(relativePath: videoChunkPath)
+    }
+  }
+}
+
+extension RewindDatabase {
+  /// Insert a screenshot only when its video generation was not durably
+  /// abandoned. This is the persistence boundary for late OCR continuations.
+  @discardableResult
+  func insertScreenshot(_ screenshot: Screenshot) throws -> Screenshot {
+    guard let dbQueue = getDatabaseQueue() else {
+      throw RewindError.databaseNotInitialized
+    }
+
+    return try dbQueue.write { db in
+      if let videoChunkPath = screenshot.videoChunkPath, !videoChunkPath.isEmpty {
+        try RewindAbandonedVideoChunkQuarantine.requireAvailable(db, videoChunkPath: videoChunkPath)
+      }
+      var record = screenshot
+      // `imagePath` is NOT NULL in SQLite, whereas video-backed screenshots
+      // carry nil in the model.
+      if record.imagePath == nil { record.imagePath = "" }
+      try record.insert(db)
+      return record
+    }
+  }
+
+  /// Tombstone a cancelled writer generation and remove every persisted frame
+  /// in one transaction. Repeating this after a filesystem failure is safe.
+  @discardableResult
+  func abandonVideoChunk(relativePath: String) throws -> Int {
+    guard let dbQueue = getDatabaseQueue() else {
+      throw RewindError.databaseNotInitialized
+    }
+    guard !relativePath.isEmpty else {
+      throw RewindError.storageError("Cannot abandon a video chunk with an empty path")
+    }
+
+    return try dbQueue.write { db in
+      try db.execute(
+        sql: "INSERT OR IGNORE INTO abandoned_video_chunks (videoChunkPath) VALUES (?)",
+        arguments: [relativePath]
+      )
+      let deletedCount =
+        try Int.fetchOne(
+          db,
+          sql: "SELECT COUNT(*) FROM screenshots WHERE videoChunkPath = ?",
+          arguments: [relativePath]
+        ) ?? 0
+      try db.execute(sql: "DELETE FROM screenshots WHERE videoChunkPath = ?", arguments: [relativePath])
+      return deletedCount
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindArtifactGauntlet.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindArtifactGauntlet.swift
@@ -92,7 +92,7 @@ enum RewindArtifactGauntlet {
       }
       chunkPath = storedChunkPath
 
-      let flush = try await VideoChunkEncoder.shared.flushCurrentChunk()
+      let flush = try await RewindStorage.shared.flushCurrentVideoChunk()
       guard let flush, flush.videoChunkPath == storedChunkPath, flush.frames.count == persistedRows.count else {
         throw RewindError.storageError("Rewind artifact gauntlet could not finalize its video chunk")
       }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2562,6 +2562,8 @@ actor RewindDatabase {
       }
     }
 
+    RewindAbandonedVideoChunkQuarantine.registerMigration(on: &migrator)
+
     try migrator.migrate(queue)
   }
 
@@ -2713,24 +2715,6 @@ actor RewindDatabase {
 
   // MARK: - CRUD Operations
 
-  /// Insert a new screenshot record
-  @discardableResult
-  func insertScreenshot(_ screenshot: Screenshot) throws -> Screenshot {
-    guard let dbQueue = dbQueue else {
-      throw RewindError.databaseNotInitialized
-    }
-
-    return try dbQueue.write { db -> Screenshot in
-      var record = screenshot
-      // The `imagePath` column is NOT NULL in the schema, but the model field is
-      // optional (nil for video-based screenshots). Coalesce nil → "" so a video
-      // screenshot never trips a NOT NULL constraint violation on insert.
-      if record.imagePath == nil { record.imagePath = "" }
-      try record.insert(db)
-      return record
-    }
-  }
-
   /// Atomically replace every database row reconstructed from one video chunk.
   ///
   /// Rebuilds can be retried, so inserting reconstructed rows one at a time would
@@ -2763,6 +2747,8 @@ actor RewindDatabase {
     }
 
     return try dbQueue.write { db in
+      try RewindAbandonedVideoChunkQuarantine.requireAvailable(db, videoChunkPath: path)
+
       try db.execute(
         sql: "DELETE FROM screenshots WHERE videoChunkPath = ?",
         arguments: [path]

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
@@ -28,6 +28,12 @@ actor RewindStorage {
 
   // Track corrupted video chunks to avoid repeated frame extraction attempts
   private var corruptedChunks = Set<String>()
+  /// A deterministic seam proving sidecar retention across a one-shot cleanup
+  /// failure. Production leaves this at zero.
+  private var abandonedChunkCleanupFailuresForTesting = 0
+  /// Deterministic failure injection for the DB half of abandoned-chunk
+  /// recovery. Production leaves this at zero.
+  private var abandonedChunkDatabaseFailuresForTesting = 0
 
   // MARK: - Initialization
 
@@ -39,11 +45,46 @@ actor RewindStorage {
 
   /// Reset storage state (called on user switch / sign-out)
   func reset() async {
+    do {
+      try await resetForOwnerTransition()
+    } catch {
+      logError("RewindStorage: Could not safely reset old video owner", error: error)
+    }
+  }
+
+  /// The throwing owner-transition boundary. A marker-write failure may leave
+  /// the old writer live, so callers changing the effective owner must stop
+  /// before publishing new defaults when the DB-first fallback also fails.
+  func resetForOwnerTransition() async throws {
+    let cancellation = await VideoChunkEncoder.shared.resetForUserSwitch()
+    switch cancellation {
+    case .markerWriteFailed(let reservation):
+      // Do not clear the old owner configuration while its writer remains
+      // active or its database has not accepted the durable tombstone.
+      try await recoverAfterMarkerWriteFailure(reservation: reservation)
+    case .markerRecorded:
+      do {
+        try await reconcileAbandonedVideoChunks()
+      } catch {
+        // The sidecar is deliberately retained. A later initialization for
+        // this user retries the DB/file cleanup before capture starts again.
+        logError("RewindStorage: Deferred abandoned video chunk recovery", error: error)
+      }
+    case .noActiveChunk:
+      if videosDirectory != nil {
+        do {
+          try await reconcileAbandonedVideoChunks()
+        } catch {
+          logError("RewindStorage: Deferred abandoned video chunk recovery", error: error)
+        }
+      }
+    }
+
+    await VideoChunkEncoder.shared.clearConfigurationAfterUserSwitch()
     screenshotsDirectory = nil
     videosDirectory = nil
     frameCache.removeAllObjects()
     corruptedChunks.removeAll()
-    await VideoChunkEncoder.shared.resetForUserSwitch()
     log("RewindStorage: Reset for user switch")
   }
 
@@ -68,6 +109,10 @@ actor RewindStorage {
 
     try fileManager.createDirectory(at: screenshotsDirectory, withIntermediateDirectories: true)
     try fileManager.createDirectory(at: videosDirectory, withIntermediateDirectories: true)
+
+    // Finish any previous crashed/cancelled writer before this owner can start
+    // another one. A marker remains until both database and file cleanup work.
+    try await reconcileAbandonedVideoChunks()
 
     // Initialize video encoder with videos directory
     try await VideoChunkEncoder.shared.initialize(videosDirectory: videosDirectory)
@@ -571,6 +616,126 @@ actor RewindStorage {
 
     log("RewindStorage: Cleaned up corrupted chunk \(videoPath), deleted \(deletedCount) DB entries")
     return deletedCount
+  }
+
+  /// Reconcile every durable cancellation marker for the current owner. The
+  /// marker is removed only after the tombstone/row deletion and file deletion
+  /// both succeed; repeating the operation is therefore safe after a restart.
+  func reconcileAbandonedVideoChunks() async throws {
+    guard let videosDirectory else {
+      throw RewindError.storageError("Videos directory not initialized")
+    }
+
+    for marker in try RewindAbandonedVideoChunkJournal.markers(in: videosDirectory) {
+      let deletedCount = try await abandonVideoChunk(relativePath: marker.relativePath)
+      try deleteAbandonedVideoChunkFile(relativePath: marker.relativePath, videosDirectory: videosDirectory)
+      try RewindAbandonedVideoChunkJournal.remove(marker)
+      corruptedChunks.remove(marker.relativePath)
+      log("RewindStorage: Recovered abandoned video chunk, deleted \(deletedCount) DB rows")
+    }
+  }
+
+  /// Marker creation can fail (for example, transient disk exhaustion). The
+  /// owner-transition fallback tombstones the old path first, then cancels only
+  /// that still-current writer and removes the file before retargeting storage.
+  func recoverAfterMarkerWriteFailure(reservation: RewindVideoChunkReservation) async throws {
+    guard let videosDirectory else {
+      throw RewindError.storageError("Videos directory not initialized for marker fallback")
+    }
+
+    _ = try await abandonVideoChunk(relativePath: reservation.relativePath)
+    // The DB tombstone is already durable. Retry the sidecar opportunistically
+    // so a post-cancel filesystem failure still has a startup retry path.
+    let fallbackMarker = try? RewindAbandonedVideoChunkJournal.record(
+      reservation: reservation,
+      in: videosDirectory
+    )
+    await VideoChunkEncoder.shared.forceCancelAfterStorageFallback(for: reservation)
+    do {
+      try deleteAbandonedVideoChunkFile(relativePath: reservation.relativePath, videosDirectory: videosDirectory)
+      if let fallbackMarker {
+        try RewindAbandonedVideoChunkJournal.remove(fallbackMarker)
+      }
+    } catch {
+      // The durable tombstone prevents an orphaned partial file from appearing
+      // in the timeline. Keep a fallback marker when possible and do not block
+      // the nonthrowing effective-owner transition on filesystem cleanup.
+      logError("RewindStorage: Could not delete tombstoned fallback chunk", error: error)
+    }
+    corruptedChunks.remove(reservation.relativePath)
+    log("RewindStorage: Recovered abandoned chunk after marker write failure")
+  }
+
+  /// Shared recovery classifier for every producer path, including indexer
+  /// frame processing, explicit flush, and the encoder's staleness timer.
+  func recoverAbandonedVideoChunkIfNeeded(_ error: Error) async throws -> Bool {
+    if error is RewindAbandonedVideoChunkError {
+      try await reconcileAbandonedVideoChunks()
+      return true
+    }
+    if let markerFailure = error as? RewindAbandonedVideoChunkMarkerWriteError {
+      try await recoverAfterMarkerWriteFailure(reservation: markerFailure.reservation)
+      return true
+    }
+    return false
+  }
+
+  /// Finalize the active encoder generation and reconcile any durable
+  /// abandonment marker before returning an error to non-indexer callers.
+  func flushCurrentVideoChunk() async throws -> VideoChunkEncoder.ChunkFlushResult? {
+    do {
+      return try await VideoChunkEncoder.shared.flushCurrentChunk()
+    } catch {
+      _ = try await recoverAbandonedVideoChunkIfNeeded(error)
+      throw error
+    }
+  }
+
+  func setAbandonedChunkCleanupFailuresForTesting(_ failures: Int) {
+    precondition(failures >= 0)
+    abandonedChunkCleanupFailuresForTesting = failures
+  }
+
+  func setAbandonedChunkDatabaseFailuresForTesting(_ failures: Int) {
+    precondition(failures >= 0)
+    abandonedChunkDatabaseFailuresForTesting = failures
+  }
+
+  func abandonedVideoChunkMarkerCountForTesting() throws -> Int {
+    guard let videosDirectory else {
+      throw RewindError.storageError("Videos directory not initialized")
+    }
+    return try RewindAbandonedVideoChunkJournal.markers(in: videosDirectory).count
+  }
+
+  /// Models a process relaunch after the sidecar was durably written but before
+  /// any in-process DB reconciliation ran. Tests seed the marker and live rows,
+  /// clear only volatile configuration, then exercise normal initialization.
+  func clearVolatileConfigurationForProcessRestartTesting() async {
+    await VideoChunkEncoder.shared.clearConfigurationAfterUserSwitch()
+    screenshotsDirectory = nil
+    videosDirectory = nil
+    frameCache.removeAllObjects()
+    corruptedChunks.removeAll()
+  }
+
+  private func abandonVideoChunk(relativePath: String) async throws -> Int {
+    guard abandonedChunkDatabaseFailuresForTesting == 0 else {
+      abandonedChunkDatabaseFailuresForTesting -= 1
+      throw RewindError.storageError("Injected abandoned-chunk database failure")
+    }
+    return try await RewindDatabase.shared.abandonVideoChunk(relativePath: relativePath)
+  }
+
+  private func deleteAbandonedVideoChunkFile(relativePath: String, videosDirectory: URL) throws {
+    let fullPath = try RewindAbandonedVideoChunkJournal.videoURL(relativePath: relativePath, in: videosDirectory)
+    guard abandonedChunkCleanupFailuresForTesting == 0 else {
+      abandonedChunkCleanupFailuresForTesting -= 1
+      throw RewindError.storageError("Injected abandoned-chunk cleanup failure")
+    }
+    if fileManager.fileExists(atPath: fullPath.path) {
+      try fileManager.removeItem(at: fullPath)
+    }
   }
 
   /// Get all currently known corrupted chunks

--- a/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
@@ -13,6 +13,27 @@ struct RewindVideoChunkReservation: Equatable, Sendable {
   let relativePath: String
 }
 
+/// Signals that one exact writer generation was cancelled before it produced a
+/// durable MP4 trailer. The encoder deliberately emits this ownership token
+/// instead of reaching into persistence: the indexer/storage boundary owns the
+/// corresponding database and filesystem recovery.
+struct RewindAbandonedVideoChunkError: Error, Sendable {
+  let relativePath: String
+}
+
+/// A marker could not be persisted before a writer needed cancellation. The
+/// storage owner must use its DB-first fallback before it force-cancels this
+/// exact reservation.
+struct RewindAbandonedVideoChunkMarkerWriteError: Error, Sendable {
+  let reservation: RewindVideoChunkReservation
+}
+
+enum RewindVideoChunkCancellationResult: Sendable {
+  case noActiveChunk
+  case markerRecorded(RewindVideoChunkReservation)
+  case markerWriteFailed(RewindVideoChunkReservation)
+}
+
 private enum RewindVideoChunkLifecyclePhase: Equatable, Sendable {
   case writing
   case finalizing
@@ -161,6 +182,16 @@ actor VideoChunkEncoder {
   // published, without relying on wall-clock scheduling.
   private var beforeFinishWritingForTesting: (@Sendable () async -> Void)?
   private var finalizationJoinedForTesting: (@Sendable () -> Void)?
+  /// When set, appends succeed this many times before every later append fails.
+  /// This intentionally models an AVFoundation append failure after rows may
+  /// already have been persisted for earlier frames in the same chunk.
+  private var appendFailureAfterSuccessfulFramesForTesting: Int?
+  /// Exercises the DB-first owner-transition fallback when a sidecar cannot
+  /// be created before cancellation.
+  private var abandonmentMarkerWriteFailuresForTesting = 0
+  /// Exercises finalization recovery at the indexer stop boundary without
+  /// relying on an AVFoundation codec failure.
+  private var finishWritingFailuresForTesting = 0
 
   // MARK: - Types
 
@@ -188,7 +219,7 @@ actor VideoChunkEncoder {
   func initialize(videosDirectory: URL) async throws {
     if isInitialized {
       guard self.videosDirectory != videosDirectory else { return }
-      await resetForUserSwitch()
+      throw RewindError.storageError("Video encoder must reset before changing storage owner")
     }
 
     self.videosDirectory = videosDirectory
@@ -206,6 +237,23 @@ actor VideoChunkEncoder {
   ) {
     beforeFinishWritingForTesting = beforeFinishWriting
     finalizationJoinedForTesting = finalizationJoined
+  }
+
+  func setAppendFailureAfterSuccessfulFramesForTesting(_ successfulFrames: Int?) {
+    if let successfulFrames {
+      precondition(successfulFrames >= 0)
+    }
+    appendFailureAfterSuccessfulFramesForTesting = successfulFrames
+  }
+
+  func setAbandonmentMarkerWriteFailuresForTesting(_ failures: Int) {
+    precondition(failures >= 0)
+    abandonmentMarkerWriteFailuresForTesting = failures
+  }
+
+  func setFinishWritingFailuresForTesting(_ failures: Int) {
+    precondition(failures >= 0)
+    finishWritingFailuresForTesting = failures
   }
 
   func hasFinalizedChunkForDedupe() -> Bool {
@@ -226,7 +274,9 @@ actor VideoChunkEncoder {
     if frameTimestamps.count >= maxBufferFrames {
       log("VideoChunkEncoder: Buffer exceeded \(maxBufferFrames) frames, forcing flush to prevent memory leak")
       logError("VideoChunkEncoder: Emergency buffer flush triggered - \(frameTimestamps.count) frames")
-      try await emergencyReset(reason: "buffer_overflow")
+      if let abandonment = try await emergencyReset(reason: "buffer_overflow") {
+        throw abandonment
+      }
     }
 
     // Check if aspect ratio changed significantly.
@@ -315,7 +365,9 @@ actor VideoChunkEncoder {
 
         if consecutiveWriteFailures >= maxConsecutiveFailures {
           logError("VideoChunkEncoder: Too many video writer failures, performing emergency reset")
-          try await emergencyReset(reason: "writer_start_failure")
+          if let abandonment = try await emergencyReset(reason: "writer_start_failure") {
+            throw abandonment
+          }
         }
         throw error
       }
@@ -340,6 +392,8 @@ actor VideoChunkEncoder {
       }
       consecutiveWriteFailures = 0  // Reset on successful write
       resetStalenessTimer()
+    } catch let abandonment as RewindAbandonedVideoChunkError {
+      throw abandonment
     } catch {
       // `waitForWriterInputReady` can suspend. If a cancel/restart replaced
       // this writer while it was waiting, the old call must not increment or
@@ -354,7 +408,9 @@ actor VideoChunkEncoder {
 
       if consecutiveWriteFailures >= maxConsecutiveFailures {
         logError("VideoChunkEncoder: Too many write failures, performing emergency reset")
-        try await emergencyReset(reason: "write_failure")
+        if let abandonment = try await emergencyReset(reason: "write_failure") {
+          throw abandonment
+        }
       }
       throw error
     }
@@ -463,17 +519,12 @@ actor VideoChunkEncoder {
     let writer = try AVAssetWriter(outputURL: fullPath, fileType: .mp4)
     writer.shouldOptimizeForNetworkUse = true
 
-    let settings: [String: Any] = [
-      AVVideoCodecKey: AVVideoCodecType.hevc,
-      AVVideoWidthKey: width,
-      AVVideoHeightKey: height,
-      AVVideoCompressionPropertiesKey: [
-        AVVideoAverageBitRateKey: bitrate,
-        AVVideoExpectedSourceFrameRateKey: max(1, Int(ceil(frameRate))),
-        AVVideoMaxKeyFrameIntervalDurationKey: 10,
-        AVVideoAllowFrameReorderingKey: false,
-      ],
-    ]
+    let settings = Self.hevcVideoSettings(
+      width: width,
+      height: height,
+      bitrate: bitrate,
+      frameRate: frameRate
+    )
 
     let input = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
     input.expectsMediaDataInRealTime = true
@@ -525,6 +576,29 @@ actor VideoChunkEncoder {
     SentrySDK.addBreadcrumb(breadcrumb)
   }
 
+  /// HEVC's VideoToolbox encoder rejects
+  /// `AVVideoMaxKeyFrameIntervalDurationKey` on some Intel/macOS combinations
+  /// (including hvc1), terminating the app while constructing the writer input.
+  /// Keep the common HEVC settings in one testable factory and omit that
+  /// unsupported property; keyframe cadence is encoder-controlled instead.
+  nonisolated static func hevcVideoSettings(
+    width: Int,
+    height: Int,
+    bitrate: Int,
+    frameRate: Double
+  ) -> [String: Any] {
+    [
+      AVVideoCodecKey: AVVideoCodecType.hevc,
+      AVVideoWidthKey: width,
+      AVVideoHeightKey: height,
+      AVVideoCompressionPropertiesKey: [
+        AVVideoAverageBitRateKey: bitrate,
+        AVVideoExpectedSourceFrameRateKey: max(1, Int(ceil(frameRate))),
+        AVVideoAllowFrameReorderingKey: false,
+      ],
+    ]
+  }
+
   /// Presentation timestamp (in seconds) for the frame at `frameOffset` within a chunk.
   /// Callers pass the offset of the frame being written now; the writer requires strictly
   /// increasing timestamps, so this must be a strictly increasing function of frameOffset
@@ -559,7 +633,9 @@ actor VideoChunkEncoder {
 
       if writerNotReadyCount >= maxConsecutiveNotReadyFailures {
         logError("VideoChunkEncoder: Video writer not ready \(writerNotReadyCount)x, resetting encoder state")
-        try await emergencyReset(reason: "writer_not_ready_loop")
+        if let abandonment = try await emergencyReset(reason: "writer_not_ready_loop") {
+          throw abandonment
+        }
       } else {
         log("VideoChunkEncoder: Video writer not ready (\(writerNotReadyCount)/\(maxConsecutiveNotReadyFailures))")
       }
@@ -593,6 +669,12 @@ actor VideoChunkEncoder {
       ),
       preferredTimescale: 600
     )
+    if let successfulFrames = appendFailureAfterSuccessfulFramesForTesting {
+      guard successfulFrames > 0 else {
+        throw RewindError.storageError("Injected append failure for abandoned-chunk recovery test")
+      }
+      appendFailureAfterSuccessfulFramesForTesting = successfulFrames - 1
+    }
     guard adaptor.append(pixelBuffer, withPresentationTime: presentationTime) else {
       if let writerError = assetWriter?.error {
         throw RewindError.storageWriteFailed("Failed to append frame to HEVC writer", underlying: writerError)
@@ -637,16 +719,30 @@ actor VideoChunkEncoder {
     do {
       try await finishWriting(writer)
     } catch {
-      writer.cancelWriting()
       // A cancellation/restart may have replaced this writer while its finish
       // callback was pending. That stale completion is an expected no-op for
       // the caller rather than an error from the newer generation.
-      guard resetCurrentChunkState(onlyIfCurrent: reservation) else {
+      guard chunkLifecycle.owns(reservation) else {
         resolveInFlightFinalization(reservation, with: .success(false))
         return false
       }
-      resolveInFlightFinalization(reservation, with: .failure(error))
-      throw error
+
+      // A failed finish may leave an MP4 without its trailer. Record its exact
+      // path before cancelling the writer so recovery survives a crash between
+      // this failure and the indexer/storage cleanup.
+      switch cancelCurrentChunkAfterRecordingAbandonment() {
+      case .markerRecorded(let abandonedReservation):
+        let abandonment = RewindAbandonedVideoChunkError(relativePath: abandonedReservation.relativePath)
+        resolveInFlightFinalization(reservation, with: .failure(abandonment))
+        throw abandonment
+      case .markerWriteFailed(let failedReservation):
+        let markerFailure = RewindAbandonedVideoChunkMarkerWriteError(reservation: failedReservation)
+        resolveInFlightFinalization(reservation, with: .failure(markerFailure))
+        throw markerFailure
+      case .noActiveChunk:
+        resolveInFlightFinalization(reservation, with: .success(false))
+        return false
+      }
     }
 
     guard resetCurrentChunkState(onlyIfCurrent: reservation) else {
@@ -770,8 +866,20 @@ actor VideoChunkEncoder {
     do {
       _ = try await finalizeCurrentChunk()
     } catch {
-      logError("VideoChunkEncoder: Failed to finalize stale video chunk", error: error)
+      do {
+        let recovered = try await RewindStorage.shared.recoverAbandonedVideoChunkIfNeeded(error)
+        if !recovered {
+          logError("VideoChunkEncoder: Failed to finalize stale video chunk", error: error)
+        }
+      } catch {
+        logError("VideoChunkEncoder: Failed to recover stale video chunk", error: error)
+      }
     }
+  }
+
+  func finalizeStaleChunkForTesting() async {
+    guard let reservation = chunkLifecycle.activeReservation else { return }
+    await finalizeStaleChunkIfNeeded(onlyIfCurrent: reservation)
   }
 
   // MARK: - Helpers
@@ -898,6 +1006,10 @@ actor VideoChunkEncoder {
   }
 
   private func finishWriting(_ writer: AVAssetWriter) async throws {
+    guard finishWritingFailuresForTesting == 0 else {
+      finishWritingFailuresForTesting -= 1
+      throw RewindError.storageError("Injected finishWriting failure for abandoned-chunk recovery test")
+    }
     let writerBox = AssetWriterBox(writer)
     try await withCheckedThrowingContinuation { continuation in
       writerBox.writer.finishWriting {
@@ -956,34 +1068,38 @@ actor VideoChunkEncoder {
 
   // MARK: - Cleanup
 
-  /// Cancel any in-progress encoding and clean up
-  func cancel() async {
-    stalenessCheckTask?.cancel()
-    stalenessCheckTask = nil
-
-    let cancelledFinalization = inFlightFinalization?.reservation
-    writerInput?.markAsFinished()
-    assetWriter?.cancelWriting()
-    _ = resetCurrentChunkState()
-    if let cancelledFinalization {
-      resolveInFlightFinalization(cancelledFinalization, with: .success(false))
-    }
-    writerNotReadyCount = 0
+  /// Cancel any in-progress encoding. A marker is written before the writer is
+  /// touched; callers that own persistence can use the marker-write-failure
+  /// result to execute the DB-first fallback.
+  @discardableResult
+  func cancel() -> RewindVideoChunkCancellationResult {
+    cancelCurrentChunkAfterRecordingAbandonment()
   }
 
-  func resetForUserSwitch() async {
-    await cancel()
+  /// Stop the current owner before its database/directory configuration is
+  /// released. RewindStorage reconciles the marker or performs the fallback,
+  /// then calls `clearConfigurationAfterUserSwitch`.
+  @discardableResult
+  func resetForUserSwitch() -> RewindVideoChunkCancellationResult {
+    cancelCurrentChunkAfterRecordingAbandonment()
+  }
+
+  func clearConfigurationAfterUserSwitch() {
     videosDirectory = nil
     isInitialized = false
     hasFinalizedAnyChunk = false
   }
 
+  /// This is intentionally only callable by the storage owner after it has
+  /// tombstoned the old path in the still-open old-user database.
+  func forceCancelAfterStorageFallback(for reservation: RewindVideoChunkReservation) {
+    guard chunkLifecycle.owns(reservation) else { return }
+    cancelCurrentChunkState()
+  }
+
   /// Emergency reset when encoding fails repeatedly or buffer overflows
   /// Clears all state and allows fresh start on next frame
-  private func emergencyReset(reason: String = "failure_threshold") async throws {
-    stalenessCheckTask?.cancel()
-    stalenessCheckTask = nil
-
+  private func emergencyReset(reason: String = "failure_threshold") async throws -> RewindAbandonedVideoChunkError? {
     let droppedFrames = frameTimestamps.count
     emergencyResetCount += 1
 
@@ -1005,17 +1121,59 @@ actor VideoChunkEncoder {
     logError(
       "VideoChunkEncoder: Emergency reset (reason=\(reason)) - dropping \(droppedFrames) frames to prevent memory leak")
 
+    switch cancelCurrentChunkAfterRecordingAbandonment() {
+    case .noActiveChunk:
+      log("VideoChunkEncoder: Emergency reset complete, ready for new frames")
+      return nil
+    case .markerRecorded(let abandonedReservation):
+      log("VideoChunkEncoder: Emergency reset complete, ready for new frames")
+      return RewindAbandonedVideoChunkError(relativePath: abandonedReservation.relativePath)
+    case .markerWriteFailed(let failedReservation):
+      throw RewindAbandonedVideoChunkMarkerWriteError(reservation: failedReservation)
+    }
+  }
+
+  /// Records the recovery sidecar before an AVFoundation cancellation can make
+  /// the partial MP4 unreadable. This actor contains no persistence dependency;
+  /// RewindStorage later consumes the durable record.
+  private func cancelCurrentChunkAfterRecordingAbandonment() -> RewindVideoChunkCancellationResult {
+    if let reservation = chunkLifecycle.activeReservation {
+      do {
+        try recordAbandonment(reservation)
+      } catch {
+        logError("VideoChunkEncoder: Refusing to cancel chunk without durable recovery marker", error: error)
+        return .markerWriteFailed(reservation)
+      }
+      cancelCurrentChunkState()
+      return .markerRecorded(reservation)
+    }
+
+    cancelCurrentChunkState()
+    return .noActiveChunk
+  }
+
+  private func recordAbandonment(_ reservation: RewindVideoChunkReservation) throws {
+    guard let videosDirectory else {
+      throw RewindError.storageError("Video encoder has no storage directory for abandoned chunk")
+    }
+    guard abandonmentMarkerWriteFailuresForTesting == 0 else {
+      abandonmentMarkerWriteFailuresForTesting -= 1
+      throw RewindError.storageError("Injected abandoned-chunk marker write failure")
+    }
+    _ = try RewindAbandonedVideoChunkJournal.record(reservation: reservation, in: videosDirectory)
+  }
+
+  private func cancelCurrentChunkState() {
+    stalenessCheckTask?.cancel()
+    stalenessCheckTask = nil
     let cancelledFinalization = inFlightFinalization?.reservation
     writerInput?.markAsFinished()
     assetWriter?.cancelWriting()
-
-    resetCurrentChunkState()
+    _ = resetCurrentChunkState()
     if let cancelledFinalization {
       resolveInFlightFinalization(cancelledFinalization, with: .success(false))
     }
     writerNotReadyCount = 0
-
-    log("VideoChunkEncoder: Emergency reset complete, ready for new frames")
   }
 
   struct EncoderStatus {

--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -13,6 +13,10 @@ actor RewindIndexer {
 
   private var isInitialized = false
   private var isInitializing = false
+  /// The effective-owner fence sets this before releasing storage for owner A
+  /// and clears it only after the database targets the committed next owner.
+  /// Frames arriving in that window are dropped instead of recreating A paths.
+  private var ownerTransitionSuspended = false
 
   /// OCR frequency: only run OCR every Nth frame to reduce CPU
   private var framesSinceLastOCR = 0
@@ -51,17 +55,39 @@ actor RewindIndexer {
   /// Reset the indexer state so it re-initializes on the next frame.
   /// Called during sign-out to avoid stale `isInitialized = true` after the database is closed.
   func reset() {
+    resetInitializationState()
+    log("RewindIndexer: Reset (will re-initialize on next frame)")
+  }
+
+  func suspendForOwnerTransition() {
+    ownerTransitionSuspended = true
+    resetInitializationState()
+    log("RewindIndexer: Suspended for effective-owner transition")
+  }
+
+  func resumeAfterOwnerTransition() {
+    ownerTransitionSuspended = false
+    log("RewindIndexer: Resumed after effective-owner transition")
+  }
+
+  func isOwnerTransitionSuspendedForTesting() -> Bool {
+    ownerTransitionSuspended
+  }
+
+  private func resetInitializationState() {
     isInitialized = false
     isInitializing = false
     initFailureCount = 0
     nextRetryTime = .distantPast
     lastEncodedFrameSignature = nil
     lastEncodedFrameTimestamp = nil
-    log("RewindIndexer: Reset (will re-initialize on next frame)")
   }
 
   /// Initialize all Rewind services
   func initialize() async throws {
+    guard !ownerTransitionSuspended else {
+      throw RewindError.storageError("Rewind initialization is suspended during an effective-owner transition")
+    }
     let databaseIsInitialized = await RewindDatabase.shared.isInitialized
     guard !(isInitialized && databaseIsInitialized), !isInitializing else { return }
     // RewindDatabase can close itself after repeated I/O/corruption errors.
@@ -98,6 +124,7 @@ actor RewindIndexer {
 
   /// Try to initialize with exponential backoff. Returns true if initialized.
   private func ensureInitialized() async -> Bool {
+    guard !ownerTransitionSuspended else { return false }
     let databaseIsInitialized = await RewindDatabase.shared.isInitialized
     if isInitialized && databaseIsInitialized { return true }
 
@@ -199,6 +226,20 @@ actor RewindIndexer {
     return false
   }
 
+  /// The encoder reports an immutable path when it abandons a writer
+  /// generation. Storage owns the DB tombstone and file deletion; keeping that
+  /// mutation out of the encoder avoids a circular actor dependency and lets
+  /// the persistence boundary reject stale post-OCR inserts for the path.
+  @discardableResult
+  private func discardAbandonedVideoChunkIfNeeded(_ error: Error) async -> Bool {
+    do {
+      return try await RewindStorage.shared.recoverAbandonedVideoChunkIfNeeded(error)
+    } catch {
+      logError("RewindIndexer: Failed to discard abandoned video chunk", error: error)
+      return true
+    }
+  }
+
   // MARK: - Frame Processing
 
   /// Process a captured frame from ProactiveAssistantsPlugin
@@ -236,6 +277,7 @@ actor RewindIndexer {
       // Frame was dropped by encoder (e.g. aspect ratio debounce) — skip DB insert
       // since there's no video chunk to load later
       guard let encodedFrame = encodedFrame else { return }
+      guard !ownerTransitionSuspended else { return }
 
       // OCR gating: throttle frequency, deduplicate, then check battery
       var ocrText: String?
@@ -281,6 +323,7 @@ actor RewindIndexer {
         clientDeviceId: currentClientDeviceId
       )
 
+      guard !ownerTransitionSuspended else { return }
       let inserted = try await RewindDatabase.shared.insertScreenshot(screenshot)
       markFrameEncodedForDedupe(dedupeSignature, timestamp: frame.captureTime)
 
@@ -298,6 +341,9 @@ actor RewindIndexer {
       }
 
     } catch {
+      if await discardAbandonedVideoChunkIfNeeded(error) {
+        return
+      }
       logError("RewindIndexer: Failed to process frame", error: error)
       await RewindDatabase.shared.reportQueryError(error)
     }
@@ -322,6 +368,7 @@ actor RewindIndexer {
 
       // Frame was dropped by encoder (e.g. aspect ratio debounce) — skip DB insert
       guard let encodedFrame = encodedFrame else { return }
+      guard !ownerTransitionSuspended else { return }
 
       // OCR gating: throttle frequency, deduplicate, then check battery
       var ocrText: String?
@@ -366,6 +413,7 @@ actor RewindIndexer {
         clientDeviceId: currentClientDeviceId
       )
 
+      guard !ownerTransitionSuspended else { return }
       let inserted = try await RewindDatabase.shared.insertScreenshot(screenshot)
       markFrameEncodedForDedupe(dedupeSignature, timestamp: captureTime)
 
@@ -382,6 +430,9 @@ actor RewindIndexer {
       }
 
     } catch {
+      if await discardAbandonedVideoChunkIfNeeded(error) {
+        return
+      }
       logError("RewindIndexer: Failed to process CGImage frame", error: error)
       await RewindDatabase.shared.reportQueryError(error)
     }
@@ -421,6 +472,7 @@ actor RewindIndexer {
 
       // Frame was dropped by encoder (e.g. aspect ratio debounce) — skip DB insert
       guard let encodedFrame = encodedFrame else { return }
+      guard !ownerTransitionSuspended else { return }
 
       // OCR gating: throttle frequency, deduplicate, then check battery
       var ocrText: String?
@@ -477,6 +529,7 @@ actor RewindIndexer {
         clientDeviceId: currentClientDeviceId
       )
 
+      guard !ownerTransitionSuspended else { return }
       let inserted = try await RewindDatabase.shared.insertScreenshot(screenshot)
       if !carriesMetadata {
         markFrameEncodedForDedupe(dedupeSignature, timestamp: frame.captureTime)
@@ -496,6 +549,9 @@ actor RewindIndexer {
       }
 
     } catch {
+      if await discardAbandonedVideoChunkIfNeeded(error) {
+        return
+      }
       logError("RewindIndexer: Failed to process frame with metadata", error: error)
       await RewindDatabase.shared.reportQueryError(error)
     }
@@ -565,8 +621,9 @@ actor RewindIndexer {
   func stop() async -> Bool {
     // Flush any pending video frames before stopping
     do {
-      _ = try await VideoChunkEncoder.shared.flushCurrentChunk()
+      _ = try await RewindStorage.shared.flushCurrentVideoChunk()
     } catch {
+      _ = await discardAbandonedVideoChunkIfNeeded(error)
       logError("RewindIndexer: Failed to flush video chunk", error: error)
       return false
     }

--- a/desktop/macos/Desktop/Sources/Services/LocalMutationAuthorization.swift
+++ b/desktop/macos/Desktop/Sources/Services/LocalMutationAuthorization.swift
@@ -59,6 +59,11 @@ actor EffectiveOwnerTransitionFence {
       @Sendable (
         _ previousOwner: String?, _ plannedNextOwner: String?
       ) async -> Void,
+    prepareLocalStorageTransition:
+      @Sendable (
+        _ previousOwner: String?, _ plannedNextOwner: String?
+      ) async throws -> Void = { _, _ in },
+    finalizeLocalStorageTransition: @Sendable () async -> Void = {},
     transition: @Sendable () async throws -> T,
     retargetLocalStorage: @Sendable (_ previousOwner: String?, _ nextOwner: String?) async -> Void,
     ownerDidChange: @Sendable () async -> Void
@@ -76,6 +81,10 @@ actor EffectiveOwnerTransitionFence {
         beginAuthorizationRevocation(previousOwner)
         authorizationRevoked = true
         await quiescePreviousOwner(previousOwner, plannedOwner)
+        // Owner-bound physical storage must be safely released while defaults
+        // and the database still resolve to the previous owner. A failure here
+        // aborts before the transition closure can publish the next owner.
+        try await prepareLocalStorageTransition(previousOwner, plannedOwner)
       }
       let result = try await transition()
       let nextOwner = currentOwner()
@@ -93,12 +102,14 @@ actor EffectiveOwnerTransitionFence {
         endAuthorizationRevocation()
         authorizationRevoked = false
       }
+      await finalizeLocalStorageTransition()
       endTransition()
       return result
     } catch {
       if authorizationRevoked {
         endAuthorizationRevocation()
       }
+      await finalizeLocalStorageTransition()
       endTransition()
       throw error
     }

--- a/desktop/macos/Desktop/Tests/APIClientAuthRetryTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientAuthRetryTests.swift
@@ -362,18 +362,22 @@ import XCTest
     }
 
     private func transitionOwnerForAuthTest(to ownerID: String?) async {
-      _ = await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-        plannedNextOwner: { _, _ in ownerID },
-        quiesceVoice: { _, _ in },
-        retargetLocalStorage: { _, _ in },
-        ownerDidChange: {}
-      ) { defaults in
-        defaults.removeObject(forKey: .automationOwnerOverride)
-        if let ownerID {
-          defaults.set(ownerID, forKey: .authUserId)
-        } else {
-          defaults.removeObject(forKey: .authUserId)
+      do {
+        _ = try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+          plannedNextOwner: { _, _ in ownerID },
+          quiesceVoice: { _, _ in },
+          retargetLocalStorage: { _, _ in },
+          ownerDidChange: {}
+        ) { defaults in
+          defaults.removeObject(forKey: .automationOwnerOverride)
+          if let ownerID {
+            defaults.set(ownerID, forKey: .authUserId)
+          } else {
+            defaults.removeObject(forKey: .authUserId)
+          }
         }
+      } catch {
+        XCTFail("owner transition failed: \(error)")
       }
     }
 

--- a/desktop/macos/Desktop/Tests/AuthSessionAttemptFenceTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthSessionAttemptFenceTests.swift
@@ -89,7 +89,7 @@ final class AuthSessionAttemptFenceTests: XCTestCase {
 
   override func tearDown() async throws {
     let cleanupAttempt = auth.beginSessionAttempt()
-    _ = await auth.commitSignedOutSession(attempt: cleanupAttempt, phase: .signedOut)
+    _ = try? await auth.commitSignedOutSession(attempt: cleanupAttempt, phase: .signedOut)
     auth.tokenStorageHooks = .live
     auth.tokenRefreshHooks = .live
     auth = nil
@@ -122,7 +122,7 @@ final class AuthSessionAttemptFenceTests: XCTestCase {
 
     let signOutAttempt = auth.beginSessionAttempt()
     let signOutTask = Task {
-      await auth.commitSignedOutSession(attempt: signOutAttempt, phase: .signedOut)
+      try await auth.commitSignedOutSession(attempt: signOutAttempt, phase: .signedOut)
     }
     await EffectiveOwnerTransitionFence.shared.waitUntilTransitionIsPending()
 
@@ -136,7 +136,7 @@ final class AuthSessionAttemptFenceTests: XCTestCase {
 
     await gate.release()
     try await leaseTask.value
-    let staleSignOutCommitted = await signOutTask.value
+    let staleSignOutCommitted = try await signOutTask.value
     let ownerBCommitted = try await signInTask.value
     XCTAssertFalse(staleSignOutCommitted)
     XCTAssertTrue(ownerBCommitted)
@@ -145,6 +145,36 @@ final class AuthSessionAttemptFenceTests: XCTestCase {
     XCTAssertEqual(UserDefaults.standard.string(forKey: .authTokenUserId), ownerB)
     XCTAssertEqual(UserDefaults.standard.string(forKey: .authIdToken), "id-\(ownerB)")
     XCTAssertEqual(AuthState.shared.sessionPhase, .authenticated)
+  }
+
+  func testStoragePreparationFailureLeavesPreviousCredentialGenerationIntact() async throws {
+    enum PreparationFailure: Error { case injected }
+
+    let ownerA = makeOwnerID("failed-signout-a")
+    let seedAttempt = auth.beginSessionAttempt()
+    let seededOwnerA = try await auth.commitSignedInSession(
+      tokens: tokens(for: ownerA),
+      email: "a@example.test",
+      attempt: seedAttempt)
+    XCTAssertTrue(seededOwnerA)
+    let phaseBeforeSignOut = AuthState.shared.sessionPhase
+
+    let signOutAttempt = auth.beginSessionAttempt()
+    do {
+      _ = try await auth.commitSignedOutSession(
+        attempt: signOutAttempt,
+        phase: .signedOut,
+        prepareLocalStorageTransition: { _, _ in throw PreparationFailure.injected })
+      XCTFail("Storage preparation failure must be surfaced")
+    } catch PreparationFailure.injected {
+      // Expected: the transition closure must not clear credentials or owner state.
+    }
+
+    XCTAssertEqual(UserDefaults.standard.string(forKey: .authUserId), ownerA)
+    XCTAssertEqual(UserDefaults.standard.string(forKey: .authTokenUserId), ownerA)
+    XCTAssertEqual(UserDefaults.standard.string(forKey: .authIdToken), "id-\(ownerA)")
+    XCTAssertTrue(UserDefaults.standard.bool(forKey: .authIsSignedIn))
+    XCTAssertEqual(AuthState.shared.sessionPhase, phaseBeforeSignOut)
   }
 
   func testReplacementCredentialsPublishAtomicallyWithTheirOwner() async throws {
@@ -223,13 +253,13 @@ final class AuthSessionAttemptFenceTests: XCTestCase {
 
     let signOutAttempt = auth.beginSessionAttempt()
     let signOutTask = Task {
-      await auth.commitSignedOutSession(attempt: signOutAttempt, phase: .signedOut)
+      try await auth.commitSignedOutSession(attempt: signOutAttempt, phase: .signedOut)
     }
 
     await gate.release()
     try await leaseTask.value
     let staleRestoreCommitted = await restoreTask.value
-    let signOutCommitted = await signOutTask.value
+    let signOutCommitted = try await signOutTask.value
     XCTAssertFalse(staleRestoreCommitted)
     XCTAssertTrue(signOutCommitted)
 
@@ -264,7 +294,7 @@ final class AuthSessionAttemptFenceTests: XCTestCase {
     await responseGate.waitUntilReached()
 
     let signOutAttempt = auth.beginSessionAttempt()
-    let signedOut = await auth.commitSignedOutSession(
+    let signedOut = try await auth.commitSignedOutSession(
       attempt: signOutAttempt,
       phase: .signedOut)
     XCTAssertTrue(signedOut)

--- a/desktop/macos/Desktop/Tests/AuthSessionCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthSessionCoordinatorTests.swift
@@ -74,7 +74,7 @@ final class AuthSessionCoordinatorTests: XCTestCase {
     XCTAssertTrue(authSource.contains("func invalidateSession(reason:"))
     XCTAssertTrue(authSource.contains("func performLightSessionInvalidation()"))
     XCTAssertTrue(authSource.contains("clearTokens()"))
-    XCTAssertTrue(authSource.contains("commitSignedOutSession(attempt: attempt"))
+    XCTAssertTrue(authSource.contains("commitSignedOutSession("))
 
     // Nuclear signOut still wipes onboarding — invalidate must not.
     let signOutRange = authSource.range(of: "func signOut() async throws")

--- a/desktop/macos/Desktop/Tests/AuthSessionCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthSessionCoordinatorTests.swift
@@ -142,8 +142,9 @@ final class AuthSessionCoordinatorTests: XCTestCase {
     XCTAssertTrue(signOutSnippet.contains("commitSignedOutSession"))
     XCTAssertFalse(signOutSnippet.contains("RewindDatabase.shared.closeIfStale"))
     XCTAssertTrue(ownerSource.contains("RewindDatabase.shared.retargetEffectiveOwner"))
-    XCTAssertTrue(ownerSource.contains("RewindIndexer.shared.reset()"))
-    XCTAssertTrue(ownerSource.contains("RewindStorage.shared.reset()"))
+    XCTAssertTrue(ownerSource.contains("RewindIndexer.shared.suspendForOwnerTransition()"))
+    XCTAssertTrue(ownerSource.contains("RewindStorage.shared.resetForOwnerTransition()"))
+    XCTAssertTrue(ownerSource.contains("RewindIndexer.shared.resumeAfterOwnerTransition()"))
     XCTAssertTrue(ownerSource.contains("AgentSyncService.shared.stop(flushPendingChanges: false)"))
     XCTAssertTrue(ownerSource.contains("FileIndexerService.shared.invalidateCache()"))
   }

--- a/desktop/macos/Desktop/Tests/AuthorizedToolOwnerBoundAuthTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthorizedToolOwnerBoundAuthTests.swift
@@ -557,22 +557,26 @@ private actor PermissionCallbackBox<Value: Sendable> {
   }
 
   private func replaceStandardOwner(with ownerID: String?) async {
-    await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-      defaults: .standard,
-      allowAutomationOverride: false,
-      plannedNextOwner: { _, _ in ownerID },
-      quiesceVoice: { _, _ in },
-      revokeKernelOwner: { _, _ in },
-      retargetLocalStorage: { _, _ in },
-      ownerDidChange: {}
-    ) { defaults in
-      defaults.removeObject(forKey: .automationOwnerOverride)
-      defaults.removeObject(forKey: .automationOwnerABackup)
-      if let ownerID {
-        defaults.set(ownerID, forKey: .authUserId)
-      } else {
-        defaults.removeObject(forKey: .authUserId)
+    do {
+      try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+        defaults: .standard,
+        allowAutomationOverride: false,
+        plannedNextOwner: { _, _ in ownerID },
+        quiesceVoice: { _, _ in },
+        revokeKernelOwner: { _, _ in },
+        retargetLocalStorage: { _, _ in },
+        ownerDidChange: {}
+      ) { defaults in
+        defaults.removeObject(forKey: .automationOwnerOverride)
+        defaults.removeObject(forKey: .automationOwnerABackup)
+        if let ownerID {
+          defaults.set(ownerID, forKey: .authUserId)
+        } else {
+          defaults.removeObject(forKey: .authUserId)
+        }
       }
+    } catch {
+      XCTFail("owner transition failed: \(error)")
     }
   }
 
@@ -597,26 +601,30 @@ private actor PermissionCallbackBox<Value: Sendable> {
     // Force one distinct completed generation first so even an authority that
     // a mismatch test deliberately left revoked is quiescent before restore.
     await replaceStandardOwner(with: "authorized-tool-owner-restore")
-    await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-      defaults: .standard,
-      allowAutomationOverride: true,
-      plannedNextOwner: { _, _ in effectiveOwner },
-      quiesceVoice: { _, _ in },
-      revokeKernelOwner: { _, _ in },
-      retargetLocalStorage: { _, _ in },
-      ownerDidChange: {}
-    ) { defaults in
-      for (key, value) in [
-        (DefaultsKey.authUserId, authOwner),
-        (DefaultsKey.automationOwnerOverride, ownerOverride),
-        (DefaultsKey.automationOwnerABackup, ownerBackup),
-      ] {
-        if let value {
-          defaults.set(value, forKey: key.rawValue)
-        } else {
-          defaults.removeObject(forKey: key.rawValue)
+    do {
+      try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+        defaults: .standard,
+        allowAutomationOverride: true,
+        plannedNextOwner: { _, _ in effectiveOwner },
+        quiesceVoice: { _, _ in },
+        revokeKernelOwner: { _, _ in },
+        retargetLocalStorage: { _, _ in },
+        ownerDidChange: {}
+      ) { defaults in
+        for (key, value) in [
+          (DefaultsKey.authUserId, authOwner),
+          (DefaultsKey.automationOwnerOverride, ownerOverride),
+          (DefaultsKey.automationOwnerABackup, ownerBackup),
+        ] {
+          if let value {
+            defaults.set(value, forKey: key.rawValue)
+          } else {
+            defaults.removeObject(forKey: key.rawValue)
+          }
         }
       }
+    } catch {
+      XCTFail("owner restoration failed: \(error)")
     }
   }
 }

--- a/desktop/macos/Desktop/Tests/ChatToolExecutorSQLTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatToolExecutorSQLTests.swift
@@ -328,22 +328,26 @@ final class ChatToolExecutorSQLTests: XCTestCase {
   }
 
   private static func transitionStandardOwner(to ownerID: String?) async {
-    await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-      defaults: .standard,
-      allowAutomationOverride: false,
-      plannedNextOwner: { _, _ in ownerID },
-      quiesceVoice: { _, _ in },
-      revokeKernelOwner: { _, _ in },
-      retargetLocalStorage: { _, _ in },
-      ownerDidChange: {}
-    ) { defaults in
-      defaults.removeObject(forKey: .automationOwnerOverride)
-      defaults.removeObject(forKey: .automationOwnerABackup)
-      if let ownerID {
-        defaults.set(ownerID, forKey: .authUserId)
-      } else {
-        defaults.removeObject(forKey: .authUserId)
+    do {
+      try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+        defaults: .standard,
+        allowAutomationOverride: false,
+        plannedNextOwner: { _, _ in ownerID },
+        quiesceVoice: { _, _ in },
+        revokeKernelOwner: { _, _ in },
+        retargetLocalStorage: { _, _ in },
+        ownerDidChange: {}
+      ) { defaults in
+        defaults.removeObject(forKey: .automationOwnerOverride)
+        defaults.removeObject(forKey: .automationOwnerABackup)
+        if let ownerID {
+          defaults.set(ownerID, forKey: .authUserId)
+        } else {
+          defaults.removeObject(forKey: .authUserId)
+        }
       }
+    } catch {
+      XCTFail("owner transition failed: \(error)")
     }
   }
 
@@ -356,26 +360,30 @@ final class ChatToolExecutorSQLTests: XCTestCase {
       ? ownerOverride
       : authOwner
     await Self.transitionStandardOwner(to: "chat-tool-sql-owner-restore")
-    await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-      defaults: .standard,
-      allowAutomationOverride: true,
-      plannedNextOwner: { _, _ in effectiveOwner },
-      quiesceVoice: { _, _ in },
-      revokeKernelOwner: { _, _ in },
-      retargetLocalStorage: { _, _ in },
-      ownerDidChange: {}
-    ) { defaults in
-      for (key, value) in [
-        (DefaultsKey.authUserId, authOwner),
-        (DefaultsKey.automationOwnerOverride, ownerOverride),
-        (DefaultsKey.automationOwnerABackup, ownerBackup),
-      ] {
-        if let value {
-          defaults.set(value, forKey: key.rawValue)
-        } else {
-          defaults.removeObject(forKey: key.rawValue)
+    do {
+      try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+        defaults: .standard,
+        allowAutomationOverride: true,
+        plannedNextOwner: { _, _ in effectiveOwner },
+        quiesceVoice: { _, _ in },
+        revokeKernelOwner: { _, _ in },
+        retargetLocalStorage: { _, _ in },
+        ownerDidChange: {}
+      ) { defaults in
+        for (key, value) in [
+          (DefaultsKey.authUserId, authOwner),
+          (DefaultsKey.automationOwnerOverride, ownerOverride),
+          (DefaultsKey.automationOwnerABackup, ownerBackup),
+        ] {
+          if let value {
+            defaults.set(value, forKey: key.rawValue)
+          } else {
+            defaults.removeObject(forKey: key.rawValue)
+          }
         }
       }
+    } catch {
+      XCTFail("owner restoration failed: \(error)")
     }
   }
 }

--- a/desktop/macos/Desktop/Tests/EffectiveOwnerDatabaseBoundaryTests.swift
+++ b/desktop/macos/Desktop/Tests/EffectiveOwnerDatabaseBoundaryTests.swift
@@ -55,7 +55,7 @@ final class EffectiveOwnerDatabaseBoundaryTests: XCTestCase {
     originalAuthOwner = UserDefaults.standard.string(forKey: .authUserId)
     originalOverride = UserDefaults.standard.string(forKey: .automationOwnerOverride)
     originalBackup = UserDefaults.standard.string(forKey: .automationOwnerABackup)
-    await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+    try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
       allowAutomationOverride: true,
       plannedNextOwner: { _, _ in nil }
     ) { defaults in
@@ -71,7 +71,7 @@ final class EffectiveOwnerDatabaseBoundaryTests: XCTestCase {
     let authOwner = originalAuthOwner
     let override = originalOverride
     let backup = originalBackup
-    await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+    try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
       allowAutomationOverride: true,
       plannedNextOwner: { _, _ in
         let normalizedOverride = override?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -161,11 +161,15 @@ final class EffectiveOwnerDatabaseBoundaryTests: XCTestCase {
   }
 
   private func setOwner(_ ownerID: String) async {
-    await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-      allowAutomationOverride: false,
-      plannedNextOwner: { _, _ in ownerID }
-    ) { defaults in
-      defaults.set(ownerID, forKey: .authUserId)
+    do {
+      try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+        allowAutomationOverride: false,
+        plannedNextOwner: { _, _ in ownerID }
+      ) { defaults in
+        defaults.set(ownerID, forKey: .authUserId)
+      }
+    } catch {
+      XCTFail("owner transition failed: \(error)")
     }
   }
 

--- a/desktop/macos/Desktop/Tests/FirebaseAuthAvailabilityTests.swift
+++ b/desktop/macos/Desktop/Tests/FirebaseAuthAvailabilityTests.swift
@@ -27,7 +27,7 @@ final class FirebaseAuthAvailabilityTests: XCTestCase {
 
   override func tearDown() async throws {
     let cleanupAttempt = auth.beginSessionAttempt()
-    _ = await auth.commitSignedOutSession(attempt: cleanupAttempt, phase: .signedOut)
+    _ = try? await auth.commitSignedOutSession(attempt: cleanupAttempt, phase: .signedOut)
     auth.firebaseAuthAvailability = .live
     auth.tokenStorageHooks = .live
     await RewindDatabase.shared.close()

--- a/desktop/macos/Desktop/Tests/FirebaseAuthAvailabilityTests.swift
+++ b/desktop/macos/Desktop/Tests/FirebaseAuthAvailabilityTests.swift
@@ -1,0 +1,121 @@
+import OmiSupport
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class FirebaseAuthAvailabilityTests: XCTestCase {
+  private var auth = AuthService()
+  private var originalPhase: AuthSessionPhase = .signedOut
+  private var createdOwnerIDs: [String] = []
+
+  override func setUp() async throws {
+    originalPhase = AuthState.shared.sessionPhase
+    clearAuthDefaults()
+    auth = AuthService()
+    auth.firebaseAuthAvailability = FirebaseAuthAvailability(configuredAuth: { nil })
+    auth.tokenStorageHooks = AuthService.TokenStorageHooks(
+      usesKeychainTokenStorage: { false },
+      allowsUserDefaultsFallback: { true },
+      readKeychainString: { _, _ in nil },
+      writeKeychainString: { _, _, _ in true },
+      deleteKeychainString: { _, _ in },
+      recordsFallbackTelemetry: false
+    )
+    await RewindDatabase.shared.close()
+  }
+
+  override func tearDown() async throws {
+    let cleanupAttempt = auth.beginSessionAttempt()
+    _ = await auth.commitSignedOutSession(attempt: cleanupAttempt, phase: .signedOut)
+    auth.firebaseAuthAvailability = .live
+    auth.tokenStorageHooks = .live
+    await RewindDatabase.shared.close()
+    clearAuthDefaults()
+    for ownerID in createdOwnerIDs {
+      try? FileManager.default.removeItem(at: userDirectory(ownerID))
+    }
+    createdOwnerIDs = []
+    AuthState.shared.transition(to: originalPhase)
+  }
+
+  func testUnavailableFirebaseConfiguresRESTBackedAuth() async {
+    await auth.configure()
+
+    XCTAssertEqual(AuthState.shared.sessionPhase, .signedOut)
+  }
+
+  func testUnavailableFirebaseKeepsRESTBackedSignInAndSignOutUsable() async throws {
+    let ownerID = makeOwnerID("firebase-unavailable")
+    let signInAttempt = auth.beginSessionAttempt()
+
+    let committed = try await auth.commitSignedInSession(
+      tokens: .init(
+        idToken: "id-\(ownerID)",
+        refreshToken: "refresh-\(ownerID)",
+        expiresIn: 3600,
+        localId: ownerID),
+      email: "firebase-unavailable@example.test",
+      attempt: signInAttempt)
+
+    XCTAssertTrue(committed)
+    let restoredToken = try await auth.getIdToken()
+    XCTAssertEqual(restoredToken, "id-\(ownerID)")
+    XCTAssertEqual(AuthState.shared.sessionPhase, .authenticated)
+
+    try await auth.signOut()
+
+    XCTAssertEqual(AuthState.shared.sessionPhase, .signedOut)
+    XCTAssertNil(UserDefaults.standard.string(forKey: .authUserId))
+    XCTAssertNil(UserDefaults.standard.string(forKey: .authIdToken))
+    XCTAssertNil(UserDefaults.standard.string(forKey: .authRefreshToken))
+  }
+
+  func testUnavailableFirebaseNativeApplePathUsesRESTFallback() async throws {
+    var restFallbackCalled = false
+    let result = try await FirebaseAuthAvailability.signInWithNativeApple(
+      auth: nil,
+      identityToken: "identity-token",
+      nonce: "nonce",
+      isSessionCurrent: { true },
+      discardStaleFirebaseUser: { _ in XCTFail("unconfigured SDK must not produce a stale Firebase user") },
+      restFallback: {
+        restFallbackCalled = true
+        return .init(
+          idToken: "rest-id-token", refreshToken: "rest-refresh-token", expiresIn: 3600, localId: "rest-user")
+      }
+    )
+
+    XCTAssertTrue(restFallbackCalled)
+    XCTAssertEqual(result.tokens.localId, "rest-user")
+    XCTAssertEqual(result.fallbackReason, "config_incomplete")
+  }
+
+  private func makeOwnerID(_ prefix: String) -> String {
+    let ownerID = "\(prefix)-\(UUID().uuidString)"
+    createdOwnerIDs.append(ownerID)
+    return ownerID
+  }
+
+  private func userDirectory(_ ownerID: String) -> URL {
+    DesktopLocalProfile.applicationSupportURL()
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(ownerID, isDirectory: true)
+  }
+
+  private func clearAuthDefaults() {
+    for key in [
+      DefaultsKey.authIsSignedIn,
+      .authUserEmail,
+      .authUserId,
+      .authIdToken,
+      .authRefreshToken,
+      .authTokenExpiry,
+      .authTokenUserId,
+      .automationOwnerOverride,
+      .automationOwnerABackup,
+    ] {
+      UserDefaults.standard.removeObject(forKey: key)
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/LegacyMainChatSessionAliasMigrationTests.swift
+++ b/desktop/macos/Desktop/Tests/LegacyMainChatSessionAliasMigrationTests.swift
@@ -268,7 +268,7 @@ final class LegacyMainChatSessionAliasMigrationTests: XCTestCase {
     await importer.waitUntilStarted()
 
     let transition = Task {
-      await EffectiveOwnerTransitionFence.shared.performEffectiveOwnerTransition(
+      try await EffectiveOwnerTransitionFence.shared.performEffectiveOwnerTransition(
         currentOwner: { authorization.isCurrent() ? "owner-a" : "owner-b" },
         plannedNextOwner: { _ in "owner-b" },
         beginAuthorizationRevocation: { _ in authorization.revoke() },
@@ -287,7 +287,7 @@ final class LegacyMainChatSessionAliasMigrationTests: XCTestCase {
     XCTAssertEqual(defaults.dictionary(forKey: defaultsKey) as? [String: String], original)
     let transitionReleased = await transitionGate.release()
     XCTAssertTrue(transitionReleased)
-    await transition.value
+    try await transition.value
 
     let outcome = await migration.value
     XCTAssertEqual(outcome, .retained(reason: "owner_authorization_revoked"))

--- a/desktop/macos/Desktop/Tests/LocalMutationAuthorizationTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalMutationAuthorizationTests.swift
@@ -240,7 +240,7 @@ final class LocalMutationAuthorizationTests: XCTestCase {
     let allowQuiescenceToFinish = OwnerTransitionTestGate()
 
     let transition = Task {
-      await fence.performEffectiveOwnerTransition(
+      try await fence.performEffectiveOwnerTransition(
         currentOwner: { probe.owner() },
         plannedNextOwner: { _ in "owner-b" },
         quiescePreviousOwner: { previousOwner, plannedOwner in
@@ -274,7 +274,7 @@ final class LocalMutationAuthorizationTests: XCTestCase {
     XCTAssertEqual(snapshot.events, ["quiesce_started"])
 
     await allowQuiescenceToFinish.open()
-    await transition.value
+    try await transition.value
     try await ownerBMutation.value
 
     snapshot = probe.snapshot()

--- a/desktop/macos/Desktop/Tests/RewindAbandonedChunkRecoveryTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindAbandonedChunkRecoveryTests.swift
@@ -1,0 +1,407 @@
+import CoreGraphics
+import Foundation
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for an encoder append failure after earlier frames from
+/// the same writer have already been persisted. Recovery must remove the
+/// unusable chunk, reject a delayed stale insert, and leave the next writer
+/// generation usable.
+final class RewindAbandonedChunkRecoveryTests: XCTestCase {
+  private var fixture: RewindStorageTestIsolation.Fixture?
+
+  override func setUp() async throws {
+    try await super.setUp()
+    await VideoChunkEncoder.shared.setAppendFailureAfterSuccessfulFramesForTesting(nil)
+    await VideoChunkEncoder.shared.setAbandonmentMarkerWriteFailuresForTesting(0)
+    await VideoChunkEncoder.shared.setFinishWritingFailuresForTesting(0)
+    await RewindStorage.shared.setAbandonedChunkCleanupFailuresForTesting(0)
+    await RewindStorage.shared.setAbandonedChunkDatabaseFailuresForTesting(0)
+    await RewindIndexer.shared.reset()
+    await RewindStorage.shared.reset()
+    fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "rewind-abandoned-chunk")
+    try await RewindIndexer.shared.initialize()
+  }
+
+  override func tearDown() async throws {
+    await VideoChunkEncoder.shared.setAppendFailureAfterSuccessfulFramesForTesting(nil)
+    await VideoChunkEncoder.shared.setAbandonmentMarkerWriteFailuresForTesting(0)
+    await VideoChunkEncoder.shared.setFinishWritingFailuresForTesting(0)
+    await RewindStorage.shared.setAbandonedChunkCleanupFailuresForTesting(0)
+    await RewindStorage.shared.setAbandonedChunkDatabaseFailuresForTesting(0)
+    await VideoChunkEncoder.shared.cancel()
+    await RewindIndexer.shared.reset()
+    await RewindStorage.shared.reset()
+    await RewindStorageTestIsolation.tearDown(userDir: fixture?.userDir)
+    fixture = nil
+    try await super.tearDown()
+  }
+
+  func testAbandonedChunkRetriesAtStartupRejectsDelayedInsertAndAllowsNewGeneration() async throws {
+    let encoder = VideoChunkEncoder.shared
+    let image = try solidRedImage()
+    let captureTime = Date()
+
+    for offset in 0..<2 {
+      await RewindIndexer.shared.processFrame(
+        cgImage: image,
+        appName: "AbandonedChunkRecovery",
+        windowTitle: "Initial frame \(offset)",
+        captureTime: captureTime.addingTimeInterval(Double(offset))
+      )
+    }
+
+    let initialRows = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    XCTAssertEqual(initialRows.count, 2)
+    let abandonedPath = try XCTUnwrap(initialRows.first?.videoChunkPath)
+    XCTAssertTrue(initialRows.allSatisfy { $0.videoChunkPath == abandonedPath })
+
+    let maybeVideosDirectory = await RewindStorage.shared.getVideosDirectory()
+    let videosDirectory = try XCTUnwrap(maybeVideosDirectory)
+    let abandonedURL = videosDirectory.appendingPathComponent(abandonedPath)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: abandonedURL.path))
+
+    // The first recovery attempt tombstones the rows but cannot complete file
+    // cleanup. AVAssetWriter may already have removed its cancelled output, so
+    // the durable marker—not file presence—is the retry contract. Reset
+    // consumes the second injected failure, leaving the marker for the next
+    // storage startup to retry.
+    await RewindStorage.shared.setAbandonedChunkCleanupFailuresForTesting(2)
+
+    // Fail the next five appends. The final failure crosses the production
+    // emergency-reset threshold and reaches the indexer recovery boundary.
+    await encoder.setAppendFailureAfterSuccessfulFramesForTesting(0)
+    for offset in 0..<5 {
+      await RewindIndexer.shared.processFrame(
+        cgImage: image,
+        appName: "AbandonedChunkRecovery",
+        windowTitle: "Failure \(offset)",
+        captureTime: captureTime.addingTimeInterval(Double(offset + 2))
+      )
+    }
+
+    let rowsAfterRecovery = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    XCTAssertTrue(rowsAfterRecovery.isEmpty)
+    let markerCountAfterInitialFailure = try await RewindStorage.shared.abandonedVideoChunkMarkerCountForTesting()
+    XCTAssertEqual(markerCountAfterInitialFailure, 1)
+
+    await RewindIndexer.shared.reset()
+    await RewindStorage.shared.reset()
+    XCTAssertEqual(try RewindAbandonedVideoChunkJournal.markers(in: videosDirectory).count, 1)
+
+    // Storage initialization must retry the retained sidecar before it starts
+    // a new writer for this user.
+    try await RewindIndexer.shared.initialize()
+    let markerCountAfterStartupRetry = try await RewindStorage.shared.abandonedVideoChunkMarkerCountForTesting()
+    XCTAssertEqual(markerCountAfterStartupRetry, 0)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: abandonedURL.path))
+
+    // Simulate an older pipeline continuation completing after the reset. The
+    // durable tombstone must reject it inside the same DB transaction as insert.
+    let staleScreenshot = Screenshot(
+      timestamp: captureTime.addingTimeInterval(10),
+      appName: "AbandonedChunkRecovery",
+      windowTitle: "Delayed stale insert",
+      imagePath: "",
+      videoChunkPath: abandonedPath,
+      frameOffset: 99,
+      isIndexed: false
+    )
+    do {
+      _ = try await RewindDatabase.shared.insertScreenshot(staleScreenshot)
+      XCTFail("a stale abandoned-chunk row must be rejected")
+    } catch let error as RewindAbandonedVideoChunkError {
+      XCTAssertEqual(error.relativePath, abandonedPath)
+    } catch {
+      XCTFail("expected abandoned-chunk rejection, got \(error)")
+    }
+
+    do {
+      _ = try await RewindDatabase.shared.replaceScreenshotsForVideoChunk(
+        path: abandonedPath,
+        screenshots: [staleScreenshot])
+      XCTFail("rebuild must not resurrect an abandoned video chunk")
+    } catch let error as RewindAbandonedVideoChunkError {
+      XCTAssertEqual(error.relativePath, abandonedPath)
+    } catch {
+      XCTFail("expected abandoned-chunk rebuild rejection, got \(error)")
+    }
+    let rowsAfterDelayedInsert = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    XCTAssertTrue(rowsAfterDelayedInsert.isEmpty)
+
+    await encoder.setAppendFailureAfterSuccessfulFramesForTesting(nil)
+    await RewindIndexer.shared.processFrame(
+      cgImage: image,
+      appName: "AbandonedChunkRecovery",
+      windowTitle: "Replacement generation",
+      captureTime: captureTime.addingTimeInterval(11)
+    )
+    let replacementRows = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    XCTAssertEqual(replacementRows.count, 1)
+    let replacementPath = try XCTUnwrap(replacementRows.first?.videoChunkPath)
+    XCTAssertNotEqual(replacementPath, abandonedPath)
+
+    let flush = try await encoder.flushCurrentChunk()
+    XCTAssertEqual(flush?.frames.count, 1)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: videosDirectory.appendingPathComponent(replacementPath).path))
+  }
+
+  func testMarkerWriteFailureUsesDatabaseFirstOwnerResetFallback() async throws {
+    let image = try solidRedImage()
+    let captureTime = Date()
+
+    await RewindIndexer.shared.processFrame(
+      cgImage: image,
+      appName: "AbandonedChunkOwnerReset",
+      windowTitle: "Initial frame",
+      captureTime: captureTime
+    )
+
+    let initialRows = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    let abandonedPath = try XCTUnwrap(initialRows.first?.videoChunkPath)
+    let maybeVideosDirectory = await RewindStorage.shared.getVideosDirectory()
+    let videosDirectory = try XCTUnwrap(maybeVideosDirectory)
+    let abandonedURL = videosDirectory.appendingPathComponent(abandonedPath)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: abandonedURL.path))
+
+    // The sidecar write fails once. RewindStorage must instead tombstone the
+    // old DB path before force-cancelling that reservation and clearing owner
+    // configuration, rather than leaving a mixed old/new encoder state.
+    await VideoChunkEncoder.shared.setAbandonmentMarkerWriteFailuresForTesting(1)
+    await RewindIndexer.shared.reset()
+    await RewindStorage.shared.reset()
+
+    let rowsAfterFallback = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    XCTAssertTrue(rowsAfterFallback.isEmpty)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: abandonedURL.path))
+    let encoderDirectoryAfterReset = await VideoChunkEncoder.shared.videosDirectoryForTesting()
+    XCTAssertNil(encoderDirectoryAfterReset)
+
+    try await RewindIndexer.shared.initialize()
+    await RewindIndexer.shared.processFrame(
+      cgImage: image,
+      appName: "AbandonedChunkOwnerReset",
+      windowTitle: "Replacement frame",
+      captureTime: captureTime.addingTimeInterval(1)
+    )
+    let replacementRows = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    XCTAssertEqual(replacementRows.count, 1)
+    XCTAssertNotEqual(replacementRows.first?.videoChunkPath, abandonedPath)
+  }
+
+  func testNonIndexerFlushReconcilesFinishWritingFailure() async throws {
+    let image = try solidRedImage()
+    let captureTime = Date()
+
+    await RewindIndexer.shared.processFrame(
+      cgImage: image,
+      appName: "AbandonedChunkFinishFailure",
+      windowTitle: "Initial frame",
+      captureTime: captureTime
+    )
+    let initialRows = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    let abandonedPath = try XCTUnwrap(initialRows.first?.videoChunkPath)
+    let maybeVideosDirectory = await RewindStorage.shared.getVideosDirectory()
+    let videosDirectory = try XCTUnwrap(maybeVideosDirectory)
+    let abandonedURL = videosDirectory.appendingPathComponent(abandonedPath)
+
+    await VideoChunkEncoder.shared.setFinishWritingFailuresForTesting(1)
+    do {
+      _ = try await RewindStorage.shared.flushCurrentVideoChunk()
+      XCTFail("explicit storage flush must surface finalization failure")
+    } catch {
+      // Expected after the shared flush boundary reconciles the marker.
+    }
+
+    let rowsAfterFinishFailure = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    XCTAssertTrue(rowsAfterFinishFailure.isEmpty)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: abandonedURL.path))
+    let markerCountAfterFinishFailure = try await RewindStorage.shared.abandonedVideoChunkMarkerCountForTesting()
+    XCTAssertEqual(markerCountAfterFinishFailure, 0)
+
+    await VideoChunkEncoder.shared.setFinishWritingFailuresForTesting(0)
+    await RewindIndexer.shared.processFrame(
+      cgImage: image,
+      appName: "AbandonedChunkFinishFailure",
+      windowTitle: "Replacement frame",
+      captureTime: captureTime.addingTimeInterval(1)
+    )
+    let rowsAfterFinishReplacement = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    XCTAssertEqual(rowsAfterFinishReplacement.count, 1)
+  }
+
+  func testStaleTimerFinishFailureReconcilesImmediately() async throws {
+    let image = try solidRedImage()
+    let staleCaptureTime = Date().addingTimeInterval(-3_600)
+
+    await RewindIndexer.shared.processFrame(
+      cgImage: image,
+      appName: "AbandonedChunkStaleTimer",
+      windowTitle: "Stale frame",
+      captureTime: staleCaptureTime
+    )
+    let initialRows = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    let abandonedPath = try XCTUnwrap(initialRows.first?.videoChunkPath)
+    let maybeVideosDirectory = await RewindStorage.shared.getVideosDirectory()
+    let videosDirectory = try XCTUnwrap(maybeVideosDirectory)
+    let abandonedURL = videosDirectory.appendingPathComponent(abandonedPath)
+
+    await VideoChunkEncoder.shared.setFinishWritingFailuresForTesting(1)
+    await VideoChunkEncoder.shared.finalizeStaleChunkForTesting()
+
+    let rowsAfterRecovery = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    let markerCount = try await RewindStorage.shared.abandonedVideoChunkMarkerCountForTesting()
+    XCTAssertTrue(rowsAfterRecovery.isEmpty)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: abandonedURL.path))
+    XCTAssertEqual(markerCount, 0)
+  }
+
+  func testStartupReconcilesMarkerWrittenBeforeDatabaseQuarantine() async throws {
+    let maybeVideosDirectory = await RewindStorage.shared.getVideosDirectory()
+    let videosDirectory = try XCTUnwrap(maybeVideosDirectory)
+    let relativePath = "2099-01-02/chunk_crash_gap.mp4"
+    let videoURL = videosDirectory.appendingPathComponent(relativePath)
+    try FileManager.default.createDirectory(
+      at: videoURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true)
+    try Data("partial-mp4".utf8).write(to: videoURL)
+
+    let row = Screenshot(
+      timestamp: Date(),
+      appName: "AbandonedChunkCrashGap",
+      windowTitle: "Pre-crash row",
+      imagePath: "",
+      videoChunkPath: relativePath,
+      frameOffset: 0,
+      isIndexed: false)
+    _ = try await RewindDatabase.shared.insertScreenshot(row)
+    _ = try RewindAbandonedVideoChunkJournal.record(
+      reservation: .init(generation: 99, relativePath: relativePath),
+      in: videosDirectory)
+
+    // This is the exact process-loss boundary: volatile actor configuration is
+    // gone, while the sidecar, partial file, and unquarantined DB row survive.
+    await RewindStorage.shared.clearVolatileConfigurationForProcessRestartTesting()
+    await RewindIndexer.shared.reset()
+    let rowsBeforeStartup = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    XCTAssertEqual(rowsBeforeStartup.count, 1)
+
+    try await RewindIndexer.shared.initialize()
+
+    let rowsAfterStartup = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    let markerCount = try await RewindStorage.shared.abandonedVideoChunkMarkerCountForTesting()
+    XCTAssertTrue(rowsAfterStartup.isEmpty)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: videoURL.path))
+    XCTAssertEqual(markerCount, 0)
+  }
+
+  func testOwnerTransitionStopsBeforeDefaultsChangeWhenDurableResetFails() async throws {
+    let image = try solidRedImage()
+    await RewindIndexer.shared.processFrame(
+      cgImage: image,
+      appName: "AbandonedChunkOwnerFence",
+      windowTitle: "Owner A frame",
+      captureTime: Date())
+
+    let ownerA = try XCTUnwrap(fixture?.testUserId)
+    let ownerB = "\(ownerA)-replacement"
+    let maybeVideosDirectory = await RewindStorage.shared.getVideosDirectory()
+    let videosDirectory = try XCTUnwrap(maybeVideosDirectory)
+    let suiteName = "rewind-owner-transition-\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    defaults.set(ownerA, forKey: .authUserId)
+
+    await VideoChunkEncoder.shared.setAbandonmentMarkerWriteFailuresForTesting(1)
+    await RewindStorage.shared.setAbandonedChunkDatabaseFailuresForTesting(1)
+    do {
+      _ = try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+        defaults: defaults,
+        allowAutomationOverride: false,
+        plannedNextOwner: { _, _ in ownerB },
+        quiesceVoice: { _, _ in },
+        revokeKernelOwner: { _, _ in },
+        retargetLocalStorage: { _, _ in XCTFail("retarget must not run after failed preparation") },
+        ownerDidChange: { XCTFail("owner notification must not publish after failed preparation") }
+      ) { defaults in
+        defaults.set(ownerB, forKey: .authUserId)
+      }
+      XCTFail("owner transition must surface a non-durable Rewind reset")
+    } catch {
+      // Expected: neither the sidecar nor DB tombstone became durable.
+    }
+
+    XCTAssertEqual(defaults.string(forKey: .authUserId), ownerA)
+    XCTAssertEqual(RewindDatabase.currentUserId, ownerA)
+    let encoderDirectory = await VideoChunkEncoder.shared.videosDirectoryForTesting()
+    let isSuspended = await RewindIndexer.shared.isOwnerTransitionSuspendedForTesting()
+    XCTAssertEqual(encoderDirectory, videosDirectory)
+    XCTAssertFalse(isSuspended)
+  }
+
+  func testSuspendedOwnerTransitionDropsNewFramesBeforeReinitialization() async throws {
+    let image = try solidRedImage()
+    let maybeVideosDirectory = await RewindStorage.shared.getVideosDirectory()
+    let videosDirectory = try XCTUnwrap(maybeVideosDirectory)
+    await RewindIndexer.shared.suspendForOwnerTransition()
+
+    await RewindIndexer.shared.processFrame(
+      cgImage: image,
+      appName: "AbandonedChunkOwnerFence",
+      windowTitle: "Blocked owner A frame",
+      captureTime: Date())
+
+    let rows = try await RewindDatabase.shared.getRecentScreenshots(limit: 10)
+    XCTAssertTrue(rows.isEmpty)
+    let files = try FileManager.default.subpathsOfDirectory(atPath: videosDirectory.path)
+    XCTAssertFalse(files.contains(where: { $0.hasSuffix(".mp4") }))
+    await RewindIndexer.shared.resumeAfterOwnerTransition()
+  }
+
+  private func solidRedImage() throws -> CGImage {
+    let context = try XCTUnwrap(
+      CGContext(
+        data: nil,
+        width: 96,
+        height: 64,
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      ))
+    context.setFillColor(red: 1, green: 0, blue: 0, alpha: 1)
+    context.fill(CGRect(x: 0, y: 0, width: 96, height: 64))
+    return try XCTUnwrap(context.makeImage())
+  }
+
+  func testOwnerTransitionKeepsRewindSuspendedThroughNotification() async throws {
+    let ownerA = try XCTUnwrap(fixture?.testUserId)
+    let ownerB = "\(ownerA)-replacement"
+    let suiteName = "rewind-owner-resume-order-\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    defaults.set(ownerA, forKey: .authUserId)
+
+    _ = try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+      defaults: defaults,
+      allowAutomationOverride: false,
+      plannedNextOwner: { _, _ in ownerB },
+      quiesceVoice: { _, _ in },
+      revokeKernelOwner: { _, _ in },
+      retargetLocalStorage: { _, _ in
+        let isSuspended = await RewindIndexer.shared.isOwnerTransitionSuspendedForTesting()
+        XCTAssertTrue(isSuspended)
+      },
+      ownerDidChange: {
+        let isSuspended = await RewindIndexer.shared.isOwnerTransitionSuspendedForTesting()
+        XCTAssertTrue(isSuspended)
+      }
+    ) { defaults in
+      defaults.set(ownerB, forKey: .authUserId)
+    }
+
+    let isSuspended = await RewindIndexer.shared.isOwnerTransitionSuspendedForTesting()
+    XCTAssertFalse(isSuspended)
+  }
+}

--- a/desktop/macos/Desktop/Tests/RewindActiveChunkRetentionCleanupTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindActiveChunkRetentionCleanupTests.swift
@@ -77,12 +77,13 @@ final class RewindActiveChunkRetentionCleanupTests: XCTestCase {
 
   override func setUp() async throws {
     try await super.setUp()
+    await RewindStorage.shared.reset()
     fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "rewind-active-chunk-cleanup")
     try await RewindStorage.shared.initialize()
   }
 
   override func tearDown() async throws {
-    await VideoChunkEncoder.shared.cancel()
+    await RewindStorage.shared.reset()
     await RewindStorageTestIsolation.tearDown(userDir: fixture?.userDir)
     fixture = nil
     try await super.tearDown()

--- a/desktop/macos/Desktop/Tests/RuntimeOwnerAuthorityTestSupport.swift
+++ b/desktop/macos/Desktop/Tests/RuntimeOwnerAuthorityTestSupport.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XCTest
 
 @testable import Omi_Computer
 
@@ -76,18 +77,22 @@ final class RuntimeOwnerAuthorityTestFixture: @unchecked Sendable {
     automationBackupID: String?
   ) async {
     let nextOwner = normalized(automationOverrideID) ?? normalized(authOwnerID)
-    await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-      defaults: defaults.value,
-      allowAutomationOverride: true,
-      plannedNextOwner: { _, _ in nextOwner },
-      quiesceVoice: { _, _ in },
-      revokeKernelOwner: { _, _ in },
-      retargetLocalStorage: { _, _ in },
-      ownerDidChange: {}
-    ) { defaults in
-      set(authOwnerID, forKey: .authUserId, defaults: defaults)
-      set(automationOverrideID, forKey: .automationOwnerOverride, defaults: defaults)
-      set(automationBackupID, forKey: .automationOwnerABackup, defaults: defaults)
+    do {
+      try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+        defaults: defaults.value,
+        allowAutomationOverride: true,
+        plannedNextOwner: { _, _ in nextOwner },
+        quiesceVoice: { _, _ in },
+        revokeKernelOwner: { _, _ in },
+        retargetLocalStorage: { _, _ in },
+        ownerDidChange: {}
+      ) { defaults in
+        set(authOwnerID, forKey: .authUserId, defaults: defaults)
+        set(automationOverrideID, forKey: .automationOwnerOverride, defaults: defaults)
+        set(automationBackupID, forKey: .automationOwnerABackup, defaults: defaults)
+      }
+    } catch {
+      XCTFail("owner transition failed: \(error)")
     }
   }
 

--- a/desktop/macos/Desktop/Tests/RuntimeOwnerIdentityTests.swift
+++ b/desktop/macos/Desktop/Tests/RuntimeOwnerIdentityTests.swift
@@ -322,7 +322,7 @@ final class RuntimeOwnerIdentityTests: XCTestCase {
     let gate = RuntimeOwnerKernelRevokeGate(recorder: recorder)
 
     let transition = Task {
-      await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+      try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
         defaults: defaultsReference.value,
         allowAutomationOverride: true,
         plannedNextOwner: { _, _ in "owner-b" },
@@ -352,7 +352,11 @@ final class RuntimeOwnerIdentityTests: XCTestCase {
     XCTAssertEqual(recorder.snapshot(), ["voice_quiesced", "kernel_revoke_enter"])
 
     await gate.release()
-    await transition.value
+    do {
+      try await transition.value
+    } catch {
+      XCTFail("owner transition failed: \(error)")
+    }
 
     XCTAssertEqual(
       RuntimeOwnerIdentity.currentOwnerId(
@@ -385,7 +389,7 @@ final class RuntimeOwnerIdentityTests: XCTestCase {
     await probe.waitUntilEffectStarted()
 
     let transition = Task {
-      await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+      try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
         defaults: defaultsReference.value,
         allowAutomationOverride: true,
         plannedNextOwner: { _, _ in "owner-b" },
@@ -423,7 +427,11 @@ final class RuntimeOwnerIdentityTests: XCTestCase {
     XCTAssertTrue(physicalEffect.isCancelled)
 
     await probe.releaseEffect()
-    await transition.value
+    do {
+      try await transition.value
+    } catch {
+      XCTFail("owner transition failed: \(error)")
+    }
 
     XCTAssertEqual(
       RuntimeOwnerIdentity.currentOwnerId(

--- a/desktop/macos/Desktop/Tests/TaskContextualResurfacingTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskContextualResurfacingTests.swift
@@ -109,22 +109,26 @@ private actor SuspendedContextClient: TaskContextualResurfacingClient {
 }
 
 private func transitionContextTestOwner(to ownerID: String?) async {
-  _ = await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-    plannedNextOwner: { _, _ in ownerID },
-    quiesceVoice: { _, _ in },
-    retargetLocalStorage: { _, _ in },
-    ownerDidChange: {
-      await MainActor.run {
-        NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+  do {
+    _ = try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+      plannedNextOwner: { _, _ in ownerID },
+      quiesceVoice: { _, _ in },
+      retargetLocalStorage: { _, _ in },
+      ownerDidChange: {
+        await MainActor.run {
+          NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+        }
+      }
+    ) { defaults in
+      defaults.removeObject(forKey: .automationOwnerOverride)
+      if let ownerID {
+        defaults.set(ownerID, forKey: .authUserId)
+      } else {
+        defaults.removeObject(forKey: .authUserId)
       }
     }
-  ) { defaults in
-    defaults.removeObject(forKey: .automationOwnerOverride)
-    if let ownerID {
-      defaults.set(ownerID, forKey: .authUserId)
-    } else {
-      defaults.removeObject(forKey: .authUserId)
-    }
+  } catch {
+    XCTFail("owner transition failed: \(error)")
   }
 }
 

--- a/desktop/macos/Desktop/Tests/TaskThreadProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskThreadProjectionTests.swift
@@ -690,22 +690,26 @@ import XCTest
     }
 
     private func transitionOwner(to ownerID: String?) async {
-      _ = await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-        plannedNextOwner: { _, _ in ownerID },
-        quiesceVoice: { _, _ in },
-        retargetLocalStorage: { _, _ in },
-        ownerDidChange: {
-          await MainActor.run {
-            NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+      do {
+        _ = try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+          plannedNextOwner: { _, _ in ownerID },
+          quiesceVoice: { _, _ in },
+          retargetLocalStorage: { _, _ in },
+          ownerDidChange: {
+            await MainActor.run {
+              NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+            }
+          }
+        ) { defaults in
+          defaults.removeObject(forKey: .automationOwnerOverride)
+          if let ownerID {
+            defaults.set(ownerID, forKey: .authUserId)
+          } else {
+            defaults.removeObject(forKey: .authUserId)
           }
         }
-      ) { defaults in
-        defaults.removeObject(forKey: .automationOwnerOverride)
-        if let ownerID {
-          defaults.set(ownerID, forKey: .authUserId)
-        } else {
-          defaults.removeObject(forKey: .authUserId)
-        }
+      } catch {
+        XCTFail("owner transition failed: \(error)")
       }
     }
   }

--- a/desktop/macos/Desktop/Tests/TasksSortOrderSyncFailureTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksSortOrderSyncFailureTests.swift
@@ -133,22 +133,26 @@ final class TasksSortOrderSyncFailureTests: XCTestCase {
 
   @MainActor
   private func transition(to ownerID: String?) async {
-    _ = await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-      plannedNextOwner: { _, _ in ownerID },
-      quiesceVoice: { _, _ in },
-      retargetLocalStorage: { _, _ in },
-      ownerDidChange: {
-        await MainActor.run {
-          NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+    do {
+      _ = try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+        plannedNextOwner: { _, _ in ownerID },
+        quiesceVoice: { _, _ in },
+        retargetLocalStorage: { _, _ in },
+        ownerDidChange: {
+          await MainActor.run {
+            NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+          }
+        }
+      ) { defaults in
+        defaults.removeObject(forKey: .automationOwnerOverride)
+        if let ownerID {
+          defaults.set(ownerID, forKey: .authUserId)
+        } else {
+          defaults.removeObject(forKey: .authUserId)
         }
       }
-    ) { defaults in
-      defaults.removeObject(forKey: .automationOwnerOverride)
-      if let ownerID {
-        defaults.set(ownerID, forKey: .authUserId)
-      } else {
-        defaults.removeObject(forKey: .authUserId)
-      }
+    } catch {
+      XCTFail("owner transition failed: \(error)")
     }
   }
 }

--- a/desktop/macos/Desktop/Tests/TasksStoreEmptyCloudReconcileTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksStoreEmptyCloudReconcileTests.swift
@@ -433,30 +433,34 @@ final class TasksStoreEmptyCloudReconcileTests: XCTestCase {
     automationOverrideID: String?
   ) async {
     let plannedOwner = normalizedOwner(automationOverrideID) ?? normalizedOwner(authOwnerID)
-    _ = await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-      allowAutomationOverride: true,
-      plannedNextOwner: { _, _ in plannedOwner },
-      quiesceVoice: { _, _ in },
-      revokeKernelOwner: { _, _ in },
-      retargetLocalStorage: { _, _ in },
-      ownerDidChange: {
-        await MainActor.run {
-          NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+    do {
+      _ = try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+        allowAutomationOverride: true,
+        plannedNextOwner: { _, _ in plannedOwner },
+        quiesceVoice: { _, _ in },
+        revokeKernelOwner: { _, _ in },
+        retargetLocalStorage: { _, _ in },
+        ownerDidChange: {
+          await MainActor.run {
+            NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+          }
+        },
+        { defaults in
+          if let authOwnerID {
+            defaults.set(authOwnerID, forKey: .authUserId)
+          } else {
+            defaults.removeObject(forKey: .authUserId)
+          }
+          if let automationOverrideID {
+            defaults.set(automationOverrideID, forKey: .automationOwnerOverride)
+          } else {
+            defaults.removeObject(forKey: .automationOwnerOverride)
+          }
         }
-      },
-      { defaults in
-        if let authOwnerID {
-          defaults.set(authOwnerID, forKey: .authUserId)
-        } else {
-          defaults.removeObject(forKey: .authUserId)
-        }
-        if let automationOverrideID {
-          defaults.set(automationOverrideID, forKey: .automationOwnerOverride)
-        } else {
-          defaults.removeObject(forKey: .automationOwnerOverride)
-        }
-      }
-    )
+      )
+    } catch {
+      XCTFail("owner transition failed: \(error)")
+    }
   }
 
   private func normalizedOwner(_ value: String?) -> String? {

--- a/desktop/macos/Desktop/Tests/TasksStoreOwnerBoundaryTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksStoreOwnerBoundaryTests.swift
@@ -704,28 +704,32 @@ final class TasksStoreOwnerBoundaryTests: XCTestCase {
     automationOverrideID: String?
   ) async {
     let plannedOwner = normalizedOwner(automationOverrideID) ?? normalizedOwner(authOwnerID)
-    _ = await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
-      allowAutomationOverride: true,
-      plannedNextOwner: { _, _ in plannedOwner },
-      quiesceVoice: { _, _ in },
-      revokeKernelOwner: { _, _ in },
-      retargetLocalStorage: { _, _ in },
-      ownerDidChange: {
-        await MainActor.run {
-          NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+    do {
+      _ = try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+        allowAutomationOverride: true,
+        plannedNextOwner: { _, _ in plannedOwner },
+        quiesceVoice: { _, _ in },
+        revokeKernelOwner: { _, _ in },
+        retargetLocalStorage: { _, _ in },
+        ownerDidChange: {
+          await MainActor.run {
+            NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+          }
+        }
+      ) { defaults in
+        if let authOwnerID {
+          defaults.set(authOwnerID, forKey: .authUserId)
+        } else {
+          defaults.removeObject(forKey: .authUserId)
+        }
+        if let automationOverrideID {
+          defaults.set(automationOverrideID, forKey: .automationOwnerOverride)
+        } else {
+          defaults.removeObject(forKey: .automationOwnerOverride)
         }
       }
-    ) { defaults in
-      if let authOwnerID {
-        defaults.set(authOwnerID, forKey: .authUserId)
-      } else {
-        defaults.removeObject(forKey: .authUserId)
-      }
-      if let automationOverrideID {
-        defaults.set(automationOverrideID, forKey: .automationOwnerOverride)
-      } else {
-        defaults.removeObject(forKey: .automationOwnerOverride)
-      }
+    } catch {
+      XCTFail("owner transition failed: \(error)")
     }
   }
 

--- a/desktop/macos/Desktop/Tests/VideoChunkEncoderHEVCWriterTests.swift
+++ b/desktop/macos/Desktop/Tests/VideoChunkEncoderHEVCWriterTests.swift
@@ -1,0 +1,92 @@
+import AVFoundation
+import CoreGraphics
+import Foundation
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the writer settings that reach `AVAssetWriterInput`.
+/// Intel macOS 15 rejects the duration-based keyframe setting for HEVC/hvc1
+/// while constructing the input, so this test pins the supported configuration
+/// and exercises the real `VideoChunkEncoder` start, append, and finalization
+/// path that uses it.
+final class VideoChunkEncoderHEVCWriterTests: XCTestCase {
+  private var fixture: RewindStorageTestIsolation.Fixture?
+
+  override func setUp() async throws {
+    try await super.setUp()
+    await RewindStorage.shared.reset()
+    fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "rewind-hevc-writer")
+    try await RewindStorage.shared.initialize()
+  }
+
+  override func tearDown() async throws {
+    await VideoChunkEncoder.shared.cancel()
+    await RewindStorage.shared.reset()
+    await RewindStorageTestIsolation.tearDown(userDir: fixture?.userDir)
+    fixture = nil
+    try await super.tearDown()
+  }
+
+  func testHEVCWriterSettingsOmitUnsupportedDurationKey() throws {
+    let settings = VideoChunkEncoder.hevcVideoSettings(
+      width: 96,
+      height: 64,
+      bitrate: 128_000,
+      frameRate: 1.0 / 3.0
+    )
+    let compressionProperties = try XCTUnwrap(settings[AVVideoCompressionPropertiesKey] as? [String: Any])
+
+    XCTAssertEqual(settings[AVVideoCodecKey] as? AVVideoCodecType, .hevc)
+    XCTAssertEqual(compressionProperties[AVVideoAverageBitRateKey] as? Int, 128_000)
+    XCTAssertEqual(compressionProperties[AVVideoExpectedSourceFrameRateKey] as? Int, 1)
+    XCTAssertEqual(compressionProperties[AVVideoAllowFrameReorderingKey] as? Bool, false)
+    XCTAssertNil(compressionProperties[AVVideoMaxKeyFrameIntervalDurationKey])
+  }
+
+  func testHEVCWriterStartsAppendsAndFinalizesAChunk() async throws {
+    let encoder = VideoChunkEncoder.shared
+    let image = try solidRedImage()
+    let startedAt = Date()
+
+    let firstFrame = try await encoder.addFrame(image: image, timestamp: startedAt)
+    let secondFrame = try await encoder.addFrame(image: image, timestamp: startedAt.addingTimeInterval(3))
+    XCTAssertNotNil(firstFrame)
+    XCTAssertNotNil(secondFrame)
+
+    let flushResult = try await encoder.flushCurrentChunk()
+    let result = try XCTUnwrap(flushResult)
+    XCTAssertEqual(result.frames.map(\.frameOffset), [0, 1])
+
+    let maybeVideosDirectory = await RewindStorage.shared.getVideosDirectory()
+    let videosDirectory = try XCTUnwrap(maybeVideosDirectory)
+    let videoURL = videosDirectory.appendingPathComponent(result.videoChunkPath)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: videoURL.path))
+
+    let center = try await RewindStorage.shared.videoFrameCenterPixel(
+      videoPath: result.videoChunkPath,
+      frameOffset: 0
+    )
+    XCTAssertGreaterThan(center.red, center.green)
+    XCTAssertGreaterThan(center.red, center.blue)
+  }
+
+  private func solidRedImage() throws -> CGImage {
+    let width = 96
+    let height = 64
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let context = try XCTUnwrap(
+      CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: colorSpace,
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      ))
+    context.setFillColor(red: 1, green: 0, blue: 0, alpha: 1)
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    return try XCTUnwrap(context.makeImage())
+  }
+}

--- a/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/PushToTalkStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/PushToTalkStateMachineTests.swift
@@ -333,13 +333,17 @@ final class PushToTalkStateMachineTests: XCTestCase {
       // the transition from a nonisolated static helper so neither `defaults` nor
       // `self` crosses an isolation boundary.
       let boxed = OwnerDefaultsBox(value: defaults)
-      await Self.runOwnerTransition(boxed: boxed, ownerID: ownerID)
+      do {
+        try await Self.runOwnerTransition(boxed: boxed, ownerID: ownerID)
+      } catch {
+        XCTFail("owner transition failed: \(error)")
+      }
     }
 
     private static nonisolated func runOwnerTransition(
       boxed: OwnerDefaultsBox, ownerID: String
-    ) async {
-      await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+    ) async throws {
+      try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
         defaults: boxed.value,
         allowAutomationOverride: false,
         plannedNextOwner: { _, _ in ownerID },

--- a/desktop/macos/changelog/unreleased/20260722-firebase-auth-config-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260722-firebase-auth-config-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed sign-in and sign-out crashing when the app's Firebase configuration is unavailable"
+}

--- a/desktop/macos/changelog/unreleased/20260722-hevc-writer-settings.json
+++ b/desktop/macos/changelog/unreleased/20260722-hevc-writer-settings.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a Rewind crash on some Intel Macs when starting HEVC video capture"
+}

--- a/desktop/macos/changelog/unreleased/20260722-rewind-abandoned-chunk-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260722-rewind-abandoned-chunk-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Rewind recovery after a failed video write so abandoned chunks cannot leave broken timeline frames behind"
+}

--- a/desktop/macos/e2e/flows/logout.yaml
+++ b/desktop/macos/e2e/flows/logout.yaml
@@ -4,6 +4,8 @@ tier: manual
 description: Sign out via bridge sign_out — local Auth emulator only, not prod OAuth (Live P2)
 app: com.omi.computer-macos
 covers:
+  - desktop/macos/Desktop/Sources/Auth/AuthOwnerTransition.swift
+  - desktop/macos/Desktop/Sources/Auth/FirebaseAuthAvailability.swift
   - desktop/macos/Desktop/Sources/AuthService.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift
   - desktop/macos/Desktop/Sources/SignInView.swift

--- a/desktop/macos/e2e/flows/rewind-artifact-recovery.yaml
+++ b/desktop/macos/e2e/flows/rewind-artifact-recovery.yaml
@@ -6,6 +6,7 @@ app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindArtifactGauntlet.swift
+  - desktop/macos/Desktop/Sources/Rewind/Core/RewindAbandonedVideoChunkRecovery.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindModels.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift


### PR DESCRIPTION
## What changed and why

Fixes three non-PTT failures from the July 22 macOS beta incident: missing Firebase packaged configuration no longer disables REST-backed auth, Rewind cannot retain DB rows for abandoned video chunks across finalization/owner transitions, and the HEVC writer no longer supplies an unsupported keyframe-duration setting.

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1

## How it was verified

- `xcrun swift test --package-path desktop/macos/Desktop --filter 'RewindAbandonedChunkRecoveryTests|VideoChunkEncoderHEVCWriterTests|FirebaseAuthAvailabilityTests'` — 13 tests passed, including a real AVAssetWriter HEVC append/finalize/readback path
- Focused auth and owner-boundary suites — 44 tests ran; the one stale source-contract expectation was updated, then `AuthSessionCoordinatorTests` passed 9/9
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed
- product file line-count ratchet, changelog validation, and diff hygiene — passed

The packaged beta app and Intel/macOS 15 hardware were not available in this worktree session; HEVC runtime coverage used the current Apple Silicon host.

## Tests

- `FirebaseAuthAvailabilityTests` covers configuration, REST-backed session use, and native Apple fallback without Firebase
- `VideoChunkEncoderHEVCWriterTests` covers the invalid setting and real writer lifecycle
- `RewindAbandonedChunkRecoveryTests` covers crash-gap markers, stale finalization, non-indexer flush, owner-transition failure/ordering, delayed inserts, and startup reconciliation

## Failure class (fixes)

Failure-Class: FC-split-mutation-authority


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

