### PR TITLE
fix(setup): resolve repo root without a work tree in linked worktrees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 HOOKS_DIR := $(shell git rev-parse --git-path hooks)
-PYTHON ?= $(shell bash -c 'source "$$(git rev-parse --show-toplevel)/scripts/dev-harness/_resolve_python.sh"; dev_harness_python')
+# Fall back to the working directory (where make runs, i.e. the repo root) when
+# `git rev-parse --show-toplevel` cannot resolve a work tree. In a linked
+# worktree whose git context resolves to a git dir rather than a work tree,
+# show-toplevel exits 128 and previously expanded to an empty prefix, turning
+# the source into `/scripts/dev-harness/_resolve_python.sh: No such file` and
+# breaking every target. The root stays computed in-shell (never interpolated
+# into recipe text) so a checkout path with quote/`$` characters cannot inject.
+PYTHON ?= $(shell bash -c 'source "$$(git rev-parse --show-toplevel 2>/dev/null || pwd)/scripts/dev-harness/_resolve_python.sh"; dev_harness_python')
 # Export so recipes use $$PYTHON (shell variable expansion) instead of $(PYTHON)
 # (Make text interpolation). Shell variable expansion treats the resolved path
 # as data and cannot be broken by quote or command-substitution characters in

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -2,7 +2,12 @@
 
 set -euo pipefail
 
-ROOT="$(git rev-parse --show-toplevel)"
+# Resolve the repo root from this script's own location, not `git rev-parse
+# --show-toplevel`. In a linked worktree whose git context resolves to a git dir
+# rather than a work tree, show-toplevel exits 128 ("this operation must be run
+# in a work tree") and setup-hooks dies with Error 128. `--git-path hooks` works
+# in that context (it does not require a work tree), so keep it for HOOKS_DIR.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HOOKS_DIR="$(git rev-parse --git-path hooks)"
 
 mkdir -p "$HOOKS_DIR"
@@ -18,7 +23,11 @@ install_dispatch_hook() {
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(git rev-parse --show-toplevel)"
+# Git runs hooks with the working directory at the top of the invoking work
+# tree, so fall back to it when show-toplevel cannot resolve a work tree (linked
+# worktree git-dir contexts exit 128 here and otherwise abort the hook, forcing
+# a --no-verify push that silently bypasses the local gate).
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 HOOK_NAME="$(basename "$0")"
 if [ "$HOOK_NAME" = "pre-push" ]; then
   if [ -x "$ROOT/scripts/pre-push-singleflight" ]; then

--- a/scripts/test-make-setup.sh
+++ b/scripts/test-make-setup.sh
@@ -88,3 +88,43 @@ chmod +x "$TMPDIR/sync/bin/uv"
 )
 
 echo "backend dependency sync rerun test passed."
+
+# Regression: when `git rev-parse --show-toplevel` cannot resolve a work tree
+# (a linked worktree whose git context resolves to a git dir exits 128 here with
+# "this operation must be run in a work tree"), the Makefile previously expanded
+# the repo root to an empty prefix and broke every target with
+# `/scripts/dev-harness/_resolve_python.sh: No such file`. The root now falls
+# back to the working directory make runs in, so the resolver must still be found
+# and PYTHON must resolve. A bare GIT_DIR reproduces the exact condition:
+# show-toplevel exits 128 while `--git-path hooks` still resolves.
+FB_ROOT="$TMPDIR/fallback"
+mkdir -p "$FB_ROOT/scripts/dev-harness" "$FB_ROOT/backend/.venv/bin"
+cp "$ROOT/Makefile" "$FB_ROOT/Makefile"
+cat >"$FB_ROOT/scripts/dev-harness/_resolve_python.sh" <<'EOF'
+dev_harness_python() {
+  local repo_root candidate
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  candidate="$repo_root/backend/.venv/bin/python"
+  if [ -x "$candidate" ]; then
+    printf '%s\n' "$candidate"
+    return
+  fi
+  printf '%s\n' python3
+}
+EOF
+: >"$FB_ROOT/backend/.venv/bin/python"
+chmod +x "$FB_ROOT/backend/.venv/bin/python"
+cat >>"$FB_ROOT/Makefile" <<'EOF'
+
+print-resolved-python:
+	@printf 'PYTHON=%s\n' "$(PYTHON)"
+EOF
+git init -q --bare "$TMPDIR/fallback-bare.git"
+out="$(cd "$FB_ROOT" && env -u PYTHON GIT_DIR="$TMPDIR/fallback-bare.git" make print-resolved-python 2>/dev/null)"
+expected="PYTHON=$(cd "$FB_ROOT" && pwd)/backend/.venv/bin/python"
+if [ "$out" != "$expected" ]; then
+  echo "FAIL: Makefile repo-root resolution collapsed when show-toplevel could not resolve a work tree." >&2
+  printf 'Expected: %s\nGot:      %s\n' "$expected" "$out" >&2
+  exit 1
+fi
+echo "linked-worktree repo-root fallback test passed."


