### PR TITLE
fix(release): robust Codemagic qualification handoff + fail-open fallback gating

### DIFF
--- a/.github/scripts/desktop_codemagic_qualification.py
+++ b/.github/scripts/desktop_codemagic_qualification.py
@@ -13,12 +13,15 @@ self-hosted qualification lane.
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
+import posixpath
 import sys
 import time
 import urllib.error
 import urllib.request
+import zipfile
 
 API_BASE = "https://api.codemagic.io"
 SUCCESS_STATUSES = {"finished"}
@@ -42,9 +45,7 @@ def _request(url: str, token: str, payload: dict | None = None) -> dict:
         return json.loads(response.read().decode("utf-8"))
 
 
-def start_build(
-    token: str, app_id: str, workflow_id: str, branch: str, release_tag: str, gh_token: str
-) -> str:
+def start_build(token: str, app_id: str, workflow_id: str, branch: str, release_tag: str, gh_token: str) -> str:
     variables = {"OMI_QUALIFY_TAG": release_tag}
     if gh_token:
         # Short-lived Omi Bot app token for the build's read-only gh calls; the
@@ -103,10 +104,7 @@ def verify_result_payload(payload: dict, release_tag: str, target_sha: str) -> N
     if payload.get("ok") is not True:
         fail(f"qualification result does not report ok=true: {json.dumps(payload)[:500]}")
     if payload.get("release_tag") != release_tag:
-        fail(
-            "qualification result is bound to a different tag: "
-            f"{payload.get('release_tag')!r} != {release_tag!r}"
-        )
+        fail("qualification result is bound to a different tag: " f"{payload.get('release_tag')!r} != {release_tag!r}")
     if payload.get("source_sha") != target_sha:
         fail(
             "qualification result is bound to a different source SHA: "
@@ -114,19 +112,58 @@ def verify_result_payload(payload: dict, release_tag: str, target_sha: str) -> N
         )
 
 
-def fetch_result_artifact(token: str, build: dict) -> dict:
-    artefacts = build.get("artefacts") or []
-    url = ""
-    for artefact in artefacts:
-        if isinstance(artefact, dict) and artefact.get("name") == RESULT_ARTIFACT_NAME:
-            url = str(artefact.get("url", ""))
-            break
-    if not url:
-        names = [a.get("name") for a in artefacts if isinstance(a, dict)]
-        fail(f"finished Codemagic build has no {RESULT_ARTIFACT_NAME} artifact (found: {names})")
+def _download_artifact(token: str, url: str) -> bytes:
     request = urllib.request.Request(url, headers={"x-auth-token": token})
     with urllib.request.urlopen(request, timeout=60) as response:
-        return json.loads(response.read().decode("utf-8"))
+        return response.read()
+
+
+def _result_from_zip(payload: bytes) -> dict | None:
+    """Return the qualification result from a Codemagic artifact zip, if present.
+
+    Codemagic exposes recognized build outputs as top-level artefacts but
+    packages arbitrary files (our JSON) that match a directory/`**` glob into a
+    zip artefact. Match by basename so the archive's internal path
+    (e.g. `qualification/qualification-result.json`) still resolves.
+    """
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(payload))
+    except zipfile.BadZipFile:
+        return None
+    for name in archive.namelist():
+        if posixpath.basename(name) == RESULT_ARTIFACT_NAME:
+            with archive.open(name) as member:
+                return json.loads(member.read().decode("utf-8"))
+    return None
+
+
+def fetch_result_artifact(token: str, build: dict) -> dict:
+    """Retrieve qualification-result.json however Codemagic exposed it.
+
+    Preference order: a top-level artefact named exactly the result file, then
+    any zip artefact that contains it. This adapts to Codemagic packaging the
+    `build/qualification/**` glob either as individual files or a single zip,
+    so the handoff does not silently fail (which would drop every candidate to
+    the self-hosted fallback lanes).
+    """
+    artefacts = [a for a in (build.get("artefacts") or []) if isinstance(a, dict)]
+
+    for artefact in artefacts:
+        if artefact.get("name") == RESULT_ARTIFACT_NAME and artefact.get("url"):
+            return json.loads(_download_artifact(token, str(artefact["url"])).decode("utf-8"))
+
+    # No direct file artefact — search zip artefacts for the packaged result.
+    for artefact in artefacts:
+        name = str(artefact.get("name", ""))
+        url = str(artefact.get("url", ""))
+        if url and name.lower().endswith(".zip"):
+            result = _result_from_zip(token and _download_artifact(token, url) or b"")
+            if result is not None:
+                return result
+
+    names = [a.get("name") for a in artefacts]
+    fail(f"finished Codemagic build exposes no {RESULT_ARTIFACT_NAME} (top-level or zipped); artefacts: {names}")
+    raise AssertionError("unreachable")
 
 
 def main() -> None:

--- a/.github/scripts/test_desktop_codemagic_qualification.py
+++ b/.github/scripts/test_desktop_codemagic_qualification.py
@@ -20,9 +20,7 @@ class VerifyResultPayloadTests(unittest.TestCase):
     SHA = "a" * 40
 
     def test_accepts_exact_binding(self) -> None:
-        lane.verify_result_payload(
-            {"ok": True, "release_tag": self.TAG, "source_sha": self.SHA}, self.TAG, self.SHA
-        )
+        lane.verify_result_payload({"ok": True, "release_tag": self.TAG, "source_sha": self.SHA}, self.TAG, self.SHA)
 
     def test_rejects_not_ok(self) -> None:
         with self.assertRaises(SystemExit):
@@ -108,6 +106,65 @@ class FetchResultArtifactTests(unittest.TestCase):
                 {"artefacts": [{"name": "qualification-result.json", "url": "https://example/x"}]},
             )
         self.assertEqual(result, payload)
+
+    def test_extracts_result_from_zip_artifact(self) -> None:
+        """Codemagic zips the build/qualification/** glob; the driver must still find the result."""
+        import io
+        import zipfile
+
+        payload = {"ok": True, "release_tag": "v0.12.113+12113-macos"}
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as archive:
+            archive.writestr("qualification/candidate-gate.json", "{}")
+            archive.writestr("qualification/qualification-result.json", json.dumps(payload))
+        zip_bytes = buffer.getvalue()
+
+        with mock.patch.object(lane, "_download_artifact", return_value=zip_bytes):
+            result = lane.fetch_result_artifact(
+                "token",
+                {"artefacts": [{"name": "qualification.zip", "url": "https://example/z"}]},
+            )
+        self.assertEqual(result, payload)
+
+    def test_prefers_top_level_file_over_zip(self) -> None:
+        direct = {"ok": True, "source": "file"}
+
+        def fake_download(_token, url):
+            import io
+            import zipfile
+
+            if url.endswith(".json"):
+                return json.dumps(direct).encode("utf-8")
+            buffer = io.BytesIO()
+            with zipfile.ZipFile(buffer, "w") as archive:
+                archive.writestr("qualification-result.json", json.dumps({"ok": True, "source": "zip"}))
+            return buffer.getvalue()
+
+        with mock.patch.object(lane, "_download_artifact", side_effect=fake_download):
+            result = lane.fetch_result_artifact(
+                "token",
+                {
+                    "artefacts": [
+                        {"name": "qualification.zip", "url": "https://example/z.zip"},
+                        {"name": "qualification-result.json", "url": "https://example/r.json"},
+                    ]
+                },
+            )
+        self.assertEqual(result["source"], "file")
+
+    def test_zip_without_result_fails(self) -> None:
+        import io
+        import zipfile
+
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as archive:
+            archive.writestr("qualification/candidate-gate.json", "{}")
+        with mock.patch.object(lane, "_download_artifact", return_value=buffer.getvalue()):
+            with self.assertRaises(SystemExit):
+                lane.fetch_result_artifact(
+                    "token",
+                    {"artefacts": [{"name": "qualification.zip", "url": "https://example/z"}]},
+                )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -246,12 +246,17 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         self.assertIn("runs-on: [self-hosted, macos, omi-desktop-qualification, omi-qual-m4-mini]", m4_job)
 
         # Lanes are serialized and each runs only when no earlier lane
-        # qualified; offline runners are skipped rather than queue-stalled.
+        # qualified. Runner gating fails OPEN: a lane is skipped only when the
+        # planner explicitly reported the runner offline ('!= false'), so a
+        # plan-fallbacks failure (e.g. token generation) cannot skip every
+        # self-hosted lane and re-create the single-point-of-failure outage.
         self.assertIn("needs.codemagic-lane.outputs.qualified != 'true'", m1_job)
-        self.assertIn("needs.plan-fallbacks.outputs.m1_online == 'true'", m1_job)
+        self.assertIn("needs.plan-fallbacks.outputs.m1_online != 'false'", m1_job)
+        self.assertNotIn("needs.plan-fallbacks.outputs.m1_online == 'true'", m1_job)
         self.assertIn("needs.codemagic-lane.outputs.qualified != 'true'", m4_job)
         self.assertIn("needs.qualify-m1-studio.outputs.qualified != 'true'", m4_job)
