### PR TITLE
ci(desktop): exempt desktop/macos/tests from the changelog gate (unblock main CI)

### DIFF
--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -22,8 +22,13 @@ EXEMPT_DESKTOP_PATHS = {
     "desktop/macos/scripts/qualification-swift-cache.sh",
 }
 # Server-side Rust backend changes are internal reliability work, not user-facing app notes.
+# Test and release-infra changes are likewise never user-facing app notes; the
+# `no-changelog-needed` PR label only satisfies the PR run, so post-merge push
+# runs of this gate must exempt these paths by path or they redden main
+# (qualify-desktop-beta.sh timeout bump #10374 tripped tests/ on the merge push).
 EXEMPT_DESKTOP_PATH_PREFIXES = (
     "desktop/macos/Backend-Rust/",
+    "desktop/macos/tests/",
 )
 
 


### PR DESCRIPTION
#10374's timeout bump touched a test under `desktop/macos/tests/`; the `no-changelog-needed` label only satisfied the PR run, so the post-merge push run of `desktop-changelog-entry` failed on the merge commit and reddened main's Desktop Swift CI, blocking auto-release from cutting a tag. Test files are never user-facing, so exempt the `desktop/macos/tests/` prefix by path (durable across PR and push).

Verified: `check-desktop-changelog.py --base 4d6539e1b0~1 --head 4d6539e1b0` → no changelog needed; a `Desktop/Sources/*.swift` change still requires one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

