### PR TITLE
Restore chat history atomically on macOS startup

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1969,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3643,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4496,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4494,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3298,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5706,
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1690

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6304,
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6258,
     "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2861
   },
   "raise_justifications": {

--- a/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
+++ b/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
@@ -242,9 +242,9 @@ final class KernelTurnProjection {
         await self.refresh(surface: surface)
       }
     }
-    if let surface = host?.mainChatSurfaceReference() {
-      await refresh(surface: surface, lease: lease)
-    }
+    // The visible-chat loader owns the first replay so it can keep the
+    // transcript in its loading state until the complete snapshot is ready.
+    // Event notifications above still refresh an already-mounted surface.
   }
 
   /// Attach the owner-bound client for a non-production journal control action
@@ -289,6 +289,14 @@ final class KernelTurnProjection {
       }
     }
 
+    // A restored conversation is not live streaming. Collect all contiguous
+    // turns fetched by this refresh, then publish one coherent transcript
+    // snapshot after the journal range is settled. Publishing each durable row
+    // independently makes first launch look like the user is watching old
+    // history arrive in real time, and causes the chat viewport to chase it.
+    var pendingProjectionTurns: [KernelJournalTurn] = []
+    var shouldResetProjection = false
+
     repeat {
       guard isCurrent(lease) else { return }
       if refreshRequestedSurfaceEpochs[surfaceKey] == lease.epoch {
@@ -323,7 +331,10 @@ final class KernelTurnProjection {
             highWaterByConversation[checkpointKey] = page.generationBaseTurnSeq
             generationByConversation[checkpointKey] = page.conversationGeneration
             guard isCurrent(lease) else { return }
-            host?.resetJournalProjection(surface: surface)
+            // A newer generation invalidates every accumulated row from the
+            // prior one. Keep the reset and its replacement snapshot atomic.
+            pendingProjectionTurns.removeAll()
+            shouldResetProjection = true
           }
           generationByConversation[checkpointKey] = page.conversationGeneration
           var contiguous = highWaterByConversation[checkpointKey] ?? 0
@@ -333,7 +344,7 @@ final class KernelTurnProjection {
           )
           for turn in contiguousPage {
             guard isCurrent(lease) else { return }
-            host?.projectJournalTurn(turn)
+            pendingProjectionTurns.append(turn)
             contiguous = turn.turnSeq
             highWaterByConversation[checkpointKey] = contiguous
           }
@@ -361,6 +372,12 @@ final class KernelTurnProjection {
         }
       }
     } while isCurrent(lease) && refreshRequestedSurfaceEpochs[surfaceKey] == lease.epoch
