### PR TITLE
fix(release): pre-tag readiness gate crashed on bash 3.2, blocking every auto-release

### DIFF
--- a/.github/failure-classes/FC-shell-unset-array-under-nounset.json
+++ b/.github/failure-classes/FC-shell-unset-array-under-nounset.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "FC-shell-unset-array-under-nounset",
+  "violated_contract": "A release/CI gate script must not crash on its own shell portability defect; expanding a possibly-empty bash array must be safe under `set -u` on every shell the gate actually runs on (the trusted macOS runners use bash 3.2).",
+  "canonical_prevention": "Expand optional arrays with the `${arr[@]+\"${arr[@]}\"}` form (never bare `\"${arr[@]}\"`) so an empty array does not trap `unbound variable` on bash 3.2; assert the safe form in the gate's contract test.",
+  "evidence_prs": [10388],
+  "scope_hints": ["desktop/macos/scripts/**", ".github/scripts/**"],
+  "status": "open"
+}

--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -20,6 +20,9 @@ EXEMPT_DESKTOP_PATHS = {
     # Sibling qualification-runner helper to qualify-desktop-beta.sh: internal
     # release infrastructure with no user-facing app surface.
     "desktop/macos/scripts/qualification-swift-cache.sh",
+    # Pre-tag readiness gate script: internal release infrastructure (runs on the
+    # trusted M1 before tagging), no user-facing app surface.
+    "desktop/macos/scripts/pre-tag-readiness.sh",
 }
 # Server-side Rust backend changes are internal reliability work, not user-facing app notes.
 # Test and release-infra changes are likewise never user-facing app notes; the

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -139,6 +139,13 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertNotIn("fetch --quiet --force origin main", readiness_script)
         self.assertIn("pre-tag-readiness:", workflow)
         self.assertIn("verify-pre-tag-readiness.py verify", workflow)
+        # Regression: the gate runs on the trusted M1 under macOS bash 3.2, where
+        # `"${arr[@]}"` on an EMPTY array under `set -u` traps "unbound variable"
+        # and failed the readiness gate on every release with KEEP_STACK != 1 (the
+        # normal path), silently blocking all auto-tagging. Optional array flags
+        # must use the bash-3.2-safe `${arr[@]+"${arr[@]}"}` expansion.
+        self.assertNotIn('--readiness "${KEEP_FLAG[@]}"', readiness_script)
+        self.assertIn('${KEEP_FLAG[@]+"${KEEP_FLAG[@]}"}', readiness_script)
 
 
 if __name__ == "__main__":

--- a/desktop/macos/scripts/pre-tag-readiness.sh
+++ b/desktop/macos/scripts/pre-tag-readiness.sh
@@ -202,7 +202,12 @@ KEEP_FLAG=()
 [[ "$KEEP_STACK" -eq 1 ]] && KEEP_FLAG=(--keep-stack)
 (
   cd "$WORKTREE/desktop/macos"
-  OMI_READINESS_LANE="$LANE" ./scripts/desktop-core-harness.sh --readiness "${KEEP_FLAG[@]}"
+  # `${arr[@]+"${arr[@]}"}` — NOT plain `"${arr[@]}"`. Under `set -u`, expanding
+  # an EMPTY array as `"${arr[@]}"` traps "unbound variable" on the trusted M1's
+  # macOS bash 3.2, which fails this gate on every release where KEEP_STACK != 1
+  # (the normal path) and silently blocks every auto-tag. The `[@]+` form is
+  # bash-3.2-safe for both empty and populated arrays.
+  OMI_READINESS_LANE="$LANE" ./scripts/desktop-core-harness.sh --readiness ${KEEP_FLAG[@]+"${KEEP_FLAG[@]}"}
 )
 
 # 5. Locate and validate the harness readiness manifest. Re-check passed,


### PR DESCRIPTION
## Summary
Fix the bug that has been silently blocking every desktop auto-release. `pre-tag-readiness.sh` runs on the trusted M1 under **macOS bash 3.2**, and line 205 expanded `"${KEEP_FLAG[@]}"` — an EMPTY array under `set -u`, which traps `unbound variable` on bash 3.2 and exits 1. `KEEP_FLAG` is empty on the normal path (`KEEP_STACK != 1`), so the readiness gate failed on effectively every release, and `tag-release` (which `needs: pre-tag-readiness`) skipped → no tag, no GitHub release, no Codemagic build. This is why scheduled/auto releases produced no tags and I had to hand-tag 111–114.

## Fix
Use the bash-3.2-safe `${KEEP_FLAG[@]+"${KEEP_FLAG[@]}"}` expansion (only expands when set). Behaves identically on bash 4.4+.

## Verification
- Reproduced on `/bin/bash` 3.2.57 (the M1 runner's bash): `set -u; KEEP_FLAG=(); "${KEEP_FLAG[@]}"` → `unbound variable`, exit 1. The `[@]+` form → no error, empty→`[--readiness]`, populated→`[--readiness --keep-stack]`.
- `bash -n` clean. Failing live evidence: run 30022355954, `pre-tag-readiness` step `KEEP_FLAG[@]: unbound variable` at line 205.
- Regression guard added to `test_pre_tag_readiness_workflow_contract` (forbids the unsafe form, requires the safe one). `pytest` plan suite → 6 passed.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

