### PR TITLE
ci(desktop): run all macOS Codemagic workflows on M4

### DIFF
--- a/.github/scripts/fixtures/codemagic_workflow_contract/v1.json
+++ b/.github/scripts/fixtures/codemagic_workflow_contract/v1.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
-  "codemagic_raw_sha256": "c247bc3a7b2242151de67ce63784655533f2878ffb69c7b88364f8745d261435",
-  "codemagic_semantic_sha256": "e363dc6cbb9755c24eec9bb1590a096ac3dcb35fb5375bdbf163710177ba825f",
+  "codemagic_raw_sha256": "4bbea2e7a566e2882830d0fb2c581ce617a0c1ca7347d292ef754ecad31a5681",
+  "codemagic_semantic_sha256": "119aa1d6e14cd36e229a74366fd240054152791dfa683a66d841e20fe32d00b1",
   "omi-desktop-swift-preview": {
-    "semantic_sha256": "0f2740d44fc86e6d24f5a69df3a2336d11d303ab5dfa6fb7c1d9771c61172833"
+    "semantic_sha256": "66057233b4178c958f470b405f6ea4bd4090b32b70d7f49e9c88c08a9265d809"
   },
   "omi-desktop-swift-release": {
     "publication_script": "if [[ \"${PREVIEW_MODE:-false}\" == \"true\" ]]; then\n  echo \"External previews do not create GitHub releases.\"\n  exit 0\nfi\nset -euo pipefail\nCHANGELOG_MD=$(python3 ../../.github/scripts/desktop-changelog.py latest-release --format markdown || echo \"- Bug fixes and improvements\")\n\n# Build changelog as pipe-separated string for KEY_VALUE_START\nCHANGELOG_PIPE=$(echo \"$CHANGELOG_MD\" | sed 's/^- //' | tr '\\n' '|' | sed 's/|$//')\n\nRELEASE_NOTES=\"## OMI Desktop v${VERSION}\n\n### What's New\n${CHANGELOG_MD}\n\n### Downloads\n- **DMG Installer**: For fresh installs, download the DMG below\n- **Auto-Update**: Existing users will receive this update automatically via Sparkle\n\n<!-- KEY_VALUE_START\nisLive: false\nchannel: candidate\nedSignature: ${ED_SIGNATURE}\nbetaEdSignature: ${BETA_ED_SIGNATURE}\nchangelog: ${CHANGELOG_PIPE}\nKEY_VALUE_END -->\"\n\n# A candidate is the evidence container. Once published, preserve its\n# signed artifacts and every qualification observation; retries only\n# resume the dispatch handoff below.\nif gh release view \"$CM_TAG\" --repo \"$GITHUB_REPO\" >/dev/null 2>&1; then\n  echo \"GitHub release candidate already exists; preserving immutable evidence for $CM_TAG\"\nelse\n  # The backend reservation is the authoritative Beta fence. It runs\n  # only after package, signature, notarization, and signed smoke pass,\n  # immediately before this workflow creates the immutable candidate.\n  set -euo pipefail\n  test -n \"${BETA_PROMOTION_TOKEN:-}\" || {\n    echo \"ERROR: BETA_PROMOTION_TOKEN is required to reserve a canonical candidate\" >&2\n    exit 1\n  }\n  curl --fail-with-body --silent --show-error \\\n    --request POST \"${OMI_PYTHON_API_URL%/}/v2/desktop/beta/candidates/reserve\" \\\n    --header \"Authorization: Bearer ${BETA_PROMOTION_TOKEN}\" \\\n    --header 'Content-Type: application/json' \\\n    --data \"{\\\"tag\\\":\\\"${CM_TAG}\\\"}\"\n  gh release create \"$CM_TAG\" \\\n    --repo \"$GITHUB_REPO\" \\\n    --title \"Omi Desktop v${VERSION} (candidate)\" \\\n    --notes \"$RELEASE_NOTES\" \\\n    \"$SPARKLE_ZIP_PATH\" \\\n    \"$DMG_PATH\" \\\n    \"$BETA_SPARKLE_ZIP_PATH\" \\\n    \"$BETA_DMG_PATH\" \\\n    \"$BUILD_DIR/desktop-smoke-result.json\" \\\n    \"$BUILD_DIR/desktop-smoke-result-beta.json\"\n  echo \"GitHub release candidate created: $CM_TAG\"\nfi\n",
     "publication_script_sha256": "1a1fe7453daf01cb0aa6e3aa311c57594b758ed671ed939058add5c6fa74b989",
-    "semantic_sha256": "ec88d63979a6d4df8017800eee25d08f72161bfd1e4a5fd78cfa1c9930dc67d1"
+    "semantic_sha256": "ea127480417dab20570e3b34f4ef5d04f5989bf51951f05d182be0b2fc3da746"
   }
 }

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -641,7 +641,7 @@ workflows:
 
   macos-prod-appstore:
     name: Release macOS to App Store
