### PR TITLE
fix(release): admit the sanctioned Omi Beta assets in qualified-beta promotion

### DIFF
--- a/.cross-review-verify.json
+++ b/.cross-review-verify.json
@@ -1,0 +1,39 @@
+{
+  "captured_at_utc": "2026-07-22T19:44:29.878541+00:00",
+  "gate": "INV-BETA-1 side-by-side runtime evidence",
+  "running_omi_processes": {
+    "Omi Beta": 13492,
+    "omi": 22053,
+    "omi-richmond": 41200
+  },
+  "installed_identities": {
+    "/Applications/omi.app": "com.omi.computer-macos",
+    "/Applications/Omi Beta.app": "com.omi.computer-macos.beta"
+  },
+  "on_screen_windows": [
+    {
+      "owner": "Omi Beta",
+      "pid": 13492,
+      "w": 40,
+      "h": 14
+    },
+    {
+      "owner": "Omi Beta",
+      "pid": 13492,
+      "w": 1200,
+      "h": 712
+    }
+  ],
+  "isolated_storage_roots": {
+    "Omi": true,
+    "Omi Beta": true
+  },
+  "log_files_identity": {
+    "/tmp/omi.log": "com.omi.computer-macos",
+    "/tmp/omi-beta.log": "com.omi.computer-macos.beta"
+  },
+  "single_instance_guard_refusals": {
+    "/tmp/omi.log": 8,
+    "/tmp/omi-beta.log": 1
+  }
+}

--- a/backend/tests/unit/test_qualified_beta_promotion.py
+++ b/backend/tests/unit/test_qualified_beta_promotion.py
@@ -256,6 +256,65 @@ def _candidate():
     return release, evidence_bytes, run
 
 
+def _candidate_with_beta():
+    """A candidate that also ships the sanctioned INV-BETA-1 Omi Beta assets."""
+    release, _evidence_bytes, run = _candidate()
+    beta_zip_url = f"https://github.com/BasedHardware/omi/releases/download/{TAG}/Omi.Beta.zip"
+    beta_dmg_url = f"https://github.com/BasedHardware/omi/releases/download/{TAG}/omi-beta.dmg"
+    evidence_name = f"qualification-evidence-{TAG}.json"
+    evidence = {
+        "schema_version": 1,
+        "release_id": TAG,
+        "source_sha": SHA,
+        "qualification_run_id": 123,
+        "source_qualification": {"passed": True, "tier": "T2", "subject": "source-built named-bundle"},
+        "signed_artifact_verification": {"passed": True, "subject": "exact signed ZIP/DMG bytes"},
+        "artifacts": {
+            "Omi.zip": {
+                "url": release["assets"][0]["browser_download_url"],
+                "sha256": hashlib.sha256(b"zip bytes").hexdigest(),
+                "signature": "sparkle",
+            },
+            "omi.dmg": {
+                "url": release["assets"][1]["browser_download_url"],
+                "sha256": hashlib.sha256(b"dmg bytes").hexdigest(),
+            },
+            "Omi.Beta.zip": {
+                "url": beta_zip_url,
+                "sha256": hashlib.sha256(b"beta zip bytes").hexdigest(),
+                "signature": "beta-sparkle",
+            },
+            "omi-beta.dmg": {"url": beta_dmg_url, "sha256": hashlib.sha256(b"beta dmg bytes").hexdigest()},
+        },
+    }
+    evidence_bytes = json.dumps(evidence).encode()
+    # rebuild release body + assets with the beta pair and the refreshed evidence
+    release["body"] = (
+        "<!-- KEY_VALUE_START\nedSignature: sparkle\nbetaEdSignature: beta-sparkle\n"
+        "changelog: Qualified candidate\nKEY_VALUE_END -->"
+    )
+    release["assets"] = [
+        {
+            "name": "Omi.zip",
+            "browser_download_url": release["assets"][0]["browser_download_url"],
+            "digest": _digest(b"zip bytes"),
+        },
+        {
+            "name": "omi.dmg",
+            "browser_download_url": release["assets"][1]["browser_download_url"],
+            "digest": _digest(b"dmg bytes"),
+        },
+        {
+            "name": evidence_name,
+            "browser_download_url": release["assets"][2]["browser_download_url"],
+            "digest": _digest(evidence_bytes),
+        },
+        {"name": "Omi.Beta.zip", "browser_download_url": beta_zip_url, "digest": _digest(b"beta zip bytes")},
+        {"name": "omi-beta.dmg", "browser_download_url": beta_dmg_url, "digest": _digest(b"beta dmg bytes")},
+    ]
+    return release, evidence_bytes, run, {beta_zip_url: b"beta zip bytes", beta_dmg_url: b"beta dmg bytes"}
+
+
 def _artifact_archive(evidence):
     output = io.BytesIO()
     with zipfile.ZipFile(output, "w") as archive:
