### PR TITLE
fix(desktop): restore onboarding functionality dropped by Second Brain redesign

### DIFF
--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingFlow.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingFlow.swift
@@ -227,6 +227,12 @@ enum OnboardingFlow {
     "onboardingStep",
     "onboardingFurthestStep",
     "onboardingHowDidYouHearSource",
+    // Second Brain onboarding keys: the resume step (SBOnboardingModel.resumeStepKey)
+    // and the picked role (DefaultsKey.onboardingRole). Both are account-scoped —
+    // without them here a mid-onboarding sign-out leaks the prior user's resume
+    // point + role to the next account on the same Mac.
+    "sbOnboardingResumeStep",
+    "onboardingRole",
     "onboardingGoalDraft",
     "onboardingJustCompleted",
     "hasSeenRewindIntro",

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -39,6 +39,11 @@ extension SBOnboardingModel {
     fdaState = .waiting
     if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles") {
       NSWorkspace.shared.open(url)
+      // Show the drag-to-grant helper card (drag the Omi icon into the FDA list),
+      // matching Screen Recording's flow. Full Disk Access has no in-place toggle,
+      // so the drag card is the fastest grant path (#9742). Both FDA entry points
+      // (the permission step and the Files connector) route through here.
+      Task { await PermissionDragGuidance.presentDragToGrantHelper() }
     }
     pollPermission("full_disk_access")
   }
