### PR TITLE
feat(desktop): per-tool latency telemetry for realtime voice turns

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -15,6 +15,7 @@ enum DesktopHealthEventName: String {
   case pttAudioCaptureLifecycle = "ptt_audio_capture_lifecycle"
   case voiceTurnStarted = "voice_turn_started"
   case voiceTurnTerminal = "voice_turn_terminal"
+  case voiceToolLatency = "voice_tool_latency"
   case realtimeTokenMintFailed = "realtime_token_mint_failed"
   case realtimeProviderExpectedIdleTeardown = "realtime_provider_expected_idle_teardown"
   case realtimeProviderExpectedSessionRotation = "realtime_provider_expected_session_rotation"
@@ -65,6 +66,10 @@ final class DesktopDiagnosticsManager {
   private var snapshots: [DesktopHealthSnapshot] = []
   private var betaTrailSnapshots: [DesktopHealthSnapshot] = []
   private let snapshotLimit = 150
+  /// Wall-clock start of each in-flight realtime voice tool call, keyed by the
+  /// hub's transport key. A start/stop timer for `voice_tool_latency`; cleared
+  /// on turn reset so it can't grow unbounded.
+  private var voiceToolStarts: [String: Date] = [:]
   private let betaTrailSnapshotLimit = 50
   private var consecutiveNearZeroPTTTurns = 0
   private var lastPTTWatchdogIncidentAt: Date?
@@ -283,6 +288,53 @@ final class DesktopDiagnosticsManager {
         "tcc_microphone_granted": micPermissionGranted,
       ],
       trackRemotely: false)
+  }
+
+  /// Per-tool wall time on a realtime voice turn: from the provider's tool
+  /// request to the result being returned — i.e. the "dead air" the user hears
+  /// while a tool runs. Instruments where voice latency actually goes (fast
+  /// local reads vs. slow backend/RAG round-trips) so optimization targets the
+  /// real cost instead of a guess. Bounded dimensions only: `tool_name` and
+  /// `provider` are a fixed low-cardinality set; no arguments or output content.
+  func recordVoiceToolLatency(toolName: String, provider: String, durationMs: Double, resultBytes: Int) {
+    record(
+      .voiceToolLatency,
+      properties: [
+        "tool_name": toolName,
+        "provider": provider,
+        "duration_ms": rounded(durationMs),
+        "result_bytes": resultBytes,
+      ])
+  }
+
+  /// Start a `voice_tool_latency` timer for a realtime tool call (the hub's
+  /// transport key). Kept here rather than on the hub so the 1500-line
+  /// RealtimeHubController does not grow.
+  func markVoiceToolStart(key: String) {
+    lock.lock()
+    voiceToolStarts[key] = Date()
+    lock.unlock()
+  }
+
+  /// Stop the timer for `key` and emit `voice_tool_latency`. No-op if no start
+  /// was recorded (stale/dropped result).
+  func finishVoiceToolLatency(key: String, toolName: String, provider: String, resultBytes: Int) {
+    lock.lock()
+    let start = voiceToolStarts.removeValue(forKey: key)
+    lock.unlock()
+    guard let start else { return }
+    recordVoiceToolLatency(
+      toolName: toolName,
+      provider: provider,
+      durationMs: Date().timeIntervalSince(start) * 1000,
+      resultBytes: resultBytes)
+  }
+
+  /// Drop any in-flight voice tool timers — called on realtime turn reset.
+  func clearVoiceToolStarts() {
+    lock.lock()
+    voiceToolStarts.removeAll()
+    lock.unlock()
   }
 
   func recordPTTSilentTurn(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -76,6 +76,8 @@ extension RealtimeHubController {
       return
     }
     toolEffectIdentityByTransportKey.removeValue(forKey: key)
+    DesktopDiagnosticsManager.shared.finishVoiceToolLatency(
+      key: key, toolName: name, provider: providerTag, resultBytes: output.utf8.count)
     let turnID = VoiceTurnID(identity.generation)
     let deferredScreenProtocol =
       name == HubTool.screenshot.rawValue
@@ -866,6 +868,8 @@ extension RealtimeHubController {
       log("RealtimeHub[\(providerTag)]: reducer rejected tool call \(name) id=\(callId)")
       return
     }
+    // Tool is admitted for this turn — start the voice_tool_latency timer.
+    DesktopDiagnosticsManager.shared.markVoiceToolStart(key: transportKey)
     if name == HubTool.screenshot.rawValue {
       admitScreenScreenshotRequest(
         source: source,
@@ -1189,6 +1193,7 @@ extension RealtimeHubController {
   func clearRealtimeToolTracking() {
     realtimeToolTurnEpoch += 1
     toolEffectIdentityByTransportKey.removeAll()
+    DesktopDiagnosticsManager.shared.clearVoiceToolStarts()
     authorizedRealtimeInvocations.removeAll()
     authorizedRealtimeScreenshotImages.removeAll()
     acceptedSpawnJournalReceiptByContinuityKey.removeAll()

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -428,6 +428,45 @@ import XCTest
       XCTAssertEqual(snapshot["telemetry_schema_version"] as? Int, 1)
     }
 
+    func testVoiceToolLatencyRecordsBoundedPerToolDuration() throws {
+      DesktopDiagnosticsManager.shared.recordVoiceToolLatency(
+        toolName: "search_conversations",
+        provider: "gemini",
+        durationMs: 4_213.6,
+        resultBytes: 1_842)
+
+      let snapshot = try latestSnapshot()
+      XCTAssertEqual(snapshot["event"] as? String, "voice_tool_latency")
+      XCTAssertEqual(snapshot["tool_name"] as? String, "search_conversations")
+      XCTAssertEqual(snapshot["provider"] as? String, "gemini")
+      XCTAssertEqual(snapshot["result_bytes"] as? Int, 1_842)
+      XCTAssertEqual((snapshot["duration_ms"] as? Double) ?? -1, 4_213.6, accuracy: 0.01)
+    }
+
+    func testVoiceToolLatencyTimerEmitsOnlyForAMatchedStart() throws {
+      // Finish without a start is a no-op (stale/dropped result).
+      DesktopDiagnosticsManager.shared.finishVoiceToolLatency(
+        key: "no-start", toolName: "get_tasks", provider: "openai", resultBytes: 10)
+      // Matched start → finish emits exactly one voice_tool_latency event.
+      DesktopDiagnosticsManager.shared.markVoiceToolStart(key: "call-1")
+      DesktopDiagnosticsManager.shared.finishVoiceToolLatency(
+        key: "call-1", toolName: "get_tasks", provider: "openai", resultBytes: 42)
+
+      let url = try XCTUnwrap(DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment())
+      defer { try? FileManager.default.removeItem(at: url) }
+      let root = try XCTUnwrap(
+        JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any])
+      let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+      let latencyEvents = snapshots.filter { $0["event"] as? String == "voice_tool_latency" }
+
+      XCTAssertEqual(latencyEvents.count, 1)
+      let snapshot = try XCTUnwrap(latencyEvents.last)
+      XCTAssertEqual(snapshot["tool_name"] as? String, "get_tasks")
+      XCTAssertEqual(snapshot["provider"] as? String, "openai")
+      XCTAssertEqual(snapshot["result_bytes"] as? Int, 42)
+      XCTAssertGreaterThanOrEqual((snapshot["duration_ms"] as? Double) ?? -1, 0)
+    }
+
     func testVoiceTurnOutcomeExcludesUserControlledEnds() {
       XCTAssertEqual(DesktopDiagnosticsManager.voiceTurnOutcome(for: "success"), "success")
       XCTAssertEqual(DesktopDiagnosticsManager.voiceTurnOutcome(for: "cancelled"), "excluded")

--- a/desktop/macos/changelog/unreleased/20260723-voice-tool-latency-telemetry.json
+++ b/desktop/macos/changelog/unreleased/20260723-voice-tool-latency-telemetry.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added per-tool voice response latency diagnostics to pinpoint slow voice tools"
+}


### PR DESCRIPTION
## Why

Voice turns feel slow because the realtime model holds the session while a tool
runs synchronously. Existing telemetry only captures **turn-level** duration
(`voice_turn_terminal`) — no per-tool breakdown, so we can't tell whether the
seconds go to fast local reads (`get_tasks`, `execute_sql`) or slow backend/RAG
round-trips (`search_conversations`, `search_memories`).

## What

Emit a **`voice_tool_latency`** desktop health event, measured at the **provider
boundary** (tool request → result) so it's path-independent and covers every
realtime tool. The start/stop timer state lives in `DesktopDiagnosticsManager`
(not on the hub) so the 1500-line `RealtimeHubController` doesn't grow.

Bounded dimensions only: `tool_name`, `provider` (fixed low-cardinality set),
`duration_ms`, `result_bytes` — no arguments or output content.

## How you read it

One PostHog query: `median(duration_ms) by tool_name` (and `by provider`).

## Product invariants affected
- INV-CHAT-1

(Path-based citation: `RealtimeHubController+SessionDelegate.swift` is under the
chat-continuity globs. This change only adds diagnostics `mark`/`finish` calls at
the tool boundary — it does not touch the chat write-path, so the invariant holds.)

## Testing

- `DesktopDiagnosticsManagerTests`: **22/22 pass** on Mac mini; new tests cover the
  bounded emit fields and that the timer emits exactly once for a matched start.
- Desktop **static checks (16/16) pass** on the mini (ratchet, changelog, format,
  swiftlint, main-actor-xctest, test-quality).
- Instrument only — true end-to-end verification is a live PTT turn emitting
  `voice_tool_latency` events (the measurement step itself).