@@ -590,6 +649,42 @@ async def test_server_builds_the_canonical_manifest_from_qualified_immutable_ass
     assert manifest["zip_url"].endswith("/Omi.zip")
     assert manifest["dmg_url"].endswith("/omi.dmg")
     assert manifest["qualification_evidence_sha256"] == _digest(evidence)
+
+
+@pytest.mark.asyncio
+async def test_server_admits_a_candidate_that_ships_the_side_by_side_beta_assets():
+    # INV-BETA-1: Omi.Beta.zip/omi-beta.dmg are sanctioned, not retired; the
+    # manifest builds and the beta digests are verified against the evidence.
+    release, evidence, run, beta_downloads = _candidate_with_beta()
+    reader = FakeQualifiedBetaReader(release, evidence, run)
+    reader.downloaded.update(beta_downloads)
+
+    manifest = await build_qualified_beta_manifest(
+        TAG,
+        reader=reader,
+        now=datetime(2026, 7, 21, 12, 2, tzinfo=timezone.utc),
+    )
+
+    assert manifest["release_id"] == TAG
+    assert manifest["zip_url"].endswith("/Omi.zip")
+
+
+@pytest.mark.asyncio
+async def test_server_rejects_a_non_sanctioned_beta_like_identity():
+    release, evidence, run = _candidate()
+    release["assets"].append(
+        {
+            "name": "Omi Beta.zip",
+            "browser_download_url": f"https://github.com/BasedHardware/omi/releases/download/{TAG}/Omi%20Beta.zip",
+            "digest": _digest(b"rogue"),
+        }
+    )
+    with pytest.raises(QualifiedBetaAdmissionError, match="retired desktop identity"):
+        await build_qualified_beta_manifest(
+            TAG,
+            reader=FakeQualifiedBetaReader(release, evidence, run),
+            now=datetime(2026, 7, 21, 12, 2, tzinfo=timezone.utc),
+        )
 
 
 @pytest.mark.asyncio

--- a/backend/utils/qualified_beta_promotion.py
+++ b/backend/utils/qualified_beta_promotion.py
@@ -24,7 +24,11 @@ REPOSITORY = "BasedHardware/omi"
 TAG_RE = re.compile(r"^v(?P<version>[0-9]+\.[0-9]+(?:\.[0-9]+)?)\+(?P<build>[1-9][0-9]*)-macos$")
 SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 UTC_RFC3339_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,6})?Z$")
-RETIRED_ASSET_NAMES = frozenset({"Omi.Beta.zip", "omi-beta.dmg", "Omi Beta.zip", "Omi Beta.dmg"})
+# INV-BETA-1: the side-by-side Omi Beta app ships these two sanctioned assets on
+# every macOS candidate. Any OTHER "omi beta"-ish asset name is still a retired
+# identity and rejected. Kept in canonical form used by codemagic/updates.py.
+SANCTIONED_BETA_ASSET_NAMES = ("Omi.Beta.zip", "omi-beta.dmg")
+RETIRED_ASSET_NAMES = frozenset({"Omi Beta.zip", "Omi Beta.dmg"})
 QUALIFICATION_WORKFLOW = "desktop_qualify_beta.yml"
 QUALIFICATION_ARTIFACT_PREFIX = "desktop-qualification-evidence-"
 QUALIFICATION_EVIDENCE_FILE = "qualification-evidence.json"
