### PR TITLE
fix(release): bind candidates to build configuration

### DIFF
--- a/.github/failure-classes/FC-release-build-config-source-binding.json
+++ b/.github/failure-classes/FC-release-build-config-source-binding.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "FC-release-build-config-source-binding",
+  "violated_contract": "An immutable desktop release tag must contain the artifact-producing build configuration and release-control revision that selected it, and the exact tagged source must have the checks required by the release gate.",
+  "canonical_prevention": "Treat build configuration and release-control files as desktop candidate inputs, keep the planner and exact-SHA CI producer path sets aligned, and enforce that alignment with contract tests.",
+  "evidence_prs": [10356],
+  "scope_hints": [
+    "codemagic.yaml",
+    ".github/scripts/plan-desktop-release.py",
+    ".github/workflows/desktop_auto_release.yml",
+    ".github/workflows/desktop-swift-ci.yml"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -18,6 +18,13 @@ REQUIRED_SOURCE_CHECK_NAMES = (
 )
 RECENT_TAG_WITHOUT_CHECK_SECONDS = 10 * 60
 AUTO_RELEASE_QUIET_SECONDS = 10 * 60
+DESKTOP_RELEASE_PATHS = (
+    "desktop/macos",
+    "codemagic.yaml",
+    ".github/scripts/plan-desktop-release.py",
+    ".github/workflows/desktop_auto_release.yml",
+    ".github/workflows/desktop-swift-ci.yml",
+)
 
 
 def run(args: list[str], *, check: bool = True) -> str:
@@ -43,9 +50,9 @@ def latest_desktop_tag() -> str | None:
 
 def releasable_desktop_changes_since(ref: str | None) -> list[str]:
     if ref is None:
-        output = git(["ls-files", "desktop/macos"])
+        output = git(["ls-files", *DESKTOP_RELEASE_PATHS])
     else:
-        output = git(["diff", "--name-only", "--diff-filter=ACDMR", f"{ref}..HEAD", "--", "desktop/macos"])
+        output = git(["diff", "--name-only", "--diff-filter=ACDMR", f"{ref}..HEAD", "--", *DESKTOP_RELEASE_PATHS])
 
     changes = []
     for path in output.splitlines():

--- a/.github/scripts/test_desktop_swift_ci_contract.py
+++ b/.github/scripts/test_desktop_swift_ci_contract.py
@@ -99,6 +99,19 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
         release_job = self.jobs["desktop-swift-release-compile"]
         self.assertIn("fetch-depth: 1", release_job)
 
+    def test_release_control_inputs_produce_exact_sha_checks(self):
+        """Candidate-building config must run the checks consumed by the release planner."""
+        changes = self.jobs["changes"]
+
+        for path in (
+            "codemagic.yaml",
+            ".github/scripts/plan-desktop-release.py",
+            ".github/workflows/desktop_auto_release.yml",
+            ".github/workflows/desktop-swift-ci.yml",
+        ):
+            with self.subTest(path=path):
+                self.assertIn(path, changes)
+
     def test_macos_jobs_have_a_bounded_runner_budget(self):
         """A stuck Swift invocation must not consume hosted macOS capacity forever."""
         for job_id in MACOS_JOBS:

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -27,6 +27,26 @@ RELEASABLE_PATH = "desktop/macos/Desktop/Sources/AppDelegate.swift"
 
 
 class DesktopCandidateSourceCheckTests(unittest.TestCase):
+    def test_codemagic_config_is_a_releasable_desktop_input(self) -> None:
+        expected_args = [
+            "diff",
+            "--name-only",
+            "--diff-filter=ACDMR",
+            f"{LATEST_TAG}..HEAD",
+            "--",
+            "desktop/macos",
+            "codemagic.yaml",
+            ".github/scripts/plan-desktop-release.py",
+            ".github/workflows/desktop_auto_release.yml",
+            ".github/workflows/desktop-swift-ci.yml",
+        ]
+
+        with patch.object(planner, "git", return_value="codemagic.yaml\ndesktop/macos/AGENTS.md") as git:
+            changes = planner.releasable_desktop_changes_since(LATEST_TAG)
+
+        git.assert_called_once_with(expected_args)
+        self.assertEqual(changes, ["codemagic.yaml"])
+
     def test_exact_source_sha_success_for_every_required_check_passes_the_gate(self) -> None:
         checked: list[tuple[str, str]] = []
 

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -54,7 +54,7 @@ jobs:
             case "$path" in
               desktop/macos/Backend-Rust/*|desktop/macos/changelog/*|desktop/macos/CHANGELOG[.]json|desktop/macos/AGENTS[.]md)
                 ;;
-              desktop/macos/*)
+              desktop/macos/*|codemagic.yaml|.github/scripts/plan-desktop-release.py|.github/workflows/desktop_auto_release.yml|.github/workflows/desktop-swift-ci.yml)
                 RELEASABLE_DESKTOP=true
                 break
                 ;;

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -54,7 +54,7 @@ Provider/mode switches and fail-open paths must call `DesktopDiagnosticsManager.
 
 ## Release Pipeline
 
-Merging `desktop/macos/**` changes queues them for the next hourly candidate retry. A candidate advances to beta automatically only after every qualification gate passes:
+Merging `desktop/macos/**` or the release-owning root `codemagic.yaml` queues it for the next hourly candidate retry. This keeps immutable tags bound to the Codemagic configuration that builds them. A candidate advances to beta automatically only after every qualification gate passes:
 
 1. **GitHub Actions** (`desktop_auto_release.yml`) — batches mainline changes, auto-increments the version, and pushes a `v*-macos` build-candidate tag. It is schedule-only and fails closed before changelog or tag mutation unless `Release Eligibility`, `Desktop Swift Build & Tests`, and `Desktop Swift Release Compile` all completed successfully for the exact newest queued releasable desktop SHA. Later backend/docs-only commits do not replace that immutable source with a SHA where desktop CI was skipped; the tag includes the newly consolidated release notes.
 2. **Codemagic** (`codemagic.yaml`, workflow `omi-desktop-swift-release`) — triggered by the tag, runs on Mac mini M4:


### PR DESCRIPTION
## Summary

- Treat the root Codemagic configuration and desktop release-control files as immutable desktop candidate inputs.
- Run the exact-SHA Desktop Swift checks whenever one of those inputs changes.
- Keep the planner and CI path contracts aligned with regression coverage.

## Verification

- `python3 .github/scripts/test_plan_desktop_release.py`
- `python3 .github/scripts/test_desktop_swift_ci_contract.py`
- `make preflight`

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

