### PR TITLE
fix(desktop/windows): check-agent-deps also verifies the Claude Code …

### DIFF
--- a/desktop/windows/scripts/check-agent-deps.mjs
+++ b/desktop/windows/scripts/check-agent-deps.mjs
@@ -22,6 +22,7 @@
 import { existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { checkClaudeBinary } from './claude-binary-check.mjs'
 
 const CRITICAL_DEPS = [
   '@agentclientprotocol/claude-agent-acp', // dynamically imported by src/main/codingAgent/claude-acp-entry.mjs
@@ -66,6 +67,21 @@ try {
       message: err instanceof Error ? err.message : String(err)
     })
   }
+}
+
+// The Claude Code EXECUTABLE (claude.exe, from the binary-only optional
+// package @anthropic-ai/claude-agent-sdk-win32-x64) can be silently absent or
+// truncated after a failed optional download — pnpm still exits 0 and
+// import.meta.resolve() can't see a binary-only package. Without it, agent
+// tasks pass the ACP handshake and then have nothing to spawn. See
+// claude-binary-check.mjs (validated against a real failed install in
+// PR #9304 review).
+const binaryCheck = checkClaudeBinary(join(dirname(fileURLToPath(import.meta.url)), '..'))
+if (!binaryCheck.ok) {
+  missing.push({
+    dep: '@anthropic-ai/claude-agent-sdk-win32-x64/claude.exe',
+    message: binaryCheck.reason
+  })
 }
 
 if (missing.length > 0) {

--- a/desktop/windows/scripts/claude-binary-check.mjs
+++ b/desktop/windows/scripts/claude-binary-check.mjs
@@ -1,0 +1,80 @@
+// Pure helpers for check-agent-deps.mjs: verify the Claude Code EXECUTABLE is
+// actually installed, not just the JS packages around it.
+//
+// The failure mode this closes (hit live in PR #9304 review on a flaky
+// network): @anthropic-ai/claude-agent-sdk-win32-x64 — which contains
+// claude.exe (~235 MB), the binary the Claude Agent SDK spawns for every agent
+// turn; the SDK ships no JS fallback — is an optionalDependency, so a failed
+// download leaves `pnpm install` exiting 0. import.meta.resolve() checks can't
+// catch it either: the platform package is binary-only with no resolvable JS
+// entry. The result is an app where the ACP `initialize` handshake succeeds
+// but the first real agent task has nothing to spawn.
+//
+// Kept side-effect-free (exported functions only) so it is unit-testable;
+// check-agent-deps.mjs owns the process-level reporting/exit.
+
+import { existsSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+// claude.exe is ~235 MB; anything far below that is a truncated download.
+export const DEFAULT_MIN_BYTES = 50 * 1024 * 1024
+
+const BINARY_PACKAGE = '@anthropic-ai/claude-agent-sdk-win32-x64'
+
+/** Locate claude.exe in either the flattened or the pnpm virtual-store layout. */
+export function findClaudeBinary(root) {
+  const direct = join(root, 'node_modules', ...BINARY_PACKAGE.split('/'), 'claude.exe')
+  if (existsSync(direct)) return direct
+
+  const pnpmDir = join(root, 'node_modules', '.pnpm')
+  if (existsSync(pnpmDir)) {
+    const prefix = BINARY_PACKAGE.replace('/', '+') + '@'
+    for (const entry of readdirSync(pnpmDir)) {
+      if (!entry.startsWith(prefix)) continue
+      // NOTE: a failed optional download can leave an EMPTY matching directory
+      // behind in the virtual store — requiring claude.exe itself (not the
+      // directory) is what makes this check catch that case.
+      const candidate = join(
+        pnpmDir,
+        entry,
+        'node_modules',
+        ...BINARY_PACKAGE.split('/'),
+        'claude.exe'
+      )
+      if (existsSync(candidate)) return candidate
+    }
+  }
+  return null
+}
+
+/**
+ * Verify the Claude Code binary is present and plausibly complete. Only
+ * meaningful when installing for Windows; other platforms get their binary
+ * from their own platform package and skip here.
+ */
+export function checkClaudeBinary(root, platform = process.platform, minBytes = DEFAULT_MIN_BYTES) {
+  if (platform !== 'win32') {
+    return { ok: true, skipped: true }
+  }
+  const binary = findClaudeBinary(root)
+  if (!binary) {
+    return {
+      ok: false,
+      reason:
+        `${BINARY_PACKAGE} is not installed (claude.exe not found). It is an ` +
+        'optionalDependency, so a failed ~247 MB download does NOT fail `pnpm install` — ' +
+        'but without it the bundled Claude Code agent answers the ACP handshake and then ' +
+        'cannot run any task. Re-run `pnpm install` on a reliable network.'
+    }
+  }
+  const size = statSync(binary).size
+  if (size < minBytes) {
+    return {
+      ok: false,
+      reason:
+        `claude.exe at ${binary} is only ${size} bytes — looks like a truncated ` +
+        'download. Remove it and re-run `pnpm install`.'
+    }
+  }
+  return { ok: true, binary, size }
+}

--- a/desktop/windows/scripts/claude-binary-check.test.mjs
+++ b/desktop/windows/scripts/claude-binary-check.test.mjs
@@ -1,0 +1,90 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+import { checkClaudeBinary, findClaudeBinary } from './claude-binary-check.mjs'
+
+const roots = []
+
+function makeRoot() {
+  const root = mkdtempSync(join(tmpdir(), 'omi-claude-binary-check-'))
+  roots.push(root)
+  return root
+}
+
+function writeBinary(dir, bytes) {
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'claude.exe'), Buffer.alloc(bytes, 1))
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe('checkClaudeBinary', () => {
+  it('skips on non-Windows platforms', () => {
+    expect(checkClaudeBinary(makeRoot(), 'darwin')).toEqual({ ok: true, skipped: true })
+  })
+
+  it('fails loudly when the optional package is absent (the pnpm-exit-0 case)', () => {
+    const result = checkClaudeBinary(makeRoot(), 'win32')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('optionalDependency')
+    expect(result.reason).toContain('pnpm install')
+  })
+
+  it('does not mistake an empty residual virtual-store directory for an install', () => {
+    // A failed optional download can leave the .pnpm dir behind with no
+    // claude.exe inside — the exact shape seen in the PR #9304 review.
+    const root = makeRoot()
+    mkdirSync(
+      join(
+        root,
+        'node_modules',
+        '.pnpm',
+        '@anthropic-ai+claude-agent-sdk-win32-x64@0.3.205',
+        'node_modules',
+        '@anthropic-ai',
+        'claude-agent-sdk-win32-x64'
+      ),
+      { recursive: true }
+    )
+    const result = checkClaudeBinary(root, 'win32')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('claude.exe not found')
+  })
+
+  it('fails on a truncated download', () => {
+    const root = makeRoot()
+    writeBinary(join(root, 'node_modules', '@anthropic-ai', 'claude-agent-sdk-win32-x64'), 10)
+    const result = checkClaudeBinary(root, 'win32', 1024)
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('truncated')
+  })
+
+  it('passes with a plausible binary in the flattened layout', () => {
+    const root = makeRoot()
+    writeBinary(join(root, 'node_modules', '@anthropic-ai', 'claude-agent-sdk-win32-x64'), 2048)
+    const result = checkClaudeBinary(root, 'win32', 1024)
+    expect(result.ok).toBe(true)
+    expect(result.size).toBe(2048)
+  })
+
+  it('finds the binary in the pnpm virtual-store layout too', () => {
+    const root = makeRoot()
+    writeBinary(
+      join(
+        root,
+        'node_modules',
+        '.pnpm',
+        '@anthropic-ai+claude-agent-sdk-win32-x64@0.3.205',
+        'node_modules',
+        '@anthropic-ai',
+        'claude-agent-sdk-win32-x64'
+      ),
+      2048
+    )
+    expect(findClaudeBinary(root)).toContain('.pnpm')
+    expect(checkClaudeBinary(root, 'win32', 1024).ok).toBe(true)
+  })
+})


### PR DESCRIPTION
Follow-up to #9304 / #9302, closing the one gap from that review cycle still open on main.

`scripts/check-agent-deps.mjs` verifies the coding-agent JS packages resolve, but the
Claude Code **executable** (`claude.exe`, ~235 MB — spawned by the Claude Agent SDK for
every agent turn; SDK 0.3.205 ships no JS fallback) lives in the binary-only
optionalDependency `@anthropic-ai/claude-agent-sdk-win32-x64`: a failed download leaves
`pnpm install` exiting 0, and `import.meta.resolve()` can't see a package with no JS
entry. Result: an app where the ACP initialize handshake succeeds and every real agent
task fails to spawn. This exact failure shape occurred live during the #9304 review
(flaky network → error 23 → empty residual `.pnpm` directory → exit 0), and the reviewer
validated this check's logic against that broken tree at the time.

- `scripts/claude-binary-check.mjs` (pure, unit-tested): locates `claude.exe` in the
  flattened or pnpm virtual-store layout — requiring the binary itself, so an empty
  residual store directory doesn't pass — and rejects truncated (<50 MB) downloads.
- `check-agent-deps.mjs` reports it through its existing missing-deps path (so it runs
  at postinstall and standalone, same as today). Non-Windows installs skip.

## Test plan
- [x] `node scripts/check-agent-deps.mjs` on a clean pnpm@10 hoisted install — OK,
      finds the real 236 MB binary
- [x] `vitest run scripts/claude-binary-check.test.mjs` — 6 passed (absent package,
      empty residual virtual-store dir, truncated download, both layouts, non-Windows skip)
- [x] Full postinstall chain (incl. verify-pimono-unpack) green with the check wired in
- [x] eslint clean

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

