### PR TITLE
fix: recycle poisoned Parakeet GPU workers

### DIFF
--- a/.github/failure-classes/FC-poisoned-accelerator-readiness.json
+++ b/.github/failure-classes/FC-poisoned-accelerator-readiness.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "FC-poisoned-accelerator-readiness",
+  "violated_contract": "A GPU inference replica whose process-local accelerator context is unsafe must stop accepting work and must not remain Ready.",
+  "canonical_prevention": "Classify fatal accelerator errors at the authoritative GPU worker, fail new work closed, surface the poisoned state through readiness and liveness, and reject decoder configurations that can invalidate a shared CUDA context.",
+  "evidence_prs": [7938],
+  "scope_hints": ["backend/parakeet/**", "backend/charts/parakeet/**"],
+  "status": "open"
+}

--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -9194,5 +9194,203 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "omi-parakeet-ready-pod-no-success",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Parakeet",
+    "title": "Parakeet - ready pod is failing every request",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "((sum by (pod) (increase(parakeet_requests_total{container=\"parakeet\",namespace=\"prod-omi-backend\",status=\"error\"}[5m])) >= 10) unless on (pod) (sum by (pod) (increase(parakeet_requests_total{container=\"parakeet\",namespace=\"prod-omi-backend\",status=\"success\"}[5m])) > 0)) and on (pod) (max by (pod) (kube_pod_status_ready{namespace=\"prod-omi-backend\",condition=\"true\",pod=~\"prod-omi-parakeet-.*\"}) == 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-07-23T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "2m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
+      "__panelId__": "103",
+      "summary": "A Ready Parakeet pod has at least 10 failed requests and no successful requests in five minutes.",
+      "user_impact": "Users routed to the affected pod are receiving transcription failures.",
+      "scope": "One production Parakeet pod, evaluated independently from healthy sibling replicas.",
+      "verification": "Compare per-pod success and error outcomes, then inspect the affected pod health and recent CUDA errors.",
+      "safe_next_action": "If the pod is still Ready and has zero successes, replace only that replica and verify its replacement serves successful requests."
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-parakeet-ready-pod-no-success",
+      "component": "speech-processing",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-parakeet-fatal-cuda",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Parakeet",
+    "title": "Parakeet - fatal CUDA state detected",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (pod) (increase(parakeet_gpu_fatal_errors_total{container=\"parakeet\",namespace=\"prod-omi-backend\"}[5m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-07-23T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "0s",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
+      "__panelId__": "21",
+      "summary": "A Parakeet worker detected a CUDA error that makes further inference unsafe.",
+      "user_impact": "No confirmed user impact yet; the affected replica is leaving service and will be restarted automatically.",
+      "scope": "One production Parakeet GPU process and its Kubernetes replica.",
+      "verification": "Confirm the pod became unready, restarted, and was replaced by a replica serving successful transcription requests.",
+      "safe_next_action": "Allow the health probes to recycle the replica; intervene only if the replacement also reports a fatal CUDA state."
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-parakeet-fatal-cuda",
+      "component": "speech-processing",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
   }
 ]

--- a/backend/charts/monitoring/alerts/parakeet.json
+++ b/backend/charts/monitoring/alerts/parakeet.json
@@ -995,5 +995,203 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "omi-parakeet-ready-pod-no-success",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Parakeet",
+    "title": "Parakeet - ready pod is failing every request",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "((sum by (pod) (increase(parakeet_requests_total{container=\"parakeet\",namespace=\"prod-omi-backend\",status=\"error\"}[5m])) >= 10) unless on (pod) (sum by (pod) (increase(parakeet_requests_total{container=\"parakeet\",namespace=\"prod-omi-backend\",status=\"success\"}[5m])) > 0)) and on (pod) (max by (pod) (kube_pod_status_ready{namespace=\"prod-omi-backend\",condition=\"true\",pod=~\"prod-omi-parakeet-.*\"}) == 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-07-23T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "2m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
+      "__panelId__": "103",
+      "summary": "A Ready Parakeet pod has at least 10 failed requests and no successful requests in five minutes.",
+      "user_impact": "Users routed to the affected pod are receiving transcription failures.",
+      "scope": "One production Parakeet pod, evaluated independently from healthy sibling replicas.",
+      "verification": "Compare per-pod success and error outcomes, then inspect the affected pod health and recent CUDA errors.",
+      "safe_next_action": "If the pod is still Ready and has zero successes, replace only that replica and verify its replacement serves successful requests."
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-parakeet-ready-pod-no-success",
+      "component": "speech-processing",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-parakeet-fatal-cuda",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Parakeet",
+    "title": "Parakeet - fatal CUDA state detected",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 900,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (pod) (increase(parakeet_gpu_fatal_errors_total{container=\"parakeet\",namespace=\"prod-omi-backend\"}[5m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-07-23T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "0s",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "07e4c65f-ae79-414d-bf05-99468267d199",
+      "__panelId__": "21",
+      "summary": "A Parakeet worker detected a CUDA error that makes further inference unsafe.",
+      "user_impact": "No confirmed user impact yet; the affected replica is leaving service and will be restarted automatically.",
+      "scope": "One production Parakeet GPU process and its Kubernetes replica.",
+      "verification": "Confirm the pod became unready, restarted, and was replaced by a replica serving successful transcription requests.",
+      "safe_next_action": "Allow the health probes to recycle the replica; intervene only if the replacement also reports a fatal CUDA state."
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-parakeet-fatal-cuda",
+      "component": "speech-processing",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
   }
 ]

--- a/backend/charts/monitoring/dashboards/gke/parakeet-asr-monitoring.json
+++ b/backend/charts/monitoring/dashboards/gke/parakeet-asr-monitoring.json
@@ -127,7 +127,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "1 - (\n  (sum(rate(parakeet_requests_total{namespace=\"prod-omi-backend\", status=~\"[45]..\"}[$__rate_interval])) or vector(0))\n  /\n  (sum(rate(parakeet_requests_total{namespace=\"prod-omi-backend\"}[$__rate_interval])) > 0)\n)",
+          "expr": "1 - (\n  (sum(rate(parakeet_requests_total{namespace=\"prod-omi-backend\", status=\"error\"}[$__rate_interval])) or vector(0))\n  /\n  (sum(rate(parakeet_requests_total{namespace=\"prod-omi-backend\"}[$__rate_interval])) > 0)\n)",
           "instant": true,
           "legendFormat": "Success Rate",
           "refId": "A"
@@ -1561,7 +1561,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(sum(rate(parakeet_requests_total{namespace=\"prod-omi-backend\", status=~\"[45]..\"}[$__rate_interval])) or vector(0))\n/\n(sum(rate(parakeet_requests_total{namespace=\"prod-omi-backend\"}[$__rate_interval])) > 0)",
+          "expr": "(sum(rate(parakeet_requests_total{namespace=\"prod-omi-backend\", status=\"error\"}[$__rate_interval])) or vector(0))\n/\n(sum(rate(parakeet_requests_total{namespace=\"prod-omi-backend\"}[$__rate_interval])) > 0)",
           "legendFormat": "Error Rate",
           "refId": "A"
         }

--- a/backend/charts/parakeet/dev_omi_parakeet_values.yaml
+++ b/backend/charts/parakeet/dev_omi_parakeet_values.yaml
@@ -107,7 +107,7 @@ env:
   - name: PARAKEET_TORCH_COMPILE
     value: "true"
   - name: PARAKEET_CUDA_GRAPHS
-    value: "true"
+    value: "false"
   - name: HOSTED_SPEAKER_EMBEDDING_API_URL
     value: "http://dev-omi-diarizer.dev-omi-backend.svc.cluster.local:8080"
 
@@ -127,16 +127,17 @@ resources:
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
-  tcpSocket:
+  httpGet:
+    path: /health
     port: 8080
-  failureThreshold: 30
+  failureThreshold: 3
   periodSeconds: 10
 
 readinessProbe:
   httpGet:
     path: /health
     port: 8080
-  failureThreshold: 30
+  failureThreshold: 1
   periodSeconds: 10
 
 startupProbe:

--- a/backend/charts/parakeet/prod_omi_parakeet_values.yaml
+++ b/backend/charts/parakeet/prod_omi_parakeet_values.yaml
@@ -107,7 +107,7 @@ env:
   - name: PARAKEET_TORCH_COMPILE
     value: "true"
   - name: PARAKEET_CUDA_GRAPHS
-    value: "true"
+    value: "false"
   - name: PARAKEET_ATTENTION_MODE
     value: "auto"
   - name: PARAKEET_AUTO_ATTN_THRESHOLD
@@ -145,16 +145,17 @@ resources:
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
-  tcpSocket:
+  httpGet:
+    path: /health
     port: 8080
-  failureThreshold: 30
+  failureThreshold: 3
   periodSeconds: 10
 
 readinessProbe:
   httpGet:
     path: /health
     port: 8080
-  failureThreshold: 30
+  failureThreshold: 1
   periodSeconds: 10
 
 startupProbe:

--- a/backend/parakeet/README.md
+++ b/backend/parakeet/README.md
@@ -26,7 +26,10 @@ WebSocket: send raw PCM16 chunks, receive JSON segments in real-time.
 - No punctuation (RNNT limitation — lowercase output)
 
 ### `GET /health` — Health check
-Returns `{"status": "healthy", "ready": true}` (200) when model is loaded, or `{"status": "loading", "ready": false}` (503) during model initialization. K8s readiness/startup probes use this endpoint.
+Returns `{"status": "healthy", "ready": true}` (200) when the model is ready,
+`{"status": "loading", "ready": false}` (503) during initialization, or
+`{"status": "unhealthy", "ready": false, "reason": "..."}` (503) after a fatal
+CUDA error. Kubernetes readiness, liveness, and startup probes use this endpoint.
 
 ### `GET /batch/metrics` — Batch engine stats
 Returns `{"total_requests", "total_batches", "total_files", "rejected_requests", "pending_requests"}`.
@@ -40,7 +43,7 @@ Returns `{"total_requests", "total_batches", "total_files", "rejected_requests",
 | `PARAKEET_MODEL` | `nvidia/parakeet-tdt-0.6b-v3` | Batch model |
 | `PARAKEET_DEVICE` | `cuda:0` | GPU device for batch inference |
 | `PARAKEET_TORCH_COMPILE` | `true` | Enable torch.compile (+20-30% throughput from kernel fusion) |
-| `PARAKEET_CUDA_GRAPHS` | `true` | Enable CUDA graph decoding (disable for T4/Turing GPUs) |
+| `PARAKEET_CUDA_GRAPHS` | `false` | Enable CUDA graph decoding. Must stay disabled when `PARAKEET_STREAM_MODEL` is configured because batch and streaming inference share one CUDA context. |
 | `PARAKEET_GC_INTERVAL` | `50` | Full gc.collect() every N batches (gc.collect(0) per batch) |
 | `PARAKEET_GPU_POLL_TIMEOUT` | `0.05` | GPU worker queue poll interval in seconds |
 | `PARAKEET_BF16` | `1` | BF16 model loading (halves GPU memory) |

--- a/backend/parakeet/gpu_worker.py
+++ b/backend/parakeet/gpu_worker.py
@@ -8,7 +8,7 @@ import time
 import wave as _wave
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 import soundfile as sf
 import torch  # type: ignore[reportMissingImports]  # torch not installed in dev venv
@@ -42,6 +42,35 @@ _MAX_GPU_QUEUE = 512
 
 _VALID_ATTN_MODES = ("full", "local", "auto")
 
+_FATAL_CUDA_MESSAGE_MARKERS: Tuple[Tuple[str, str], ...] = (
+    ("device-side assert", "device_side_assert"),
+    ("cudaerrorassert", "device_side_assert"),
+    ("an illegal memory access was encountered", "illegal_memory_access"),
+    ("cudaerrorillegaladdress", "illegal_memory_access"),
+    ("unspecified launch failure", "launch_failure"),
+    ("cudaerrorlaunchfailure", "launch_failure"),
+    ("capture must end on the same stream it began on", "stream_capture"),
+    ("operation not permitted when stream is capturing", "stream_capture"),
+    ("cudaerrorstreamcaptureunsupported", "stream_capture"),
+)
+
+
+def classify_fatal_cuda_error(exc: BaseException) -> Optional[str]:
+    """Return a bounded reason when CUDA state is unsafe for further inference."""
+    current: Optional[BaseException] = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        message = str(current).lower()
+        for marker, reason in _FATAL_CUDA_MESSAGE_MARKERS:
+            if marker in message:
+                return reason
+        accelerator_error_type: Any = getattr(_torch.cuda, "AcceleratorError", None)
+        if isinstance(accelerator_error_type, type) and isinstance(current, accelerator_error_type):
+            return "accelerator_error"
+        current = current.__cause__ or current.__context__
+    return None
+
 
 class AudioDurationExceededError(Exception):
     pass
@@ -67,7 +96,7 @@ class WorkItem:
 
 
 class GPUWorker:
-    def __init__(self) -> None:
+    def __init__(self, on_fatal_cuda_error: Optional[Callable[[str], None]] = None) -> None:
         self._queue: queue.Queue[WorkItem] = queue.Queue(maxsize=_MAX_GPU_QUEUE)
         self._thread: Optional[threading.Thread] = None
         self._model: Any = None
@@ -77,6 +106,9 @@ class GPUWorker:
         self._gc_counter: int = 0
         self._ready: threading.Event = threading.Event()
         self._load_error: Optional[Exception] = None
+        self._fatal_cuda_reason: Optional[str] = None
+        self._state_lock: threading.Lock = threading.Lock()
+        self._on_fatal_cuda_error = on_fatal_cuda_error
         self._running: bool = False
         self._submit_lock: threading.Lock = threading.Lock()
         self._attn_mode: str = os.getenv("PARAKEET_ATTENTION_MODE", "full").lower()
@@ -93,7 +125,14 @@ class GPUWorker:
 
     @property
     def is_ready(self) -> bool:
-        return self._ready.is_set() and self._load_error is None
+        with self._state_lock:
+            fatal_cuda_reason = self._fatal_cuda_reason
+        return self._ready.is_set() and self._load_error is None and fatal_cuda_reason is None
+
+    @property
+    def fatal_cuda_reason(self) -> Optional[str]:
+        with self._state_lock:
+            return self._fatal_cuda_reason
 
     @property
     def vram_info(self) -> Dict[str, Any]:
@@ -114,19 +153,52 @@ class GPUWorker:
             raise TimeoutError(f"GPU model did not load within {timeout}s")
         if self._load_error is not None:
             raise self._load_error
+        if self.fatal_cuda_reason is not None:
+            raise RuntimeError("GPU worker encountered a fatal CUDA error")
 
     def stop(self) -> None:
         with self._submit_lock:
-            if not self._running:
-                return
+            should_signal = self._running
             self._running = False
-        evt = threading.Event()
-        try:
-            self._queue.put(WorkItem(WorkType.SHUTDOWN, None, sync_event=evt), timeout=5)
-        except queue.Full:
-            pass
-        if self._thread:
+        if should_signal:
+            evt = threading.Event()
+            try:
+                self._queue.put(WorkItem(WorkType.SHUTDOWN, None, sync_event=evt), timeout=5)
+            except queue.Full:
+                pass
+        if self._thread and self._thread is not threading.current_thread():
             self._thread.join(timeout=30)
+
+    def report_inference_error(self, exc: BaseException) -> bool:
+        """Fail the worker closed when an inference error invalidates CUDA state."""
+        reason = classify_fatal_cuda_error(exc)
+        if reason is None:
+            return False
+
+        first_report = False
+        with self._state_lock:
+            if self._fatal_cuda_reason is None:
+                self._fatal_cuda_reason = reason
+                first_report = True
+        with self._submit_lock:
+            self._running = False
+
+        if first_report:
+            self._drain_queue(RuntimeError("GPU worker unavailable after fatal CUDA error"))
+            logger.critical(
+                "Fatal CUDA error marked GPU worker unavailable (reason=%s, exception_type=%s)",
+                reason,
+                type(exc).__name__,
+            )
+            if self._on_fatal_cuda_error is not None:
+                try:
+                    self._on_fatal_cuda_error(reason)
+                except Exception as callback_error:
+                    logger.error(
+                        "Fatal CUDA metric callback failed (exception_type=%s)",
+                        type(callback_error).__name__,
+                    )
+        return True
 
     def submit(
         self, payload: Dict[str, Any], loop: asyncio.AbstractEventLoop
@@ -201,6 +273,8 @@ class GPUWorker:
             logger.error(f"Model loading failed: {exc}")
             self._load_error = exc
             self._ready.set()
+            with self._submit_lock:
+                self._running = False
             return
 
         while self._running:
@@ -212,6 +286,7 @@ class GPUWorker:
             if item.work_type == WorkType.SHUTDOWN:
                 break
 
+            fatal_cuda_error = False
             try:
                 t_infer = time.monotonic()
                 if item.work_type == WorkType.EMBEDDING:
@@ -219,13 +294,25 @@ class GPUWorker:
                 else:
                     result = self._batch_transcribe(item.payload)
                 item.inference_seconds = time.monotonic() - t_infer
-                self._deliver_result(item, result)
+                if self.fatal_cuda_reason is None:
+                    self._deliver_result(item, result)
+                else:
+                    self._deliver_error(item, RuntimeError("GPU worker unavailable after fatal CUDA error"))
             except Exception as exc:
+                fatal_cuda_error = self.report_inference_error(exc)
                 self._deliver_error(item, exc)
-            finally:
+            try:
                 self._maybe_gc()
+            except Exception as gc_error:
+                fatal_cuda_error = self.report_inference_error(gc_error) or fatal_cuda_error
+                if not fatal_cuda_error:
+                    logger.error("GPU worker garbage collection failed (exception_type=%s)", type(gc_error).__name__)
+            if fatal_cuda_error or self.fatal_cuda_reason is not None:
+                break
 
         self._drain_queue()
+        with self._submit_lock:
+            self._running = False
         logger.info("GPU worker thread stopped")
 
     @staticmethod
@@ -249,6 +336,8 @@ class GPUWorker:
         device = os.getenv("PARAKEET_DEVICE", "cuda:0")
         do_compile = os.getenv("PARAKEET_TORCH_COMPILE", "false").lower() in ("true", "1", "yes")
         disable_cuda_graphs = os.getenv("PARAKEET_CUDA_GRAPHS", "false").lower() not in ("true", "1", "yes")
+        if not disable_cuda_graphs and os.getenv("PARAKEET_STREAM_MODEL", "").strip():
+            raise ValueError("PARAKEET_CUDA_GRAPHS must be false when PARAKEET_STREAM_MODEL is configured")
 
         _torch.backends.cudnn.benchmark = True
         if hasattr(_torch, 'set_float32_matmul_precision'):
@@ -345,6 +434,8 @@ class GPUWorker:
             self._embedding_model = inference
             logger.info("Built-in speaker embedding model loaded (wespeaker-voxceleb-resnet34-LM)")
         except Exception as e:
+            if self.report_inference_error(e):
+                raise
             logger.warning(f"Could not load built-in embedding model: {e}")
 
     @_torch.inference_mode()
@@ -454,12 +545,12 @@ class GPUWorker:
                 out.append({"text": str(r)})
         return out
 
-    def _drain_queue(self) -> None:
+    def _drain_queue(self, error: Optional[Exception] = None) -> None:
         while not self._queue.empty():
             try:
                 item = self._queue.get_nowait()
                 if item.work_type != WorkType.SHUTDOWN:
-                    err = RuntimeError("GPU worker shutting down")
+                    err = error or RuntimeError("GPU worker shutting down")
                     self._deliver_error(item, err)
             except queue.Empty:
                 break

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -79,6 +79,10 @@ INFERENCE_DURATION = Histogram(
     buckets=_ASR_BUCKETS,
 )
 GPU_OOM_TOTAL = Counter('parakeet_gpu_oom_total', 'CUDA out-of-memory events')
+GPU_FATAL_ERRORS_TOTAL = Counter(
+    'parakeet_gpu_fatal_errors_total',
+    'Fatal CUDA errors that make a Parakeet GPU worker unavailable',
+)
 REQUESTS_TOTAL = Counter('parakeet_requests_total', 'Total requests by status', ['endpoint', 'status'])
 
 gpu_worker: Optional[GPUWorker] = None
@@ -122,6 +126,10 @@ def _on_gpu_oom() -> None:
     GPU_OOM_TOTAL.inc()
 
 
+def _on_fatal_cuda_error(_reason: str) -> None:
+    GPU_FATAL_ERRORS_TOTAL.inc()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global gpu_worker, batch_engine, stream_admission, start_time
@@ -131,7 +139,7 @@ async def lifespan(app: FastAPI):
     os.makedirs("_temp", exist_ok=True)
 
     if INFERENCE_MODE != "nim":
-        gpu_worker = GPUWorker()
+        gpu_worker = GPUWorker(on_fatal_cuda_error=_on_fatal_cuda_error)
         gpu_worker.start()
         set_gpu_worker(gpu_worker)
 
@@ -308,6 +316,10 @@ async def stream_transcribe(
     hangover_s: float = Query(None),
 ):
     await websocket.accept()
+    if gpu_worker is not None and not gpu_worker.is_ready:
+        REQUESTS_TOTAL.labels(endpoint='v3_stream', status='error').inc()
+        await websocket.close(code=1013, reason='service_not_ready')
+        return
     if stream_admission is None:
         logger.error('v3/stream admission unavailable')
         await websocket.close(code=1011, reason='service_not_ready')
@@ -375,11 +387,14 @@ async def stream_transcribe(
 async def health_check() -> JSONResponse | Dict[str, Any]:
     if gpu_worker is not None:
         ready = gpu_worker.is_ready
+        fatal_cuda_reason = gpu_worker.fatal_cuda_reason
         body = {
-            "status": "healthy" if ready else "loading",
+            "status": "healthy" if ready else "unhealthy" if fatal_cuda_reason is not None else "loading",
             "ready": ready,
             "uptime_seconds": round(time.monotonic() - start_time, 1),
         }
+        if fatal_cuda_reason is not None:
+            body["reason"] = fatal_cuda_reason
         if not ready:
             return JSONResponse(status_code=503, content=body)
         return body

--- a/backend/parakeet/stream_handler.py
+++ b/backend/parakeet/stream_handler.py
@@ -55,6 +55,7 @@ from transcribe import (
     _stream_model as _asr_model_raw,  # type: ignore[reportPrivateUsage,reportUnknownVariableType]
     INFERENCE_MODE as _INFERENCE_MODE,
     has_builtin_embedding,
+    report_gpu_inference_error,
     wav_bytes_to_waveform,
 )
 
@@ -141,7 +142,11 @@ def warmup_rnnt_decoder(sample_rate: int = 16000) -> None:
         decoder.decode_pcm(dummy_pcm, is_last_chunk=True)
         logger.info("RNNT warmup complete")
     except Exception as e:
-        logger.warning(f"RNNT warmup failed (non-fatal): {e}")
+        if report_gpu_inference_error(e):
+            logger.error("RNNT warmup hit a fatal CUDA error; GPU worker is unavailable")
+            raise
+        else:
+            logger.warning(f"RNNT warmup failed (non-fatal): {e}")
 
 
 class _NemoRNNTStreamingDecoder:
@@ -541,6 +546,9 @@ class StreamSession:
         try:
             await loop.run_in_executor(_asr_executor, self._drain_streaming_asr_sync, force, pad_partial)
         except Exception as e:
+            if report_gpu_inference_error(e):
+                logger.error("RNNT streaming decode hit a fatal CUDA error; closing the stream")
+                raise
             logger.warning(f"RNNT streaming decode failed, falling back to VAD utterance transcribe: {e}")
             self._streaming_decoder = None
             self._streaming_failed = True

--- a/backend/parakeet/transcribe.py
+++ b/backend/parakeet/transcribe.py
@@ -69,6 +69,15 @@ def set_gpu_worker(worker: Any) -> None:
     _gpu_worker = worker
 
 
+def report_gpu_inference_error(error: BaseException) -> bool:
+    if _gpu_worker is None:
+        return False
+    reporter: Any = getattr(_gpu_worker, "report_inference_error", None)
+    if reporter is None:
+        return False
+    return bool(reporter(error))
+
+
 def _load_nemo_model(model_name: str) -> Any:
     if nemo_asr is None:
         raise RuntimeError("nemo_toolkit[asr] is not installed")

--- a/backend/tests/unit/test_monitoring_alert_rule_contract.py
+++ b/backend/tests/unit/test_monitoring_alert_rule_contract.py
@@ -39,6 +39,19 @@ LIVE_TRANSCRIPTION_FAILURE_RULE = "omi-journey-live-transcription-fail"
 LIVE_TRANSCRIPTION_FAILURE_EXPR = (
     'sum(increase(omi_journey_terminal_total{journey="live_transcription",outcome=~"success|failure"}[30m]))'
 )
+PARAKEET_READY_POD_NO_SUCCESS_RULE = "omi-parakeet-ready-pod-no-success"
+PARAKEET_READY_POD_NO_SUCCESS_EXPR = (
+    '((sum by (pod) (increase(parakeet_requests_total{container="parakeet",namespace="prod-omi-backend",'
+    'status="error"}[5m])) >= 10) unless on (pod) (sum by (pod) '
+    '(increase(parakeet_requests_total{container="parakeet",namespace="prod-omi-backend",'
+    'status="success"}[5m])) > 0)) and on (pod) (max by (pod) '
+    '(kube_pod_status_ready{namespace="prod-omi-backend",condition="true",'
+    'pod=~"prod-omi-parakeet-.*"}) == 1)'
+)
+PARAKEET_FATAL_CUDA_RULE = "omi-parakeet-fatal-cuda"
+PARAKEET_FATAL_CUDA_EXPR = (
+    'sum by (pod) (increase(parakeet_gpu_fatal_errors_total{container="parakeet",' 'namespace="prod-omi-backend"}[5m]))'
+)
 
 
 def _rules(path: Path) -> dict[str, dict]:
@@ -156,6 +169,33 @@ def test_parakeet_stream_capacity_alerts_link_the_matching_dashboard_and_runbook
         assert f"{threshold} active streams per ready replica" in runbook
 
     assert PARAKEET_STREAMS_PER_READY_REPLICA in runbook
+
+
+def test_parakeet_alerts_detect_fatal_cuda_and_ready_pod_black_holes():
+    for rules in _all_rule_exports().values():
+        no_success = rules[PARAKEET_READY_POD_NO_SUCCESS_RULE]
+        assert no_success["data"][0]["model"]["expr"] == PARAKEET_READY_POD_NO_SUCCESS_EXPR
+        assert no_success["noDataState"] == "OK"
+        assert no_success["for"] == "2m"
+        assert no_success["labels"]["severity"] == "critical"
+        assert no_success["labels"]["impact"] == "user-experience"
+
+        fatal_cuda = rules[PARAKEET_FATAL_CUDA_RULE]
+        assert fatal_cuda["data"][0]["model"]["expr"] == PARAKEET_FATAL_CUDA_EXPR
+        assert fatal_cuda["noDataState"] == "OK"
+        assert fatal_cuda["for"] == "0s"
+        assert fatal_cuda["labels"]["severity"] == "critical"
+        assert fatal_cuda["labels"]["impact"] == "infrastructure"
+
+
+def test_parakeet_dashboard_uses_application_request_status_labels():
+    dashboard = json.loads(PARAKEET_CAPACITY_DASHBOARD.read_text(encoding="utf-8"))
+
+    for panel_id in (1, 7):
+        panel = next(panel for panel in dashboard["panels"] if panel["id"] == panel_id)
+        expression = panel["targets"][0]["expr"]
+        assert 'status="error"' in expression
+        assert 'status=~"[45].."' not in expression
 
 
 def test_pusher_degradation_uses_listener_emitter_metrics():

--- a/backend/tests/unit/test_parakeet_endpoints.py
+++ b/backend/tests/unit/test_parakeet_endpoints.py
@@ -78,7 +78,7 @@ def _parakeet_modules():
         yield
 
 
-def _make_app_with_mocks(gpu_ready=True, nim_mode=False):
+def _make_app_with_mocks(gpu_ready=True, nim_mode=False, fatal_cuda_reason=None):
     import importlib.util
 
     parakeet_main = sys.modules.get("main")
@@ -95,6 +95,7 @@ def _make_app_with_mocks(gpu_ready=True, nim_mode=False):
 
     mock_gpu = MagicMock(spec=GPUWorker)
     mock_gpu.is_ready = gpu_ready
+    mock_gpu.fatal_cuda_reason = fatal_cuda_reason
 
     mock_engine = MagicMock(spec=BatchEngine)
     mock_engine._pending = []
@@ -136,6 +137,34 @@ class TestHealthEndpoint:
         assert data["status"] == "healthy"
         assert data["ready"] is True
 
+    def test_health_returns_503_after_fatal_cuda_error(self):
+        app, mod, _, _ = _make_app_with_mocks(gpu_ready=False, fatal_cuda_reason="stream_capture")
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/health")
+        assert resp.status_code == 503
+        assert resp.json()["status"] == "unhealthy"
+        assert resp.json()["reason"] == "stream_capture"
+
+    def test_exact_incident_error_transitions_real_worker_health_to_unhealthy(self):
+        app, mod, _, _ = _make_app_with_mocks(gpu_ready=True)
+        worker = GPUWorker()
+        worker._ready.set()
+        mod.gpu_worker = worker
+
+        assert worker.report_inference_error(
+            RuntimeError("CUDA error: operation not permitted when stream is capturing")
+        )
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/health")
+        assert resp.status_code == 503
+        assert resp.json() == {
+            "status": "unhealthy",
+            "ready": False,
+            "uptime_seconds": resp.json()["uptime_seconds"],
+            "reason": "stream_capture",
+        }
+
     def test_health_returns_200_nim_mode(self):
         app, mod, _, _ = _make_app_with_mocks(nim_mode=True)
         client = TestClient(app, raise_server_exceptions=False)
@@ -164,6 +193,18 @@ class TestBatchMetricsEndpoint:
 
 
 class TestStreamAdmissionEndpoint:
+    def test_unhealthy_gpu_rejects_stream_before_admission(self):
+        app, mod, _, _ = _make_app_with_mocks(gpu_ready=False, fatal_cuda_reason="stream_capture")
+        mod.stream_admission = MagicMock()
+
+        client = TestClient(app, raise_server_exceptions=False)
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with client.websocket_connect('/v3/stream') as websocket:
+                websocket.receive_json()
+
+        assert exc_info.value.code == 1013
+        mod.stream_admission.try_acquire.assert_not_called()
+
     def test_capacity_rejection_happens_before_stream_session_construction(self):
         app, mod, _, _ = _make_app_with_mocks(gpu_ready=True)
         mod.stream_admission = MagicMock()
@@ -525,6 +566,7 @@ class TestMetricsEndpoint:
             "parakeet_queue_duration_seconds",
             "parakeet_inference_duration_seconds",
             "parakeet_gpu_oom_total",
+            "parakeet_gpu_fatal_errors_total",
             "parakeet_requests_total",
         ]:
             assert name in body, f"Missing metric: {name}"

--- a/backend/tests/unit/test_parakeet_gpu_worker.py
+++ b/backend/tests/unit/test_parakeet_gpu_worker.py
@@ -72,6 +72,7 @@ def _gpu_worker_module():
         g["WorkItem"] = gw.WorkItem
         g["WorkType"] = gw.WorkType
         g["AudioDurationExceededError"] = gw.AudioDurationExceededError
+        g["classify_fatal_cuda_error"] = gw.classify_fatal_cuda_error
         g["_safe_set_result"] = gw._safe_set_result
         g["_safe_set_exception"] = gw._safe_set_exception
         g["_torch"] = _torch
@@ -99,8 +100,8 @@ def _make_mock_model():
     return model
 
 
-def _start_worker_with_mock():
-    w = GPUWorker()
+def _start_worker_with_mock(on_fatal_cuda_error=None):
+    w = GPUWorker(on_fatal_cuda_error=on_fatal_cuda_error)
     mock_model = _make_mock_model()
     nemo_asr = _get_nemo_asr()
     nemo_asr.models.ASRModel.from_pretrained.return_value = mock_model
@@ -108,6 +109,10 @@ def _start_worker_with_mock():
     w.start()
     w.wait_ready(timeout=10)
     return w
+
+
+class AcceleratorError(RuntimeError):
+    pass
 
 
 class TestGPUWorkerLifecycle:
@@ -154,6 +159,77 @@ class TestGPUWorkerLifecycle:
         blocker.set()
         nemo_asr.models.ASRModel.from_pretrained.side_effect = None
         worker.stop()
+
+
+class TestGPUWorkerFatalCUDA:
+    def test_typed_accelerator_error_is_fatal_without_known_message(self):
+        import gpu_worker as gw_mod
+
+        gw_mod._torch.cuda.AcceleratorError = AcceleratorError
+
+        assert classify_fatal_cuda_error(AcceleratorError("unknown CUDA runtime failure")) == "accelerator_error"
+
+    def test_accelerator_error_fails_worker_closed_and_reports_once(self):
+        import gpu_worker as gw_mod
+
+        gw_mod._torch.cuda.AcceleratorError = AcceleratorError
+        fatal_reasons = []
+        worker = _start_worker_with_mock(on_fatal_cuda_error=fatal_reasons.append)
+        model = worker._model
+        model.transcribe.side_effect = AcceleratorError("CUDA error: operation not permitted when stream is capturing")
+
+        with pytest.raises(AcceleratorError):
+            worker.submit_sync({"audio_paths": ["/tmp/a.wav"], "timestamps": True})
+
+        assert not worker.is_ready
+        assert worker.fatal_cuda_reason == "stream_capture"
+        assert fatal_reasons == ["stream_capture"]
+        assert worker.report_inference_error(AcceleratorError("another CUDA failure"))
+        assert fatal_reasons == ["stream_capture"]
+        with pytest.raises(RuntimeError, match="not ready"):
+            worker.submit_sync({"audio_paths": ["/tmp/b.wav"], "timestamps": True})
+        assert model.transcribe.call_count == 1
+        worker.stop()
+        assert worker._thread is not None and not worker._thread.is_alive()
+
+    def test_ordinary_runtime_error_does_not_poison_next_request(self):
+        worker = _start_worker_with_mock()
+        original_transcribe = worker._model.transcribe.side_effect
+        attempts = 0
+
+        def transient_error(*args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("temporary decoder failure")
+            return original_transcribe(*args, **kwargs)
+
+        worker._model.transcribe.side_effect = transient_error
+        try:
+            with pytest.raises(RuntimeError, match="temporary decoder failure"):
+                worker.submit_sync({"audio_paths": ["/tmp/a.wav"], "timestamps": True})
+            assert worker.is_ready
+
+            result = worker.submit_sync({"audio_paths": ["/tmp/b.wav"], "timestamps": True})
+            assert result[0]["text"] == "transcribed:/tmp/b.wav"
+            assert worker.fatal_cuda_reason is None
+        finally:
+            worker.stop()
+
+    def test_cuda_oom_is_not_classified_as_fatal(self):
+        assert classify_fatal_cuda_error(RuntimeError("CUDA out of memory")) is None
+
+    def test_cuda_graphs_are_rejected_when_streaming_shares_the_gpu(self):
+        worker = GPUWorker()
+        with patch.dict(
+            os.environ,
+            {
+                "PARAKEET_STREAM_MODEL": "nvidia/parakeet-rnnt-1.1b",
+                "PARAKEET_CUDA_GRAPHS": "true",
+            },
+        ):
+            with pytest.raises(ValueError, match="must be false"):
+                worker._load_model()
 
 
 class TestGPUWorkerSubmitSync:
@@ -508,7 +584,13 @@ class TestCUDAGraphConfig:
 
         worker = GPUWorker()
         with patch.dict(
-            os.environ, {"PARAKEET_CUDA_GRAPHS": "true", "PARAKEET_TORCH_COMPILE": "false", "PARAKEET_BF16": "0"}
+            os.environ,
+            {
+                "PARAKEET_STREAM_MODEL": "",
+                "PARAKEET_CUDA_GRAPHS": "true",
+                "PARAKEET_TORCH_COMPILE": "false",
+                "PARAKEET_BF16": "0",
+            },
         ):
             worker._load_model()
 

--- a/backend/tests/unit/test_parakeet_helm_contract.py
+++ b/backend/tests/unit/test_parakeet_helm_contract.py
@@ -35,7 +35,29 @@ def test_parakeet_values_own_explicit_stream_capacity_and_allocation(environment
 
     assert env['PARAKEET_STREAM_CAPACITY'] == '25'
     assert env['PARAKEET_STREAM_ALLOCATION_PERCENT'] == '100'
+    assert env['PARAKEET_CUDA_GRAPHS'] == 'false'
     assert int(values['autoscaling']['requestsPerPod']) < int(env['PARAKEET_STREAM_CAPACITY'])
+
+
+@pytest.mark.parametrize('environment', ['dev', 'prod'])
+def test_parakeet_probes_remove_and_recycle_fatal_gpu_workers(environment):
+    values = _values(environment)
+
+    assert values['readinessProbe'] == {
+        'httpGet': {'path': '/health', 'port': 8080},
+        'failureThreshold': 1,
+        'periodSeconds': 10,
+    }
+    assert values['livenessProbe'] == {
+        'httpGet': {'path': '/health', 'port': 8080},
+        'failureThreshold': 3,
+        'periodSeconds': 10,
+    }
+    assert values['startupProbe'] == {
+        'httpGet': {'path': '/health', 'port': 8080},
+        'failureThreshold': 60,
+        'periodSeconds': 10,
+    }
 
 
 def test_rendered_prod_deployment_contains_stream_admission_settings():
@@ -61,6 +83,12 @@ def test_rendered_prod_deployment_contains_stream_admission_settings():
 
     assert 'name: PARAKEET_STREAM_CAPACITY\n              value: "25"' in rendered
     assert 'name: PARAKEET_STREAM_ALLOCATION_PERCENT\n              value: "100"' in rendered
+    deployment = next(document for document in yaml.safe_load_all(rendered) if document.get('kind') == 'Deployment')
+    container = deployment['spec']['template']['spec']['containers'][0]
+    assert container['readinessProbe']['httpGet']['path'] == '/health'
+    assert container['readinessProbe']['failureThreshold'] == 1
+    assert container['livenessProbe']['httpGet']['path'] == '/health'
+    assert container['livenessProbe']['failureThreshold'] == 3
 
 
 def test_parakeet_deploy_workflow_selects_environment_owned_values_file():

--- a/backend/tests/unit/test_parakeet_stream_session.py
+++ b/backend/tests/unit/test_parakeet_stream_session.py
@@ -54,6 +54,7 @@ def _stream_handler_module():
     mock_transcribe._gpu_worker = None
     mock_transcribe.INFERENCE_MODE = "nemo"
     mock_transcribe.has_builtin_embedding = MagicMock(return_value=False)
+    mock_transcribe.report_gpu_inference_error = MagicMock(return_value=False)
     mock_transcribe.wav_bytes_to_waveform = _mock_wav_bytes_to_waveform
 
     _langdetect = types.ModuleType('langdetect')
@@ -151,6 +152,30 @@ class TestCosineDistance:
         assert sh.cosine_distance is speaker_math.cosine_distance
 
 
+class TestRNNTWarmup:
+    def test_fatal_cuda_error_aborts_startup(self):
+        fatal_error = RuntimeError("CUDA error: operation not permitted when stream is capturing")
+        model = MagicMock()
+        model.decoding.decoding.decoding_computer = object()
+
+        with patch.object(sh, '_asr_model', model), patch.object(
+            sh, '_NemoRNNTStreamingDecoder', side_effect=fatal_error
+        ), patch.object(sh, 'report_gpu_inference_error', return_value=True) as report:
+            with pytest.raises(RuntimeError, match="stream is capturing"):
+                sh.warmup_rnnt_decoder()
+
+        report.assert_called_once_with(fatal_error)
+
+    def test_nonfatal_error_keeps_startup_available(self):
+        model = MagicMock()
+        model.decoding.decoding.decoding_computer = object()
+
+        with patch.object(sh, '_asr_model', model), patch.object(
+            sh, '_NemoRNNTStreamingDecoder', side_effect=RuntimeError("temporary decoder failure")
+        ), patch.object(sh, 'report_gpu_inference_error', return_value=False):
+            sh.warmup_rnnt_decoder()
+
+
 class TestStreamSessionFeed:
 
     def test_silence_produces_no_segments(self):
@@ -229,6 +254,30 @@ class TestStreamSessionRNNTStreaming:
         assert decoder.calls == [(b"abcd", False), (b"ef", False)]
         assert session._streaming_text == "hello world"
         assert session._asr_audio_buf == bytearray()
+
+    def test_fatal_cuda_decode_reports_and_closes_instead_of_falling_back(self):
+        class AcceleratorError(RuntimeError):
+            pass
+
+        session = sh.StreamSession(sample_rate=16000)
+        fatal_error = AcceleratorError("CUDA stream capture failed")
+        with patch.object(session, '_streaming_enabled', return_value=True), patch.object(
+            session, '_drain_streaming_asr_sync', side_effect=fatal_error
+        ), patch.object(sh, 'report_gpu_inference_error', return_value=True) as report:
+            with pytest.raises(AcceleratorError):
+                asyncio.run(session._drain_streaming_asr(force=True))
+
+        report.assert_called_once_with(fatal_error)
+        assert session._streaming_failed is False
+
+    def test_nonfatal_decode_error_keeps_batch_fallback(self):
+        session = sh.StreamSession(sample_rate=16000)
+        with patch.object(session, '_streaming_enabled', return_value=True), patch.object(
+            session, '_drain_streaming_asr_sync', side_effect=RuntimeError("temporary decode failure")
+        ), patch.object(sh, 'report_gpu_inference_error', return_value=False):
+            asyncio.run(session._drain_streaming_asr(force=True))
+
+        assert session._streaming_failed is True
 
     def test_streaming_utterance_does_not_call_batch_transcribe_when_text_not_ready(self):
         session = sh.StreamSession(sample_rate=16000)


### PR DESCRIPTION
## What changed and why

Parakeet could keep a replica Ready after a fatal CUDA stream-capture error, so one poisoned process served only HTTP 500s indefinitely. This disables CUDA graph decoding when batch and streaming inference share the GPU, makes fatal accelerator errors poison the authoritative GPU worker state, and lets health probes recycle the replica.

It also adds per-pod black-hole and fatal-CUDA alerts and fixes the dashboard to use Parakeet's `success`/`error` status labels.

## Product invariants affected

none

## How it was verified

- Recycled the original poisoned production pod and observed its replacement become Ready and serve successful transcriptions with no CUDA/HTTP 500 errors.
- The live Prometheus form of the new black-hole query then detected the same failure recurring on that replacement. Production logs confirmed the exact `cudaErrorStreamCaptureUnsupported` failure.
- Completed a rolling Parakeet-only configuration change to `PARAKEET_CUDA_GRAPHS=false` while the healthy sibling continued serving. Both replacement replicas became Ready with healthy `/health` responses and served 211 real transcriptions immediately after rollout (209 + 2), with zero HTTP 500s and zero fatal-CUDA signatures.
- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_parakeet_gpu_worker.py backend/tests/unit/test_parakeet_endpoints.py backend/tests/unit/test_parakeet_stream_session.py backend/tests/unit/test_parakeet_helm_contract.py backend/tests/unit/test_monitoring_alert_rule_contract.py` — 149 passed.
- `make runtime-image-source-closure` — all 10 registered runtime-image contracts passed.
- `PYTHON=.venv/bin/python bash test-preflight.sh` — 18 checks passed, 0 failed.
- `OMI_PR_BODY_FILE=/tmp/parakeet-pr-body.md make preflight` — all 20 diff-scoped checks passed; the bounded pre-push typecheck, unit-test, OpenAPI, and formatting gate also passed.
- The repository-wide `PYTHON=.venv/bin/python bash test.sh` run reached and passed every Parakeet test, but was not green due unrelated current-tree failures in desktop release contracts and fast-unit timing guards; one unrelated memory-adapter process was interrupted after remaining idle on a live Google connection for more than eight minutes.
- GitHub's backend unit, image-smoke, source-closure, API-contract, sync-gauntlet, and listen-gauntlet checks passed. The broad hermetic E2E job twice reproduced the current unrelated `TestSurfaceDefaultAccessMatrix...[agent_tools]` failure (113 passed, 3 skipped); the identical failure is present on PR #10400, whose diff only touches sync cloud-task files.

The real CUDA concurrency trigger was not reproduced on a development GPU. Its production recurrence and removal by the live configuration rollout provide the runtime evidence.

## Tests

- `test_exact_incident_error_transitions_real_worker_health_to_unhealthy` covers the incident error flowing through the real worker state into HTTP 503 health.
- `TestGPUWorkerFatalCUDA` covers fatal classification, fail-closed admission, callback idempotency, thread shutdown, ordinary error recovery, and OOM separation.
- RNNT tests cover fatal startup/decode propagation and the nonfatal fallback path.
- Helm tests require CUDA graphs off plus HTTP readiness/liveness probes.
- Monitoring contract tests require both per-pod alerts and application status labels.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

This adds `FC-poisoned-accelerator-readiness`. Violated contract: a serving GPU process whose CUDA context is unsafe must not remain Ready or accept more inference. The canonical guard is the GPU worker's fatal state, surfaced through `/health` to Kubernetes readiness/liveness, with CUDA graphs prohibited when batch and streaming inference share a process. Evidence is the 2026-07-23 production incident, its recurrence on replacement pod `prod-omi-parakeet-6cf8b5ccbf-d5786`, and the enabling configuration from PR #7938.

## New guards (only when adding a check or ratchet)

The Helm and monitoring contract checks would have caught the 2026-07-23 Parakeet incident configuration and observability gaps. This is not a shared primitive because CUDA-context validity and Parakeet's mixed batch/streaming decoder configuration are specific to this GPU service.

## Scoped cleanups (optional)

The Parakeet dashboard's HTTP-style `status=~"[45].."` filters were changed to the application's actual `status="error"` label.
