### PR TITLE
feat(release): Codemagic-primary desktop beta qualification with self-hosted fallback lanes

### DIFF
--- a/.github/failure-classes/FC-single-machine-release-gate.json
+++ b/.github/failure-classes/FC-single-machine-release-gate.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-single-machine-release-gate",
+  "violated_contract": "A release-blocking automated gate must not depend on exactly one machine: every mandatory pipeline stage needs at least two independently healthy executors (an always-available primary lane plus at least one fallback), with the gate passing when any lane produces valid evidence and failing only on the candidate itself.",
+  "canonical_prevention": "Desktop beta qualification runs a Codemagic primary lane plus a pool of interchangeable self-hosted runners behind an at-least-one-passes verdict; machine-specific prerequisites (global backend python, Docker-only Typesense) are eliminated so any admin Mac or ephemeral CI Mac can execute the lane.",
+  "evidence_prs": [10354],
+  "scope_hints": [
+    ".github/workflows/desktop_qualify_beta.yml",
+    ".github/scripts/desktop_codemagic_qualification.py",
+    "codemagic.yaml",
+    "desktop/macos/scripts/qualify-desktop-beta.sh",
+    "scripts/dev-harness/dev_harness/cli.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -27,25 +27,53 @@ def codemagic() -> str:
 
 
 class DesktopReleaseFlowContractTests(unittest.TestCase):
-    def _qualification_identity_expressions(self) -> tuple[str, str]:
+    def _qualification_jobs(self) -> dict[str, str]:
+        """Slice the qualification workflow into per-job text regions.
+
+        The workflow runs the same qualification contract in two lanes
+        (codemagic-lane orchestration plus the self-hosted qualify fallback),
+        so single-occurrence full-document searches are ambiguous.
+        """
         qualification = workflow("desktop_qualify_beta.yml")
-        candidate_step = qualification.split("      - name: Download and validate newest candidate evidence", 1)[1]
-        candidate_step = candidate_step.split("\n      - name:", 1)[0]
-        target = re.search(r"^\s*TARGET_SHA=\$\((.+)\)$", candidate_step, re.MULTILINE)
-        checkout = re.search(r"^\s*CHECKOUT_SHA=\$\((.+)\)$", candidate_step, re.MULTILINE)
-        self.assertIsNotNone(target)
-        self.assertIsNotNone(checkout)
-        return target.group(1), checkout.group(1)
+        jobs_document = qualification.split("\njobs:\n", 1)[1]
+        headers = list(re.finditer(r"^  ([a-z][a-z0-9-]*):\n", jobs_document, re.MULTILINE))
+        self.assertTrue(headers)
+        jobs: dict[str, str] = {}
+        for index, match in enumerate(headers):
+            end = headers[index + 1].start() if index + 1 < len(headers) else len(jobs_document)
+            jobs[match.group(1)] = jobs_document[match.start() : end]
+        return jobs
+
+    def _qualification_lane_jobs(self) -> tuple[str, str]:
+        jobs = self._qualification_jobs()
+        self.assertIn("codemagic-lane", jobs)
+        self.assertIn("qualify", jobs)
+        return jobs["codemagic-lane"], jobs["qualify"]
+
+    def _qualification_identity_expressions(self) -> tuple[str, str]:
+        expressions: list[tuple[str, str]] = []
+        for lane in self._qualification_lane_jobs():
+            candidate_step = lane.split("      - name: Download and validate newest candidate evidence", 1)[1]
+            candidate_step = candidate_step.split("\n      - name:", 1)[0]
+            target = re.search(r"^\s*TARGET_SHA=\$\((.+)\)$", candidate_step, re.MULTILINE)
+            checkout = re.search(r"^\s*CHECKOUT_SHA=\$\((.+)\)$", candidate_step, re.MULTILINE)
+            self.assertIsNotNone(target)
+            self.assertIsNotNone(checkout)
+            expressions.append((target.group(1), checkout.group(1)))
+        # Both lanes must bind candidate identity with the exact same expressions.
+        self.assertEqual(expressions[0], expressions[1])
+        return expressions[0]
 
     def _qualification_step(self, name: str) -> str:
-        qualification = workflow("desktop_qualify_beta.yml")
+        _, qualify_job = self._qualification_lane_jobs()
         marker = f"      - name: {name}"
-        self.assertEqual(qualification.count(marker), 1)
-        return qualification.split(marker, 1)[1].split("\n      - name:", 1)[0]
+        self.assertEqual(qualify_job.count(marker), 1)
+        return qualify_job.split(marker, 1)[1].split("\n      - name:", 1)[0]
 
     def _gitlink_cleanup_script(self, name: str) -> str:
         script = self._qualification_step(name).split("        run: |\n", 1)[1]
-        return "\n".join(line[10:] if line.startswith("          ") else line for line in script.splitlines())
+        dedented = "\n".join(line[10:] if line.startswith("          ") else line for line in script.splitlines())
+        return dedented.rstrip("\n")
 
     def _gitlink_cleanup_scripts(self) -> tuple[tuple[str, str], ...]:
         return tuple((name, self._gitlink_cleanup_script(name)) for name in (PRECLEAN_NAME, POSTCLEAN_NAME))
@@ -157,9 +185,10 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         target_expression, checkout_expression = self._qualification_identity_expressions()
         self.assertEqual(target_expression, 'git rev-parse "$RELEASE_TAG^{commit}"')
         self.assertEqual(checkout_expression, 'git rev-parse "HEAD^{commit}"')
+        # Candidate validation plus evidence creation in each of the two lanes.
         self.assertEqual(
             workflow("desktop_qualify_beta.yml").count('TARGET_SHA=$(git rev-parse "$RELEASE_TAG^{commit}")'),
-            2,
+            4,
         )
 
     def test_beta_qualification_accepts_annotated_tag_at_exact_checkout_commit(self) -> None:
@@ -169,13 +198,13 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         self._assert_qualification_tag_identity(annotated=False)
 
     def test_beta_qualification_bounds_checkout_with_identical_exact_cleanup(self) -> None:
-        qualification = workflow("desktop_qualify_beta.yml")
+        _, qualify_job = self._qualification_lane_jobs()
         checkout_name = "Checkout qualification controls"
         attach_name = "Attach immutable qualification evidence to the candidate release"
-        self.assertLess(qualification.index(PRECLEAN_NAME), qualification.index(checkout_name))
-        self.assertLess(qualification.index(checkout_name), qualification.index(POSTCLEAN_NAME))
-        self.assertLess(qualification.index(attach_name), qualification.index(POSTCLEAN_NAME))
-        self.assertEqual(re.findall(r"^      - name: (.+)$", qualification, re.MULTILINE)[-1], POSTCLEAN_NAME)
+        self.assertLess(qualify_job.index(PRECLEAN_NAME), qualify_job.index(checkout_name))
+        self.assertLess(qualify_job.index(checkout_name), qualify_job.index(POSTCLEAN_NAME))
+        self.assertLess(qualify_job.index(attach_name), qualify_job.index(POSTCLEAN_NAME))
+        self.assertEqual(re.findall(r"^      - name: (.+)$", qualify_job, re.MULTILINE)[-1], POSTCLEAN_NAME)
 
         preclean_step = self._qualification_step(PRECLEAN_NAME)
         postclean_step = self._qualification_step(POSTCLEAN_NAME)

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -358,10 +358,10 @@ jobs:
             }
           fi
 
