### PR TITLE
SCA-61: bind signed app names to bundle identities

### DIFF
--- a/desktop/macos/changelog/unreleased/20260722-signed-installer-name-guard.json
+++ b/desktop/macos/changelog/unreleased/20260722-signed-installer-name-guard.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved Omi and Omi Beta installer release reliability"
+}

--- a/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
+++ b/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
@@ -192,6 +192,14 @@ build_from_tag() {
   printf '%s\n' "${BASH_REMATCH[2]}"
 }
 
+expected_app_bundle_name() {
+  case "$EXPECTED_BUNDLE_ID" in
+    com.omi.computer-macos) printf '%s\n' "Omi.app" ;;
+    com.omi.computer-macos.beta) printf '%s\n' "Omi Beta.app" ;;
+    *) basename "$APP_BUNDLE" ;;
+  esac
+}
+
 extract_zip_if_needed() {
   [[ -n "$SPARKLE_ZIP" ]] || return 0
   [[ -f "$SPARKLE_ZIP" ]] || fail "Sparkle ZIP not found: $SPARKLE_ZIP"
@@ -360,6 +368,7 @@ assert_bundle_identity() {
   [[ -d "$APP_BUNDLE/Contents" ]] || fail "app bundle not found: $APP_BUNDLE"
 
   local bundle_id version build executable url_scheme feed_url external_preview_marker automatic_checks
+  local app_bundle_name required_app_bundle_name
   bundle_id="$(plist_read CFBundleIdentifier)"
   version="$(plist_read CFBundleShortVersionString)"
   build="$(plist_read CFBundleVersion)"
@@ -370,6 +379,10 @@ assert_bundle_identity() {
   automatic_checks="$(plist_read SUEnableAutomaticChecks)"
 
   [[ "$bundle_id" == "$EXPECTED_BUNDLE_ID" ]] || fail "bundle id must be $EXPECTED_BUNDLE_ID, got ${bundle_id:-missing}"
+  app_bundle_name="$(basename "$APP_BUNDLE")"
+  required_app_bundle_name="$(expected_app_bundle_name)"
+  [[ "$app_bundle_name" == "$required_app_bundle_name" ]] \
+    || fail "app bundle name for $EXPECTED_BUNDLE_ID must be $required_app_bundle_name, got $app_bundle_name"
   [[ "$url_scheme" == "$EXPECTED_URL_SCHEME" ]] || fail "URL scheme must be $EXPECTED_URL_SCHEME, got ${url_scheme:-missing}"
   if [[ "$IS_EXTERNAL_PREVIEW" == true ]]; then
     [[ "$bundle_id" =~ ^com[.]omi[.]preview[.][a-z0-9-]+$ ]] \
@@ -493,7 +506,7 @@ assert_sparkle_and_artifacts() {
     hdiutil attach "$DMG_PATH" -nobrowse -readonly -mountpoint "$DMG_MOUNTPOINT" -quiet \
       || fail "DMG attach failed"
     local dmg_app_name dmg_app
-    dmg_app_name="$(basename "$APP_BUNDLE")"
+    dmg_app_name="$(expected_app_bundle_name)"
     [[ "$dmg_app_name" == *.app && "$dmg_app_name" != ".app" ]] \
       || fail "validated app bundle name must end in .app: $dmg_app_name"
     dmg_app="$DMG_MOUNTPOINT/$dmg_app_name"

--- a/desktop/macos/tests/test-signed-artifact-smoke.sh
+++ b/desktop/macos/tests/test-signed-artifact-smoke.sh
@@ -71,7 +71,7 @@ grep -q -- "--expected-bundle-id requires a value" /tmp/omi-smoke-preview-missin
 
 tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/omi-smoke-test.XXXXXX")"
 TMP_ROOTS+=("$tmp_root")
-tmp_app="$tmp_root/omi.app"
+tmp_app="$tmp_root/Omi.app"
 mkdir -p "$tmp_app/Contents/MacOS" "$tmp_app/Contents/Resources" "$tmp_app/Contents/Frameworks"
 cat > "$tmp_app/Contents/Info.plist" <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
@@ -227,10 +227,18 @@ chmod +x "$mock_bin"/*
 
 canonical_dmg_app="$tmp_root/Omi.app"
 signed_beta_app="$tmp_root/signed/Omi Beta.app"
+renamed_canonical_app="$tmp_root/Anything.app"
+renamed_beta_app="$tmp_root/signed/Anything Beta.app"
 make_signed_smoke_fixture "$canonical_dmg_app" \
   com.omi.computer-macos \
   https://api.omi.me/v2/desktop/appcast.xml
 make_signed_smoke_fixture "$signed_beta_app" \
+  com.omi.computer-macos.beta \
+  'https://api.omi.me/v2/desktop/appcast.xml?identity=beta'
+make_signed_smoke_fixture "$renamed_canonical_app" \
+  com.omi.computer-macos \
+  https://api.omi.me/v2/desktop/appcast.xml
+make_signed_smoke_fixture "$renamed_beta_app" \
   com.omi.computer-macos.beta \
   'https://api.omi.me/v2/desktop/appcast.xml?identity=beta'
 dummy_dmg="$tmp_root/fixture.dmg"
@@ -260,6 +268,28 @@ if PATH="$mock_bin:$PATH" OMI_TEST_DMG_APP_SOURCE="$canonical_dmg_app" \
 fi
 grep -q "DMG must contain exact Omi Beta.app" /tmp/omi-smoke-beta-wrong-dmg.err \
   || fail "wrong-name DMG rejection should name the exact expected bundle"
+
+if PATH="$mock_bin:$PATH" OMI_TEST_DMG_APP_SOURCE="$renamed_canonical_app" \
+  "$SMOKE" --app "$renamed_canonical_app" --dmg "$dummy_dmg" \
+  --tag v0.12.34+12034-macos \
+  >/tmp/omi-smoke-renamed-canonical.out 2>/tmp/omi-smoke-renamed-canonical.err; then
+  fail "canonical identity must reject a renamed app and matching DMG"
+fi
+grep -q "app bundle name for com.omi.computer-macos must be Omi.app, got Anything.app" \
+  /tmp/omi-smoke-renamed-canonical.err \
+  || fail "renamed canonical rejection should bind Omi.app to its bundle identity"
+
+if PATH="$mock_bin:$PATH" OMI_TEST_DMG_APP_SOURCE="$renamed_beta_app" \
+  "$SMOKE" --app "$renamed_beta_app" --dmg "$dummy_dmg" \
+  --tag v0.12.34+12034-macos \
+  --expected-bundle-id com.omi.computer-macos.beta \
+  --expected-feed-url 'https://api.omi.me/v2/desktop/appcast.xml?identity=beta' \
+  >/tmp/omi-smoke-renamed-beta.out 2>/tmp/omi-smoke-renamed-beta.err; then
+  fail "beta identity must reject a renamed app and matching DMG"
+fi
+grep -q "app bundle name for com.omi.computer-macos.beta must be Omi Beta.app, got Anything Beta.app" \
+  /tmp/omi-smoke-renamed-beta.err \
+  || fail "renamed beta rejection should bind Omi Beta.app to its bundle identity"
 
 # Regression (v0.12.91 build failure): macOS mktemp creates the LITERAL template
 # file when characters follow the final XXXXXX, so the second smoke invocation


### PR DESCRIPTION
## Summary
- forward-fix the identity-name weakening merged in #10347
- bind `com.omi.computer-macos` to `Omi.app` and `com.omi.computer-macos.beta` to `Omi Beta.app`
- derive the exact DMG bundle path from that identity mapping, not an arbitrary `--app` basename
- add behavioral rejection for renamed canonical and beta app/DMG pairs while retaining canonical success, beta success, and wrong-name DMG rejection
- add the unreleased desktop changelog fragment required for exact-main Release Eligibility

## Failure class

PR #10347 fixed the `.110` Beta DMG lookup but trusted any `.app` basename supplied alongside matching signed metadata. That allowed renamed canonical or beta app/DMG pairs to pass. This forward fix makes the signed bundle identity authoritative for the allowed app name.

Failure-Class: none

## Product invariants affected

- INV-AUTH-1

## Verification
- `/bin/bash desktop/macos/tests/test-signed-artifact-smoke.sh`
  - output: `signed artifact smoke tests passed`
- `/bin/bash -n desktop/macos/scripts/smoke-signed-desktop-artifact.sh desktop/macos/tests/test-signed-artifact-smoke.sh`
- verified with Apple `/bin/bash` 3.2.57
- `python3 .github/scripts/check-desktop-changelog.py --base origin/main --head HEAD`
  - output: `Desktop changelog fragment found.`
- TDD red before implementation: `FAIL: canonical identity must reject a renamed app and matching DMG`

Changelog fragment: `desktop/macos/changelog/unreleased/20260722-signed-installer-name-guard.json`.

## Release safety

`v0.12.110+12110-macos` remains immutable and failed at Codemagic build `6a612775997989ee5683ece6`, Step 21. Candidate tagging/building must wait for this guard; recovery still requires a higher candidate. This PR performs no publication, promotion, Stable, release-asset, or tag mutation and must not be merged without independent review.

Closes SCA-61
