### PR TITLE
ci(desktop): cut auto-release quiet window to 60s for prompt per-merge builds

### DIFF
--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -535,8 +535,8 @@ def check_desktop_codemagic_release() -> list[str]:
 
     planner = ROOT / ".github/scripts/plan-desktop-release.py"
     planner_text = planner.read_text(encoding="utf-8")
-    if "AUTO_RELEASE_QUIET_SECONDS = 10 * 60" not in planner_text:
-        errors.append("desktop auto-release planner must keep a 10 minute quiet window before auto-tagging")
+    if "AUTO_RELEASE_QUIET_SECONDS = 60" not in planner_text:
+        errors.append("desktop auto-release planner must keep a short (60s) quiet window before auto-tagging")
     if "latest_change_age is None" not in planner_text:
         errors.append("desktop auto-release planner must fail closed when latest change age cannot be determined")
     if "RECENT_TAG_WITHOUT_CHECK_SECONDS = 10 * 60" not in planner_text:

--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -17,7 +17,11 @@ REQUIRED_SOURCE_CHECK_NAMES = (
     "Desktop Swift Release Compile",
 )
 RECENT_TAG_WITHOUT_CHECK_SECONDS = 10 * 60
-AUTO_RELEASE_QUIET_SECONDS = 10 * 60
+# Short debounce so a merge is tagged within ~a minute instead of waiting ten.
+# The one-active-release fence (Codemagic build status on the latest tag) already
+# collapses rapid bursts to the newest SHA while a build runs, so this window only
+# needs to coalesce near-simultaneous merges, not batch a whole feature.
+AUTO_RELEASE_QUIET_SECONDS = 60
 DESKTOP_RELEASE_PATHS = (
     "desktop/macos",
     "codemagic.yaml",


### PR DESCRIPTION
## Summary
Cut the desktop auto-release quiet window from **10 minutes to 60 seconds** so a macOS-affecting merge to main is tagged (GitHub release → Codemagic) within ~a minute of landing, instead of waiting ten. Combined with the push trigger (#10370/#10371), every macOS change now flows to a Codemagic build promptly.

## Why it's safe
The one-active-release fence keys off the **Codemagic build status** on the latest tag, so while a build runs (~78 min) rapid bursts already collapse to the newest SHA. The quiet window therefore only needs to coalesce near-simultaneous merges, not batch a whole feature — 60s is sufficient. Builds still serialize (one Codemagic build at a time); this only removes the artificial pre-tag delay.

## Changes
- `plan-desktop-release.py`: `AUTO_RELEASE_QUIET_SECONDS = 60` (was `10 * 60`).
- `check-release-process-guards.py`: guard updated to assert the new 60s value.

## Verification
- `check-release-process-guards.py` passes; `pytest` on planner + release-flow contract tests → **25 passed, 21 subtests**.
- Live: v0.12.113 is already building on Codemagic (manually tagged to unblock the immediate case); this change makes future merges tag within ~60s automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