### PR DESCRIPTION
## What

Make repo-root resolution in `make setup`, the git hook installer, and the installed hook dispatchers survive a linked worktree whose git context resolves to a git dir rather than a work tree.

## Why

In a linked worktree (e.g. a Conductor workspace whose gitdir lives under the main clone's `.git/worktrees/`), `git rev-parse --show-toplevel` exits 128 with `fatal: this operation must be run in a work tree`. Three call sites assumed it always returns a path:

- **`Makefile`** — `PYTHON ?= $(shell … source "$(git rev-parse --show-toplevel)/scripts/dev-harness/_resolve_python.sh" …)` collapsed to an empty prefix, so every target failed with `/scripts/dev-harness/_resolve_python.sh: No such file` and `dev_harness_python: command not found`.
- **`scripts/install-git-hooks.sh`** — `ROOT="$(git rev-parse --show-toplevel)"` aborted `make setup` at `setup-hooks` with `Error 128`.
- **The installed pre-commit/pre-push dispatcher** — the same call aborted the hook, forcing `git push --no-verify` and silently bypassing the local gate.

`AGENTS.md` mandates worktrees for all code changes, so this hit every agent working from a secondary workspace mount. Reported in #10352 (and duplicate #10293).

## Fix

- `Makefile` and the dispatcher fall back to `pwd` (git runs hooks, and make, from the top of the work tree) when `--show-toplevel` can't resolve a work tree. The root stays computed **in-shell** and is never interpolated into recipe text, so `FC-shell-source-path-interpolation` still holds (a checkout path with quote/`$` characters cannot inject).
- `install-git-hooks.sh` resolves its root from the script's own location (`${BASH_SOURCE[0]}`), matching the pattern `_resolve_python.sh` already uses. `--git-path hooks` is kept as-is for `HOOKS_DIR` — it does not require a work tree and resolves correctly in this context.

## Tested

- `bash scripts/test-make-setup.sh` — added a regression that reproduces the exact condition (bare `GIT_DIR` -> `--show-toplevel` exits 128 while `--git-path hooks` still resolves) and asserts `PYTHON` resolves. It **fails** on the pre-fix Makefile (`PYTHON=` empty, exit 1) and passes after.
- `python3 -m pytest scripts/dev-harness/tests/test_python_resolver.py` — 5 passed (the shell-injection/space-in-path contract still holds; an earlier `$(REPO_ROOT)` interpolation attempt was rejected by these tests).
- `bash scripts/dev-harness/run-tests.sh` — 50 passed.
- Exercised the real installer in a linked worktree from both the work-tree top and the git-dir context: `make setup-hooks` succeeds and installs dispatchers carrying the `pwd` fallback; firing the installed pre-push/pre-commit dispatchers routes to the invoking worktree's `scripts/`.

Failure-Class: FC-shell-source-path-interpolation

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

