### PR TITLE
fix(desktop): provider-neutral copy when a background agent fails to start

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentFailureTranscriptFormatter.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentFailureTranscriptFormatter.swift
@@ -1,7 +1,11 @@
 import Foundation
 
 enum AgentFailureTranscriptFormatter {
-  static let genericSpawnFailure = "Agent couldn't start — check OpenClaw setup"
+  // Provider-neutral fallback: the default background agent is Omi-native, so a
+  // generic start failure must not blame OpenClaw (or any external provider) —
+  // the user may never have installed or intended to use one. Genuine
+  // missing-adapter errors still map to provider-specific setup copy below.
+  static let genericSpawnFailure = "Agent couldn't start — try again"
 
   static func errorText(for projection: AgentRunProjection) -> String? {
     switch projection.status {

--- a/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/VoiceTurnUIProjectionCopyTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/VoiceTurnUIProjectionCopyTests.swift
@@ -125,4 +125,31 @@ final class VoiceTurnUIProjectionCopyTests: XCTestCase {
         for: "URLSessionTask failed with error: timeout https://x"),
       "Failed: \(AgentFailureTranscriptFormatter.genericSpawnFailure)")
   }
+
+  /// A generic spawn failure (empty/transport/technical error with no known
+  /// external provider) must not blame OpenClaw — the default agent is
+  /// Omi-native, and the user may never have installed or intended OpenClaw.
+  /// Regression for the "Agent couldn't start — check OpenClaw setup" copy that
+  /// showed on plain background-agent failures.
+  func testGenericSpawnFailureIsProviderNeutral() {
+    XCTAssertFalse(
+      AgentFailureTranscriptFormatter.genericSpawnFailure.lowercased().contains("openclaw"),
+      "Generic spawn-failure copy must be provider-neutral")
+    XCTAssertFalse(
+      AgentFailureTranscriptFormatter.genericSpawnFailure.lowercased().contains("hermes"),
+      "Generic spawn-failure copy must be provider-neutral")
+
+    // A raw transport failure with no directed/known provider maps to the
+    // neutral generic copy — never a provider-specific setup hint.
+    let neutral = AgentFailureTranscriptFormatter.userFacingFailure(
+      "URLSessionTask failed with error: The request timed out. (-1001) https://example.com/v1")
+    XCTAssertFalse(neutral.lowercased().contains("openclaw"))
+
+    // Genuine missing-OpenClaw errors still map to OpenClaw setup copy.
+    XCTAssertEqual(
+      AgentFailureTranscriptFormatter.userFacingFailure(
+        "openclaw adapter not found",
+        harnessMode: .openclaw),
+      AgentPillsManager.DirectedProvider.openclaw.setupNeededStatus)
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260722-generic-agent-start-failure-copy.json
+++ b/desktop/macos/changelog/unreleased/20260722-generic-agent-start-failure-copy.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed background agents that fail to start showing a misleading \"check OpenClaw setup\" message even when OpenClaw was never used"
+}


### PR DESCRIPTION
## What

Background agents that fail to start showed **"Agent couldn't start — check OpenClaw setup"** even when OpenClaw was never used or installed. The default background agent is Omi-native (pi-mono), so a plain backend/transport failure on an ordinary task (e.g. "search the web and build an HTML page") wrongly told the user to check OpenClaw setup.

## Root cause

`AgentFailureTranscriptFormatter.genericSpawnFailure` hardcoded `"Agent couldn't start — check OpenClaw setup"` and was returned as the catch-all fallback for **any** unclassified start failure — empty errors, raw transport guts (URLSession/HTTP/timeouts), and long technical messages — regardless of which provider (if any) was used. Genuine missing-adapter errors are already handled separately by `looksLikeSetupNeeded()`, which maps to provider-specific setup copy; only the generic fallback was mislabeled.

## Fix

Make the generic fallback provider-neutral: `"Agent couldn't start — try again"`. Real OpenClaw/Hermes setup guidance is preserved — `looksLikeSetupNeeded()` still routes genuine missing-adapter errors to `DirectedProvider.setupNeededStatus` ("OpenClaw needs setup" / "Hermes needs setup").

## Product invariants

INV-CHAT-1 (One shared transcript across surfaces): respected. This change only edits a user-facing failure string and its unit test in `AgentFailureTranscriptFormatter`; it does not touch transcript/session ownership, the journal, or any store — no new continuity surface is introduced.

Failure-Class: none

## Verification

`cd desktop/macos && xcrun swift test --package-path Desktop --filter VoiceTurnUIProjectionCopyTests`

```
Test Suite 'VoiceTurnUIProjectionCopyTests' passed
Executed 8 tests, with 0 failures (0 unexpected)
```

- New `testGenericSpawnFailureIsProviderNeutral` asserts the generic fallback names no provider (OpenClaw/Hermes) and that a raw transport failure with no known provider maps to neutral copy.
- Existing `testAgentFailureSanitizesTransportGutsAndMapsSetupNeeded` still passes, confirming genuine missing-OpenClaw/Hermes errors continue to map to the correct provider setup copy.
- `cubic review -b`: 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

