### PR TITLE
fix(desktop): grow home ask bar to fit multi-line messages

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1969,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3643,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4494,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4508,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3298,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5706,
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1690
@@ -10,7 +10,7 @@
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": "SB redesign: Omi-mark avatar on replies that spins while thinking (typing-dots suppressed for Omi's own replies) and tool-call chips gated to the streaming turn, merged with main's metadata-row reveal honoring keyboard focus (shared FocusState + testable ChatBubbleMetadataReveal); a component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "Rebase reconciliation applies the pinned swift-format to the main-branch app-detail safety fixes; runtime behavior is unchanged.",
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": "SB redesign: home now opens directly in the continuous chat with auto-rotating suggestion chips above the ask bar (hero/knows-cards removed), plus insight surfacing and the persistent-top-bar extraction, merged with main's DashboardPage bug fixes (hub-safe collapse-catcher, Continue-in-Omi chat-landing consume); a component split is tracked follow-up; pinned swift-format normalized layout (+2 lines) without runtime change.",
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": "Home ask bar now auto-grows as a multi-line TextField so long messages wrap instead of scrolling off-screen (+14 lines over the prior SB-redesign home/chat layout); a component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": "Bridge memory search now awaits the active initial or pagination projection before refreshing, preventing an immediate post-navigation marker search from using stale lifecycle capability state.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": "SB redesign: adds the Notion-style status board (time-bucket columns, task cards with priority/due chips) and Board/List toggle alongside the existing list; a component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": "SB redesign: adds the hover-expand AppNavRail (icons\u2192labels) and the merged/simplified navigation (Memory, Insights) driving selectedIndex; a component split is tracked follow-up."

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -2319,34 +2319,48 @@ struct HomeAskBar: View {
         .padding(.horizontal, OmiSpacing.md)
       }
 
-      HStack(spacing: OmiSpacing.sm) {
+      HStack(alignment: .bottom, spacing: OmiSpacing.sm) {
         Button(action: pickFiles) {
           Image(systemName: "paperclip")
             .scaledFont(size: OmiType.subheading, weight: .medium)
             .foregroundStyle(isFocused ? HomePalette.secondary : HomePalette.muted)
-            .frame(width: 24, height: 24)
+            .frame(width: 24, height: 34)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .disabled(attachments.count >= kMaxChatAttachments)
         .help("Attach files")
 
+        // Auto-growing input: `axis: .vertical` + `lineLimit(1...6)` grow the pill
+        // as text wraps (scrolls past six lines). Return submits, Shift+Return
+        // newlines — via onKeyPress, since a vertical field would otherwise insert
+        // a newline on Return and never fire onSubmit.
         TextField(
           "",
           text: $text,
-          prompt: Text("Ask omi anything").foregroundColor(HomePalette.muted)
+          prompt: Text("Ask omi anything").foregroundColor(HomePalette.muted),
+          axis: .vertical
         )
         .textFieldStyle(.plain)
         .font(.system(size: 15))
         .foregroundStyle(HomePalette.ink)
+        .lineLimit(1...6)
         .focused(focus)
-        .onSubmit(handleSubmit)
+        .padding(.vertical, 7)
+        .onKeyPress(phases: .down) { press in
+          guard press.key == .return else { return .ignored }
+          // Shift+Return falls through to the field's newline handling.
+          if press.modifiers.contains(.shift) { return .ignored }
+          handleSubmit()
+          return .handled
+        }
 
         actionButton
       }
       .padding(.leading, OmiSpacing.lg)
       .padding(.trailing, OmiSpacing.sm)
-      .frame(height: 58)
+      .padding(.vertical, 12)
+      .frame(minHeight: 58)
     }
     .background(
       RoundedRectangle(cornerRadius: 29, style: .continuous)

--- a/desktop/macos/changelog/unreleased/20260723-home-ask-bar-grows.json
+++ b/desktop/macos/changelog/unreleased/20260723-home-ask-bar-grows.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the home chat bar so it grows to fit multi-line messages instead of scrolling the text out of view"
+}


### PR DESCRIPTION
## Problem

On the desktop home screen, the **"Ask omi anything"** chat bar used a single-line `TextField` pinned to a fixed `.frame(height: 58)` pill. When the typed text got longer than the bar's width, the bar did not grow — the text just scrolled horizontally out of view, so you couldn't see what you'd typed.

## Fix

`HomeAskBar` now uses a vertical, auto-growing `TextField`:

- `axis: .vertical` + `lineLimit(1...6)` — the bar grows as text wraps, up to six lines, then scrolls internally.
- Removed the fixed `.frame(height: 58)`; the pill now uses `minHeight: 58` (unchanged single-line look) and grows with content.
- Row is bottom-aligned so the paperclip / send / connect controls sit with the last line as the bar expands — the standard chat-input pattern.
- `Return` submits (matching the main chat input); `Shift+Return` inserts a newline.
- Corner radius stays `29` (a capsule when single-line, a clean rounded rectangle when taller).

No other layout depends on the old fixed 58pt height (the bar is only ever width-constrained at its call sites).

## Verification

- `xcrun swift build -c debug --package-path Desktop` — **clean** (from a fresh worktree).
- `xcrun swift build -c release --triple arm64-apple-macosx` — clean.
- Built and ran a signed named bundle (`omi-askbar`); exercised the bar: long text now wraps and grows the pill instead of scrolling off-screen, Enter sends, Shift+Enter adds a newline.
- Local CI-parity checks pass: `check-e2e-flow-coverage.py --strict` (DashboardPage covered), `check-desktop-changelog.py`, `desktop-changelog.py validate`.

## Changelog

Added `desktop/macos/changelog/unreleased/20260723-home-ask-bar-grows.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Failure-Class: none
