### PR TITLE
ci(desktop): include codemagic.yaml in auto-release push trigger

### DIFF
--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -129,6 +129,25 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertIn("ref: ${{ steps.recheck.outputs.source_sha }}", workflow)
         self.assertLess(workflow.index('git commit -m "chore: consolidate changelog for v${VERSION}"'), workflow.index('git tag "$RELEASE_TAG"'))
 
+    def test_push_paths_cover_releasable_desktop_paths(self) -> None:
+        # Every releasable desktop input the planner recognizes must also be in
+        # the workflow's push filter, or a merge touching only that input would be
+        # releasable yet never get the immediate push trigger (only the hourly
+        # cron would catch it). A directory entry maps to '<dir>/**'.
+        import yaml
+
+        on = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))[True]
+        push_paths = set(on["push"]["paths"])
+        self.assertEqual(on["push"]["branches"], ["main"])
+        for path in planner.DESKTOP_RELEASE_PATHS:
+            expected = f"{path}/**" if (ROOT / path).is_dir() else path
+            self.assertIn(
+                expected,
+                push_paths,
+                f"releasable desktop path {path!r} (expected push filter {expected!r}) "
+                "is missing from desktop_auto_release.yml push.paths",
+            )
+
     def test_pre_tag_readiness_workflow_contract(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         readiness_script = (ROOT / "desktop/macos/scripts/pre-tag-readiness.sh").read_text(encoding="utf-8")

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -8,10 +8,15 @@ on:
   # excluding CHANGELOG/AGENTS/changelog/Backend-Rust); the same quiet-window,
   # exact-SHA, and one-active-release fences below still admit at most one
   # eligible candidate at a time, so bursts collapse to the newest SHA.
+  # Keep these in lockstep with DESKTOP_RELEASE_PATHS in plan-desktop-release.py
+  # (a directory X there maps to 'X/**' here); test_push_paths_cover_releasable_
+  # desktop_paths enforces the alignment so a releasable input can't silently
+  # lose its immediate trigger.
   push:
     branches: [main]
     paths:
       - 'desktop/macos/**'
+      - 'codemagic.yaml'
       - '.github/scripts/plan-desktop-release.py'
       - '.github/workflows/desktop_auto_release.yml'
       - '.github/workflows/desktop-swift-ci.yml'


### PR DESCRIPTION
## Summary
Follow-up to #10370. That PR's push filter omitted `codemagic.yaml`, which `plan-desktop-release.py` treats as a releasable desktop input (`DESKTOP_RELEASE_PATHS`). So a Codemagic-config-only merge to main would be releasable but would NOT get the immediate push trigger — only the hourly cron would eventually catch it, defeating "trigger on every macOS-affecting merge" for that input.

## Fix
- Added `codemagic.yaml` to `desktop_auto_release.yml` `push.paths`.
- Added `test_push_paths_cover_releasable_desktop_paths`: iterates `planner.DESKTOP_RELEASE_PATHS` and asserts each is covered by the workflow's push filter (a directory `X` maps to `X/**`), so the filter can't drift out of alignment again.

## Verification
- Proved the new guard fails on exactly the omitted `codemagic.yaml` (negative check), then passes with it added.
- `pytest` on all 3 affected release test files → **46 passed, 34 subtests**.
- `actionlint` clean. push.paths now = desktop/macos/**, codemagic.yaml, plan-desktop-release.py, desktop_auto_release.yml, desktop-swift-ci.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

