### PR TITLE
fix(desktop): flip onboarding chatgpt/claude connect chip after browser oauth

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -3,13 +3,13 @@
     "desktop/macos/Desktop/Sources/AuthService.swift": 2812,
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4256,
-    "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1578,
+    "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1593,
     "desktop/macos/Desktop/Sources/OmiApp.swift": 1693
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/AuthService.swift": "Apple first-auth name capture signals observers (authNameDidUpdate) and persists the name to Firebase so it survives reinstalls.",
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": "present_onboarding_opener QA action renders the real post-onboarding opener in-process for verification.",
-    "desktop/macos/Desktop/Sources/MemoryExportService.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
+    "desktop/macos/Desktop/Sources/MemoryExportService.swift": "Adds cloudOAuthGrantClientIDs so ChatGPT directory grants (always omi-chatgpt-prod) verify on dev/Beta builds, fixing the connector chip never flipping to connected.",
     "desktop/macos/Desktop/Sources/OmiApp.swift": "Current main already contains 1693 lines after the menu-bar summon and chat-landing additions; this PR changes the Firebase-missing launch branch without increasing that count."
   },
   "threshold": 1500

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -26,6 +26,47 @@ LATEST_TAG = "v0.0.1+1-macos"
 RELEASABLE_PATH = "desktop/macos/Desktop/Sources/AppDelegate.swift"
 
 
+def _parse_push_filter(workflow_text: str) -> tuple[list[str], set[str]]:
+    """Extract `on.push.branches` and `on.push.paths` from the release workflow.
+
+    A deliberately small parser for the workflow's fixed shape (a `push:` block
+    with an inline `branches: [main]` and a `paths:` list of single-quoted
+    strings), so the check needs no PyYAML in any lane. Raises if the expected
+    structure is missing rather than silently returning empty results.
+    """
+    lines = workflow_text.splitlines()
+    branches: list[str] = []
+    paths: set[str] = set()
+    in_push = False
+    in_paths = False
+    for raw in lines:
+        stripped = raw.strip()
+        indent = len(raw) - len(raw.lstrip(" "))
+        if indent <= 2 and stripped.endswith(":") and stripped != "push:":
+            # Left the push block on any sibling/parent key (e.g. schedule:).
+            if in_push and indent <= 2:
+                in_push = False
+            in_paths = False
+        if stripped == "push:":
+            in_push = True
+            continue
+        if not in_push:
+            continue
+        if stripped.startswith("branches:"):
+            inside = stripped.split("branches:", 1)[1].strip().strip("[]")
+            branches = [b.strip().strip("'\"") for b in inside.split(",") if b.strip()]
+            in_paths = False
+        elif stripped == "paths:":
+            in_paths = True
+        elif in_paths and stripped.startswith("- "):
+            paths.add(stripped[2:].strip().strip("'\""))
+        elif in_paths and not stripped.startswith("- ") and stripped:
+            in_paths = False
+    if not branches or not paths:
+        raise AssertionError("Could not parse push.branches/push.paths from desktop_auto_release.yml")
+    return branches, paths
+
+
 class DesktopCandidateSourceCheckTests(unittest.TestCase):
     def test_codemagic_config_is_a_releasable_desktop_input(self) -> None:
         expected_args = [
@@ -134,11 +175,13 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         # the workflow's push filter, or a merge touching only that input would be
         # releasable yet never get the immediate push trigger (only the hourly
         # cron would catch it). A directory entry maps to '<dir>/**'.
-        import yaml
-
-        on = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))[True]
-        push_paths = set(on["push"]["paths"])
-        self.assertEqual(on["push"]["branches"], ["main"])
+        #
+        # Parse the push filter without PyYAML: this check runs in the `local` and
+        # `ci` lanes across environments that do not all ship PyYAML (the ubuntu
+        # preflight and macOS static-contracts runners both lack it), matching how
+        # run_checks.py and check-e2e-flow-coverage.py avoid the dependency.
+        branches, push_paths = _parse_push_filter(WORKFLOW.read_text(encoding="utf-8"))
+        self.assertEqual(branches, ["main"])
         for path in planner.DESKTOP_RELEASE_PATHS:
             expected = f"{path}/**" if (ROOT / path).is_dir() else path
             self.assertIn(

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -50,6 +50,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
+          # Preflight can select manifest checks that import pyyaml
+          # (e.g. desktop-candidate-source-gate), matching the Hygiene job below.
+          pip install -q pyyaml
           scripts/pr-preflight \
             --base "${{ github.event.pull_request.base.sha }}" \
             --repository "${{ github.repository }}" \

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -50,9 +50,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          # Preflight can select manifest checks that import pyyaml
-          # (e.g. desktop-candidate-source-gate), matching the Hygiene job below.
-          pip install -q pyyaml
           scripts/pr-preflight \
             --base "${{ github.event.pull_request.base.sha }}" \
             --repository "${{ github.repository }}" \

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
@@ -208,10 +208,7 @@ private struct ConnectOptionCard: View {
         .fill(OmiColors.backgroundSecondary)
     )
     .task {
-      statuses[destination] =
-        destination == .chatgpt
-        ? await MemoryExportService.shared.refreshChatGPTDirectoryConnectionStatus()
-        : await MemoryExportService.shared.status(for: destination)
+      statuses[destination] = await MemoryExportService.shared.refreshCloudGrantConnectionStatus(for: destination)
       await prepareMCPKeyIfNeeded()
     }
     .onReceive(permissionRefreshTimer) { _ in
@@ -219,7 +216,7 @@ private struct ConnectOptionCard: View {
     }
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
       refreshPermissionStateIfNeeded()
-      refreshChatGPTDirectoryConnectionIfNeeded()
+      refreshCloudGrantConnectionIfNeeded()
     }
   }
 
