### PR TITLE
fix(admin): guard every HogQL query against PostHog's silent default LIMIT 100 (ports #10194)

### DIFF
--- a/web/admin/app/api/omi/releases/route.ts
+++ b/web/admin/app/api/omi/releases/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
+import { withRowLimit } from "@/lib/posthog";
 import {
   desktopQualificationFromMetadata,
   desktopReleaseLifecycle,
@@ -106,7 +107,13 @@ async function posthogQuery(query: string): Promise<any> {
         Authorization: `Bearer ${POSTHOG_API_KEY}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
+      // This route has its own fetch (bypasses lib/posthog's posthogFetch), so
+      // it applies the same shared row-limit guard directly — the version×event
+      // query has no LIMIT and 5 events × ~40-80 versions exceeds the silent
+      // default 100, dropping per-version counts to 0 (#10190).
+      body: JSON.stringify({
+        query: { kind: "HogQLQuery", query: withRowLimit(query) },
+      }),
       cache: "no-store",
     },
   );

--- a/web/admin/app/api/omi/stats/onboarding/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/onboarding/posthog/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
 import { getPayload, setPayload } from '@/lib/payload-cache';
+import { withRowLimit } from '@/lib/posthog';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 3600;
 
@@ -117,7 +118,8 @@ export async function computeOnboarding(days: number) {
     const body = {
       query: {
         kind: 'HogQLQuery',
-        query: `
+        // Own fetch (bypasses posthogFetch); guard directly (#10190).
+        query: withRowLimit(`
           WITH entrant_actors AS (
             SELECT actor_id
             FROM (
@@ -142,7 +144,7 @@ export async function computeOnboarding(days: number) {
             AND COALESCE(person_id, distinct_id) IN (SELECT actor_id FROM entrant_actors)
           GROUP BY actor_id, event
           LIMIT 10000
-        `,
+        `),
       },
     };
 

--- a/web/admin/app/api/omi/stats/profitability/route.ts
+++ b/web/admin/app/api/omi/stats/profitability/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
+import { withRowLimit } from "@/lib/posthog";
 import { getOptionalStripe } from "@/lib/stripe";
 import { getAdminAuth, getDb } from "@/lib/firebase/admin";
 import { getPayload, setPayload } from "@/lib/payload-cache";
@@ -184,7 +185,9 @@ async function fetchDesktopUidsFromPostHog(days: number): Promise<Set<string> | 
     const response = await fetch(`${host}/api/projects/${projectId}/query/`, {
       method: "POST",
       headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
-      body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
+      // Own fetch (bypasses lib/posthog's posthogFetch); apply the shared
+      // row-limit guard directly so this can't silently truncate (#10190).
+      body: JSON.stringify({ query: { kind: "HogQLQuery", query: withRowLimit(query) } }),
     });
     if (!response.ok) {
       console.error("PostHog desktop uids failed:", response.status, await response.text());
@@ -218,7 +221,9 @@ async function fetchDesktopActivePerDay(days: number): Promise<Record<string, nu
     const response = await fetch(`${host}/api/projects/${projectId}/query/`, {
       method: "POST",
       headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
-      body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
+      // Own fetch (bypasses lib/posthog's posthogFetch); apply the shared
+      // row-limit guard directly so this can't silently truncate (#10190).
+      body: JSON.stringify({ query: { kind: "HogQLQuery", query: withRowLimit(query) } }),
     });
     if (!response.ok) return null;
     const raw = await response.json();

--- a/web/admin/lib/__tests__/posthog-no-bypass.test.ts
+++ b/web/admin/lib/__tests__/posthog-no-bypass.test.ts
@@ -1,0 +1,48 @@
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join, resolve } from "path";
+
+import { describe, expect, it } from "vitest";
+
+// #10190 regression guard: any admin code that sends a raw HogQL query directly
+// (a `kind: "HogQLQuery"` body via its own fetch, bypassing lib/posthog's
+// posthogFetch chokepoint) must apply the shared `withRowLimit` guard, or it
+// re-introduces the silent default-100 truncation. Routes that go through
+// posthogFetch/posthogResults/cachedPosthogFetch never contain the literal, so
+// they are covered automatically and don't trip this check.
+
+const ADMIN_ROOT = resolve(__dirname, "..", "..");
+// lib/posthog.ts is the definition site — it holds both the literal and the
+// guard, so it passes the rule below without being a special case.
+const SCAN_DIRS = ["app", "lib"];
+
+function tsFiles(dir: string): string[] {
+  let out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "__tests__") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out = out.concat(tsFiles(full));
+    else if (full.endsWith(".ts") || full.endsWith(".tsx")) out.push(full);
+  }
+  return out;
+}
+
+describe("HogQL row-limit guard has no bypass", () => {
+  it("every file that sends a raw HogQLQuery also applies withRowLimit", () => {
+    const offenders: string[] = [];
+    for (const scanDir of SCAN_DIRS) {
+      for (const file of tsFiles(join(ADMIN_ROOT, scanDir))) {
+        const src = readFileSync(file, "utf8");
+        if (!/HogQLQuery/.test(src)) continue;
+        if (!/withRowLimit/.test(src)) {
+          offenders.push(file.slice(ADMIN_ROOT.length + 1));
+        }
+      }
+    }
+    expect(
+      offenders,
+      `These files send a raw HogQLQuery without the withRowLimit guard (see #10190). ` +
+        `Route the fetch through lib/posthog's posthogFetch/posthogResults, or wrap the query with withRowLimit:\n` +
+        offenders.join("\n"),
+    ).toEqual([]);
+  });
+});