+
+    guard isCurrent(lease) else { return }
+    if shouldResetProjection {
+      host?.resetJournalProjection(surface: surface)
+    }
+    host?.projectJournalTurns(pendingProjectionTurns)
   }
 
   func reload(surface: AgentSurfaceReference) async {

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -138,6 +138,11 @@ struct ChatMessagesView<WelcomeContent: View>: View {
   /// Whether the initial history load for this conversation has been handled.
   /// Prevents repeated initial bottom settling on subsequent messages.count changes.
   @State private var initialRestoreHandled = false
+  /// The one deferred initial restore waits for the first transcript layout.
+  /// Geometry changes during that interval must not introduce additional
+  /// bottom-scroll commands, or saved history visibly flies through the view.
+  @State private var isInitialRestorePending = false
+  @State private var initialRestoreWorkItem: DispatchWorkItem?
 
   // MARK: - Prepend Preservation (Load Earlier Messages)
 
@@ -195,6 +200,13 @@ struct ChatMessagesView<WelcomeContent: View>: View {
     // MARK: - React to message count changes
     .onChange(of: messages.count) { oldCount, newCount in
       handleMessagesCountChange(oldCount: oldCount, newCount: newCount, proxy: proxy)
+    }
+    // A journal restore may be populated by background events while the
+    // loader is still collecting its canonical snapshot. Reveal it only after
+    // loading completes, then make one initial placement at the live edge.
+    .onChange(of: isLoadingInitial) { wasLoading, isLoading in
+      guard wasLoading, !isLoading, !messages.isEmpty else { return }
+      handleInitialRestore(proxy: proxy)
     }
     // MARK: - React to streaming text changes
     .onChange(of: messages.last?.text) { _, _ in
@@ -254,7 +266,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
       }
     }
     .onAppear {
-      if !messages.isEmpty {
+      if !isLoadingInitial, !messages.isEmpty {
         handleInitialRestore(proxy: proxy)
       }
     }
@@ -272,6 +284,10 @@ struct ChatMessagesView<WelcomeContent: View>: View {
   /// - New messages arriving while scrolled away (activity indicator)
   /// - Prepend detection (load earlier)
   private func handleMessagesCountChange(oldCount: Int, newCount: Int, proxy: ScrollViewProxy) {
+    // Saved journal rows are not live arrivals. The loading-complete observer
+    // above performs their one final placement after the snapshot is visible.
+    guard !isLoadingInitial else { return }
+
     if newCount > oldCount {
       // --- Initial restore: messages went from 0→N ---
       if oldCount == 0 && newCount > 0 {
@@ -295,6 +311,8 @@ struct ChatMessagesView<WelcomeContent: View>: View {
   }
 
   private func handleLiveContentChange(proxy: ScrollViewProxy) {
+    guard !isLoadingInitial else { return }
+
     switch scrollMode {
     case .followingBottom:
       throttledScrollToBottom(proxy: proxy)
@@ -314,10 +332,18 @@ struct ChatMessagesView<WelcomeContent: View>: View {
 
     scrollMode = .followingBottom
     hasActivityBelow = false
-    scrollToBottom(proxy: proxy)
-    scheduleInitialScroll(proxy: proxy, delay: 0.05)
-    scheduleInitialScroll(proxy: proxy, delay: 0.18)
-    scheduleInitialScroll(proxy: proxy, delay: 0.45)
+    isInitialRestorePending = true
+
+    let work = DispatchWorkItem { [self] in
+      defer {
+        isInitialRestorePending = false
+        initialRestoreWorkItem = nil
+      }
+      guard scrollMode == .followingBottom, !userIsScrolling else { return }
+      scrollToBottom(proxy: proxy)
+    }
+    initialRestoreWorkItem = work
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
   }
 
   // MARK: - Local Send / Turn Anchoring
@@ -374,7 +400,15 @@ struct ChatMessagesView<WelcomeContent: View>: View {
     guard size != lastScrollViewportSize else { return }
     lastScrollViewportSize = size
 
-    guard scrollMode == .followingBottom, !userIsScrolling, !messages.isEmpty else { return }
+    guard
+      !isLoadingInitial,
+      scrollMode == .followingBottom,
+      !userIsScrolling,
+      !isInitialRestorePending,
+      !messages.isEmpty
+    else {
+      return
+    }
     scrollToBottom(proxy: proxy)
     scheduleInitialScroll(proxy: proxy, delay: 0.08)
   }
@@ -415,6 +449,9 @@ struct ChatMessagesView<WelcomeContent: View>: View {
     scrollThrottleWorkItem = nil
     userScrollEndWorkItem?.cancel()
     userScrollEndWorkItem = nil
+    initialRestoreWorkItem?.cancel()
+    initialRestoreWorkItem = nil
+    isInitialRestorePending = false
     for item in initialScrollWorkItems {
       item.cancel()
     }
@@ -449,7 +486,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
 
   @ViewBuilder
   private var messageContent: some View {
-    if isLoadingInitial && messages.isEmpty && sessionsLoadError == nil {
+    if isLoadingInitial && sessionsLoadError == nil {
       VStack(spacing: OmiSpacing.md) {
         ProgressView()
           .scaleEffect(0.8)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
@@ -377,8 +377,7 @@ struct ChatPage: View {
       isSending: chatProvider.isSending,
       hasMoreMessages: chatProvider.hasMoreMessages,
       isLoadingMoreMessages: chatProvider.isLoadingMoreMessages,
-      isLoadingInitial: (chatProvider.isLoading || chatProvider.isLoadingSessions)
-        && !chatProvider.isClearing,
+      isLoadingInitial: chatProvider.isLoading && !chatProvider.isClearing,
       app: selectedApp,
       onLoadMore: { await chatProvider.loadMoreMessages() },
       onRate: { messageId, rating in

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -595,8 +595,7 @@ struct DashboardPage: View {
         isSending: chatProvider.isSending,
         hasMoreMessages: chatProvider.hasMoreMessages,
         isLoadingMoreMessages: chatProvider.isLoadingMoreMessages,
-        isLoadingInitial: (chatProvider.isLoading || chatProvider.isLoadingSessions)
-          && !chatProvider.isClearing,
+        isLoadingInitial: chatProvider.isLoading && !chatProvider.isClearing,
         app: selectedApp,
         onLoadMore: { await chatProvider.loadMoreMessages() },
         onRate: { messageId, rating in
@@ -1092,8 +1091,7 @@ struct DashboardPage: View {
         isSending: chatProvider.isSending,
         hasMoreMessages: chatProvider.hasMoreMessages,
         isLoadingMoreMessages: chatProvider.isLoadingMoreMessages,
-        isLoadingInitial: (chatProvider.isLoading || chatProvider.isLoadingSessions)
-          && !chatProvider.isClearing,
+        isLoadingInitial: chatProvider.isLoading && !chatProvider.isClearing,
         app: selectedApp,
         onLoadMore: { await chatProvider.loadMoreMessages() },
         onRate: { messageId, rating in

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+extension ChatProvider {
+  /// Projects a journal refresh as one visible transcript update. The kernel
+  /// can return a complete saved history in several pages; treating each row
+  /// as a live UI mutation makes startup replay visibly scroll through old
+  /// messages. Keep the journal ordered at the boundary, then publish its
+  /// complete projection atomically.
+  func projectJournalTurns(_ turns: [KernelJournalTurn]) {
+    guard !turns.isEmpty else { return }
+
+    let expected = mainChatSurfaceReference()
+    let voiceCompanion = expected.realtimeVoiceCompanion()
+    var updatedMessages = messages
+
+    for turn in turns {
+      let isCanonicalChatSurface =
+        turn.surfaceKind == expected.surfaceKind
+        || turn.surfaceKind == voiceCompanion.surfaceKind
+      guard isCanonicalChatSurface,
+        turn.externalRefKind == expected.externalRefKind,
+        turn.externalRefId == expected.externalRefId
+      else { continue }
+
+      let projected = turn.chatMessage()
+      for block in projected.contentBlocks {
+        guard case .agentSpawn(_, let projectedPillID, _, _, _, _, _) = block,
+          let pillID = projectedPillID
+        else { continue }
+        AgentPillsManager.shared.bindProducingJournalSurface(
+          pillID: pillID,
+          surface: expected
+        )
+      }
+
+      let isEmptyTerminalPlaceholder =
+        turn.status == .failed
+        && projected.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        && projected.contentBlocks.isEmpty
+        && projected.resources.isEmpty
+      if isEmptyTerminalPlaceholder {
+        updatedMessages.removeAll { $0.id == projected.id }
+      } else if let index = updatedMessages.firstIndex(where: { $0.id == projected.id }) {
+        updatedMessages[index] = Self.carryingLocalOnlyFields(projected, from: updatedMessages[index])
+      } else if let continuityKey = projected.clientTurnId,
+        let index = updatedMessages.firstIndex(where: {
+          $0.clientTurnId == continuityKey && $0.sender == projected.sender
+        })
+      {
+        updatedMessages[index] = Self.carryingLocalOnlyFields(projected, from: updatedMessages[index])
+      } else {
+        updatedMessages.append(projected)
+      }
+    }
+
+    updatedMessages.sort {
+      if $0.createdAt == $1.createdAt { return $0.id < $1.id }
+      return $0.createdAt < $1.createdAt
+    }
+    messages = updatedMessages
+  }
+
+  func projectJournalTurn(_ turn: KernelJournalTurn) {
+    projectJournalTurns([turn])
+  }
+}

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -3320,52 +3320,6 @@ class ChatProvider: ObservableObject {
     return merged
   }
 
-  func projectJournalTurn(_ turn: KernelJournalTurn) {
-    let expected = mainChatSurfaceReference()
-    let voiceCompanion = expected.realtimeVoiceCompanion()
-    let isCanonicalChatSurface =
-      turn.surfaceKind == expected.surfaceKind
-      || turn.surfaceKind == voiceCompanion.surfaceKind
-    guard isCanonicalChatSurface,
-      turn.externalRefKind == expected.externalRefKind,
-      turn.externalRefId == expected.externalRefId
-    else { return }
-    let projected = turn.chatMessage()
-    for block in projected.contentBlocks {
-      guard case .agentSpawn(_, let projectedPillID, _, _, _, _, _) = block,
-        let pillID = projectedPillID
-      else { continue }
-      AgentPillsManager.shared.bindProducingJournalSurface(
-        pillID: pillID,
-        surface: expected
-      )
-    }
-    let isEmptyTerminalPlaceholder =
-      turn.status == .failed
-      && projected.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-      && projected.contentBlocks.isEmpty
-      && projected.resources.isEmpty
-    if isEmptyTerminalPlaceholder {
-      messages.removeAll { $0.id == projected.id }
-      return
-    }
-    if let index = messages.firstIndex(where: { $0.id == projected.id }) {
-      messages[index] = Self.carryingLocalOnlyFields(projected, from: messages[index])
-    } else if let continuityKey = projected.clientTurnId,
-      let index = messages.firstIndex(where: {
-        $0.clientTurnId == continuityKey && $0.sender == projected.sender
-      })
-    {
-      messages[index] = Self.carryingLocalOnlyFields(projected, from: messages[index])
-    } else {
-      messages.append(projected)
-    }
-    messages.sort {
-      if $0.createdAt == $1.createdAt { return $0.id < $1.id }
-      return $0.createdAt < $1.createdAt
-    }
-  }
-
   func resetJournalProjection(surface: AgentSurfaceReference) {
     guard surface == mainChatSurfaceReference() else { return }
     messages = []

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -967,10 +967,13 @@ import XCTest
     let source = try chatMessagesViewSource()
 
     XCTAssertTrue(source.contains("On the first load of a saved conversation, follow the latest message."))
-    XCTAssertTrue(
-      source.contains("    scrollToBottom(proxy: proxy)\n    scheduleInitialScroll(proxy: proxy, delay: 0.05)"))
-    XCTAssertTrue(source.contains("scheduleInitialScroll(proxy: proxy, delay: 0.18)"))
-    XCTAssertTrue(source.contains("scheduleInitialScroll(proxy: proxy, delay: 0.45)"))
+    // omi-test-quality: source-inspection -- static contract: startup history
+    // has one deferred restore; its behavioral counterpart asserts one atomic
+    // journal snapshot in KernelTurnRecordedProjectionTests.
+    XCTAssertTrue(source.contains("isInitialRestorePending = true"))
+    XCTAssertTrue(source.contains("DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)"))
+    XCTAssertFalse(source.contains("scheduleInitialScroll(proxy: proxy, delay: 0.18)"))
+    XCTAssertFalse(source.contains("scheduleInitialScroll(proxy: proxy, delay: 0.45)"))
     XCTAssertTrue(source.contains("private func handleViewportSizeChange(_ size: CGSize, proxy: ScrollViewProxy)"))
     XCTAssertTrue(source.contains(".background(viewportResizeDetector(proxy: proxy))"))
     XCTAssertTrue(

--- a/desktop/macos/Desktop/Tests/DesktopChatDriftGuardTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopChatDriftGuardTests.swift
@@ -41,6 +41,29 @@ final class DesktopChatDriftGuardTests: XCTestCase {
     XCTAssertTrue(mainChat.contains(".padding(.vertical, OmiSpacing.sm)"))
   }
 
+  func testChatTranscriptLoaderIgnoresSessionListRefreshes() throws {
+    let chatPage = try sourceFile("MainWindow/Pages/ChatPage.swift")
+    let dashboardPage = try sourceFile("MainWindow/Pages/DashboardPage.swift")
+
+    for source in [chatPage, dashboardPage] {
+      XCTAssertFalse(
+        source.contains("isLoadingInitial: (chatProvider.isLoading || chatProvider.isLoadingSessions)"),
+        "Session-list refreshes must not hide a non-empty transcript behind the initial message-history loader."
+      )
+      XCTAssertFalse(
+        source.contains("isLoadingInitial: chatProvider.isLoadingSessions"),
+        "Session-list refreshes must not drive the transcript's initial loader."
+      )
+    }
+
+    XCTAssertTrue(chatPage.contains("isLoadingInitial: chatProvider.isLoading && !chatProvider.isClearing"))
+    XCTAssertEqual(
+      dashboardPage.components(separatedBy: "isLoadingInitial: chatProvider.isLoading && !chatProvider.isClearing")
+        .count - 1,
+      2
+    )
+  }
+
   func testNoNewMirroredFromChatProviderTaskChatHelperBlocks() throws {
     let markers = try swiftSourceLines(containingAnyOf: [
       "mirrored from ChatProvider",

--- a/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import XCTest
 
 @testable import Omi_Computer
@@ -370,6 +371,55 @@ import XCTest
 
       XCTAssertEqual(provider.messages.map(\.id), ["owner-b-turn"])
       XCTAssertEqual(provider.messages.map(\.text), ["Owner B history"])
+    }
+
+    func testInitialHistoryReplayPublishesOneCompleteTranscriptSnapshot() async throws {
+      let provider = ChatProvider()
+      let surface = provider.mainChatSurfaceReference()
+      let first = try turn(surface: surface, turnId: "saved-1", turnSeq: 1, content: "First saved reply")
+      let second = try turn(surface: surface, turnId: "saved-2", turnSeq: 2, content: "Second saved reply")
+      let third = try turn(surface: surface, turnId: "saved-3", turnSeq: 3, content: "Latest saved reply")
+      var publishedSnapshots: [[String]] = []
+      let observation = provider.$messages.dropFirst().sink { messages in
+        guard !messages.isEmpty else { return }
+        publishedSnapshots.append(messages.map(\.id))
+      }
+      defer { observation.cancel() }
+
+      let projection = KernelTurnProjection(
+        host: provider,
+        client: AgentClient.Session(harnessMode: "piMono"),
+        ownerIDProvider: { "history-owner" },
+        journalListOperation: { _, _, _, afterTurnSeq, _ in
+          if afterTurnSeq == 0 {
+            return AgentRuntimeProcess.JournalOperationResult(
+              operation: "list",
+              conversationId: "history-conversation",
+              turn: nil,
+              turns: [first, second],
+              clearedCount: 0,
+              highWaterTurnSeq: 3,
+              conversationGeneration: 1,
+              generationBaseTurnSeq: 0
+            )
+          }
+          return AgentRuntimeProcess.JournalOperationResult(
+            operation: "list",
+            conversationId: "history-conversation",
+            turn: nil,
+            turns: [third],
+            clearedCount: 0,
+            highWaterTurnSeq: 3,
+            conversationGeneration: 1,
+            generationBaseTurnSeq: 0
+          )
+        }
+      )
+
+      await projection.refresh(surface: surface)
+
+      XCTAssertEqual(provider.messages.map(\.id), ["saved-1", "saved-2", "saved-3"])
+      XCTAssertEqual(publishedSnapshots, [["saved-1", "saved-2", "saved-3"]])
     }
 
     func testClearBootstrapsExactGenerationAfterOwnerProjectionInvalidation() async {

--- a/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
@@ -1106,6 +1106,7 @@ import XCTest
     /// Static architecture tripwire; behavioral journal coverage lives above.
     func testKernelJournalIsOnlyDurableDesktopChatWriter() throws {
       let provider = try sourceFile("Providers/ChatProvider.swift")
+      let journalProjection = try sourceFile("Providers/ChatProvider+JournalProjection.swift")
       let taskState = try sourceFile(
         "ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift")
       let taskStorage = try sourceFile("Rewind/Core/TaskChatMessageStorage.swift")
@@ -1142,7 +1143,7 @@ import XCTest
       let projection = try sourceFile("Chat/KernelTurnProjection.swift")
       let floating = try sourceFile("FloatingControlBar/FloatingControlBarWindow.swift")
       let pills = try sourceFile("FloatingControlBar/AgentPill.swift")
-      XCTAssertTrue(provider.contains("AgentPillsManager.shared.bindProducingJournalSurface("))
+      XCTAssertTrue(journalProjection.contains("AgentPillsManager.shared.bindProducingJournalSurface("))
       XCTAssertTrue(floating.contains("pill?.producingJournalSurface"))
       XCTAssertTrue(pills.contains("producingSurface: pill.producingJournalSurface"))
       for source in [projection, floating, pills] {

--- a/desktop/macos/changelog/unreleased/20260722-atomic-chat-history-restore.json
+++ b/desktop/macos/changelog/unreleased/20260722-atomic-chat-history-restore.json
@@ -1,0 +1,3 @@
+{
+  "change": "Saved chat history now opens as a complete conversation instead of visibly replaying message by message."
+}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -19,6 +19,7 @@ covers:
   - desktop/macos/Desktop/Sources/BrowserExtensionSetup.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
   - desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+  - desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
   - desktop/macos/Desktop/Sources/Providers/ChatProvider+Skills.swift
   - desktop/macos/Desktop/Sources/Providers/ChatSkillCatalog.swift
   - desktop/macos/Desktop/Sources/Providers/ChatProvider+HarnessReset.swift


### PR DESCRIPTION
## Summary

- Batch the initial main-chat journal replay into one complete transcript publication.
- Keep saved history behind the loading surface and restore the live edge once after loading.
- Split journal projection batching into a focused provider extension and ratchet the oversized provider baseline down.

## Product invariants

- INV-AUTH-1
- INV-CHAT-1

## Verification

- `xcrun swift test -c debug --package-path Desktop --filter KernelTurnRecordedProjectionTests/testInitialHistoryReplayPublishesOneCompleteTranscriptSnapshot`
- `xcrun swift test -c debug --package-path Desktop --filter AgentPillLifecycleTests/testSharedChatMessagesOpenAndSendFollowLatest`
- `./scripts/agent-logic-harness.sh` (506 focused Swift tests, 579 agent-runtime tests, Node package test)
- Named `omi-history-restore` bundle: Home opened in chat with five restored messages and no sending, streaming, or error state.
- `make preflight`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



Failure-Class: none
