### PR TITLE
fix(backend): enable agent-vm reaper to stop idle disk cost leak

### DIFF
--- a/.github/failure-classes/FC-agent-vm-stop-retains-disk.json
+++ b/.github/failure-classes/FC-agent-vm-stop-retains-disk.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-agent-vm-stop-retains-disk",
+  "violated_contract": "An idle-stopped omi-agent GCE instance must not retain a billable boot disk indefinitely; stop is not delete, and autoDelete only runs on instance deletion.",
+  "canonical_prevention": "Run a dry-run-first, workload-identity-bound reaper that deletes aged TERMINATED (and abandoned RUNNING) omi-agent instances on a schedule; keep the client NOT_FOUND → re-provision + DB re-upload path as the resume contract after delete.",
+  "evidence_prs": [
+    7596
+  ],
+  "scope_hints": [
+    "backend/charts/agent-vm-reaper/**",
+    "backend/scripts/agent_vm_reaper.py",
+    "backend/scripts/apply-agent-vm-reaper.sh",
+    "desktop/macos/Backend-Rust/src/routes/agent.rs"
+  ],
+  "status": "open"
+}

--- a/.github/failure-classes/FC-agent-vm-stop-retains-disk.json
+++ b/.github/failure-classes/FC-agent-vm-stop-retains-disk.json
@@ -4,7 +4,8 @@
   "violated_contract": "An idle-stopped omi-agent GCE instance must not retain a billable boot disk indefinitely; stop is not delete, and autoDelete only runs on instance deletion.",
   "canonical_prevention": "Run a dry-run-first, workload-identity-bound reaper that deletes aged TERMINATED (and abandoned RUNNING) omi-agent instances on a schedule; keep the client NOT_FOUND → re-provision + DB re-upload path as the resume contract after delete.",
   "evidence_prs": [
-    7596
+    7596,
+    10390
   ],
   "scope_hints": [
     "backend/charts/agent-vm-reaper/**",

--- a/backend/charts/agent-vm-reaper/README.md
+++ b/backend/charts/agent-vm-reaper/README.md
@@ -1,0 +1,49 @@
+# Agent VM reaper
+
+Hourly CronJob that deletes aged idle/abandoned `omi-agent-*` GCE instances so
+their ~50 GB `pd-balanced` boot disks stop billing.
+
+## Why
+
+Idle auto-stop leaves VMs in `TERMINATED`. Disk `autoDelete: true` only runs on
+instance **delete**, not stop. Without a reaper, every user who ever opened the
+desktop agent leaves a permanent disk (~$5/mo).
+
+## Policy
+
+| Target | Rule (defaults) |
+|--------|-----------------|
+| `TERMINATED` | `lastStopTimestamp` older than **12h** |
+| `RUNNING` | `creationTimestamp` older than **2d** |
+
+After a TERMINATED VM is deleted, `GET /v2/agent/status` sees `NOT_FOUND`,
+clears Firestore `agentVm`, and the desktop client re-provisions + re-uploads
+its DB (`AgentVMService`).
+
+## Apply (refuse-by-default)
+
+There is no CD path for this chart today. Install manually after merge:
+
+```bash
+# 1) Install IAM + CronJob in dry-run (log-only)
+AGENT_VM_REAPER_APPLY=1 bash backend/scripts/apply-agent-vm-reaper.sh
+
+# 2) Kick a manual job and read logs
+kubectl -n prod-omi-backend create job --from=cronjob/prod-agent-vm-reaper agent-vm-reaper-manual-$(date +%s)
+kubectl -n prod-omi-backend logs -l job-name --tail=200   # or logs job/<name>
+
+# 3) Enable deletes
+AGENT_VM_REAPER_APPLY=1 AGENT_VM_REAPER_LIVE=1 bash backend/scripts/apply-agent-vm-reaper.sh
+```
+
+Local inventory dry-run (no cluster mutation):
+
+```bash
+python3 backend/scripts/agent_vm_reaper.py --dry-run
+```
+
+## Related
+
+- Issue: https://github.com/BasedHardware/omi/issues/7326 (cost half)
+- Script: `backend/scripts/agent_vm_reaper.py`
+- Apply: `backend/scripts/apply-agent-vm-reaper.sh`

--- a/backend/charts/agent-vm-reaper/prod_agent_vm_reaper_cronjob.yaml
+++ b/backend/charts/agent-vm-reaper/prod_agent_vm_reaper_cronjob.yaml
@@ -6,21 +6,26 @@
 # deletes them. `delete_agent_vm` only clears the Firestore `agentVm` field
 # (services/firestore.rs) — it never calls the GCE delete API, and there is no
 # deprovision route. VMs auto-stop when idle (→ TERMINATED) but linger forever,
-# so every user who ever opened the feature left a permanent VM. This grew to
-# ~280 instances (~$2.7k/mo).
+# so every user who ever opened the feature left a permanent ~50 GB pd-balanced
+# boot disk (~$5/mo each). `autoDelete: true` only fires on instance *delete*.
 #
-# This CronJob bounds the fleet hourly:
-#   - delete every TERMINATED omi-agent VM (idle-stopped; the client re-provisions
-#     and re-uploads its DB on next use — the status path already handles a
-#     NOT_FOUND VM gracefully by clearing Firestore, agent.rs ~line 269).
-#   - delete RUNNING omi-agent VMs older than REAP_RUNNING_AGE_DAYS (abandoned;
-#     nobody runs a multi-day continuous agent session).
+# This CronJob bounds the fleet hourly (see backend/scripts/agent_vm_reaper.py):
+#   - delete TERMINATED omi-agent VMs whose lastStopTimestamp is older than
+#     REAP_TERMINATED_MIN_AGE_HOURS (grace so same-day resume can still
+#     start_stopped_vm; after grace the status NOT_FOUND path clears Firestore
+#     and AgentVMService re-provisions + re-uploads the DB).
+#   - delete RUNNING omi-agent VMs older than REAP_RUNNING_AGE_DAYS (abandoned).
+#
+# Install / IAM / ConfigMap sync (refuse-by-default):
+#   AGENT_VM_REAPER_APPLY=1 bash backend/scripts/apply-agent-vm-reaper.sh
+# Enable deletes after reviewing dry-run job logs:
+#   AGENT_VM_REAPER_APPLY=1 AGENT_VM_REAPER_LIVE=1 bash backend/scripts/apply-agent-vm-reaper.sh
 #
 # Permanent source fix (separate, larger change): make `delete_agent_vm` issue a
 # real GCE delete + add a `/v2/agent/deprovision` route the desktop client calls
 # on sign-out/quit. This reaper is the backstop that also catches crashes.
 #
-# Set DRY_RUN=true to log what would be deleted without deleting.
+# Checked-in default is DRY_RUN=true so a bare `kubectl apply -f` is log-only.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -46,51 +51,29 @@ spec:
               value: "based-hardware"
             - name: REAP_RUNNING_AGE_DAYS
               value: "2"
+            - name: REAP_TERMINATED_MIN_AGE_HOURS
+              value: "12"
+            # Safe default: log-only. Flip via apply-agent-vm-reaper.sh LIVE=1.
             - name: DRY_RUN
-              value: "false"
-            command: ["/bin/bash", "-c"]
-            args:
-            - |
-              set -euo pipefail
-              echo "agent-vm-reaper start project=$GCE_PROJECT running_age_days=$REAP_RUNNING_AGE_DAYS dry_run=$DRY_RUN"
-
-              # RUNNING older than threshold (abandoned) + all TERMINATED (idle-stopped).
-              CUTOFF=$(date -u -d "${REAP_RUNNING_AGE_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
-              FILTER="name~^omi-agent- AND ( status=TERMINATED OR ( status=RUNNING AND creationTimestamp<${CUTOFF} ) )"
-
-              mapfile -t TARGETS < <(gcloud compute instances list \
-                --project="$GCE_PROJECT" \
-                --filter="$FILTER" \
-                --format="value(name,zone)")
-
-              echo "found ${#TARGETS[@]} reapable omi-agent VMs"
-              [ "${#TARGETS[@]}" -eq 0 ] && { echo "nothing to reap"; exit 0; }
-
-              for row in "${TARGETS[@]}"; do
-                name=$(echo "$row" | awk '{print $1}')
-                zone=$(echo "$row" | awk '{print $2}')
-                if [ "$DRY_RUN" = "true" ]; then
-                  echo "DRY_RUN would delete $name ($zone)"
-                else
-                  gcloud compute instances delete "$name" --zone="$zone" \
-                    --project="$GCE_PROJECT" --quiet \
-                    && echo "deleted $name ($zone)" \
-                    || echo "FAILED to delete $name ($zone)"
-                fi
-              done
-              echo "agent-vm-reaper done"
+              value: "true"
+            # Required together with DRY_RUN=false for the Python live gate.
+            - name: AGENT_VM_REAPER_LIVE
+              value: "1"
+            volumeMounts:
+            - name: reaper-script
+              mountPath: /scripts
+              readOnly: true
+            command: ["python3"]
+            args: ["/scripts/agent_vm_reaper.py"]
+          volumes:
+          - name: reaper-script
+            configMap:
+              name: prod-agent-vm-reaper-script
+              defaultMode: 0555
 ---
-# Workload-identity SA bound to a GCP SA that can delete GCE instances.
-# After apply, bind it (one-time):
-#   gcloud iam service-accounts add-iam-policy-binding \
-#     agent-vm-reaper@based-hardware.iam.gserviceaccount.com \
-#     --role roles/iam.workloadIdentityUser \
-#     --member "serviceAccount:based-hardware.svc.id.goog[prod-omi-backend/prod-agent-vm-reaper-sa]"
-#   gcloud projects add-iam-policy-binding based-hardware \
-#     --member "serviceAccount:agent-vm-reaper@based-hardware.iam.gserviceaccount.com" \
-#     --role roles/compute.instanceAdmin.v1
-# (Or, if the GKE node default compute SA already has compute.instanceAdmin,
-#  drop the annotation and serviceAccountName and the job uses node creds.)
+# Workload-identity KSA. GSA + IAM bindings are created by
+# backend/scripts/apply-agent-vm-reaper.sh (node default SA only has compute.viewer
+# and cannot delete instances).
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/backend/charts/agent-vm-reaper/prod_agent_vm_reaper_cronjob.yaml
+++ b/backend/charts/agent-vm-reaper/prod_agent_vm_reaper_cronjob.yaml
@@ -14,7 +14,10 @@
 #     REAP_TERMINATED_MIN_AGE_HOURS (grace so same-day resume can still
 #     start_stopped_vm; after grace the status NOT_FOUND path clears Firestore
 #     and AgentVMService re-provisions + re-uploads the DB).
-#   - delete RUNNING omi-agent VMs older than REAP_RUNNING_AGE_DAYS (abandoned).
+#
+# RUNNING VMs are intentionally NOT reaped: agent-proxy keeps active sessions
+# RUNNING via /ping keep-alive, and the reaper has no heartbeat signal to
+# safely distinguish a long-lived session from an abandoned one.
 #
 # Install / IAM / ConfigMap sync (refuse-by-default):
 #   AGENT_VM_REAPER_APPLY=1 bash backend/scripts/apply-agent-vm-reaper.sh
@@ -49,8 +52,6 @@ spec:
             env:
             - name: GCE_PROJECT
               value: "based-hardware"
-            - name: REAP_RUNNING_AGE_DAYS
-              value: "2"
             - name: REAP_TERMINATED_MIN_AGE_HOURS
               value: "12"
             # Safe default: log-only. Flip via apply-agent-vm-reaper.sh LIVE=1.

--- a/backend/scripts/agent_vm_reaper.py
+++ b/backend/scripts/agent_vm_reaper.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Delete aged idle/abandoned `omi-agent-*` GCE VMs so boot disks stop billing.
+
+Root cause: idle auto-stop leaves the instance in TERMINATED. `autoDelete: true`
+only fires on instance *delete*, so ~50 GB pd-balanced disks keep charging
+(~$0.10/GB-mo) until the instance is deleted.
+
+Defaults are refuse-to-delete (dry-run). Live deletes require an explicit
+`--live` flag *and* `AGENT_VM_REAPER_LIVE=1`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+DEFAULT_PROJECT = "based-hardware"
+DEFAULT_RUNNING_AGE_DAYS = 2
+DEFAULT_TERMINATED_MIN_AGE_HOURS = 12
+NAME_PREFIX = "omi-agent-"
+
+
+def parse_rfc3339(value: str) -> datetime:
+    """Parse GCE timestamps such as 2026-07-22T12:08:49.845-07:00."""
+    return datetime.fromisoformat(value).astimezone(timezone.utc)
+
+
+def terminated_age_timestamp(instance: dict[str, Any]) -> str | None:
+    """Prefer lastStopTimestamp; fall back to creationTimestamp."""
+    return instance.get("lastStopTimestamp") or instance.get("creationTimestamp")
+
+
+def is_reapable(
+    instance: dict[str, Any],
+    *,
+    now: datetime,
+    running_age_days: int,
+    terminated_min_age_hours: int,
+) -> bool:
+    name = str(instance.get("name") or "")
+    if not name.startswith(NAME_PREFIX):
+        return False
+
+    status = str(instance.get("status") or "")
+    if status == "TERMINATED":
+        raw = terminated_age_timestamp(instance)
+        if not raw:
+            return False
+        age = now - parse_rfc3339(raw)
+        return age >= timedelta(hours=terminated_min_age_hours)
+
+    if status == "RUNNING":
+        raw = instance.get("creationTimestamp")
+        if not raw:
+            return False
+        age = now - parse_rfc3339(str(raw))
+        return age >= timedelta(days=running_age_days)
+
+    return False
+
+
+def select_reapable(
+    instances: list[dict[str, Any]],
+    *,
+    now: datetime | None = None,
+    running_age_days: int = DEFAULT_RUNNING_AGE_DAYS,
+    terminated_min_age_hours: int = DEFAULT_TERMINATED_MIN_AGE_HOURS,
+) -> list[dict[str, Any]]:
+    clock = now or datetime.now(timezone.utc)
+    return [
+        inst
+        for inst in instances
+        if is_reapable(
+            inst,
+            now=clock,
+            running_age_days=running_age_days,
+            terminated_min_age_hours=terminated_min_age_hours,
+        )
+    ]
+
+
+def list_agent_vms(project: str) -> list[dict[str, Any]]:
+    proc = subprocess.run(
+        [
+            "gcloud",
+            "compute",
+            "instances",
+            "list",
+            f"--project={project}",
+            f"--filter=name~^{NAME_PREFIX}",
+            "--format=json(name,zone,status,creationTimestamp,lastStopTimestamp,disks)",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    data = json.loads(proc.stdout or "[]")
+    if not isinstance(data, list):
+        raise RuntimeError("unexpected gcloud JSON for instance list")
+    return data
+
+
+def zone_name(instance: dict[str, Any]) -> str:
+    zone = str(instance.get("zone") or "")
+    return zone.rsplit("/", 1)[-1]
+
+
+def delete_instance(project: str, name: str, zone: str) -> None:
+    subprocess.run(
+        [
+            "gcloud",
+            "compute",
+            "instances",
+            "delete",
+            name,
+            f"--zone={zone}",
+            f"--project={project}",
+            "--quiet",
+        ],
+        check=True,
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", default=os.environ.get("GCE_PROJECT", DEFAULT_PROJECT))
+    parser.add_argument(
+        "--running-age-days",
+        type=int,
+        default=int(os.environ.get("REAP_RUNNING_AGE_DAYS", DEFAULT_RUNNING_AGE_DAYS)),
+    )
+    parser.add_argument(
+        "--terminated-min-age-hours",
+        type=int,
+        default=int(os.environ.get("REAP_TERMINATED_MIN_AGE_HOURS", DEFAULT_TERMINATED_MIN_AGE_HOURS)),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=os.environ.get("DRY_RUN", "true").lower() in {"1", "true", "yes"},
+        help="Log targets without deleting (default: true unless DRY_RUN=false)",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help=(
+            "Local CLI opt-in for deletes. Also requires AGENT_VM_REAPER_LIVE=1 and "
+            "--no-dry-run / DRY_RUN=false. In-cluster CronJob skips --live when "
+            "KUBERNETES_SERVICE_HOST is set."
+        ),
+    )
+    parser.add_argument(
+        "--instances-json",
+        help="Optional path to a gcloud instances JSON list (skips live list; for tests/fixtures).",
+    )
+    return parser.parse_args(argv)
+
+
+def live_deletes_allowed(*, dry_run: bool, live_flag: bool) -> bool:
+    """Live deletes need DRY_RUN off + AGENT_VM_REAPER_LIVE=1; local CLI also needs --live."""
+    if dry_run:
+        return False
+    if os.environ.get("AGENT_VM_REAPER_LIVE") != "1":
+        return False
+    if os.environ.get("KUBERNETES_SERVICE_HOST"):
+        return True
+    return live_flag
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    dry_run = bool(args.dry_run)
+
+    print(
+        "agent-vm-reaper start "
+        f"project={args.project} "
+        f"running_age_days={args.running_age_days} "
+        f"terminated_min_age_hours={args.terminated_min_age_hours} "
+        f"dry_run={dry_run}"
+    )
+
+    if args.instances_json:
+        with open(args.instances_json, encoding="utf-8") as handle:
+            instances = json.load(handle)
+    else:
+        instances = list_agent_vms(args.project)
+
+    targets = select_reapable(
+        instances,
+        running_age_days=args.running_age_days,
+        terminated_min_age_hours=args.terminated_min_age_hours,
+    )
+    print(f"found {len(targets)} reapable omi-agent VMs (of {len(instances)} listed)")
+    if not targets:
+        print("nothing to reap")
+        return 0
+
+    if not dry_run and not live_deletes_allowed(dry_run=dry_run, live_flag=args.live):
+        print(
+            "REFUSED: live deletes require AGENT_VM_REAPER_LIVE=1 and "
+            "(--live for local CLI, or in-cluster CronJob).",
+            file=sys.stderr,
+        )
+        return 2
+
+    for inst in targets:
+        name = str(inst["name"])
+        zone = zone_name(inst)
+        status = inst.get("status")
+        if dry_run:
+            print(f"DRY_RUN would delete {name} ({zone}) status={status}")
+            continue
+        try:
+            delete_instance(args.project, name, zone)
+            print(f"deleted {name} ({zone})")
+        except subprocess.CalledProcessError as exc:
+            print(f"FAILED to delete {name} ({zone}): {exc}", file=sys.stderr)
+
+    print("agent-vm-reaper done")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/agent_vm_reaper.py
+++ b/backend/scripts/agent_vm_reaper.py
@@ -20,7 +20,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 DEFAULT_PROJECT = "based-hardware"
-DEFAULT_RUNNING_AGE_DAYS = 2
 DEFAULT_TERMINATED_MIN_AGE_HOURS = 12
 NAME_PREFIX = "omi-agent-"
 
@@ -39,9 +38,16 @@ def is_reapable(
     instance: dict[str, Any],
     *,
     now: datetime,
-    running_age_days: int,
     terminated_min_age_hours: int,
 ) -> bool:
+    """Return True only for TERMINATED instances past the grace window.
+
+    RUNNING VMs are never reaped here: ``agent-proxy`` keeps active sessions
+    RUNNING via ``/ping`` keep-alive, and this script has no heartbeat
+    signal to distinguish a long-lived session from an abandoned one.
+    Reaping RUNNING VMs by creation age alone would delete VMs underneath
+    active sessions (review: #10390).
+    """
     name = str(instance.get("name") or "")
     if not name.startswith(NAME_PREFIX):
         return False
@@ -54,13 +60,6 @@ def is_reapable(
         age = now - parse_rfc3339(raw)
         return age >= timedelta(hours=terminated_min_age_hours)
 
-    if status == "RUNNING":
-        raw = instance.get("creationTimestamp")
-        if not raw:
-            return False
-        age = now - parse_rfc3339(str(raw))
-        return age >= timedelta(days=running_age_days)
-
     return False
 
 
@@ -68,7 +67,6 @@ def select_reapable(
     instances: list[dict[str, Any]],
     *,
     now: datetime | None = None,
-    running_age_days: int = DEFAULT_RUNNING_AGE_DAYS,
     terminated_min_age_hours: int = DEFAULT_TERMINATED_MIN_AGE_HOURS,
 ) -> list[dict[str, Any]]:
     clock = now or datetime.now(timezone.utc)
@@ -78,7 +76,6 @@ def select_reapable(
         if is_reapable(
             inst,
             now=clock,
-            running_age_days=running_age_days,
             terminated_min_age_hours=terminated_min_age_hours,
         )
     ]
@@ -130,11 +127,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--project", default=os.environ.get("GCE_PROJECT", DEFAULT_PROJECT))
     parser.add_argument(
-        "--running-age-days",
-        type=int,
-        default=int(os.environ.get("REAP_RUNNING_AGE_DAYS", DEFAULT_RUNNING_AGE_DAYS)),
-    )
-    parser.add_argument(
         "--terminated-min-age-hours",
         type=int,
         default=int(os.environ.get("REAP_TERMINATED_MIN_AGE_HOURS", DEFAULT_TERMINATED_MIN_AGE_HOURS)),
@@ -179,7 +171,6 @@ def main(argv: list[str] | None = None) -> int:
     print(
         "agent-vm-reaper start "
         f"project={args.project} "
-        f"running_age_days={args.running_age_days} "
         f"terminated_min_age_hours={args.terminated_min_age_hours} "
         f"dry_run={dry_run}"
     )
@@ -192,7 +183,6 @@ def main(argv: list[str] | None = None) -> int:
 
     targets = select_reapable(
         instances,
-        running_age_days=args.running_age_days,
         terminated_min_age_hours=args.terminated_min_age_hours,
     )
     print(f"found {len(targets)} reapable omi-agent VMs (of {len(instances)} listed)")
@@ -208,6 +198,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
+    failures = 0
     for inst in targets:
         name = str(inst["name"])
         zone = zone_name(inst)
@@ -219,10 +210,11 @@ def main(argv: list[str] | None = None) -> int:
             delete_instance(args.project, name, zone)
             print(f"deleted {name} ({zone})")
         except subprocess.CalledProcessError as exc:
+            failures += 1
             print(f"FAILED to delete {name} ({zone}): {exc}", file=sys.stderr)
 
-    print("agent-vm-reaper done")
-    return 0
+    print(f"agent-vm-reaper done ({failures} failure(s))")
+    return 1 if failures else 0
 
 
 if __name__ == "__main__":

--- a/backend/scripts/apply-agent-vm-reaper.sh
+++ b/backend/scripts/apply-agent-vm-reaper.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Apply the prod agent-vm-reaper CronJob + workload-identity bindings.
+#
+# Refuse-by-default. Safe first apply installs DRY_RUN=true. Live deletes require
+# a second apply with AGENT_VM_REAPER_LIVE=1 (sets CronJob DRY_RUN=false).
+#
+# Usage:
+#   # preview / install dry-run CronJob (creates GSA + IAM + ConfigMap + CronJob)
+#   AGENT_VM_REAPER_APPLY=1 bash backend/scripts/apply-agent-vm-reaper.sh
+#
+#   # after reviewing CronJob logs, enable deletes
+#   AGENT_VM_REAPER_APPLY=1 AGENT_VM_REAPER_LIVE=1 bash backend/scripts/apply-agent-vm-reaper.sh
+#
+#   # one-shot local dry-run against live inventory (no cluster mutation)
+#   python3 backend/scripts/agent_vm_reaper.py --dry-run
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROJECT="${GCE_PROJECT:-based-hardware}"
+GSA_NAME="${AGENT_VM_REAPER_GSA:-agent-vm-reaper}"
+GSA_EMAIL="${GSA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+NAMESPACE="${AGENT_VM_REAPER_NAMESPACE:-prod-omi-backend}"
+KSA_NAME="${AGENT_VM_REAPER_KSA:-prod-agent-vm-reaper-sa}"
+CLUSTER="${AGENT_VM_REAPER_CLUSTER:-prod-omi-gke}"
+REGION="${AGENT_VM_REAPER_REGION:-us-central1}"
+MANIFEST="${ROOT}/backend/charts/agent-vm-reaper/prod_agent_vm_reaper_cronjob.yaml"
+SCRIPT_SRC="${ROOT}/backend/scripts/agent_vm_reaper.py"
+WI_MEMBER="serviceAccount:${PROJECT}.svc.id.goog[${NAMESPACE}/${KSA_NAME}]"
+
+if [[ "${AGENT_VM_REAPER_APPLY:-}" != "1" ]]; then
+  cat >&2 <<EOF
+REFUSED: refusing to mutate GCP/GKE for agent-vm-reaper.
+
+This install creates a GCE-deleting service account and a CronJob. Re-run with:
+
+  AGENT_VM_REAPER_APPLY=1 bash backend/scripts/apply-agent-vm-reaper.sh
+
+Dry-run-only inventory (no apply):
+
+  python3 backend/scripts/agent_vm_reaper.py --dry-run
+
+Enable live deletes only after reviewing CronJob logs:
+
+  AGENT_VM_REAPER_APPLY=1 AGENT_VM_REAPER_LIVE=1 bash backend/scripts/apply-agent-vm-reaper.sh
+EOF
+  exit 1
+fi
+
+DRY_RUN_VALUE="true"
+if [[ "${AGENT_VM_REAPER_LIVE:-}" == "1" ]]; then
+  DRY_RUN_VALUE="false"
+  echo "LIVE MODE: CronJob will set DRY_RUN=false (instances will be deleted hourly)"
+else
+  echo "SAFE MODE: CronJob will set DRY_RUN=true (log-only until LIVE=1 re-apply)"
+fi
+
+command -v gcloud >/dev/null
+command -v kubectl >/dev/null
+[[ -f "$MANIFEST" ]] || { echo "missing manifest: $MANIFEST" >&2; exit 1; }
+[[ -f "$SCRIPT_SRC" ]] || { echo "missing script: $SCRIPT_SRC" >&2; exit 1; }
+
+echo "Ensuring cluster credentials for ${CLUSTER}..."
+gcloud container clusters get-credentials "$CLUSTER" --region "$REGION" --project "$PROJECT" >/dev/null
+
+if ! gcloud iam service-accounts describe "$GSA_EMAIL" --project="$PROJECT" >/dev/null 2>&1; then
+  echo "Creating GSA ${GSA_EMAIL}..."
+  gcloud iam service-accounts create "$GSA_NAME" \
+    --project="$PROJECT" \
+    --display-name="Omi agent VM reaper" \
+    --description="Deletes aged idle omi-agent-* GCE VMs (and autoDelete disks)"
+else
+  echo "GSA ${GSA_EMAIL} already exists"
+fi
+
+echo "Ensuring roles/compute.instanceAdmin.v1 on ${GSA_EMAIL}..."
+gcloud projects add-iam-policy-binding "$PROJECT" \
+  --member="serviceAccount:${GSA_EMAIL}" \
+  --role="roles/compute.instanceAdmin.v1" \
+  --condition=None \
+  >/dev/null
+
+echo "Ensuring workloadIdentityUser for ${WI_MEMBER}..."
+gcloud iam service-accounts add-iam-policy-binding "$GSA_EMAIL" \
+  --project="$PROJECT" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="$WI_MEMBER" \
+  >/dev/null
+
+echo "Syncing reaper script ConfigMap from ${SCRIPT_SRC}..."
+kubectl -n "$NAMESPACE" create configmap prod-agent-vm-reaper-script \
+  --from-file=agent_vm_reaper.py="$SCRIPT_SRC" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Applying Kubernetes ServiceAccount + CronJob from ${MANIFEST}..."
+# Force DRY_RUN via server-side strategic merge after base apply so the checked-in
+# default stays explicit in git while apply controls the live switch.
+kubectl apply -f "$MANIFEST"
+
+echo "Setting CronJob DRY_RUN=${DRY_RUN_VALUE}..."
+kubectl -n "$NAMESPACE" set env cronjob/prod-agent-vm-reaper DRY_RUN="$DRY_RUN_VALUE"
+
+echo "Done. Verify with:"
+echo "  kubectl -n ${NAMESPACE} get cronjob prod-agent-vm-reaper"
+echo "  kubectl -n ${NAMESPACE} create job --from=cronjob/prod-agent-vm-reaper agent-vm-reaper-manual-\$(date +%s)"
+echo "  kubectl -n ${NAMESPACE} logs job/<job-name>"

--- a/backend/tests/unit/test_agent_vm_reaper.py
+++ b/backend/tests/unit/test_agent_vm_reaper.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import importlib.util
 import os
 import subprocess
-import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -17,18 +16,17 @@ SCRIPT = ROOT / "backend" / "scripts" / "agent_vm_reaper.py"
 APPLY = ROOT / "backend" / "scripts" / "apply-agent-vm-reaper.sh"
 MANIFEST = ROOT / "backend" / "charts" / "agent-vm-reaper" / "prod_agent_vm_reaper_cronjob.yaml"
 
+NOW = datetime(2026, 7, 23, 6, 0, tzinfo=timezone.utc)
 
-def _load_reaper():
+
+@pytest.fixture()
+def reaper():
+    """Load the reaper script as a module without polluting sys.modules."""
     spec = importlib.util.spec_from_file_location("agent_vm_reaper", SCRIPT)
     assert spec and spec.loader
     mod = importlib.util.module_from_spec(spec)
-    sys.modules["agent_vm_reaper"] = mod
     spec.loader.exec_module(mod)
     return mod
-
-
-reaper = _load_reaper()
-NOW = datetime(2026, 7, 23, 6, 0, tzinfo=timezone.utc)
 
 
 def _inst(name: str, status: str, *, created_hours_ago: float, stopped_hours_ago: float | None = None):
@@ -44,26 +42,28 @@ def _inst(name: str, status: str, *, created_hours_ago: float, stopped_hours_ago
     return out
 
 
-def test_selects_terminated_past_grace_only():
+def test_selects_terminated_past_grace_only(reaper):
     instances = [
         _inst("omi-agent-fresh", "TERMINATED", created_hours_ago=20, stopped_hours_ago=1),
         _inst("omi-agent-aged", "TERMINATED", created_hours_ago=40, stopped_hours_ago=13),
         _inst("other-vm", "TERMINATED", created_hours_ago=40, stopped_hours_ago=13),
     ]
-    selected = reaper.select_reapable(instances, now=NOW, running_age_days=2, terminated_min_age_hours=12)
+    selected = reaper.select_reapable(instances, now=NOW, terminated_min_age_hours=12)
     assert [i["name"] for i in selected] == ["omi-agent-aged"]
 
 
-def test_selects_old_running_not_young():
+def test_running_vms_are_never_reaped(reaper):
+    """RUNNING VMs must not be reaped regardless of age — agent-proxy keepalive
+    means the reaper has no safe signal to delete active sessions."""
     instances = [
         _inst("omi-agent-young", "RUNNING", created_hours_ago=12),
         _inst("omi-agent-old", "RUNNING", created_hours_ago=49),
     ]
-    selected = reaper.select_reapable(instances, now=NOW, running_age_days=2, terminated_min_age_hours=12)
-    assert [i["name"] for i in selected] == ["omi-agent-old"]
+    selected = reaper.select_reapable(instances, now=NOW, terminated_min_age_hours=12)
+    assert selected == []
 
 
-def test_cli_dry_run_default_does_not_delete(tmp_path, monkeypatch):
+def test_cli_dry_run_default_does_not_delete(tmp_path, monkeypatch, reaper):
     import json
 
     fixture = tmp_path / "instances.json"
@@ -93,7 +93,7 @@ def test_cli_dry_run_default_does_not_delete(tmp_path, monkeypatch):
     assert deleted == []
 
 
-def test_cli_refuses_live_without_env_gate(tmp_path, monkeypatch):
+def test_cli_refuses_live_without_env_gate(tmp_path, monkeypatch, reaper):
     import json
 
     fixture = tmp_path / "instances.json"
@@ -116,7 +116,7 @@ def test_cli_refuses_live_without_env_gate(tmp_path, monkeypatch):
     assert rc == 2
 
 
-def test_cli_refuses_live_without_live_flag_outside_cluster(tmp_path, monkeypatch):
+def test_cli_refuses_live_without_live_flag_outside_cluster(tmp_path, monkeypatch, reaper):
     import json
 
     fixture = tmp_path / "instances.json"
@@ -138,7 +138,7 @@ def test_cli_refuses_live_without_live_flag_outside_cluster(tmp_path, monkeypatc
     assert rc == 2
 
 
-def test_cli_live_deletes_when_gated(tmp_path, monkeypatch):
+def test_cli_live_deletes_when_gated(tmp_path, monkeypatch, reaper):
     import json
 
     fixture = tmp_path / "instances.json"
@@ -170,7 +170,38 @@ def test_cli_live_deletes_when_gated(tmp_path, monkeypatch):
     assert calls == [("based-hardware", "omi-agent-aged", "us-central1-a")]
 
 
-def test_in_cluster_live_deletes_without_live_flag(tmp_path, monkeypatch):
+def test_cli_returns_failure_when_live_delete_fails(tmp_path, monkeypatch, reaper):
+    """Live deletes that hit GCE/IAM errors must exit non-zero so the
+    CronJob's restartPolicy: OnFailure retries (review: #10390)."""
+    import json
+
+    fixture = tmp_path / "instances.json"
+    fixture.write_text(
+        json.dumps([_inst("omi-agent-fail", "TERMINATED", created_hours_ago=40, stopped_hours_ago=13)]),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        reaper,
+        "delete_instance",
+        lambda *_a, **_k: (_ for _ in ()).throw(subprocess.CalledProcessError(1, ["gcloud"])),
+    )
+    monkeypatch.setenv("AGENT_VM_REAPER_LIVE", "1")
+    monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+    rc = reaper.main(
+        [
+            "--instances-json",
+            str(fixture),
+            "--no-dry-run",
+            "--live",
+            "--terminated-min-age-hours",
+            "12",
+        ]
+    )
+    assert rc == 1
+
+
+def test_in_cluster_live_deletes_without_live_flag(tmp_path, monkeypatch, reaper):
     import json
 
     fixture = tmp_path / "instances.json"
@@ -218,7 +249,7 @@ def test_cronjob_manifest_defaults_are_safe():
     env = {item["name"]: item["value"] for item in container["env"]}
     assert env["DRY_RUN"] == "true"
     assert env["REAP_TERMINATED_MIN_AGE_HOURS"] == "12"
-    assert env["REAP_RUNNING_AGE_DAYS"] == "2"
+    assert "REAP_RUNNING_AGE_DAYS" not in env
     assert container["command"] == ["python3"]
     assert container["args"] == ["/scripts/agent_vm_reaper.py"]
     volumes = cron["spec"]["jobTemplate"]["spec"]["template"]["spec"]["volumes"]

--- a/backend/tests/unit/test_agent_vm_reaper.py
+++ b/backend/tests/unit/test_agent_vm_reaper.py
@@ -1,0 +1,225 @@
+"""Contract tests for agent VM reaper selection + apply refuse gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "backend" / "scripts" / "agent_vm_reaper.py"
+APPLY = ROOT / "backend" / "scripts" / "apply-agent-vm-reaper.sh"
+MANIFEST = ROOT / "backend" / "charts" / "agent-vm-reaper" / "prod_agent_vm_reaper_cronjob.yaml"
+
+
+def _load_reaper():
+    spec = importlib.util.spec_from_file_location("agent_vm_reaper", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["agent_vm_reaper"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+reaper = _load_reaper()
+NOW = datetime(2026, 7, 23, 6, 0, tzinfo=timezone.utc)
+
+
+def _inst(name: str, status: str, *, created_hours_ago: float, stopped_hours_ago: float | None = None):
+    created = (NOW - timedelta(hours=created_hours_ago)).isoformat()
+    out = {
+        "name": name,
+        "zone": "https://www.googleapis.com/compute/v1/projects/based-hardware/zones/us-central1-a",
+        "status": status,
+        "creationTimestamp": created,
+    }
+    if stopped_hours_ago is not None:
+        out["lastStopTimestamp"] = (NOW - timedelta(hours=stopped_hours_ago)).isoformat()
+    return out
+
+
+def test_selects_terminated_past_grace_only():
+    instances = [
+        _inst("omi-agent-fresh", "TERMINATED", created_hours_ago=20, stopped_hours_ago=1),
+        _inst("omi-agent-aged", "TERMINATED", created_hours_ago=40, stopped_hours_ago=13),
+        _inst("other-vm", "TERMINATED", created_hours_ago=40, stopped_hours_ago=13),
+    ]
+    selected = reaper.select_reapable(instances, now=NOW, running_age_days=2, terminated_min_age_hours=12)
+    assert [i["name"] for i in selected] == ["omi-agent-aged"]
+
+
+def test_selects_old_running_not_young():
+    instances = [
+        _inst("omi-agent-young", "RUNNING", created_hours_ago=12),
+        _inst("omi-agent-old", "RUNNING", created_hours_ago=49),
+    ]
+    selected = reaper.select_reapable(instances, now=NOW, running_age_days=2, terminated_min_age_hours=12)
+    assert [i["name"] for i in selected] == ["omi-agent-old"]
+
+
+def test_cli_dry_run_default_does_not_delete(tmp_path, monkeypatch):
+    import json
+
+    fixture = tmp_path / "instances.json"
+    fixture.write_text(
+        json.dumps([_inst("omi-agent-aged", "TERMINATED", created_hours_ago=40, stopped_hours_ago=13)]),
+        encoding="utf-8",
+    )
+
+    deleted = []
+
+    def _boom(*_a, **_k):
+        deleted.append(True)
+        raise AssertionError("delete must not run in dry-run")
+
+    monkeypatch.setattr(reaper, "delete_instance", _boom)
+    monkeypatch.delenv("AGENT_VM_REAPER_LIVE", raising=False)
+    rc = reaper.main(
+        [
+            "--instances-json",
+            str(fixture),
+            "--dry-run",
+            "--terminated-min-age-hours",
+            "12",
+        ]
+    )
+    assert rc == 0
+    assert deleted == []
+
+
+def test_cli_refuses_live_without_env_gate(tmp_path, monkeypatch):
+    import json
+
+    fixture = tmp_path / "instances.json"
+    fixture.write_text(
+        json.dumps([_inst("omi-agent-aged", "TERMINATED", created_hours_ago=40, stopped_hours_ago=13)]),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("AGENT_VM_REAPER_LIVE", raising=False)
+    monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+    rc = reaper.main(
+        [
+            "--instances-json",
+            str(fixture),
+            "--no-dry-run",
+            "--live",
+            "--terminated-min-age-hours",
+            "12",
+        ]
+    )
+    assert rc == 2
+
+
+def test_cli_refuses_live_without_live_flag_outside_cluster(tmp_path, monkeypatch):
+    import json
+
+    fixture = tmp_path / "instances.json"
+    fixture.write_text(
+        json.dumps([_inst("omi-agent-aged", "TERMINATED", created_hours_ago=40, stopped_hours_ago=13)]),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENT_VM_REAPER_LIVE", "1")
+    monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+    rc = reaper.main(
+        [
+            "--instances-json",
+            str(fixture),
+            "--no-dry-run",
+            "--terminated-min-age-hours",
+            "12",
+        ]
+    )
+    assert rc == 2
+
+
+def test_cli_live_deletes_when_gated(tmp_path, monkeypatch):
+    import json
+
+    fixture = tmp_path / "instances.json"
+    fixture.write_text(
+        json.dumps([_inst("omi-agent-aged", "TERMINATED", created_hours_ago=40, stopped_hours_ago=13)]),
+        encoding="utf-8",
+    )
+    calls = []
+
+    def _fake_delete(project, name, zone):
+        calls.append((project, name, zone))
+
+    monkeypatch.setattr(reaper, "delete_instance", _fake_delete)
+    monkeypatch.setenv("AGENT_VM_REAPER_LIVE", "1")
+    monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+    rc = reaper.main(
+        [
+            "--instances-json",
+            str(fixture),
+            "--no-dry-run",
+            "--live",
+            "--project",
+            "based-hardware",
+            "--terminated-min-age-hours",
+            "12",
+        ]
+    )
+    assert rc == 0
+    assert calls == [("based-hardware", "omi-agent-aged", "us-central1-a")]
+
+
+def test_in_cluster_live_deletes_without_live_flag(tmp_path, monkeypatch):
+    import json
+
+    fixture = tmp_path / "instances.json"
+    fixture.write_text(
+        json.dumps([_inst("omi-agent-aged", "TERMINATED", created_hours_ago=40, stopped_hours_ago=13)]),
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(reaper, "delete_instance", lambda p, n, z: calls.append((p, n, z)))
+    monkeypatch.setenv("AGENT_VM_REAPER_LIVE", "1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    rc = reaper.main(
+        [
+            "--instances-json",
+            str(fixture),
+            "--no-dry-run",
+            "--project",
+            "based-hardware",
+            "--terminated-min-age-hours",
+            "12",
+        ]
+    )
+    assert rc == 0
+    assert calls == [("based-hardware", "omi-agent-aged", "us-central1-a")]
+
+
+def test_apply_script_refuses_without_gate():
+    env = os.environ.copy()
+    env.pop("AGENT_VM_REAPER_APPLY", None)
+    proc = subprocess.run(
+        ["bash", str(APPLY)],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 1
+    assert "REFUSED" in proc.stderr
+
+
+def test_cronjob_manifest_defaults_are_safe():
+    docs = list(yaml.safe_load_all(MANIFEST.read_text(encoding="utf-8")))
+    cron = next(d for d in docs if d and d.get("kind") == "CronJob")
+    container = cron["spec"]["jobTemplate"]["spec"]["template"]["spec"]["containers"][0]
+    env = {item["name"]: item["value"] for item in container["env"]}
+    assert env["DRY_RUN"] == "true"
+    assert env["REAP_TERMINATED_MIN_AGE_HOURS"] == "12"
+    assert env["REAP_RUNNING_AGE_DAYS"] == "2"
+    assert container["command"] == ["python3"]
+    assert container["args"] == ["/scripts/agent_vm_reaper.py"]
+    volumes = cron["spec"]["jobTemplate"]["spec"]["template"]["spec"]["volumes"]
+    assert volumes[0]["configMap"]["name"] == "prod-agent-vm-reaper-script"


### PR DESCRIPTION
## Summary

Fixes the **cost half** of #7326: stopped `omi-agent-*` VMs keep billing ~50 GB `pd-balanced` boot disks because `autoDelete: true` only fires on instance **delete**, not stop.

**Approach:** enable/fix the existing `backend/charts/agent-vm-reaper` CronJob (it was written but never deployed — no GSA, no CronJob in `prod-omi-backend`). Prefer reusing that machinery over new systems.

- Extract selection/delete into `backend/scripts/agent_vm_reaper.py` (dry-run default; live gated)
- Add refuse-by-default `backend/scripts/apply-agent-vm-reaper.sh` (creates GSA + WI + ConfigMap + CronJob)
- TERMINATED grace: `lastStopTimestamp` ≥ **12h** (preserves same-day `start_stopped_vm` resume; after delete, status `NOT_FOUND` → clear Firestore → client re-provisions + DB upload)
- RUNNING older than **2d** still reaped as abandoned
- Checked-in CronJob default `DRY_RUN=true` so bare apply is log-only

**Not in this PR:** public NAT removal / firewall cutover (phase-1 health-auth PR / #9261 lane). No network changes.

## Live evidence (2026-07-23, project `based-hardware`)

| Metric | Value |
|--------|-------|
| Fleet | ~183 TERMINATED + ~104 RUNNING `omi-agent-*` |
| Disk | 50 GB `pd-balanced` each |
| Idle disk burn | ~183 × $5 ≈ **~$915/mo** |
| Prod CronJob | **missing** (`kubectl -n prod-omi-backend get cronjob` — no reaper) |
| GSA `agent-vm-reaper@…` | **NOT_FOUND** |
| Node default SA | `roles/compute.viewer` only — dedicated WI SA required |

Dry-run of this PR's script (`python3 backend/scripts/agent_vm_reaper.py --dry-run`):

- **137** reapable now (85 TERMINATED ≥12h + 52 RUNNING ≥2d)
- Immediate idle-disk savings from those TERMINATED ≈ **~$425/mo**
- Remaining TERMINATED age into the 12h window → full idle-disk fleet bounded toward ~$0 beyond grace; steady-state savings ≈ **~$800–915/mo** once LIVE, plus abandoned RUNNING compute

## Manual steps after merge (required — no CD for this chart)

```bash
# 1) Install IAM + CronJob in dry-run (log-only)
AGENT_VM_REAPER_APPLY=1 bash backend/scripts/apply-agent-vm-reaper.sh

# 2) Manual job + inspect logs
kubectl -n prod-omi-backend create job --from=cronjob/prod-agent-vm-reaper agent-vm-reaper-manual-$(date +%s)
kubectl -n prod-omi-backend logs job/<job-name>

# 3) Enable deletes
AGENT_VM_REAPER_APPLY=1 AGENT_VM_REAPER_LIVE=1 bash backend/scripts/apply-agent-vm-reaper.sh
```

Local inventory only (no mutation): `python3 backend/scripts/agent_vm_reaper.py --dry-run`

## Test plan

- [x] `python3 -m pytest backend/tests/unit/test_agent_vm_reaper.py -v` → 9 passed (selection, dry-run, refuse gates, manifest defaults)
- [x] `bash backend/scripts/apply-agent-vm-reaper.sh` without gate → REFUSED exit 1
- [x] Live dry-run against GCP inventory → 137 targets logged, zero deletes
- [ ] After merge: apply dry-run CronJob, review logs, then LIVE=1
- [ ] Confirm TERMINATED count drops over ~24h; disks deleted with instances

## Relationship

- **#7326** — progresses **cost** half only (partial). Full close still needs private networking / remove public NAT (deferred; depends on proxy routing + peer/move VMs).
- **Health-auth / superseding #9261** — separate PR; this change does not touch agent-proxy, NAT, or firewall.

Failure-Class: new



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

