### PR TITLE
fix(sync): recover stuck offline recordings and enumerate current-firmware devices

### DIFF
--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -476,9 +476,11 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     await getDeviceInfo();
     SharedPreferencesUtil().deviceName = device.name;
 
-    // Wals
+    // Wals — pass the firmware resolved by getDeviceInfo() above so background
+    // discovery routes ring-buffer devices correctly; `device` here is the raw
+    // connect object whose firmwareRevision is often still 'Unknown'.
     final syncs = ServiceManager.instance().wal.getSyncs();
-    syncs.setDevice(device);
+    syncs.setDevice(device, firmwareVersion: currentFirmwareVersion);
     syncs.sdcard.setDevice(device);
     syncs.flashPage.setDevice(device);
     syncs.storage.setDevice(device);

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -26,6 +26,13 @@ import 'package:omi/utils/wal_file_manager.dart';
 const _kBackendBusyErrorHint = 'background worker likely died';
 const _freshSyncCutoffSeconds = 6 * 60 * 60;
 
+/// Files per upload batch, the same for both lanes. The lanes exist to keep
+/// rate-limit domains separate — a backfill cooldown must not stall a freshly
+/// captured recording — not to throttle throughput. Draining a backlog a few
+/// files at a time made offline recovery needlessly slow; the backend caps part
+/// size (200 MB), not file count.
+const _syncUploadBatchLimit = 20;
+
 enum SyncJobTerminalPolicy { wait, acknowledge, retry }
 
 /// The shared WAL acknowledgement boundary for async sync jobs.
