### PR TITLE
ci: weekly guardrail baseline health pulse (#9454)

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -445,8 +445,15 @@ checks:
     triggers: [".github/workflows/desktop_retry_beta_qualification.yml", ".github/scripts/desktop_beta_qualification_retry.py", ".github/scripts/test_desktop_beta_qualification_retry.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-49 bounded automatic retry of transient failed/cancelled Beta qualification must stay tag-bound, exact-SHA, bounded, and never re-dispatch in-progress/successful runs"
+  - id: guardrail-pulse-tests
+    command: ["python3", ".github/scripts/test_guardrail_pulse.py"]
+    triggers: [".github/scripts/guardrail_pulse.py", ".github/scripts/test_guardrail_pulse.py", ".github/workflows/guardrail-baseline-pulse.yml", ".github/guardrail-pulse-history.jsonl", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#9454 weekly baseline health pulse parsing, JSONL record, and 30-day staleness detection"
 
 exempt:
+  - path: ".github/scripts/guardrail_pulse.py"
+    reason: "informational weekly baseline health pulse (#9454); unit tests gate via guardrail-pulse-tests, schedule owns --record"
   - path: ".github/scripts/check-desktop-auto-beta-candidate.py"
     reason: "release pipeline check requires published candidate artifacts and workflow inputs"
   - path: ".github/scripts/check-desktop-prod-promotion-policy.py"

--- a/.github/guardrail-pulse-history.jsonl
+++ b/.github/guardrail-pulse-history.jsonl
@@ -1,0 +1,1 @@
+{"date": "2026-07-23", "metrics": {"brand_ui_purple": {"baseline": 1776, "count": 1776}, "deferred_work_markers": {"baseline": 837, "count": 837}, "lifecycle_unlabeled_scripts": {"baseline": 17, "count": 17}, "mapless_packages": {"baseline": 6, "count": 3}, "union_return_isinstance": {"baseline": 0, "count": 0}, "version_prefixed_files": {"baseline": 42, "count": 42}}}

--- a/.github/scripts/guardrail_pulse.py
+++ b/.github/scripts/guardrail_pulse.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Guardrail baseline health pulse (#9454 Part 2).
+
+Invokes each existing check script's counter (never reimplements counting).
+Emits one line per baseline, optional JSON, optional JSONL history append, and
+staleness detection when a nonzero count has not decreased for 30 days.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_brand_ui  # noqa: E402
+import check_isinstance_return_ratchet  # noqa: E402
+import check_lifecycle_headers  # noqa: E402
+import check_package_architecture_maps  # noqa: E402
+import check_version_prefixed_filenames  # noqa: E402
+
+DEFAULT_HISTORY = Path(".github/guardrail-pulse-history.jsonl")
+STALENESS_DAYS = 30
+
+
+@dataclass(frozen=True)
+class Metric:
+    name: str
+    count: int
+    baseline: int
+
+
+def _load_hyphen_module(filename: str, module_name: str):
+    path = SCRIPT_DIR / filename
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _union_return_metric(repo_root: Path) -> Metric:
+    baseline_path = repo_root / check_isinstance_return_ratchet.DEFAULT_BASELINE
+    baseline = check_isinstance_return_ratchet.load_baseline(baseline_path)
+    counts = check_isinstance_return_ratchet.collect_counts(
+        repo_root, check_isinstance_return_ratchet.DEFAULT_SCAN_ROOT
+    )
+    return Metric(
+        "union_return_isinstance",
+        sum(counts.values()),
+        sum(baseline.values()),
+    )
+
+
+def _lifecycle_metric(repo_root: Path) -> Metric:
+    baseline_path = repo_root / check_lifecycle_headers.BASELINE_PATH
+    baseline_entries, _errors = check_lifecycle_headers.load_baseline(baseline_path)
+    headerless = 0
+    for _relative_path, path in check_lifecycle_headers.iter_designated_files(repo_root):
+        lifecycle, header_error = check_lifecycle_headers.parse_lifecycle_header(path)
+        if header_error is None and lifecycle is None:
+            headerless += 1
+    return Metric("lifecycle_unlabeled_scripts", headerless, len(baseline_entries))
+
+
+def _mapless_metric(repo_root: Path) -> Metric:
+    baseline_path = repo_root / ".github" / "scripts" / "package_architecture_baseline.json"
+    baseline = check_package_architecture_maps.load_baseline(baseline_path)
+    findings = check_package_architecture_maps.evaluate_packages(
+        repo_root, baseline, check_package_architecture_maps.DEFAULT_THRESHOLD
+    )
+    # Live mapless packages (warnings + errors); baseline is the committed grandfather map.
+    return Metric("mapless_packages", len(findings), len(baseline))
+
+
+def _version_prefixed_metric() -> Metric:
+    # Grandfathered paths are the frozen debt the pulse tracks for burn-down.
+    # New violations outside the set fail CI separately (live_new should stay 0).
+    grandfathered = len(check_version_prefixed_filenames.GRANDFATHERED_VIOLATIONS)
+    live_new = len(check_version_prefixed_filenames.violations(check_version_prefixed_filenames.tracked_paths()))
+    return Metric("version_prefixed_files", grandfathered + live_new, grandfathered)
+
+
+def _deferred_metric(repo_root: Path) -> Metric:
+    deferred = _load_hyphen_module("deferred-work-marker-count.py", "deferred_work_marker_count")
+    marker_counts, _file_counts = deferred.count_markers(repo_root, raw=False)
+    total = sum(marker_counts.values())
+    # No committed ceiling — baseline tracks the live normalized total for display.
+    return Metric("deferred_work_markers", total, total)
+
+
+def _brand_ui_metric(repo_root: Path) -> Metric:
+    total = 0
+    for prefix in check_brand_ui.UI_ROOTS:
+        root = repo_root / prefix
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            relative = path.relative_to(repo_root).as_posix()
+            if not check_brand_ui.is_ui_source(relative):
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            total += check_brand_ui.count_purple(text)
+    return Metric("brand_ui_purple", total, total)
+
+
+def collect_metrics(repo_root: Path) -> list[Metric]:
+    return [
+        _union_return_metric(repo_root),
+        _lifecycle_metric(repo_root),
+        _mapless_metric(repo_root),
+        _version_prefixed_metric(),
+        _deferred_metric(repo_root),
+        _brand_ui_metric(repo_root),
+    ]
+
+
+def format_text(metrics: list[Metric]) -> str:
+    width = max(len(metric.name) for metric in metrics)
+    lines = [f"{metric.name:<{width}}  {metric.count:<5} (baseline {metric.baseline})" for metric in metrics]
+    return "\n".join(lines)
+
+
+def metrics_payload(metrics: list[Metric], *, recorded_at: str) -> dict[str, Any]:
+    return {
+        "date": recorded_at,
+        "metrics": {metric.name: {"count": metric.count, "baseline": metric.baseline} for metric in metrics},
+    }
+
+
+def append_history(history_path: Path, payload: dict[str, Any]) -> None:
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    with history_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def load_history(history_path: Path) -> list[dict[str, Any]]:
+    if not history_path.is_file():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line_number, line in enumerate(history_path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{history_path}:{line_number}: invalid JSONL: {exc}") from exc
+        if not isinstance(row, dict) or "date" not in row or "metrics" not in row:
+            raise ValueError(f"{history_path}:{line_number}: expected object with date and metrics")
+        rows.append(row)
+    return rows
+
+
+def _parse_iso_date(value: str) -> date:
+    return date.fromisoformat(value[:10])
+
+
+def find_stale_metrics(
+    history: list[dict[str, Any]],
+    *,
+    as_of: date | None = None,
+    window_days: int = STALENESS_DAYS,
+) -> list[str]:
+    """Return metric names whose nonzero count has not decreased for ``window_days``.
+
+    Requires history spanning at least ``window_days``. A metric that only appeared
+    recently is not stale yet.
+    """
+    as_of = as_of or datetime.now(timezone.utc).date()
+    series_by_name: dict[str, list[tuple[date, int]]] = {}
+    for row in history:
+        day = _parse_iso_date(str(row["date"]))
+        metrics = row.get("metrics") or {}
+        if not isinstance(metrics, dict):
+            continue
+        for name, payload in metrics.items():
+            if not isinstance(payload, dict):
+                continue
+            count = payload.get("count")
+            if not isinstance(count, int):
+                continue
+            series_by_name.setdefault(name, []).append((day, count))
+
+    stale: list[str] = []
+    for name, series in sorted(series_by_name.items()):
+        series.sort(key=lambda item: item[0])
+        current_count = series[-1][1]
+        if current_count <= 0:
+            continue
+        last_decrease: date | None = None
+        for previous, current in zip(series, series[1:]):
+            if current[1] < previous[1]:
+                last_decrease = current[0]
+        reference = last_decrease or series[0][0]
+        if (as_of - reference).days >= window_days:
+            stale.append(name)
+    return stale
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=REPO_ROOT, help="Repository root.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    parser.add_argument(
+        "--record",
+        action="store_true",
+        help=f"Append today's snapshot to {DEFAULT_HISTORY.as_posix()}.",
+    )
+    parser.add_argument(
+        "--history",
+        type=Path,
+        default=None,
+        help="JSONL history path (default: repo-relative guardrail-pulse-history.jsonl).",
+    )
+    parser.add_argument(
+        "--date",
+        default=None,
+        help="ISO date for the snapshot / staleness as-of (default: today UTC).",
+    )
+    parser.add_argument(
+        "--check-staleness",
+        action="store_true",
+        help="Print stale metrics (nonzero, no decrease for 30 days) and exit 1 if any.",
+    )
+    parser.add_argument(
+        "--staleness-days",
+        type=int,
+        default=STALENESS_DAYS,
+        help="Staleness window in days (default: 30).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = args.root.resolve()
+    history_path = args.history or (repo_root / DEFAULT_HISTORY)
+    if not history_path.is_absolute():
+        history_path = repo_root / history_path
+
+    recorded_at = args.date or datetime.now(timezone.utc).date().isoformat()
+    metrics = collect_metrics(repo_root)
+    payload = metrics_payload(metrics, recorded_at=recorded_at)
+
+    if args.record:
+        append_history(history_path, payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(format_text(metrics))
+
+    if args.check_staleness:
+        history = load_history(history_path)
+        # Include the just-computed snapshot even when --record was not used.
+        if not args.record:
+            history = [*history, payload]
+        as_of = _parse_iso_date(recorded_at)
+        stale = find_stale_metrics(history, as_of=as_of, window_days=args.staleness_days)
+        if stale:
+            print("STALE: nonzero baselines with no decrease for " f"{args.staleness_days} days: {', '.join(stale)}")
+            return 1
+        print(f"OK: no stale nonzero baselines (window={args.staleness_days}d).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_guardrail_pulse.py
+++ b/.github/scripts/test_guardrail_pulse.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Unit tests for guardrail baseline health pulse (#9454)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import date, timedelta
+from pathlib import Path
+
+import guardrail_pulse
+
+
+class GuardrailPulseTests(unittest.TestCase):
+    def test_format_text_parses_counts(self) -> None:
+        text = guardrail_pulse.format_text(
+            [
+                guardrail_pulse.Metric("union_return_isinstance", 0, 0),
+                guardrail_pulse.Metric("lifecycle_unlabeled_scripts", 14, 19),
+            ]
+        )
+        self.assertIn("union_return_isinstance", text)
+        self.assertIn("0", text)
+        self.assertIn("(baseline 0)", text)
+        self.assertIn("lifecycle_unlabeled_scripts", text)
+        self.assertIn("(baseline 19)", text)
+
+    def test_staleness_triggers_on_31_day_unchanged_nonzero(self) -> None:
+        as_of = date(2026, 7, 23)
+        old = (as_of - timedelta(days=31)).isoformat()
+        mid = (as_of - timedelta(days=15)).isoformat()
+        history = [
+            {
+                "date": old,
+                "metrics": {"lifecycle_unlabeled_scripts": {"count": 14, "baseline": 19}},
+            },
+            {
+                "date": mid,
+                "metrics": {"lifecycle_unlabeled_scripts": {"count": 14, "baseline": 19}},
+            },
+            {
+                "date": as_of.isoformat(),
+                "metrics": {"lifecycle_unlabeled_scripts": {"count": 14, "baseline": 19}},
+            },
+        ]
+        self.assertEqual(
+            guardrail_pulse.find_stale_metrics(history, as_of=as_of, window_days=30),
+            ["lifecycle_unlabeled_scripts"],
+        )
+
+    def test_staleness_skips_decreasing_metric(self) -> None:
+        as_of = date(2026, 7, 23)
+        old = (as_of - timedelta(days=31)).isoformat()
+        recent = (as_of - timedelta(days=7)).isoformat()
+        history = [
+            {
+                "date": old,
+                "metrics": {"mapless_packages": {"count": 7, "baseline": 7}},
+            },
+            {
+                "date": recent,
+                "metrics": {"mapless_packages": {"count": 6, "baseline": 7}},
+            },
+            {
+                "date": as_of.isoformat(),
+                "metrics": {"mapless_packages": {"count": 6, "baseline": 7}},
+            },
+        ]
+        self.assertEqual(guardrail_pulse.find_stale_metrics(history, as_of=as_of, window_days=30), [])
+
+    def test_staleness_skips_zero_counts(self) -> None:
+        as_of = date(2026, 7, 23)
+        old = (as_of - timedelta(days=40)).isoformat()
+        history = [
+            {"date": old, "metrics": {"union_return_isinstance": {"count": 0, "baseline": 0}}},
+            {
+                "date": as_of.isoformat(),
+                "metrics": {"union_return_isinstance": {"count": 0, "baseline": 0}},
+            },
+        ]
+        self.assertEqual(guardrail_pulse.find_stale_metrics(history, as_of=as_of), [])
+
+    def test_record_appends_jsonl(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            history = Path(tmp) / "history.jsonl"
+            payload = guardrail_pulse.metrics_payload(
+                [guardrail_pulse.Metric("union_return_isinstance", 0, 0)],
+                recorded_at="2026-07-23",
+            )
+            guardrail_pulse.append_history(history, payload)
+            guardrail_pulse.append_history(history, payload)
+            rows = guardrail_pulse.load_history(history)
+            self.assertEqual(len(rows), 2)
+            self.assertEqual(rows[0]["date"], "2026-07-23")
+            self.assertEqual(rows[0]["metrics"]["union_return_isinstance"]["count"], 0)
+
+    def test_json_round_trip_shape(self) -> None:
+        payload = guardrail_pulse.metrics_payload(
+            [guardrail_pulse.Metric("brand_ui_purple", 3, 3)],
+            recorded_at="2026-01-01",
+        )
+        encoded = json.dumps(payload)
+        decoded = json.loads(encoded)
+        self.assertEqual(decoded["metrics"]["brand_ui_purple"]["baseline"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/guardrail-baseline-pulse.yml
+++ b/.github/workflows/guardrail-baseline-pulse.yml
@@ -1,0 +1,101 @@
+# LIFECYCLE: permanent
+# Weekly guardrail baseline health pulse (#9454).
+# Records committed JSONL history and opens/updates one tracking issue when any
+# nonzero baseline count has not decreased for 30 days.
+name: Guardrail baseline pulse
+
+on:
+  schedule:
+    # Mondays 15:00 UTC
+    - cron: "0 15 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  pulse:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          # Allow the job to push the recorded history line back to main.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run pulse and record snapshot
+        id: pulse
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/guardrail_pulse.py --json --record | tee /tmp/pulse.json
+          set +e
+          python3 .github/scripts/guardrail_pulse.py --check-staleness > /tmp/staleness.txt
+          status=$?
+          set -e
+          echo "staleness_exit=${status}" >> "$GITHUB_OUTPUT"
+          cat /tmp/staleness.txt
+          {
+            echo "## Guardrail baseline pulse"
+            echo
+            echo '```'
+            python3 .github/scripts/guardrail_pulse.py
+            echo '```'
+            echo
+            echo "### Staleness"
+            echo
+            echo '```'
+            cat /tmp/staleness.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit history snapshot
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- .github/guardrail-pulse-history.jsonl; then
+            echo "No history change to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/guardrail-pulse-history.jsonl
+          git commit -m "chore: record weekly guardrail baseline pulse"
+          git push
+
+      - name: Open or update staleness tracking issue
+        if: steps.pulse.outputs.staleness_exit == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          TITLE="Guardrail baseline health: stale nonzero baselines"
+          BODY_FILE=$(mktemp)
+          {
+            echo "Automated weekly pulse detected one or more **nonzero** guardrail baselines that have not decreased for 30 days."
+            echo
+            echo "Run: ${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}"
+            echo
+            echo "## Pulse"
+            echo
+            echo '```'
+            python3 .github/scripts/guardrail_pulse.py
+            echo '```'
+            echo
+            echo "## Staleness"
+            echo
+            echo '```'
+            cat /tmp/staleness.txt
+            echo '```'
+            echo
+            echo "Burn down the listed baselines (shrink the committed grandfather / pay the debt). This issue is updated in place by \`.github/workflows/guardrail-baseline-pulse.yml\`."
+          } > "$BODY_FILE"
+
+          EXISTING=$(gh issue list --repo "$REPO" --state open --search "in:title Guardrail baseline health: stale nonzero baselines" --json number,title --jq '.[0].number // empty')
+          if [[ -n "$EXISTING" ]]; then
+            gh issue edit "$EXISTING" --repo "$REPO" --body-file "$BODY_FILE"
+            gh issue comment "$EXISTING" --repo "$REPO" --body "Weekly pulse refreshed this issue (run ${GITHUB_RUN_ID})."
+            echo "Updated issue #${EXISTING}"
+          else
+            gh issue create --repo "$REPO" --title "$TITLE" --body-file "$BODY_FILE"
+          fi


### PR DESCRIPTION
## Summary

- Add `.github/scripts/guardrail_pulse.py`: weekly (and on-demand) health pulse over the existing no-increase guardrail baselines. Counts come from the same modules the ratchets already use (`check_isinstance_return_ratchet`, `check_lifecycle_headers`, `check_package_architecture_maps`, `check_version_prefixed_filenames`, `deferred-work-marker-count`, `check_brand_ui`) — no duplicated counters.
- `--json` / `--record` append dated snapshots to `.github/guardrail-pulse-history.jsonl`; `--check-staleness` fails when a **nonzero** metric has not decreased for 30 days.
- Weekly workflow `.github/workflows/guardrail-baseline-pulse.yml` records history (commits the JSONL on `main`) and opens/updates one tracking issue on staleness. Unit tests + manifest registration (`guardrail-pulse-tests`); pulse script listed under `exempt:` as informational.

Part 1 of #9454 (empty union-return baseline) already shipped via #9456. This PR is **pulse only**.

Closes #9454

## Product invariants affected

none

## Failure class (fixes)

No `fix:` commits; `Failure-Class: none` on the `ci:` commit.

## New guards

- Why not a shared primitive: the pulse is a thin aggregator over existing per-pattern counters; sharing would just add an unused registry.
- Real instance: #9454 — grandfathered baselines otherwise become permanent with no scheduled prompt to burn down.

## Validation

- `python3 .github/scripts/test_guardrail_pulse.py` (6 passed)
- `python3 .github/scripts/test_run_checks.py ManifestContractTests` (manifest + exempt drift)
- Live pulse on this branch:

```
union_return_isinstance      0     (baseline 0)
lifecycle_unlabeled_scripts  17    (baseline 17)
mapless_packages             3     (baseline 6)
version_prefixed_files       42    (baseline 42)
deferred_work_markers        837   (baseline 837)
brand_ui_purple              1776  (baseline 1776)
```

### Synthetic staleness (30-day trigger)

```
STALE trigger (31d unchanged nonzero): ['lifecycle_unlabeled_scripts']
No trigger when decreased within window: []
```

## Manual steps after merge

None required for the pulse to start. First scheduled run is Monday 15:00 UTC (`workflow_dispatch` available). Staleness alerts need ≥30 days of JSONL history before they can fire.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