--- a/web/admin/lib/__tests__/posthog-row-limit.test.ts
+++ b/web/admin/lib/__tests__/posthog-row-limit.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { POSTHOG_SERVED_MAX_ROWS, withRowLimit } from "../posthog";
+
+// #10190: PostHog silently fills LIMIT 100 into any HogQL (sub)query without
+// one. withRowLimit binds one explicit outer LIMIT so the default cap can never
+// truncate, and wraps in a subquery so a UNION's total (not just its last arm)
+// is bounded.
+describe("withRowLimit", () => {
+  it("binds an explicit outer LIMIT at the served max by default", () => {
+    const out = withRowLimit(
+      "SELECT version, count() FROM events GROUP BY version",
+    );
+    expect(out).toContain(`LIMIT ${POSTHOG_SERVED_MAX_ROWS}`);
+    // The served max is 50k, verified live (LIMIT 100000 returns 50000).
+    expect(POSTHOG_SERVED_MAX_ROWS).toBe(50_000);
+  });
+
+  it("wraps in a subquery so the LIMIT binds the whole UNION, not the last arm", () => {
+    const union = "SELECT 1 AS a UNION ALL SELECT 2 AS a";
+    const out = withRowLimit(union);
+    // The union must sit inside a subquery; the LIMIT must come after the close
+    // paren, not inline with the last arm (which would bind that arm only).
+    expect(out).toMatch(
+      /SELECT \* FROM \(\s*[\s\S]*UNION ALL[\s\S]*\)\s*AS _row_limit_guard\s*LIMIT/,
+    );
+    const limitPos = out.lastIndexOf("LIMIT");
+    const closeParenPos = out.lastIndexOf(")");
+    expect(limitPos).toBeGreaterThan(closeParenPos);
+  });
+
+  it("is ceiling-only: a caller's tighter inner LIMIT is preserved inside the wrap", () => {
+    const out = withRowLimit("SELECT * FROM events LIMIT 10");
+    // The inner LIMIT 10 survives (inside the subquery); the outer is just a cap.
+    expect(out).toContain("LIMIT 10");
+    expect(out).toContain(`LIMIT ${POSTHOG_SERVED_MAX_ROWS}`);
+    // Inner limit appears before the guard's outer limit.
+    expect(out.indexOf("LIMIT 10")).toBeLessThan(
+      out.lastIndexOf(`LIMIT ${POSTHOG_SERVED_MAX_ROWS}`),
+    );
+  });
+
+  it("honors a custom max", () => {
+    expect(withRowLimit("SELECT 1", 500)).toContain("LIMIT 500");
+  });
+});