@@ -228,10 +225,10 @@ private struct ConnectOptionCard: View {
     permissionRefreshID += 1
   }
 
-  private func refreshChatGPTDirectoryConnectionIfNeeded() {
-    guard destination == .chatgpt else { return }
+  private func refreshCloudGrantConnectionIfNeeded() {
+    guard destination.cloudOAuthClientID != nil else { return }
     Task {
-      statuses[.chatgpt] = await MemoryExportService.shared.refreshChatGPTDirectoryConnectionStatus()
+      statuses[destination] = await MemoryExportService.shared.refreshCloudGrantConnectionStatus(for: destination)
     }
   }
 
@@ -270,10 +267,7 @@ private struct ConnectOptionCard: View {
         case .completed:
           resultMessage = .success(outcome.taskTitle)
         }
-        statuses[destination] =
-          destination == .chatgpt
-          ? await MemoryExportService.shared.refreshChatGPTDirectoryConnectionStatus()
-          : await MemoryExportService.shared.status(for: destination)
+        statuses[destination] = await MemoryExportService.shared.refreshCloudGrantConnectionStatus(for: destination)
       } catch {
         resultMessage = .failure(setupFailureMessage(for: error))
       }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -518,10 +518,7 @@ struct MemoryExportDestinationSheet: View {
     .background(OmiColors.backgroundPrimary)
     .task {
       await model.loadConfiguration()
-      statuses[destination] =
-        destination == .chatgpt
-        ? await MemoryExportService.shared.refreshChatGPTDirectoryConnectionStatus()
-        : await MemoryExportService.shared.status(for: destination)
+      statuses[destination] = await MemoryExportService.shared.refreshCloudGrantConnectionStatus(for: destination)
       if destination.supportsMCP && destination.requiresHostedMCPKeyForSetup && model.mcpKey == nil {
         await model.generateMCPKey()
       }
@@ -531,7 +528,7 @@ struct MemoryExportDestinationSheet: View {
     }
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
       refreshPermissionStateIfNeeded()
-      refreshChatGPTDirectoryConnectionIfNeeded()
+      refreshCloudGrantConnectionIfNeeded()
     }
   }
 
@@ -540,10 +537,10 @@ struct MemoryExportDestinationSheet: View {
     permissionRefreshID += 1
   }
 
