### PR TITLE
fix(desktop): restore capture services on launch

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -4,6 +4,21 @@ import SwiftUI
 
 private struct AnySendableBox: @unchecked Sendable { let value: Any? }
 
+/// Decides whether a persisted capture intent needs its runtime service restored.
+///
+/// Intent is stored independently from the running services. A fresh launch and a
+/// settings sync therefore both need to reconcile the two states instead of using
+/// a one-time readiness check as the source of truth.
+enum PersistedCaptureLaunchPolicy {
+  static func shouldStartTranscription(intentEnabled: Bool, isTranscribing: Bool) -> Bool {
+    intentEnabled && !isTranscribing
+  }
+
+  static func shouldStartScreenAnalysis(intentEnabled: Bool, isMonitoring: Bool) -> Bool {
+    intentEnabled && !isMonitoring
+  }
+}
+
 // MARK: - NSHostingView sizingOptions access
 
 /// Protocol to access sizingOptions on any NSHostingView<Content> regardless of the generic parameter.
@@ -51,6 +66,7 @@ struct DesktopHomeView: View {
   @State private var lastActivationRefresh = Date.distantPast
   @State private var didScheduleAgentVMProvisioning = false
   @State private var proactiveMonitoringStartGate = RetryableDelayedStartGate()
+  @State private var isWaitingForScreenAnalysisKeys = false
   // Anchor for the proactive-monitoring warmup budget. Captured at view
   // creation (≈ launch) so the delay is spent once per session, not once per
   // trigger — see StartupWarmupPolicy.remainingProactiveAssistantsStartDelay.
@@ -191,22 +207,6 @@ struct DesktopHomeView: View {
                 scheduleInitialFileIndexing()
               }
 
-              let settings = AssistantSettings.shared
-
-              // Auto-start transcription if enabled in settings.
-              // If API keys aren't loaded yet, onChange below retries.
-              if settings.transcriptionEnabled && !appState.isTranscribing {
-                if APIKeyService.keysAvailable {
-                  log("DesktopHomeView: Auto-starting transcription")
-                  appState.startTranscription()
-                } else {
-                  log("DesktopHomeView: Deferring transcription — API keys not yet loaded")
-                  Task { await APIKeyService.shared.waitForKeys() }
-                }
-              } else if !settings.transcriptionEnabled {
-                log("DesktopHomeView: Transcription disabled in settings, skipping auto-start")
-              }
-
               // Migration: one-time reset for users whose screenAnalysisEnabled
               // was incorrectly set to false by a bug in syncMonitoringState() that
               // persisted false whenever monitoring stopped for any reason.
@@ -238,19 +238,7 @@ struct DesktopHomeView: View {
                 log("DesktopHomeView: Restored screen capture default for quiet named bundle")
               }
 
-              // Start proactive assistants monitoring if enabled in settings.
-              // If API keys aren't loaded yet, this may fail — onChange below retries.
-              if settings.screenAnalysisEnabled {
-                if APIKeyService.keysAvailable {
-                  scheduleProactiveMonitoringStart(reason: "launch")
-                } else {
-                  log(
-                    "DesktopHomeView: Deferring screen analysis — API keys not yet loaded"
-                  )
-                }
-              } else {
-                log("DesktopHomeView: Screen analysis disabled in settings, skipping auto-start")
-              }
+              restorePersistedCaptureServices(reason: "launch")
 
               // Start Crisp chat in background for notifications, scoped to the signed-in user
               CrispManager.shared.start(
@@ -287,31 +275,17 @@ struct DesktopHomeView: View {
                 Task { await appState.refreshConversations() }
               }
               updatePolicyManager.refresh()
-              // Auto-start monitoring when returning to app if screen analysis is enabled
-              // but monitoring is not running. Handles the case where the user granted
-              // screen recording permission in System Settings and switched back.
-              let plugin = ProactiveAssistantsPlugin.shared
-              if AssistantSettings.shared.screenAnalysisEnabled && !plugin.isMonitoring {
-                plugin.refreshScreenRecordingPermission()
-                if plugin.hasScreenRecordingPermission {
-                  log("DesktopHomeView: Permission available on app active — scheduling monitoring")
-                  scheduleProactiveMonitoringStart(reason: "app active")
-                }
-              }
+              // Reconcile persisted intent after returning from System Settings or
+              // after a runtime service stopped while the app was inactive.
+              restorePersistedCaptureServices(reason: "app active")
             }
             .onChange(of: apiKeyService.isLoaded) { _, loaded in
               guard loaded else { return }
               log("DesktopHomeView: API keys loaded — retrying deferred services")
-              // Retry transcription
-              if AssistantSettings.shared.transcriptionEnabled && !appState.isTranscribing {
-                log("DesktopHomeView: Starting deferred transcription")
-                appState.startTranscription()
-              }
-              // Retry screen analysis
-              let plugin = ProactiveAssistantsPlugin.shared
-              if AssistantSettings.shared.screenAnalysisEnabled && !plugin.isMonitoring {
-                scheduleProactiveMonitoringStart(reason: "key load")
-              }
+              restorePersistedCaptureServices(reason: "key load")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .assistantSettingsDidSyncFromServer)) { _ in
+              reconcileCaptureServicesAfterSettingsSync()
             }
             // Cmd+R: refresh all data (conversations, chat, tasks, memories)
             .onReceive(NotificationCenter.default.publisher(for: .refreshAllData)) { _ in
@@ -929,6 +903,63 @@ struct DesktopHomeView: View {
       }
     }
     if !scheduled { proactiveMonitoringStartGate.finishAttempt() }