@@ -87,10 +94,9 @@ List<Wal> nextSyncUploadBatch(
   if (ordered.isEmpty) return const [];
   final lane = effectiveLane(ordered.first);
   final conversationId = ordered.first.conversationId;
-  final batchLimit = lane == SyncUploadLane.fresh ? 20 : 3;
   return ordered
       .where((wal) => effectiveLane(wal) == lane && wal.conversationId == conversationId)
-      .take(batchLimit)
+      .take(_syncUploadBatchLimit)
       .toList();
 }
 

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -33,11 +33,30 @@ class WalSyncs implements IWalSync {
 
   bool _isCancelled = false;
   BtDevice? _device;
+  String? _firmwareVersion;
 
   /// Called from DeviceProvider when a device connects/disconnects so the
   /// firmware-version gate in syncAll() can route to the right Phase-0 sync.
-  void setDevice(BtDevice? device) {
+  ///
+  /// [firmwareVersion] is the enriched value resolved after getDeviceInfo();
+  /// prefer it over [device].firmwareRevision, which on the raw connect object
+  /// is frequently still 'Unknown' and would misroute ring-buffer devices to
+  /// the multi-file enumerator (so their recordings never enumerate).
+  void setDevice(BtDevice? device, {String? firmwareVersion}) {
     _device = device;
+    _firmwareVersion = firmwareVersion;
+  }
+
+  /// Best available firmware for discovery routing: the enriched value if it
+  /// resolved, otherwise whatever the raw connect object carries.
+  String? get _resolvedFirmware => resolveDiscoveryFirmware(_firmwareVersion, _device?.firmwareRevision);
+
+  /// Prefer the enriched firmware over the raw connect-object value, which is
+  /// frequently still 'Unknown'. A missing/'Unknown' enriched value falls back
+  /// to the raw one so behavior is never worse than before.
+  static String? resolveDiscoveryFirmware(String? enriched, String? raw) {
+    if (enriched != null && enriched.isNotEmpty && enriched != 'Unknown') return enriched;
+    return raw;
   }
 
   /// Firmware >= 3.0.20 speaks the ring-buffer protocol; older multi-file
@@ -105,12 +124,12 @@ class WalSyncs implements IWalSync {
   /// while a sync is in progress.
   Future<void> refreshWalsFromDevice({String? firmwareVersion}) async {
     if (_device == null) return;
-    // Prefer the caller-supplied firmware (resolved from the enriched
-    // pairedDevice) — _device here is the raw connect object whose
-    // firmwareRevision can still be 'Unknown', which would misroute discovery.
+    // Prefer the caller-supplied firmware, then the enriched value stored at
+    // setDevice — the raw connect object's firmwareRevision can still be
+    // 'Unknown', which would misroute ring-buffer discovery.
     final fw = (firmwareVersion != null && firmwareVersion.isNotEmpty && firmwareVersion != 'Unknown')
         ? firmwareVersion
-        : _device?.firmwareRevision;
+        : _resolvedFirmware;
     if (isRingBufferFirmware(fw)) {
       await _ringSync.refreshWalsFromDevice();
     } else {
@@ -263,7 +282,7 @@ class WalSyncs implements IWalSync {
     //   fw >= 3.0.20  -> ring-buffer protocol (RingStorageSync)
     //   fw 3.0.17–.19 -> multi-file LittleFS protocol (StorageSync)
     //   fw < 3.0.17   -> falls through to Phase 1a legacy SD-card path
-    final fwVersion = _device?.firmwareRevision;
+    final fwVersion = _resolvedFirmware;
     final useRing = isRingBufferFirmware(fwVersion);
     if (useRing) {
       await _ringSync.refreshWalsFromDevice();

--- a/app/test/services/wals/wal_syncs_firmware_routing_test.dart
+++ b/app/test/services/wals/wal_syncs_firmware_routing_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/services/wals/wal_syncs.dart';
+
+// Regression: background/auto-sync discovery read firmware off the raw connect
+// object, which is frequently 'Unknown'. isRingBufferFirmware('Unknown') is
+// false, so ring-buffer devices (fw >= 3.0.20 — current firmware) were routed
+// to the multi-file enumerator and their offline recordings were never
+// enumerated, uploaded, or turned into conversations (#10033). The fix resolves
+// the enriched firmware first; only the Auto Sync page used to pass it.
+void main() {
+  group('resolveDiscoveryFirmware', () {
+    test('enriched value wins over a raw Unknown connect object', () {
+      expect(WalSyncs.resolveDiscoveryFirmware('3.0.20', 'Unknown'), '3.0.20');
+    });
+
+    test('falls back to raw when enriched is Unknown/empty/null', () {
+      expect(WalSyncs.resolveDiscoveryFirmware('Unknown', '3.0.20'), '3.0.20');
+      expect(WalSyncs.resolveDiscoveryFirmware('', '3.0.20'), '3.0.20');
+      expect(WalSyncs.resolveDiscoveryFirmware(null, '3.0.17'), '3.0.17');
+    });
+  });
+
+  group('end-to-end routing decision', () {
+    test('a ring-buffer device with a raw Unknown object now routes to ring', () {
+      // Before the fix this classified false (raw 'Unknown') -> multi-file
+      // enumerator -> recordings never discovered.
+      final resolved = WalSyncs.resolveDiscoveryFirmware('3.0.20', 'Unknown');
+      expect(WalSyncs.isRingBufferFirmware(resolved), isTrue);
+    });
+
+    test('older multi-file firmware still routes to storage', () {
+      final resolved = WalSyncs.resolveDiscoveryFirmware('3.0.18', 'Unknown');
+      expect(WalSyncs.isRingBufferFirmware(resolved), isFalse);
+    });
+  });
+}

--- a/app/test/unit/local_wal_sync_test.dart
+++ b/app/test/unit/local_wal_sync_test.dart
@@ -279,17 +279,29 @@ void main() {
       expect(syncUploadLaneForTimestamp(now - 60, now, hasServerCaptureProof: true), SyncUploadLane.fresh);
     });
 
-    test('historical batches are bounded to three newest WALs', () {
+    test('a small historical backlog drains in one batch instead of a few files at a time', () {
       const now = 2000000000;
       final historical = List.generate(
-        5,
+        8,
         (index) => Wal(timerStart: now - 7 * 60 * 60 - index, codec: BleAudioCodec.opus, seconds: 60),
       );
 
       final batch = nextSyncUploadBatch(historical.reversed.toList(), now);
 
-      expect(batch.length, 3);
-      expect(batch.map((wal) => wal.timerStart), historical.take(3).map((wal) => wal.timerStart));
+      expect(batch.length, 8);
+    });
+
+    test('historical batches are bounded by the shared upload batch limit, newest first', () {
+      const now = 2000000000;
+      final historical = List.generate(
+        25,
+        (index) => Wal(timerStart: now - 7 * 60 * 60 - index, codec: BleAudioCodec.opus, seconds: 60),
+      );
+
+      final batch = nextSyncUploadBatch(historical.reversed.toList(), now);
+
+      expect(batch.length, 20);
+      expect(batch.map((wal) => wal.timerStart), historical.take(20).map((wal) => wal.timerStart));
     });
 
     test('an oversized fresh conversation is downgraded as one unit', () {
@@ -310,7 +322,9 @@ void main() {
       expect(forcedBackfill, {'oversized-conversation'});
 
       final batch = nextSyncUploadBatch(oversized, now, forcedBackfillConversationIds: forcedBackfill);
-      expect(batch.length, 3);
+      // Downgraded to the backfill rate-limit domain, but still drained at the
+      // shared batch limit rather than a few files at a time.
+      expect(batch.length, 20);
       expect(batch.every((wal) => wal.conversationId == 'oversized-conversation'), isTrue);
     });
   });

--- a/backend/database/sync_jobs.py
+++ b/backend/database/sync_jobs.py
@@ -194,7 +194,17 @@ def delete_sync_job(job_id: str) -> None:
 
 
 def get_sync_job(job_id: str) -> Optional[Dict[str, Any]]:
-    """Get a sync job by ID without changing its lifecycle state."""
+    """Get a sync job by ID, self-healing a dead worker on read.
+
+    A job stuck in 'processing' past STALE_THRESHOLD_SECONDS is finalized to
+    'failed' here, on every read and for every dispatch mode, so the client
+    reverts the WAL to 'miss' and re-uploads within ~10 minutes instead of
+    waiting out the 24h reconcile TTL. The pipeline heartbeats 'updated_at' at
+    every stage and per segment, so 600s of silence only ever means the worker
+    is gone — see is_sync_job_stale. 'queued' jobs are never finalized: no
+    worker has claimed them, and flipping them to 'failed' caused spurious
+    client "retrying" loops (#7469).
+    """
     key = f'{JOB_KEY_PREFIX}{job_id}'
     data = r.get(key)
     if not data:
@@ -208,15 +218,28 @@ def get_sync_job(job_id: str) -> Optional[Dict[str, Any]]:
         return None
     job: Dict[str, Any] = cast(Dict[str, Any], raw) if isinstance(raw, dict) else {}
 
+    if is_sync_job_stale(job):
+        updated_at = job.get('updated_at') or job.get('created_at') or time.time()
+        logger.warning(
+            "sync_job %s (uid=%s) stale after %.0fs in 'processing' — marking failed",
+            job_id,
+            job.get('uid'),
+            time.time() - updated_at,
+        )
+        job['status'] = 'failed'
+        job['error'] = 'Job timed out (background worker likely died)'
+        job['completed_at'] = time.time()
+        r.set(key, json.dumps(job, default=str), ex=JOB_TTL_SECONDS)
+
     return job
 
 
 def is_sync_job_stale(job: Dict[str, Any], *, now: Optional[float] = None) -> bool:
-    """Return whether a processing job needs an explicit owner-safe finalizer.
+    """Return whether a 'processing' job has gone silent past the stale bound.
 
-    A read must never publish a terminal failure: callers first acquire the
-    per-job run lease, re-read, then finalize/release retry material. Queued
-    jobs are intentionally never stale because no worker has claimed them.
+    True only for a job in 'processing' whose 'updated_at' is older than
+    STALE_THRESHOLD_SECONDS. Queued jobs are never stale — no worker has claimed
+    them. get_sync_job finalizes stale jobs to 'failed' on read.
     """
     if job.get('status') != 'processing':
         return False

--- a/backend/tests/unit/test_sync_job_stale_self_heal.py
+++ b/backend/tests/unit/test_sync_job_stale_self_heal.py
@@ -1,0 +1,69 @@
+"""get_sync_job self-heals a dead worker on read.
+
+A job stuck in 'processing' past STALE_THRESHOLD_SECONDS is finalized to 'failed'
+on read, for every dispatch mode, so the client reverts the WAL to 'miss' and
+re-uploads instead of waiting out the 24h reconcile TTL. 'queued' jobs are never
+finalized (no worker claimed them; flipping them caused #7469 retry loops).
+
+This restores the dispatch-agnostic self-heal that PR #9616 narrowed to a
+client-poll, cloud_tasks-only path — the regression behind offline recordings
+sitting at "Uploaded · processing on Omi" for 12+ hours (#10033).
+"""
+
+import json
+import time
+
+import database.sync_jobs as sync_jobs
+
+
+class _FakeRedis:
+    def __init__(self, job: dict):
+        self._blob = json.dumps(job).encode()
+        self.sets: list[tuple[str, dict]] = []
+
+    def get(self, key):
+        return self._blob
+
+    def set(self, key, value, ex=None):
+        self._blob = value if isinstance(value, (bytes, str)) else json.dumps(value).encode()
+        self.sets.append((key, json.loads(value)))
+
+
+def _stale_at():
+    return time.time() - (sync_jobs.STALE_THRESHOLD_SECONDS + 60)
+
+
+def test_stale_processing_job_self_heals_for_inline_dispatch(monkeypatch):
+    fake = _FakeRedis({'id': 'j1', 'status': 'processing', 'dispatch_mode': 'inline', 'updated_at': _stale_at()})
+    monkeypatch.setattr(sync_jobs, 'r', fake)
+
+    job = sync_jobs.get_sync_job('j1')
+
+    assert job['status'] == 'failed'
+    assert job['error']
+    # Persisted, not just returned — a later read stays failed.
+    assert fake.sets and fake.sets[-1][1]['status'] == 'failed'
+
+
+def test_stale_processing_job_self_heals_for_cloud_tasks_dispatch(monkeypatch):
+    fake = _FakeRedis({'id': 'j2', 'status': 'processing', 'dispatch_mode': 'cloud_tasks', 'updated_at': _stale_at()})
+    monkeypatch.setattr(sync_jobs, 'r', fake)
+
+    assert sync_jobs.get_sync_job('j2')['status'] == 'failed'
+
+
+def test_fresh_processing_job_is_not_finalized(monkeypatch):
+    fake = _FakeRedis({'id': 'j3', 'status': 'processing', 'dispatch_mode': 'inline', 'updated_at': time.time()})
+    monkeypatch.setattr(sync_jobs, 'r', fake)
+
+    assert sync_jobs.get_sync_job('j3')['status'] == 'processing'
+    assert fake.sets == []
+
+
+def test_stale_queued_job_is_never_finalized(monkeypatch):
+    # No worker has claimed it — flipping queued -> failed caused #7469 retry loops.
+    fake = _FakeRedis({'id': 'j4', 'status': 'queued', 'dispatch_mode': 'cloud_tasks', 'updated_at': _stale_at()})
+    monkeypatch.setattr(sync_jobs, 'r', fake)
+
+    assert sync_jobs.get_sync_job('j4')['status'] == 'queued'
+    assert fake.sets == []

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -400,8 +400,8 @@ class TestSyncJobsRedis:
         mock_redis.get.return_value = None
         assert mod.get_sync_job('nonexistent') is None
 
-    def test_get_sync_job_is_pure_for_stale_processing_job(self):
-        """Polling reads cannot publish a terminal state without a run lease."""
+    def test_get_sync_job_self_heals_stale_processing_job(self):
+        """A dead worker's job is finalized to failed on read so the client re-uploads."""
         mod, mock_redis = self._load_sync_jobs_module()
         stale_job = {
             'job_id': 'stale-1',
@@ -413,9 +413,9 @@ class TestSyncJobsRedis:
         mock_redis.get.return_value = json.dumps(stale_job).encode()
 
         result = mod.get_sync_job('stale-1')
-        assert result['status'] == 'processing'
-        assert mod.is_sync_job_stale(result) is True
-        mock_redis.set.assert_not_called()
+        assert result['status'] == 'failed'
+        assert result['error']
+        mock_redis.set.assert_called()
 
     def test_get_sync_job_does_not_mark_fresh_as_stale(self):
         """Processing jobs within threshold should not be marked failed."""
@@ -807,8 +807,8 @@ class TestSyncJobsRedisBoundary:
         result = mod.get_sync_job('j')
         assert result['status'] == 'processing'
 
-    def test_stale_just_over_threshold_is_reported_without_mutating_read(self):
-        """The owner-safe route finalizer, not the database read, owns failure."""
+    def test_stale_just_over_threshold_self_heals(self):
+        """A job one second past the stale bound is finalized to failed on read."""
         mod, mock_redis = self._load_sync_jobs_module()
         job = {
             'job_id': 'j',
@@ -818,11 +818,10 @@ class TestSyncJobsRedisBoundary:
         }
         mock_redis.get.return_value = json.dumps(job).encode()
         result = mod.get_sync_job('j')
-        assert result['status'] == 'processing'
-        assert mod.is_sync_job_stale(result) is True
+        assert result['status'] == 'failed'
 
-    def test_stale_read_never_persists_to_redis(self):
-        """A stale read alone cannot strand the content claim or telemetry."""
+    def test_stale_read_persists_failure(self):
+        """The self-heal is durable — the failed status is written back, not just returned."""
         mod, mock_redis = self._load_sync_jobs_module()
         job = {
             'job_id': 'j',
@@ -832,8 +831,8 @@ class TestSyncJobsRedisBoundary:
         }
         mock_redis.get.return_value = json.dumps(job).encode()
         result = mod.get_sync_job('j')
-        assert mod.is_sync_job_stale(result) is True
-        mock_redis.set.assert_not_called()
+        assert result['status'] == 'failed'
+        mock_redis.set.assert_called()
 
     def test_completed_job_not_stale_checked(self):
         """Terminal jobs must not be re-evaluated for staleness."""


### PR DESCRIPTION
Closes #10033. Closes #10197.

Offline recordings upload and then sit at "Uploaded · processing on Omi" for
12+ hours without becoming conversations, some never sync at all, and stuck
recordings never retry. Three independent causes, each fixed here.

## 1. Stuck sync jobs never self-healed (backend)

A job whose worker died stayed in `processing` until the 24h reconcile TTL, so
the client polled a job that would never finish.

`get_sync_job` used to finalize any `processing` job quiet past
`STALE_THRESHOLD_SECONDS` (600s) to `failed`, on every read and for every
dispatch mode. That finalizer was later moved to the status-poll endpoint and
gated on `dispatch_mode == 'cloud_tasks'`, which left inline/BYOK jobs with no
self-heal at all and made every other job depend on a client actively polling.

Restored the original behaviour. The pipeline heartbeats `updated_at` at every
stage and per segment, so 600s of silence only ever means the worker is gone.
`queued` jobs stay exempt — no worker has claimed them, and failing them caused
the spurious "retrying" loops in #7469.

This fixes the reported symptom end to end: the client already reverts a WAL
from `uploaded` to `miss` and re-uploads when the server reports `failed`, so a
dead job now recovers in ~10 minutes instead of 24 hours.

## 2. Ring-buffer devices were never enumerated in auto-sync (app)

Background and auto-sync discovery read `firmwareRevision` off the raw connect
object, which is frequently still `'Unknown'`. `isRingBufferFirmware('Unknown')`
is false, so devices on firmware 3.0.20 and up — the current firmware — were
routed to the multi-file enumerator, which returns nothing for them. Their
offline recordings were never enumerated, never uploaded, and never became
conversations, unless the user happened to open the Auto Sync page, the one
caller that already passed the enriched firmware.

`setDevice` now carries the firmware resolved by `getDeviceInfo`, and both
discovery paths prefer it, falling back to the raw value so behaviour is never
worse than before.

## 3. Offline backlogs drained a few files at a time (app)

The backfill lane uploaded three files per batch, so recovering a backlog
crawled. Both lanes now share one batch limit of twenty.

The two lanes are kept. They earn their keep in `SyncUploadGate`, which holds a
separate rate-limit domain per lane so a backfill cooldown cannot stall a
freshly captured recording. They were not buying throughput control: ordering is
newest-first regardless of lane, and the backend caps multipart part size
(200 MB), not file count — the fresh lane has been sending twenty per batch all
along.

## Tests

- `test_sync_job_stale_self_heal.py` — stale `processing` self-heals for inline
  and cloud_tasks, a fresh job is untouched, and a stale `queued` job is never
  finalized.
- `wal_syncs_firmware_routing_test.dart` — the enriched firmware wins over a raw
  `'Unknown'`, falls back when absent, and a 3.0.20 device now classifies as
  ring.
- `local_wal_sync_test.dart` — a small backlog drains in one batch; larger ones
  are bounded by the shared limit, newest first.
- Existing sync-job tests updated to the restored self-heal contract.

`cd backend && pytest` on the sync suites — 193 passed.
`cd app && bash test.sh` — 933 passed. `bash scripts/analyze_ratchet.sh` — passed.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

