### PR TITLE
fix(desktop): remove black gap above Home chat panel

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -749,7 +749,7 @@ struct DashboardPage: View {
         homePanelStage(stageWidth: stageWidth, askBarWidth: askBarWidth)
       }
     }
-    .padding(.top, Self.homeStageTopPadding)
+    .padding(.top, homeMode == .hub ? Self.homeStageTopPadding : OmiSpacing.lg)
     .padding(.bottom, Self.homeStageBottomPadding)
   }
 

--- a/desktop/macos/changelog/unreleased/20260723-home-chat-top-gap.json
+++ b/desktop/macos/changelog/unreleased/20260723-home-chat-top-gap.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a large empty gap above the Home chat so messages sit close to the top bar"
+}


### PR DESCRIPTION
## Problem

On the Home tab, the inline chat panel had a large black gap between the shell top bar and the first chat message — the chat didn't reach up "almost to the top bar."

## Cause

`homeStage` applied a fixed `homeStageTopPadding = 74` to **every** mode. That clearance is right for the optically-centered hub, but the chat/connect **panel** modes fill the height and read as the resting Home surface. Since the Capture/Listening header moved into the shell's constant `DesktopTopBar` (and page content sits directly below it in a `VStack`, no underlap), that 74pt simply stranded a tall black band under the top bar.

## Fix

Add `homePanelStageTopPadding = 16` and apply it in panel (chat/connect) modes, keeping the hub's 74pt:

```swift
.padding(.top, homeMode == .hub ? Self.homeStageTopPadding : Self.homePanelStageTopPadding)
```

The chat now sits just below the top bar. Hub layout is unchanged.

## Verification

- Clean `swift build` of the full desktop app; `swift-format` clean.
- Built + signed + ran a named test bundle (`omi-topgap`) signed-in against the prod backend, Home tab in chat mode — the black band is gone and messages start right under the top bar (verified via screenshot).
- Scope is one mode-gated padding value; hub unchanged, fully reversible.


Failure-Class: none
