### PR TITLE
test(release): cover the desktop/macos/tests changelog exemption

### DIFF
--- a/.github/scripts/test_desktop_changelog.py
+++ b/.github/scripts/test_desktop_changelog.py
@@ -72,15 +72,26 @@ class ChangelogRequirementTests(unittest.TestCase):
         for path in (
             "desktop/macos/docs/release.md",
             "desktop/macos/scripts/qualify-desktop-beta.sh",
+            # Sibling qualification-runner helper (EXEMPT_DESKTOP_PATHS).
+            "desktop/macos/scripts/qualification-swift-cache.sh",
+            # Test files are never user-facing app changes (EXEMPT_DESKTOP_PATH_PREFIXES).
+            # #10374's timeout bump touched this file; without the exemption the
+            # post-merge push run of the changelog gate reddened main (#10387).
+            "desktop/macos/tests/test-qualify-desktop-beta-contract.sh",
+            "desktop/macos/tests/some-other-desktop-test.sh",
+            # Rust backend prefix.
+            "desktop/macos/Backend-Rust/src/main.rs",
         ):
             with self.subTest(path=path):
                 self.assertFalse(checker.is_desktop_change_requiring_changelog(path))
 
-        self.assertTrue(
-            checker.is_desktop_change_requiring_changelog(
-                "desktop/macos/Desktop/Sources/AppDelegate.swift"
-            )
-        )
+        # Product source still requires a changelog — the exemptions must not leak.
+        for path in (
+            "desktop/macos/Desktop/Sources/AppDelegate.swift",
+            "desktop/macos/scripts/some-user-facing-script.sh",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(checker.is_desktop_change_requiring_changelog(path))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Regression coverage for #10387: asserts `desktop/macos/tests/` and `qualification-swift-cache.sh` are changelog-exempt while product source (Desktop/Sources, non-exempt scripts) still requires a changelog. Wired via the existing `desktop-changelog-io-tests` manifest check. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