-    instance_type: mac_mini_m2
+    instance_type: mac_mini_m4
     max_build_duration: 120
     integrations:
       app_store_connect: codemagic_v4
@@ -1136,7 +1136,7 @@ workflows:
 
   # Retained only for local artifact diagnostics; it has no trigger or publisher.
   macos-prod-legacy-no-publish:
-    instance_type: mac_mini_m2
+    instance_type: mac_mini_m4
     max_build_duration: 120
     integrations:
       app_store_connect: codemagic_v4
@@ -1874,7 +1874,7 @@ workflows:
   # ============================================
   omi-desktop-swift-release:
     name: Release OMI Desktop (Swift)
-    instance_type: mac_mini_m2
+    instance_type: mac_mini_m4
     max_build_duration: 120
     environment:
       groups:
@@ -2930,7 +2930,7 @@ workflows:
   # this trusted configuration has loaded (same posture as the preview lane).
   omi-desktop-qualification:
     name: Qualify OMI Desktop Beta (hermetic T2)
-    instance_type: mac_mini_m2
+    instance_type: mac_mini_m4
     max_build_duration: 120
     environment:
       # Deliberately no credential groups (check-release-process-guards.py
@@ -3070,7 +3070,7 @@ workflows:
   # after this trusted configuration has loaded.
   omi-desktop-swift-preview:
     name: Publish OMI Desktop Preview (Swift)
-    instance_type: mac_mini_m2
+    instance_type: mac_mini_m4
     max_build_duration: 120
     environment:
       # TEMPORARY — tracked by #10221. The dedicated Preview group was not

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -57,7 +57,7 @@ Provider/mode switches and fail-open paths must call `DesktopDiagnosticsManager.
 Merging `desktop/macos/**` changes queues them for the next hourly candidate retry. A candidate advances to beta automatically only after every qualification gate passes:
 
 1. **GitHub Actions** (`desktop_auto_release.yml`) — batches mainline changes, auto-increments the version, and pushes a `v*-macos` build-candidate tag. It is schedule-only and fails closed before changelog or tag mutation unless `Release Eligibility`, `Desktop Swift Build & Tests`, and `Desktop Swift Release Compile` all completed successfully for the exact newest queued releasable desktop SHA. Later backend/docs-only commits do not replace that immutable source with a SHA where desktop CI was skipped; the tag includes the newly consolidated release notes.
-2. **Codemagic** (`codemagic.yaml`, workflow `omi-desktop-swift-release`) — triggered by the tag, runs on Mac mini M2:
+2. **Codemagic** (`codemagic.yaml`, workflow `omi-desktop-swift-release`) — triggered by the tag, runs on Mac mini M4:
    - Builds universal binary (arm64 + x86_64)
    - Signs with Developer ID, notarizes with Apple
    - Creates DMG + Sparkle ZIP


### PR DESCRIPTION
## Summary

- move every macOS Codemagic workflow from `mac_mini_m2` to `mac_mini_m4`
- include the current production/Beta release, Beta qualification, preview, App Store, and legacy diagnostic lanes
- refresh the exact Codemagic workflow contract and release-runner documentation

## Product invariants affected

- INV-AUTH-1
- INV-DATA-1
- INV-BETA-1

## Verification

- `python3 .github/scripts/check-release-process-guards.py`
- parsed `codemagic.yaml` and asserted every `macos-*` / `omi-desktop-*` workflow resolves to `mac_mini_m4`
- exact workflow-contract acceptance and independent fixture-hash tests pass
- `.github/scripts/test_desktop_release_flow_contract.py` (18 tests)
- `make preflight` with this PR body

The full release-guard unit file reports 78 passed and the same 9 historical-parent failures reproduced on untouched `origin/main`; those tests expect the pre-existing 21-step workflow while main already contains 22 approved steps.
