### PR TITLE
SCA-71: fix chat-agent gateway capability mismatch

### DIFF
--- a/backend/llm_gateway/config/generated_route_overrides.yaml
+++ b/backend/llm_gateway/config/generated_route_overrides.yaml
@@ -6,7 +6,6 @@ generated_route_overrides:
     provider_options: {reasoning_effort: medium}
   - feature: chat_agent
     primary: {provider: anthropic, model: claude-sonnet-5}
-    provider_options: {effort: medium}
   - feature: chat_extraction
     primary: {provider: openai, model: gpt-5.4-nano}
     provider_options: {reasoning_effort: low}

--- a/backend/tests/unit/test_llm_gateway_anthropic_passthrough.py
+++ b/backend/tests/unit/test_llm_gateway_anthropic_passthrough.py
@@ -60,6 +60,7 @@ class _FakeAsyncClient:
         self.stream_calls: list[dict[str, Any]] = []
         self._post_response: httpx.Response | None = None
         self._stream_context: _FakeAsyncStreamContext | None = None
+        self._stream_context_factory = None
 
     async def post(self, url: str, *, json: dict[str, Any], headers: dict[str, str], **kwargs):
         self.post_calls.append({'url': url, 'json': json, 'headers': headers, **kwargs})
@@ -67,7 +68,10 @@ class _FakeAsyncClient:
         return self._post_response
 
     def stream(self, method: str, url: str, *, json: dict[str, Any], headers: dict[str, str], **kwargs):
-        self.stream_calls.append({'method': method, 'url': url, 'json': json, 'headers': headers, **kwargs})
+        call = {'method': method, 'url': url, 'json': json, 'headers': headers, **kwargs}
+        self.stream_calls.append(call)
+        if self._stream_context_factory is not None:
+            return self._stream_context_factory(call)
         assert self._stream_context is not None
         return self._stream_context
 
@@ -159,7 +163,7 @@ def test_anthropic_messages_passthrough_preserves_cache_control(_reset_anthropic
     assert len(fake.post_calls) == 1
     forwarded = fake.post_calls[0]['json']
     assert forwarded['model'] == 'claude-sonnet-5'
-    assert forwarded['effort'] == 'medium'
+    assert 'effort' not in forwarded
     assert forwarded['system'][0]['cache_control'] == {'type': 'ephemeral', 'ttl': '1h'}
     assert forwarded['tools'][0]['name'] == 'get_memories_tool'
     assert fake.post_calls[0]['headers']['x-api-key'] == 'anthropic-test-key'
@@ -246,6 +250,33 @@ def test_anthropic_messages_stream_passthrough_preserves_server_tool_sse(_reset_
     assert recorded[0]['outcome'] == 'success'
     assert recorded[0]['phase'] == 'terminal_marker'
     assert recorded[0]['context'].credential_source == 'omi_managed'
+
+
+def test_chat_agent_stream_omits_unsupported_effort_option(_reset_anthropic_client):
+    """The production chat-agent streaming shape must not trigger Anthropic capability rejection."""
+    fake: _FakeAsyncClient = _reset_anthropic_client
+
+    def provider_response(call: dict[str, Any]) -> _FakeAsyncStreamContext:
+        if 'effort' in call['json']:
+            return _FakeAsyncStreamContext(
+                status_code=400,
+                chunks=[b'{"error":{"type":"invalid_request_error","message":"effort is not supported"}}'],
+            )
+        return _FakeAsyncStreamContext(
+            status_code=200,
+            chunks=[b'event: message_stop\n', b'data: {"type":"message_stop"}\n\n'],
+        )
+
+    fake._stream_context_factory = provider_response
+
+    response = TestClient(app).post(
+        '/v1/messages',
+        json=_agentic_request(stream=True),
+        headers=_auth_headers(),
+    )
+
+    assert response.status_code == 200
+    assert 'effort' not in fake.stream_calls[0]['json']
 
 
 def test_anthropic_messages_stream_returns_upstream_error_status(_reset_anthropic_client, monkeypatch):

--- a/backend/tests/unit/test_llm_gateway_config.py
+++ b/backend/tests/unit/test_llm_gateway_config.py
@@ -41,7 +41,7 @@ def test_gateway_route_overrides_do_not_change_the_legacy_model_profile():
     assert config.route_artifacts['route.fair_use.model_config.001'].primary.model == 'gpt-5.6-luna'
     assert config.route_artifacts['route.chat_agent.model_config.001'].primary.model == 'claude-sonnet-5'
     assert config.route_artifacts['route.memory_l2.model_config.001'].provider_options['reasoning_effort'] == 'medium'
-    assert config.route_artifacts['route.chat_agent.model_config.001'].provider_options['effort'] == 'medium'
+    assert config.route_artifacts['route.chat_agent.model_config.001'].provider_options == {}
     chat_agent_lane = config.lanes['omi:auto:chat-agent']
     assert chat_agent_lane.surface == Surface.ANTHROPIC_MESSAGES
     assert chat_agent_lane.capabilities.streaming is True


### PR DESCRIPTION
## Summary

- Fix the gateway-only `chat_agent` Anthropic Messages route by removing its injected `effort: medium` provider option.
- The route adapter merges provider options into every request after replacing the caller model with `route.chat_agent.model_config.001`; Anthropic rejected the resulting streaming request with HTTP 400 before output. The direct chat-agent client does not send that option.
- Keep the gateway-specific model, native Anthropic surface, transport-only fallback policy, circuit behavior, accounting, and bounded metric labels unchanged.
- This branch is rebased onto the emergency revert in #10384. Production Cloud Run gateway mode remains source-controlled `off`; this PR does not enable a caller, deploy, or route traffic.

## Ranked hypotheses and evidence

1. **Confirmed:** the generated route's Anthropic-only `effort` parameter was injected into the exact chat-agent Messages streaming shape and caused a simulated provider capability 400. Removing it makes the same request complete its `message_stop` stream.
2. **Ruled out at this boundary:** a generic Anthropic transport error would invoke the existing direct-provider fallback; an HTTP 4xx remains a non-transport terminal error and intentionally does not silently fall back.
3. **Not changed:** the `claude-sonnet-5` gateway model differs from the direct `claude-sonnet-4-6` profile, but the deterministic reproduction isolates the failing capability to `effort`; no model-name change is needed for this fix.

## RED / GREEN evidence

- RED before the configuration change: `source backend/.venv/bin/activate && pytest -q backend/tests/unit/test_llm_gateway_anthropic_passthrough.py -k unsupported_effort_option` — 1 failed: the exact streaming request returned HTTP 400 and recorded `provider_4xx` before output.
- GREEN after the change: `source backend/.venv/bin/activate && pytest -q backend/tests/unit/test_llm_gateway_anthropic_passthrough.py backend/tests/unit/test_llm_gateway_config.py backend/tests/unit/test_gateway_anthropic_client.py` — 43 passed.
- `make preflight` — passed (19 deterministic checks).

## Rollout verification and rollback

- Keep the production caller flags off. In a separately approved non-production activation, send the authenticated `omi:auto:chat-agent` Anthropic Messages tool stream and verify a terminal `message_stop`, no `provider_4xx` / `capability_mismatch`, unchanged accounting labels, and unchanged fallback/circuit telemetry.
- Roll back by reverting this PR; no live state is changed by this PR.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

