### PR TITLE
fix(desktop): onboarding polish from user testing

### DIFF
--- a/desktop/macos/Desktop/Sources/MemoryBankConnector.swift
+++ b/desktop/macos/Desktop/Sources/MemoryBankConnector.swift
@@ -29,6 +29,35 @@ enum MemoryBankConnector {
     }
   }
 
+  /// Whether the local tool for `destination` is actually installed on this Mac,
+  /// using the SAME evidence the matching `connect…` path requires. Onboarding's
+  /// upfront probe must agree with the connect outcome, otherwise a row offers
+  /// "Connect" and then fails to "not installed" only after the click (e.g. a
+  /// stray `~/.codex` dir with no `codex` on PATH). May shell out (`command -v`),
+  /// so call it off the main thread.
+  static func isInstalled(_ destination: MemoryExportDestination) -> Bool {
+    let fm = FileManager.default
+    switch destination {
+    case .claudeCode:
+      return fm.fileExists(atPath: home.appendingPathComponent(".claude.json").path)
+        || fm.fileExists(atPath: home.appendingPathComponent(".claude/settings.json").path)
+        || executablePath(named: "claude", override: claudeCLIPathOverrideForTesting) != nil
+    case .codex:
+      return executablePath(named: "codex", override: codexCLIPathOverrideForTesting) != nil
+    case .openclaw:
+      let config = home.appendingPathComponent(".openclaw/openclaw.json")
+      guard fm.fileExists(atPath: config.path), let cliPath = openClawCLIPath() else { return false }
+      let workspace =
+        openClawConfiguredWorkspace(configURL: config, cliPath: cliPath)
+        ?? home.appendingPathComponent(".openclaw/workspace")
+      return fm.fileExists(atPath: workspace.path)
+    case .hermes:
+      return hermesInstallIsPresent(hermesDir: home.appendingPathComponent(".hermes"), fileManager: fm)
+    default:
+      return false
+    }
+  }
+
   /// Performs the write. Returns a short user-facing success line. Throws
   /// `ConnectError.notInstalled` when the framework isn't found locally.
   @discardableResult

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -80,6 +80,23 @@ extension SBOnboardingModel {
         self.refreshPermCheck(key)
         if self.isGranted(key) {
           self.setPermOn(key)
+          // System audio needs a SEPARATE Core Audio tap consent (the "bypass the
+          // private window picker … screen and audio" prompt) beyond the Screen
+          // Recording TCC this step grants. Prime it here — in-context on this step,
+          // and awaited BEFORE we advance — so the modal surfaces on the system-audio
+          // step (not a later one) and the real capture path never re-prompts after
+          // onboarding. Screen Recording (which the tap requires) is granted now.
+          if key == "system_audio", #available(macOS 14.4, *) {
+            _ = await SystemAudioCaptureService.primePermission()
+            guard !Task.isCancelled else { return }
+          }
+          // Auto-advance once the grant lands — the user shouldn't have to click
+          // Continue after granting. Brief pause so the ✓ is visible, then only
+          // advance if they're still on this permission's step (a late poll for a
+          // step already left must never yank the flow forward).
+          try? await Task.sleep(nanoseconds: 600_000_000)
+          guard !Task.isCancelled else { return }
+          self.autoAdvanceIfCurrent(key)
           return
         }
       }
