### PR TITLE
fix(macos): return to Omi after OAuth

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/AuthService.swift": 3198,
+    "desktop/macos/Desktop/Sources/AuthService.swift": 2812,
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4256,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1578,

--- a/desktop/macos/Desktop/Sources/Auth/OAuthLoopbackCallbackServer.swift
+++ b/desktop/macos/Desktop/Sources/Auth/OAuthLoopbackCallbackServer.swift
@@ -1,0 +1,447 @@
+import Darwin
+import Foundation
+
+final class OAuthLoopbackCallbackServer: @unchecked Sendable {
+  enum ServerError: Error {
+    case socketCreationFailed
+    case bindFailed
+    case listenFailed
+    case portLookupFailed
+    case invalidRequest
+  }
+
+  private var socketFD: Int32?
+  private var activeClientFD: Int32?
+  private let queue = DispatchQueue(label: "com.omi.desktop.oauth-loopback-callback")
+  private let lock = NSLock()
+  private var continuation: CheckedContinuation<(code: String, state: String), Error>?
+  private var pendingResult: Result<(code: String, state: String), Error>?
+  private var completed = false
+  private let expectedState: String
+  private let appOpenURL: String
+
+  let port: UInt16
+  let redirectURI: String
+
+  private init(socketFD: Int32, port: UInt16, expectedState: String, appOpenURL: String) {
+    self.socketFD = socketFD
+    self.port = port
+    self.expectedState = expectedState
+    self.appOpenURL = appOpenURL
+    self.redirectURI = "http://127.0.0.1:\(port)/callback"
+  }
+
+  static func start(expectedState: String, appOpenURL: String) throws -> OAuthLoopbackCallbackServer {
+    let fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+    guard fd >= 0 else { throw ServerError.socketCreationFailed }
+
+    var addr = sockaddr_in()
+    addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+    addr.sin_family = sa_family_t(AF_INET)
+    addr.sin_port = 0
+    inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr)
+
+    let bindResult = withUnsafePointer(to: &addr) {
+      $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+        bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+      }
+    }
+    guard bindResult == 0 else {
+      close(fd)
+      throw ServerError.bindFailed
+    }
+
+    guard listen(fd, 1) == 0 else {
+      close(fd)
+      throw ServerError.listenFailed
+    }
+
+    var boundAddr = sockaddr_in()
+    var boundAddrLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+    let portResult = withUnsafeMutablePointer(to: &boundAddr) {
+      $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+        getsockname(fd, $0, &boundAddrLen)
+      }
+    }
+    guard portResult == 0 else {
+      close(fd)
+      throw ServerError.portLookupFailed
+    }
+
+    let server = OAuthLoopbackCallbackServer(
+      socketFD: fd,
+      port: UInt16(bigEndian: boundAddr.sin_port),
+      expectedState: expectedState,
+      appOpenURL: appOpenURL
+    )
+    server.acceptRequests()
+    return server
+  }
+
+  func waitForCallback() async throws -> (code: String, state: String) {
+    try await withCheckedThrowingContinuation { continuation in
+      lock.lock()
+      if let pendingResult {
+        lock.unlock()
+        continuation.resume(with: pendingResult)
+        return
+      }
+      self.continuation = continuation
+      lock.unlock()
+    }
+  }
+
+  func cancel() {
+    finish(.failure(AuthError.cancelled))
+  }
+
+  func fail(with error: Error) {
+    finish(.failure(error))
+  }
+
+  func stop() {
+    lock.lock()
+    let alreadyCompleted = completed
+    completed = true
+    closeSocketsLocked()
+    lock.unlock()
+    if !alreadyCompleted {
+      resumeIfNeeded(.failure(AuthError.cancelled))
+    }
+  }
+
+  deinit {
+    stop()
+  }
+
+  private func acceptRequests() {
+    queue.async { [weak self] in
+      guard let self else { return }
+
+      while !self.isCompleted {
+        guard let listenFD = self.currentListenSocket() else { return }
+
+        var remoteAddr = sockaddr()
+        var remoteLen = socklen_t(MemoryLayout<sockaddr>.size)
+        let clientFD = accept(listenFD, &remoteAddr, &remoteLen)
+        guard clientFD >= 0 else { continue }
+
+        self.setActiveClient(clientFD)
+        defer {
+          self.closeActiveClientIfMatching(clientFD)
+        }
+
+        var noSigPipe: Int32 = 1
+        setsockopt(clientFD, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
+
+        var timeout = timeval(tv_sec: 5, tv_usec: 0)
+        setsockopt(clientFD, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+        var buffer = [UInt8](repeating: 0, count: 8192)
+        let bytesRead = recv(clientFD, &buffer, buffer.count - 1, 0)
+        guard bytesRead > 0,
+          let request = String(bytes: buffer.prefix(bytesRead), encoding: .utf8)
+        else {
+          self.sendResponse(clientFD, page: .invalid)
+          continue
+        }
+
+        switch self.parseCallbackRequest(request) {
+        case .success(let code, let state):
+          self.sendResponse(clientFD, page: .success, appOpenURL: self.appOpenURL)
+          self.finish(.success((code: code, state: state)))
+          return
+        case .providerError(let error):
+          self.sendResponse(clientFD, page: .failure)
+          self.finish(.failure(AuthError.oauthError(error)))
+          return
+        case .ignore:
+          self.sendResponse(clientFD, page: .invalid)
+          continue
+        }
+      }
+    }
+  }
+
+  enum CallbackPage {
+    case success
+    case failure
+    case invalid
+
+    var httpStatus: String {
+      switch self {
+      case .success: return "200 OK"
+      case .failure, .invalid: return "400 Bad Request"
+      }
+    }
+
+    var documentTitle: String {
+      switch self {
+      case .success: return "Signed in - Omi"
+      case .failure, .invalid: return "Authentication failed - Omi"
+      }
+    }
+
+    var heading: String {
+      switch self {
+      case .success: return "You're signed in"
+      case .failure: return "Authentication failed"
+      case .invalid: return "Invalid callback"
+      }
+    }
+
+    var message: String {
+      switch self {
+      case .success: return "You can close this tab and return to Omi."
+      case .failure: return "You can close this tab and try again in the app."
+      case .invalid: return "This authentication callback was invalid. You can close this tab."
+      }
+    }
+
+    var icon: String {
+      switch self {
+      case .success: return "✓"
+      case .failure, .invalid: return "!"
+      }
+    }
+
+    var iconBackground: String {
+      switch self {
+      case .success: return "#111111"
+      case .failure, .invalid: return "#d32f2f"
+      }
+    }
+  }
+
+  /// Branded HTML body served on the local OAuth loopback callback.
+  /// Kept pure/static so unit tests can assert markup without opening a socket.
+  static func responseHTML(for page: CallbackPage, appOpenURL: String? = nil) -> String {
+    let openAppAction: String
+    switch (page, appOpenURL) {
+    case (.success, let .some(appOpenURL)):
+      let escapedURL = htmlAttributeEscaped(appOpenURL)
+      openAppAction = """
+                <p class="open-app-message">Opening Omi… If it doesn’t come to the front, select Open Omi.</p>
+                <a class="open-app-button" id="open-omi" href="\(escapedURL)">Open Omi</a>
+        """
+    default:
+      openAppAction = ""
+    }
+
+    let openAppScript: String
+    switch (page, appOpenURL) {
+    case (.success, .some):
+      openAppScript = """
+            <script>
+                window.setTimeout(function () {
+                    var openOmi = document.getElementById("open-omi");
+                    if (openOmi) { window.location.assign(openOmi.href); }
+                }, 100);
+            </script>
+        """
+    default:
+      openAppScript = ""
+    }
+
+    return """
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>\(page.documentTitle)</title>
+          <style>
+              body {
+                  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+                  display: flex;
+                  flex-direction: column;
+                  align-items: center;
+                  justify-content: center;
+                  min-height: 100vh;
+                  margin: 0;
+                  background-color: #f7f7f7;
+                  color: #333;
+              }
+              .card {
+                  background-color: white;
+                  border-radius: 8px;
+                  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+                  padding: 48px 32px;
+                  text-align: center;
+                  max-width: 400px;
+              }
+              .icon {
+                  width: 56px;
+                  height: 56px;
+                  margin: 0 auto 16px;
+                  border-radius: 50%;
+                  background-color: \(page.iconBackground);
+                  color: white;
+                  font-size: 28px;
+                  font-weight: 600;
+                  line-height: 56px;
+              }
+              h1 {
+                  font-size: 24px;
+                  font-weight: 600;
+                  margin: 0 0 12px 0;
+              }
+              p {
+                  font-size: 16px;
+                  color: #555;
+                  margin: 0;
+                  line-height: 1.5;
+              }
+              .open-app-message {
+                  margin-top: 20px;
+              }
+              .open-app-button {
+                  display: inline-block;
+                  margin-top: 16px;
+                  padding: 12px 20px;
+                  border-radius: 8px;
+                  background-color: #111111;
+                  color: white;
+                  font-size: 16px;
+                  font-weight: 600;
+                  text-decoration: none;
+              }
+          </style>
+      </head>
+      <body>
+          <div class="card">
+              <div class="icon">\(page.icon)</div>
+              <h1>\(page.heading)</h1>
+              <p>\(page.message)</p>
+      \(openAppAction)
+          </div>
+      \(openAppScript)
+      </body>
+      </html>
+      """
+  }
+
+  private static func htmlAttributeEscaped(_ value: String) -> String {
+    value
+      .replacingOccurrences(of: "&", with: "&amp;")
+      .replacingOccurrences(of: "\"", with: "&quot;")
+      .replacingOccurrences(of: "<", with: "&lt;")
+      .replacingOccurrences(of: ">", with: "&gt;")
+  }
+
+  private enum ParsedCallbackRequest {
+    case success(code: String, state: String)
+    case providerError(String)
+    case ignore
+  }
+
+  private func parseCallbackRequest(_ request: String) -> ParsedCallbackRequest {
+    guard let requestLine = request.split(separator: "\r\n", maxSplits: 1).first else {
+      return .ignore
+    }
+    let parts = requestLine.split(separator: " ")
+    guard parts.count >= 2, parts[0] == "GET" else {
+      return .ignore
+    }
+
+    let target = String(parts[1])
+    guard let components = URLComponents(string: "http://127.0.0.1\(target)"),
+      components.path == "/callback"
+    else {
+      return .ignore
+    }
+
+    let queryItems = components.queryItems ?? []
+    guard let state = queryItems.first(where: { $0.name == "state" })?.value,
+      state == expectedState
+    else {
+      return .ignore
+    }
+
+    if let providerError = queryItems.first(where: { $0.name == "error" })?.value {
+      return .providerError(providerError)
+    }
+
+    guard let code = queryItems.first(where: { $0.name == "code" })?.value else {
+      return .ignore
+    }
+    return .success(code: code, state: state)
+  }
+
+  private func sendResponse(_ clientFD: Int32, page: CallbackPage, appOpenURL: String? = nil) {
+    let body = Self.responseHTML(for: page, appOpenURL: appOpenURL)
+    let response = """
+      HTTP/1.1 \(page.httpStatus)\r
+      Content-Type: text/html; charset=utf-8\r
+      Content-Length: \(body.utf8.count)\r
+      Connection: close\r
+      \r
+      \(body)
+      """
+    response.withCString { pointer in
+      _ = send(clientFD, pointer, strlen(pointer), 0)
+    }
+  }
+
+  private func finish(_ result: Result<(code: String, state: String), Error>) {
+    lock.lock()
+    guard !completed else {
+      lock.unlock()
+      return
+    }
+    completed = true
+    closeSocketsLocked()
+    lock.unlock()
+    resumeIfNeeded(result)
+  }
+
+  private func resumeIfNeeded(_ result: Result<(code: String, state: String), Error>) {
+    lock.lock()
+    if let continuation {
+      self.continuation = nil
+      lock.unlock()
+      continuation.resume(with: result)
+    } else {
+      pendingResult = result
+      lock.unlock()
+    }
+  }
+
+  private var isCompleted: Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return completed
+  }
+
+  private func currentListenSocket() -> Int32? {
+    lock.lock()
+    defer { lock.unlock() }
+    return socketFD
+  }
+
+  private func setActiveClient(_ fd: Int32) {
+    lock.lock()
+    activeClientFD = fd
+    lock.unlock()
+  }
+
+  private func closeActiveClientIfMatching(_ fd: Int32) {
+    lock.lock()
+    if activeClientFD == fd {
+      activeClientFD = nil
+      close(fd)
+    }
+    lock.unlock()
+  }
+
+  private func closeSocketsLocked() {
+    if let activeClientFD {
+      close(activeClientFD)
+      self.activeClientFD = nil
+    }
+    if let socketFD {
+      close(socketFD)
+      self.socketFD = nil
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -1,7 +1,6 @@
 import AppKit
 import AuthenticationServices
 import CryptoKit
-import Darwin
 @preconcurrency import FirebaseAuth
 import FirebaseCore
 import Foundation
@@ -16,402 +15,6 @@ extension Notification.Name {
   /// plain UserDefaults, so onboarding can't observe them directly — it listens
   /// for this and re-reads `AuthService.shared.givenName`.
   static let authNameDidUpdate = Notification.Name("com.omi.desktop.authNameDidUpdate")
-}
-
-final class OAuthLoopbackCallbackServer: @unchecked Sendable {
-  enum ServerError: Error {
-    case socketCreationFailed
-    case bindFailed
-    case listenFailed
-    case portLookupFailed
-    case invalidRequest
-  }
-
-  private var socketFD: Int32?
-  private var activeClientFD: Int32?
-  private let queue = DispatchQueue(label: "com.omi.desktop.oauth-loopback-callback")
-  private let lock = NSLock()
-  private var continuation: CheckedContinuation<(code: String, state: String), Error>?
-  private var pendingResult: Result<(code: String, state: String), Error>?
-  private var completed = false
-  private let expectedState: String
-
-  let port: UInt16
-  let redirectURI: String
-
-  private init(socketFD: Int32, port: UInt16, expectedState: String) {
-    self.socketFD = socketFD
-    self.port = port
-    self.expectedState = expectedState
-    self.redirectURI = "http://127.0.0.1:\(port)/callback"
-  }
-
-  static func start(expectedState: String) throws -> OAuthLoopbackCallbackServer {
-    let fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
-    guard fd >= 0 else { throw ServerError.socketCreationFailed }
-
-    var addr = sockaddr_in()
-    addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
-    addr.sin_family = sa_family_t(AF_INET)
-    addr.sin_port = 0
-    inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr)
-
-    let bindResult = withUnsafePointer(to: &addr) {
-      $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-        bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
-      }
-    }
-    guard bindResult == 0 else {
-      close(fd)
-      throw ServerError.bindFailed
-    }
-
-    guard listen(fd, 1) == 0 else {
-      close(fd)
-      throw ServerError.listenFailed
-    }
-
-    var boundAddr = sockaddr_in()
-    var boundAddrLen = socklen_t(MemoryLayout<sockaddr_in>.size)
-    let portResult = withUnsafeMutablePointer(to: &boundAddr) {
-      $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-        getsockname(fd, $0, &boundAddrLen)
-      }
-    }
-    guard portResult == 0 else {
-      close(fd)
-      throw ServerError.portLookupFailed
-    }
-
-    let server = OAuthLoopbackCallbackServer(
-      socketFD: fd,
-      port: UInt16(bigEndian: boundAddr.sin_port),
-      expectedState: expectedState
-    )
-    server.acceptRequests()
-    return server
-  }
-
-  func waitForCallback() async throws -> (code: String, state: String) {
-    try await withCheckedThrowingContinuation { continuation in
-      lock.lock()
-      if let pendingResult {
-        lock.unlock()
-        continuation.resume(with: pendingResult)
-        return
-      }
-      self.continuation = continuation
-      lock.unlock()
-    }
-  }
-
-  func cancel() {
-    finish(.failure(AuthError.cancelled))
-  }
-
-  func fail(with error: Error) {
-    finish(.failure(error))
-  }
-
-  func stop() {
-    lock.lock()
-    let alreadyCompleted = completed
-    completed = true
-    closeSocketsLocked()
-    lock.unlock()
-    if !alreadyCompleted {
-      resumeIfNeeded(.failure(AuthError.cancelled))
-    }
-  }
-
-  deinit {
-    stop()
-  }
-
-  private func acceptRequests() {
-    queue.async { [weak self] in
-      guard let self else { return }
-
-      while !self.isCompleted {
-        guard let listenFD = self.currentListenSocket() else { return }
-
-        var remoteAddr = sockaddr()
-        var remoteLen = socklen_t(MemoryLayout<sockaddr>.size)
-        let clientFD = accept(listenFD, &remoteAddr, &remoteLen)
-        guard clientFD >= 0 else { continue }
-
-        self.setActiveClient(clientFD)
-        defer {
-          self.closeActiveClientIfMatching(clientFD)
-        }
-
-        var noSigPipe: Int32 = 1
-        setsockopt(clientFD, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
-
-        var timeout = timeval(tv_sec: 5, tv_usec: 0)
-        setsockopt(clientFD, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
-
-        var buffer = [UInt8](repeating: 0, count: 8192)
-        let bytesRead = recv(clientFD, &buffer, buffer.count - 1, 0)
-        guard bytesRead > 0,
-          let request = String(bytes: buffer.prefix(bytesRead), encoding: .utf8)
-        else {
-          self.sendResponse(clientFD, page: .invalid)
-          continue
-        }
-
-        switch self.parseCallbackRequest(request) {
-        case .success(let code, let state):
-          self.sendResponse(clientFD, page: .success)
-          self.finish(.success((code: code, state: state)))
-          return
-        case .providerError(let error):
-          self.sendResponse(clientFD, page: .failure)
-          self.finish(.failure(AuthError.oauthError(error)))
-          return
-        case .ignore:
-          self.sendResponse(clientFD, page: .invalid)
-          continue
-        }
-      }
-    }
-  }
-
-  enum CallbackPage {
-    case success
-    case failure
-    case invalid
-
-    var httpStatus: String {
-      switch self {
-      case .success: return "200 OK"
-      case .failure, .invalid: return "400 Bad Request"
-      }
-    }
-
-    var documentTitle: String {
-      switch self {
-      case .success: return "Signed in - Omi"
-      case .failure, .invalid: return "Authentication failed - Omi"
-      }
-    }
-
-    var heading: String {
-      switch self {
-      case .success: return "You're signed in"
-      case .failure: return "Authentication failed"
-      case .invalid: return "Invalid callback"
-      }
-    }
-
-    var message: String {
-      switch self {
-      case .success: return "You can close this tab and return to Omi."
-      case .failure: return "You can close this tab and try again in the app."
-      case .invalid: return "This authentication callback was invalid. You can close this tab."
-      }
-    }
-
-    var icon: String {
-      switch self {
-      case .success: return "✓"
-      case .failure, .invalid: return "!"
-      }
-    }
-
-    var iconBackground: String {
-      switch self {
-      case .success: return "#111111"
-      case .failure, .invalid: return "#d32f2f"
-      }
-    }
-  }
-
-  /// Branded HTML body served on the local OAuth loopback callback.
-  /// Kept pure/static so unit tests can assert markup without opening a socket.
-  static func responseHTML(for page: CallbackPage) -> String {
-    """
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>\(page.documentTitle)</title>
-        <style>
-            body {
-                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-                display: flex;
-                flex-direction: column;
-                align-items: center;
-                justify-content: center;
-                min-height: 100vh;
-                margin: 0;
-                background-color: #f7f7f7;
-                color: #333;
-            }
-            .card {
-                background-color: white;
-                border-radius: 8px;
-                box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-                padding: 48px 32px;
-                text-align: center;
-                max-width: 400px;
-            }
-            .icon {
-                width: 56px;
-                height: 56px;
-                margin: 0 auto 16px;
-                border-radius: 50%;
-                background-color: \(page.iconBackground);
-                color: white;
-                font-size: 28px;
-                font-weight: 600;
-                line-height: 56px;
-            }
-            h1 {
-                font-size: 24px;
-                font-weight: 600;
-                margin: 0 0 12px 0;
-            }
-            p {
-                font-size: 16px;
-                color: #555;
-                margin: 0;
-                line-height: 1.5;
-            }
-        </style>
-    </head>
-    <body>
-        <div class="card">
-            <div class="icon">\(page.icon)</div>
-            <h1>\(page.heading)</h1>
-            <p>\(page.message)</p>
-        </div>
-        <script>
-            setTimeout(function () {
-                try { window.close(); } catch (e) {}
-            }, 1200);
-        </script>
-    </body>
-    </html>
-    """
-  }
-
-  private enum ParsedCallbackRequest {
-    case success(code: String, state: String)
-    case providerError(String)
-    case ignore
-  }
-
-  private func parseCallbackRequest(_ request: String) -> ParsedCallbackRequest {
-    guard let requestLine = request.split(separator: "\r\n", maxSplits: 1).first else {
-      return .ignore
-    }
-    let parts = requestLine.split(separator: " ")
-    guard parts.count >= 2, parts[0] == "GET" else {
-      return .ignore
-    }
-
-    let target = String(parts[1])
-    guard let components = URLComponents(string: "http://127.0.0.1\(target)"),
-      components.path == "/callback"
-    else {
-      return .ignore
-    }
-
-    let queryItems = components.queryItems ?? []
-    guard let state = queryItems.first(where: { $0.name == "state" })?.value,
-      state == expectedState
-    else {
-      return .ignore
-    }
-
-    if let providerError = queryItems.first(where: { $0.name == "error" })?.value {
-      return .providerError(providerError)
-    }
-
-    guard let code = queryItems.first(where: { $0.name == "code" })?.value else {
-      return .ignore
-    }
-    return .success(code: code, state: state)
-  }
-
-  private func sendResponse(_ clientFD: Int32, page: CallbackPage) {
-    let body = Self.responseHTML(for: page)
-    let response = """
-      HTTP/1.1 \(page.httpStatus)\r
-      Content-Type: text/html; charset=utf-8\r
-      Content-Length: \(body.utf8.count)\r
-      Connection: close\r
-      \r
-      \(body)
-      """
-    response.withCString { pointer in
-      _ = send(clientFD, pointer, strlen(pointer), 0)
-    }
-  }
-
-  private func finish(_ result: Result<(code: String, state: String), Error>) {
-    lock.lock()
-    guard !completed else {
-      lock.unlock()
-      return
-    }
-    completed = true
-    closeSocketsLocked()
-    lock.unlock()
-    resumeIfNeeded(result)
-  }
-
-  private func resumeIfNeeded(_ result: Result<(code: String, state: String), Error>) {
-    lock.lock()
-    if let continuation {
-      self.continuation = nil
-      lock.unlock()
-      continuation.resume(with: result)
-    } else {
-      pendingResult = result
-      lock.unlock()
-    }
-  }
-
-  private var isCompleted: Bool {
-    lock.lock()
-    defer { lock.unlock() }
-    return completed
-  }
-
-  private func currentListenSocket() -> Int32? {
-    lock.lock()
-    defer { lock.unlock() }
-    return socketFD
-  }
-
-  private func setActiveClient(_ fd: Int32) {
-    lock.lock()
-    activeClientFD = fd
-    lock.unlock()
-  }
-
-  private func closeActiveClientIfMatching(_ fd: Int32) {
-    lock.lock()
-    if activeClientFD == fd {
-      activeClientFD = nil
-      close(fd)
-    }
-    lock.unlock()
-  }
-
-  private func closeSocketsLocked() {
-    if let activeClientFD {
-      close(activeClientFD)
-      self.activeClientFD = nil
-    }
-    if let socketFD {
-      close(socketFD)
-      self.socketFD = nil
-    }
-  }
 }
 
 @MainActor
@@ -1246,7 +849,10 @@ class AuthService {
 
       let callbackServer: OAuthLoopbackCallbackServer?
       do {
-        callbackServer = try OAuthLoopbackCallbackServer.start(expectedState: state)
+        callbackServer = try OAuthLoopbackCallbackServer.start(
+          expectedState: state,
+          appOpenURL: "\(urlScheme)://open"
+        )
         activeCallbackServer = callbackServer
         loopbackCallbackServer = callbackServer
       } catch {
@@ -1847,12 +1453,20 @@ class AuthService {
   }
 
   /// Focus the main Omi window after the browser finishes the OAuth handoff.
-  /// Filters to titled main windows so ordered-out panels (floating bar, overlays)
-  /// are not resurrected by a blanket `orderFrontRegardless()` sweep.
+  /// Reuses the app's primary summon path, which requests LaunchServices
+  /// activation when AppKit alone cannot take focus from the browser.
   @MainActor
   private func bringAppToFrontAfterAuthCallback() {
-    NSApp.activate()
+    if let appDelegate = AppDelegate.summonWindowTarget() {
+      appDelegate.openMainAppWindow()
+      return
+    }
+
+    NSApp.activate(ignoringOtherApps: true)
     for window in NSApp.windows where window.title.lowercased().hasPrefix("omi") {
+      if window.isMiniaturized {
+        window.deminiaturize(nil)
+      }
       window.makeKeyAndOrderFront(nil)
     }
   }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -2,6 +2,10 @@ import AppKit
 import OmiTheme
 import SwiftUI
 
+enum SBOnboardingRepository {
+  static let url = URL(string: "https://github.com/BasedHardware/omi")!
+}
+
 /// The Second Brain conversational onboarding — a chat with Omi that streams
 /// word-by-word and performs real side-effects. Replaces the legacy wizard.
 struct SBOnboardingView: View {
@@ -175,22 +179,29 @@ struct SBOnboardingView: View {
   private var promiseWidget: some View {
     VStack(alignment: .leading, spacing: 12) {
       VStack(spacing: 0) {
-        trustRow("OPEN", "Every line of me is on GitHub.")
+        trustRow("OPEN") {
+          HStack(spacing: 0) {
+            Text("Every line of me is on ")
+            Link("GitHub", destination: SBOnboardingRepository.url)
+              .underline()
+            Text(".")
+          }
+        }
         Divider().overlay(sb.ink(.w08))
-        trustRow("PRIVATE", "Your data is encrypted, and only yours.")
+        trustRow("PRIVATE") { Text("Your data is encrypted, and only yours.") }
         Divider().overlay(sb.ink(.w08))
-        trustRow("YOURS", "Pause me from the notch. Delete anything, forever.")
+        trustRow("YOURS") { Text("Pause me from the notch. Delete anything, forever.") }
       }
       .overlay(RoundedRectangle(cornerRadius: 13).stroke(sb.ink(.w1), lineWidth: 1))
       SBInkButton(title: "Set up Omi →") { model.answerPromise() }
     }
   }
 
-  private func trustRow(_ tag: String, _ text: String) -> some View {
+  private func trustRow<Content: View>(_ tag: String, @ViewBuilder content: () -> Content) -> some View {
     HStack(alignment: .top, spacing: 12) {
       Text(tag).geistMono(size: 11.5, weight: .medium).foregroundStyle(sb.ink(.w4)).frame(
         width: 52, alignment: .leading)
-      Text(text).geist(size: 14).foregroundStyle(sb.ink(.w85))
+      content().geist(size: 14).foregroundStyle(sb.ink(.w85))
       Spacer(minLength: 0)
     }
     .padding(.horizontal, 14).padding(.vertical, 12)

--- a/desktop/macos/Desktop/Tests/OAuthLoopbackCallbackServerTests.swift
+++ b/desktop/macos/Desktop/Tests/OAuthLoopbackCallbackServerTests.swift
@@ -5,7 +5,10 @@ import XCTest
 
 final class OAuthLoopbackCallbackServerTests: XCTestCase {
   func testReceivesCodeAndStateFromLoopbackCallback() async throws {
-    let server = try OAuthLoopbackCallbackServer.start(expectedState: "test-state")
+    let server = try OAuthLoopbackCallbackServer.start(
+      expectedState: "test-state",
+      appOpenURL: "omi-test://open"
+    )
     defer { server.stop() }
 
     let callbackTask = Task {
@@ -15,8 +18,9 @@ final class OAuthLoopbackCallbackServerTests: XCTestCase {
     let response = try sendLoopbackRequest(port: server.port, target: "/callback?code=test-code&state=test-state")
     XCTAssertTrue(response.hasPrefix("HTTP/1.1 200 OK"))
     XCTAssertTrue(response.contains("You're signed in"))
-    XCTAssertTrue(response.contains("You can close this tab and return to Omi."))
-    XCTAssertTrue(response.contains("window.close()"))
+    XCTAssertTrue(response.contains("Opening Omi…"))
+    XCTAssertTrue(response.contains("href=\"omi-test://open\""))
+    XCTAssertTrue(response.contains("window.location.assign(openOmi.href)"))
 
     let result = try await callbackTask.value
     XCTAssertEqual(result.code, "test-code")
@@ -27,7 +31,10 @@ final class OAuthLoopbackCallbackServerTests: XCTestCase {
   }
 
   func testIgnoresInvalidAndMismatchedRequestsBeforeValidCallback() async throws {
-    let server = try OAuthLoopbackCallbackServer.start(expectedState: "expected-state")
+    let server = try OAuthLoopbackCallbackServer.start(
+      expectedState: "expected-state",
+      appOpenURL: "omi-test://open"
+    )
     defer { server.stop() }
 
     let callbackTask = Task {
@@ -52,7 +59,10 @@ final class OAuthLoopbackCallbackServerTests: XCTestCase {
   }
 
   func testProviderErrorReturnsBrandedFailurePage() async throws {
-    let server = try OAuthLoopbackCallbackServer.start(expectedState: "expected-state")
+    let server = try OAuthLoopbackCallbackServer.start(
+      expectedState: "expected-state",
+      appOpenURL: "omi-test://open"
+    )
     defer { server.stop() }
 
     let callbackTask = Task {
@@ -76,10 +86,14 @@ final class OAuthLoopbackCallbackServerTests: XCTestCase {
   }
 
   func testResponseHTMLBuilderProducesBrandedSuccessAndFailurePages() {
-    let success = OAuthLoopbackCallbackServer.responseHTML(for: .success)
+    let success = OAuthLoopbackCallbackServer.responseHTML(for: .success, appOpenURL: "omi-test://open")
     XCTAssertTrue(success.contains("<title>Signed in - Omi</title>"))
     XCTAssertTrue(success.contains("You're signed in"))
     XCTAssertTrue(success.contains("background-color: #f7f7f7"))
+    XCTAssertTrue(success.contains("Open Omi"))
+    XCTAssertTrue(success.contains("href=\"omi-test://open\""))
+    XCTAssertTrue(success.contains("window.location.assign(openOmi.href)"))
+    XCTAssertFalse(success.contains("window.close()"))
     XCTAssertFalse(success.contains("Authentication complete. You can close this tab."))
 
     let failure = OAuthLoopbackCallbackServer.responseHTML(for: .failure)

--- a/desktop/macos/Desktop/Tests/SBOnboardingRepositoryTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingRepositoryTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class SBOnboardingRepositoryTests: XCTestCase {
+  func testGitHubLinkUsesOfficialOmiRepository() {
+    XCTAssertEqual(SBOnboardingRepository.url.absoluteString, "https://github.com/BasedHardware/omi")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260722-oauth-return-github-link.json
+++ b/desktop/macos/changelog/unreleased/20260722-oauth-return-github-link.json
@@ -1,0 +1,3 @@
+{
+  "change": "After signing in on macOS, Omi now returns to the app automatically with an Open Omi fallback; onboarding also links directly to Omi's GitHub repository."
+}

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -11,6 +11,7 @@ covers:
   - desktop/macos/Desktop/Sources/BundleEnvironment.swift
   - desktop/macos/Desktop/Sources/DesktopBackendEnvironment.swift
   - desktop/macos/Desktop/Sources/AuthService.swift
+  - desktop/macos/Desktop/Sources/Auth/OAuthLoopbackCallbackServer.swift
   - desktop/macos/Desktop/Sources/AuthSessionCoordinator.swift
   - desktop/macos/Desktop/Sources/Auth/SessionRecoveryView.swift
   - desktop/macos/Desktop/Sources/Auth/AuthStorageCanary.swift


### PR DESCRIPTION
## Summary

- Return macOS users to Omi after a successful loopback OAuth callback, with a browser-side **Open Omi** fallback.
- Link only the onboarding **GitHub** word to the official Omi repository.
- Move the callback server into the Auth feature area and ratchet the oversized AuthService baseline down.

## Product invariants affected

- INV-AUTH-1

## Failure class

Failure-Class: none

## Validation

- `swift test --package-path desktop/macos/Desktop --filter 'OAuthLoopbackCallbackServerTests|SBOnboardingRepositoryTests'` — 5 tests passed.
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed.
- `python3 desktop/macos/scripts/omi-harness run e2e/flows/harness-smoke.yaml --lane bridge --port 47895 --allow-legacy-flow-version` — passed.
- `make preflight` with this PR body — passed.

## Manual exercise

- Built and launched the isolated, ad-hoc-signed named bundle `/Applications/omi-auth-callback-github.app`; its local automation health endpoint reported a running macOS app and the expected development bundle identity.

## Independent review

- A subagent review found no P0–P3 issues; it confirmed the custom `://open` route cannot resume or mutate the OAuth session and that the GitHub link is scoped to the intended word.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

