### PR TITLE
fix(release): raise qualification cold-build timeout so fresh tags stop timing out (Beta unblock)

### DIFF
--- a/.github/failure-classes/FC-gate-timeout-below-cold-cost.json
+++ b/.github/failure-classes/FC-gate-timeout-below-cold-cost.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "id": "FC-gate-timeout-below-cold-cost",
+  "violated_contract": "A release gate's fixed time budget must exceed the worst-case cost of the healthy work it bounds (a cold, from-scratch rebuild), and a timed-out attempt must not poison the cache that would let the retry run warm.",
+  "canonical_prevention": "Size the qualification cold-preparation budget to the observed cold-build duration with headroom (env-overridable), and keep the static timing-contract test asserting the current budget plus its recurrence history so the value cannot silently regress below the cold cost again.",
+  "evidence_prs": [10374],
+  "scope_hints": [
+    "desktop/macos/scripts/qualify-desktop-beta.sh",
+    "desktop/macos/tests/test-qualify-desktop-beta-contract.sh"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -119,7 +119,17 @@ LAUNCH_LOG=""
 LAUNCH_SIGNAL_FILE=""
 DESKTOP_LAUNCH_PID=""
 QUALIFICATION_SUCCESS=0
-DESKTOP_PREPARE_WAIT_SECS=3600
+# Cold, from-scratch rebuild of the exact tag compiles ~1190 SwiftPM modules
+# (FluidAudio, MarkdownUI, Firebase, ONNX, …) before the named bundle is even
+# packaged/signed/launched. On a self-hosted M1 that first cold build alone runs
+# ~65 min and, with packaging + install, dispatches the desktop launch at ~75 min
+# — past the old 3600s budget, so every fresh tag timed out at [~1139/1190]
+# compiling and left no reusable .build for the warm retry, stalling Beta
+# (v0.12.99–v0.12.113 all failed, self-hosted lane, `not dispatched within 3600s`).
+# 5400s (90 min) covers the observed cold path with headroom while staying within
+# the self-hosted job cap; warm same-SHA retry/prewarm still completes in a
+# fraction of this. Overridable per runner via OMI_QUALIFY_PREPARE_WAIT_SECS.
+DESKTOP_PREPARE_WAIT_SECS="${OMI_QUALIFY_PREPARE_WAIT_SECS:-5400}"
 BRIDGE_WAIT_SECS=900
 
 gh release view "$RELEASE_TAG" --repo BasedHardware/omi --json tagName,isDraft,isPrerelease,publishedAt,assets,body \

--- a/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
+++ b/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
@@ -71,19 +71,21 @@ require_text 'python3 "$KEYVALUE_PY" update-qualified-beta'
 require_text 'derive_omi_app_config "$BUNDLE"' "$CORE_HARNESS"
 require_text 'wrong bundle on port' "$CORE_HARNESS"
 
-# Static timing contract: cold preparation has its own bounded 3600-second phase
-# and run.sh explicitly signals successful launch dispatch before the separate
-# 900-second bridge readiness phase starts. The combined bound remains 4500
-# seconds. This guards https://github.com/BasedHardware/omi/actions/runs/29904736566,
-# where Swift was still compiling at 1107/1182 units when the 1800-second
-# preparation phase expired.
-require_text 'DESKTOP_PREPARE_WAIT_SECS=3600'
+# Static timing contract: cold preparation has its own bounded phase (env-
+# overridable via OMI_QUALIFY_PREPARE_WAIT_SECS) and run.sh explicitly signals
+# successful launch dispatch before the separate 900-second bridge readiness
+# phase starts. Default preparation budget 5400s; combined bound 6300s.
+# History: 1800s (compiling stalled at 1107/1182, run 29904736566) → 3600s,
+# which STILL expired at 1139/1190 on a cold M1 self-hosted build (run
+# 29965341760), timing out every fresh tag (v0.12.99–v0.12.113) and leaving no
+# reusable .build for the warm retry. 5400s covers the observed ~75-min cold path.
+require_text 'DESKTOP_PREPARE_WAIT_SECS="${OMI_QUALIFY_PREPARE_WAIT_SECS:-5400}"'
 require_text 'BRIDGE_WAIT_SECS=900'
-prepare_wait_secs="$(sed -n 's/^DESKTOP_PREPARE_WAIT_SECS=//p' "$QUALIFIER")"
+prepare_wait_secs="$(sed -n 's/.*OMI_QUALIFY_PREPARE_WAIT_SECS:-\([0-9]*\)}.*/\1/p' "$QUALIFIER")"
 bridge_wait_secs="$(sed -n 's/^BRIDGE_WAIT_SECS=//p' "$QUALIFIER")"
-if [[ "$prepare_wait_secs" -ne 3600 || "$bridge_wait_secs" -ne 900 \
-  || $((prepare_wait_secs + bridge_wait_secs)) -ne 4500 ]]; then
-  echo "FAIL: qualification timing bounds must remain 3600s preparation + 900s bridge = 4500s total" >&2
+if [[ "$prepare_wait_secs" -ne 5400 || "$bridge_wait_secs" -ne 900 \
+  || $((prepare_wait_secs + bridge_wait_secs)) -ne 6300 ]]; then
+  echo "FAIL: qualification timing bounds must remain 5400s preparation + 900s bridge = 6300s total" >&2
   exit 1
 fi
 require_text 'OMI_DESKTOP_LAUNCH_SIGNAL_FILE="$LAUNCH_SIGNAL_FILE"'


### PR DESCRIPTION
## Problem — this is why Beta has been stuck since v0.12.103

Every fresh desktop candidate times out in qualification. Root cause, from run [29965341760](https://github.com/BasedHardware/omi/actions/runs/29965341760) (v0.12.111 on David's M1):

```
qualification failed: desktop launch not dispatched within 3600s
```

A cold, from-scratch rebuild of the exact tag compiles **~1190 SwiftPM modules** (FluidAudio, MarkdownUI, Firebase, ONNX, …) *before* the named bundle is even packaged, signed, installed, and launched. On a self-hosted M1 that cold build alone runs ~65 min and dispatches the launch at ~75 min — past the **3600s (60 min)** `DESKTOP_PREPARE_WAIT_SECS` budget. The build log ends at `[1139/1190] Compiling` right at the deadline.

It doesn't self-heal: a timed-out build leaves an incomplete `.build` that the qualification swift-cache **fail-closes on**, so the warm retry rebuilds cold and times out again — an unbreakable loop. And the hourly auto-release cuts a new tag (superseding the old one) before any tag's retry can pass. Result: v0.12.99–v0.12.112 all failed qualification; Beta served v0.12.103 for a day.

This is the **same boundary already bumped once** (1800s→3600s, run 29904736566, which stalled at `1107/1182`). 3600s was still short.

## Fix

Raise the default cold-preparation budget to **5400s (90 min)**, overridable via `OMI_QUALIFY_PREPARE_WAIT_SECS`, covering the observed ~75-min cold path with headroom while staying under the self-hosted job cap. Warm same-SHA retries still finish in a fraction of this. The static timing-contract test is updated to the new default and records the recurrence history.

Two-line functional change (`desktop/macos/scripts/qualify-desktop-beta.sh`) plus its contract test. Independent of #10363 (which hardens the *lanes*); this fixes the *time budget* every lane shares. It takes effect for tags cut after merge — so the next hourly `v*-macos` tag is the first that can actually qualify.

**Note on the Codemagic lane:** CM's `max_build_duration` is 120 min, so a *cold* CM build (90-min prepare + install + T2) may exceed it; the self-hosted lanes are the reliable cold-build path under the at-least-one-passes verdict, and CM carries warm/incremental builds. Raising CM's budget is a follow-up (touches the same codemagic.yaml workflow as #10363).

## Verification

- Reproduced the root cause from the live run log (`not dispatched within 3600s`, build at `[1139/1190]` at the 3600s mark, job window 23:11→00:24 = 73 min).
- `bash -n desktop/macos/scripts/qualify-desktop-beta.sh` → OK
- Value resolves as an integer for the `SECONDS + DESKTOP_PREPARE_WAIT_SECS` arithmetic; default 5400, `OMI_QUALIFY_PREPARE_WAIT_SECS` override honored.
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh` → passed (asserts new 5400 default + 6300 combined bound)
- `python3 .github/scripts/check-release-process-guards.py` → passed
- `python3 .github/scripts/test_desktop_release_flow_contract.py` → 19 OK

**UNVERIFIED until a post-merge tag runs:** that 5400s is actually sufficient end-to-end on the slowest registered runner. If a cold build ever exceeds 90 min, bump `OMI_QUALIFY_PREPARE_WAIT_SECS` on that runner — no code change needed.

Failure-Class: new



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->