### PR TITLE
fix(desktop): restore Package.swift/Package.resolved stubbed by a test fixture (#10323)

### DIFF
--- a/desktop/macos/Desktop/Package.resolved
+++ b/desktop/macos/Desktop/Package.resolved
@@ -1,1 +1,212 @@
-{"pins":[]}
+{
+  "originHash" : "a71a71d21fa17d870fe706bdbc8d24164f43179ad6d21882d241f0e0e619fe64",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "3e33dd27dd4c69bd81c7c81fe61d8ccf58846902",
+        "version" : "11.3.1"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "fdc352fabaf5916e7faa1f96ad02b1957e93e5a5",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "fluidaudio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/FluidInference/FluidAudio.git",
+      "state" : {
+        "revision" : "19600a485baa4998812e4654b70d2bab8f2c9949"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "a2d0f1f1666de591eb1a811f40b1706f5c63a2ed",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "45ce435e9406d3c674dd249a042b932bee006f60",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
+        "version" : "8.1.2"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift.git",
+      "state" : {
+        "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
+        "version" : "6.29.3"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "c756a29784521063b6a1202907e2cc47f41b667c",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "3851d94a41890dea16dc3db34caf60e585cb4163",
+        "version" : "2.30910.1"
+      }
+    },
+    {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
+      }
+    },
+    {
+      "identity" : "onnxruntime-swift-package-manager",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/onnxruntime-swift-package-manager.git",
+      "state" : {
+        "revision" : "b7fb7f7dea8a2469e6335d95a61b8f36d0dc83b2",
+        "version" : "1.24.2"
+      }
+    },
+    {
+      "identity" : "posthog-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PostHog/posthog-ios.git",
+      "state" : {
+        "revision" : "33145b13ffa1135623e6a2624e29234288a52258",
+        "version" : "3.65.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
+        "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa.git",
+      "state" : {
+        "revision" : "16cd512711375fa73f25ae5e373f596bdf4251ae",
+        "version" : "8.58.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown-ui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
+      "state" : {
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
+        "version" : "1.38.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/desktop/macos/Desktop/Package.swift
+++ b/desktop/macos/Desktop/Package.swift
@@ -1,1 +1,166 @@
-// package-a
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+  name: "Omi Computer",
+  platforms: [
+    .macOS("14.0")
+  ],
+  dependencies: [
+    .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.0.0"),
+    .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
+    .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.58.0"),
+    .package(url: "https://github.com/groue/GRDB.swift.git", from: "6.24.0"),
+    .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
+    .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.0"),
+    .package(
+      url: "https://github.com/microsoft/onnxruntime-swift-package-manager.git", from: "1.20.0"),
+    // FluidAudio removed the v0.14.8+ tags that its semantic requirement used.
+    // Keep the audited Package.resolved source revision without re-resolving it
+    // against the now-truncated upstream tag set.
+    .package(
+      url: "https://github.com/FluidInference/FluidAudio.git",
+      revision: "19600a485baa4998812e4654b70d2bab8f2c9949"
+    ),
+  ],
+  targets: [
+    .target(
+      name: "ObjCExceptionCatcher",
+      path: "ObjCExceptionCatcher",
+      publicHeadersPath: "include"
+    ),
+    .systemLibrary(
+      name: "CWebP",
+      path: "CWebP",
+      pkgConfig: "libwebp",
+      providers: [
+        .brew(["webp"])
+      ]
+    ),
+    .target(
+      name: "OmiSupport",
+      path: "Sources/OmiSupport",
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .target(
+      name: "OmiTheme",
+      path: "Sources/Theme",
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .target(
+      name: "OmiWAL",
+      path: "Sources/OmiWAL",
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .target(
+      name: "VoiceTurnDomain",
+      path: "Sources/VoiceTurnDomain",
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .executableTarget(
+      name: "Omi Computer",
+      dependencies: [
+        "ObjCExceptionCatcher",
+        "CWebP",
+        "OmiSupport",
+        "OmiTheme",
+        "OmiWAL",
+        "VoiceTurnDomain",
+        .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
+        .product(name: "FirebaseAuth", package: "firebase-ios-sdk"),
+        .product(name: "PostHog", package: "posthog-ios"),
+        .product(name: "Sentry", package: "sentry-cocoa"),
+        .product(name: "GRDB", package: "GRDB.swift"),
+        .product(name: "Sparkle", package: "Sparkle"),
+        .product(name: "MarkdownUI", package: "swift-markdown-ui"),
+        .product(name: "onnxruntime", package: "onnxruntime-swift-package-manager"),
+        .product(name: "FluidAudio", package: "FluidAudio"),
+      ],
+      path: "Sources",
+      exclude: [
+        "GoogleService-Info-Dev.plist",
+        "GoogleService-Info-Local.plist",
+        "Theme",
+        "OmiSupport",
+        "OmiWAL",
+        "VoiceTurnDomain",
+        "Bluetooth/ARCHITECTURE.md",
+        "FloatingControlBar/ARCHITECTURE.md",
+      ],
+      resources: [
+        .process("GoogleService-Info.plist"),
+        // Bundles everything under Resources/ (incl. *_logo.png brand marks,
+        // signin_bg.png, and Resources/Fonts/*.ttf — Geist / Geist Mono fonts).
+        // NOTE: SwiftPM caches the resource manifest, so new files added to
+        // Resources/ are only picked up when the manifest regenerates — editing
+        // this file forces incremental builds to re-scan and include them.
+        .process("Resources"),
+      ],
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .testTarget(
+      name: "Omi ComputerTests",
+      dependencies: [
+        .target(name: "Omi Computer"),
+        "OmiSupport",
+        "OmiTheme",
+        "OmiWAL",
+        "VoiceTurnDomain",
+      ],
+      path: "Tests",
+      exclude: [
+        "fixtures",
+        "SemanticFeatureSentinels",
+        "OmiSupportTests",
+        "OmiWALTests",
+        "VoiceTurnDomainTests",
+      ],
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .testTarget(
+      name: "OmiSupportTests",
+      dependencies: ["OmiSupport"],
+      path: "Tests/OmiSupportTests",
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .testTarget(
+      name: "OmiWALTests",
+      dependencies: ["OmiWAL"],
+      path: "Tests/OmiWALTests",
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
+      ]
+    ),
+    .testTarget(
+      name: "VoiceTurnDomainTests",
+      dependencies: [
+        .target(name: "Omi Computer"),
+        "VoiceTurnDomain",
+      ],
+      path: "Tests/VoiceTurnDomainTests"
+    ),
+    .testTarget(
+      name: "SemanticFeatureSentinels",
+      dependencies: [],
+      path: "Tests/SemanticFeatureSentinels",
+      swiftSettings: [
+        .unsafeFlags(["-strict-concurrency=complete"])
+      ]
+    ),
+  ],
+  swiftLanguageModes: [.v6]
+)

--- a/desktop/macos/changelog/unreleased/20260722-restore-desktop-package-manifest.json
+++ b/desktop/macos/changelog/unreleased/20260722-restore-desktop-package-manifest.json
@@ -1,0 +1,3 @@
+{
+  "change": "Restored the desktop Swift package manifest (Package.swift/Package.resolved) that a stray test fixture had replaced with a stub, unblocking desktop release builds"
+}


### PR DESCRIPTION
## Problem

`main` desktop release builds are **currently broken** at the `Resolve SPM packages` step. PR #10323 ("SCA-52: prevent desktop admission Firebase emulator leaks") merged a stray commit titled **"Cache Test / fixture"** (`991d02a345`) that replaced:

- `desktop/macos/Desktop/Package.swift` (166 lines → `// package-a` stub)
- `desktop/macos/Desktop/Package.resolved` (212 lines → stub)

With no real package manifest, SPM cannot resolve dependencies, so every Codemagic `omi-desktop-swift-release` build fails before compiling, and the beta release pipeline is blocked. The current `main` tip still carries the stub.

## Fix

Restore both files verbatim from the pre-stub parent `fe323c0379` — which is byte-identical to the manifest on the shipped redesign merge (`60e3e766`). **No dependency-graph change**; this is a pure revert of the accidental stub. No commit after the fixture legitimately touched these files, so nothing else is clobbered.

## Verification

- `Package.swift` back to 166 lines (`name: "Omi Computer"`, swift-tools 6.0, Firebase/Sentry/GRDB/Sparkle/FluidAudio/onnxruntime deps).
- `Package.resolved` back to 212 lines.
- `git diff fe323c0379 HEAD -- Package.swift Package.resolved` is empty (exact restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012weG6Y6Fhae8nLrp83aZKV

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

