### PR TITLE
Fix desktop task receipt confirmations

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2375,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2664,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2639,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4849,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2448,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1621

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarReceiptCard.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarReceiptCard.swift
@@ -1,0 +1,41 @@
+import OmiTheme
+import SwiftUI
+
+extension FloatingControlBarView {
+  /// Durable receipt — "✓ Saved to Tasks — <task>" with Review and Undo, shown
+  /// only after Omi can read the task through the canonical action-items path.
+  /// Monochrome, on the pill's black glass. Auto-collapses.
+  @ViewBuilder
+  func notchReceiptCard(_ notification: FloatingBarNotification) -> some View {
+    HStack(spacing: 10) {
+      Text(notification.title)
+        .scaledFont(size: 12.5)
+        .foregroundColor(.white)
+        .lineLimit(1)
+      Spacer(minLength: 8)
+      Button {
+        NotchMomentsCoordinator.shared.reviewLastReceipt()
+        FloatingControlBarManager.shared.dismissCurrentNotification()
+      } label: {
+        Text("Review")
+          .scaledFont(size: 11.5)
+          .foregroundColor(.white)
+          .underline()
+      }
+      .buttonStyle(.plain)
+      Button {
+        NotchMomentsCoordinator.shared.undoLastReceipt()
+        FloatingControlBarManager.shared.dismissCurrentNotification()
+      } label: {
+        Text("Undo")
+          .scaledFont(size: 11.5)
+          .foregroundColor(.white.opacity(0.55))
+          .underline()
+      }
+      .buttonStyle(.plain)
+    }
+    .padding(.horizontal, OmiSpacing.md)
+    .padding(.vertical, OmiSpacing.sm)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -559,31 +559,6 @@ struct FloatingControlBarView: View {
     }
   }
 
-  /// Live receipt — "✓ Noted — <task>" with Undo, shown while listening as Omi
-  /// writes something down. Monochrome, on the pill's black glass. Auto-collapses.
-  private func notchReceiptCard(_ notification: FloatingBarNotification) -> some View {
-    HStack(spacing: 10) {
-      Text(notification.title)
-        .scaledFont(size: 12.5)
-        .foregroundColor(.white)
-        .lineLimit(1)
-      Spacer(minLength: 8)
-      Button {
-        NotchMomentsCoordinator.shared.undoLastReceipt()
-        FloatingControlBarManager.shared.dismissCurrentNotification()
-      } label: {
-        Text("Undo")
-          .scaledFont(size: 11.5)
-          .foregroundColor(.white.opacity(0.55))
-          .underline()
-      }
-      .buttonStyle(.plain)
-    }
-    .padding(.horizontal, OmiSpacing.md)
-    .padding(.vertical, OmiSpacing.sm)
-    .frame(maxWidth: .infinity, alignment: .leading)
-  }
-
   /// Conversation ends — the USP moment. "N follow-ups ready" + Review / Later.
   private func notchEndCard(_ notification: FloatingBarNotification) -> some View {
     VStack(alignment: .leading, spacing: 2) {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/NotchMomentsCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/NotchMomentsCoordinator.swift
@@ -29,6 +29,10 @@ final class NotchMomentsCoordinator {
   private var sessionStartedAt: Date?
   /// The task shown in the most recent receipt (so Undo can retract it).
   private var lastReceiptTask: TaskActionItem?
+  /// Receipt verification runs asynchronously against the canonical action-items
+  /// read path. Keep one request per observed task so cache updates cannot emit
+  /// duplicate success receipts while that read is in flight.
+  private var pendingReceiptVerificationIDs = Set<String>()
 
   private init() {}
 
@@ -107,10 +111,51 @@ final class NotchMomentsCoordinator {
         .filter({ newIds.contains($0.id) && $0.createdAt >= freshCutoff })
         .max(by: { $0.createdAt < $1.createdAt })
     else { return }
-    lastReceiptTask = newTask
-    post(
-      title: "✓ Noted — \(newTask.description)", message: "",
-      assistantId: NotchMoment.receiptAssistantId)
+    verifyAndPostReceipt(for: newTask)
+  }
+
+  /// A local cache insert is not a durable-save acknowledgement. Read the task
+  /// through the canonical API before claiming it was saved, then make sure it
+  /// still remains in the active local projection before presenting the receipt.
+  private func verifyAndPostReceipt(for task: TaskActionItem) {
+    guard pendingReceiptVerificationIDs.insert(task.id).inserted else { return }
+    guard let ownerID = RuntimeOwnerIdentity.currentOwnerId(),
+      let authorizationSnapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot(expectedOwnerID: ownerID)
+    else {
+      pendingReceiptVerificationIDs.remove(task.id)
+      return
+    }
+
+    Task { @MainActor [weak self] in
+      defer { self?.pendingReceiptVerificationIDs.remove(task.id) }
+      guard let self else { return }
+      do {
+        let canonicalTask = try await APIClient.shared.getActionItem(
+          id: task.id,
+          expectedOwnerId: ownerID,
+          authorizationSnapshot: authorizationSnapshot)
+        guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
+          self.appState?.isTranscribing == true,
+          Self.isReceiptConfirmation(task, canonicalTask),
+          TasksStore.shared.incompleteTasks.contains(where: { $0.id == task.id })
+        else { return }
+        self.lastReceiptTask = canonicalTask
+        self.post(
+          title: "✓ Saved to Tasks — \(canonicalTask.description)", message: "",
+          assistantId: NotchMoment.receiptAssistantId)
+      } catch {
+        // Deliberately do not claim a save when the canonical task read fails.
+        // The next store update can re-attempt with a new task identity once
+        // the task has actually made it through the durable read path.
+        log("NotchMoments: Suppressed unconfirmed task receipt")
+      }
+    }
+  }
+
+  /// The receipt contract: the canonical read must name the same active task.
+  /// Keep this pure so its behavior remains covered without a live API.
+  nonisolated static func isReceiptConfirmation(_ observed: TaskActionItem, _ canonical: TaskActionItem) -> Bool {
+    observed.id == canonical.id && !canonical.completed && !canonical.isRetired
   }
 
   // MARK: actions from the cards
@@ -122,6 +167,11 @@ final class NotchMomentsCoordinator {
   }
 
   func reviewFollowUps() {
+    AppDelegate.openMainWindow?()
+    NotificationCenter.default.post(name: .navigateToTasks, object: nil)
+  }
+
+  func reviewLastReceipt() {
     AppDelegate.openMainWindow?()
     NotificationCenter.default.post(name: .navigateToTasks, object: nil)
   }

--- a/desktop/macos/Desktop/Tests/NotchMomentsFollowUpCountTests.swift
+++ b/desktop/macos/Desktop/Tests/NotchMomentsFollowUpCountTests.swift
@@ -58,4 +58,26 @@ final class NotchMomentsFollowUpCountTests: XCTestCase {
     XCTAssertEqual(
       NotchMomentsCoordinator.followUpCount(tasks: tasks, baselineIds: baseline, since: nil), 1)
   }
+
+  func testReceiptRequiresMatchingActiveCanonicalTask() {
+    let observed = task("task-1", createdAt: sessionStart)
+    let canonical = task("task-1", createdAt: sessionStart)
+
+    XCTAssertTrue(NotchMomentsCoordinator.isReceiptConfirmation(observed, canonical))
+    XCTAssertFalse(
+      NotchMomentsCoordinator.isReceiptConfirmation(
+        observed,
+        task("different-task", createdAt: sessionStart)),
+      "a different canonical task must never acknowledge the observed cache insert")
+  }
+
+  func testReceiptRejectsCompletedOrRetiredCanonicalTask() {
+    let observed = task("task-1", createdAt: sessionStart)
+    let completed = TaskActionItem(id: "task-1", description: "task-1", completed: true, createdAt: sessionStart)
+    let retired = TaskActionItem(
+      id: "task-1", description: "task-1", completed: false, createdAt: sessionStart, deleted: true)
+
+    XCTAssertFalse(NotchMomentsCoordinator.isReceiptConfirmation(observed, completed))
+    XCTAssertFalse(NotchMomentsCoordinator.isReceiptConfirmation(observed, retired))
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260722-confirmed-task-receipts.json
+++ b/desktop/macos/changelog/unreleased/20260722-confirmed-task-receipts.json
@@ -1,0 +1,3 @@
+{
+  "change": "Task receipts now confirm that a task was saved and offer a direct Review link to Tasks."
+}

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -40,6 +40,7 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceWaveformBars.swift
   - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Tools.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/NotchMomentsCoordinator.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarReceiptCard.swift
 preconditions:
   - automation_bridge_ready
 


### PR DESCRIPTION
## Summary

- verify a newly observed task through the canonical action-items read before presenting a notch save receipt
- label the confirmed receipt as "Saved to Tasks" and add a Review action that opens Tasks
- keep the oversized floating-bar view within its line-count ratchet by extracting the receipt card into a focused view file

## Product invariants

- INV-CHAT-1: the receipt continues through the existing floating-bar notification and main-chat journal path; the change only narrows when a success receipt is emitted.

## Failure class

Failure-Class: FC-split-mutation-authority

## Verification

- `xcrun swift test -c debug --package-path Desktop --filter NotchMomentsFollowUpCountTests` — 6 passed
- `make preflight` — passes
- QA named bundle launch: `OMI_APP_NAME=omi-qa-main NO_WAIT=1 ./run.sh --yolo --full`; confirmed signed bundle and live automation health on port 47919 before the final view-only extraction


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

