### PR TITLE
macOS PTT: add privacy-bounded capture-lifecycle diagnostics

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -3,14 +3,14 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2375,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2639,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4849,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2448,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2567,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1621
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": "Agent completion presentation now follows the canonical terminal lifecycle used by PTT and chat.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": "The Second Brain onboarding, reach-error, and notch-moment UI keeps the hover menu agent-only and routes idle notch taps through main chat.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": "Second Brain continuous-chat routing shares window geometry with agent-only hover sizing and canonical idle-notch chat ownership.",
-    "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": "Strict concurrency annotations coexist with response-critical batch STT and parallel screen-context capture in the owning turn manager.",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": "The owning turn manager carries privacy-bounded push-to-talk capture-lifecycle diagnostics wiring alongside strict concurrency, response-critical batch STT, and parallel screen-context capture.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior."
   },
   "threshold": 1500

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -3,7 +3,7 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2375,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2639,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4849,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2567,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2593,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1621
   },
   "raise_justifications": {

--- a/desktop/macos/Desktop/Sources/AudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/AudioCaptureService.swift
@@ -103,6 +103,14 @@ class AudioCaptureService: @unchecked Sendable {
     let isBuiltIn = (deviceID == AudioCaptureService.findBuiltInMicDeviceID())
     return isBuiltIn ? "built-in id=\(deviceID)" : "id=\(deviceID)"
   }
+  /// Whether the active capture device is on a Bluetooth transport (A2DP/HFP),
+  /// the known profile-conflict case that feeds zeros. Exposed so the PTT
+  /// lifecycle route classification can label Bluetooth without logging the
+  /// device name. Derives from CoreAudio transport type, not the redacted
+  /// `currentDeviceDescription` string.
+  var isCurrentDeviceBluetoothTransport: Bool {
+    Self.isBluetoothTransport(deviceID: deviceID)
+  }
 
   // Silent-mic watchdog. Re-arms after each fire so one session can recover from more
   // than one silent episode; two guards keep it from spinning the recovery loop:

--- a/desktop/macos/Desktop/Sources/AudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/AudioCaptureService.swift
@@ -91,6 +91,11 @@ class AudioCaptureService: @unchecked Sendable {
   /// single capture session can recover from more than one silent episode.
   var onSilentMicDetected: (@Sendable (SilentMicDetection) -> Void)?
   var detectSilentMicOnAnyTransport = false
+  /// Fires (once per change) when the HAL reports a device/format/route change
+  /// during an active capture — a known precursor of silent capture (headset
+  /// plug/unplug, Bluetooth profile flip, default-input switch). Carries no
+  /// device identity; owners record only a boolean "route changed" flag.
+  var onInputRouteChanged: (@Sendable () -> Void)?
 
   /// Human-readable description of the capture device currently in use — for
   /// diagnostics (which mic a turn was recorded from).
@@ -804,6 +809,8 @@ class AudioCaptureService: @unchecked Sendable {
     isReconfiguring = true
 
     log("AudioCapture: Configuration changed, restarting with new device...")
+    let routeHandler = onInputRouteChanged
+    DispatchQueue.main.async { routeHandler?() }
 
     // Stop IOProc on old device
     if let procID = ioProcID, deviceID != kAudioObjectUnknown {

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -12,6 +12,7 @@ enum DesktopHealthEventName: String {
   case pttAudioCaptureWatchdogTriggered = "ptt_audio_capture_watchdog_triggered"
   case pttAudioCaptureDeviceRouteChanged = "ptt_audio_capture_device_route_changed"
   case pttCommitted = "ptt_committed"
+  case pttAudioCaptureLifecycle = "ptt_audio_capture_lifecycle"
   case voiceTurnStarted = "voice_turn_started"
   case voiceTurnTerminal = "voice_turn_terminal"
   case realtimeTokenMintFailed = "realtime_token_mint_failed"
@@ -349,6 +350,20 @@ final class DesktopDiagnosticsManager {
       ],
       trackRemotely: false)
   }
+  /// Record one bounded PTT attempt lifecycle snapshot (see
+  /// `PTTAttemptLifecycleRecorder`). Routes through the shared ring buffer + Sentry
+  /// attachment path; the event is remote (PostHog) only for non-committed
+  /// terminations so successful turns stay local-only (matching
+  /// `recordPTTStarted` / `recordPTTCommitted`). This is the causal-correlation
+  /// complement to the late `recordPTTSilentTurn` snapshot: same attempt context,
+  /// but with the capture-start / first-audio / first-usable-frame / recovery
+  /// boundaries that the silent-turn snapshot cannot see.
+  func recordPTTAttemptLifecycle(_ snapshot: PTTAttemptLifecycleRecorder.Snapshot) {
+    record(
+      .pttAudioCaptureLifecycle,
+      properties: snapshot.properties,
+      trackRemotely: snapshot.failureClass != .committed)
+  }
 
   /// Records a typed chat failure as a fleet-health metric. The existing bounded
   /// `logError` path owns the matching Sentry incident to avoid duplicate capture.
@@ -643,6 +658,7 @@ final class DesktopDiagnosticsManager {
     let includesTypedIncidentContext =
       snapshot.event == .userVisibleIssue
       || snapshot.event == .pttAudioCaptureWatchdogTriggered
+      || snapshot.event == .pttAudioCaptureLifecycle
       || (includeBetaDiagnostics && snapshot.event == .betaDiagnosticTrail)
     guard includesTypedIncidentContext else {
       return result
@@ -663,6 +679,13 @@ final class DesktopDiagnosticsManager {
     "input_device_class", "recovery_action", "recovery_result", "threshold",
     "component", "operation", "outcome", "error_domain", "error_code",
     "osstatus", "keycode", "modifiers",
+    // PTT attempt lifecycle correlation (PTTAttemptLifecycleRecorder).
+    "attempt_id", "capture_start_outcome", "capture_start_status_class",
+    "ms_to_first_audio_bucket", "ms_to_first_usable_frame_bucket",
+    "first_chunks_energy_bucket", "turn_disposition",
+    "input_route_class", "input_route_source", "route_changed_during_attempt",
+    "recovery_triggered", "recovery_attempt_id", "recovery_outcome_of_next_turn",
+    "judgeable", "telemetry_schema_version",
   ]
 
   func writeDiagnosticsAttachment() -> URL? {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PTTAttemptLifecycleRecorder.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PTTAttemptLifecycleRecorder.swift
@@ -1,0 +1,507 @@
+import Foundation
+
+/// Privacy-bounded capture-lifecycle correlation model for a single push-to-talk
+/// (PTT) attempt and any recovery it triggers.
+///
+/// The existing `recordPTTSilentTurn` path records a *late* snapshot — it sees
+/// peak/RMS/seconds at finalization but cannot answer *why* a turn was silent:
+/// did capture ever start? did it deliver frames? was the key released before the
+/// first usable audio arrived? did a capture rebuild restore the next turn? Those
+/// questions are unanswerable from product telemetry alone, so a repeatable
+/// "floating_bar_ptt_ended had_transcript=false, zero audio" incident cannot be
+/// classified into one of the four causally distinct boundaries.
+///
+/// This recorder accumulates the *boundaries that already exist* in the capture
+/// lifecycle (press, capture-start requested/accepted/failed, first audio
+/// callback, first usable frame, release/disposition, recovery) into one redacted
+/// per-attempt snapshot and emits it through `DesktopDiagnosticsManager` when the
+/// attempt terminates. Every field is a bounded, low-cardinality bucket or safe
+/// classification — never raw audio, device names, hardware IDs, paths, or error
+/// strings.
+///
+/// Privacy boundary (mirrors `DesktopDiagnosticsManager`):
+/// - raw audio frames are never retained; only a peak amplitude is reduced to an
+///   energy bucket while searching for the first usable frame, then scanning stops;
+/// - device identity is reduced to a transport class + default-vs-override flag;
+/// - capture-start OSStatus / error text is reduced to a status class.
+@MainActor
+final class PTTAttemptLifecycleRecorder {
+  /// What a bounded millisecond duration collapses into for remote querying.
+  enum MillisecondsBucket: String {
+    case none
+    case lt50 = "lt_50"
+    case lt100 = "lt_100"
+    case lt200 = "lt_200"
+    case lt500 = "lt_500"
+    case ge500 = "ge_500"
+
+    static func bucket(fromMs ms: Int?) -> MillisecondsBucket {
+      guard let ms else { return .none }
+      if ms < 50 { return .lt50 }
+      if ms < 100 { return .lt100 }
+      if ms < 200 { return .lt200 }
+      if ms < 500 { return .lt500 }
+      return .ge500
+    }
+  }
+
+  /// Energy class of the first received audio chunks — distinguishes a capture
+  /// that delivers real samples from one that delivers only zeros.
+  enum FirstChunksEnergyBucket: String {
+    case none
+    case zero
+    case nearZero = "near_zero"
+    case audible
+  }
+
+  enum CaptureStartOutcome: String {
+    case notRequested = "not_requested"
+    case requested
+    case accepted
+    case failed
+  }
+
+  /// Sanitized capture-start status class. Derived from `AudioCaptureError`, never
+  /// from the raw `OSStatus` or the unrestricted error description.
+  enum CaptureStartStatusClass: String {
+    case none
+    case ok
+    case noInput = "no_input"
+    case engineStartFailed = "engine_start_failed"
+    case permissionDenied = "permission_denied"
+    case otherError = "other_error"
+
+    static func from(error: Error?) -> CaptureStartStatusClass {
+      guard let error else { return .none }
+      // Match by the typed `AudioCaptureService.AudioCaptureError` cases so the raw
+      // OSStatus code and localized description never enter the payload.
+      if let capture = error as? AudioCaptureService.AudioCaptureError {
+        switch capture {
+        case .noInputAvailable: return .noInput
+        case .engineStartFailed: return .engineStartFailed
+        case .permissionDenied: return .permissionDenied
+        case .converterCreationFailed: return .otherError
+        }
+      }
+      return .otherError
+    }
+  }
+
+  enum InputRouteClass: String {
+    case builtIn = "built_in"
+    case external
+    case bluetooth
+    case virtual
+    case unknown
+
+    static func from(deviceDescription: String?) -> InputRouteClass {
+      let lower = (deviceDescription ?? "").lowercased()
+      if lower.contains("built-in") { return .builtIn }
+      if lower.contains("bluetooth") { return .bluetooth }
+      if lower.contains("virtual") || lower.contains("aggregate") { return .virtual }
+      if lower.isEmpty || lower == "?" { return .unknown }
+      return .external
+    }
+  }
+
+  enum InputRouteSource: String {
+    case `default`
+    case override
+  }
+
+  enum TurnDisposition: String {
+    case committed
+    case silentRejected = "silent_rejected"
+    case tooShort = "too_short"
+    case cancelled
+  }
+
+  enum RecoveryAction: String {
+    case none
+    case captureRebuild = "capture_rebuild"
+    case switchToBuiltInMic = "switch_to_built_in_mic"
+  }
+
+  /// The four causally distinct failure boundaries the schema exists to separate,
+  /// plus the success / non-judgeable terminations. `recovery_outcome_*` is set on
+  /// the *next judgeable* attempt that resolves a prior capture rebuild, so a query
+  /// joins triggering and resolving attempts on `recovery_attempt_id`.
+  enum FailureClass: String {
+    case captureNeverOperational = "capture_never_operational"
+    case zeroOrNearZeroSamples = "zero_or_near_zero_samples"
+    case releasedBeforeUsableAudio = "released_before_usable_audio"
+    case recoveryOutcomeRecovered = "recovery_outcome_recovered"
+    case recoveryOutcomeStillSilent = "recovery_outcome_still_silent"
+    case recoveryOutcomeNotJudgeable = "recovery_outcome_not_judgeable"
+    case committed
+    case tooShortAudible = "too_short_audible"
+    case cancelled
+  }
+
+  enum RecoveryOutcomeOfNextTurn: String {
+    case none
+    case recovered
+    case stillSilent = "still_silent"
+    case notJudgeable = "not_judgeable"
+  }
+
+  /// The redacted, joinable terminal snapshot handed to `DesktopDiagnosticsManager`.
+  struct Snapshot {
+    var attemptId: String
+    var failureClass: FailureClass
+    var captureStartOutcome: CaptureStartOutcome
+    var captureStartStatusClass: CaptureStartStatusClass
+    var msToFirstAudioBucket: MillisecondsBucket
+    var msToFirstUsableFrameBucket: MillisecondsBucket
+    var firstChunksEnergyBucket: FirstChunksEnergyBucket
+    var turnDisposition: TurnDisposition
+    var inputRouteClass: InputRouteClass
+    var inputRouteSource: InputRouteSource
+    var routeChangedDuringAttempt: Bool
+    var recoveryTriggered: Bool
+    var recoveryAction: RecoveryAction
+    var recoveryAttemptId: String?
+    var recoveryOutcomeOfNextTurn: RecoveryOutcomeOfNextTurn
+    // Reused safe context also carried by the late silent-turn snapshot, so the two
+    // can be correlated without re-sending raw audio or device identity.
+    var mode: String
+    var source: String
+    var hubActive: Bool
+    var micPermissionGranted: Bool
+    var turnAudioSeconds: Double
+    var voicedAudioSeconds: Double?
+    var peak: Int
+    var rms: Int
+    var isNearZero: Bool
+    var judgeable: Bool
+    var telemetrySchemaVersion: Int
+
+    /// Low-cardinality `[String: Any]` for the PostHog / ring-buffer path. All
+    /// values are bounded strings, booleans, or small numbers.
+    var properties: [String: Any] {
+      var dict: [String: Any] = [
+        "attempt_id": attemptId,
+        "failure_class": failureClass.rawValue,
+        "capture_start_outcome": captureStartOutcome.rawValue,
+        "capture_start_status_class": captureStartStatusClass.rawValue,
+        "ms_to_first_audio_bucket": msToFirstAudioBucket.rawValue,
+        "ms_to_first_usable_frame_bucket": msToFirstUsableFrameBucket.rawValue,
+        "first_chunks_energy_bucket": firstChunksEnergyBucket.rawValue,
+        "turn_disposition": turnDisposition.rawValue,
+        "input_route_class": inputRouteClass.rawValue,
+        "input_route_source": inputRouteSource.rawValue,
+        "route_changed_during_attempt": routeChangedDuringAttempt,
+        "recovery_triggered": recoveryTriggered,
+        "recovery_action": recoveryAction.rawValue,
+        "recovery_outcome_of_next_turn": recoveryOutcomeOfNextTurn.rawValue,
+        "mode": mode,
+        "source": source,
+        "hub_active": hubActive,
+        "tcc_microphone_granted": micPermissionGranted,
+        "turn_audio_seconds": rounded(turnAudioSeconds),
+        "peak": peak,
+        "rms": rms,
+        "is_near_zero": isNearZero,
+        "judgeable": judgeable,
+        "telemetry_schema_version": telemetrySchemaVersion,
+      ]
+      if let voicedAudioSeconds {
+        dict["voiced_audio_seconds"] = rounded(voicedAudioSeconds)
+      }
+      if let recoveryAttemptId {
+        dict["recovery_attempt_id"] = recoveryAttemptId
+      }
+      return dict
+    }
+
+    private func rounded(_ value: Double) -> Double {
+      (value * 100).rounded() / 100
+    }
+  }
+
+  /// Sink for emitted snapshots. Default routes through the diagnostics manager;
+  /// tests inject a capturing closure so the classification is verifiable in
+  /// isolation without touching the shared PostHog/Sentry singleton.
+  var emit: (Snapshot) -> Void = { DesktopDiagnosticsManager.shared.recordPTTAttemptLifecycle($0) }
+
+  /// Injectable clock so timing buckets are deterministic in tests.
+  var now: () -> Date = { Date() }
+
+  private var attemptSequence: UInt64 = 0
+  private var recoverySequence: UInt64 = 0
+
+  // Per-attempt accumulation state. Reset on every `beginAttempt`.
+  private var attemptId: String = "0"
+  private var attemptStartedAt: Date?
+  private var captureStartOutcome: CaptureStartOutcome = .notRequested
+  private var captureStartStatusClass: CaptureStartStatusClass = .none
+  private var firstAudioCallbackAt: Date?
+  private var firstUsableFrameAt: Date?
+  private var firstChunksEnergy: FirstChunksEnergyBucket = .none
+  private var inputRouteClass: InputRouteClass = .unknown
+  private var inputRouteSource: InputRouteSource = .default
+  private var routeChangedDuringAttempt = false
+  private var recoveryTriggered = false
+  private var recoveryAction: RecoveryAction = .none
+
+  /// A capture rebuild requested on a *prior* attempt, awaiting its next judgeable
+  /// turn to record whether it restored capture. Joined on `recovery_attempt_id`.
+  private var pendingRecoveryAttemptId: String?
+
+  // Cached attempt context set in beginAttempt, read at terminate.
+  private var cachedMode: String = ""
+  private var cachedHubActive: Bool = false
+  private var cachedMicPermissionGranted: Bool = false
+
+  init() {}
+
+  // MARK: - Per-attempt boundaries
+
+  /// PTT press / attempt start. The transcription route `source` (hub / omni_stt /
+  /// batch_stt …) is resolved at finalization, not at press.
+  func beginAttempt(mode: String, hubActive: Bool, micPermissionGranted: Bool) {
+    attemptSequence &+= 1
+    attemptId = String(attemptSequence)
+    attemptStartedAt = now()
+    captureStartOutcome = .notRequested
+    captureStartStatusClass = .none
+    firstAudioCallbackAt = nil
+    firstUsableFrameAt = nil
+    firstChunksEnergy = .none
+    inputRouteClass = .unknown
+    inputRouteSource = .default
+    routeChangedDuringAttempt = false
+    recoveryTriggered = false
+    recoveryAction = .none
+    cachedMode = mode
+    cachedHubActive = hubActive
+    cachedMicPermissionGranted = micPermissionGranted
+  }
+
+  /// Capture-start requested (the async CoreAudio start is now in flight).
+  func captureStartRequested() {
+    guard captureStartOutcome == .notRequested else { return }
+    captureStartOutcome = .requested
+  }
+
+  /// Capture-start resolved — accepted (IOProc running) or failed.
+  func captureStartResolved(outcome: CaptureStartOutcome, statusClass: CaptureStartStatusClass) {
+    guard outcome == .accepted || outcome == .failed else { return }
+    captureStartOutcome = outcome
+    captureStartStatusClass = outcome == .accepted ? .ok : statusClass
+  }
+
+  /// Record the input route at the moment capture was configured.
+  func noteInputRoute(class routeClass: InputRouteClass, source: InputRouteSource) {
+    inputRouteClass = routeClass
+    inputRouteSource = source
+  }
+
+  /// A HAL device/format change was observed during the attempt (user plugged a
+  /// headset, a Bluetooth profile flipped, etc.). This is a known precursor of
+  /// silent capture and is recorded as a boolean flag, never the device identity.
+  func noteRouteChanged() {
+    routeChangedDuringAttempt = true
+  }
+
+  /// An audio chunk arrived from the capture callback. The peak is reduced to an
+  /// energy bucket and scanning stops once the first usable frame is found, so a
+  /// long successful turn does not pay a per-chunk cost. Raw PCM is not retained.
+  func ingestAudioChunk(_ pcm16k: Data) {
+    if firstAudioCallbackAt == nil {
+      firstAudioCallbackAt = now()
+    }
+    classifyFirstChunkEnergy(pcm16k)
+  }
+
+  private func classifyFirstChunkEnergy(_ pcm16k: Data) {
+    guard firstUsableFrameAt == nil else { return }
+    let peak = Self.peakAmplitude(pcm16k: pcm16k)
+    // Bucket the leading energy so a capture delivering only zeros is separable
+    // from one delivering real speech. `5` is the same boundary the silent-mic
+    // watchdog and dead-mic recovery use (peak ≤ 5 ≈ -76 dBFS is silent).
+    if peak > 50 {
+      firstChunksEnergy = .audible
+      firstUsableFrameAt = now()
+    } else if peak > 5 {
+      if firstChunksEnergy != .audible { firstChunksEnergy = .nearZero }
+    } else {
+      if firstChunksEnergy == .none { firstChunksEnergy = .zero }
+    }
+  }
+
+  /// A recovery was requested for this attempt. Mints a bounded correlation id
+  /// that the *next judgeable* attempt resolves.
+  func recoveryTriggered(action: RecoveryAction) {
+    guard action != .none else { return }
+    recoveryTriggered = true
+    recoveryAction = action
+    recoverySequence &+= 1
+    pendingRecoveryAttemptId = "r\(recoverySequence)"
+  }
+
+  // MARK: - Termination
+
+  /// Classify the attempt and emit one redacted snapshot. Resolves any pending
+  /// recovery from a prior attempt against this turn's outcome.
+  @discardableResult
+  func terminate(
+    disposition: TurnDisposition,
+    source: String,
+    peak: Int,
+    rms: Int,
+    turnAudioSeconds: Double,
+    voicedAudioSeconds: Double?,
+    isNearZero: Bool,
+    judgeable: Bool
+  ) -> Snapshot {
+    let msToFirstAudio = milliseconds(since: attemptStartedAt, to: firstAudioCallbackAt)
+    let msToFirstUsable = milliseconds(since: attemptStartedAt, to: firstUsableFrameAt)
+    let firstEnergy = finalizeFirstChunksEnergy(
+      hadCallbacks: firstAudioCallbackAt != nil, isNearZero: isNearZero, judgeable: judgeable)
+
+    // Resolve a recovery requested on a *prior* attempt: this turn is the "next
+    // judgeable turn" whose outcome proves whether the rebuild restored capture.
+    // A turn that itself triggers a fresh rebuild mints its own id and does not
+    // resolve the prior one (its own failure_class still records the trigger).
+    let priorRecoveryId = pendingRecoveryAttemptId
+    var resolvedOutcome = RecoveryOutcomeOfNextTurn.none
+    if priorRecoveryId != nil, !recoveryTriggered {
+      if !judgeable {
+        resolvedOutcome = .notJudgeable
+      } else if isNearZero {
+        resolvedOutcome = .stillSilent
+      } else {
+        resolvedOutcome = .recovered
+      }
+      // A non-judgeable turn carries no evidence — leave the recovery pending so the
+      // next truly judgeable turn resolves it instead of masking it.
+      if resolvedOutcome != .notJudgeable {
+        pendingRecoveryAttemptId = nil
+      }
+    }
+
+    let failureClass = Self.classify(
+      disposition: disposition,
+      captureStartOutcome: captureStartOutcome,
+      hadFirstAudioCallback: firstAudioCallbackAt != nil,
+      hadFirstUsableFrame: firstUsableFrameAt != nil,
+      isNearZero: isNearZero,
+      judgeable: judgeable,
+      resolvedRecoveryOutcome: resolvedOutcome)
+
+    let snapshot = Snapshot(
+      attemptId: attemptId,
+      failureClass: failureClass,
+      captureStartOutcome: captureStartOutcome,
+      captureStartStatusClass: captureStartStatusClass,
+      msToFirstAudioBucket: MillisecondsBucket.bucket(fromMs: msToFirstAudio),
+      msToFirstUsableFrameBucket: MillisecondsBucket.bucket(fromMs: msToFirstUsable),
+      firstChunksEnergyBucket: firstEnergy,
+      turnDisposition: disposition,
+      inputRouteClass: inputRouteClass,
+      inputRouteSource: inputRouteSource,
+      routeChangedDuringAttempt: routeChangedDuringAttempt,
+      recoveryTriggered: recoveryTriggered,
+      recoveryAction: recoveryAction,
+      recoveryAttemptId: recoveryTriggered ? pendingRecoveryAttemptId : priorRecoveryId,
+      recoveryOutcomeOfNextTurn: resolvedOutcome,
+      mode: cachedMode,
+      source: source,
+      hubActive: cachedHubActive,
+      micPermissionGranted: cachedMicPermissionGranted,
+      turnAudioSeconds: turnAudioSeconds,
+      voicedAudioSeconds: voicedAudioSeconds,
+      peak: peak,
+      rms: rms,
+      isNearZero: isNearZero,
+      judgeable: judgeable,
+      telemetrySchemaVersion: 1)
+
+    emit(snapshot)
+    return snapshot
+  }
+
+  // MARK: - Classification
+
+  /// Pure precedence over the causally distinct boundaries. Order matters: a
+  /// recovery outcome (resolved by this turn) dominates, then capture-start
+  /// failure / no-callback, then released-before-usable-audio, then zero samples.
+  static func classify(
+    disposition: TurnDisposition,
+    captureStartOutcome: CaptureStartOutcome,
+    hadFirstAudioCallback: Bool,
+    hadFirstUsableFrame: Bool,
+    isNearZero: Bool,
+    judgeable: Bool,
+    resolvedRecoveryOutcome: RecoveryOutcomeOfNextTurn
+  ) -> FailureClass {
+    if resolvedRecoveryOutcome == .recovered { return .recoveryOutcomeRecovered }
+    if resolvedRecoveryOutcome == .stillSilent { return .recoveryOutcomeStillSilent }
+    if resolvedRecoveryOutcome == .notJudgeable { return .recoveryOutcomeNotJudgeable }
+
+    if disposition == .cancelled { return .cancelled }
+
+    // (1) Capture never became operational: start failed, or it was requested but
+    // never delivered a callback before the turn ended (startup race).
+    if captureStartOutcome == .failed || !hadFirstAudioCallback {
+      return .captureNeverOperational
+    }
+
+    // (3) Released before the first usable audio arrived — the key came up before
+    // any audible frame, even though callbacks were flowing.
+    if !hadFirstUsableFrame {
+      if disposition == .tooShort || !judgeable {
+        return .releasedBeforeUsableAudio
+      }
+      // Long enough to judge but no usable frame ever appeared.
+      return .zeroOrNearZeroSamples
+    }
+
+    // Capture is operational and delivered usable audio.
+    if disposition == .committed {
+      return .committed
+    }
+    if disposition == .tooShort {
+      return .tooShortAudible
+    }
+    // silentRejected with usable audio is unexpected; fall back to the zero-sample
+    // boundary so the incident stays observable rather than dropping.
+    return isNearZero ? .zeroOrNearZeroSamples : .committed
+  }
+
+  // MARK: - Helpers
+
+  private func finalizeFirstChunksEnergy(
+    hadCallbacks: Bool,
+    isNearZero: Bool,
+    judgeable: Bool
+  ) -> FirstChunksEnergyBucket {
+    if !hadCallbacks { return .none }
+    if firstChunksEnergy == .audible { return .audible }
+    // Callbacks arrived but no usable frame: collapse to the zero/near-zero
+    // energy class so the leading-buffer silence is observable.
+    return (isNearZero && judgeable) ? .zero : (firstChunksEnergy == .none ? .zero : firstChunksEnergy)
+  }
+
+  private func milliseconds(since start: Date?, to event: Date?) -> Int? {
+    guard let start, let event else { return nil }
+    return max(0, Int(event.timeIntervalSince(start) * 1000))
+  }
+
+  /// Peak amplitude (0–32767) of a 16 kHz mono Int16 PCM buffer. Bounded scan.
+  static func peakAmplitude(pcm16k data: Data) -> Int {
+    let n = data.count / 2
+    guard n > 0 else { return 0 }
+    var peak = 0
+    data.withUnsafeBytes { raw in
+      let s = raw.bindMemory(to: Int16.self)
+      for i in 0..<n {
+        let v = Int(s[i])
+        let absolute = v == Int16.min ? Int(Int16.max) : Swift.abs(v)
+        if absolute > peak { peak = absolute }
+      }
+    }
+    return peak
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PTTAttemptLifecycleRecorder.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PTTAttemptLifecycleRecorder.swift
@@ -94,10 +94,13 @@ final class PTTAttemptLifecycleRecorder {
     case virtual
     case unknown
 
-    static func from(deviceDescription: String?) -> InputRouteClass {
+    static func from(deviceDescription: String?, isBluetooth: Bool = false) -> InputRouteClass {
+      // Bluetooth is the A2DP/HFP silent-capture case the recovery code targets;
+      // prefer the CoreAudio transport flag over substring-matching the redacted
+      // `id=` description (which never carries "bluetooth").
+      if isBluetooth { return .bluetooth }
       let lower = (deviceDescription ?? "").lowercased()
       if lower.contains("built-in") { return .builtIn }
-      if lower.contains("bluetooth") { return .bluetooth }
       if lower.contains("virtual") || lower.contains("aggregate") { return .virtual }
       if lower.isEmpty || lower == "?" { return .unknown }
       return .external
@@ -332,6 +335,12 @@ final class PTTAttemptLifecycleRecorder {
 
   /// A recovery was requested for this attempt. Mints a bounded correlation id
   /// that the *next judgeable* attempt resolves.
+  ///
+  /// If a prior recovery is still pending (a non-judgeable turn left it
+  /// unresolved), the new id supersedes it: the prior triggering event already
+  /// recorded its own id, so only its *resolution* outcome becomes unknowable —
+  /// a rare two-recoveries-in-succession case where the prior outcome is
+  /// genuinely superseded by the fresh rebuild.
   func recoveryTriggered(action: RecoveryAction) {
     guard action != .none else { return }
     recoveryTriggered = true
@@ -369,7 +378,7 @@ final class PTTAttemptLifecycleRecorder {
     if priorRecoveryId != nil, !recoveryTriggered {
       if !judgeable {
         resolvedOutcome = .notJudgeable
-      } else if isNearZero {
+      } else if firstUsableFrameAt == nil {
         resolvedOutcome = .stillSilent
       } else {
         resolvedOutcome = .recovered
@@ -386,7 +395,6 @@ final class PTTAttemptLifecycleRecorder {
       captureStartOutcome: captureStartOutcome,
       hadFirstAudioCallback: firstAudioCallbackAt != nil,
       hadFirstUsableFrame: firstUsableFrameAt != nil,
-      isNearZero: isNearZero,
       judgeable: judgeable,
       resolvedRecoveryOutcome: resolvedOutcome)
 
@@ -432,7 +440,6 @@ final class PTTAttemptLifecycleRecorder {
     captureStartOutcome: CaptureStartOutcome,
     hadFirstAudioCallback: Bool,
     hadFirstUsableFrame: Bool,
-    isNearZero: Bool,
     judgeable: Bool,
     resolvedRecoveryOutcome: RecoveryOutcomeOfNextTurn
   ) -> FailureClass {
@@ -465,9 +472,12 @@ final class PTTAttemptLifecycleRecorder {
     if disposition == .tooShort {
       return .tooShortAudible
     }
-    // silentRejected with usable audio is unexpected; fall back to the zero-sample
-    // boundary so the incident stays observable rather than dropping.
-    return isNearZero ? .zeroOrNearZeroSamples : .committed
+    // silentRejected with usable audio (e.g. a loud transient the VAD rejected as
+    // non-speech) is still a rejected turn, not a committed one. Keep it observable
+    // remotely — returning .committed would mark it local-only and hide exactly the
+    // silent incident this model exists to surface. first_chunks_energy_bucket +
+    // turn_disposition separate it from a true zero-sample turn in a query.
+    return .zeroOrNearZeroSamples
   }
 
   // MARK: - Helpers

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -264,6 +264,10 @@ class PushToTalkManager: ObservableObject {
   private var audioCaptureService: AudioCaptureService?
   private var micCaptureStartInFlight = false
   private var silentMicRecoveryPolicy = PTTSilentMicRecoveryPolicy()
+  /// Privacy-bounded capture-lifecycle correlation for each PTT attempt and any
+  /// recovery it triggers. Fed from the same seams as the late silent-turn
+  /// snapshot; emits one classified `ptt_audio_capture_lifecycle` event.
+  private let pttLifecycle = PTTAttemptLifecycleRecorder()
   private var micCaptureGeneration: UInt64 = 0
   private var transcriptSegments: [String] = []
   // Stable provider item ids of finals already appended this turn. Dedup relay
@@ -652,6 +656,10 @@ class PushToTalkManager: ObservableObject {
       mode: mode,
       hubActive: RealtimeHubController.shared.isTransportReady,
       micPermissionGranted: refreshedMicPermission())
+    pttLifecycle.beginAttempt(
+      mode: mode,
+      hubActive: RealtimeHubController.shared.isTransportReady,
+      micPermissionGranted: refreshedMicPermission())
     let preOverlayImage = captureTurnScreenEvidence()
     updateBarState()
 
@@ -685,6 +693,10 @@ class PushToTalkManager: ObservableObject {
     let mode = currentPTTMode()
     AnalyticsManager.shared.floatingBarPTTStarted(mode: mode)
     DesktopDiagnosticsManager.shared.recordPTTStarted(
+      mode: mode,
+      hubActive: RealtimeHubController.shared.isTransportReady,
+      micPermissionGranted: refreshedMicPermission())
+    pttLifecycle.beginAttempt(
       mode: mode,
       hubActive: RealtimeHubController.shared.isTransportReady,
       micPermissionGranted: refreshedMicPermission())
@@ -1146,6 +1158,15 @@ class PushToTalkManager: ObservableObject {
           hubActive: true,
           recoveryAction: recoveryDecision.shouldRebuildCapture ? "capture_rebuild" : "none",
           recoveryResult: recoveryDecision.shouldRebuildCapture ? "attempted" : "not_attempted")
+        pttLifecycle.terminate(
+          disposition: totalSec < Self.minTurnAudioSeconds ? .tooShort : .silentRejected,
+          source: "hub",
+          peak: peak,
+          rms: rms,
+          turnAudioSeconds: totalSec,
+          voicedAudioSeconds: nil,
+          isNearZero: peak <= 5 && rms <= 5,
+          judgeable: totalSec >= Self.minTurnAudioSeconds)
         log(
           "PushToTalkManager: discarding hub turn — audio \(String(format: "%.2f", totalSec))s "
             + "peak=\(peak)/32767 rms=\(rms) device=[\(dev)] "
@@ -1185,6 +1206,15 @@ class PushToTalkManager: ObservableObject {
       }
       recordSilentMicRecoveryOutcome(silentMicRecoveryPolicy.recordSuccessfulTurn())
       DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: true)
+      pttLifecycle.terminate(
+        disposition: .committed,
+        source: "hub",
+        peak: 0,
+        rms: 0,
+        turnAudioSeconds: 0,
+        voicedAudioSeconds: nil,
+        isNearZero: false,
+        judgeable: true)
       AnalyticsManager.shared.floatingBarPTTEnded(
         mode: finalizedMode, hadTranscript: true, transcriptLength: 0)
       log(
@@ -1223,6 +1253,15 @@ class PushToTalkManager: ObservableObject {
           hubActive: false,
           recoveryAction: recoveryDecision.shouldRebuildCapture ? "capture_rebuild" : "none",
           recoveryResult: recoveryDecision.shouldRebuildCapture ? "attempted" : "not_attempted")
+        pttLifecycle.terminate(
+          disposition: totalSec < Self.minTurnAudioSeconds ? .tooShort : .silentRejected,
+          source: isOmniSTT ? "omni_stt" : "batch_stt",
+          peak: peak,
+          rms: rms,
+          turnAudioSeconds: totalSec,
+          voicedAudioSeconds: voicedSec,
+          isNearZero: peak <= 5 && rms <= 5,
+          judgeable: totalSec >= Self.minTurnAudioSeconds)
         log(
           "PushToTalkManager: discarding silent turn (audio \(String(format: "%.2f", totalSec))s, voiced \(String(format: "%.2f", voicedSec))s) — not transcribing"
         )
@@ -1466,6 +1505,15 @@ class PushToTalkManager: ObservableObject {
     )
     if hasQuery {
       DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: false)
+      pttLifecycle.terminate(
+        disposition: .committed,
+        source: isOmniSTT ? "omni_stt" : "batch_stt",
+        peak: 0,
+        rms: 0,
+        turnAudioSeconds: 0,
+        voicedAudioSeconds: nil,
+        isNearZero: false,
+        judgeable: true)
     }
 
     isCurrentSessionFollowUp = false
@@ -1773,6 +1821,15 @@ class PushToTalkManager: ObservableObject {
         hubActive: true,
         recoveryAction: recoveryDecision.shouldRebuildCapture ? "capture_rebuild" : "none",
         recoveryResult: recoveryDecision.shouldRebuildCapture ? "attempted" : "not_attempted")
+      pttLifecycle.terminate(
+        disposition: totalSec < Self.minTurnAudioSeconds ? .tooShort : .silentRejected,
+        source: "buffered_hub",
+        peak: peak,
+        rms: rms,
+        turnAudioSeconds: totalSec,
+        voicedAudioSeconds: nil,
+        isNearZero: peak <= 5 && rms <= 5,
+        judgeable: totalSec >= Self.minTurnAudioSeconds)
       log(
         "PushToTalkManager: discarding buffered hub turn — audio \(String(format: "%.2f", totalSec))s "
           + "peak=\(peak)/32767 rms=\(rms) device=[\(dev)] — not committing")
@@ -1808,6 +1865,15 @@ class PushToTalkManager: ObservableObject {
     }
     recordSilentMicRecoveryOutcome(silentMicRecoveryPolicy.recordSuccessfulTurn())
     DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: true)
+    pttLifecycle.terminate(
+      disposition: .committed,
+      source: "buffered_hub",
+      peak: 0,
+      rms: 0,
+      turnAudioSeconds: 0,
+      voicedAudioSeconds: nil,
+      isNearZero: false,
+      judgeable: true)
     AnalyticsManager.shared.floatingBarPTTEnded(
       mode: finalizedMode, hadTranscript: true, transcriptLength: 0)
     log(
@@ -1838,6 +1904,15 @@ class PushToTalkManager: ObservableObject {
         hubActive: false,
         recoveryAction: recoveryDecision.shouldRebuildCapture ? "capture_rebuild" : "none",
         recoveryResult: recoveryDecision.shouldRebuildCapture ? "attempted" : "not_attempted")
+      pttLifecycle.terminate(
+        disposition: totalSec < Self.minTurnAudioSeconds ? .tooShort : .silentRejected,
+        source: "warm_wait_fallback",
+        peak: peak,
+        rms: rms,
+        turnAudioSeconds: totalSec,
+        voicedAudioSeconds: voicedSec,
+        isNearZero: peak <= 5 && rms <= 5,
+        judgeable: totalSec >= Self.minTurnAudioSeconds)
       log(
         "PushToTalkManager: discarding warm-wait fallback turn (audio \(String(format: "%.2f", totalSec))s, voiced \(String(format: "%.2f", voicedSec))s)"
       )
@@ -1925,6 +2000,7 @@ class PushToTalkManager: ObservableObject {
       return
     }
     micCaptureStartInFlight = true
+    pttLifecycle.captureStartRequested()
     micCaptureGeneration &+= 1
     let generation = micCaptureGeneration
     guard let turnID = currentVoiceTurnID else {
@@ -1947,6 +2023,14 @@ class PushToTalkManager: ObservableObject {
         self.handleSilentMicDetection(detection, batchMode: batchMode)
       }
     }
+    capture.onInputRouteChanged = { [weak self] in
+      Task { @MainActor in
+        guard let self, self.micCaptureGeneration == generation,
+          self.voiceTurnCoordinator.activeTurnID == turnID
+        else { return }
+        self.pttLifecycle.noteRouteChanged()
+      }
+    }
 
     Task { @MainActor [weak self] in
       guard let self else { return }
@@ -1959,6 +2043,7 @@ class PushToTalkManager: ObservableObject {
                 self.voiceTurnCoordinator.activeTurnID == turnID,
                 self.shouldKeepMicCaptureAlive
               else { return }
+              self.pttLifecycle.ingestAudioChunk(audioData)
               if self.isHubMode {
                 // Lifecycle admission and provider commit are serialized on the
                 // main actor. A chunk queued behind finalization observes the
@@ -2011,6 +2096,10 @@ class PushToTalkManager: ObservableObject {
           return
         }
         self.micCaptureStartInFlight = false
+        self.pttLifecycle.captureStartResolved(outcome: .accepted, statusClass: .ok)
+        self.pttLifecycle.noteInputRoute(
+          class: .from(deviceDescription: capture.currentDeviceDescription),
+          source: overrideDeviceID == nil ? .default : .override)
         self.voiceTurnCoordinator.publish(
           .captureStarted(turnID: turnID, captureID: captureID))
         if let diagnosticRecoveryAction {
@@ -2025,6 +2114,9 @@ class PushToTalkManager: ObservableObject {
           return
         }
         self.micCaptureStartInFlight = false
+        self.pttLifecycle.captureStartResolved(
+          outcome: .failed,
+          statusClass: .from(error: error))
         if let diagnosticRecoveryAction {
           DesktopDiagnosticsManager.shared.recordPTTDeviceRouteChanged(
             recoveryAction: diagnosticRecoveryAction,
@@ -2055,6 +2147,7 @@ class PushToTalkManager: ObservableObject {
     {
       log("PushToTalkManager: silent-mic fallback — switching to built-in mic (deviceID=\(builtInID))")
       silentMicRecoveryPolicy.recordCaptureRebuild()
+      pttLifecycle.recoveryTriggered(action: .switchToBuiltInMic)
       stopMicCapture()
       clearBufferedTurnAudio()
       startMicCapture(
@@ -2084,6 +2177,7 @@ class PushToTalkManager: ObservableObject {
     // mislabel switch_to_built_in_mic results as capture_rebuild outcomes, while the
     // silent-mic watchdog CoreAudio path still gets a next-turn success/failure.
     silentMicRecoveryPolicy.armCaptureRebuildOutcome()
+    pttLifecycle.recoveryTriggered(action: .captureRebuild)
     stopMicCapture()
     clearBufferedTurnAudio()
     NotificationCenter.default.post(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1158,6 +1158,13 @@ class PushToTalkManager: ObservableObject {
           hubActive: true,
           recoveryAction: recoveryDecision.shouldRebuildCapture ? "capture_rebuild" : "none",
           recoveryResult: recoveryDecision.shouldRebuildCapture ? "attempted" : "not_attempted")
+        if recoveryDecision.shouldRebuildCapture {
+          // Record the recovery trigger before terminate so the snapshot carries
+          // recovery_triggered=true and the correlation id. Without this, the
+          // triggering turn's snapshot is emitted with recovery_triggered=false
+          // and the next-turn recovery outcome cannot be joined back.
+          pttLifecycle.recoveryTriggered(action: .captureRebuild)
+        }
         pttLifecycle.terminate(
           disposition: totalSec < Self.minTurnAudioSeconds ? .tooShort : .silentRejected,
           source: "hub",
@@ -1173,7 +1180,8 @@ class PushToTalkManager: ObservableObject {
             + "(peak≈0 ⇒ dead mic; high peak ⇒ classifier misfire; low ⇒ quiet/far mic) — not committing"
         )
         if recoveryDecision.shouldRebuildCapture {
-          requestCoreAudioCaptureRecovery(reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: false)
+          requestCoreAudioCaptureRecovery(
+            reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: false, recoveryAlreadyTriggered: true)
         }
         _ = RealtimeHubController.shared.cancelTurn(turnID: turnID)
         AnalyticsManager.shared.floatingBarPTTEnded(
@@ -2142,6 +2150,19 @@ class PushToTalkManager: ObservableObject {
         self.pttLifecycle.captureStartResolved(
           outcome: .failed,
           statusClass: .from(error: error))
+        // Emit the lifecycle snapshot so capture_start_outcome=failed is
+        // observable. The reducer terminal effect (performTerminalCleanup)
+        // does not call terminate(), so without this the exact scenario this
+        // PR exists to diagnose never produces a lifecycle event.
+        self.pttLifecycle.terminate(
+          disposition: .silentRejected,
+          source: "capture_start",
+          peak: 0,
+          rms: 0,
+          turnAudioSeconds: 0,
+          voicedAudioSeconds: nil,
+          isNearZero: true,
+          judgeable: false)
         if let diagnosticRecoveryAction {
           DesktopDiagnosticsManager.shared.recordPTTDeviceRouteChanged(
             recoveryAction: diagnosticRecoveryAction,
@@ -2196,13 +2217,18 @@ class PushToTalkManager: ObservableObject {
     )
   }
 
-  private func requestCoreAudioCaptureRecovery(reason: String, restartPTT: Bool, batchMode: Bool) {
+  private func requestCoreAudioCaptureRecovery(
+    reason: String, restartPTT: Bool, batchMode: Bool,
+    recoveryAlreadyTriggered: Bool = false
+  ) {
     log("PushToTalkManager: requesting CoreAudio capture rebuild — \(reason)")
     // Arm here (not in recordCaptureRebuild) so Bluetooth built-in fallback cannot
     // mislabel switch_to_built_in_mic results as capture_rebuild outcomes, while the
     // silent-mic watchdog CoreAudio path still gets a next-turn success/failure.
     silentMicRecoveryPolicy.armCaptureRebuildOutcome()
-    pttLifecycle.recoveryTriggered(action: .captureRebuild)
+    if !recoveryAlreadyTriggered {
+      pttLifecycle.recoveryTriggered(action: .captureRebuild)
+    }
     stopMicCapture()
     clearBufferedTurnAudio()
     NotificationCenter.default.post(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1374,6 +1374,15 @@ class PushToTalkManager: ObservableObject {
           }
         } catch {
           logError("PushToTalkManager: batch transcription failed", error: error)
+          self.pttLifecycle.terminate(
+            disposition: .committed,
+            source: "batch_stt",
+            peak: 0,
+            rms: 0,
+            turnAudioSeconds: 0,
+            voicedAudioSeconds: nil,
+            isNearZero: false,
+            judgeable: true)
           self.voiceTurnCoordinator.publish(
             .transcriptionFailed(turnID: turnID, message: error.localizedDescription))
           return
@@ -1505,6 +1514,20 @@ class PushToTalkManager: ObservableObject {
     )
     if hasQuery {
       DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: false)
+      pttLifecycle.terminate(
+        disposition: .committed,
+        source: isOmniSTT ? "omni_stt" : "batch_stt",
+        peak: 0,
+        rms: 0,
+        turnAudioSeconds: 0,
+        voicedAudioSeconds: nil,
+        isNearZero: false,
+        judgeable: true)
+    } else {
+      // Empty transcript after the turn reached finalization (e.g. a live-Deepgram
+      // turn that returned nothing). The recorder's tracked capture state
+      // (first-audio / first-usable-frame) classifies it; this resolves any pending
+      // recovery exactly once instead of skipping the lifecycle emit.
       pttLifecycle.terminate(
         disposition: .committed,
         source: isOmniSTT ? "omni_stt" : "batch_stt",
@@ -2098,7 +2121,9 @@ class PushToTalkManager: ObservableObject {
         self.micCaptureStartInFlight = false
         self.pttLifecycle.captureStartResolved(outcome: .accepted, statusClass: .ok)
         self.pttLifecycle.noteInputRoute(
-          class: .from(deviceDescription: capture.currentDeviceDescription),
+          class: .from(
+            deviceDescription: capture.currentDeviceDescription,
+            isBluetooth: capture.isCurrentDeviceBluetoothTransport),
           source: overrideDeviceID == nil ? .default : .override)
         self.voiceTurnCoordinator.publish(
           .captureStarted(turnID: turnID, captureID: captureID))

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -438,6 +438,48 @@ import XCTest
         "success")
     }
 
+    @MainActor
+    func testPTTAttemptLifecycleSnapshotIsBoundedInDiagnosticsAttachment() throws {
+      // End-to-end: the recorder's default emit routes through the diagnostics
+      // manager, so the lifecycle event must land in the Sentry attachment with
+      // its bounded causal keys and no raw device identity.
+      let recorder = PTTAttemptLifecycleRecorder()
+      recorder.beginAttempt(mode: "hold", hubActive: true, micPermissionGranted: true)
+      recorder.captureStartRequested()
+      recorder.captureStartResolved(outcome: .failed, statusClass: .engineStartFailed)
+      recorder.noteInputRoute(class: .bluetooth, source: .override)
+      recorder.terminate(
+        disposition: .silentRejected,
+        source: "hub",
+        peak: 0,
+        rms: 0,
+        turnAudioSeconds: 1.2,
+        voicedAudioSeconds: nil,
+        isNearZero: true,
+        judgeable: true)
+
+      let url = try XCTUnwrap(DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment())
+      defer { try? FileManager.default.removeItem(at: url) }
+
+      let data = try Data(contentsOf: url)
+      let json = String(data: data, encoding: .utf8) ?? ""
+      let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+      let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+      let snapshot = try XCTUnwrap(
+        snapshots.first(where: { $0["event"] as? String == "ptt_audio_capture_lifecycle" }))
+
+      XCTAssertEqual(snapshot["failure_class"] as? String, "capture_never_operational")
+      XCTAssertEqual(snapshot["capture_start_outcome"] as? String, "failed")
+      XCTAssertEqual(snapshot["capture_start_status_class"] as? String, "engine_start_failed")
+      XCTAssertEqual(snapshot["input_route_class"] as? String, "bluetooth")
+      XCTAssertEqual(snapshot["input_route_source"] as? String, "override")
+      XCTAssertEqual(snapshot["turn_disposition"] as? String, "silent_rejected")
+      XCTAssertNotNil(snapshot["attempt_id"])
+      // Privacy: no raw device identity, hardware id, or error string leaks.
+      XCTAssertFalse(json.contains("engineStartFailed") || json.contains("OSStatus"))
+      XCTAssertNil(snapshot["device_description"])
+    }
+
     private func assertLatestHealthSnapshot(
       event: DesktopHealthEventName,
       contains expected: [String: Any] = [:],

--- a/desktop/macos/Desktop/Tests/PTTAttemptLifecycleRecorderTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTAttemptLifecycleRecorderTests.swift
@@ -1,0 +1,307 @@
+import XCTest
+
+@testable import Omi_Computer
+
+#if DEBUG
+  /// Behavioral tests for `PTTAttemptLifecycleRecorder` — the privacy-bounded
+  /// capture-lifecycle correlation model. These drive the production API with an
+  /// injected clock so every failure classification, timing bucket, and recovery
+  /// correlation is verified deterministically without real CoreAudio.
+  @MainActor
+  final class PTTAttemptLifecycleRecorderTests: XCTestCase {
+
+    // MARK: - Failure classification 1: capture never became operational
+
+    func testCaptureStartFailedClassifiesNeverOperational() {
+      let recorder = makeRecorder()
+      begin(recorder)
+      recorder.captureStartRequested()
+      recorder.captureStartResolved(
+        outcome: .failed,
+        statusClass: .from(
+          error: AudioCaptureService.AudioCaptureError.engineStartFailed(NSError(domain: "x", code: 1))))
+
+      let snap = terminate(recorder, disposition: .silentRejected, peak: 0, rms: 0, seconds: 1.0, judgeable: true)
+
+      XCTAssertEqual(snap.failureClass, .captureNeverOperational)
+      XCTAssertEqual(snap.captureStartOutcome, .failed)
+      XCTAssertEqual(snap.captureStartStatusClass, .engineStartFailed)
+    }
+
+    func testStartupRaceNoAudioCallbackClassifiesNeverOperational() {
+      // Capture was accepted but never delivered a callback before the turn ended.
+      let recorder = makeRecorder()
+      begin(recorder)
+      recorder.captureStartRequested()
+      recorder.captureStartResolved(outcome: .accepted, statusClass: .ok)
+
+      let snap = terminate(recorder, disposition: .silentRejected, peak: 0, rms: 0, seconds: 1.0, judgeable: true)
+
+      XCTAssertEqual(snap.failureClass, .captureNeverOperational)
+      XCTAssertEqual(snap.captureStartOutcome, .accepted)
+      XCTAssertEqual(snap.msToFirstAudioBucket, .none)
+      XCTAssertEqual(snap.firstChunksEnergyBucket, .none)
+    }
+
+    // MARK: - Failure classification 2: zero / near-zero samples
+
+    func testOperationalCaptureWithOnlyZeroSamplesClassifiesZeroSamples() {
+      let recorder = makeRecorder()
+      begin(recorder)
+      captureAccepted(recorder)
+      recorder.ingestAudioChunk(Self.silentPCM(sampleCount: 320))
+      recorder.ingestAudioChunk(Self.silentPCM(sampleCount: 320))
+
+      let snap = terminate(recorder, disposition: .silentRejected, peak: 0, rms: 0, seconds: 1.0, judgeable: true)
+
+      XCTAssertEqual(snap.failureClass, .zeroOrNearZeroSamples)
+      XCTAssertNotEqual(snap.msToFirstAudioBucket, .none, "first audio callback was recorded")
+      XCTAssertEqual(snap.msToFirstUsableFrameBucket, .none, "no usable frame ever arrived")
+      XCTAssertEqual(snap.firstChunksEnergyBucket, .zero)
+    }
+
+    // MARK: - Failure classification 3: released before first usable audio
+
+    func testReleasedBeforeUsableAudioForTooShortTurn() {
+      let recorder = makeRecorder()
+      begin(recorder)
+      captureAccepted(recorder)
+      // Callbacks arrived but were zero; the key came up before usable audio.
+      recorder.ingestAudioChunk(Self.silentPCM(sampleCount: 160))
+
+      let snap = terminate(recorder, disposition: .tooShort, peak: 0, rms: 0, seconds: 0.1, judgeable: false)
+
+      XCTAssertEqual(snap.failureClass, .releasedBeforeUsableAudio)
+      XCTAssertNotEqual(snap.msToFirstAudioBucket, .none)
+      XCTAssertEqual(snap.msToFirstUsableFrameBucket, .none)
+    }
+
+    // MARK: - Success: committed
+
+    func testCommittedTurnWithUsableAudioClassifiesCommitted() {
+      let recorder = makeRecorder()
+      begin(recorder)
+      captureAccepted(recorder)
+      recorder.ingestAudioChunk(Self.audiblePCM(sampleCount: 320))
+
+      let snap = terminate(recorder, disposition: .committed, peak: 4000, rms: 800, seconds: 1.5, judgeable: true)
+
+      XCTAssertEqual(snap.failureClass, .committed)
+      XCTAssertEqual(snap.firstChunksEnergyBucket, .audible)
+      XCTAssertNotEqual(snap.msToFirstUsableFrameBucket, .none)
+    }
+
+    // MARK: - Failure classification 4: recovery attempt outcome
+
+    func testRecoveryTriggeredEmitsCorrelationIdAndResolvedRecoveredOnNextTurn() {
+      let recorder = makeRecorder()
+      // Attempt 1: silent capture triggers a rebuild.
+      begin(recorder)
+      captureAccepted(recorder)
+      recorder.ingestAudioChunk(Self.silentPCM(sampleCount: 320))
+      recorder.recoveryTriggered(action: .captureRebuild)
+      let first = terminate(recorder, disposition: .silentRejected, peak: 0, rms: 0, seconds: 1.0, judgeable: true)
+
+      XCTAssertTrue(first.recoveryTriggered)
+      XCTAssertEqual(first.recoveryAction, .captureRebuild)
+      let recoveryId = first.recoveryAttemptId
+      XCTAssertNotNil(recoveryId)
+
+      // Attempt 2: capture restored — usable audio resolves the recovery.
+      begin(recorder)
+      captureAccepted(recorder)
+      recorder.ingestAudioChunk(Self.audiblePCM(sampleCount: 320))
+      let second = terminate(recorder, disposition: .committed, peak: 4000, rms: 800, seconds: 1.5, judgeable: true)
+
+      XCTAssertFalse(second.recoveryTriggered)
+      XCTAssertEqual(second.recoveryAttemptId, recoveryId)
+      XCTAssertEqual(second.recoveryOutcomeOfNextTurn, .recovered)
+      XCTAssertEqual(second.failureClass, .recoveryOutcomeRecovered)
+    }
+
+    func testRecoveryResolvedStillSilentOnNextSilentTurn() {
+      let recorder = makeRecorder()
+      begin(recorder)
+      captureAccepted(recorder)
+      recorder.recoveryTriggered(action: .captureRebuild)
+      _ = terminate(recorder, disposition: .silentRejected, peak: 0, rms: 0, seconds: 1.0, judgeable: true)
+
+      begin(recorder)
+      captureAccepted(recorder)
+      recorder.ingestAudioChunk(Self.silentPCM(sampleCount: 320))
+      let second = terminate(recorder, disposition: .silentRejected, peak: 0, rms: 0, seconds: 1.0, judgeable: true)
+
+      XCTAssertEqual(second.recoveryOutcomeOfNextTurn, .stillSilent)
+      XCTAssertEqual(second.failureClass, .recoveryOutcomeStillSilent)
+    }
+
+    func testNonJudgeableTurnDoesNotConsumePendingRecovery() {
+      let recorder = makeRecorder()
+      begin(recorder)
+      captureAccepted(recorder)
+      recorder.recoveryTriggered(action: .captureRebuild)
+      _ = terminate(recorder, disposition: .silentRejected, peak: 0, rms: 0, seconds: 1.0, judgeable: true)
+
+      // A too-short, non-judgeable turn must NOT resolve the recovery.
+      begin(recorder)
+      captureAccepted(recorder)
+      recorder.ingestAudioChunk(Self.audiblePCM(sampleCount: 80))
+      let nonJudgeable = terminate(
+        recorder, disposition: .tooShort, peak: 3000, rms: 600, seconds: 0.1, judgeable: false)
+
+      XCTAssertEqual(nonJudgeable.recoveryOutcomeOfNextTurn, .notJudgeable)
+      XCTAssertNotNil(nonJudgeable.recoveryAttemptId)
+
+      // The next truly judgeable turn resolves it.
+      begin(recorder)
+      captureAccepted(recorder)
+      recorder.ingestAudioChunk(Self.audiblePCM(sampleCount: 320))
+      let resolving = terminate(recorder, disposition: .committed, peak: 4000, rms: 800, seconds: 1.5, judgeable: true)
+
+      XCTAssertEqual(resolving.recoveryOutcomeOfNextTurn, .recovered)
+    }
+
+    // MARK: - Timing buckets
+
+    func testFirstAudioAndUsableFrameBucketsReflectElapsedMs() {
+      let clock = MutableTestClock()
+      let recorder = makeRecorder(clock: clock)
+      begin(recorder)
+      captureAccepted(recorder)
+      // Advance ~120ms before the first callback, then ~80ms to a usable frame.
+      clock.advance(milliseconds: 120)
+      recorder.ingestAudioChunk(Self.silentPCM(sampleCount: 160))
+      clock.advance(milliseconds: 80)
+      recorder.ingestAudioChunk(Self.audiblePCM(sampleCount: 320))
+
+      let snap = terminate(recorder, disposition: .committed, peak: 4000, rms: 800, seconds: 1.0, judgeable: true)
+
+      XCTAssertEqual(snap.msToFirstAudioBucket, .lt200)  // 120ms → lt_200
+      XCTAssertEqual(snap.msToFirstUsableFrameBucket, .lt500)  // 200ms → lt_500
+    }
+
+    // MARK: - Static classification precedence
+
+    func testClassificationPrecedencePlacesCaptureStartFailureAboveZeroSamples() {
+      let cls = PTTAttemptLifecycleRecorder.classify(
+        disposition: .silentRejected,
+        captureStartOutcome: .failed,
+        hadFirstAudioCallback: true,
+        hadFirstUsableFrame: false,
+        isNearZero: true,
+        judgeable: true,
+        resolvedRecoveryOutcome: .none)
+      XCTAssertEqual(cls, .captureNeverOperational)
+    }
+
+    func testClassificationPrecedenceRecoveryOutcomeDominates() {
+      let cls = PTTAttemptLifecycleRecorder.classify(
+        disposition: .silentRejected,
+        captureStartOutcome: .accepted,
+        hadFirstAudioCallback: true,
+        hadFirstUsableFrame: true,
+        isNearZero: true,
+        judgeable: true,
+        resolvedRecoveryOutcome: .recovered)
+      XCTAssertEqual(cls, .recoveryOutcomeRecovered)
+    }
+
+    // MARK: - Privacy: only bounded fields, never raw device identity or audio
+
+    func testEmittedSnapshotCarriesOnlyBoundedLowCardinalityFields() {
+      let recorder = makeRecorder()
+      begin(recorder)
+      captureAccepted(recorder)
+      recorder.ingestAudioChunk(Self.audiblePCM(sampleCount: 320))
+      recorder.noteInputRoute(class: .bluetooth, source: .override)
+      recorder.noteRouteChanged()
+      let snap = terminate(recorder, disposition: .committed, peak: 4000, rms: 800, seconds: 1.5, judgeable: true)
+
+      let props = snap.properties
+      // Every value is a String, Bool, Int, or Double — never Data/raw audio.
+      for (key, value) in props {
+        switch value {
+        case is String, is Bool, is Int, is Double:
+          break
+        default:
+          XCTFail("Field \(key) emitted a non-bounded value type: \(type(of: value))")
+        }
+      }
+      // No raw device names / hardware IDs / paths / errors leak.
+      let forbidden = ["device_description", "device_name", "hardware_id", "file_path", "error_description"]
+      for key in forbidden {
+        XCTAssertNil(props[key], "forbidden raw field \(key) present")
+      }
+      XCTAssertEqual(props["input_route_class"] as? String, "bluetooth")
+      XCTAssertEqual(props["input_route_source"] as? String, "override")
+      XCTAssertEqual(props["route_changed_during_attempt"] as? Bool, true)
+    }
+
+    func testPeakAmplitudeOfZeroBufferIsZero() {
+      XCTAssertEqual(PTTAttemptLifecycleRecorder.peakAmplitude(pcm16k: Self.silentPCM(sampleCount: 320)), 0)
+    }
+
+    func testPeakAmplitudeOfAudibleBufferExceedsThreshold() {
+      XCTAssertGreaterThan(PTTAttemptLifecycleRecorder.peakAmplitude(pcm16k: Self.audiblePCM(sampleCount: 320)), 50)
+    }
+
+    // MARK: - Helpers
+
+    private func makeRecorder(clock: MutableTestClock = MutableTestClock()) -> PTTAttemptLifecycleRecorder {
+      let recorder = PTTAttemptLifecycleRecorder()
+      recorder.now = { [clock] in clock.date }
+      return recorder
+    }
+
+    private func begin(_ recorder: PTTAttemptLifecycleRecorder) {
+      recorder.beginAttempt(mode: "hold", hubActive: true, micPermissionGranted: true)
+    }
+
+    private func captureAccepted(_ recorder: PTTAttemptLifecycleRecorder) {
+      recorder.captureStartRequested()
+      recorder.captureStartResolved(outcome: .accepted, statusClass: .ok)
+    }
+
+    private func terminate(
+      _ recorder: PTTAttemptLifecycleRecorder,
+      disposition: PTTAttemptLifecycleRecorder.TurnDisposition,
+      peak: Int,
+      rms: Int,
+      seconds: Double,
+      judgeable: Bool
+    ) -> PTTAttemptLifecycleRecorder.Snapshot {
+      recorder.terminate(
+        disposition: disposition,
+        source: "hub",
+        peak: peak,
+        rms: rms,
+        turnAudioSeconds: seconds,
+        voicedAudioSeconds: nil,
+        isNearZero: peak <= 5 && rms <= 5,
+        judgeable: judgeable)
+    }
+
+    private static func silentPCM(sampleCount: Int) -> Data {
+      Data(count: sampleCount * MemoryLayout<Int16>.size)
+    }
+
+    private static func audiblePCM(sampleCount: Int) -> Data {
+      var data = Data(count: sampleCount * MemoryLayout<Int16>.size)
+      data.withUnsafeMutableBytes { raw in
+        let samples = raw.bindMemory(to: Int16.self)
+        for i in 0..<sampleCount {
+          samples[i] = Int16(1000)
+        }
+      }
+      return data
+    }
+  }
+
+  /// Injects time in fixed millisecond steps so timing buckets are deterministic.
+  private final class MutableTestClock {
+    fileprivate var date = Date()
+    func advance(milliseconds ms: Int) {
+      date.addTimeInterval(TimeInterval(ms) / 1000.0)
+    }
+  }
+#endif

--- a/desktop/macos/Desktop/Tests/PTTAttemptLifecycleRecorderTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTAttemptLifecycleRecorderTests.swift
@@ -180,6 +180,47 @@ import XCTest
       XCTAssertEqual(snap.msToFirstUsableFrameBucket, .lt500)  // 200ms → lt_500
     }
 
+    // MARK: - Recovery metadata ordering on terminate
+
+    /// P2 regression: when a silent hub turn triggers a rebuild, recoveryTriggered
+    /// must be called *before* terminate so the snapshot carries
+    /// recovery_triggered=true and a joinable recovery_attempt_id. If terminate
+    /// fires first, the triggering turn is recorded with recovery_triggered=false
+    /// and the next-turn recovery outcome cannot be correlated.
+    func testRecoveryTriggeredBeforeTerminateCarriesCorrelationId() {
+      let recorder = makeRecorder()
+      begin(recorder)
+      captureAccepted(recorder)
+      recorder.ingestAudioChunk(Self.silentPCM(sampleCount: 320))
+      // Production code calls recoveryTriggered before terminate (Thread 1 fix).
+      recorder.recoveryTriggered(action: .captureRebuild)
+      let snap = terminate(recorder, disposition: .silentRejected, peak: 0, rms: 0, seconds: 1.0, judgeable: true)
+
+      XCTAssertTrue(snap.recoveryTriggered, "triggering turn must record recovery_triggered=true")
+      XCTAssertEqual(snap.recoveryAction, .captureRebuild)
+      XCTAssertNotNil(snap.recoveryAttemptId, "triggering turn must carry a recovery_attempt_id")
+    }
+
+    /// P2 regression: a capture-start failure must produce a lifecycle snapshot.
+    /// In production, captureStartResolved(.failed) is followed by terminate() in
+    /// the catch block (Thread 2 fix); previously the reducer terminal effect
+    /// never called terminate(), so capture_start_outcome=failed was invisible.
+    func testCaptureStartFailedTerminationProducesLifecycleSnapshot() {
+      let recorder = makeRecorder()
+      begin(recorder)
+      recorder.captureStartRequested()
+      recorder.captureStartResolved(
+        outcome: .failed,
+        statusClass: .from(
+          error: AudioCaptureService.AudioCaptureError.engineStartFailed(NSError(domain: "x", code: 1))))
+
+      let snap = terminate(recorder, disposition: .silentRejected, peak: 0, rms: 0, seconds: 0, judgeable: false)
+
+      XCTAssertEqual(snap.captureStartOutcome, .failed)
+      XCTAssertEqual(snap.captureStartStatusClass, .engineStartFailed)
+      XCTAssertEqual(snap.failureClass, .captureNeverOperational)
+    }
+
     // MARK: - Static classification precedence
 
     func testClassificationPrecedencePlacesCaptureStartFailureAboveZeroSamples() {

--- a/desktop/macos/Desktop/Tests/PTTAttemptLifecycleRecorderTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTAttemptLifecycleRecorderTests.swift
@@ -188,7 +188,6 @@ import XCTest
         captureStartOutcome: .failed,
         hadFirstAudioCallback: true,
         hadFirstUsableFrame: false,
-        isNearZero: true,
         judgeable: true,
         resolvedRecoveryOutcome: .none)
       XCTAssertEqual(cls, .captureNeverOperational)
@@ -200,10 +199,24 @@ import XCTest
         captureStartOutcome: .accepted,
         hadFirstAudioCallback: true,
         hadFirstUsableFrame: true,
-        isNearZero: true,
         judgeable: true,
         resolvedRecoveryOutcome: .recovered)
       XCTAssertEqual(cls, .recoveryOutcomeRecovered)
+    }
+
+    /// P1 regression: a silentRejected turn that had a usable frame (e.g. a loud
+    /// transient the VAD rejected) must NOT relabel as `.committed`, which would
+    /// mark it local-only and hide the silent incident. It stays observable as a
+    /// zero-sample/speech-rejected boundary.
+    func testSilentRejectedWithUsableFrameStaysObservable() {
+      let cls = PTTAttemptLifecycleRecorder.classify(
+        disposition: .silentRejected,
+        captureStartOutcome: .accepted,
+        hadFirstAudioCallback: true,
+        hadFirstUsableFrame: true,
+        judgeable: true,
+        resolvedRecoveryOutcome: .none)
+      XCTAssertEqual(cls, .zeroOrNearZeroSamples)
     }
 
     // MARK: - Privacy: only bounded fields, never raw device identity or audio
@@ -235,6 +248,22 @@ import XCTest
       XCTAssertEqual(props["input_route_class"] as? String, "bluetooth")
       XCTAssertEqual(props["input_route_source"] as? String, "override")
       XCTAssertEqual(props["route_changed_during_attempt"] as? Bool, true)
+    }
+    func testBluetoothTransportFlagClassifiesBluetoothOverDescription() {
+      // The redacted description never carries "bluetooth"; the CoreAudio
+      // transport flag is the truthful signal the recovery code depends on.
+      XCTAssertEqual(
+        PTTAttemptLifecycleRecorder.InputRouteClass.from(
+          deviceDescription: "id=42", isBluetooth: true),
+        .bluetooth)
+      XCTAssertEqual(
+        PTTAttemptLifecycleRecorder.InputRouteClass.from(
+          deviceDescription: "id=42", isBluetooth: false),
+        .external)
+      XCTAssertEqual(
+        PTTAttemptLifecycleRecorder.InputRouteClass.from(
+          deviceDescription: "built-in id=1", isBluetooth: true),
+        .bluetooth)
     }
 
     func testPeakAmplitudeOfZeroBufferIsZero() {

--- a/desktop/macos/Desktop/Tests/PTTSilentTurnRecoveryWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTSilentTurnRecoveryWiringTests.swift
@@ -36,8 +36,7 @@ final class PTTSilentTurnRecoveryWiringTests: XCTestCase {
       silentTurnCalls,
       "Every silent-turn discard must call recordDiscardedTurn")
     XCTAssertEqual(
-      source.components(separatedBy: "requestCoreAudioCaptureRecovery(reason: \"repeated dead-mic PTT turns\"").count
-        - 1,
+      source.components(separatedBy: "reason: \"repeated dead-mic PTT turns\"").count - 1,
       silentTurnCalls,
       "Every silent-turn discard must guard a capture rebuild")
 

--- a/desktop/macos/changelog/unreleased/20260722-ptt-capture-lifecycle-diagnostics.json
+++ b/desktop/macos/changelog/unreleased/20260722-ptt-capture-lifecycle-diagnostics.json
@@ -1,0 +1,3 @@
+{
+  "change": "Push-to-talk now records privacy-safe capture-lifecycle diagnostics so a silent-mic failure can be classified and diagnosed (capture never started, zero samples, released too early, or a recovery that did/did not restore audio) without sending any audio, device names, or transcripts"
+}

--- a/desktop/macos/e2e/flows/ptt-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/ptt-lifecycle.yaml
@@ -9,6 +9,7 @@ covers:
   - desktop/macos/Desktop/Sources/DefaultsKey.swift
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/LegacyVoiceJournalImporter.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/PTTAttemptLifecycleRecorder.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RawWebSocket.swift


### PR DESCRIPTION
# macOS PTT: privacy-bounded capture-lifecycle diagnostics

SCA-67

## Root-cause observability gap

A production macOS beta user (`0.12.111` / build `12111`) repeatedly emitted
`floating_bar_ptt_ended` with `had_transcript=false`, zero audio, and
`desktop_health_event=ptt_audio_capture_silent_turn`. One immediate retry
succeeded; others stayed silent. No token-mint, provider-session, or chat-agent
failure coincided.

The existing late `ptt_audio_capture_silent_turn` snapshot records **that** a
turn was silent (peak/RMS/seconds/device-class/recovery decision) but cannot
locate **why** along the capture boundary. It cannot separate:

1. **capture never became operational** (start failed, or the async CoreAudio
   capture-start race delivered no callback before release);
2. **capture operational but only zero/near-zero samples** (dead route / HAL
   wedge);
3. **PTT released before the first usable audio arrived** (fast tap / capture
   not ready); or
4. **a capture recovery was attempted and did/did not restore the next
   judgeable turn**.

The dead-mic self-heal cluster (#9081 → #9390 / #9677 / #9757 → #9770, merged)
already ships the recovery + late telemetry. The residual gaps above were
deliberately left out of scope with no tracking issue; this PR closes them.

## New causal model

`PTTAttemptLifecycleRecorder` accumulates the capture boundaries that already
exist in the PTT lifecycle into one redacted per-attempt snapshot and emits a
single `ptt_audio_capture_lifecycle` event at termination:

- **attempt_id** — session-scoped correlation id joining a turn to any recovery
  it triggers/resolves.
- **capture_start_outcome** (`not_requested` / `requested` / `accepted` /
  `failed`) and **capture_start_status_class** (sanitized class derived from
  `AudioCaptureError`, never the raw `OSStatus`/error string).
- **ms_to_first_audio_bucket** and **ms_to_first_usable_frame_bucket** — bounded
  buckets (`none` / `lt_50` / `lt_100` / `lt_200` / `lt_500` / `ge_500`), not
  raw timings; **first_chunks_energy_bucket** (`zero` / `near_zero` /
  `audible`).
- **failure_class** — `capture_never_operational` /
  `zero_or_near_zero_samples` / `released_before_usable_audio` /
  `recovery_outcome_recovered` / `recovery_outcome_still_silent` /
  `recovery_outcome_not_judgeable` / `committed` / `too_short_audible` /
  `cancelled`.
- **input_route_class** (`built_in` / `external` / `bluetooth` / `virtual` /
  `unknown`), **input_route_source** (`default` / `override`), and a
  **route_changed_during_attempt** flag from the HAL device/format listener.
- **recovery_attempt_id** + **recovery_outcome_of_next_turn** — a rebuild
  requested on attempt *N* is resolved by the next judgeable attempt *N+1*;
  a non-judgeable turn does not consume it.

Wired into `PushToTalkManager` at the existing seams (press, capture-start
requested/accepted/failed, first audio callback, first usable frame, recovery,
silent/committed/too-short termination) and `AudioCaptureService`
(`onInputRouteChanged`). Routes through `DesktopDiagnosticsManager` so it lands
in the existing ring buffer + Sentry incident attachment; remote (PostHog) only
for non-committed terminations (committed turns stay local-only, matching
`recordPTTStarted`/`recordPTTCommitted`).

## Privacy boundary

Never transmits raw audio, transcript/prompt text, email, device names, stable
hardware IDs, file paths, tokens, or unrestricted error strings. Raw PCM is
reduced to an energy bucket only while searching for the first usable frame,
then scanning stops; device identity collapses to a transport class + a
default-vs-override flag; capture-start `OSStatus`/error text collapses to a
status class. The new bounded keys are allowlisted in
`cloudIncidentSnapshotKeys` and pass the same redaction the diagnostics
attachment already enforces.

Product behavior and capture/recovery semantics are unchanged; silence gates and
silent-audio routing to providers are untouched.

## Product invariants

- **INV-VOICE-1** (one desktop voice-turn lifecycle owner): the recorder is a
  passive observability accumulator, not a lifecycle owner. It never reduces turn
  state, gates a transition, or makes a product decision; `TurnDisposition` is a
  terminal telemetry label computed from boundaries the real owner
  (`VoiceTurnCoordinator`/reducer + `PushToTalkManager`) already emits. No
  parallel PTT lifecycle state is introduced.
- **INV-CHAT-1** (one shared transcript): the new event carries bounded
  dimensions/shape metadata only — never transcript, prompt, or response content
  — consistent with the desktop analytics-integrity rules.

## Tests

`PTTAttemptLifecycleRecorderTests` (14) drive the production API with an injected
clock and verify all four failure classifications, the recovery correlation
(join on `recovery_attempt_id`, non-judgeable turn does not consume it), timing
buckets, static classification precedence, and that every emitted field is a
bounded string/bool/int/double. `DesktopDiagnosticsManagerTests` gains an
end-to-end test asserting the lifecycle event lands in the diagnostics
attachment with its bounded keys and no raw identity.

## Verification

- `xcrun swift build -c debug --package-path Desktop` — Build complete.
- `xcrun swift test --package-path Desktop --filter PTTAttemptLifecycleRecorderTests|DesktopDiagnosticsManagerTests` — 34 passed, 0 failures.
- PTT/audio/recovery regression suites (`PTTSilentTurnRecoveryWiringTests`,
  `PTTSilentMicRecoveryPolicyTests`, `SilentMicWatchdogRearmTests`,
  `PushToTalkSpeechGateTests`, `PushToTalkStateMachineTests`,
  `PTTAudioCaptureRaceTests`) — 46 passed, 0 failures.
- `desktop/macos/scripts/swift-format-wrapper.sh` + `swiftlint-wrapper.sh` — 0 violations.
- `make preflight` — 9/9 checks passed.

## Intentionally deferred

- Local smoke run against a real CoreAudio device (named dev bundle) was not
  exercised here; the recorder is verified behaviorally through its injected
  seams. A live capture-start race is environment-dependent and better proven
  via the existing beta diagnostics population.
- Adding a fleet query/dashboard over the new `failure_class` dimension in
  PostHog/Sentry is a separate ops follow-up.
