### PR TITLE
chore(release): correct FC evidence PR to #10402

### DIFF
--- a/.github/failure-classes/FC-shell-unset-array-under-nounset.json
+++ b/.github/failure-classes/FC-shell-unset-array-under-nounset.json
@@ -3,7 +3,7 @@
   "id": "FC-shell-unset-array-under-nounset",
   "violated_contract": "A release/CI gate script must not crash on its own shell portability defect; expanding a possibly-empty bash array must be safe under `set -u` on every shell the gate actually runs on (the trusted macOS runners use bash 3.2).",
   "canonical_prevention": "Expand optional arrays with the `${arr[@]+\"${arr[@]}\"}` form (never bare `\"${arr[@]}\"`) so an empty array does not trap `unbound variable` on bash 3.2; assert the safe form in the gate's contract test.",
-  "evidence_prs": [10388],
+  "evidence_prs": [10402],
   "scope_hints": ["desktop/macos/scripts/**", ".github/scripts/**"],
   "status": "open"
 }


### PR DESCRIPTION
Registry-only correction: FC-shell-unset-array-under-nounset was authored with a placeholder evidence PR (#10388, an unrelated changelog-exemption test) before the real fix existed. The bash 3.2 pre-tag-readiness fix merged as #10402; evidence_prs now points at it.

Checks: JSON valid; pytest test_plan_desktop_release + test_desktop_release_flow_contract = 26 passed; bash -n pre-tag-readiness.sh clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