-  private func refreshChatGPTDirectoryConnectionIfNeeded() {
-    guard destination == .chatgpt else { return }
+  private func refreshCloudGrantConnectionIfNeeded() {
+    guard destination.cloudOAuthClientID != nil else { return }
     Task {
-      statuses[.chatgpt] = await MemoryExportService.shared.refreshChatGPTDirectoryConnectionStatus()
+      statuses[destination] = await MemoryExportService.shared.refreshCloudGrantConnectionStatus(for: destination)
     }
   }
 
@@ -766,10 +763,8 @@ struct MemoryExportDestinationSheet: View {
         Button {
           Task {
             await model.executeWithOmi(destination: destination)
-            statuses[destination] =
-              destination == .chatgpt
-              ? await MemoryExportService.shared.refreshChatGPTDirectoryConnectionStatus()
-              : await MemoryExportService.shared.status(for: destination)
+            statuses[destination] = await MemoryExportService.shared.refreshCloudGrantConnectionStatus(
+              for: destination)
             // Assisted flow: the user pastes values by hand, so surface the
             // field-by-field steps instead of leaving them collapsed.
             if destination.mcpExecuteKind == .assisted, destination.assistedOverlayHint != nil {

--- a/desktop/macos/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportService.swift
@@ -51,6 +51,20 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
     }
   }
 
+  /// Client IDs that count as "authorized" when scanning OAuth grants — NOT the
+  /// same as `cloudOAuthClientID` (the setup form's per-backend value). The
+  /// ChatGPT directory is one global plugin that always grants under
+  /// `omi-chatgpt-prod`, even on a dev-backend build, so verification must accept
+  /// it or ChatGPT never connects on Beta. Mirrors backend `PUBLIC_CHATGPT_CLIENT_IDS`.
+  var cloudOAuthGrantClientIDs: Set<String> {
+    switch self {
+    case .chatgpt: return ["omi-chatgpt-prod", "omi-chatgpt-dev"]
+    case .claude: return ["omi-claude-prod"]
+    case .notion, .obsidian, .gemini, .agents, .claudeCode, .codex, .openclaw, .hermes:
+      return []
+    }
+  }
+
   var cloudOAuthClientSecret: String? {
     switch self {
     case .chatgpt, .claude:
@@ -870,11 +884,12 @@ actor MemoryExportService {
   /// grant list knows the truth. Network failures intentionally retain the last
   /// known state rather than presenting an authorization as revoked.
   func refreshCloudGrantConnectionStatus(for destination: MemoryExportDestination) async -> MemoryExportStatus {
-    guard let clientID = destination.cloudOAuthClientID else { return status(for: destination) }
+    let clientIDs = destination.cloudOAuthGrantClientIDs
+    guard !clientIDs.isEmpty else { return status(for: destination) }
     do {
       let response: OAuthGrantsResponse = try await APIClient.shared.get(
         "v1/mcp/oauth/grants", includeBYOK: false)
-      let isAuthorized = response.grants.contains { $0.clientID == clientID && $0.isActive }
+      let isAuthorized = response.grants.contains { clientIDs.contains($0.clientID) && $0.isActive }
 
       if isAuthorized {
         defaults.set(Date().timeIntervalSince1970, forKey: destination.connectedAtKey)

--- a/desktop/macos/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportService.swift
@@ -865,29 +865,29 @@ actor MemoryExportService {
       })
   }
 
-  /// Refreshes the authoritative connection state after returning from the
-  /// ChatGPT directory. Network failures intentionally retain the last known
-  /// state rather than presenting an authorization as revoked.
-  func refreshChatGPTDirectoryConnectionStatus() async -> MemoryExportStatus {
+  /// Refreshes the authoritative connection state for a cloud OAuth connector
+  /// (ChatGPT/Claude) after the user authorizes in the browser — only the backend
+  /// grant list knows the truth. Network failures intentionally retain the last
+  /// known state rather than presenting an authorization as revoked.
+  func refreshCloudGrantConnectionStatus(for destination: MemoryExportDestination) async -> MemoryExportStatus {
+    guard let clientID = destination.cloudOAuthClientID else { return status(for: destination) }
     do {
       let response: OAuthGrantsResponse = try await APIClient.shared.get(
         "v1/mcp/oauth/grants", includeBYOK: false)
-      let isAuthorized = response.grants.contains {
-        $0.clientID == MemoryExportDestination.chatgptOAuthClientID && $0.isActive
-      }
+      let isAuthorized = response.grants.contains { $0.clientID == clientID && $0.isActive }
 
       if isAuthorized {
-        defaults.set(Date().timeIntervalSince1970, forKey: MemoryExportDestination.chatgpt.connectedAtKey)
-        defaults.set("Authorized through ChatGPT", forKey: MemoryExportDestination.chatgpt.detailKey)
+        defaults.set(Date().timeIntervalSince1970, forKey: destination.connectedAtKey)
+        defaults.set("Authorized through \(destination.title)", forKey: destination.detailKey)
       } else {
-        defaults.removeObject(forKey: MemoryExportDestination.chatgpt.connectedAtKey)
-        defaults.removeObject(forKey: MemoryExportDestination.chatgpt.detailKey)
+        defaults.removeObject(forKey: destination.connectedAtKey)
+        defaults.removeObject(forKey: destination.detailKey)
       }
     } catch {
-      log("MemoryExportService: ChatGPT OAuth grant refresh failed: \(error.localizedDescription)")
+      log("MemoryExportService: \(destination.title) OAuth grant refresh failed: \(error.localizedDescription)")
     }
 
-    return status(for: .chatgpt)
+    return status(for: destination)
   }
 
   func notionConfiguration() -> (token: String, parentPageID: String) {

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -560,7 +560,12 @@ extension SBOnboardingModel {
       guard let self else { return }
       for id in ["chatgpt", "claude"] {
         let dest: MemoryExportDestination = id == "chatgpt" ? .chatgpt : .claude
-        if await MemoryExportService.shared.status(for: dest).hasConnection { self.contextStates[id] = "on" }
+        // OAuth for these completes in the browser, so only the backend grant
+        // list knows the truth — a local status check would never flip the chip.
+        let connected = await MemoryExportService.shared.refreshCloudGrantConnectionStatus(for: dest).hasConnection
+        if let resolved = Self.cloudContextState(current: self.contextStates[id], connected: connected) {
+          self.contextStates[id] = resolved
+        }
       }
       // Apple Notes rides the same Full Disk Access grant that powers Files, so a
       // readable NoteStore should show "✓ on" up front — not a "Connect" button
@@ -576,6 +581,15 @@ extension SBOnboardingModel {
       let gmail = await GmailReaderService.shared.verifyConnection()
       if gmail.isConnected { self.contextStates["gmail"] = "on" }
     }
+  }
+
+  /// Chip state for a cloud OAuth connector (ChatGPT/Claude) after a backend
+  /// grant refresh: connected always wins; an unfinished "connecting" (the user
+  /// came back without completing OAuth) resolves to "idle" so the Connect
+  /// button returns; anything else is left unchanged (nil).
+  nonisolated static func cloudContextState(current: String?, connected: Bool) -> String? {
+    if connected { return "on" }
+    return current == "connecting" ? "idle" : nil
   }
 
   /// Resolve a cookie-based Google connector (Calendar, Gmail). These don't OAuth —
@@ -654,12 +668,17 @@ extension SBOnboardingModel {
     case "chatgpt", "claude":
       let dest: MemoryExportDestination = id == "chatgpt" ? .chatgpt : .claude
       Task { [weak self] in
+        let outcome: MemoryExportExecutor.Outcome
         do {
-          _ = try await MemoryExportExecutor.run(dest)
+          outcome = try await MemoryExportExecutor.run(dest)
         } catch {
           self?.contextStates[id] = "unavailable"
           return
         }
+        // Assisted/directory flows finish in the browser — checking now would
+        // always read "not connected" and reset the chip. Keep it "connecting";
+        // the app-activation refresh resolves it when the user comes back.
+        guard outcome.mode == .completed else { return }
         let connected = await MemoryExportService.shared.status(for: dest).hasConnection
         self?.contextStates[id] = connected ? "on" : "idle"
       }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -62,6 +62,11 @@ struct SBOnboardingView: View {
       .padding(.top, 20).padding(.trailing, 24)
     }
     .onAppear { model.begin() }
+    // ChatGPT/Claude OAuth finishes in the browser — re-check the grants when
+    // the user comes back so their chip actually flips to "✓ on".
+    .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+      if model.step == .context { model.refreshContextStates() }
+    }
     // Safety net: the `.shortcut` step suspends global hotkeys and nulls the main
     // menu (restored only via the advance/skip/complete buttons). If the view is
     // removed by any other path (e.g. auth flips to signed-out), restore them here

--- a/desktop/macos/Desktop/Tests/MemoryExportStatusTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryExportStatusTests.swift
@@ -41,6 +41,18 @@ final class MemoryExportStatusTests: XCTestCase {
     XCTAssertFalse(hermesStatus.hasConnection)
   }
 
+  /// The ChatGPT directory listing is a single global plugin that always
+  /// authorizes under `omi-chatgpt-prod`, even on a build pointed at the dev
+  /// backend. Grant verification must accept that prod client ID regardless of
+  /// `chatgptOAuthClientID`'s env switch, or ChatGPT never flips to connected on
+  /// Beta (the shipped symptom: Claude verified, ChatGPT stuck).
+  func testChatGPTGrantVerificationAcceptsProdDirectoryClientOnAnyBackend() {
+    XCTAssertTrue(MemoryExportDestination.chatgpt.cloudOAuthGrantClientIDs.contains("omi-chatgpt-prod"))
+    XCTAssertTrue(MemoryExportDestination.chatgpt.cloudOAuthGrantClientIDs.contains("omi-chatgpt-dev"))
+    XCTAssertEqual(MemoryExportDestination.claude.cloudOAuthGrantClientIDs, ["omi-claude-prod"])
+    XCTAssertTrue(MemoryExportDestination.notion.cloudOAuthGrantClientIDs.isEmpty)
+  }
+
   func testMarkConnectedDoesNotMaskMissingLocalMCPConfig() async {
     storeOwnedMCPKey()
 

--- a/desktop/macos/Desktop/Tests/SBOnboardingCloudContextStateTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingCloudContextStateTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the onboarding ChatGPT/Claude connect chip (#new-onboarding).
+///
+/// The connect flow opens the provider's OAuth page in the browser and used to
+/// check the local connection status immediately after — which always read "not
+/// connected" (OAuth hadn't happened yet) and silently reset the chip to
+/// "Connect", never flipping to "✓ on" even after a successful authorization.
+/// Resolution now happens through a backend grant refresh when the app becomes
+/// active again, mapped through `cloudContextState`.
+final class SBOnboardingCloudContextStateTests: XCTestCase {
+
+  func testConnectedFlipsChipOnFromAnyState() {
+    for current in [nil, "idle", "connecting", "needsSignIn", "on"] {
+      XCTAssertEqual(SBOnboardingModel.cloudContextState(current: current, connected: true), "on")
+    }
+  }
+
+  func testUnfinishedConnectingResolvesToIdleSoConnectButtonReturns() {
+    XCTAssertEqual(SBOnboardingModel.cloudContextState(current: "connecting", connected: false), "idle")
+  }
+
+  func testNotConnectedLeavesNonConnectingStatesUntouched() {
+    for current in [nil, "idle", "on", "unavailable"] {
+      XCTAssertNil(SBOnboardingModel.cloudContextState(current: current, connected: false))
+    }
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260722-onboarding-cloud-connector-chip.json
+++ b/desktop/macos/changelog/unreleased/20260722-onboarding-cloud-connector-chip.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed onboarding ChatGPT and Claude connect chips not flipping to connected after authorizing in the browser"
+}


### PR DESCRIPTION
## Problem

In the Second Brain onboarding, clicking Connect on the ChatGPT or Claude context row opens the provider's OAuth page in the browser, then immediately checks the local connection status — before the user could possibly have authorized. The check always reads "not connected", silently resets the chip to "Connect", and nothing re-checks when the user returns. The chip never flips to "✓ on".

A second, ChatGPT-specific defect surfaced during live testing: even once the grant check runs, ChatGPT never verifies on non-prod (Beta/dev) builds. The ChatGPT directory listing is a single global plugin that always authorizes under `omi-chatgpt-prod`, but the app looked for the env-switched `chatgptOAuthClientID` (`omi-chatgpt-dev` on non-prod), so the grant never matched. Claude worked because its client ID is hardcoded `omi-claude-prod`.

## Fix

The authoritative connection signal is the backend OAuth grant list (`GET /v1/mcp/oauth/grants`).

- `MemoryExportService`: generalize `refreshChatGPTDirectoryConnectionStatus()` into `refreshCloudGrantConnectionStatus(for:)` covering any destination with cloud OAuth grants; all prior call sites migrated (no compat alias).
- New `cloudOAuthGrantClientIDs` set used for verification (distinct from the setup form's `cloudOAuthClientID`): ChatGPT accepts `{omi-chatgpt-prod, omi-chatgpt-dev}` so the always-prod directory grant verifies on any backend; Claude keeps `{omi-claude-prod}`. Mirrors the backend's `PUBLIC_CHATGPT_CLIENT_IDS`.
- Onboarding (`SBOnboardingModel+Steps`): the connect flow keeps the chip at "connecting" for assisted/directory outcomes instead of resetting it pre-OAuth; `refreshContextStates()` resolves ChatGPT/Claude through the grant refresh via a pure `cloudContextState(current:connected:)` mapping.
- `SBOnboardingView`: re-runs `refreshContextStates()` on `didBecomeActive` during the context step, so returning from the browser resolves the chip.
- Export destination sheet + agent connect picker: Claude gets the same authoritative grant refresh as ChatGPT.

There is no OAuth redirect back into the app (redirects target the providers' own callbacks), so activation-triggered polling is the only completion signal.

## Product invariants

- INV-INT-1
- INV-MEM-1

Failure-Class: none

## Verification

- Built and ran a named bundle at the onboarding context step, signed in against prod, with both ChatGPT and Claude grants active on the backend.
  - Before the client-id fix: Claude showed "✓ on", ChatGPT reset to "Connect" (never verified) — reproduced the reported symptom exactly.
  - After the fix: both ChatGPT and Claude show "✓ on" (verified via accessibility snapshot of the live app).
- `xcrun swift test --filter MemoryExportStatusTests/testChatGPTGrantVerificationAcceptsProdDirectoryClientOnAnyBackend|SBOnboardingCloudContextStateTests` — 4/4 pass.
- `scripts/pr-preflight` — 19/19 checks pass.