--- a/web/admin/lib/posthog.ts
+++ b/web/admin/lib/posthog.ts
@@ -21,6 +21,26 @@ import { getDb } from "@/lib/firebase/admin";
 const CACHE_COLLECTION = "admin_stats_cache";
 const SOFT_TTL_MS = 30 * 60 * 1000; // serve cached without re-querying for 30 min
 
+// PostHog's query API fills `LIMIT 100` into any HogQL (sub)query that carries
+// none and truncates silently — this cut the newest days off the
+// response-reliability charts (#10191) and drops per-version rows on the
+// releases panel (#10190). 50_000 is PostHog's served maximum (verified live:
+// `LIMIT 100000` returns exactly 50000 rows).
+export const POSTHOG_SERVED_MAX_ROWS = 50_000;
+
+// Guard against the silent default cap by binding one explicit outer LIMIT to
+// the whole result. Wrapping in a subquery is required for correctness with
+// `UNION ALL`, where a trailing `LIMIT` binds to the last arm only (verified:
+// `SELECT 1 UNION ALL SELECT 2 LIMIT 1` returns 2 rows). Wrapping only ever
+// adds a ceiling: a caller's tighter inner `LIMIT` still wins, so this never
+// widens an intentionally small query.
+export function withRowLimit(
+  query: string,
+  max: number = POSTHOG_SERVED_MAX_ROWS,
+): string {
+  return `SELECT * FROM (\n${query}\n) AS _row_limit_guard\nLIMIT ${max}`;
+}
+
 type CacheDoc = { payload: string; freshAt: number };
 
 async function readCache(
@@ -67,7 +87,9 @@ export async function posthogFetch(
         "Content-Type": "application/json",
         Accept: "application/json",
       },
-      body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
+      body: JSON.stringify({
+        query: { kind: "HogQLQuery", query: withRowLimit(query) },
+      }),
     });
     if (res.status !== 429 || attempt === maxRetries) return res;
     const waitMs = 800 * (attempt + 1) + Math.floor(Math.random() * 300);
@@ -146,13 +168,15 @@ export async function posthogResults(
     }
     const raw = await res.json();
     const results = Array.isArray(raw.results) ? raw.results : [];
