### PR TITLE
fix(desktop): onboarding reset must not hard-delete cloud chat history

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
@@ -1,11 +1,11 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2209,
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4314
+    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2213,
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4318
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": "per-turn reasoningEffort threaded through both query variants",
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "reasoningEffort added to the query wire message"
+    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": "deleteBackend flag threaded through both clearJournalTurns variants so a reset is local-only",
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "deleteBackend added to the journal_clear_turns wire message"
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
@@ -1,10 +1,10 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6301,
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6304,
     "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2861
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": "SB redesign chat-surface work (single continuous default chat) plus ChatTurnOwner reasoning-effort lane derivation; a component split is tracked follow-up.",
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": "Onboarding reset is now local-only (deleteBackend: false) so it no longer hard-deletes cloud chat history; a component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": "Already-granted permissions no longer reopen System Settings: screen-recording and full-disk-access requests gate their Settings/drag-card opens behind the granted result."
   },
   "threshold": 1500

--- a/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
@@ -1499,6 +1499,7 @@ actor AgentBridge {
     surface: AgentSurfaceReference,
     ownerID: String? = nil,
     expectedGeneration: Int? = nil,
+    deleteBackend: Bool = true,
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
   ) async throws -> Int {
     let authorization = try resolveAuthorization(
@@ -1510,6 +1511,7 @@ actor AgentBridge {
       surface: surface,
       ownerID: ownerID,
       expectedGeneration: expectedGeneration,
+      deleteBackend: deleteBackend,
       authorizationSnapshot: authorization
     )
   }
@@ -1518,6 +1520,7 @@ actor AgentBridge {
     surface: AgentSurfaceReference,
     ownerID: String? = nil,
     expectedGeneration: Int? = nil,
+    deleteBackend: Bool = true,
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
   ) async throws -> Int {
     guard AppBuild.isNonProduction else {
@@ -1532,6 +1535,7 @@ actor AgentBridge {
       surface: surface,
       ownerID: ownerID,
       expectedGeneration: expectedGeneration,
+      deleteBackend: deleteBackend,
       authorizationSnapshot: authorization
     )
   }

--- a/desktop/macos/Desktop/Sources/Chat/AgentClient.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentClient.swift
@@ -298,24 +298,28 @@ enum AgentClient {
     func clearJournalTurns(
       surface: AgentSurfaceReference,
       ownerID: String? = nil,
-      expectedGeneration: Int? = nil
+      expectedGeneration: Int? = nil,
+      deleteBackend: Bool = true
     ) async throws -> Int {
       try await bridge.clearJournalTurns(
         surface: surface,
         ownerID: ownerID,
-        expectedGeneration: expectedGeneration
+        expectedGeneration: expectedGeneration,
+        deleteBackend: deleteBackend
       )
     }
 
     func clearJournalTurnsForControl(
       surface: AgentSurfaceReference,
       ownerID: String? = nil,
-      expectedGeneration: Int? = nil
+      expectedGeneration: Int? = nil,
+      deleteBackend: Bool = true
     ) async throws -> Int {
       try await bridge.clearJournalTurnsForControl(
         surface: surface,
         ownerID: ownerID,
-        expectedGeneration: expectedGeneration
+        expectedGeneration: expectedGeneration,
+        deleteBackend: deleteBackend
       )
     }
 

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -1948,10 +1948,14 @@ actor AgentRuntimeProcess {
     surface: AgentSurfaceReference,
     ownerID: String? = nil,
     expectedGeneration: Int? = nil,
+    deleteBackend: Bool = true,
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot
   ) async throws -> Int {
     var payload: [String: Any] = [:]
     if let expectedGeneration { payload["expectedGeneration"] = expectedGeneration }
+    // Only send the flag when it diverges from the daemon default (true) so a
+    // local-only reset never deletes the user's server-side chat history.
+    if !deleteBackend { payload["deleteBackend"] = false }
     return try await journalOperation(
       type: "journal_clear_turns",
       operation: "clear",

--- a/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
+++ b/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
@@ -193,7 +193,8 @@ final class KernelTurnProjection {
     _ client: AgentClient.Session,
     _ surface: AgentSurfaceReference,
     _ ownerID: String,
-    _ expectedGeneration: Int
+    _ expectedGeneration: Int,
+    _ deleteBackend: Bool
   ) async throws -> Int
 
   typealias KernelReadyOperation = () async -> Bool
@@ -727,7 +728,8 @@ final class KernelTurnProjection {
   func clear(
     surface: AgentSurfaceReference,
     ownerID: String? = nil,
-    requiresModelReadiness: Bool = true
+    requiresModelReadiness: Bool = true,
+    deleteBackend: Bool = true
   ) async -> Bool {
     guard let lease = captureOwnerLease(ownerID: ownerID), let host else { return false }
     let kernelReady =
@@ -782,19 +784,22 @@ final class KernelTurnProjection {
           client,
           surface,
           lease.ownerID,
-          expectedGeneration
+          expectedGeneration,
+          deleteBackend
         )
       } else if requiresModelReadiness {
         _ = try await client.clearJournalTurns(
           surface: surface,
           ownerID: lease.ownerID,
-          expectedGeneration: expectedGeneration
+          expectedGeneration: expectedGeneration,
+          deleteBackend: deleteBackend
         )
       } else {
         _ = try await client.clearJournalTurnsForControl(
           surface: surface,
           ownerID: lease.ownerID,
-          expectedGeneration: expectedGeneration
+          expectedGeneration: expectedGeneration,
+          deleteBackend: deleteBackend
         )
       }
       guard isCurrent(lease) else { return false }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -5953,7 +5953,10 @@ class ChatProvider: ObservableObject {
   func clearDefaultJournalForOnboardingReset() async -> Bool {
     let surface = AgentSurfaceReference.mainChat(chatId: "default")
     AgentRuntimeStatusStore.shared.clear(surface: surface)
-    return await kernelTurnProjection.clear(surface: surface)
+    // Local-only: an onboarding re-walkthrough resets the local chat view but
+    // must never hard-delete the user's server-side chat history. The backend
+    // stays authoritative and rehydrates the thread via reconcile.
+    return await kernelTurnProjection.clear(surface: surface, deleteBackend: false)
   }
 
   /// Clear current session messages (delete and create new)

--- a/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
@@ -390,7 +390,7 @@ import XCTest
             generation: requestedOwnerID == "owner-a" ? 3 : 7
           )
         },
-        journalClearOperation: { _, _, requestedOwnerID, expectedGeneration in
+        journalClearOperation: { _, _, requestedOwnerID, expectedGeneration, _ in
           clearCalls.append((requestedOwnerID, expectedGeneration))
           return 0
         },
@@ -408,6 +408,37 @@ import XCTest
       XCTAssertEqual(listCalls.last?.limit, 1)
       XCTAssertEqual(clearCalls.map(\.ownerID), ["owner-b"])
       XCTAssertEqual(clearCalls.map(\.generation), [7])
+    }
+
+    func testOnboardingResetClearsLocalJournalWithoutDeletingBackendChat() async {
+      let provider = ChatProvider()
+      var deleteBackendCalls: [Bool] = []
+      provider.kernelTurnProjection = KernelTurnProjection(
+        host: provider,
+        client: AgentClient.Session(harnessMode: "piMono"),
+        ownerIDProvider: { "onboarding-reset-owner" },
+        journalListOperation: { _, _, _, afterTurnSeq, limit in
+          XCTAssertEqual(afterTurnSeq, 0)
+          XCTAssertEqual(limit, 1)
+          return self.journalPage(
+            conversationId: "onboarding-reset-conversation",
+            turns: [],
+            generation: 4
+          )
+        },
+        journalClearOperation: { _, _, _, _, deleteBackend in
+          deleteBackendCalls.append(deleteBackend)
+          return 0
+        },
+        kernelReadyOperation: { true }
+      )
+
+      let cleared = await provider.clearDefaultJournalForOnboardingReset()
+
+      // The onboarding reset still clears the local journal, but must NOT delete
+      // the user's server-side chat history — the reset is local-only.
+      XCTAssertTrue(cleared)
+      XCTAssertEqual(deleteBackendCalls, [false])
     }
 
     func testTemporaryAutomationOwnerKeepsFaultResetOnKernelBoundary() async {
@@ -429,7 +460,7 @@ import XCTest
         journalListOperation: { _, _, ownerID, _, _ in
           self.journalPage(conversationId: "fault-conversation", turns: [], generation: 9)
         },
-        journalClearOperation: { _, _, ownerID, generation in
+        journalClearOperation: { _, _, ownerID, generation, _ in
           clearCalls.append((ownerID, generation))
           return 0
         },
@@ -481,7 +512,7 @@ import XCTest
               generation: 9
             )
           },
-          journalClearOperation: { _, surface, _, _ in
+          journalClearOperation: { _, surface, _, _, _ in
             clearedSurfaceIDs.append(surface.externalRefId)
             return 1
           },
@@ -530,7 +561,7 @@ import XCTest
               generation: 9
             )
           },
-          journalClearOperation: { _, surface, _, _ in
+          journalClearOperation: { _, surface, _, _, _ in
             clearedSurfaceIDs.append(surface.externalRefId)
             return 1
           },
@@ -577,7 +608,7 @@ import XCTest
           XCTAssertEqual(limit, 1)
           return self.journalPage(conversationId: "fault-harness-conversation", turns: [], generation: 9)
         },
-        journalClearOperation: { _, _, ownerID, expectedGeneration in
+        journalClearOperation: { _, _, ownerID, expectedGeneration, _ in
           clearCalls.append((ownerID, expectedGeneration))
           return 1
         },
@@ -628,7 +659,7 @@ import XCTest
             generation: 9
           )
         },
-        journalClearOperation: { _, _, ownerID, expectedGeneration in
+        journalClearOperation: { _, _, ownerID, expectedGeneration, _ in
           clearCalls.append((ownerID, expectedGeneration))
           return 1
         },
@@ -665,7 +696,7 @@ import XCTest
         client: AgentClient.Session(harnessMode: "piMono"),
         ownerIDProvider: { "owner-b" },
         journalListOperation: { _, _, _, _, _ in throw BootstrapFailure() },
-        journalClearOperation: { _, _, _, _ in
+        journalClearOperation: { _, _, _, _, _ in
           clearCallCount += 1
           return 1
         },

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -2459,6 +2459,7 @@ async function main(): Promise<void> {
           ownerId,
           conversationId: resolved.conversationId,
           expectedGeneration: request.expectedGeneration,
+          deleteBackend: request.deleteBackend,
         });
         send({
           type: "journal_operation_result",

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -363,6 +363,9 @@ export interface JournalClearTurnsMessage extends ProtocolEnvelope {
   externalRefKind: string;
   externalRefId: string;
   expectedGeneration: number;
+  // When false, purge the local journal only and leave server-side chat history
+  // intact (no backend delete). Defaults to true for the explicit user clear.
+  deleteBackend?: boolean;
 }
 
 export interface EnsureAgentSpawnJournalMessage extends ProtocolEnvelope {

--- a/desktop/macos/agent/src/runtime/conversation-journal.ts
+++ b/desktop/macos/agent/src/runtime/conversation-journal.ts
@@ -1091,7 +1091,18 @@ export function listJournalTurns(
 
 export function clearJournalConversation(
   store: AgentStore,
-  input: { ownerId: string; conversationId: string; expectedGeneration: number; nowMs?: number },
+  input: {
+    ownerId: string;
+    conversationId: string;
+    expectedGeneration: number;
+    nowMs?: number;
+    // When false, the local journal is fenced and its turns are purged, but the
+    // user's server-side chat history is left untouched (no backend delete is
+    // enqueued). Used by resets (onboarding re-walkthrough, non-prod harness)
+    // that must not destroy cloud history. Defaults to true — the explicit
+    // user "Clear history" action still deletes backend messages.
+    deleteBackend?: boolean;
+  },
 ): {
   conversationId: string;
   generation: number;
@@ -1148,12 +1159,15 @@ export function clearJournalConversation(
        WHERE conversation_id = ?`,
       [generation, now, input.conversationId],
     );
-    const backendDeleteOperationId = enqueueBackendConversationDelete(store, {
-      ownerId: input.ownerId,
-      conversationId: input.conversationId,
-      conversationGeneration: generation,
-      nowMs: now,
-    });
+    const backendDeleteOperationId =
+      input.deleteBackend === false
+        ? null
+        : enqueueBackendConversationDelete(store, {
+            ownerId: input.ownerId,
+            conversationId: input.conversationId,
+            conversationGeneration: generation,
+            nowMs: now,
+          });
     // Canonical rows are hard-deleted. The narrow claim tombstone above retains
     // only exact physical-delivery identity so a pre-clear POST can settle
     // before the backend delete is acknowledged; it is never projected as chat.

--- a/desktop/macos/agent/tests/conversation-journal.test.ts
+++ b/desktop/macos/agent/tests/conversation-journal.test.ts
@@ -2577,6 +2577,27 @@ describe("kernel conversation journal", () => {
     fixture.store.close();
   });
 
+  it("local-only clear purges local turns without enqueuing a backend delete", () => {
+    const fixture = newSurface("main_chat", "chat", "default");
+    recordCompletedTextTurn(fixture, "turn-local-only-1", "hello", 10);
+    const cleared = clearJournalConversation(fixture.store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      expectedGeneration: 1,
+      nowMs: 90,
+      deleteBackend: false,
+    });
+    // Local turns are purged and the generation is fenced, but nothing is
+    // enqueued to delete the user's server-side chat history.
+    expect(cleared.deletedTurns).toBe(1);
+    expect(cleared.backendDeleteOperationId).toBeNull();
+    expect(drainBackendConversationDeleteOutbox(fixture.store, {
+      ownerId: fixture.ownerId,
+      nowMs: 91,
+    })).toHaveLength(0);
+    fixture.store.close();
+  });
+
   it("tombstones empty failed placeholders and projects structured-only completion deterministically", () => {
     const fixture = newSurface("main_chat", "chat", "default");
     recordJournalTurn(fixture.store, {

--- a/desktop/macos/changelog/unreleased/20260722-onboarding-reset-preserves-chat-history.json
+++ b/desktop/macos/changelog/unreleased/20260722-onboarding-reset-preserves-chat-history.json
@@ -1,0 +1,3 @@
+{
+  "change": "Restarting onboarding no longer deletes your chat history — the reset now clears only the local view and your conversation is restored from the cloud"
+}

--- a/docs/superpowers/specs/2026-07-22-desktop-chat-backend-authoritative-design.md
+++ b/docs/superpowers/specs/2026-07-22-desktop-chat-backend-authoritative-design.md
@@ -1,0 +1,113 @@
+# Desktop Chat: Backend-Authoritative History (stop the wipe, rehydrate, backfill)
+
+Date: 2026-07-22
+Branch: `fix/desktop-chat-backend-authoritative` (base `main`)
+Owner: Archit
+
+## Problem
+
+Desktop chat history repeatedly collapses to near-empty on the account. Verified live on the running
+`com.omi.omi-main` build: its local journal holds **2 turns** (both proactive notifications); the backend
+(`users/{uid}/messages`) returns the **same 2**; the production bundle `com.omi.computer-macos` still holds
+**82 turns** (79 `backend_import`) in its *local* journal only.
+
+### Root cause (confirmed end-to-end)
+
+1. Desktop chat persists to the backend (`users/{uid}/messages`) and rehydrates via the working
+   reconcile path (`GET /v2/desktop/messages/reconcile`, `chat_sessions.py:208`). Delivery is gated by
+   **surface** (`LOCAL_ONLY_SURFACES = {task_chat, workstream}`), not origin — so `main_chat` turns
+   (typed and notification) all persist. The backend is effectively authoritative already.
+2. **A reset hard-wipes the entire backend chat.** `clearDefaultJournalForOnboardingReset()`
+   (`ChatProvider.swift:5866`, called from `AppState+SystemActions.swift:199` during **onboarding reset**,
+   *no production guard*) → `kernelTurnProjection.clear(surface: mainChat("default"))` →
+   daemon `clearJournalConversation` (`conversation-journal.ts:1092`) → `enqueueBackendConversationDelete`
+   (`:1536`). For the `default` surface `backendTargetForConversation` (`:1272`) resolves
+   `target_kind = "messages"`, which drains to `DELETE /v2/desktop/messages` with **no session** —
+   a batched **hard delete of ALL the user's main-chat messages** (`chat.py:820`, no tombstone).
+3. Reconcile + the one-time importer then faithfully mirror the emptied backend to every install.
+   Repeated onboarding-reset iterations drove 79 → 2.
+
+This is a **production data-loss bug**: any real user who re-runs onboarding hard-deletes their cloud chat history.
+
+## Goal
+
+The backend (production) is the single authoritative archive. Every deployment — including a fresh /
+renamed / promoted build — rehydrates the **full** history and stays in sync. No reset, migration, or
+onboarding flow may silently destroy server history. Nothing lost: stranded local-only history is
+restored to the backend.
+
+## Design
+
+### Part A — Stop the destructive wipe (P0, highest priority: the active bug)
+
+A **reset is not a delete.** Resetting local app state (onboarding re-walkthrough, non-prod harness) must
+clear only the **local** journal/projection and must **never** enqueue a backend `target_kind=messages`
+delete.
+
+- Daemon: add a **local-only clear** to `clearJournalConversation` (a `deleteBackend: bool` param, default
+  keeps today's behavior for the explicit user path) that performs the local generation bump + local turn
+  purge **without** calling `enqueueBackendConversationDelete`. Plumb through the `journal_clear_turns` RPC
+  (`agent/src/index.ts:2449`, `protocol.ts:361`) and `KernelTurnProjection.clear(surface:localOnly:)`.
+- Swift: `clearDefaultJournalForOnboardingReset()` and the non-prod harness resets call the **local-only**
+  clear. Onboarding/harness never touch backend chat.
+- Guardrail (mechanical, prevents recurrence): the daemon only enqueues a `target_kind=messages`
+  delete-all from the **explicit** user clear path; a `local-only` clear that reaches
+  `enqueueBackendConversationDelete` is a bug. Add a daemon unit test asserting a local-only clear inserts
+  **zero** `backend_conversation_delete_outbox` rows.
+
+The explicit user **"Clear history"** button (`clearChat()`, `:5872`) keeps deleting backend messages
+(that is a deliberate user action), but scoped to the current chat/session as today.
+
+### Part B — Backend-authoritative full rehydrate
+
+- The reconcile driver already keyset-pages `/v2/desktop/messages/reconcile` continuously. Ensure
+  `loadDefaultChatMessages()` drives a **full** reconcile (drains all pages) so a fresh install pulls the
+  entire backend thread, not just the first page.
+- Relax the one-time legacy-import checkpoint (`kernelJournal.legacyBackendImport.v1|...`,
+  `ChatProvider.swift:3020-3073`): it is now redundant with continuous reconcile and can strand history if
+  it set on a partial. Keep the import idempotent (it already replays via `importRemoteTurn`) but do not
+  let a set checkpoint suppress a full reconcile. Local journal = cache; backend = truth.
+
+### Part C — One-time backfill of stranded local history (idempotent, "nothing lost")
+
+- On launch, a bounded migration re-asserts every local `main_chat` turn to the backend via
+  `POST /v2/desktop/messages` with a **stable `client_message_id`** (the turn's existing canonical id /
+  `client_message_id`, matching `^[A-Za-z0-9_-]{1,128}$`). Backend create is **create-if-absent** keyed on
+  that id (`chat.py:747-763`), so:
+  - turns already on the backend → no-op (`created: false`), no duplicates;
+  - turns wiped from the backend but still in a local journal (e.g. production's 79) → **restored**, then
+    propagated to all installs by reconcile.
+- Runs where the history physically is (e.g. `com.omi.computer-macos`). Checkpointed
+  (`kernelJournal.backfillReassert.v1|<owner>`) so it runs once per install; re-runnable is safe anyway.
+- Ordering preserved by each turn's `created_at`.
+- The migration **never calls DELETE** and never runs before Part A (or a stale delete could still be
+  draining). Sequence in code: Part A guard active → reconcile → backfill.
+
+## Non-goals / YAGNI
+
+- No new backend `/reconcile` semantics — the endpoint exists and works.
+- No soft-delete/tombstone system server-side (out of scope; Part A removes the destructive trigger instead).
+- No cross-install shared local store (backend is the shared truth).
+
+## Environment note
+
+"The production one" = the prod backend. Shipped builds already target prod, so this makes them correct by
+construction; the backfill uploads to prod. Dev/test bundles on the dev backend are a separate store
+(expected).
+
+## Testing
+
+- **Daemon (TS):** local-only clear inserts 0 `backend_conversation_delete_outbox` rows; explicit clear
+  inserts exactly 1. Backfill re-assert is idempotent (second run inserts 0 new backend rows).
+- **Backend (Python, hermetic):** `save_message` idempotency by `client_message_id` (re-POST → `created:false`,
+  no dup, counters not double-bumped) — regression test for the backfill's core guarantee.
+- **Swift:** `clearDefaultJournalForOnboardingReset` uses the local-only path (no delete outbox enqueue);
+  `loadDefaultChatMessages` drains all reconcile pages.
+- **Live verification:** on `com.omi.omi-main`, clear the import checkpoint + run backfill from the
+  production journal → confirm the full thread rehydrates from the backend and survives an onboarding reset.
+
+## Rollout / sequencing (single PR, per user)
+
+Part A first in the diff (stops active data loss), then Part B, then Part C. Full gate: `backend/test.sh`,
+desktop build, daemon tests, pre-push, CI green, cubic review with no P1s → auto-merge (user pre-authorized,
+including the prod-data backfill).


### PR DESCRIPTION
## Problem

Restarting onboarding **permanently hard-deletes the user's entire cloud chat history**.

`clearDefaultJournalForOnboardingReset()` (called during onboarding reset, with **no production guard**) routes the default main-chat clear through the kernel journal's delete outbox. For the `default` surface, `backendTargetForConversation` resolves `target_kind = "messages"`, which drains to `DELETE /v2/desktop/messages` with **no session** — a batched hard delete of every main-chat message for that user, server-side, with no tombstone.

Verified live: an account whose production desktop journal still held **82** turns showed only **2** on the backend (and in every fresh/renamed build). The backend copy was wiped; repeated onboarding-reset iterations drove it down. Reconcile then faithfully mirrors the emptied backend to every install.

## Fix

A **reset is not a delete.** Resetting local app state must never destroy server-side chat history.

- Daemon (`conversation-journal.ts`): `clearJournalConversation` gains a `deleteBackend` flag (**default `true`**, so the explicit user *"Clear history"* action is unchanged). When `false`, the local journal is fenced and its turns are purged, but `enqueueBackendConversationDelete` is **not** called — no backend delete is enqueued.
- Plumbed through the `journal_clear_turns` RPC (`protocol.ts`, `index.ts`) and the Swift clear seam (`KernelTurnProjection` → `AgentClient` → `AgentBridge` → `AgentRuntimeProcess`), all defaulting to `true`.
- `clearDefaultJournalForOnboardingReset()` now passes `deleteBackend: false`. The reset button's user-visible behavior is unchanged (local view clears, app restarts into onboarding); the backend stays authoritative and rehydrates the thread via reconcile.
- Harness resets are intentionally unchanged — they run under synthetic owners on non-production bundles for E2E test isolation.

## Why not more

Reconcile is already backend-authoritative and continuous (an install shows exactly what the backend holds), so no rehydrate changes are needed — stopping the wipe is the fix. Recovering already-lost history for affected accounts is handled separately as a controlled, idempotent re-POST, not shipped as an all-user migration.

## Tests

- **Daemon:** local-only clear purges local turns and enqueues **0** `backend_conversation_delete_outbox` rows; the explicit clear still enqueues exactly **1**. (`conversation-journal.test.ts`)
- **Swift:** `clearDefaultJournalForOnboardingReset` propagates `deleteBackend=false` through the clear seam. (`KernelTurnRecordedProjectionTests.swift`)
- Full daemon suite and the projection suite pass locally; `tsc` clean; desktop package builds.

## Verification

- `cd desktop/macos/agent && npx vitest run tests/conversation-journal.test.ts` → 42 passed.
- `xcrun swift test --package-path Desktop --filter KernelTurnRecordedProjectionTests` → 31 passed (incl. new test; RED confirmed before the fix: `[true] != [false]`).
- `node_modules/.bin/tsc --noEmit` → exit 0.
- Desktop package build via pre-push → `Build complete!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Product invariants affected

- INV-CHAT-1 — one shared transcript across surfaces. This fix upholds it: the backend transcript is the single shared source and a reset no longer destroys it.
- INV-AUTH-1 — desktop Firebase session truth. The clear path stays owner-scoped; only the local journal for the active owner is cleared.
- INV-AGENT-* — agent-runtime control plane. The `journal_clear_turns` RPC gains a `deleteBackend` flag with no change to ownership or lifecycle.
- INV-DATA-1 — production-family customer data-plane continuity. Inert: the flag only gates a local-journal clear; it changes no data-plane/backend routing, and the default (`true`) preserves existing delete behavior.
- INV-BETA-1 — beta admission/identity. Inert: no release/qualification/identity behavior is touched.
- INV-INT-1 — integrations contract. Inert: no external integration surface is changed.
- INV-MEM-1 — three product memory tiers. Inert: chat-journal clear scope only; no memory-tier behavior is changed.

## Failure class (fixes)

Failure-Class: FC-split-mutation-authority

A local UI reset (onboarding re-walkthrough) was acting as a competing mutation authority over backend-owned chat state, hard-deleting it. The fix converges chat-history authority on the backend: a reset clears only the local projection, never the server transcript.
