### PR TITLE
feat(desktop): make Brain Map full-bleed

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1224,26 +1224,55 @@ private struct MemoryHubPage: View {
   let viewModelContainer: ViewModelContainer
   @State private var segment = 0
 
-  var body: some View {
-    VStack(spacing: 0) {
-      // The "Memory" rail item lands here, so Memories is the default segment;
-      // Conversations (with its live transcript) is second, and the Brain Map
-      // graph is its own tab.
-      HubSegmentedControl(segments: ["Memories", "Conversations", "Brain Map"], selection: $segment)
-        .padding(.top, 22)
-        .padding(.horizontal, 28)
-        .padding(.bottom, 4)
+  /// Memories and conversations stay easy to scan in a calm, readable column;
+  /// the spatial Brain Map needs the full content surface so users can pan and
+  /// zoom without hitting an artificial canvas boundary.
+  private static let listContentWidth: CGFloat = 900
 
-      if segment == 0 {
-        MemoriesPage(
-          viewModel: viewModelContainer.memoriesViewModel,
-          graphViewModel: viewModelContainer.memoryGraphViewModel)
-      } else if segment == 1 {
-        ConversationsPageHost(appState: appState)
+  var body: some View {
+    Group {
+      if segment == 2 {
+        ZStack(alignment: .top) {
+          // Keep the graph's camera framing intact while removing the list-page
+          // width cap. The map only occupies more of the visual field when the
+          // user deliberately pans or zooms into it.
+          MemoryGraphPage(viewModel: viewModelContainer.memoryGraphViewModel)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+          hubSegmentedControl
+        }
       } else {
-        MemoryGraphPage(viewModel: viewModelContainer.memoryGraphViewModel)
+        VStack(spacing: 0) {
+          hubSegmentedControl
+
+          if segment == 0 {
+            constrainedListContent(
+              MemoriesPage(
+                viewModel: viewModelContainer.memoriesViewModel,
+                graphViewModel: viewModelContainer.memoryGraphViewModel))
+          } else {
+            constrainedListContent(ConversationsPageHost(appState: appState))
+          }
+        }
       }
     }
+  }
+
+  private var hubSegmentedControl: some View {
+    // The "Memory" rail item lands here, so Memories is the default segment;
+    // Conversations (with its live transcript) is second, and the Brain Map
+    // graph is its own tab.
+    HubSegmentedControl(segments: ["Memories", "Conversations", "Brain Map"], selection: $segment)
+      .frame(maxWidth: Self.listContentWidth)
+      .padding(.top, 22)
+      .padding(.horizontal, 28)
+      .padding(.bottom, 4)
+  }
+
+  private func constrainedListContent<V: View>(_ content: V) -> some View {
+    content
+      .frame(maxWidth: Self.listContentWidth, maxHeight: .infinity)
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 }
 
@@ -1308,7 +1337,7 @@ private struct PageContentView: View {
           taskChatCoordinator: viewModelContainer.taskChatCoordinator,
           selectedIndex: $selectedTabIndex)
       case 1:
-        constrainedListPage(MemoryHubPage(appState: appState, viewModelContainer: viewModelContainer))
+        MemoryHubPage(appState: appState, viewModelContainer: viewModelContainer)
       case 2:
         ChatPage(
           appProvider: viewModelContainer.appProvider,

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
@@ -10,8 +10,9 @@ struct MemoryGraphPage: View {
 
   var body: some View {
     ZStack {
-      // Full-bleed background + 3D scene
-      OmiColors.backgroundSecondary.ignoresSafeArea()
+      // Match the SceneKit canvas to the page, so the graph blends into the
+      // Memory page instead of drawing a separate gray rectangle.
+      OmiColors.backgroundPrimary.ignoresSafeArea()
 
       if !viewModel.isEmpty {
         MemoryGraphSceneView(viewModel: viewModel)
@@ -146,8 +147,7 @@ struct MemoryGraphSceneView: NSViewRepresentable {
     scnView.pointOfView = viewModel.cameraNode
     scnView.allowsCameraControl = true
     scnView.autoenablesDefaultLighting = false  // We set up our own lights
-    scnView.backgroundColor = NSColor(
-      red: 0x1A / 255.0, green: 0x1A / 255.0, blue: 0x1A / 255.0, alpha: 1.0)  // Match OmiColors.backgroundSecondary
+    scnView.backgroundColor = NSColor(OmiColors.backgroundPrimary)
     scnView.antialiasingMode = .multisampling2X  // Lighter AA
     scnView.preferredFramesPerSecond = 30  // Cap render rate
 

--- a/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
@@ -16,6 +16,13 @@ final class MemoryGraphRevisitTests: XCTestCase {
     // The Brain Map moved from an inline Memories card to its own hub tab, still
     // driven by the persistent, container-owned view model.
     XCTAssertTrue(home.contains("MemoryGraphPage(viewModel: viewModelContainer.memoryGraphViewModel)"))
+    // Static wiring tripwire: list content keeps its capped column while the
+    // Brain Map owns the full content surface and paints with the page's shared
+    // background token instead of a distinct gray canvas.
+    XCTAssertFalse(home.contains("constrainedListPage(MemoryHubPage"))
+    XCTAssertTrue(home.contains("if segment == 2"))
+    XCTAssertTrue(home.contains("MemoryGraphPage(viewModel: viewModelContainer.memoryGraphViewModel)"))
+    XCTAssertTrue(graph.contains("scnView.backgroundColor = NSColor(OmiColors.backgroundPrimary)"))
   }
 
   @MainActor

--- a/desktop/macos/changelog/unreleased/20260722-brain-map-full-bleed.json
+++ b/desktop/macos/changelog/unreleased/20260722-brain-map-full-bleed.json
@@ -1,0 +1,3 @@
+{
+  "change": "Brain Map now fills the Memory page while keeping its familiar initial framing, and its canvas blends with the app background as you pan and zoom"
+}


### PR DESCRIPTION
## Summary

- Give the Brain Map its own full Memory-page canvas while keeping Memories and Conversations in their readable, width-capped layouts.
- Paint SceneKit with the shared app background and preserve the existing initial camera framing and zoom controls.

## Product invariants affected

- INV-MEM-1

## Verification

- `rtk proxy xcrun swift test --package-path Desktop --filter MemoryGraphRevisitTests` (5 passed)
- `./scripts/agent-logic-harness.sh --cross-surface-smoke` (73 passed)
- `OMI_APP_NAME=omi-qa-main ./run.sh --full --yolo`, then opened Memory → Brain Map in the named dev-GCP QA bundle; the live graph rendered successfully.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