-  # The workflow_run promotion trigger reads this run's conclusion, so exactly
-  # one job may fail the run: qualification succeeds iff at least one lane
-  # published immutable evidence.
   verdict:
+    # The workflow_run promotion trigger reads this run's conclusion, so
+    # exactly one job may fail the run: qualification succeeds iff at least
+    # one lane published immutable evidence.
     needs: [codemagic-lane, qualify]
     if: always()
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Desktop beta qualification is a single point of failure: one trusted lane on one self-hosted machine (David's M1 Mac Studio). On Jul 22 every qualification from v0.12.99 to v0.12.108 failed or was cancelled (machine DNS/git infra sickness in the afternoon, then a real T2 failure), and the beta channel served v0.12.103 all day with no path forward.

## Change

Qualification becomes two serialized lanes with an at-least-one-passes verdict, per the operator's directive (Codemagic first priority, self-hosted Macs as fallback, at least one lane must pass):

1. **`codemagic-lane` (primary)** — a GitHub-hosted job validates the candidate exactly as before, then starts the new `omi-desktop-qualification` Codemagic workflow via API and polls it. The Codemagic build (config trusted from `main`, candidate source materialized from the immutable tag, controls for validation taken from the tag checkout) rebuilds the exact tag and runs hermetic T2 + the fault suite on an ephemeral Mac. The GitHub job publishes the immutable Actions evidence only after the build finishes, its tag binding matches, and its `qualification-result.json` artifact binds to the exact tag + SHA (`.github/scripts/desktop_codemagic_qualification.py`, unit-tested). Codemagic already builds and signs the candidate, so qualifying there extends it no new trust; it imports **no** credential group (release-process guard enforced) and receives only a short-lived Omi Bot token for read-only `gh` calls.
2. **`qualify` (fallback)** — the existing self-hosted lane with byte-identical qualification steps, entered only when the Codemagic lane did not qualify. Runner prerequisite widened from Docker-only to "healthy Docker **or** native `typesense-server`".
3. **`verdict`** — the only job allowed to fail the run, so the `workflow_run` promotion trigger sees success iff at least one lane published evidence. Both lanes stay fail-closed on the candidate itself.

Enablers in the same PR:

- **Native Typesense runtime for the dev harness** (`OMI_TYPESENSE_RUNTIME=docker|native`, auto-detected, announced at `dev-up`): Docker's only role in the hermetic stack was running `typesense/typesense:27.1`; ephemeral Codemagic Macs have no nested virtualization. Native mode runs a sha256-pinned `typesense-server` binary under the same supervised process contract; the container cross-check now keys off the recorded service command.
- **Tag-pinned backend venv in qualification**: `qualify-desktop-beta.sh` runs `make setup-backend` in the exact-SHA worktree when `uv` exists, removing the hidden dependency on a hand-maintained global python3 with backend deps on each runner.
- **dev-harness unit tests wired into the checks manifest** (they previously ran in no CI lane) plus new behavioral tests for runtime resolution/command construction, and the release-flow contract test made job-aware for the two-lane workflow.
- `codemagic.yaml` digest fixtures updated deliberately (reviewed change; `check-release-process-guards.py` passes).
- Docs: `desktop/macos/AGENTS.md` Release Pipeline rewritten for the two lanes and the new runner bar.

**Activation note:** the qualification workflow executes from the tag ref, so the lanes take effect for tags cut after this merges. Existing tags are covered immediately by the second self-hosted runner registered tonight (`mac-mini-m4-qualification`, Nik's M4 mini — online alongside David's with identical labels; `CODEMAGIC_API_TOKEN` repo secret added).

## Product invariants affected

- INV-AUTH-1
- INV-DATA-1
- INV-BETA-1

Path-glob matched via `scripts/pr-preflight --suggest`; no invariant behavior changes — the beta admission authority, promotion trigger contract (`workflow_run` success + `head_sha` == tag SHA + `workflow_dispatch` event), evidence format, and fail-closed semantics are preserved, with guard tests updated where the workflow's internal structure changed (`test_desktop_release_flow_contract.py` job-aware slicing).

## Verification

Local (all green):
- `python3 .github/scripts/check-release-process-guards.py` → passed (fixture digests updated deliberately)
- `python3 .github/scripts/test_desktop_release_flow_contract.py` → 18 OK
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh` → passed
- `python3 .github/scripts/test_desktop_beta_qualification_retry.py` → OK
- `python3 .github/scripts/test_desktop_codemagic_qualification.py` → 10 OK
- `bash scripts/dev-harness/run-tests.sh` → 48 passed (uv-pinned lane)
- `python3 .github/scripts/test_run_checks.py` → 21 OK
- `make preflight` → PR preflight passed: 13 checks

Live (release-infra exercised for real):
- **Second self-hosted runner online and executing jobs**: `mac-mini-m4-qualification` picked up qualification run [29963424017](https://github.com/BasedHardware/omi/actions/runs/29963424017) (dispatched for v0.12.109 while David's runner was busy), completed checkout/token/validation on the mini and failed correctly with `release not found` (v0.12.109 has no published candidate — fail-closed as designed).
- **Fail-closed on the poisoned newest candidate**: run [29963327772](https://github.com/BasedHardware/omi/actions/runs/29963327772) (v0.12.110, David's runner) failed candidate validation — correct, since v0.12.110's release assets were hand-replaced after smoke and its DMG carries the launch crash fixed in #10350.
- **Codemagic qualification workflow running live pre-merge**: build `6a614556897e5e3019e029c6` (workflow `omi-desktop-qualification` from this branch, `OMI_QUALIFY_TAG=v0.12.110+12110-macos`) — result will be posted in a PR comment when it completes. UNVERIFIED until then: a full hermetic T2 pass on an ephemeral Codemagic Mac; a full T2 pass on the M4 mini likewise awaits the first valid newest candidate (v0.12.111+, which carries the #10350 crash fix).

Related issues found during this work: #10351 (guard self-tests failing on main, unwired), #10352 (make setup / hooks broken in linked worktrees).

Failure-Class: new

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