-    // PostHog fills LIMIT 100 into any HogQL (sub)query that has none and
-    // truncates silently — exactly 100 rows from a LIMIT-less query is the
-    // signature of that cap (it cut the newest days off response-reliability).
-    if (results.length === 100 && !/\blimit\b/i.test(query)) {
+    // posthogFetch now binds an explicit LIMIT of POSTHOG_SERVED_MAX_ROWS to
+    // every query, so the silent default-100 cap can no longer truncate. The
+    // remaining ceiling is PostHog's served maximum: a result at that count is
+    // itself truncated and the caller should widen its window or paginate.
+    if (results.length >= POSTHOG_SERVED_MAX_ROWS) {
       console.warn(
-        "PostHog returned exactly 100 rows for a query without LIMIT — likely truncated by the default cap",
+        "PostHog returned the served-max row count — result is truncated at the ceiling",
         {
+          servedMax: POSTHOG_SERVED_MAX_ROWS,
           querySnippet: query.replace(/\s+/g, " ").trim().slice(0, 160),
         },
       );


### PR DESCRIPTION
# Summary

PostHog's query API fills `LIMIT 100` into any HogQL (sub)query that carries none and truncates silently. This PR ports the fix from #10194 — a shared guard that closes that class across the **web admin** app — onto current `main`, carrying the original commits forward verbatim so their authors retain credit.

**Ported from #10194 by @aryanorastar.** Both commits cherry-pick cleanly onto `main` (none of the six touched files have changed since #10194's base), so the original author (`Aryan <aryangupts05@gmail.com>`) remains the commit author of both. No reconstruction was needed — this is a direct cherry-pick, not a rewrite.

Fixes #10190.

# Root cause

PostHog silently injects `LIMIT 100` into any HogQL query (or subquery) that lacks an explicit `LIMIT`. The cap truncates results with no error and no log, so affected panels read plausible-but-wrong numbers (often `0`) for the rows that were dropped:

- The **releases** route groups by version × event over 60 days with no `LIMIT` and bypasses the shared fetch helper — 5 events × ~40–80 desktop versions exceeds 100, so per-version crash/launch/feedback counts read `0` for most versions **today**.
- Several other routes hand-fixed this with ad-hoc limits that **overstate** PostHog's real served max (`LIMIT 100000` / `LIMIT 500000`, when the verified served maximum is **50 000**).
- The response-reliability charts were already fixed in #10191 by pinning explicit limits; the same class remained everywhere else.

Verified live against project 302298 in #10190: `SELECT 1 UNION ALL SELECT 2 LIMIT 1` → 2 rows (a trailing `LIMIT` after `UNION ALL` binds the **last arm only**), and `LIMIT 100000` returns exactly **50 000** rows.

# Durable guard

- New `withRowLimit(query, max)` in `web/admin/lib/posthog.ts` — binds **one explicit outer `LIMIT`** at PostHog's served max (50 000) via a subquery wrap.
- Applied at **`posthogFetch`**, the low-level chokepoint that both `posthogResults` and `cachedPosthogFetch` route through — so every shared-helper caller is guarded automatically.
- Applied directly in the **three routes with their own `fetch`** that bypass the chokepoint: `releases`, `stats/profitability` (incl. `fetchDesktopActivePerDay`'s previously `LIMIT`-less GROUP BY), and `stats/onboarding/posthog`.
- **No-bypass ratchet** (`lib/__tests__/posthog-no-bypass.test.ts`): any file sending a raw `kind: "HogQLQuery"` body must also apply `withRowLimit`, so a future own-fetch route can't silently reintroduce the truncation. Fails on exactly the pre-fix state.

Correctness properties of the wrap:
- **UNION safety:** wrapping in a subquery makes the single outer `LIMIT` bind the whole result (not just the last arm).
- **Ceiling-only:** wrapping never widens an intentionally small query — a caller's tighter inner `LIMIT 10` sits inside the subquery and still wins; the outer 50 000 is just a cap.
- `posthogResults`' truncation observer moves from the fragile exactly-100 heuristic to the real signal now that an explicit limit is guaranteed.

# Attribution treatment

Both source commits from #10194 are cherry-picked verbatim onto current `main` (their tree-diff is byte-identical to #10194's — verified with `git diff`). Original commit author `Aryan <aryangupts05@gmail.com>` (`@aryanorastar`) is preserved as author on both; only the committer changed (expected for a cherry-pick). This is a direct port, not a reconstruction; credit is fully retained.

# Validation (run independently on current `main`, head `9b7ffc7`)

From `web/admin`:

- `npm run typecheck` (`tsc --noEmit`) → **clean**.
- `npx vitest run` → **36 passed** (5 files), incl. the new `posthog-row-limit.test.ts` (plain query gets an explicit outer `LIMIT`; a `UNION` is wrapped so the `LIMIT` binds the whole result; ceiling-only inner-limit preservation; custom max) and `posthog-no-bypass.test.ts` (the bypass ratchet).
- `npm run lint` → **0 errors** (23 pre-existing `<img>` / `react-hooks/exhaustive-deps` warnings in unrelated components, unchanged by this diff).
- `scripts/pr-preflight --base origin/main --head HEAD --lane local` (with this body) → **PASS**; product invariants: **none**; failure-class: **none**.

# Limitations of live PostHog verification

Not exercised against a live PostHog project: no admin PostHog key is available in this environment. The truncation mechanism, the UNION binding behavior, and the 50 000 served max are documented and verified live in #10190; this PR bounds every query path so the default-100 cap can no longer apply, and the unit tests assert the wrap shape directly. A live run against project 302298 would be the maintainer's call during review.

# Out of scope (per #10194)

- The `writeCache` >900 KB Firestore-field skip — a separate caching-completeness concern, not query truncation.
- Full migration of the releases route onto `posthogResults` (for Firestore caching) — a larger, separable refactor.
- A hard upper bound on the unclamped `days` param for notifications — now truncation-safe via the chokepoint guard; a resource-shape concern, not correctness.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

