### PR TITLE
feat(desktop): scroll Conversations page as one + expand live transcript full screen

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Components/LiveTranscriptView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/LiveTranscriptView.swift
@@ -108,8 +108,17 @@ struct RecordingBarTranscriptText: View {
 /// Live transcript card shown at the top of Conversations while recording —
 /// updates in real time as speech is transcribed. Observes the monitor directly
 /// so the surrounding page doesn't re-render on every segment.
+///
+/// Clicking anywhere on the card invokes `onExpand`, letting the parent present
+/// a full-screen view of the live transcript.
 struct ConversationsLiveTranscript: View {
   @ObservedObject private var monitor = LiveTranscriptMonitor.shared
+
+  /// Invoked when the user clicks the card. When non-nil, the card shows an
+  /// expand affordance and the whole surface becomes tappable.
+  var onExpand: (() -> Void)? = nil
+
+  @State private var isHovered = false
 
   var body: some View {
     VStack(alignment: .leading, spacing: OmiSpacing.sm) {
@@ -118,6 +127,11 @@ struct ConversationsLiveTranscript: View {
         Text("Live").scaledFont(size: OmiType.caption, weight: .semibold)
           .foregroundColor(OmiColors.textSecondary)
         Spacer()
+        if onExpand != nil {
+          Image(systemName: "arrow.up.left.and.arrow.down.right")
+            .scaledFont(size: OmiType.caption)
+            .foregroundColor(isHovered ? OmiColors.textSecondary : OmiColors.textTertiary)
+        }
       }
       if monitor.isEmpty {
         Text("Listening…").scaledFont(size: OmiType.body).foregroundColor(OmiColors.textTertiary)
@@ -125,6 +139,9 @@ struct ConversationsLiveTranscript: View {
       } else {
         LiveTranscriptView(segments: monitor.segments)
           .frame(maxHeight: 220)
+          // Let clicks fall through to the card's expand tap rather than being
+          // captured by the inner scroll / text selection.
+          .allowsHitTesting(false)
       }
     }
     .padding(OmiSpacing.lg)
@@ -133,8 +150,110 @@ struct ConversationsLiveTranscript: View {
         .fill(OmiColors.backgroundSecondary)
         .overlay(
           RoundedRectangle(cornerRadius: OmiChrome.cardRadius, style: .continuous)
-            .stroke(OmiColors.border.opacity(0.3), lineWidth: 1))
+            .stroke(
+              OmiColors.border.opacity(onExpand != nil && isHovered ? 0.55 : 0.3), lineWidth: 1))
     )
+    .contentShape(RoundedRectangle(cornerRadius: OmiChrome.cardRadius, style: .continuous))
+    .modifier(LiveTranscriptExpandTap(onExpand: onExpand, isHovered: $isHovered))
+  }
+}
+
+/// Adds the click-to-expand behavior only when an `onExpand` handler is present,
+/// so the card stays inert (no pointer cursor, no tap) when expansion is
+/// unavailable.
+private struct LiveTranscriptExpandTap: ViewModifier {
+  let onExpand: (() -> Void)?
+  @Binding var isHovered: Bool
+
+  /// Tracks whether we currently hold a pushed cursor so push/pop stay balanced
+  /// and the pointing-hand cursor is always popped when the card stops being
+  /// hovered — SwiftUI doesn't deliver an `onHover(false)` when the view leaves
+  /// the hierarchy. Two exit paths are handled explicitly: `onDisappear`
+  /// (recording stops and the `if appState.isTranscribing` card is removed) and
+  /// the tap handler (expanding draws the full-screen overlay over the card,
+  /// which stays mounted, so `onDisappear` never fires there).
+  @State private var didPushCursor = false
+
+  private func setHovered(_ hovering: Bool) {
+    isHovered = hovering
+    if hovering, !didPushCursor {
+      NSCursor.pointingHand.push()
+      didPushCursor = true
+    } else if !hovering, didPushCursor {
+      NSCursor.pop()
+      didPushCursor = false
+    }
+  }
+
+  func body(content: Content) -> some View {
+    if let onExpand {
+      content
+        .onTapGesture {
+          // Pop the pointing-hand before the overlay covers the still-mounted
+          // card, otherwise it lingers over the full-screen transcript.
+          setHovered(false)
+          onExpand()
+        }
+        .onHover { setHovered($0) }
+        .onDisappear { setHovered(false) }
+        .help("Expand live transcript")
+    } else {
+      content
+    }
+  }
+}
+
+/// Full-screen live transcript, presented when the user clicks the compact live
+/// transcript card. Observes the monitor directly so it keeps updating live.
+struct ConversationsLiveTranscriptFullScreen: View {
+  @ObservedObject private var monitor = LiveTranscriptMonitor.shared
+  var onCollapse: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack(spacing: OmiSpacing.sm) {
+        Circle().fill(Color.red).frame(width: 8, height: 8)
+        Text("Live Transcript")
+          .scaledFont(size: OmiType.subheading, weight: .semibold)
+          .foregroundColor(OmiColors.textPrimary)
+        Spacer()
+        Button(action: onCollapse) {
+          Image(systemName: "arrow.down.right.and.arrow.up.left")
+            .scaledFont(size: OmiType.body)
+            .foregroundColor(OmiColors.textSecondary)
+            .padding(OmiSpacing.sm)
+            .omiControlSurface(
+              fill: OmiColors.backgroundSecondary, radius: 14, stroke: OmiColors.border.opacity(0.2)
+            )
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut(.escape, modifiers: [])
+        .help("Collapse")
+      }
+      .padding(.horizontal, OmiSpacing.xxl)
+      .padding(.top, OmiSpacing.lg)
+      .padding(.bottom, OmiSpacing.md)
+
+      Divider().overlay(OmiColors.border.opacity(0.3))
+
+      if monitor.isEmpty {
+        VStack(spacing: OmiSpacing.md) {
+          Image(systemName: "waveform")
+            .scaledFont(size: 48)
+            .foregroundColor(OmiColors.textTertiary)
+            .opacity(0.5)
+          Text("Listening…")
+            .scaledFont(size: OmiType.body)
+            .foregroundColor(OmiColors.textTertiary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      } else {
+        LiveTranscriptView(segments: monitor.segments)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(OmiColors.backgroundPrimary)
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -70,6 +70,9 @@ struct ConversationsPage: View {
   @State private var isMerging: Bool = false
   @State private var mergeError: String? = nil
 
+  // Full-screen live transcript overlay
+  @State private var isLiveTranscriptExpanded: Bool = false
+
   var body: some View {
     Group {
       if let selected = selectedConversation {
@@ -164,6 +167,7 @@ struct ConversationsPage: View {
       showMergeConfirmation = false
       isMerging = false
       mergeError = nil
+      isLiveTranscriptExpanded = false
     }
     .dismissableSheet(isPresented: $showCreateFolderSheet) {
       FolderFormSheet(folder: nil, onDismiss: { showCreateFolderSheet = false })
@@ -223,7 +227,8 @@ struct ConversationsPage: View {
 
   private var mainConversationsView: some View {
     VStack(spacing: 0) {
-      // Conversations header
+      // Fixed page header — title + actions stay pinned; everything below it
+      // (live transcript, search, filters, list) scrolls together as one.
       HStack {
         Text("Conversations")
           .scaledFont(size: OmiType.heading, weight: .semibold)
@@ -250,15 +255,96 @@ struct ConversationsPage: View {
       .padding(.top, OmiSpacing.lg)
       .padding(.bottom, OmiSpacing.md)
 
-      // Live transcript while recording — updates as it's spoken.
+      // The whole page below the header scrolls together. Floating action bars
+      // (load-more, merge) stay pinned to the bottom via the ZStack overlay.
+      ZStack(alignment: .bottom) {
+        scrollingBody
+        floatingActionBars
+      }
+    }
+    .overlay {
+      if isLiveTranscriptExpanded {
+        ConversationsLiveTranscriptFullScreen(
+          onCollapse: {
+            OmiMotion.withGated(.easeInOut(duration: 0.2)) {
+              isLiveTranscriptExpanded = false
+            }
+          }
+        )
+        .transition(.opacity)
+      }
+    }
+    // Collapse the full-screen transcript if transcription stops while it's open.
+    .onChange(of: appState.isTranscribing) { _, isTranscribing in
+      if !isTranscribing {
+        isLiveTranscriptExpanded = false
+      }
+    }
+  }
+
+  /// Everything below the fixed header, rendered inside a single scroll so the
+  /// live transcript, search bar, filters and conversation list all scroll
+  /// together. When `embedded`, the parent owns the scroll and this renders bare.
+  @ViewBuilder private var scrollingBody: some View {
+    let content = VStack(spacing: 0) {
+      // Live transcript while recording — updates as it's spoken. Click to
+      // expand it full screen.
       if appState.isTranscribing {
-        ConversationsLiveTranscript()
-          .padding(.horizontal, OmiSpacing.xxl)
-          .padding(.bottom, OmiSpacing.md)
+        ConversationsLiveTranscript(
+          onExpand: {
+            OmiMotion.withGated(.easeInOut(duration: 0.2)) {
+              isLiveTranscriptExpanded = true
+            }
+          }
+        )
+        .padding(.horizontal, OmiSpacing.xxl)
+        .padding(.top, OmiSpacing.md)
+        .padding(.bottom, OmiSpacing.md)
       }
 
-      // Conversation list
       conversationListSection
+    }
+
+    if embedded {
+      content
+    } else {
+      // minHeight = viewport keeps short/empty/loading states filling the
+      // window (so their `maxHeight: .infinity` centering still works) while
+      // taller content scrolls normally.
+      GeometryReader { geo in
+        ScrollView {
+          content
+            .frame(maxWidth: .infinity, minHeight: geo.size.height, alignment: .top)
+        }
+        .refreshable {
+          await appState.refreshConversations()
+        }
+      }
+    }
+  }
+
+  /// Bottom-pinned floating controls that overlay the scroll (they must not
+  /// scroll with the content). Load-more only applies to the main list; the
+  /// merge bar applies to both list and search results.
+  @ViewBuilder private var floatingActionBars: some View {
+    if !embedded {
+      if searchQuery.isEmpty && appState.canLoadMoreConversations
+        && !(isMultiSelectMode && !selectedConversationIds.isEmpty)
+      {
+        Button("Load older conversations") {
+          Task {
+            await appState.loadMoreConversations()
+          }
+        }
+        .buttonStyle(.bordered)
+        .padding(.bottom, OmiSpacing.md)
+        .accessibilityIdentifier("conversations-load-more")
+      }
+
+      if isMultiSelectMode && !selectedConversationIds.isEmpty {
+        mergeActionBar
+          .transition(.move(edge: .bottom).combined(with: .opacity))
+      }
     }
   }
 
@@ -378,61 +464,45 @@ struct ConversationsPage: View {
       .padding(.horizontal, OmiSpacing.xxl)
       .padding(.bottom, OmiSpacing.md)
 
-      // List - show search results or regular conversations
+      // List - show search results or regular conversations. Both render
+      // embedded (no inner ScrollView); the page's outer ScrollView (see
+      // `scrollingBody`) owns scrolling so the whole page scrolls together.
+      // Floating load-more / merge bars live in `floatingActionBars`.
       if !searchQuery.isEmpty {
         // Search results view
         searchResultsView
       } else {
         // Regular conversation list
-        ZStack(alignment: .bottom) {
-          ConversationListView(
-            conversations: appState.conversations,
-            isLoading: appState.isLoadingConversations,
-            error: appState.conversationsError,
-            folders: appState.folders,
-            isCompactView: isCompactView,
-            onSelect: { conversation in
-              AnalyticsManager.shared.memoryListItemClicked(conversationId: conversation.id)
-              selectedConversation = conversation
-            },
-            onRefresh: {
-              Task {
-                await appState.refreshConversations()
-              }
-            },
-            onMoveToFolder: { conversationId, folderId in
-              await appState.moveConversationToFolder(conversationId, folderId: folderId)
-            },
-            isMultiSelectMode: isMultiSelectMode,
-            selectedIds: selectedConversationIds,
-            onToggleSelection: { conversationId in
-              if selectedConversationIds.contains(conversationId) {
-                selectedConversationIds.remove(conversationId)
-              } else {
-                selectedConversationIds.insert(conversationId)
-              }
-            },
-            embedded: embedded,
-            appState: appState
-          )
-
-          if appState.canLoadMoreConversations && !(isMultiSelectMode && !selectedConversationIds.isEmpty) {
-            Button("Load older conversations") {
-              Task {
-                await appState.loadMoreConversations()
-              }
+        ConversationListView(
+          conversations: appState.conversations,
+          isLoading: appState.isLoadingConversations,
+          error: appState.conversationsError,
+          folders: appState.folders,
+          isCompactView: isCompactView,
+          onSelect: { conversation in
+            AnalyticsManager.shared.memoryListItemClicked(conversationId: conversation.id)
+            selectedConversation = conversation
+          },
+          onRefresh: {
+            Task {
+              await appState.refreshConversations()
             }
-            .buttonStyle(.bordered)
-            .padding(.bottom, OmiSpacing.md)
-            .accessibilityIdentifier("conversations-load-more")
-          }
-
-          // Floating merge action bar
-          if isMultiSelectMode && !selectedConversationIds.isEmpty {
-            mergeActionBar
-              .transition(.move(edge: .bottom).combined(with: .opacity))
-          }
-        }
+          },
+          onMoveToFolder: { conversationId, folderId in
+            await appState.moveConversationToFolder(conversationId, folderId: folderId)
+          },
+          isMultiSelectMode: isMultiSelectMode,
+          selectedIds: selectedConversationIds,
+          onToggleSelection: { conversationId in
+            if selectedConversationIds.contains(conversationId) {
+              selectedConversationIds.remove(conversationId)
+            } else {
+              selectedConversationIds.insert(conversationId)
+            }
+          },
+          embedded: true,
+          appState: appState
+        )
       }
     }
   }
@@ -475,22 +545,16 @@ struct ConversationsPage: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
       } else {
-        ZStack(alignment: .bottom) {
-          searchResultsContent
-
-          // Floating merge action bar (also show in search results)
-          if isMultiSelectMode && !selectedConversationIds.isEmpty {
-            mergeActionBar
-              .transition(.move(edge: .bottom).combined(with: .opacity))
-          }
-        }
+        // Renders bare — the page's outer ScrollView owns scrolling and the
+        // merge bar floats via `floatingActionBars`.
+        searchResultsContent
       }
     }
   }
 
   @ViewBuilder
   private var searchResultsContent: some View {
-    let content = LazyVStack(spacing: OmiSpacing.sm) {
+    LazyVStack(spacing: OmiSpacing.sm) {
       ForEach(searchResults) { conversation in
         ConversationRowView(
           conversation: conversation,
@@ -518,14 +582,6 @@ struct ConversationsPage: View {
     }
     .padding(.horizontal, OmiSpacing.lg)
     .padding(.bottom, isMultiSelectMode && !selectedConversationIds.isEmpty ? 80 : OmiSpacing.lg)
-
-    if embedded {
-      content
-    } else {
-      ScrollView {
-        content
-      }
-    }
   }
 
   // MARK: - Search

--- a/desktop/macos/changelog/unreleased/20260722-conversations-page-scroll-live-expand.json
+++ b/desktop/macos/changelog/unreleased/20260722-conversations-page-scroll-live-expand.json
@@ -1,0 +1,3 @@
+{
+  "change": "The Conversations tab now scrolls as one — the live transcript scrolls with the search bar and list instead of staying pinned — and clicking the live transcript expands it to full screen"
+}


### PR DESCRIPTION
## What

The Conversations tab (Memory → Conversations) previously pinned the **live transcript card, search bar, and folder chips** as a fixed header while only the conversation list scrolled in its own `ScrollView`. When a live transcript was active it ate a large fixed chunk, leaving the list scrolling in a cramped strip.

This PR makes two changes the user asked for:

1. **The whole page scrolls as one.** Everything below the "Conversations" title — live transcript, search, filters, folder tabs, and list — now lives in a single `ScrollView` and scrolls together. Inner `ScrollView`s are suppressed via the existing `embedded` path; the floating "Load older" / merge bars are lifted into a bottom-pinned `ZStack` overlay so they keep floating instead of scrolling. A viewport-height `minHeight` keeps empty/loading states centered.
2. **Clicking the live transcript expands it full screen.** Clicking anywhere on the live card opens a full-screen `Live Transcript` overlay (collapse button + Esc). An expand affordance icon + hover cursor advertise it; the card's inner transcript is hit-test-disabled so a click anywhere expands rather than being captured by text selection.

## Files

- `desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift` — single-scroll refactor, floating-bar overlay, full-screen overlay state.
- `desktop/macos/Desktop/Sources/MainWindow/Components/LiveTranscriptView.swift` — expand affordance + tap-to-expand on the live card, new `ConversationsLiveTranscriptFullScreen`, balanced hover-cursor push/pop.
- `desktop/macos/changelog/unreleased/20260722-conversations-page-scroll-live-expand.json`

## Verification

Exercised live in a named test bundle (`omi-conv-scroll`, non-prod) using the hermetic `capture_test_transcript` seam to drive a live transcript without a mic:

- **Scroll**: with the live card active, scrolling the page moves the live card + search + chips + list together — after scrolling, the live card/search scrolled away and only the "Conversations" title stayed pinned.
- **Expand**: clicking the live card opened the full-screen Live Transcript overlay showing all segments; collapse control present.
- `xcrun swift build -c debug` — Build complete (exit 0).
- Clean release build `rm -rf .build && xcrun swift build -c release --package-path Desktop --triple arm64-apple-macosx` — Build complete (~570s, exit 0).
- Bounded pre-push gate passed (desktop Swift build, changelog schema, formatters).
- cubic local review: clean (0 issues, after addressing one P3 hover-cursor lifecycle nit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

