### PR TITLE
fix(sync): stop routing all offline recordings through the bounded backfill lane

### DIFF
--- a/.github/actions/sync-backfill-lifecycle/action.yml
+++ b/.github/actions/sync-backfill-lifecycle/action.yml
@@ -126,8 +126,8 @@ runs:
         flags: >-
           --revision-suffix=${{ inputs.revision_suffix }}
           ${{ steps.candidate-tag.outputs.flag }}
-          --min-instances=0
-          --max-instances=4
+          --min-instances=1
+          --max-instances=30
           --concurrency=1
           --remove-env-vars=HOSTED_PUSHER_API_URL
           ${{ inputs.cloud_run_flags }}
@@ -159,16 +159,27 @@ runs:
           --member="serviceAccount:${INVOKER_SA}" \
           --role=roles/run.invoker \
           --quiet
+        # Dispatch concurrency must match the worker's --max-instances above.
+        # Offering more than the worker can admit makes Cloud Run reject the
+        # surplus with "no available instance", and Cloud Tasks then retries
+        # each rejection with exponential backoff. At the previous four-worker
+        # sizing that compounded until queued recordings were scheduled almost
+        # a day out. The bounded backoff keeps a transient rejection from
+        # stranding a recording for hours.
         if gcloud tasks queues describe sync-backfill --location=${{ inputs.region }} --project=${{ inputs.project_id }} >/dev/null 2>&1; then
           gcloud tasks queues update sync-backfill \
             --location=${{ inputs.region }} \
             --project=${{ inputs.project_id }} \
-            --max-concurrent-dispatches=4
+            --max-concurrent-dispatches=30 \
+            --min-backoff=5s \
+            --max-backoff=60s
         else
           gcloud tasks queues create sync-backfill \
             --location=${{ inputs.region }} \
             --project=${{ inputs.project_id }} \
-            --max-concurrent-dispatches=4
+            --max-concurrent-dispatches=30 \
+            --min-backoff=5s \
+            --max-backoff=60s
         fi
 
     - name: Provision and verify sync ledger TTL

--- a/backend/tests/unit/test_sync_cloud_tasks.py
+++ b/backend/tests/unit/test_sync_cloud_tasks.py
@@ -694,7 +694,12 @@ class TestVerifyCloudTasksOidc:
             with pytest.raises(RuntimeError):
                 cloud_tasks.enqueue_sync_job({'job_id': 'j'})
 
