### PR TITLE
fix(desktop): stop voice fence busy-looping agent bridge when signed out

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -4,6 +4,7 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2639,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4849,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2593,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1507,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1621
   },
   "raise_justifications": {
@@ -11,6 +12,7 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": "The Second Brain onboarding, reach-error, and notch-moment UI keeps the hover menu agent-only and routes idle notch taps through main chat.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": "Second Brain continuous-chat routing shares window geometry with agent-only hover sizing and canonical idle-notch chat ownership.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": "The owning turn manager carries privacy-bounded push-to-talk capture-lifecycle diagnostics wiring alongside strict concurrency, response-critical batch STT, and parallel screen-context capture.",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": "Adds an owner-scope guard so the persistence-fence retry loop stops instead of busy-looping agent-bridge startup when signed out; the decision logic lives in RealtimeHubSessionPolicies.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior."
   },
   "threshold": 1500

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -1451,6 +1451,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   /// and retries if either a new turn or a new write appears across an await.
   /// Callers decide when it is safe to release any stronger reconnect gate.
   func refreshVoiceContextAfterPersistenceFence(reason: String) async -> Bool {
+    let fenceOwnerScope = currentOwnerScope
     while !Task.isCancelled {
       let observedTurnEpoch = turnEpoch
       let observedPersistenceGeneration = turnPersistenceLedger.generation
@@ -1465,6 +1466,19 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
 
       guard await refreshVoiceContextSnapshot() else {
         if Task.isCancelled { return false }
+        // The snapshot cannot resolve once this fence no longer owns its original
+        // authenticated scope (sign-out / owner swap). Retrying then spins
+        // agent-bridge startup at full speed, so stop instead of looping.
+        guard
+          RealtimeHubLifecyclePolicy.canRetryPersistenceFence(
+            taskCancelled: Task.isCancelled,
+            fenceOwnerScope: fenceOwnerScope,
+            currentOwnerScope: currentOwnerScope
+          )
+        else {
+          pendingSessionRefreshReason = reason
+          return false
+        }
         continue
       }
       guard !Task.isCancelled,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
@@ -480,6 +480,27 @@ enum RealtimeHubLifecyclePolicy {
     !replacementPending
   }
 
+  /// Whether the persistence-fence refresh loop may retry after a kernel
+  /// snapshot failed to resolve.
+  ///
+  /// Retrying is only safe while the fence still owns the authenticated scope it
+  /// started under. Once the owner changes or signs out (session invalidation),
+  /// the kernel snapshot can never resolve — the agent bridge refuses to start
+  /// without a current authorization — so the snapshot fails *instantly* on
+  /// every iteration. Looping in that state spins agent-bridge startup at full
+  /// speed (thousands of "sign in to use AI chat" failures per minute). Signed-in
+  /// snapshot failures are naturally rate-limited by their network round-trip, so
+  /// this owner-scope gate is what prevents the busy-loop.
+  static func canRetryPersistenceFence(
+    taskCancelled: Bool,
+    fenceOwnerScope: RealtimeHubOwnerScope,
+    currentOwnerScope: RealtimeHubOwnerScope
+  ) -> Bool {
+    guard !taskCancelled else { return false }
+    guard case .authenticated = currentOwnerScope else { return false }
+    return fenceOwnerScope == currentOwnerScope
+  }
+
 }
 
 /// Immutable account identity attached to a realtime socket, its context, and

--- a/desktop/macos/Desktop/Tests/RealtimeHubPersistenceFencePolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubPersistenceFencePolicyTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the persistence-fence retry busy-loop.
+///
+/// `refreshVoiceContextAfterPersistenceFence` used to `continue` on every failed
+/// `refreshVoiceContextSnapshot()`. When the owner signed out or the session was
+/// invalidated mid-turn, the kernel snapshot could never resolve (the agent
+/// bridge refuses to start without a current authorization) and the failure
+/// returned instantly, so the loop spun agent-bridge startup at full speed —
+/// ~56k "sign in to use AI chat" failures per minute in one observed session,
+/// bloating the log to gigabytes. The loop now consults
+/// `RealtimeHubLifecyclePolicy.canRetryPersistenceFence`, which only permits a
+/// retry while the fence still owns its original authenticated scope.
+final class RealtimeHubPersistenceFencePolicyTests: XCTestCase {
+  private let ownerA = RealtimeHubOwnerScope.authenticated("uid-A")
+  private let ownerB = RealtimeHubOwnerScope.authenticated("uid-B")
+
+  func testRetriesWhileOwnerUnchangedAndAuthenticated() {
+    XCTAssertTrue(
+      RealtimeHubLifecyclePolicy.canRetryPersistenceFence(
+        taskCancelled: false, fenceOwnerScope: ownerA, currentOwnerScope: ownerA))
+  }
+
+  func testStopsWhenTaskCancelled() {
+    XCTAssertFalse(
+      RealtimeHubLifecyclePolicy.canRetryPersistenceFence(
+        taskCancelled: true, fenceOwnerScope: ownerA, currentOwnerScope: ownerA))
+  }
+
+  func testStopsWhenOwnerSignsOutMidFence() {
+    // The exact busy-loop trigger: fence started authenticated, owner is now signedOut.
+    XCTAssertFalse(
+      RealtimeHubLifecyclePolicy.canRetryPersistenceFence(
+        taskCancelled: false, fenceOwnerScope: ownerA, currentOwnerScope: .signedOut))
+  }
+
+  func testStopsWhenOwnerSwaps() {
+    XCTAssertFalse(
+      RealtimeHubLifecyclePolicy.canRetryPersistenceFence(
+        taskCancelled: false, fenceOwnerScope: ownerA, currentOwnerScope: ownerB))
+  }
+
+  func testNeverRetriesWhileSignedOut() {
+    // Even if the scope "matches", a signed-out bridge can never start, so never spin.
+    XCTAssertFalse(
+      RealtimeHubLifecyclePolicy.canRetryPersistenceFence(
+        taskCancelled: false, fenceOwnerScope: .signedOut, currentOwnerScope: .signedOut))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260723-voice-fence-signed-out-retry-flood.json
+++ b/desktop/macos/changelog/unreleased/20260723-voice-fence-signed-out-retry-flood.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed excessive CPU use and error-log spam when the app is left signed out"
+}


### PR DESCRIPTION
## What this fixes

A signed-out (or session-invalidated) desktop client can spin the agent-bridge
startup path at full speed, emitting tens of thousands of
`Failed to start agent bridge: Please sign in to use AI chat` errors per minute
and bloating the local log to multiple gigabytes while burning CPU. One observed
session produced **~56,000 of these errors in about a minute**.

## The issue (root cause)

The voice/realtime "persistence fence" retries a kernel context snapshot in a
tight loop:

```
RealtimeHubController.refreshVoiceContextAfterPersistenceFence()
  while !Task.isCancelled {
    ...
    guard await refreshVoiceContextSnapshot() else {
      if Task.isCancelled { return false }
      continue          // ← retried on EVERY failure, with no backoff
    }
    ...
  }
```

`refreshVoiceContextSnapshot()` returns `false` for **two very different**
situations, and the loop treated them identically:

1. **Transient** — a newer write/turn landed across an `await`; retrying is correct.
2. **Terminal** — the owner signed out or the session was invalidated mid-turn.
   The kernel snapshot can now *never* resolve, because the agent bridge refuses
   to start without a current authorization
   (`ChatProvider.ensureBridgeStarted` → `captureAuthorizationSnapshot() == nil`
   → `presentBridgeStartupFailure(.authMissing)`).

The terminal case is what makes it pathological: the auth-missing check returns
**instantly** (no network round-trip), so the loop iterates thousands of times
per second. (Signed-in snapshot failures are naturally rate-limited by their
network call, which is why this only melts down while signed out.)

Each iteration emitted one `Failed to start agent bridge` and one
`retaining the last voice context after an unresolved kernel snapshot`, matching
the 1:1 interleave seen in the logs.

## The fix

Gate the retry on ownership. The loop now captures its owner scope at entry and
only retries while it still owns that **authenticated** scope, via a new pure
policy:

```swift
RealtimeHubLifecyclePolicy.canRetryPersistenceFence(
  taskCancelled: Bool,
  fenceOwnerScope: RealtimeHubOwnerScope,
  currentOwnerScope: RealtimeHubOwnerScope
) -> Bool
// false if cancelled, if currently signed out, or if the owner changed
```

On a terminal condition the fence returns `false` (setting
`pendingSessionRefreshReason` so a later valid session can resume) instead of
busy-looping. Transient retries under the same authenticated owner are unchanged.

## Tests

New `RealtimeHubPersistenceFencePolicyTests` covers the decision table:
retry while owner unchanged + authenticated; **stop** on cancel, on sign-out
mid-fence (the exact trigger), on owner swap, and while signed out. The policy is
a pure function, so this is behavioral coverage without standing up the whole
controller.

## Product invariants

Touches path globs for **INV-CHAT-1** (one shared transcript across surfaces)
and **INV-VOICE-1** (one desktop voice-turn lifecycle owner). Both are
**preserved**: this change only alters the persistence-fence retry *termination*
condition. It adds no lifecycle owner, does not touch `VoiceTurnCoordinator` /
the reducer, and does not touch the chat write-path or transcript, so their
guard tests are unchanged.

Failure-Class: none

## Verification

- `swift-format` clean on all changed files.
- New unit test passes: `swift test --filter RealtimeHubPersistenceFencePolicyTests`.
- Fix is contained to the fence retry decision; transient-retry behavior under a
  stable authenticated owner is unchanged.
