### PR TITLE
ci(desktop): remove self-hosted pre-tag-readiness gate before candidate creation

### DIFF
--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -169,23 +169,19 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertIn("ref: ${{ steps.recheck.outputs.source_sha }}", workflow)
         self.assertLess(workflow.index('git commit -m "chore: consolidate changelog for v${VERSION}"'), workflow.index('git tag "$RELEASE_TAG"'))
 
-    def test_pre_tag_readiness_workflow_contract(self) -> None:
+    def test_candidate_creation_has_no_selfhosted_pre_tag_gate(self) -> None:
+        # Continuous deployment: candidate creation (tag-release) must depend only
+        # on the hosted planner gate, NOT on a self-hosted pre-candidate readiness
+        # job. A self-hosted gate before immutable tag creation was a single point
+        # of failure (a down runner blocked ALL releases) and contradicted "create
+        # on every change, then qualify". Heavy validation belongs to
+        # desktop_qualify_beta.yml, which runs AFTER the candidate exists.
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        readiness_script = (ROOT / "desktop/macos/scripts/pre-tag-readiness.sh").read_text(encoding="utf-8")
-        upload_step = workflow.split("      - name: Upload readiness evidence", 1)[1]
-        upload_step = upload_step.split("\n      - name:", 1)[0]
-        self.assertIn("if-no-files-found: error", upload_step)
-        self.assertIn("+refs/heads/main:refs/remotes/origin/main", readiness_script)
-        self.assertNotIn("fetch --quiet --force origin main", readiness_script)
-        self.assertIn("pre-tag-readiness:", workflow)
-        self.assertIn("verify-pre-tag-readiness.py verify", workflow)
-        # Regression: the gate runs on the trusted M1 under macOS bash 3.2, where
-        # `"${arr[@]}"` on an EMPTY array under `set -u` traps "unbound variable"
-        # and failed the readiness gate on every release with KEEP_STACK != 1 (the
-        # normal path), silently blocking all auto-tagging. Optional array flags
-        # must use the bash-3.2-safe `${arr[@]+"${arr[@]}"}` expansion.
-        self.assertNotIn('--readiness "${KEEP_FLAG[@]}"', readiness_script)
-        self.assertIn('${KEEP_FLAG[@]+"${KEEP_FLAG[@]}"}', readiness_script)
+        self.assertNotIn("pre-tag-readiness:", workflow)
+        self.assertNotIn("desktop-pre-tag-readiness-evidence", workflow)
+        self.assertNotIn("verify-pre-tag-readiness.py", workflow)
+        tag_release = workflow.split("\n  tag-release:\n", 1)[1].split("\n  ", 1)[0]
+        self.assertIn("needs: [plan-release]", tag_release)
 
     def test_push_paths_cover_releasable_desktop_paths(self) -> None:
         # Continuous deployment: every releasable desktop input the planner

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -64,54 +64,17 @@ jobs:
       - name: Show release plan
         run: echo "${{ steps.plan.outputs.reason }}"
 
-  pre-tag-readiness:
-    needs: [plan-release]
-    if: needs.plan-release.outputs.should_release == 'true'
-    # Trusted self-hosted M1 — the same runner qualification uses. The runner's
-    # single-job capacity plus the dev-harness ownership sentinel serialize use
-    # with in-flight qualification; no prod environment or pointer secrets here.
-    runs-on: [self-hosted, macos, omi-desktop-qualification]
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    concurrency:
-      group: desktop-pre-tag-readiness
-      cancel-in-progress: false
-    steps:
-      - name: Fail-closed dispatch boundary
-        run: |
-          set -euo pipefail
-          # Readiness only: contents:read, no prod environment, no release or
-          # Beta/Stable pointer authority, no new secrets/environments/IAM. The
-          # gate validates source + an OFFLINE stack and must never mutate prod.
-          test -n "${{ needs.plan-release.outputs.source_sha }}"
-
-      - name: Checkout exact source (persisted actions/checkout lifecycle)
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.plan-release.outputs.source_sha }}
-          fetch-depth: 0
-
-      - name: Run trusted-M1 pre-tag readiness gate
-        env:
-          SOURCE_SHA: ${{ needs.plan-release.outputs.source_sha }}
-          OMI_READINESS_LANE: ci
-        run: |
-          set -euo pipefail
-          desktop/macos/scripts/pre-tag-readiness.sh \
-            --evidence /tmp/pre-tag-readiness-evidence.json \
-            "$SOURCE_SHA"
-
-      - name: Upload readiness evidence
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: desktop-pre-tag-readiness-evidence
-          path: /tmp/pre-tag-readiness-evidence.json
-          if-no-files-found: error
-
+  # Continuous deployment: candidate creation is gated only by the cheap, hosted
+  # CI checks the planner verifies (`Release Eligibility`, `Desktop Swift Build &
+  # Tests`, `Desktop Swift Release Compile` on the exact source SHA). The heavy
+  # validation runs AFTER the candidate exists, in the two-machine qualification
+  # pipeline (desktop_qualify_beta.yml) — a candidate that fails qualification is
+  # simply never promoted to Beta, so no self-hosted pre-candidate gate is needed.
+  # (The former trusted-M1 pre-tag-readiness gate was a single point of failure in
+  # front of immutable tag creation and contradicted "create on every change, then
+  # qualify"; desktop/macos/scripts/pre-tag-readiness.sh remains for local use.)
   tag-release:
-    needs: [plan-release, pre-tag-readiness]
+    needs: [plan-release]
     if: needs.plan-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     concurrency:
@@ -142,26 +105,6 @@ jobs:
 
           python3 .github/scripts/plan-desktop-release.py \
             --repository "${{ github.repository }}"
-
-      - name: Download pre-tag readiness evidence
-        if: steps.recheck.outputs.should_release == 'true'
-        uses: actions/download-artifact@v7
-        with:
-          name: desktop-pre-tag-readiness-evidence
-          path: /tmp/pre-tag-readiness
-
-      - name: Verify readiness evidence covers the exact source
-        if: steps.recheck.outputs.should_release == 'true'
-        run: |
-          set -euo pipefail
-          # Never trust caller claims: prove the trusted-M1 evidence covers the
-          # EXACT source SHA about to be tagged, ran offline, and carries no
-          # production authority. Mismatch aborts before the immutable tag.
-          EVIDENCE="$(find /tmp/pre-tag-readiness -name 'pre-tag-readiness-evidence.json' | head -1)"
-          test -n "$EVIDENCE" || { echo "no readiness evidence artifact found" >&2; exit 1; }
-          python3 .github/scripts/verify-pre-tag-readiness.py verify \
-            --evidence "$EVIDENCE" \
-            --source-sha "${{ steps.recheck.outputs.source_sha }}"
 
       - name: Checkout exact releasable desktop source
         if: steps.recheck.outputs.should_release == 'true'


### PR DESCRIPTION
## Summary
Complete the continuous-deployment model: **create the beta candidate on every macOS change gated only by the hosted CI checks, then qualify it** — by removing the self-hosted `pre-tag-readiness` gate that sat *before* candidate creation.

## Why
`tag-release` previously had `needs: [plan-release, pre-tag-readiness]` and consumed a readiness-evidence artifact, so an immutable candidate tag could not be created until a job ran on the self-hosted trusted-M1 runner. That was:
- a **single point of failure** (a down/busy runner blocked ALL releases — the root of this week's release stalls), and
- contrary to "create the release on every change, then qualify it" (it qualified *before* the candidate existed).

Candidate creation is already gated by the planner's exact-SHA hosted CI checks (`Release Eligibility`, `Desktop Swift Build & Tests`, `Desktop Swift Release Compile`), and the heavy validation runs *after* the candidate in `desktop_qualify_beta.yml` (Codemagic primary + `qualify-m1-studio`/`qualify-m4-mini`). A candidate that fails qualification is simply never promoted to Beta, so the pre-candidate self-hosted gate was redundant safety.

## Changes
- `desktop_auto_release.yml`: removed the `pre-tag-readiness` job and `tag-release`'s dependency + evidence download/verify steps. `tag-release` now `needs: [plan-release]`.
- `test_plan_desktop_release.py`: replaced the readiness-workflow-contract test with one asserting candidate creation has no self-hosted pre-tag gate.
- `desktop/macos/scripts/pre-tag-readiness.sh` / `verify-pre-tag-readiness.py` retained for local readiness use (no longer in the release critical path).

## Verification
- `pytest` plan + flow-contract → 27 passed, 37 subtests. actionlint clean. `check-release-process-guards.py` passes. Jobs now `plan-release` + `tag-release`; `tag-release needs: [plan-release]`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

