### PR TITLE
fix(desktop): repair chat outbox revisions after restart

### DIFF
--- a/desktop/macos/agent/src/ARCHITECTURE.md
+++ b/desktop/macos/agent/src/ARCHITECTURE.md
@@ -46,9 +46,11 @@ Swift desktop client
 - `context-snapshot.ts` owns versioned context source selection, admission, and
   rendering. Surface policy and tool capability fingerprints are distinct from
   the shared base-content version.
-- `conversation-journal.ts` is the sole durable conversation writer. Backend
-  synchronization and deletion use its owner-scoped outboxes; Swift performs
-  physical HTTP only and returns exact claim receipts. Clear advances the
+- `conversation-journal.ts` is the sole durable conversation writer.
+  `backend-turn-projection.ts` is the shared canonical backend payload/hash
+  projection used by normal writes and startup repair. Backend synchronization
+  and deletion use owner-scoped outboxes; Swift performs physical HTTP only and
+  returns exact claim receipts. Clear advances the
   journal generation, invalidates remote reconciliation, preserves only the
   identity of already-delivering POST claims, and gates both remote reads and
   new-generation POSTs until the backend DELETE is acknowledged.

--- a/desktop/macos/agent/src/runtime/backend-turn-projection.ts
+++ b/desktop/macos/agent/src/runtime/backend-turn-projection.ts
@@ -1,0 +1,79 @@
+import { createHash } from "node:crypto";
+import type { ConversationTurn } from "./types.js";
+
+const MAX_JOURNAL_REVISION = 2_147_483_647;
+
+export interface BackendTurnPayload {
+  turnId: string;
+  clientMessageId: string;
+  journalRevision: number;
+  text: string;
+  sender: "human" | "ai";
+  appId: string | null;
+  sessionId: string | null;
+  metadata: string | null;
+  messageSource: "desktop_chat" | "realtime_voice";
+}
+
+export function backendTurnPayload(turn: ConversationTurn): BackendTurnPayload {
+  const metadata = parseObjectJson(turn.metadataJson);
+  const backendMetadata = {
+    ...metadata,
+    ...(turn.contentBlocks.length > 0 ? { content_blocks: turn.contentBlocks } : {}),
+    ...(turn.resources.length > 0 ? { resources: turn.resources } : {}),
+  };
+  const projectedText = turn.content.trim()
+    ? turn.content
+    : turn.role === "assistant"
+      && turn.status === "completed"
+      && (turn.contentBlocks.length > 0 || turn.resources.length > 0)
+      ? "Done."
+      : "";
+  return {
+    turnId: turn.turnId,
+    clientMessageId: turn.turnId,
+    journalRevision: boundedJournalRevision(turn.turnSeq),
+    text: projectedText,
+    sender: turn.role === "user" ? "human" : "ai",
+    appId: typeof metadata.appId === "string" ? metadata.appId : null,
+    sessionId: typeof metadata.sessionId === "string" ? metadata.sessionId : null,
+    metadata: Object.keys(backendMetadata).length === 0 ? null : stableJson(backendMetadata),
+    messageSource: turn.origin === "realtime_voice" ? "realtime_voice" : "desktop_chat",
+  };
+}
+
+export function backendTombstoneCode(turn: ConversationTurn): string | null {
+  const payload = backendTurnPayload(turn);
+  if (payload.text.trim()) return null;
+  if (turn.status === "failed") return "empty_failed_turn_cancelled";
+  if (turn.status === "completed") return "empty_completed_turn_cancelled";
+  return null;
+}
+
+export function backendTurnPayloadHash(payload: BackendTurnPayload): string {
+  return `sha256:${createHash("sha256").update(stableJson(payload)).digest("hex")}`;
+}
+
+function boundedJournalRevision(revision: number): number {
+  if (!Number.isSafeInteger(revision) || revision < 1 || revision > MAX_JOURNAL_REVISION) {
+    throw new Error(`Journal revision must be between 1 and ${MAX_JOURNAL_REVISION}`);
+  }
+  return revision;
+}
+
+function parseObjectJson(raw: string): Record<string, unknown> {
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    throw new Error("Journal metadata must be valid JSON");
+  }
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${stableJson(object[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}

--- a/desktop/macos/agent/src/runtime/conversation-journal.ts
+++ b/desktop/macos/agent/src/runtime/conversation-journal.ts
@@ -1,6 +1,12 @@
 import { createHash, randomUUID } from "node:crypto";
 import { conversationTurnFromRow } from "./conversation-turns.js";
 import { generateAgentId } from "./sqlite-store.js";
+import {
+  backendTombstoneCode,
+  backendTurnPayload,
+  backendTurnPayloadHash,
+  type BackendTurnPayload,
+} from "./backend-turn-projection.js";
 import type {
   AgentStore,
   BackendTurnOutboxRecord,
@@ -38,7 +44,8 @@ const DEFAULT_OUTBOX_LEASE_MS = 30_000;
 const MAX_DRAIN_BATCH = 100;
 const BACKEND_RECONCILE_PAGE_LIMIT = 100;
 const MAX_BACKEND_RECONCILE_CURSOR_BYTES = 512;
-const MAX_JOURNAL_REVISION = 2_147_483_647;
+
+export type { BackendTurnPayload } from "./backend-turn-projection.js";
 
 export type JournalDeliveryDestination = "backend" | "local";
 
@@ -157,18 +164,6 @@ export interface BackendTurnDelivery extends BackendTurnOutboxRecord {
 }
 
 export type BackendTurnResultDisposition = "active" | "superseded" | "duplicate";
-
-export interface BackendTurnPayload {
-  turnId: string;
-  clientMessageId: string;
-  journalRevision: number;
-  text: string;
-  sender: "human" | "ai";
-  appId: string | null;
-  sessionId: string | null;
-  metadata: string | null;
-  messageSource: "desktop_chat" | "realtime_voice";
-}
 
 export interface BackendConversationDeleteDelivery {
   operationId: string;
@@ -2515,52 +2510,6 @@ function sha256(value: string): string {
 
 function journalTurnPayloadHash(value: Record<string, unknown>): string {
   return sha256(stableJson(value));
-}
-
-function backendTurnPayload(turn: ConversationTurn): BackendTurnPayload {
-  const metadata = parseObjectJson(turn.metadataJson) as Record<string, unknown>;
-  const backendMetadata = {
-    ...metadata,
-    ...(turn.contentBlocks.length > 0 ? { content_blocks: turn.contentBlocks } : {}),
-    ...(turn.resources.length > 0 ? { resources: turn.resources } : {}),
-  };
-  const projectedText = turn.content.trim()
-    ? turn.content
-    : turn.role === "assistant"
-      && turn.status === "completed"
-      && (turn.contentBlocks.length > 0 || turn.resources.length > 0)
-      ? "Done."
-      : "";
-  return {
-    turnId: turn.turnId,
-    clientMessageId: turn.turnId,
-    journalRevision: boundedJournalRevision(turn.turnSeq),
-    text: projectedText,
-    sender: turn.role === "user" ? "human" : "ai",
-    appId: typeof metadata.appId === "string" ? metadata.appId : null,
-    sessionId: typeof metadata.sessionId === "string" ? metadata.sessionId : null,
-    metadata: Object.keys(backendMetadata).length === 0 ? null : stableJson(backendMetadata),
-    messageSource: turn.origin === "realtime_voice" ? "realtime_voice" : "desktop_chat",
-  };
-}
-
-function boundedJournalRevision(revision: number): number {
-  if (!Number.isSafeInteger(revision) || revision < 1 || revision > MAX_JOURNAL_REVISION) {
-    throw new Error(`Journal revision must be between 1 and ${MAX_JOURNAL_REVISION}`);
-  }
-  return revision;
-}
-
-function backendTombstoneCode(turn: ConversationTurn): string | null {
-  const payload = backendTurnPayload(turn);
-  if (payload.text.trim()) return null;
-  if (turn.status === "failed") return "empty_failed_turn_cancelled";
-  if (turn.status === "completed") return "empty_completed_turn_cancelled";
-  return null;
-}
-
-function backendTurnPayloadHash(payload: BackendTurnPayload): string {
-  return sha256(stableJson(payload));
 }
 
 function historicalBackendPayloadTurnSeq(

--- a/desktop/macos/agent/src/runtime/sqlite-store.ts
+++ b/desktop/macos/agent/src/runtime/sqlite-store.ts
@@ -2,6 +2,12 @@ import { mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { DatabaseSync, type SQLInputValue, type SQLOutputValue } from "node:sqlite";
+import {
+  backendTombstoneCode,
+  backendTurnPayload,
+  backendTurnPayloadHash,
+} from "./backend-turn-projection.js";
+import { conversationTurnFromRow } from "./conversation-turns.js";
 import type {
   AdapterBinding,
   AgentArtifact,
@@ -645,7 +651,8 @@ export class SqliteAgentStore implements AgentStore {
       }
 
       const reconciledJournalTurns = reconcileNonterminalJournalRows(this.db, now);
-      for (const repair of reconciledJournalTurns) {
+      const repairedBackendTurnOutboxes = reconcileBackendTurnOutboxRows(this.db, now);
+      for (const repair of [...reconciledJournalTurns, ...repairedBackendTurnOutboxes]) {
         const surface = this.getOptionalRow(
           `SELECT agent_session_id FROM surface_conversations
            WHERE conversation_id = ? ORDER BY last_active_at_ms DESC LIMIT 1`,
@@ -820,6 +827,7 @@ export class SqliteAgentStore implements AgentStore {
         repairedBindingProfileReferenceIds: repairedProfileReferences.bindingIds,
         repairedLegacyJournalTurnIds,
         reconciledJournalTurnIds: reconciledJournalTurns.map((repair) => repair.turnId),
+        repairedBackendTurnOutboxIds: repairedBackendTurnOutboxes.map((repair) => repair.turnId),
         recoveryDispatchIds,
         clearedAttemptInstanceIds,
         clearedBindingInstanceIds,
@@ -1844,6 +1852,55 @@ function reconcileNonterminalJournalRows(
       code,
     };
   });
+}
+
+function reconcileBackendTurnOutboxRows(
+  db: Pick<DatabaseSync, "prepare">,
+  nowMs: number,
+): StartupJournalRepair[] {
+  const rows = db.prepare(
+    `SELECT ct.*, outbox.payload_hash AS outbox_payload_hash
+     FROM backend_turn_outbox outbox
+     JOIN conversation_turns ct
+       ON ct.conversation_id = outbox.conversation_id
+      AND ct.turn_id = outbox.turn_id
+     WHERE outbox.status IN ('pending', 'retrying', 'delivering')
+       AND ct.status IN ('completed', 'failed')
+     ORDER BY outbox.created_at_ms ASC, outbox.turn_id ASC`,
+  ).all() as Row[];
+  const repairs: StartupJournalRepair[] = [];
+  for (const row of rows) {
+    const turn = conversationTurnFromRow(row);
+    const payloadHash = backendTurnPayloadHash(backendTurnPayload(turn));
+    if (payloadHash === text(row.outbox_payload_hash)) continue;
+    const tombstoneCode = backendTombstoneCode(turn);
+    db.prepare(
+      `UPDATE backend_turn_outbox
+       SET payload_hash = ?,
+           status = CASE WHEN ? IS NOT NULL THEN 'failed' ELSE 'pending' END,
+           attempt_count = 0,
+           available_at_ms = ?,
+           lease_expires_at_ms = NULL,
+           last_error_code = ?,
+           updated_at_ms = ?
+       WHERE turn_id = ? AND payload_hash != ?`,
+    ).run(
+      payloadHash,
+      tombstoneCode,
+      nowMs,
+      tombstoneCode,
+      nowMs,
+      turn.turnId,
+      payloadHash,
+    );
+    repairs.push({
+      turnId: turn.turnId,
+      conversationId: turn.conversationId,
+      producingRunId: turn.producingRunId,
+      code: "daemon_restart_outbox_revision_repair",
+    });
+  }
+  return repairs;
 }
 
 function rewriteJournalRow(

--- a/desktop/macos/agent/src/runtime/types.ts
+++ b/desktop/macos/agent/src/runtime/types.ts
@@ -658,6 +658,7 @@ export interface StartupReconciliationResult {
   repairedBindingProfileReferenceIds: string[];
   repairedLegacyJournalTurnIds: string[];
   reconciledJournalTurnIds: string[];
+  repairedBackendTurnOutboxIds: string[];
   recoveryDispatchIds: string[];
   clearedAttemptInstanceIds: number;
   clearedBindingInstanceIds: number;

--- a/desktop/macos/agent/tests/conversation-journal.test.ts
+++ b/desktop/macos/agent/tests/conversation-journal.test.ts
@@ -1725,6 +1725,96 @@ describe("kernel conversation journal", () => {
     store.close();
   });
 
+  it("repairs a startup-terminalized turn before it can starve later backend chat sync", () => {
+    const databasePath = newDatabasePath();
+    let store = new SqliteAgentStore({ databasePath, reconcileOnOpen: false, nowMs: () => 100 });
+    const fixture = insertSurface(store, "main_chat", "chat", "restart-outbox");
+    recordCompletedTextTurn(fixture, "turn-already-delivered", "Do not resend", 5);
+    const [deliveredClaim] = drainBackendTurnOutbox(store, { nowMs: 6 });
+    ackBackendTurnOutbox(store, {
+      ownerId: fixture.ownerId,
+      turnId: deliveredClaim.turnId,
+      remoteId: "remote-already-delivered",
+      attemptCount: deliveredClaim.attemptCount,
+      deliveryGeneration: deliveredClaim.deliveryGeneration,
+      conversationGeneration: deliveredClaim.conversationGeneration,
+      payloadHash: deliveredClaim.payloadHash,
+      nowMs: 7,
+    });
+    const run = store.insertRun({
+      sessionId: fixture.sessionId,
+      clientId: "client",
+      requestId: "interrupted-after-run-success",
+      status: "succeeded",
+      mode: "ask",
+      completedAtMs: 11,
+    });
+    const attempt = store.insertAttempt({
+      runId: run.runId,
+      attemptNo: 1,
+      status: "succeeded",
+      adapterId: "acp",
+      adapterInstanceId: "",
+      completedAtMs: 11,
+    });
+    recordJournalTurn(store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      turnId: "turn-interrupted",
+      role: "assistant",
+      surfaceKind: "main_chat",
+      origin: "agent_runtime",
+      status: "streaming",
+      content: "",
+      contentBlocks: [],
+      producingRunId: run.runId,
+      producingAttemptId: attempt.attemptId,
+      createdAtMs: 10,
+    });
+    const staleHash = String(store.getRow(
+      "SELECT payload_hash FROM backend_turn_outbox WHERE turn_id = ?",
+      ["turn-interrupted"],
+    ).payload_hash);
+    store.close();
+
+    store = new SqliteAgentStore({ databasePath, reconcileOnOpen: false, nowMs: () => 20 });
+    expect(store.reconcileStartup()).toMatchObject({
+      reconciledJournalTurnIds: ["turn-interrupted"],
+      repairedBackendTurnOutboxIds: ["turn-interrupted"],
+    });
+    const repairedOutbox = store.getRow(
+      "SELECT status, last_error_code, payload_hash FROM backend_turn_outbox WHERE turn_id = ?",
+      ["turn-interrupted"],
+    );
+    expect(repairedOutbox).toMatchObject({
+      status: "failed",
+      last_error_code: "empty_completed_turn_cancelled",
+    });
+    expect(repairedOutbox.payload_hash).not.toBe(staleHash);
+    expect(store.getRow(
+      "SELECT status, remote_id FROM backend_turn_outbox WHERE turn_id = ?",
+      ["turn-already-delivered"],
+    )).toEqual({
+      status: "delivered",
+      remote_id: "remote-already-delivered",
+    });
+
+    const resumedFixture = {
+      store,
+      ownerId: fixture.ownerId,
+      sessionId: fixture.sessionId,
+      conversationId: fixture.conversationId,
+    };
+    recordCompletedTextTurn(resumedFixture, "turn-after-restart", "Chat still syncs", 30);
+    expect(drainBackendTurnOutbox(store, { nowMs: 31 })).toMatchObject([
+      {
+        turnId: "turn-after-restart",
+        payload: { text: "Chat still syncs" },
+      },
+    ]);
+    store.close();
+  });
+
   it("reconciles a backend row visible before outbox ACK into the canonical turn in place", () => {
     const fixture = newSurface("main_chat", "chat", "default");
     const run = fixture.store.insertRun({

--- a/desktop/macos/changelog/unreleased/20260723-chat-sync-restart-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260723-chat-sync-restart-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed chat syncing after Omi restarts during a response."
+}


### PR DESCRIPTION
## What this fixes

Omi Beta 113 can leave a backend turn-outbox row with the old payload revision
when startup recovery terminalizes an interrupted chat turn. The outbox drain
then throws on that oldest row every second and rolls back the whole batch,
starving every later chat-sync row.

Startup recovery now repairs active outbox rows from the same canonical turn
projection used by normal journal writes. Empty recovered terminal turns become
explicit tombstones, while delivered history is left untouched.

## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1

Both are preserved. `conversation_turns` remains the sole canonical transcript,
and its backend outbox remains an atomic downstream projection. This change
repairs that projection during the existing kernel-owned startup transaction; it
does not add another lifecycle or transcript owner.

Failure-Class: FC-split-mutation-authority

## Verification

- Agent runtime suite: 581/581 passed.
- Focused journal/store regression suite: 69/69 passed.
- Agent logic harness, cross-surface smoke, and continuity gauntlet passed.
- A read-only copy of the affected Beta 113 database repaired exactly one
  poisoned row, preserved delivered history, and drained the six later rows.
- Named app: graceful restart restored auth/runtime readiness and a real visible
  main-chat reply; no outbox revision errors.
- Stopped the requested comparison early to land: fixed build 26/29 fully
  correct with 0 revision errors; Beta 113 0/12 fully correct because none of
  its successful UI turns reached durable delivery, while 366 more revision
  errors accumulated.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

