### PR TITLE
Enable production LLM Gateway for Cloud Run callers

### DIFF
--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -1010,7 +1010,7 @@ environments:
               default: http://127.0.0.1:9
               category: service_discovery
             OMI_LLM_GATEWAY_FEATURE_MODE:
-              value: 'off'
+              value: gateway
               category: rollout
             PUBLIC_SHARED_CONVERSATION_CHAT_MODE:
               value: 'off'
@@ -1169,7 +1169,7 @@ environments:
               default: http://127.0.0.1:9
               category: service_discovery
             OMI_LLM_GATEWAY_FEATURE_MODE:
-              value: 'off'
+              value: gateway
               category: rollout
             PUBLIC_SHARED_CONVERSATION_CHAT_MODE:
               value: 'off'
@@ -1267,7 +1267,7 @@ environments:
               default: http://127.0.0.1:9
               category: service_discovery
             OMI_LLM_GATEWAY_FEATURE_MODE:
-              value: 'off'
+              value: gateway
               category: rollout
             PUBLIC_SHARED_CONVERSATION_CHAT_MODE:
               value: 'off'

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -104,7 +104,7 @@ def test_llm_gateway_anthropic_secret_and_authenticated_readiness_probe_contract
         assert 'X-Omi-Service-Caller: backend' in probe_command
 
 
-def test_prod_gateway_wiring_is_off_until_verified_promotion():
+def test_prod_gateway_wiring_promotes_cloud_run_only_after_verified_endpoint_injection():
     manifest = _load_yaml('deploy/runtime_env.yaml')
     prod = manifest['environments']['prod']
     gke_env = prod['gke']['backend-listen']['env']
@@ -118,14 +118,14 @@ def test_prod_gateway_wiring_is_off_until_verified_promotion():
     assert gke_env['GCP_LOCATION']['value'] == 'us-central1'
     assert gke_env['GOOGLE_CLOUD_PROJECT']['value'] == 'based-hardware'
 
-    for service in ('backend', 'backend-sync', 'backend-integration'):
+    for service in ('backend', 'backend-sync', 'backend-sync-backfill', 'backend-integration'):
         service_config = prod['cloud_run']['services'][service]
         assert service_config['env']['OMI_LLM_GATEWAY_URL'] == {
             'env_var': 'OMI_LLM_GATEWAY_URL',
             'default': 'http://127.0.0.1:9',
             'category': 'service_discovery',
         }