-    def test_backfill_uses_dedicated_queue_handler_and_audience(self):
+    def test_backfill_lane_still_uses_the_main_queue(self):
+        # An offline recording can never carry server capture proof, so every
+        # offline upload classifies as backfill. Routing that lane to the
+        # bounded historical-recovery worker sent the whole offline workload
+        # through a few dispatch slots, and Cloud Tasks backed the surplus off
+        # for hours. The lane label stays on the payload for metering.
         cloud_tasks = _load_cloud_tasks()
         env = {
             'SYNC_TASKS_QUEUE': 'sync-jobs',
@@ -707,11 +712,10 @@ class TestVerifyCloudTasksOidc:
             cloud_tasks.enqueue_sync_job({'job_id': 'job-1', 'lane': 'backfill'})
 
         enqueue.assert_called_once_with(
-            'sync-backfill',
-            'https://backend-sync-backfill.example.com/v2/sync-jobs/run',
+            'sync-jobs',
+            'https://backend-sync.example.com/v2/sync-jobs/run',
             'job-1',
             {'job_id': 'job-1', 'lane': 'backfill'},
-            audience='https://backend-sync-backfill.example.com/v2/sync-jobs/run',
         )
 
     def test_enqueue_account_deletion_task_is_named_by_job_id(self):

--- a/backend/tests/unit/test_sync_two_lane.py
+++ b/backend/tests/unit/test_sync_two_lane.py
@@ -219,12 +219,17 @@ def test_sync_backfill_lifecycle_is_shared_by_manual_and_auto_dev():
     assert 'id: deploy-backend-sync-backfill' in action
     assert 'render_cloud_run_clone_env.py' in action
     assert 'SYNC_TASKS_QUEUE=sync-backfill' in action
-    assert '--min-instances=0' in action
-    assert '--max-instances=4' in action
+    # Dispatch concurrency must equal the worker's max instances: offering more
+    # than the worker admits makes Cloud Run reject the surplus and Cloud Tasks
+    # back it off, which previously stranded recordings for hours. A warm
+    # instance keeps a scale-from-zero poke from being rejected outright.
+    assert '--min-instances=1' in action
+    assert '--max-instances=30' in action
     assert '--concurrency=1' in action
     assert 'gcloud run services add-iam-policy-binding backend-sync-backfill' in action
     assert 'gcloud tasks queues create sync-backfill' in action
-    assert '--max-concurrent-dispatches=4' in action
+    assert '--max-concurrent-dispatches=30' in action
+    assert '--max-backoff=60s' in action
     assert 'collection-group=sync_content_ledger' in action
     assert "inputs.provision_sync_ledger_ttl == 'true'" in action
     assert "inputs.provision_budget_alerts == 'true'" in action

--- a/backend/utils/cloud_tasks.py
+++ b/backend/utils/cloud_tasks.py
@@ -188,17 +188,16 @@ def enqueue_sync_job(payload: Dict[str, Any]) -> None:
     Duplicate names are success. Callers retry the same name a bounded number
     of times, then retain staged retry material if acknowledgement remains
     uncertain; they never fall back inline after submitting this task.
+
+    Every sync job goes to the main queue. Offline recordings can never carry
+    server capture proof — the server was not in the loop when they were
+    captured — so they all classify as backfill, which sent the entire offline
+    workload to a lane provisioned for occasional historical recovery. That
+    lane's worker admitted only a few jobs at once, so Cloud Tasks retried the
+    surplus with exponential backoff until recordings sat unprocessed for many
+    hours. The lane label is still carried on the payload for metering and
+    reporting; it no longer selects the queue.
     """
-    if payload.get('lane') == 'backfill':
-        handler_url = os.getenv('SYNC_BACKFILL_TASKS_HANDLER_URL', '')
-        _enqueue_named_task(
-            os.getenv('SYNC_BACKFILL_TASKS_QUEUE', ''),
-            handler_url,
-            str(payload['job_id']),
-            payload,
-            audience=os.getenv('SYNC_BACKFILL_TASKS_OIDC_AUDIENCE') or handler_url,
-        )
-        return
     _enqueue_named_task(os.getenv('SYNC_TASKS_QUEUE', ''), _handler_url(), str(payload['job_id']), payload)
 
 


### PR DESCRIPTION
Offline recordings uploaded successfully and then sat unprocessed for many
hours. The queue backing the historical-recovery lane had built up ~14.7k
tasks, some scheduled almost a day after they were created, while the workers
behind it were idle.

## What was happening

`classify_sync_lane` marks an upload `fresh` only when the server can
corroborate its capture time against a conversation it already knows about. An
offline recording has no such conversation — the server was not in the loop
when it was captured — so **every offline upload classifies as `backfill`**,
regardless of age. Production shows recordings thirty seconds old admitted as
`lane=backfill trust=legacy reason=unbound_capture_time`.

That sent the entire offline workload to a lane provisioned for occasional
historical recovery: a worker capped at four instances at one request each,
behind a queue offering four dispatches at a time.

The failure was not throughput, it was compounding retry delay:

1. dispatch exceeds what four instances can admit
2. Cloud Run rejects the surplus with "no available instance"
3. Cloud Tasks retries each rejection with exponential backoff, up to an hour
4. tasks end up scheduled hours out, so few are eligible at any moment
5. the queue looks enormous while the workers have nothing to run

Raising the worker to thirty barely moved throughput, because the backlog was
waiting on backoff rather than capacity. Bounding the backoff took completions
from roughly eight per minute to fifty, with rejections falling to zero.

## Changes

**Route every sync job to the main queue.** The main queue has no dispatch cap,
which is what offline sync ran on before the lane split. The lane label stays on
the payload for metering and reporting; it no longer selects the queue.

**Size the lane so dispatch cannot outrun the worker.** Dispatch concurrency now
equals the worker's instance ceiling — offering more than the worker admits is
what produced the rejections. A warm instance keeps a scale-from-zero poke from
being rejected outright, and retry backoff is bounded so one transient rejection
cannot strand a recording for hours.

The deploy action previously hardcoded the old four-and-four sizing on every
run, so any manual tuning was silently reverted by the next deploy.

## Tests

`test_backfill_lane_still_uses_the_main_queue` asserts a payload carrying the
backfill lane enqueues to the main queue and handler, with the label preserved.
The lifecycle contract test asserts the matched sizing and the bounded backoff.

`tests/unit/test_sync_two_lane.py` and `tests/unit/test_sync_v2.py` — 199 passed.
Nine failures in `test_sync_cloud_tasks.py` reproduce identically on an
unmodified checkout; they are a `fakeredis` artifact in this environment and are
unrelated to this change.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