@@ -108,7 +125,16 @@ extension SBOnboardingModel {
   /// shows ✓ instead of an Allow button they'd tap for nothing.
   func precheckPerm(_ key: String) {
     refreshPermCheck(key)
-    if isGranted(key) { setPermOn(key) }
+    if isGranted(key) {
+      setPermOn(key)
+      // If the user lands on the system-audio step already holding Screen Recording,
+      // prime the separate Core Audio tap consent here (in-context) so it isn't
+      // deferred to the first capture after onboarding. precheck doesn't advance, so
+      // fire-and-forget is fine — the modal shows while this step is on screen.
+      if key == "system_audio", #available(macOS 14.4, *) {
+        Task.detached { _ = await SystemAudioCaptureService.primePermission() }
+      }
+    }
   }
 
   func isGranted(_ key: String) -> Bool {
@@ -134,6 +160,15 @@ extension SBOnboardingModel {
       // flips to "on" when FDA is granted from the context step — its poll only
       // drives fdaState, unlike every other connector that writes back its own state.
       contextStates["files"] = "on"
+      // Apple Notes reads through the same FDA grant, so re-probe it here too —
+      // otherwise granting FDA leaves Notes showing a pointless "Connect" button.
+      if contextStates["applenotes"] != "on" {
+        Task { [weak self] in
+          if await AppleNotesReaderService.shared.connectionStatus().isConnected {
+            self?.contextStates["applenotes"] = "on"
+          }
+        }
+      }
     case "accessibility": accState = .on
     case "automation": autoState = .on
     default: break
@@ -172,6 +207,22 @@ extension SBOnboardingModel {
   func answerFiles() { advance(userAnswer: fdaState == .on ? "Allowed" : "Skip", to: .accessibility) }
   func answerAccessibility() { advance(userAnswer: accState == .on ? "Allowed" : "Skip", to: .automation) }
   func answerAutomation() { advance(userAnswer: autoState == .on ? "Allowed" : "Skip", to: .shortcutOpen) }
+
+  /// Advance past a permission step automatically once its grant lands — but only
+  /// when the user is still ON that step, so a late poll never skips a step they've
+  /// already moved past.
+  func autoAdvanceIfCurrent(_ key: String) {
+    guard permissionKey(for: step) == key, permState(key) == .on else { return }
+    switch step {
+    case .mic: answerMic()
+    case .systemAudio: answerSystemAudio()
+    case .screen: answerScreen()
+    case .files: answerFiles()
+    case .accessibility: answerAccessibility()
+    case .automation: answerAutomation()
+    default: break
+    }
+  }
 
   /// The permission key a step gates on, or nil for non-permission steps.
   func permissionKey(for step: Step) -> String? {
@@ -351,11 +402,18 @@ extension SBOnboardingModel {
   /// attached automatically for screen-aware questions; the answer streams into
   /// the notch, which spins while Omi is thinking.
   func startScreenDemo() {
+    screenDemoDone = false
     FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
     FloatingControlBarManager.shared.barState?.switchAIDraft(to: .onboardingFloating)
     resetFloatingBarConversation()
     if let bar = FloatingControlBarManager.shared.barState {
       PushToTalkManager.shared.setup(barState: bar)
+      // Mark the demo done the first time Omi actually responds in the notch, so
+      // the Continue button only appears once the user has seen it work.
+      voiceCancellable = bar.$showingAIResponse
+        .filter { $0 }
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] _ in self?.screenDemoDone = true }
     }
     ShortcutSettings.shared.pttTranscriptionModeDemoOverride = .live
     Task { await chatProvider.warmupBridge() }
@@ -374,6 +432,7 @@ extension SBOnboardingModel {
     voiceTimeout?.cancel()
     voiceTimeout = nil
     voiceCancellable = nil
+    screenDemoDone = false
     ShortcutSettings.shared.pttTranscriptionModeDemoOverride = nil
     resetFloatingBarConversation()
     PushToTalkManager.shared.cleanup()
@@ -442,7 +501,7 @@ extension SBOnboardingModel {
       for row in self.agentRows {
         // Only offer Connect for agents actually present on this Mac; otherwise
         // mark "unavailable" so the row shows "not installed" with no button.
-        let installed = await Self.agentInstalled(row.id)
+        let installed = await Self.agentInstalled(self.agentDestination(row.id))
         guard installed else {
           self.agentStates[row.id] = "unavailable"
           continue
@@ -453,20 +512,12 @@ extension SBOnboardingModel {
     }
   }
 
-  /// Best-effort local install probe: presence of the tool's config/home dir.
-  private static func agentInstalled(_ id: String) async -> Bool {
-    await Task.detached {
-      let home = FileManager.default.homeDirectoryForCurrentUser
-      let fm = FileManager.default
-      func exists(_ rel: String) -> Bool { fm.fileExists(atPath: home.appendingPathComponent(rel).path) }
-      switch id {
-      case "openclaw": return exists(".openclaw")
-      case "hermes": return exists(".hermes")
-      case "claudeCode": return exists(".claude.json") || exists(".claude")
-      case "codex": return exists(".codex")
-      default: return false
-      }
-    }.value
+  /// Local install probe using the SAME evidence the real connect path requires,
+  /// so a row never offers "Connect" and then flips to "not installed" on click
+  /// (e.g. Codex: a stray `~/.codex` dir is not enough — the connector needs the
+  /// `codex` binary on PATH). Delegates to `MemoryBankConnector.isInstalled`.
+  private static func agentInstalled(_ destination: MemoryExportDestination) async -> Bool {
+    await Task.detached { MemoryBankConnector.isInstalled(destination) }.value
   }
 
   func connectAgent(_ id: String) {
@@ -510,6 +561,15 @@ extension SBOnboardingModel {
       for id in ["chatgpt", "claude"] {
         let dest: MemoryExportDestination = id == "chatgpt" ? .chatgpt : .claude
         if await MemoryExportService.shared.status(for: dest).hasConnection { self.contextStates[id] = "on" }
+      }
+      // Apple Notes rides the same Full Disk Access grant that powers Files, so a
+      // readable NoteStore should show "✓ on" up front — not a "Connect" button
+      // that would only flip to on for nothing (this precheck was missing, which
+      // made the row look fake).
+      if self.contextStates["applenotes"] != "on",
+        await AppleNotesReaderService.shared.connectionStatus().isConnected
+      {
+        self.contextStates["applenotes"] = "on"
       }
       let cal = await CalendarReaderService.shared.verifyConnection()
       if cal.isConnected { self.contextStates["calendar"] = "on" }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -73,6 +73,10 @@ final class SBOnboardingModel: ObservableObject {
   @Published var screenDemoLoading = false
   @Published var voiceHeard = false
   @Published var voiceAnswer: String?
+  /// True once Omi has actually answered the demo question (the notch shows a
+  /// response). The screen-demo Continue button stays hidden until then, so the
+  /// user can't skip past before seeing the "fun part" work.
+  @Published var screenDemoDone = false
   var voiceCancellable: AnyCancellable?
   var voiceTimeout: Task<Void, Never>?
 
@@ -169,8 +173,10 @@ final class SBOnboardingModel: ObservableObject {
     case .context:
       return "The more I can see, the more I can help. Connect anything you want me to know:"
     case .capture:
+      // The shortcut chord is rendered as keycap chips in `captureWidget` (a
+      // streamed Text can't host inline keycap views), so it's omitted here.
       return
-        "You're all set, \(name). \(summonHint) reaches me anytime. One last thing: should I listen all the time, or only during your meetings?"
+        "You're all set, \(name). One last thing: should I listen all the time, or only during your meetings?"
     }
   }
 
@@ -182,11 +188,9 @@ final class SBOnboardingModel: ObservableObject {
     return "friend"
   }
 
-  /// Human hint for the chosen open-Omi shortcut, used in the capture copy.
-  var summonHint: String {
-    let tokens = ShortcutSettings.shared.askOmiShortcut.displayTokens
-    return tokens.isEmpty ? "Your shortcut" : tokens.joined()
-  }
+  /// The chosen open-Omi chord as individual tokens, rendered as keycap chips in
+  /// `captureWidget` (e.g. ⌘ + O) rather than plain glyphs in the message copy.
+  var summonTokens: [String] { ShortcutSettings.shared.askOmiShortcut.displayTokens }
 
   // MARK: lifecycle
 

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -452,7 +452,21 @@ struct SBOnboardingView: View {
           .geist(size: 12.5).foregroundStyle(sb.ink(.w45))
           .fixedSize(horizontal: false, vertical: true)
       }
-      SBInkButton(title: "Continue") { model.answerScreenDemo() }
+      // Continue only appears once Omi has actually answered in the notch — before
+      // that, a quiet "Skip for now" so the user doesn't blow past the live demo.
+      Group {
+        if model.screenDemoDone {
+          SBInkButton(title: "Continue") { model.answerScreenDemo() }
+        } else {
+          Button {
+            model.answerScreenDemo()
+          } label: {
+            Text("Skip for now").geist(size: 13).foregroundStyle(sb.ink(.w35))
+          }
+          .buttonStyle(.plain)
+        }
+      }
+      .padding(.top, 6)
     }
     .frame(maxWidth: 380, alignment: .leading)
   }
@@ -538,6 +552,16 @@ struct SBOnboardingView: View {
 
   private var captureWidget: some View {
     VStack(spacing: 8) {
+      // The chosen open-Omi chord as keycap chips (e.g. ⌘ O), matching the ⌥ keycap
+      // on the demo step — instead of plain "⌘O" glyphs buried in the message copy.
+      if !model.summonTokens.isEmpty {
+        HStack(spacing: 5) {
+          ForEach(model.summonTokens, id: \.self) { tok in keycap(tok) }
+          Text("reaches me anytime").geist(size: 14).foregroundStyle(sb.ink(.w85))
+          Spacer(minLength: 0)
+        }
+        .padding(.bottom, 2)
+      }
       Button {
         model.captureContinuous()
       } label: {

--- a/desktop/macos/Desktop/Sources/SystemAudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/SystemAudioCaptureService.swift
@@ -92,6 +92,112 @@ class SystemAudioCaptureService: @unchecked Sendable {
     return true
   }
 
+  /// Prime the Core Audio process-tap consent DURING onboarding.
+  ///
+  /// The system-audio capture path uses a global process tap
+  /// (`CATapDescription` → `AudioHardwareCreateProcessTap`, see
+  /// `startCaptureOnQueue`) whose consent — "<app> is requesting to bypass the
+  /// system private window picker and directly access your screen and audio" —
+  /// is SEPARATE from the Screen-Recording TCC grant onboarding already
+  /// requests, and only fires the first time a tap is actually created. Because
+  /// onboarding never creates a tap, that consent would otherwise be deferred
+  /// and fire AGAIN on the first real capture, post-onboarding.
+  ///
+  /// This creates the SAME tap + aggregate device the real capture path builds
+  /// (mirroring `startCaptureOnQueue`), so macOS shows and persists the exact
+  /// same consent, then IMMEDIATELY and FULLY tears everything down (mirroring
+  /// `cleanupTap()`/`cleanup()`). It never creates an IO proc or starts real
+  /// capture. Idempotent and safe to call when permission is already granted
+  /// (no crash, no lingering device), and safe to call on a background queue.
+  /// Returns quickly.
+  ///
+  /// - Returns: `true` if the tap was created (consent granted or already
+  ///   granted); `false` if tap creation failed (e.g. the user denied consent).
+  @discardableResult
+  static func primePermission() -> Bool {
+    // Local IDs only — never touch instance state, so this is safe to call
+    // statically and concurrently with a live capture on another instance.
+    var tapID: AudioObjectID = kAudioObjectUnknown
+    var aggregateDeviceID: AudioObjectID = kAudioObjectUnknown
+
+    // Guarantee full teardown on every exit path. Mirrors cleanupTap()/cleanup()
+    // teardown order (destroy aggregate device, then tap, null out IDs). No
+    // AudioDeviceStop / AudioDeviceDestroyIOProcID — we never create an IO proc.
+    func teardown() {
+      if aggregateDeviceID != kAudioObjectUnknown {
+        AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+        aggregateDeviceID = kAudioObjectUnknown
+      }
+      if tapID != kAudioObjectUnknown {
+        AudioHardwareDestroyProcessTap(tapID)
+        tapID = kAudioObjectUnknown
+      }
+    }
+
+    // 1. Same tap description as startCaptureOnQueue (global tap, unmuted).
+    let tapUUID = UUID()
+    let tapDescription = CATapDescription(stereoGlobalTapButExcludeProcesses: [])
+    tapDescription.uuid = tapUUID
+    tapDescription.name = "OMI System Audio Tap (permission prime)"
+    tapDescription.muteBehavior = .unmuted  // Don't mute playback
+
+    // 2. Create the process tap — this is what triggers/persists the consent.
+    var status = AudioHardwareCreateProcessTap(tapDescription, &tapID)
+    guard status == noErr else {
+      log("SystemAudioCapture: primePermission tap creation failed (\(status)) — consent likely denied")
+      teardown()
+      return false
+    }
+    log("SystemAudioCapture: primePermission created tap with ID \(tapID)")
+
+    // 3. Create the same aggregate device the real path creates. Some macOS
+    //    versions only register the tap consent once a tap-backed aggregate
+    //    device is instantiated, so mirror startCaptureOnQueue exactly.
+    let aggregateDescription: [String: Any] = [
+      kAudioAggregateDeviceNameKey as String: "OMI System Audio Tap Device",
+      kAudioAggregateDeviceUIDKey as String: "omi.systemaudio.\(tapUUID.uuidString)",
+      kAudioAggregateDeviceIsPrivateKey as String: true,
+      kAudioAggregateDeviceTapListKey as String: [
+        [
+          kAudioSubTapUIDKey as String: tapUUID.uuidString,
+          kAudioSubTapDriftCompensationKey as String: NSNumber(value: 1),
+          kAudioSubTapDriftCompensationQualityKey as String:
+            NSNumber(value: kAudioAggregateDriftCompensationMaxQuality),
+        ]
+      ],
+      kAudioAggregateDeviceTapAutoStartKey as String: true,
+    ]
+
+    status = AudioHardwareCreateAggregateDevice(aggregateDescription as CFDictionary, &aggregateDeviceID)
+    guard status == noErr else {
+      log("SystemAudioCapture: primePermission aggregate device creation failed (\(status))")
+      // The tap itself was created, so the consent already fired — treat as
+      // primed after tearing the tap back down.
+      teardown()
+      return true
+    }
+    log("SystemAudioCapture: primePermission created aggregate device with ID \(aggregateDeviceID)")
+
+    // 4. Immediately and fully tear down — no IO proc, no capture ever started.
+    teardown()
+    log("SystemAudioCapture: primePermission complete, tap + aggregate device destroyed")
+    return true
+  }
+
+  /// Async convenience wrapper around `primePermission()`. The CoreAudio HAL
+  /// calls are synchronous IPC to coreaudiod and can block (seconds after wake
+  /// from sleep), so this offloads them onto a background queue — mirroring the
+  /// off-main dispatch the real capture path uses in `startCapture`. Never
+  /// throws; returns the same Bool as the sync form.
+  @discardableResult
+  static func primePermission() async -> Bool {
+    await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+      DispatchQueue.global(qos: .userInitiated).async {
+        continuation.resume(returning: primePermission())
+      }
+    }
+  }
+
   // MARK: - Public Methods
 
   /// Start capturing system audio

--- a/desktop/macos/Desktop/Tests/FloatingBarTimingSignalTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarTimingSignalTests.swift
@@ -23,14 +23,36 @@ final class FloatingBarTimingSignalTests: XCTestCase {
       contentsOf: floatingControlBarDir().appendingPathComponent("FloatingControlBarView.swift"))
   }
 
-  func testWindowActivationKeysOffWindowSignalNotFixedDelay() throws {
-    let source = try floatingBarViewSource()
+  func testIdleNotchWindowActivationDelegatesToCanonicalAuthorityNotFixedDelay() throws {
+    // BL-005: the floating bar must not re-open the main window on a fixed-delay
+    // `asyncAfter` guess. Idle-notch activation delegates to the single main-chat
+    // window authority (`AppDelegate.openMainAppChat`) via NotchIdleTapRoute — it
+    // does not run its own timed window activation. (The earlier
+    // `runWhenMainAppWindowKey` / `didBecomeKey` helper was folded into that
+    // canonical authority in a4fac7b366; this guard follows the logic there. The
+    // request/consume landing signal is covered behaviorally below.)
+    let bar = try floatingBarViewSource()
     XCTAssertTrue(
-      source.contains("func runWhenMainAppWindowKey"),
-      "window activation should route through the window-key signal helper")
+      bar.contains("NotchIdleTapRoute"),
+      "idle-notch activation should route through the single tap-route authority")
     XCTAssertTrue(
-      source.contains("NSWindow.didBecomeKeyNotification"),
-      "the transition should key off didBecomeKey, not a fixed delay")
+      bar.contains("openMainAppChat"),
+      "the floating bar should delegate window activation to the canonical main-chat "
+        + "authority, not run its own timed activation")
+  }
+
+  /// The canonical chat-landing keys off a one-shot request that survives window
+  /// creation (consumed when the window becomes visible), not a fixed delay.
+  /// Exercised behaviorally so it doesn't depend on implementation strings.
+  @MainActor
+  func testMainChatNavigationRequestIsOneShotSurvivingWindowCreation() {
+    let store = MainChatNavigationRequestStore.shared
+    _ = store.consume()  // clear any prior state
+    XCTAssertFalse(store.isPending)
+    store.request()
+    XCTAssertTrue(store.isPending, "a raised request must stay pending until the window consumes it")
+    XCTAssertTrue(store.consume(), "the window consumes the pending request on mount")
+    XCTAssertFalse(store.consume(), "the request is one-shot — a second consume yields nothing")
   }
 
   /// Anti-regression: no new fixed-delay `asyncAfter` may be added under

--- a/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
@@ -544,6 +544,44 @@ final class MemoryBankConnectorTests: XCTestCase {
     XCTAssertEqual(agents, "legacy agents prompt")
   }
 
+  // MARK: - isInstalled (onboarding upfront probe must match the connect path)
+
+  func testIsInstalledCodexRequiresCLINotJustConfigDir() throws {
+    // The exact regression: a stray ~/.codex dir with no `codex` on PATH used to
+    // pass the loose upfront probe, so onboarding showed "Connect" and only flipped
+    // to "not installed" after the click. isInstalled must require the CLI.
+    try FileManager.default.createDirectory(
+      at: tempHome.appendingPathComponent(".codex", isDirectory: true), withIntermediateDirectories: true)
+    XCTAssertFalse(MemoryBankConnector.isInstalled(.codex))  // codexCLIPathOverrideForTesting == "" from setUp
+
+    MemoryBankConnector.codexCLIPathOverrideForTesting = try writeFakeCodexCLI().path
+    XCTAssertTrue(MemoryBankConnector.isInstalled(.codex))
+  }
+
+  func testIsInstalledClaudeCodeDetectsConfig() throws {
+    XCTAssertFalse(MemoryBankConnector.isInstalled(.claudeCode))
+    try "{}".write(
+      to: tempHome.appendingPathComponent(".claude.json"), atomically: true, encoding: .utf8)
+    XCTAssertTrue(MemoryBankConnector.isInstalled(.claudeCode))
+  }
+
+  func testIsInstalledOpenClawRequiresConfigAndWorkspace() throws {
+    // setUp already provides a fake openclaw CLI, so this isolates the config gate.
+    XCTAssertFalse(MemoryBankConnector.isInstalled(.openclaw))  // no config yet
+    let workspace = tempHome.appendingPathComponent(".openclaw/workspace", isDirectory: true)
+    try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    _ = try writeOpenClawConfig(workspace: workspace)
+    XCTAssertTrue(MemoryBankConnector.isInstalled(.openclaw))
+  }
+
+  func testIsInstalledHermesRequiresInstallEvidence() throws {
+    let hermes = tempHome.appendingPathComponent(".hermes", isDirectory: true)
+    try FileManager.default.createDirectory(at: hermes, withIntermediateDirectories: true)
+    XCTAssertFalse(MemoryBankConnector.isInstalled(.hermes))  // bare dir, no config/install
+    _ = try writeHermesInstall()
+    XCTAssertTrue(MemoryBankConnector.isInstalled(.hermes))
+  }
+
   private func writeOpenClawConfig(workspace: URL, extra: String = "") throws -> URL {
     let configDir = tempHome.appendingPathComponent(".openclaw", isDirectory: true)
     try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)

--- a/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
@@ -78,6 +78,11 @@ final class RewindDatabaseLifecycleTests: XCTestCase {
     defer { try? FileManager.default.removeItem(at: userDir) }
 
     await RewindIndexer.shared.reset()
+    // The shared VideoChunkEncoder binds to one user's videos directory and refuses
+    // to re-init under a different one. RewindIndexer.reset() doesn't clear it, so a
+    // prior test in the suite can leave it bound to another directory — clear its
+    // storage-owner config here so this test is isolated regardless of run order.
+    await VideoChunkEncoder.shared.clearConfigurationAfterUserSwitch()
     await RewindDatabase.shared.close()
     RewindDatabase.currentUserId = testUserId
     await RewindDatabase.shared.configure(userId: testUserId)
@@ -111,6 +116,12 @@ final class RewindDatabaseLifecycleTests: XCTestCase {
     defer { try? FileManager.default.removeItem(at: userDir) }
 
     await RewindIndexer.shared.reset()
+    // Clear the shared VideoChunkEncoder's storage-owner binding (see the note in
+    // testInitializeReopensDatabaseClosedAfterIndexerInitialization): otherwise a
+    // prior test leaves it bound to another directory and processFrame below throws
+    // "Video encoder must reset before changing storage owner" under the CI suite's
+    // run order.
+    await VideoChunkEncoder.shared.clearConfigurationAfterUserSwitch()
     await RewindDatabase.shared.close()
     RewindDatabase.currentUserId = testUserId
     await RewindDatabase.shared.configure(userId: testUserId)

--- a/desktop/macos/changelog/unreleased/20260722-onboarding-agent-detection.json
+++ b/desktop/macos/changelog/unreleased/20260722-onboarding-agent-detection.json
@@ -1,0 +1,3 @@
+{
+    "change": "Onboarding now detects installed coding agents up front, so it no longer offers Connect and then says the agent is not installed"
+}

--- a/desktop/macos/changelog/unreleased/20260722-onboarding-apple-notes-status.json
+++ b/desktop/macos/changelog/unreleased/20260722-onboarding-apple-notes-status.json
@@ -1,0 +1,3 @@
+{
+    "change": "Onboarding shows Apple Notes as connected when Full Disk Access already covers it, instead of a Connect button that does nothing"
+}

--- a/desktop/macos/changelog/unreleased/20260722-onboarding-auto-advance-permissions.json
+++ b/desktop/macos/changelog/unreleased/20260722-onboarding-auto-advance-permissions.json
@@ -1,0 +1,3 @@
+{
+    "change": "Onboarding now advances automatically the moment you grant a permission, instead of waiting for a Continue click"
+}

--- a/desktop/macos/changelog/unreleased/20260722-onboarding-continue-when-done.json
+++ b/desktop/macos/changelog/unreleased/20260722-onboarding-continue-when-done.json
@@ -1,0 +1,3 @@
+{
+    "change": "Onboarding no longer shows Continue on the screen demo until Omi has actually answered you"
+}

--- a/desktop/macos/changelog/unreleased/20260722-onboarding-no-repeat-audio-prompt.json
+++ b/desktop/macos/changelog/unreleased/20260722-onboarding-no-repeat-audio-prompt.json
@@ -1,0 +1,3 @@
+{
+    "change": "Onboarding now primes system-audio permission so Omi no longer re-asks to record your screen and audio after setup"
+}

--- a/desktop/macos/changelog/unreleased/20260722-onboarding-shortcut-keycaps.json
+++ b/desktop/macos/changelog/unreleased/20260722-onboarding-shortcut-keycaps.json
@@ -1,0 +1,3 @@
+{
+    "change": "The open-Omi shortcut is now shown as keycaps in onboarding rather than plain text"
+}


### PR DESCRIPTION
Failure-Class: none

Seven onboarding fixes surfaced by a live run-through of the Second Brain onboarding.

## Changes
- **Agents step — real install detection.** New `MemoryBankConnector.isInstalled(_:)` uses the *same* evidence each `connect…` path requires, and `SBOnboardingModel.agentInstalled` delegates to it. A row no longer shows "Connect" and then flips to "not installed" on click (sharp case: Codex — a stray `~/.codex` dir passed the old loose probe, but the connector needs `codex` on PATH). Hermetic regression tests added.
- **Permission steps auto-advance** the moment a grant lands (only if still on that permission's step) — no more clicking Continue after granting.
- **Screen demo** hides Continue until Omi has actually answered in the notch (wired to the floating bar's response), matching the shortcut step.
- **System audio** primes the Core Audio process-tap consent in-context on the system-audio step, so the real capture path no longer re-prompts "bypass the private window picker" after onboarding.
- **Apple Notes** reflects that the Full Disk Access already powering Files makes the NoteStore readable — shows "on" instead of a Connect button that did nothing.
- **Capture step** renders the open-Omi shortcut as keycap chips (⌘ O) instead of plain glyphs.
- Gmail/Calendar were already read-only status probes (no re-auth) — left as-is.

## Product invariants
- **INV-INT-1 (Integrations harness over heuristics).** This change *strengthens* the invariant: "Connected means verified recently via a functional probe." Agent rows now derive their state from the same functional evidence the connect path uses (`MemoryBankConnector.isInstalled`), and Apple Notes shows "on" only after a real `AppleNotesReaderService.connectionStatus()` read. No connector is marked connected without a functional probe. Code still owns the contracts; no new agent-driven heuristics were added.
- **INV-MEM-1 (Exactly three product memory tiers).** `MemoryBankConnector.swift` is touched only to add an install-detection helper (`isInstalled`); the three-tier product-memory model (`short_term` / `long_term` / `archive`), the canonical collection, and the default access policy are unchanged. No memory-tier semantics are affected.

## Verification
- `xcrun swift build -c debug --package-path Desktop` — clean.
- 33 desktop tests pass (`MemoryBankConnectorTests` incl. new `isInstalled` regression tests + `SBOnboarding*`).
- `cubic review -b` — 0 issues (2 iterations).
- Three independent adversarial eval agents — no P0–P2 defects/regressions.
- App builds + boots into onboarding (fresh named bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

