### PR TITLE
fix(app): group conversations by local calendar day, not raw UTC (#10198)

### DIFF
--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -23,6 +23,18 @@ typedef ConversationSearchFetcher = Future<(List<ServerConversation>, int, int)>
   String? speakerId,
 });
 
+/// Day-bucket key for a conversation timestamp, in the viewer's **local** timezone.
+///
+/// `started_at`/`created_at` arrive as UTC (ISO-8601 `Z`), so bucketing by their raw
+/// UTC `year/month/day` filed an early-morning-local conversation under the previous
+/// day for any UTC+ viewer — it vanished from the "Today" group even though the
+/// local-day date filter still found it (#10198). Truncating the *local* calendar day
+/// keeps grouping consistent with the local-day filter and the Today/Yesterday labels.
+DateTime conversationLocalDayKey(DateTime timestamp) {
+  final local = timestamp.toLocal();
+  return DateTime(local.year, local.month, local.day);
+}
+
 class ConversationProvider extends ChangeNotifier {
   List<ServerConversation> conversations = [];
   List<ServerConversation> searchedConversations = [];
@@ -232,7 +244,7 @@ class ConversationProvider extends ChangeNotifier {
 
   int groupedSearchConvoIndex(ServerConversation convo) {
     var convoDate = convo.startedAt ?? convo.createdAt;
-    var date = DateTime(convoDate.year, convoDate.month, convoDate.day);
+    var date = conversationLocalDayKey(convoDate);
     if (groupedConversations.containsKey(date)) {
       return groupedConversations[date]!.indexWhere((element) => element.id == convo.id);
     }
@@ -591,7 +603,7 @@ class ConversationProvider extends ChangeNotifier {
       // Apply date filter if selected
       if (selectedDate != null) {
         var effectiveDate = convo.startedAt ?? convo.createdAt;
-        var convoDate = DateTime(effectiveDate.year, effectiveDate.month, effectiveDate.day);
+        var convoDate = conversationLocalDayKey(effectiveDate);
         var filterDate = DateTime(selectedDate!.year, selectedDate!.month, selectedDate!.day);
         if (convoDate != filterDate) {
           return false;
@@ -668,7 +680,7 @@ class ConversationProvider extends ChangeNotifier {
     final grouped = <DateTime, List<ServerConversation>>{};
     for (final conversation in source) {
       final effectiveDate = conversation.startedAt ?? conversation.createdAt;
-      final date = DateTime(effectiveDate.year, effectiveDate.month, effectiveDate.day);
+      final date = conversationLocalDayKey(effectiveDate);
       grouped.putIfAbsent(date, () => []).add(conversation);
     }
 
@@ -776,7 +788,7 @@ class ConversationProvider extends ChangeNotifier {
 
   void updateConversationInSortedList(ServerConversation conversation) {
     var effectiveDate = conversation.startedAt ?? conversation.createdAt;
-    var date = DateTime(effectiveDate.year, effectiveDate.month, effectiveDate.day);
+    var date = conversationLocalDayKey(effectiveDate);
     if (groupedConversations.containsKey(date)) {
       int idx = groupedConversations[date]!.indexWhere((element) => element.id == conversation.id);
       if (idx != -1) {
@@ -791,7 +803,7 @@ class ConversationProvider extends ChangeNotifier {
     conversations.sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
     int idx;
     var effectiveDate = conversation.startedAt ?? conversation.createdAt;
-    var memDate = DateTime(effectiveDate.year, effectiveDate.month, effectiveDate.day);
+    var memDate = conversationLocalDayKey(effectiveDate);
     if (groupedConversations.containsKey(memDate)) {
       var convoEffectiveDate = conversation.startedAt ?? conversation.createdAt;
       idx = groupedConversations[memDate]!.indexWhere(
@@ -978,7 +990,7 @@ class ConversationProvider extends ChangeNotifier {
     }
 
     var effectiveDate = conversation.startedAt ?? conversation.createdAt;
-    var dateKey = DateTime(effectiveDate.year, effectiveDate.month, effectiveDate.day);
+    var dateKey = conversationLocalDayKey(effectiveDate);
     if (groupedConversations.containsKey(dateKey)) {
       final groupIndex = groupedConversations[dateKey]!.indexWhere((c) => c.id == convoId);
       if (groupIndex != -1) {
@@ -1049,7 +1061,7 @@ class ConversationProvider extends ChangeNotifier {
 
   (DateTime, int)? getConversationDateAndIndex(ServerConversation conversation) {
     final effectiveDate = conversation.startedAt ?? conversation.createdAt;
-    final date = DateTime(effectiveDate.year, effectiveDate.month, effectiveDate.day);
+    final date = conversationLocalDayKey(effectiveDate);
 
     final list = groupedConversations[date];
     if (list == null) return null;

--- a/app/test/providers/conversation_local_day_key_test.dart
+++ b/app/test/providers/conversation_local_day_key_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/providers/conversation_provider.dart';
+
+/// Regression coverage for #10198: conversations were bucketed into day-groups by
+/// their raw UTC calendar day, while the date filter used the local `selectedDate`,
+/// so an early-morning-local conversation vanished from "Today" for UTC+ viewers.
+///
+/// Note on limits: `DateTime.toLocal()` uses the ambient timezone, which is UTC on
+/// CI, so this cannot reproduce the UTC-vs-local divergence there — it locks the
+/// helper's contract (local-day truncation) and catches a revert to raw-UTC on any
+/// non-UTC host. On-device confirmation in a UTC+ timezone is the end-to-end proof.
+void main() {
+  group('conversationLocalDayKey', () {
+    test('truncates a timestamp to its local calendar day (time-of-day stripped)', () {
+      final ts = DateTime.utc(2026, 7, 20, 20, 48); // 20:48 UTC
+      final key = conversationLocalDayKey(ts);
+      final local = ts.toLocal();
+
+      expect(key, DateTime(local.year, local.month, local.day));
+      expect(key.hour, 0);
+      expect(key.minute, 0);
+      expect(key.second, 0);
+      expect(key.isUtc, isFalse);
+    });
+
+    test('two moments in the same local day share a bucket; the next local day differs', () {
+      final anchor = DateTime.utc(2026, 7, 20, 2, 0).toLocal();
+      final sameDayLater = DateTime(anchor.year, anchor.month, anchor.day, 23, 30);
+      final nextDay = DateTime(anchor.year, anchor.month, anchor.day).add(const Duration(days: 1));
+
+      expect(conversationLocalDayKey(sameDayLater), conversationLocalDayKey(anchor));
+      expect(conversationLocalDayKey(nextDay), isNot(conversationLocalDayKey(anchor)));
+    });
+  });
+}


### PR DESCRIPTION
## What

Conversations from today were missing from the conversations list but appeared under the date filter (#10198).

## Root cause

`started_at`/`created_at` arrive from the API as UTC (ISO-8601 `Z`) and `ServerConversation.fromGenerated` keeps them UTC. The conversations list bucketed into day-groups by the timestamps' **raw UTC** calendar day (`_buildGroupedByDate` and the sibling groupers in `conversation_provider.dart`), while the date **filter** built its range from the **local** `selectedDate` (`_getDateFilterRange`).

So for any viewer east of UTC, an early-morning-local conversation is still the *previous* day in UTC → filed under "Yesterday", absent from "Today" — while the local-day filter still returns it. The report's 06:48-local screenshot fits a positive-UTC-offset device exactly.

## Fix

Bucket by the **local** calendar day via a single shared `conversationLocalDayKey(ts) => ts.toLocal()` day-key, applied at every grouping site (main list, search, memory groupers, index lookup). Sorts stay on raw timestamps (ordering is timezone-independent). The already-local group-key normalizers (`getConversationIndexById`, `getAdjacentConversation`) are unchanged.

## Tests

`app/test/providers/conversation_local_day_key_test.dart` — locks the helper's local-day-truncation contract and same-day/next-day bucketing.

## Verification — please read

I don't have `dart`/`flutter` in my environment, so I could **not** compile or run the analyzer/tests locally — this PR relies on the **Dart Analyze & Tests** CI check to verify compile + tests. The change is mechanical (a shared `.toLocal()` day-key swapped in at each bucketing site).

And an honest limit on the test's reach: `DateTime.toLocal()` uses the ambient timezone, which is **UTC in CI**, so the unit test can't reproduce the UTC-vs-local divergence there — it locks the contract and catches a raw-UTC revert on a non-UTC host. The end-to-end proof is on-device in a UTC+ timezone.

## Product invariants affected

none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