-        self.assertIn("needs.plan-fallbacks.outputs.m4_online == 'true'", m4_job)
+        self.assertIn("needs.plan-fallbacks.outputs.m4_online != 'false'", m4_job)
+        self.assertNotIn("needs.plan-fallbacks.outputs.m4_online == 'true'", m4_job)
 
         # Only the verdict job may fail the workflow run.
         self.assertIn("continue-on-error: true", jobs["codemagic-lane"])

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -256,10 +256,14 @@ jobs:
     # steps to qualify-m4-mini (enforced by
     # test_desktop_release_flow_contract.py); only the runner label differs.
     needs: [codemagic-lane, plan-fallbacks]
+    # Fail open: run unless the planner explicitly reported this runner offline.
+    # If plan-fallbacks itself failed (e.g. token generation), its output is
+    # empty, which must still let the fallback attempt run rather than skip
+    # every self-hosted lane and re-create the single-point-of-failure outage.
     if: >-
       ${{ always() &&
           needs.codemagic-lane.outputs.qualified != 'true' &&
-          needs.plan-fallbacks.outputs.m1_online == 'true' }}
+          needs.plan-fallbacks.outputs.m1_online != 'false' }}
     runs-on: [self-hosted, macos, omi-desktop-qualification, omi-qual-m1-studio]
     continue-on-error: true
     permissions:
@@ -437,11 +441,13 @@ jobs:
     # to qualify-m1-studio (enforced by
     # test_desktop_release_flow_contract.py); only the runner label differs.
     needs: [codemagic-lane, plan-fallbacks, qualify-m1-studio]
+    # Fail open (see qualify-m1-studio): run unless the planner explicitly
+    # reported this runner offline, so a planner failure cannot skip the lane.
     if: >-
       ${{ always() &&
           needs.codemagic-lane.outputs.qualified != 'true' &&
           needs.qualify-m1-studio.outputs.qualified != 'true' &&
-          needs.plan-fallbacks.outputs.m4_online == 'true' }}
+          needs.plan-fallbacks.outputs.m4_online != 'false' }}
     runs-on: [self-hosted, macos, omi-desktop-qualification, omi-qual-m4-mini]
     continue-on-error: true
     permissions:


### PR DESCRIPTION
## Two robustness defects in the merged qualification lanes (#10354/#10363)

Cross-review found two real gaps in the multi-lane qualification, neither covered by the existing tests. Both keep the "at least one lane qualifies a healthy candidate" guarantee honest.

### 1. Codemagic artifact handoff was shape-fragile (and unverified end-to-end)
The CM lane publishes `build/qualification/**` (JSON). Codemagic exposes recognized build outputs (`.app`/`.dmg`/`.zip`/…) as top-level artefacts but packages arbitrary files matching a directory/`**` glob into a **single zip artefact**. `desktop_codemagic_qualification.py` only matched a top-level `qualification-result.json`, so a zipped artefact would make the driver fail to find the result → **every CM qualification silently falls through to the self-hosted lanes**, defeating the CM-primary design.

`fetch_result_artifact` now prefers a top-level file and otherwise **extracts the result from a zip artefact by basename** (so an internal path like `qualification/qualification-result.json` still resolves). The driver adapts to whatever shape Codemagic produces, so the digest-pinned `codemagic.yaml` needs no change.

*Honesty note:* all prior live CM test builds died at the venv step (fixed separately in #10374), so a real CM build never produced this artefact — the handoff stays **UNVERIFIED end-to-end** until #10374 lets a CM qualification complete. This PR makes the driver correct for both artefact shapes and covers them with tests; the live confirmation is a follow-up once a green CM build exists.

### 2. `plan-fallbacks` did not fully fail open
The `gh api` runner-status step fails open, but a failure in the **earlier token-generation step** fails the whole `plan-fallbacks` job with empty outputs. The lanes gated on `m{1,4}_online == 'true'`, so empty `!= 'true'` → **both self-hosted fallbacks skipped** — re-creating the single-machine outage on any token hiccup.

Gate now fails open: `m{1,4}_online != 'false'` — a lane is skipped only when the planner **explicitly** reports the runner offline. A planner failure now lets the fallbacks attempt.

## Verification
- `python3 .github/scripts/test_desktop_codemagic_qualification.py` → 13 OK (new: extract-from-zip, prefer-top-level-over-zip, zip-without-result-fails)
- `python3 .github/scripts/test_desktop_release_flow_contract.py` → 20 OK (asserts `!= 'false'` fail-open gating on both lanes; `== 'true'` explicitly forbidden)
- `actionlint .github/workflows/desktop_qualify_beta.yml` → exit 0
- `python3 .github/scripts/check-release-process-guards.py` → passed
- `bash scripts/dev-harness/run-tests.sh` → 50 passed
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh` → passed
- `make preflight` → (see checks)

Failure-Class: FC-single-machine-release-gate


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