@@ -374,6 +379,25 @@ extension SBOnboardingModel {
     case "claudeCode": return .claudeCode
     case "codex": return .codex
     default: return .openclaw
+    }
+  }
+
+  /// Brand mark for a connector row (agents + context), so every row shows its
+  /// real logo even when the app isn't installed (#10210). Brands without a
+  /// bundled logo (openclaw/hermes/files) fall back to the icon's default glyph.
+  func connectorBrand(_ id: String) -> ConnectorBrand {
+    switch id {
+    case "openclaw": return .openclaw
+    case "hermes": return .hermes
+    case "claudeCode": return .claudeCode
+    case "codex": return .codex
+    case "calendar": return .calendar
+    case "gmail": return .gmail
+    case "applenotes": return .appleNotes
+    case "files": return .localFiles
+    case "chatgpt": return .chatgpt
+    case "claude": return .claude
+    default: return .agents
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -89,6 +89,11 @@ final class SBOnboardingModel: ObservableObject {
   /// second permission (the meetings "both" mic+system-audio step) never cancels
   /// a still-running poll for the first and strands it on "macOS…".
   var pollTasks: [String: Task<Void, Never>] = [:]
+  /// Observes late-arriving names (Apple sends the name only on first auth;
+  /// otherwise it's fetched from the backend after sign-in). `givenName` is plain
+  /// UserDefaults, not observable, so without this a name landing after the name
+  /// step already streamed would never fill in.
+  private var nameObserver: NSObjectProtocol?
 
   init(appState: AppState, chatProvider: ChatProvider, onComplete: (() -> Void)?) {
     self.appState = appState
@@ -98,6 +103,30 @@ final class SBOnboardingModel: ObservableObject {
     // journal surface so they never pollute the real Chat tab. Cleared on
     // complete()/skip(), after which the Chat tab reloads the clean default surface.
     chatProvider.isOnboarding = true
+    // Detect the user's real name automatically (mirrors the legacy paged intro):
+    // seed the editable field from what we already know, kick a backend fetch if we
+    // don't have it yet, and adopt an async arrival — so onboarding greets by name
+    // instead of "friend"/blank (regression from the SB redesign; see #9919).
+    let known = AuthService.shared.givenName.trimmingCharacters(in: .whitespaces)
+    if !known.isEmpty { nameDraft = known }
+    AuthService.shared.loadNameFromBackendIfNeeded()
+    nameObserver = NotificationCenter.default.addObserver(
+      forName: .authNameDidUpdate, object: nil, queue: .main
+    ) { [weak self] _ in
+      MainActor.assumeIsolated { self?.adoptAsyncName() }
+    }
+  }
+
+  deinit {
+    if let nameObserver { NotificationCenter.default.removeObserver(nameObserver) }
+  }
+
+  /// Adopt a name that landed after init — but only fill an empty field, never
+  /// overwrite what the user has typed.
+  private func adoptAsyncName() {
+    let resolved = AuthService.shared.givenName.trimmingCharacters(in: .whitespaces)
+    guard !resolved.isEmpty, nameDraft.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+    nameDraft = resolved
   }
 
   // MARK: copy
@@ -165,6 +194,10 @@ final class SBOnboardingModel: ObservableObject {
 
   func begin() {
     guard thread.isEmpty && streamingText == nil else { return }
+    // Re-hydrate the editable drafts from what was already saved, so stepping
+    // back to (or resuming at) name/language/role shows the prior answer instead
+    // of an empty field.
+    rehydrateDrafts()
     // Resume where the user left off. Their earlier answers (name, language, role)
     // were already saved to the backend/settings, so we just re-enter at the saved
     // step; each permission step re-checks its grant on appear, so a permission
@@ -244,6 +277,25 @@ final class SBOnboardingModel: ObservableObject {
     case .shortcutOpen, .shortcutTalk: disarmShortcutSummon()
     case .screenDemo: teardownVoiceDemo()
     default: break
+    }
+  }
+
+  /// Re-fill the editable drafts from already-saved answers so revisiting (via
+  /// Back) or resuming a name/language/role step shows the prior value, not an
+  /// empty field. Only fills empties — never clobbers in-progress typing.
+  private func rehydrateDrafts() {
+    if nameDraft.isEmpty {
+      let n = AuthService.shared.givenName.trimmingCharacters(in: .whitespaces)
+      if !n.isEmpty { nameDraft = n }
+    }
+    if roleDraft.isEmpty, role == nil {
+      let saved = UserDefaults.standard.string(forKey: .onboardingRole) ?? ""
+      if !saved.isEmpty { roleDraft = saved }
+    }
+    if languageDraft.isEmpty, languageName == nil, let code = AssistantSettings.shared.voiceLanguages.first,
+      let match = AssistantSettings.supportedLanguages.first(where: { $0.code == code })
+    {
+      languageDraft = match.name
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -484,7 +484,9 @@ struct SBOnboardingView: View {
     VStack(alignment: .leading, spacing: 12) {
       VStack(spacing: 0) {
         ForEach(Array(model.agentRows.enumerated()), id: \.element.id) { i, row in
-          connectRow(row.name, row.detail, state: model.agentStates[row.id] ?? "idle") { model.connectAgent(row.id) }
+          connectRow(id: row.id, row.name, row.detail, state: model.agentStates[row.id] ?? "idle") {
+            model.connectAgent(row.id)
+          }
           if i < model.agentRows.count - 1 { Divider().overlay(sb.ink(.w08)) }
         }
       }
@@ -499,7 +501,7 @@ struct SBOnboardingView: View {
     VStack(alignment: .leading, spacing: 12) {
       VStack(spacing: 0) {
         ForEach(Array(model.contextRows.enumerated()), id: \.element.id) { i, row in
-          connectRow(row.name, row.detail, state: model.contextStates[row.id] ?? "idle") {
+          connectRow(id: row.id, row.name, row.detail, state: model.contextStates[row.id] ?? "idle") {
             model.connectContext(row.id)
           }
           if i < model.contextRows.count - 1 { Divider().overlay(sb.ink(.w08)) }
@@ -512,14 +514,24 @@ struct SBOnboardingView: View {
     .frame(maxWidth: 380, alignment: .leading)
   }
 
-  private func connectRow(_ name: String, _ detail: String, state: String, action: @escaping () -> Void) -> some View {
-    HStack(spacing: 12) {
-      VStack(alignment: .leading, spacing: 1) {
-        Text(name).geist(size: 14, weight: .medium).foregroundStyle(sb.ink)
-        Text(detail).geist(size: 12).foregroundStyle(sb.ink(.w4))
+  private func connectRow(id: String, _ name: String, _ detail: String, state: String, action: @escaping () -> Void)
+    -> some View
+  {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 12) {
+        ConnectorBrandIcon(brand: model.connectorBrand(id), size: 26, cornerRadius: 7)
+        VStack(alignment: .leading, spacing: 1) {
+          Text(name).geist(size: 14, weight: .medium).foregroundStyle(sb.ink)
+          Text(detail).geist(size: 12).foregroundStyle(sb.ink(.w4))
+        }
+        Spacer(minLength: 8)
+        connectTrailing(state, action: action)
       }
-      Spacer(minLength: 8)
-      connectTrailing(state, action: action)
+      // Once Claude Code is connected, surface the restart prompt/button so its
+      // running sessions actually reload the new MCP config (#10205).
+      if id == "claudeCode", state == "on" {
+        ClaudeCodeRestartSubtitle()
+      }
     }
     .padding(.vertical, 10)
   }

--- a/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
@@ -35,6 +35,11 @@ final class OnboardingPersistenceClearingTests: XCTestCase {
       "hasSeenRewindIntro",
       "hasTriggeredAccessibility",
       "hasTriggeredBluetooth",
+      // Second Brain onboarding keys — the redesign added these but left them out
+      // of the shared list, leaking the prior user's resume step + role to the
+      // next account on the same Mac.
+      "sbOnboardingResumeStep",
+      "onboardingRole",
     ]
     for key in required {
       XCTAssertTrue(

--- a/desktop/macos/changelog/unreleased/20260722-onboarding-connector-icons-fda.json
+++ b/desktop/macos/changelog/unreleased/20260722-onboarding-connector-icons-fda.json
@@ -1,0 +1,3 @@
+{
+  "change": "Onboarding connectors show their brand icons, Full Disk Access gets the drag-to-grant helper, and Claude Code shows a restart prompt once connected"
+}

--- a/desktop/macos/changelog/unreleased/20260722-onboarding-name-autodetect.json
+++ b/desktop/macos/changelog/unreleased/20260722-onboarding-name-autodetect.json
@@ -1,0 +1,3 @@
+{
+  "change": "Onboarding now greets you by your real name automatically instead of a generic placeholder"
+}


### PR DESCRIPTION
## Summary

Restores onboarding functionality that the Second Brain redesign (#10218) dropped, re-implemented on top of the new conversational design (no old UI brought back). Each fix is its own commit:

- **Auto-detect user name** (#9919) — seed the name field from the known `givenName`, kick a backend name fetch, and adopt an async name arrival (Apple sends the name only on first auth), so onboarding greets by name instead of a generic placeholder. Also re-hydrates name/language/role drafts on resume.
- **Clear onboarding state on sign-out** (#10108) — `sbOnboardingResumeStep` + `onboardingRole` were added by the redesign but left out of the shared clearing list, leaking the prior user's resume step + role to the next account on the same Mac. Added both, plus a regression test.
- **Drag-to-grant Full Disk Access** (#9742) — the drag-to-grant helper was wired for Screen Recording but not FDA; now both use it.
- **Connector brand marks + Claude Code restart** (#10210 / #10205) — connect rows show each connector's brand icon, and Claude Code shows a restart prompt once connected so running sessions reload the new MCP config.
- **Remove post-onboarding walkthrough** — the coach-mark tour that ran after onboarding (spotlighting each nav pill) is deleted; a just-onboarded user lands straight on Home.
- **Pin the drag-to-grant card under System Settings** — the permission drag card was pinned to the screen's bottom quarter; it now anchors directly beneath the live Settings window (flipping above it when there's no room below) so it follows the window and never covers the drop target.

## Verification

Build/manual verification pending — depends on #10334 (restores the `Package.swift`/`Package.resolved` that a stray "fixture" commit gutted on `main`, which currently breaks the desktop Swift build). This PR carries no Package changes; once #10334 lands and this rebases, it builds on the repaired manifest.

## Product invariants affected

- INV-INT-1

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


