### PR TITLE
ci(desktop): build a beta candidate on every macOS merge to main

### DIFF
--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -141,7 +141,17 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         qualification = workflow("desktop_qualify_beta.yml")
         beta = workflow("desktop_promote_beta.yml")
         self.assertIn("schedule:", candidate)
-        self.assertIn("workflow_dispatch:\n  schedule:", candidate)
+        self.assertIn("workflow_dispatch:", candidate)
+        # Auto-release also fires on macOS-affecting merges to main so a candidate
+        # is planned within minutes of a merge. This stays a single candidate
+        # authority: every trigger runs the same fenced planner (quiet-window +
+        # one-active-release), and beta promotion keys off the qualification's
+        # workflow_dispatch event below, not this workflow's trigger. Chained
+        # triggers that could form a second authority remain forbidden.
+        self.assertIn("push:", candidate)
+        self.assertIn("branches: [main]", candidate)
+        self.assertNotIn("workflow_run:", candidate)
+        self.assertNotIn("workflow_call:", candidate)
         self.assertNotIn("uses: ./.github/workflows/desktop_promote_beta.yml", qualification)
         self.assertNotIn("promote-qualified-beta:", qualification)
         self.assertIn('workflows: ["Qualify Desktop Beta Candidate"]', beta)

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -116,7 +116,13 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
 
     def test_workflow_has_no_input_manual_trigger_and_tags_the_changelog_commit(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn("workflow_dispatch:\n  schedule:", workflow)
+        # workflow_dispatch stays bare (no manual inputs). Auto-release now also
+        # fires on macOS-affecting merges to main (push) so a candidate is planned
+        # within minutes; the schedule remains as a backstop for merges that land
+        # inside the quiet window. No `inputs:` may appear in the trigger block.
+        self.assertIn("  workflow_dispatch:\n", workflow)
+        self.assertNotIn("inputs:", workflow.split("\njobs:", 1)[0])
+        self.assertIn("  push:\n    branches: [main]", workflow)
         self.assertIn("- cron: '17 * * * *'", workflow)
         self.assertNotIn("break_glass", workflow)
         self.assertIn("source_sha: ${{ steps.plan.outputs.source_sha }}", workflow)

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -2,9 +2,22 @@ name: Build Desktop Release Candidate
 
 on:
   workflow_dispatch:
+  # Fire on every macOS-affecting merge to main so a candidate is planned within
+  # minutes of the merge instead of waiting for the hourly retry. The push filter
+  # is intentionally coarse (the planner does the precise releasable-change check,
+  # excluding CHANGELOG/AGENTS/changelog/Backend-Rust); the same quiet-window,
+  # exact-SHA, and one-active-release fences below still admit at most one
+  # eligible candidate at a time, so bursts collapse to the newest SHA.
+  push:
+    branches: [main]
+    paths:
+      - 'desktop/macos/**'
+      - '.github/scripts/plan-desktop-release.py'
+      - '.github/workflows/desktop_auto_release.yml'
+      - '.github/workflows/desktop-swift-ci.yml'
   schedule:
-    # Retry hourly; planner quiet-window, exact-SHA checks, and active-release
-    # fences still admit at most one eligible candidate at a time.
+    # Backstop retry so a merge that lands inside the quiet window (or while a
+    # release is active) is still picked up after those fences clear.
     - cron: '17 * * * *'
 
 permissions:


### PR DESCRIPTION
## Summary

Trigger the desktop beta release pipeline on **every macOS-affecting merge to main**, instead of only the hourly cron. New macOS code now plans a candidate within minutes of the merge (past the planner's 10-minute quiet window) rather than waiting up to an hour.

## What changed
- `desktop_auto_release.yml`: added a `push` trigger scoped to `main` + the desktop release paths (`desktop/macos/**`, the planner script, and the two desktop workflows). Kept `workflow_dispatch` and the hourly `schedule` as a backstop for merges that land inside the quiet window or while a release is active.
- The push filter is intentionally coarse; `plan-desktop-release.py` still does the precise releasable-change check (excluding `CHANGELOG.json`/`AGENTS.md`/`changelog/`/`Backend-Rust/`), the 10-minute quiet window debounces bursts, and the one-active-release + exact-SHA fences still admit at most one candidate at a time — so bursts collapse to the newest SHA.

## Why it's safe (single candidate→beta authority preserved)
Every trigger runs the *same* fenced planner job. Beta promotion (`desktop_promote_beta.yml`) keys off the **qualification's** `workflow_dispatch` event, not this workflow's trigger, so adding `push` here does not create a second promotion authority. Chained triggers (`workflow_run`/`workflow_call`) that *could* form a second authority remain forbidden by the contract test.

## Verification
- Updated the two contract tests that pinned the exact trigger shape (`test_desktop_release_flow_contract.py`, `test_plan_desktop_release.py`) to allow `push` while keeping the "workflow_dispatch has no manual inputs" and "no chained-trigger second authority" guards.
- `python3 -m pytest` on all three affected test files → **45 passed, 34 subtests**.
- `actionlint .github/workflows/desktop_auto_release.yml` → clean.
- `check-release-process-guards.py` → passed. YAML parses; triggers = `[workflow_dispatch, push, schedule]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