@@ -439,8 +443,15 @@ async def build_qualified_beta_manifest(
 
     assets = _release_assets(release.get("assets"))
     names = {asset.get("name") for asset in assets}
-    if names & RETIRED_ASSET_NAMES or any(isinstance(name, str) and "omi beta" in name.lower() for name in names):
+    # The sanctioned INV-BETA-1 pair is allowed; any other "omi beta" identity is
+    # still retired and rejected.
+    sanctioned_beta = set(SANCTIONED_BETA_ASSET_NAMES)
+    disallowed_beta = {
+        name for name in names if isinstance(name, str) and "omi beta" in name.lower() and name not in sanctioned_beta
+    }
+    if names & RETIRED_ASSET_NAMES or disallowed_beta:
         _fail("candidate contains a retired desktop identity")
+    has_beta_identity = sanctioned_beta.issubset(names)
     zip_asset, dmg_asset = _asset(assets, "Omi.zip"), _asset(assets, "omi.dmg")
     evidence_name = f"qualification-evidence-{tag}.json"
     evidence_asset = _asset(assets, evidence_name)
@@ -454,6 +465,12 @@ async def build_qualified_beta_manifest(
         "omi.dmg": _asset_digest(dmg_asset),
         evidence_name: _asset_digest(evidence_asset),
     }
+    beta_assets: dict[str, dict[str, Any]] = {}
+    if has_beta_identity:
+        for beta_name in SANCTIONED_BETA_ASSET_NAMES:
+            beta_asset = _asset(assets, beta_name)
+            beta_assets[beta_name] = beta_asset
+            expected_digests[beta_name] = _asset_digest(beta_asset)
     source_sha = await _read_github(source, "tag_sha", tag)
     if not isinstance(source_sha, str):
         _fail("candidate source is not a trusted merged source")
@@ -473,8 +490,12 @@ async def build_qualified_beta_manifest(
         _fail("candidate trusted qualification evidence does not bind its run")
     if not _is_exact_integer(evidence.get("schema_version")) or evidence.get("schema_version") != 1:
         _fail("candidate trusted qualification evidence is invalid")
+    download_targets = [("Omi.zip", zip_url), ("omi.dmg", dmg_url), (evidence_name, evidence_url)]
+    for beta_name in SANCTIONED_BETA_ASSET_NAMES:
+        if beta_name in beta_assets:
+            download_targets.append((beta_name, _asset_url(beta_assets[beta_name], tag, beta_name)))
     downloaded: dict[str, bytes] = {}
-    for name, url in (("Omi.zip", zip_url), ("omi.dmg", dmg_url), (evidence_name, evidence_url)):
+    for name, url in download_targets:
         content = await _read_github(source, "download", url)
         if not isinstance(content, bytes):
             _fail("candidate GitHub asset is unavailable")
@@ -485,16 +506,22 @@ async def build_qualified_beta_manifest(
     if downloaded[evidence_name] != trusted_evidence_bytes:
         _fail("candidate release qualification evidence differs from its trusted run artifact")
     contract_release = _release_for_contract(release, assets)
+    # verify_evidence requires the digest set to equal the evidence's artifact set;
+    # when the beta identity ships, its two assets are in the evidence too.
+    verify_digests = {
+        "Omi.zip": actual_digests["Omi.zip"].removeprefix("sha256:"),
+        "omi.dmg": actual_digests["omi.dmg"].removeprefix("sha256:"),
+    }
+    for beta_name in SANCTIONED_BETA_ASSET_NAMES:
+        if beta_name in beta_assets:
+            verify_digests[beta_name] = actual_digests[beta_name].removeprefix("sha256:")
     try:
         verify_evidence(
             evidence,
             contract_release,
             tag,
             source_sha,
-            {
-                "Omi.zip": actual_digests["Omi.zip"].removeprefix("sha256:"),
-                "omi.dmg": actual_digests["omi.dmg"].removeprefix("sha256:"),
-            },
+            verify_digests,
         )
     except ValueError as exc:
         raise QualifiedBetaAdmissionError("candidate qualification evidence does not bind this release") from exc


### PR DESCRIPTION
Final promotion-path landmine on the INV-BETA-1 re-land: the single-artifact hardening (`qualified_beta_promotion.py`) added a retired-identity guard that rejects `Omi.Beta.zip`/`omi-beta.dmg`. The re-land put those assets back on every candidate, so `/v2/desktop/beta/promote-qualified` would raise `candidate contains a retired desktop identity` and fail **every** side-by-side beta candidate at the last admission step. Reproduced with a real `build_qualified_beta_manifest` fixture.

Fix: the sanctioned INV-BETA-1 pair is admitted (any other "omi beta" name stays retired), downloaded, digest-checked, and threaded into `verify_evidence` so the four-artifact evidence set matches. Single-identity releases are unchanged.

## Product invariants affected

- INV-BETA-1

## Failure class

Failure-Class: none

Verified: `test_qualified_beta_promotion.py` 179 green incl. 2 new cases (beta admitted; non-sanctioned identity rejected); full focused backend + checker + release-process guard battery green (371 backend tests).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