+  }
+
+  private func restorePersistedCaptureServices(reason: String) {
+    let settings = AssistantSettings.shared
+    if PersistedCaptureLaunchPolicy.shouldStartTranscription(
+      intentEnabled: settings.transcriptionEnabled,
+      isTranscribing: appState.isTranscribing
+    ) {
+      log("DesktopHomeView: Restoring transcription from persisted intent (\(reason))")
+      // Local transcription does not require remote API keys. AppState owns the
+      // permission and provider checks, so it remains the single start boundary.
+      appState.startTranscription()
+    }
+
+    let plugin = ProactiveAssistantsPlugin.shared
+    guard
+      PersistedCaptureLaunchPolicy.shouldStartScreenAnalysis(
+        intentEnabled: settings.screenAnalysisEnabled,
+        isMonitoring: plugin.isMonitoring
+      )
+    else { return }
+
+    guard APIKeyService.keysAvailable else {
+      waitForScreenAnalysisKeys(reason: reason)
+      return
+    }
+
+    plugin.refreshScreenRecordingPermission()
+    guard plugin.hasScreenRecordingPermission else {
+      log("DesktopHomeView: Screen recording permission unavailable; retaining capture intent (\(reason))")
+      return
+    }
+    scheduleProactiveMonitoringStart(reason: reason)
+  }
+
+  private func waitForScreenAnalysisKeys(reason: String) {
+    guard !isWaitingForScreenAnalysisKeys else { return }
+    isWaitingForScreenAnalysisKeys = true
+    log("DesktopHomeView: Deferring screen analysis until API keys load (\(reason))")
+    Task { @MainActor in
+      await APIKeyService.shared.waitForKeys()
+      isWaitingForScreenAnalysisKeys = false
+      guard APIKeyService.keysAvailable else {
+        log("DesktopHomeView: API keys remain unavailable; retaining capture intent")
+        return
+      }
+      restorePersistedCaptureServices(reason: "key wait completed")
+    }
+  }
+
+  private func reconcileCaptureServicesAfterSettingsSync() {
+    let plugin = ProactiveAssistantsPlugin.shared
+    if !AssistantSettings.shared.screenAnalysisEnabled, plugin.isMonitoring {
+      log("DesktopHomeView: Stopping screen analysis after server settings sync")
+      plugin.stopMonitoring()
+    }
+    restorePersistedCaptureServices(reason: "settings sync")
   }
 
   private func updateStoreActivity(for index: Int) {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AssistantSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AssistantSettings.swift
@@ -485,6 +485,9 @@ class AssistantSettings {
 
 extension Notification.Name {
   static let assistantSettingsDidChange = Notification.Name("assistantSettingsDidChange")
+  /// Posted after server-authoritative assistant settings have been applied.
+  /// Runtime services use this to restore or stop work from the persisted intent.
+  static let assistantSettingsDidSyncFromServer = Notification.Name("assistantSettingsDidSyncFromServer")
   static let assistantMonitoringStateDidChange = Notification.Name("assistantMonitoringStateDidChange")
   static let assistantMonitoringToggleRequested = Notification.Name("assistantMonitoringToggleRequested")
   static let transcriptionSettingsDidChange = Notification.Name("transcriptionSettingsDidChange")

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
@@ -43,7 +43,9 @@ class SettingsSyncManager {
 
   // MARK: - Apply Remote → Local
 
-  private func applyRemoteSettings(_ remote: AssistantSettingsResponse) {
+  /// Applies a server-authoritative snapshot, then notifies runtime owners to
+  /// reconcile services whose persisted intent may have changed after launch.
+  func applyRemoteSettings(_ remote: AssistantSettingsResponse) {
     // Shared settings
     if let shared = remote.shared {
       if let v = shared.cooldownInterval { AssistantSettings.shared.cooldownInterval = v }
@@ -108,6 +110,8 @@ class SettingsSyncManager {
         UpdaterViewModel.shared.updateChannel = parsed
       }
     }
+
+    NotificationCenter.default.post(name: .assistantSettingsDidSyncFromServer, object: nil)
   }
 
   // MARK: - Build Local → Response

--- a/desktop/macos/Desktop/Tests/FloatingBarTimingSignalTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarTimingSignalTests.swift
@@ -18,21 +18,6 @@ final class FloatingBarTimingSignalTests: XCTestCase {
       .appendingPathComponent("Sources/FloatingControlBar")
   }
 
-  private func floatingBarViewSource() throws -> String {
-    try String(
-      contentsOf: floatingControlBarDir().appendingPathComponent("FloatingControlBarView.swift"))
-  }
-
-  func testWindowActivationKeysOffWindowSignalNotFixedDelay() throws {
-    let source = try floatingBarViewSource()
-    XCTAssertTrue(
-      source.contains("func runWhenMainAppWindowKey"),
-      "window activation should route through the window-key signal helper")
-    XCTAssertTrue(
-      source.contains("NSWindow.didBecomeKeyNotification"),
-      "the transition should key off didBecomeKey, not a fixed delay")
-  }
-
   /// Anti-regression: no new fixed-delay `asyncAfter` may be added under
   /// `FloatingControlBar/` above the pinned baseline. Recurses the directory the
   /// same way the Python ratchet does; comment mentions of the word are excluded

--- a/desktop/macos/Desktop/Tests/PersistedCaptureLaunchPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/PersistedCaptureLaunchPolicyTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class PersistedCaptureLaunchPolicyTests: XCTestCase {
+  func testRestoresListeningFromPersistedIntentWithoutWaitingForRemoteKeys() {
+    XCTAssertTrue(
+      PersistedCaptureLaunchPolicy.shouldStartTranscription(
+        intentEnabled: true,
+        isTranscribing: false
+      )
+    )
+  }
+
+  func testDoesNotRestartListeningWhenUserDisabledItOrItIsAlreadyRunning() {
+    XCTAssertFalse(
+      PersistedCaptureLaunchPolicy.shouldStartTranscription(
+        intentEnabled: false,
+        isTranscribing: false
+      )
+    )
+    XCTAssertFalse(
+      PersistedCaptureLaunchPolicy.shouldStartTranscription(
+        intentEnabled: true,
+        isTranscribing: true
+      )
+    )
+  }
+
+  func testRestoresCaptureWhenSettingsSyncFinishesAfterLaunch() {
+    XCTAssertTrue(
+      PersistedCaptureLaunchPolicy.shouldStartScreenAnalysis(
+        intentEnabled: true,
+        isMonitoring: false
+      )
+    )
+  }
+
+  func testDoesNotRestartCaptureWhenUserDisabledItOrItIsAlreadyRunning() {
+    XCTAssertFalse(
+      PersistedCaptureLaunchPolicy.shouldStartScreenAnalysis(
+        intentEnabled: false,
+        isMonitoring: false
+      )
+    )
+    XCTAssertFalse(
+      PersistedCaptureLaunchPolicy.shouldStartScreenAnalysis(
+        intentEnabled: true,
+        isMonitoring: true
+      )
+    )
+  }
+}
+
+@MainActor
+final class SettingsSyncCaptureRestorationTests: XCTestCase {
+  func testApplyingServerSettingsNotifiesCaptureRuntimeToReconcile() {
+    let notification = expectation(description: "capture runtime reconciliation notification")
+    let observer = NotificationCenter.default.addObserver(
+      forName: .assistantSettingsDidSyncFromServer,
+      object: nil,
+      queue: nil
+    ) { _ in
+      notification.fulfill()
+    }
+    defer { NotificationCenter.default.removeObserver(observer) }
+
+    SettingsSyncManager.shared.applyRemoteSettings(AssistantSettingsResponse())
+
+    XCTAssertEqual(XCTWaiter().wait(for: [notification], timeout: 0), .completed)
+  }
+}

--- a/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift
@@ -78,6 +78,7 @@ final class RewindDatabaseLifecycleTests: XCTestCase {
     defer { try? FileManager.default.removeItem(at: userDir) }
 
     await RewindIndexer.shared.reset()
+    await RewindStorage.shared.reset()
     await RewindDatabase.shared.close()
     RewindDatabase.currentUserId = testUserId
     await RewindDatabase.shared.configure(userId: testUserId)
@@ -97,6 +98,7 @@ final class RewindDatabaseLifecycleTests: XCTestCase {
       "initializing the indexer must reopen a database closed after the indexer was initialized")
 
     await RewindIndexer.shared.reset()
+    await RewindStorage.shared.reset()
     await RewindDatabase.shared.close()
     RewindDatabase.currentUserId = nil
   }
@@ -111,6 +113,7 @@ final class RewindDatabaseLifecycleTests: XCTestCase {
     defer { try? FileManager.default.removeItem(at: userDir) }
 
     await RewindIndexer.shared.reset()
+    await RewindStorage.shared.reset()
     await RewindDatabase.shared.close()
     RewindDatabase.currentUserId = testUserId
     await RewindDatabase.shared.configure(userId: testUserId)
@@ -142,6 +145,7 @@ final class RewindDatabaseLifecycleTests: XCTestCase {
       "processing a frame must reopen a database closed after the indexer was initialized")
 
     await RewindIndexer.shared.reset()
+    await RewindStorage.shared.reset()
     await RewindDatabase.shared.close()
     RewindDatabase.currentUserId = nil
   }

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -139,27 +139,6 @@ final class StartupWarmupPolicyTests: XCTestCase {
     )
   }
 
-  func testTranscriptionDeferralStartsAPIKeyFetchImmediately() throws {
-    let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
-    let homeURL =
-      testsURL
-      .deletingLastPathComponent()
-      .appendingPathComponent("Sources/MainWindow/DesktopHomeView.swift")
-    let source = try String(contentsOf: homeURL, encoding: .utf8)
-
-    guard let deferralRange = source.range(of: "DesktopHomeView: Deferring transcription — API keys not yet loaded"),
-      let immediateFetchRange = source.range(of: "Task { await APIKeyService.shared.waitForKeys() }")
-    else {
-      return XCTFail("Transcription auto-start deferral must kick off API key fetch immediately")
-    }
-
-    XCTAssertGreaterThan(
-      immediateFetchRange.lowerBound,
-      deferralRange.lowerBound,
-      "Immediate key fetch should be started from the transcription deferral branch"
-    )
-  }
-
   func testAPIKeyFetchFailureDoesNotBlockFutureWaiters() throws {
     let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
     let serviceURL =

--- a/desktop/macos/changelog/unreleased/20260722-restore-capture-on-launch.json
+++ b/desktop/macos/changelog/unreleased/20260722-restore-capture-on-launch.json
@@ -1,0 +1,3 @@
+{
+  "change": "Restored Listening and Capture after reopening the desktop app when permissions are already granted."
+}

--- a/desktop/macos/scripts/check_desktop_test_quality.py
+++ b/desktop/macos/scripts/check_desktop_test_quality.py
@@ -44,8 +44,8 @@ TEST_ROOT = "desktop/macos/Desktop/Tests"
 
 # Pinned debt ceilings. These may only decrease. Escaped sites are not counted.
 # Run with --print after improving tests, then lower both relevant values.
-SOURCE_INSPECTION_FILE_BASELINE = 57
-SOURCE_INSPECTION_SITE_BASELINE = 157
+SOURCE_INSPECTION_FILE_BASELINE = 56
+SOURCE_INSPECTION_SITE_BASELINE = 155
 WALL_CLOCK_WAIT_BASELINE = 19
 
 MIN_REASON_LENGTH = 12


### PR DESCRIPTION
## Summary

- Restore Listening immediately from its persisted enabled intent; local transcription no longer waits for remote API-key readiness.
- Reconcile Capture when server-authoritative assistant settings arrive after launch, preserving the user preference and starting only after Screen Recording is granted.
- Add policy and settings-sync regression coverage for the launch restoration boundary.
- Repair the desktop CI suites by deleting assertions for intentionally retired startup/notch paths and resetting Rewind storage between owner-isolated lifecycle tests.

## Root cause

Launch used one-shot readiness checks. Listening was deferred behind API-key availability even when the local transcription provider could run, while a delayed settings sync could update Capture intent after its only launch scheduling attempt.

The failing CI run still asserted two deleted implementation paths, and one Rewind test changed database owners without resetting the storage owner that owns the shared video encoder.

## Validation

- `xcrun swift test -c debug --package-path desktop/macos/Desktop --filter PersistedCaptureLaunchPolicyTests`
- `xcrun swift test -c debug --package-path desktop/macos/Desktop --filter SettingsSyncCaptureRestorationTests`
- `desktop/macos/scripts/swift-test-suites.sh`
- `desktop/macos/scripts/run-swift-ci.sh --test` (blocked locally: requires unavailable Xcode 16.4; GitHub uses the pinned toolchain)
- Named QA bundle `omi-launch-permission-qa` launched to the signed-in Home surface; its intentionally separate bundle identity correctly retained capture intent without prompting when Screen Recording was absent.

Failure-Class: none