-        assert service_config['env']['OMI_LLM_GATEWAY_FEATURE_MODE']['value'] == 'off'
+        assert service_config['env']['OMI_LLM_GATEWAY_FEATURE_MODE']['value'] == 'gateway'
         assert service_config['env']['OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE']['value'] == 'true'
         assert service_config['env']['OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION']['value'] == 'true'
         assert service_config['env']['USE_VERTEX_AI']['value'] == 'true'

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -199,6 +199,37 @@ def test_render_prod_keeps_memory_maintenance_job_promotion_off(capsys, monkeypa
     assert 'MEMORY_CANONICAL_PROMOTION_CRON_ENABLED' not in notifications_env
 
 
+def test_render_prod_gateway_callers_inject_verified_endpoint(capsys, monkeypatch):
+    monkeypatch.setenv('CLOUD_RUN_VPC_NETWORK', 'omi-prod-vpc')
+    monkeypatch.setenv('CLOUD_RUN_VPC_SUBNET', 'omi-prod-subnet')
+    monkeypatch.setenv('GOOGLE_CLIENT_ID', 'fake-google-client-id')
+    monkeypatch.setenv('STT_PRERECORDED_MODEL', 'dg-nova-3')
+    monkeypatch.setenv('MCP_OAUTH_CLAUDE_CLIENT_ID', 'fake-claude-client-id')
+    monkeypatch.setenv('MCP_OAUTH_CLAUDE_CLIENT_NAME', 'Claude')
+    monkeypatch.setenv('MCP_OAUTH_CLAUDE_REDIRECT_URIS', 'https://claude.example/callback')
+    monkeypatch.setenv(
+        'ACCOUNT_DELETION_HANDLER_URL', 'https://backend-sync.example.com/v1/users/account-deletion-wipes/run'
+    )
+    monkeypatch.setenv(
+        'LISTEN_FINALIZATION_TASKS_HANDLER_URL',
+        'https://backend-sync.example.com/v1/conversation-finalization-jobs/run',
+    )
+    monkeypatch.setenv('LISTEN_FINALIZATION_TASKS_INVOKER_SA', 'invoker@project.iam.gserviceaccount.com')
+    monkeypatch.setenv('SYNC_TASKS_HANDLER_URL', 'https://backend-sync.example.com/v2/sync-jobs/run')
+    monkeypatch.setenv('SYNC_TASKS_INVOKER_SA', 'invoker@project.iam.gserviceaccount.com')
+    monkeypatch.setenv('OMI_LLM_GATEWAY_URL', 'http://172.16.160.108')
+    monkeypatch.setattr('sys.argv', ['render_backend_runtime_env.py', '--env', 'prod'])
+
+    assert _MODULE['main']() == 0
+    output = capsys.readouterr().out
+
+    for service in ('backend', 'backend_sync', 'backend_sync_backfill', 'backend_integration'):
+        service_env = _job_env_block(output, service)
+        assert 'OMI_LLM_GATEWAY_FEATURE_MODE=gateway' in service_env
+        assert 'OMI_LLM_GATEWAY_URL=http://172.16.160.108' in service_env
+        assert 'OMI_LLM_GATEWAY_URL=http://127.0.0.1:9' not in service_env
+
+
 def test_render_prod_requires_vpc_env_vars_before_job_outputs(monkeypatch):
     """Prod network flags are env_var-backed; missing VPC vars abort render before job outputs.
 

--- a/backend/tests/unit/test_verify_llm_gateway_serving.py
+++ b/backend/tests/unit/test_verify_llm_gateway_serving.py
@@ -63,7 +63,9 @@ def _healthy_responses() -> dict[str, object]:
 def test_gateway_promotion_intent_tracks_runtime_and_helm_listener_surfaces(gateway_gate, tmp_path: Path) -> None:
     manifest = Path(__file__).resolve().parents[2] / 'deploy' / 'runtime_env.yaml'
 
-    assert gateway_gate.gateway_promotion_requested(manifest_path=manifest, environment='prod') is False
+    # The Cloud Run callers request gateway mode while the GKE listener remains off.
+    # That intent must still trigger endpoint verification before their revisions render.
+    assert gateway_gate.gateway_promotion_requested(manifest_path=manifest, environment='prod') is True
 
     listener_values = tmp_path / 'prod_listener_values.yaml'
     listener_values.write_text('env:\n  - name: OMI_LLM_GATEWAY_FEATURE_MODE\n    value: gateway\n', encoding='utf-8')


### PR DESCRIPTION
## Summary

- Enable `OMI_LLM_GATEWAY_FEATURE_MODE=gateway` for production Cloud Run `backend`, `backend-sync`, `backend-sync-backfill`, and `backend-integration`.
- Keep the production GKE `backend-listen` gateway mode off; retain direct-provider fallback, circuit-breaker settings, allow flags, and endpoint derivation.
- Cover Cloud Run gateway intent and rendering of a verified non-sentinel gateway endpoint for every caller surface.

## Verification

- `source backend/.venv/bin/activate && pytest -q backend/tests/unit/test_llm_gateway_deploy_contract.py backend/tests/unit/test_verify_llm_gateway_serving.py backend/tests/unit/test_render_backend_runtime_env.py` — 35 passed.
- `source backend/.venv/bin/activate && python -m pytest -q backend/tests/unit/test_backend_runtime_env_validator.py backend/tests/unit/test_llm_gateway_deploy_contract.py backend/tests/unit/test_verify_llm_gateway_serving.py backend/tests/unit/test_render_backend_runtime_env.py` — 107 passed.
- `make preflight` — passed.
- `backend/scripts/pre-deploy-check.sh` could not start its hermetic checks because the newly synced pinned local virtualenv has no `pip` module; the focused runtime/deployment contract tests above passed.

## Failure-Class

none — this is a `feat:` configuration activation, not a `fix:` commit.

## Rollback

Revert this commit to restore `OMI_LLM_GATEWAY_FEATURE_MODE=off` for all production Cloud Run callers. The deployment workflow continues to reject an empty or sentinel endpoint whenever gateway intent is requested, before Cloud Run revisions are rendered.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

