### PR TITLE
fix(desktop): stop chat freezes from outbox poison, ACP auth stall, and stdout deadlock

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
@@ -1,11 +1,11 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2213,
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4318
+    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2216,
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4330
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": "deleteBackend flag threaded through both clearJournalTurns variants so a reset is local-only",
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "deleteBackend added to the journal_clear_turns wire message"
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "Keep stdout readabilityHandler while the agent child is alive so a full pipe cannot deadlock mid-turn; deleteBackend remains on journal_clear_turns."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
@@ -1,10 +1,10 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6258,
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6300,
     "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2861
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": "Onboarding reset is now local-only (deleteBackend: false) so it no longer hard-deletes cloud chat history; a component split is tracked follow-up.",
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": "ACP authentication now terminalizes the active turn with an explicit disposition instead of awaiting OAuth; a component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": "Already-granted permissions no longer reopen System Settings: screen-recording and full-disk-access requests gate their Settings/drag-card opens behind the granted result."
   },
   "threshold": 1500

--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -567,12 +567,12 @@ class AnalyticsManager {
   func chatQueryTelemetry(_ event: ChatQueryTelemetryEvent) {
     let payload = event.analyticsPayload
     PostHogManager.shared.track(payload.eventName, properties: payload.properties)
-    if case .failed(_, _, let errorClass, _) = event {
+    if case .failed(_, _, let errorClass, _, _) = event {
       DesktopDiagnosticsManager.shared.recordChatFailure(errorClass: errorClass.rawValue)
     }
     let diagnosticKeys = [
       "duration_ms", "error_class", "cancel_reason", "partial_response",
-      "surface", "harness", "runtime_surface",
+      "surface", "harness", "runtime_surface", "session_adapter_id", "watchdog_fired",
     ]
     let diagnostics = diagnosticKeys.compactMap { key -> String? in
       guard let value = payload.properties[key] else { return nil }
@@ -580,6 +580,57 @@ class AnalyticsManager {
     }.joined(separator: " ")
     log(
       "Chat telemetry event=\(payload.eventName) attempt_id=\(payload.properties["attempt_id"] ?? "missing") \(diagnostics)"
+    )
+  }
+
+  func providerAuthRequired(
+    sessionAdapterId: String?,
+    harness: String,
+    bridgeMode: String,
+    oauthUrlValid: Bool
+  ) {
+    guard !Self.isDevBuild else { return }
+    var props: [String: Any] = [
+      "harness": boundedAnalyticsIdentifier(harness),
+      "bridge_mode": boundedAnalyticsIdentifier(bridgeMode),
+      "oauth_url_valid": oauthUrlValid,
+    ]
+    if let sessionAdapterId {
+      props["session_adapter_id"] = boundedAnalyticsIdentifier(sessionAdapterId)
+    }
+    PostHogManager.shared.track("provider_auth_required", properties: props)
+  }
+
+  func claudeOAuthBrowserOpened(harness: String, bridgeMode: String) {
+    guard !Self.isDevBuild else { return }
+    PostHogManager.shared.track(
+      "claude_oauth_browser_opened",
+      properties: [
+        "harness": boundedAnalyticsIdentifier(harness),
+        "bridge_mode": boundedAnalyticsIdentifier(bridgeMode),
+      ]
+    )
+  }
+
+  func claudeOAuthCallbackTimeout(harness: String, bridgeMode: String) {
+    guard !Self.isDevBuild else { return }
+    PostHogManager.shared.track(
+      "claude_oauth_callback_timeout",
+      properties: [
+        "harness": boundedAnalyticsIdentifier(harness),
+        "bridge_mode": boundedAnalyticsIdentifier(bridgeMode),
+      ]
+    )
+  }
+
+  func claudeOAuthCallbackReceived(harness: String, bridgeMode: String) {
+    guard !Self.isDevBuild else { return }
+    PostHogManager.shared.track(
+      "claude_oauth_callback_received",
+      properties: [
+        "harness": boundedAnalyticsIdentifier(harness),
+        "bridge_mode": boundedAnalyticsIdentifier(bridgeMode),
+      ]
     )
   }
 

--- a/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
@@ -2111,6 +2111,9 @@ enum BridgeError: LocalizedError {
     case .agentError(let message):
       return Self.isSessionAuthenticationFailureMessage(message)
     case .agentRuntimeFailure(let failure):
+      if failure.failureCode == .authentication {
+        return true
+      }
       return Self.isSessionAuthenticationFailureMessage(failure.displayMessage)
         || (failure.technicalMessage.map(Self.isSessionAuthenticationFailureMessage) ?? false)
     case .nodeNotFound, .bridgeScriptNotFound, .notRunning, .encodingError, .timeout,

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -3065,7 +3065,15 @@ actor AgentRuntimeProcess {
     handle.readabilityHandler = { [weak self] handle in
       let chunk = chunkReader.read(from: handle)
       guard !chunk.data.isEmpty else {
-        handle.readabilityHandler = nil
+        // Empty availableData usually means EOF. Only detach once the child
+        // has exited — clearing the handler while the agent is still alive
+        // stops Swift from draining stdout and can deadlock Node's writes.
+        Task { [weak self] in
+          let stillRunning = await self?.isAgentProcessRunning(generation: expectedGeneration) ?? false
+          if !stillRunning {
+            handle.readabilityHandler = nil
+          }
+        }
         return
       }
       Task { [weak self] in
@@ -3076,6 +3084,10 @@ actor AgentRuntimeProcess {
         )
       }
     }
+  }
+
+  private func isAgentProcessRunning(generation: UInt64) -> Bool {
+    generation == processGeneration && process?.isRunning == true
   }
 
   private func processStdoutData(_ data: Data, sequence: UInt64, generation: UInt64) {

--- a/desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
@@ -57,6 +57,8 @@ enum ChatQueryFailureDisposition: Equatable, Sendable {
         return .failed(.authentication)
       case .agentError where bridgeError.isSessionAuthenticationFailure:
         return .failed(.authentication)
+      case .agentRuntimeFailure(let failure) where failure.failureCode == .authentication:
+        return .failed(.authentication)
       case .failedToStart:
         return .failed(.bridgeStartFailed)
       case .nodeNotFound, .bridgeScriptNotFound, .notRunning, .processExited, .restarting:
@@ -92,6 +94,8 @@ struct ChatQueryTelemetryContext: Equatable, Sendable {
   let attemptId: String
   let surface: String
   let harness: String
+  let bridgeModePreference: String?
+  let sessionAdapterId: String?
   let runtimeSurface: String?
   let inputLengthBucket: String
   let attachmentCount: Int
@@ -101,6 +105,8 @@ struct ChatQueryTelemetryContext: Equatable, Sendable {
     attemptId: String,
     surface: String,
     harness: String,
+    bridgeModePreference: String? = nil,
+    sessionAdapterId: String? = nil,
     runtimeSurface: String? = nil,
     inputLengthBucket: String = "unknown",
     attachmentCount: Int = 0,
@@ -109,6 +115,8 @@ struct ChatQueryTelemetryContext: Equatable, Sendable {
     self.attemptId = attemptId
     self.surface = surface
     self.harness = harness
+    self.bridgeModePreference = bridgeModePreference.map { String($0.prefix(64)) }
+    self.sessionAdapterId = sessionAdapterId.map { String($0.prefix(64)) }
     self.runtimeSurface = runtimeSurface
     self.inputLengthBucket = inputLengthBucket
     self.attachmentCount = attachmentCount
@@ -205,7 +213,8 @@ enum ChatQueryTelemetryEvent: Equatable, Sendable {
     ChatQueryTelemetryContext,
     durationMs: Int,
     errorClass: ChatQueryErrorClass,
-    partialResponse: Bool
+    partialResponse: Bool,
+    watchdogFired: Bool = false
   )
   case cancelled(
     ChatQueryTelemetryContext,
@@ -253,13 +262,14 @@ extension ChatQueryTelemetryEvent {
       if let runtimeAttemptId = metrics.runtimeAttemptId {
         properties["runtime_attempt_id"] = runtimeAttemptId
       }
-    case .failed(let eventContext, let durationMs, let errorClass, let partialResponse):
+    case .failed(let eventContext, let durationMs, let errorClass, let partialResponse, let watchdogFired):
       eventName = "chat_agent_error"
       context = eventContext
       properties = [
         "duration_ms": durationMs,
         "error_class": errorClass.rawValue,
         "partial_response": partialResponse,
+        "watchdog_fired": watchdogFired,
       ]
     case .cancelled(let eventContext, let durationMs, let reason, let partialResponse):
       eventName = "chat_agent_query_cancelled"
@@ -274,6 +284,20 @@ extension ChatQueryTelemetryEvent {
     properties["attempt_id"] = context.attemptId
     properties["surface"] = context.surface
     properties["harness"] = context.harness
+    if let bridgeModePreference = context.bridgeModePreference {
+      properties["bridge_mode_preference"] = bridgeModePreference
+    }
+    if let sessionAdapterId = context.sessionAdapterId {
+      properties["session_adapter_id"] = sessionAdapterId
+      let harnessNorm = context.harness.lowercased()
+      let adapterNorm = sessionAdapterId.lowercased()
+      let harnessMatchesAdapter =
+        harnessNorm == adapterNorm
+        || (harnessNorm == "pimono" && adapterNorm == "pi-mono")
+      if !harnessMatchesAdapter {
+        properties["adapter_harness_mismatch"] = true
+      }
+    }
     properties["input_length_bucket"] = context.inputLengthBucket
     properties["attachment_count"] = context.attachmentCount
     properties["has_image"] = context.hasImage
@@ -281,11 +305,15 @@ extension ChatQueryTelemetryEvent {
       properties["runtime_surface"] = runtimeSurface
     }
     properties["telemetry_schema_version"] = 2
-    if case .failed(_, _, let errorClass, _) = self {
+    if case .failed(_, _, let errorClass, _, _) = self {
       // One-release compatibility alias for existing PostHog breakdowns.
       // It is bounded and contains the same value as `error_class`, never the
       // raw exception. Remove after LXEMscAj and Hermes exports migrate to v2.
       properties["error"] = errorClass.rawValue
+      if errorClass == .authentication {
+        properties["turn_disposition"] = "auth_blocked"
+        properties["root_cause"] = "provider_claude"
+      }
     }
     return ChatQueryAnalyticsPayload(eventName: eventName, properties: properties)
   }
@@ -306,12 +334,16 @@ final class ChatQueryTelemetryAttempt {
 
   private let elapsedMilliseconds: () -> Int
   private let eventSink: EventSink
+  private var boundSessionAdapterId: String?
+  private var boundBridgeModePreference: String?
   private(set) var isTerminal = false
 
   init(
     attemptId: String = UUID().uuidString,
     surface: String,
     harness: String,
+    bridgeModePreference: String? = nil,
+    sessionAdapterId: String? = nil,
     runtimeSurface: String? = nil,
     inputLength: Int = 0,
     attachmentCount: Int = 0,
@@ -323,6 +355,8 @@ final class ChatQueryTelemetryAttempt {
       attemptId: attemptId,
       surface: String(surface.prefix(64)),
       harness: String(harness.prefix(64)),
+      bridgeModePreference: bridgeModePreference.map { String($0.prefix(64)) },
+      sessionAdapterId: sessionAdapterId,
       runtimeSurface: runtimeSurface.map { String($0.prefix(64)) },
       inputLengthBucket: Self.inputLengthBucket(inputLength),
       attachmentCount: min(max(0, attachmentCount), 20),
@@ -341,13 +375,46 @@ final class ChatQueryTelemetryAttempt {
       }
     }
     self.eventSink = eventSink ?? { AnalyticsManager.shared.chatQueryTelemetry($0) }
-    self.eventSink(.started(context))
+    self.eventSink(.started(eventContext()))
+  }
+
+  func bindSessionAdapter(_ adapterId: String) {
+    boundSessionAdapterId = String(adapterId.prefix(64))
+  }
+
+  func bindBridgeModePreference(_ bridgeMode: String) {
+    boundBridgeModePreference = String(bridgeMode.prefix(64))
+  }
+
+  var resolvedSessionAdapterId: String? {
+    boundSessionAdapterId ?? context.sessionAdapterId
+  }
+
+  private func eventContext() -> ChatQueryTelemetryContext {
+    let sessionAdapterId = boundSessionAdapterId ?? context.sessionAdapterId
+    let bridgeModePreference = boundBridgeModePreference ?? context.bridgeModePreference
+    if sessionAdapterId == context.sessionAdapterId
+      && bridgeModePreference == context.bridgeModePreference
+    {
+      return context
+    }
+    return ChatQueryTelemetryContext(
+      attemptId: context.attemptId,
+      surface: context.surface,
+      harness: context.harness,
+      bridgeModePreference: bridgeModePreference,
+      sessionAdapterId: sessionAdapterId,
+      runtimeSurface: context.runtimeSurface,
+      inputLengthBucket: context.inputLengthBucket,
+      attachmentCount: context.attachmentCount,
+      hasImage: context.hasImage
+    )
   }
 
   @discardableResult
   func complete(metrics: ChatQueryCompletionMetrics) -> Bool {
     guard beginTerminalEvent() else { return false }
-    eventSink(.completed(context, durationMs: durationMs(), metrics: metrics))
+    eventSink(.completed(eventContext(), durationMs: durationMs(), metrics: metrics))
     return true
   }
 
@@ -364,7 +431,11 @@ final class ChatQueryTelemetryAttempt {
       toolStallAbortFired: toolStallAbortFired
     ) {
     case .failed(let errorClass):
-      return fail(errorClass: errorClass, partialResponse: partialResponse)
+      return fail(
+        errorClass: errorClass,
+        partialResponse: partialResponse,
+        watchdogFired: watchdogFired
+      )
     case .cancelled(let reason):
       return cancel(reason: reason, partialResponse: partialResponse)
     }
@@ -386,14 +457,19 @@ final class ChatQueryTelemetryAttempt {
   }
 
   @discardableResult
-  func fail(errorClass: ChatQueryErrorClass, partialResponse: Bool = false) -> Bool {
+  func fail(
+    errorClass: ChatQueryErrorClass,
+    partialResponse: Bool = false,
+    watchdogFired: Bool = false
+  ) -> Bool {
     guard beginTerminalEvent() else { return false }
     eventSink(
       .failed(
-        context,
+        eventContext(),
         durationMs: durationMs(),
         errorClass: errorClass,
-        partialResponse: partialResponse
+        partialResponse: partialResponse,
+        watchdogFired: watchdogFired
       )
     )
     return true
@@ -407,7 +483,7 @@ final class ChatQueryTelemetryAttempt {
     guard beginTerminalEvent() else { return false }
     eventSink(
       .cancelled(
-        context,
+        eventContext(),
         durationMs: durationMs(),
         reason: reason,
         partialResponse: partialResponse

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1999,7 +1999,18 @@ class ChatProvider: ObservableObject {
 
     claudeAuthLaunchRequested = true
     log("ChatProvider: Opening validated Claude OAuth URL in browser")
+    AnalyticsManager.shared.claudeOAuthBrowserOpened(
+      harness: activeBridgeHarness,
+      bridgeMode: bridgeMode
+    )
     NSWorkspace.shared.open(url)
+  }
+
+  private static func providerAuthRequiredUserMessage(isUserClaudeMode: Bool) -> String {
+    if isUserClaudeMode {
+      return "Claude sign-in is required. Reconnect Claude, then try again."
+    }
+    return "This chat uses Claude and needs sign-in. Start a new chat with Omi AI or reconnect Claude in Settings."
   }
 
   private func handleClaudeAuthRequired(methods: [[String: Any]], authUrl: String?) {
@@ -2012,14 +2023,26 @@ class ChatProvider: ObservableObject {
     }
     claudeAuthMethods = methods
     claudeAuthUrl = authUrl
-    isClaudeAuthRequired = true
-    startClaudeAuth()
+    // Provider auth is distinct from the Pro upgrade sheet.
+    isClaudeAuthRequired = false
+
+    let sessionAdapterId = activeChatTelemetryAttempt?.attempt.resolvedSessionAdapterId
+    AnalyticsManager.shared.providerAuthRequired(
+      sessionAdapterId: sessionAdapterId,
+      harness: activeBridgeHarness,
+      bridgeMode: bridgeMode,
+      oauthUrlValid: Self.validatedClaudeOAuthURL(authUrl) != nil
+    )
   }
 
   private func handleClaudeAuthSuccess() {
     isClaudeAuthRequired = false
     claudeAuthLaunchRequested = false
     claudeAuthUrl = nil
+    AnalyticsManager.shared.claudeOAuthCallbackReceived(
+      harness: activeBridgeHarness,
+      bridgeMode: bridgeMode
+    )
     checkClaudeConnectionStatus()
   }
 
@@ -3766,6 +3789,8 @@ class ChatProvider: ObservableObject {
     let accountingPolicy = ChatRunAccountingPolicy(
       pinnedAdapterID: pinnedSession.profile.adapterId
     )
+    telemetryAttempt.bindSessionAdapter(pinnedSession.profile.adapterId)
+    telemetryAttempt.bindBridgeModePreference(bridgeMode)
     let turnUsesOmiAccount = accountingPolicy.usesOmiAccountQuota
     if turnUsesOmiAccount, usageLimiter.serverQuota == nil {
       await usageLimiter.syncQuota()
@@ -3903,7 +3928,11 @@ class ChatProvider: ObservableObject {
             if toolStallAbortFired {
               telemetryAttempt.fail(errorClass: .toolStall, partialResponse: partialResponse)
             } else if watchdogFired {
-              telemetryAttempt.fail(errorClass: .timeout, partialResponse: partialResponse)
+              telemetryAttempt.fail(
+                errorClass: .timeout,
+                partialResponse: partialResponse,
+                watchdogFired: true
+              )
             } else {
               telemetryAttempt.finish(
                 stopReason: turnLifecycle.stopReason ?? self.stopReason(for: sendGen),
@@ -4496,7 +4525,8 @@ class ChatProvider: ObservableObject {
           } else if watchdogFiredBeforeResult {
             telemetryAttempt.fail(
               errorClass: .timeout,
-              partialResponse: hadPartialResponse
+              partialResponse: hadPartialResponse,
+              watchdogFired: true
             )
           } else {
             telemetryAttempt.finish(
@@ -4747,7 +4777,8 @@ class ChatProvider: ObservableObject {
           } else if watchdogFired {
             telemetryAttempt.fail(
               errorClass: .timeout,
-              partialResponse: hadPartialResponse
+              partialResponse: hadPartialResponse,
+              watchdogFired: true
             )
           } else {
             telemetryAttempt.finish(
@@ -4838,7 +4869,11 @@ class ChatProvider: ObservableObject {
         )
         switch telemetryDisposition {
         case .failed(let errorClass):
-          telemetryAttempt.fail(errorClass: errorClass, partialResponse: hadPartialResponse)
+          telemetryAttempt.fail(
+            errorClass: errorClass,
+            partialResponse: hadPartialResponse,
+            watchdogFired: watchdogFired
+          )
           logError(
             "Failed to get AI response attempt_id=\(telemetryAttempt.context.attemptId) error_class=\(errorClass.rawValue)",
             error: error
@@ -4928,6 +4963,13 @@ class ChatProvider: ObservableObject {
         lastFailedPrompt = nil
         currentError = nil
         errorMessage = nil
+      } else if let bridgeError = error as? BridgeError,
+        case .agentRuntimeFailure(let failure) = bridgeError,
+        failure.failureCode == .authentication
+      {
+        currentError = nil
+        errorMessage = Self.providerAuthRequiredUserMessage(isUserClaudeMode: isUserClaudeMode)
+        lastFailedPrompt = trimmedText
       } else if let bridgeError = error as? BridgeError,
         let card = ChatErrorState.from(bridgeError)
       {

--- a/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
@@ -238,6 +238,24 @@ final class ChatErrorStateTests: XCTestCase {
     XCTAssertFalse(BridgeError.agentError("Anthropic provider unauthorized").isSessionAuthenticationFailure)
   }
 
+  // T4: provider auth_required must not present the Pro upgrade sheet.
+  func testAuthRequiredHandlerDoesNotWireProSheet() throws {
+    let source = try sourceFile("Providers/ChatProvider.swift")
+    let range = source.range(of: "func handleClaudeAuthRequired")
+    XCTAssertNotNil(range)
+    let snippet = String(source[range!.lowerBound...]).prefix(900)
+    XCTAssertFalse(snippet.contains("isClaudeAuthRequired = true"))
+    XCTAssertFalse(snippet.contains("startClaudeAuth()"))
+  }
+
+  func testStartClaudeAuthKeepsUserClaudeGuard() throws {
+    let source = try sourceFile("Providers/ChatProvider.swift")
+    let range = source.range(of: "func startClaudeAuth()")
+    XCTAssertNotNil(range)
+    let snippet = String(source[range!.lowerBound...]).prefix(300)
+    XCTAssertTrue(snippet.contains("guard isUserClaudeMode else { return }"))
+  }
+
   func testEnsureBridgeStartedMapsAuthMissingToAuthRequired() throws {
     let source = try sourceFile("Providers/ChatProvider.swift")
     XCTAssertTrue(source.contains("ChatErrorState.from(bridgeError)"))

--- a/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
@@ -241,18 +241,20 @@ final class ChatErrorStateTests: XCTestCase {
   // T4: provider auth_required must not present the Pro upgrade sheet.
   func testAuthRequiredHandlerDoesNotWireProSheet() throws {
     let source = try sourceFile("Providers/ChatProvider.swift")
-    let range = source.range(of: "func handleClaudeAuthRequired")
-    XCTAssertNotNil(range)
-    let snippet = String(source[range!.lowerBound...]).prefix(900)
+    guard let range = source.range(of: "func handleClaudeAuthRequired") else {
+      return XCTFail("missing handleClaudeAuthRequired")
+    }
+    let snippet = String(source[range.lowerBound...]).prefix(900)
     XCTAssertFalse(snippet.contains("isClaudeAuthRequired = true"))
     XCTAssertFalse(snippet.contains("startClaudeAuth()"))
   }
 
   func testStartClaudeAuthKeepsUserClaudeGuard() throws {
     let source = try sourceFile("Providers/ChatProvider.swift")
-    let range = source.range(of: "func startClaudeAuth()")
-    XCTAssertNotNil(range)
-    let snippet = String(source[range!.lowerBound...]).prefix(300)
+    guard let range = source.range(of: "func startClaudeAuth()") else {
+      return XCTFail("missing startClaudeAuth")
+    }
+    let snippet = String(source[range.lowerBound...]).prefix(300)
     XCTAssertTrue(snippet.contains("guard isUserClaudeMode else { return }"))
   }
 

--- a/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
@@ -36,7 +36,7 @@ final class ChatQueryTelemetryTests: XCTestCase {
       Set(payload.properties.keys),
       Set([
         "attempt_id", "surface", "harness", "duration_ms", "error_class", "error",
-        "partial_response", "telemetry_schema_version", "input_length_bucket",
+        "partial_response", "watchdog_fired", "telemetry_schema_version", "input_length_bucket",
         "attachment_count", "has_image",
       ])
     )
@@ -550,5 +550,53 @@ final class ChatQueryTelemetryTests: XCTestCase {
       return XCTFail("expected superseded cancellation")
     }
     XCTAssertEqual(reason, .superseded)
+  }
+
+  // T5: auth-blocked turns classify as authentication with session adapter + disposition.
+  @MainActor
+  func testAuthenticationFailureTelemetryIncludesSessionAdapterAndDisposition() {
+    var events: [ChatQueryTelemetryEvent] = []
+    let attempt = ChatQueryTelemetryAttempt(
+      attemptId: "attempt-auth-blocked",
+      surface: "main_chat",
+      harness: "piMono",
+      bridgeModePreference: "piMono",
+      sessionAdapterId: "acp",
+      eventSink: { events.append($0) }
+    )
+
+    XCTAssertTrue(attempt.fail(errorClass: .authentication))
+    guard case .failed(_, _, let errorClass, _, let watchdogFired) = events.last else {
+      return XCTFail("expected failed terminal event")
+    }
+    XCTAssertEqual(errorClass, .authentication)
+    XCTAssertFalse(watchdogFired)
+
+    let payload = events.last!.analyticsPayload
+    XCTAssertEqual(payload.properties["error_class"] as? String, "authentication")
+    XCTAssertEqual(payload.properties["session_adapter_id"] as? String, "acp")
+    XCTAssertEqual(payload.properties["harness"] as? String, "piMono")
+    XCTAssertEqual(payload.properties["bridge_mode_preference"] as? String, "piMono")
+    XCTAssertEqual(payload.properties["turn_disposition"] as? String, "auth_blocked")
+    XCTAssertEqual(payload.properties["root_cause"] as? String, "provider_claude")
+    XCTAssertEqual(payload.properties["adapter_harness_mismatch"] as? Bool, true)
+    XCTAssertEqual(payload.properties["watchdog_fired"] as? Bool, false)
+  }
+
+  @MainActor
+  func testRuntimeAuthenticationFailureClassifiesAsAuthentication() {
+    let failure = AgentRuntimeFailure(
+      code: "provider_auth_required",
+      failureCode: .authentication,
+      userMessage: "Claude sign-in is required to continue this chat."
+    )
+    let disposition = ChatQueryFailureDisposition.classify(
+      BridgeError.agentRuntimeFailure(failure)
+    )
+    guard case .failed(let errorClass) = disposition else {
+      return XCTFail("expected failed disposition")
+    }
+    XCTAssertEqual(errorClass, .authentication)
+    XCTAssertTrue(BridgeError.agentRuntimeFailure(failure).isSessionAuthenticationFailure)
   }
 }

--- a/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
@@ -566,13 +566,15 @@ final class ChatQueryTelemetryTests: XCTestCase {
     )
 
     XCTAssertTrue(attempt.fail(errorClass: .authentication))
-    guard case .failed(_, _, let errorClass, _, let watchdogFired) = events.last else {
+    guard let terminal = events.last,
+      case .failed(_, _, let errorClass, _, let watchdogFired) = terminal
+    else {
       return XCTFail("expected failed terminal event")
     }
     XCTAssertEqual(errorClass, .authentication)
     XCTAssertFalse(watchdogFired)
 
-    let payload = events.last!.analyticsPayload
+    let payload = terminal.analyticsPayload
     XCTAssertEqual(payload.properties["error_class"] as? String, "authentication")
     XCTAssertEqual(payload.properties["session_adapter_id"] as? String, "acp")
     XCTAssertEqual(payload.properties["harness"] as? String, "piMono")

--- a/desktop/macos/agent/src/adapters/acp.ts
+++ b/desktop/macos/agent/src/adapters/acp.ts
@@ -133,7 +133,8 @@ const RECOVERABLE_AUTH_ERROR_MARKERS = [
  * Restrict wrapped-error matching to known auth markers so unrelated internal
  * errors remain terminal instead of opening a surprise login flow.
  */
-export function isRecoverableAcpAuthError(error: unknown): boolean {
+/** Classifies ACP provider auth failures. Classification-only — never retry OAuth in-band. */
+export function isAcpProviderAuthFailure(error: unknown): boolean {
   if (!(error instanceof AcpError)) return false;
   if (error.code === -32000) return true;
   if (error.code !== -32603) return false;
@@ -149,6 +150,9 @@ export function isRecoverableAcpAuthError(error: unknown): boolean {
   const searchable = `${error.message}\n${data}`.toLowerCase();
   return RECOVERABLE_AUTH_ERROR_MARKERS.some((marker) => searchable.includes(marker));
 }
+
+/** @deprecated Renamed to {@link isAcpProviderAuthFailure}; classify-only, no in-band recovery. */
+export const isRecoverableAcpAuthError = isAcpProviderAuthFailure;
 
 const MAX_RECENT_STDERR_CHARS = 2_000;
 

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -82,6 +82,7 @@ import { isProductionAdapterId, type PromptBlock, type RuntimeAdapter } from "./
 import { detectImageMimeType } from "./mime-detect.js";
 import { AcpError, AcpRuntimeAdapter, isRecoverableAcpAuthError } from "./adapters/acp.js";
 import { AdapterRegistry } from "./runtime/adapter-registry.js";
+import { nextJournalPumpDelayMs } from "./runtime/journal-pump-backoff.js";
 import { JsonlTransport, type McpServerBuildContext } from "./runtime/jsonl-transport.js";
 import { AgentRuntimeKernel } from "./runtime/kernel.js";
 import {
@@ -1457,8 +1458,10 @@ async function main(): Promise<void> {
     }
   };
   let pumpingJournalOutbox = false;
-  const pumpJournalOutbox = () => {
-    if (!ownerAuthorityEstablished || pumpingJournalOutbox) return;
+  // Returns true when the pump ran (or was safely skipped) without throwing, so
+  // the timer can back off while it keeps failing instead of hot-looping.
+  const pumpJournalOutbox = (): boolean => {
+    if (!ownerAuthorityEstablished || pumpingJournalOutbox) return true;
     pumpingJournalOutbox = true;
     try {
       const activeOwnerId = currentOwnerId;
@@ -1481,7 +1484,12 @@ async function main(): Promise<void> {
           targetId: deletion.targetId,
         });
       }
-      for (const delivery of drainBackendTurnOutbox(store, { ownerId: activeOwnerId, limit: 20 })) {
+      for (const delivery of drainBackendTurnOutbox(store, {
+        ownerId: activeOwnerId,
+        limit: 20,
+        onQuarantine: (turnId) =>
+          logErr(`Journal outbox parked turn ${turnId}: canonical payload hash mismatch (not re-delivered)`),
+      })) {
         send({
           type: "journal_backend_sync",
           requestId: `journal:${delivery.turnId}:${delivery.deliveryGeneration}`,
@@ -1496,14 +1504,37 @@ async function main(): Promise<void> {
           payloadHash: delivery.payloadHash,
         });
       }
+      return true;
     } catch (error) {
       logErr(`Journal outbox pump failed: ${error}`);
+      return false;
     } finally {
       pumpingJournalOutbox = false;
     }
   };
-  const journalPumpTimer = setInterval(pumpJournalOutbox, 1_000);
-  journalPumpTimer.unref();
+  // Self-rescheduling timer with exponential backoff: a poisoned outbox row can
+  // make the pump throw indefinitely, so a fixed interval would re-throw every
+  // second forever. Back off on consecutive failures (capped at ~1/min) and snap
+  // back to base cadence the moment a pump completes cleanly.
+  let journalPumpTimer: ReturnType<typeof setTimeout> | undefined;
+  let journalPumpFailureStreak = 0;
+  const scheduleJournalPumpTick = (delayMs: number): void => {
+    journalPumpTimer = setTimeout(runJournalPumpTick, delayMs);
+    journalPumpTimer.unref();
+  };
+  const runJournalPumpTick = (): void => {
+    const clean = pumpJournalOutbox();
+    if (clean) {
+      if (journalPumpFailureStreak > 0) {
+        logErr(`Journal outbox pump recovered after ${journalPumpFailureStreak} consecutive failure(s)`);
+        journalPumpFailureStreak = 0;
+      }
+    } else {
+      journalPumpFailureStreak += 1;
+    }
+    scheduleJournalPumpTick(nextJournalPumpDelayMs(journalPumpFailureStreak));
+  };
+  scheduleJournalPumpTick(nextJournalPumpDelayMs(0));
   // 3. Signal readiness
   send({
     type: "init",
@@ -2941,7 +2972,7 @@ async function main(): Promise<void> {
           "runtime_stopped",
           "Agent runtime stopped during tool execution",
         );
-        clearInterval(journalPumpTimer);
+        if (journalPumpTimer) clearTimeout(journalPumpTimer);
         store.close();
         await acpAdapter.stop();
         await Promise.all([...piMonoAdapters].map((adapter) => adapter.stop()));

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -21,7 +21,7 @@
  * 1. Create Unix socket server for omi-tools relay
  * 2. Spawn claude-code-acp as subprocess (JSON-RPC over stdio)
  * 3. Initialize ACP connection
- * 4. Handle auth if required (forward to Swift, wait for user action)
+ * 4. Handle auth if required (forward to Swift; never await OAuth inside a query/run)
  * 5. On query: reuse or create session, send prompt, translate notifications → JSON-lines
  * 6. On interrupt: cancel the session
  */
@@ -80,7 +80,7 @@ import {
 import { startOAuthFlow, type OAuthFlowHandle } from "./oauth-flow.js";
 import { isProductionAdapterId, type PromptBlock, type RuntimeAdapter } from "./adapters/interface.js";
 import { detectImageMimeType } from "./mime-detect.js";
-import { AcpError, AcpRuntimeAdapter, isRecoverableAcpAuthError } from "./adapters/acp.js";
+import { AcpError, AcpRuntimeAdapter, isAcpProviderAuthFailure } from "./adapters/acp.js";
 import { AdapterRegistry } from "./runtime/adapter-registry.js";
 import { nextJournalPumpDelayMs } from "./runtime/journal-pump-backoff.js";
 import { JsonlTransport, type McpServerBuildContext } from "./runtime/jsonl-transport.js";
@@ -157,6 +157,7 @@ import type {
   ConversationTurnOrigin,
   ConversationTurnStatus,
 } from "./runtime/types.js";
+import { createStdoutLineSender } from "./stdout-line-sender.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -174,12 +175,30 @@ const omiToolsStdioScript = join(__dirname, "omi-tools-stdio.js");
 
 // --- Helpers ---
 
-function send(msg: OutboundMessageDraft): void {
+function logErr(msg: string): void {
+  // Wrap to swallow EPIPE/ERR_STREAM_DESTROYED so a closed parent pipe
+  // doesn't bubble out as an uncaughtException and re-enter our handlers.
   try {
-    process.stdout.write(JSON.stringify(ensureOutboundProtocolVersion(msg)) + "\n");
-  } catch (err) {
+    process.stderr.write(`[agent] ${msg}\n`);
+  } catch {
+    // ignore — parent pipe is gone; we'll exit shortly anyway
+  }
+}
+
+// Queue stdout lines so a full parent pipe waits on `drain` instead of
+// blocking the event loop inside kernel subscribers / query completion.
+const writeStdoutLine = createStdoutLineSender(
+  (chunk) => process.stdout.write(chunk),
+  (listener) => {
+    process.stdout.once("drain", listener);
+  },
+  (err) => {
     logErr(`Failed to write to stdout: ${err}`);
   }
+);
+
+function send(msg: OutboundMessageDraft): void {
+  writeStdoutLine(JSON.stringify(ensureOutboundProtocolVersion(msg)) + "\n");
 }
 
 function runtimeErrorEnvelope(error: unknown): { message: string; failure: ReturnType<typeof failureFromError> } {
@@ -192,16 +211,6 @@ function runtimeErrorEnvelope(error: unknown): { message: string; failure: Retur
     userMessage: message,
   };
   return { message: failure.userMessage, failure };
-}
-
-function logErr(msg: string): void {
-  // Wrap to swallow EPIPE/ERR_STREAM_DESTROYED so a closed parent pipe
-  // doesn't bubble out as an uncaughtException and re-enter our handlers.
-  try {
-    process.stderr.write(`[agent] ${msg}\n`);
-  } catch {
-    // ignore — parent pipe is gone; we'll exit shortly anyway
-  }
 }
 
 function agentStateDir(): string {
@@ -943,6 +952,12 @@ async function restartAcpProcess(): Promise<void> {
  *
  * Idempotent: if a flow is already running, returns the same promise.
  */
+/** Notify Swift that provider auth is required without blocking the active turn. */
+function signalProviderAuthRequired(): void {
+  logErr("ACP provider auth required; signaling Swift without in-band OAuth");
+  send({ type: "auth_required", methods: authMethods });
+}
+
 async function startAuthFlow(): Promise<void> {
   if (activeAuthPromise) {
     logErr("Auth flow already in progress, waiting for it...");
@@ -1242,15 +1257,11 @@ async function main(): Promise<void> {
   logErr(`Omi artifact root: ${artifactStorage.rootDir}`);
   const recoverRunInput = (adapterId: string) => {
     if (adapterId !== "acp") return {};
-    let recoveries = 0;
     return {
-      maxAttempts: 3,
       recoverAfterError: async (error: unknown) => {
-        if (recoveries >= 2 || !isRecoverableAcpAuthError(error)) return false;
-        recoveries += 1;
-        logErr("ACP auth required during run; starting OAuth flow before retry");
-        await startAuthFlow();
-        return true;
+        if (!isAcpProviderAuthFailure(error)) return false;
+        signalProviderAuthRequired();
+        return false;
       },
     };
   };
@@ -1344,11 +1355,10 @@ async function main(): Promise<void> {
     log: logErr,
     defaultAdapterId,
     buildMcpServers,
-    isRecoverableError: (error, adapterId) => adapterId === "acp" && isRecoverableAcpAuthError(error),
+    isRecoverableError: (error, adapterId) => adapterId === "acp" && isAcpProviderAuthFailure(error),
     onRecoverableError: async (_error, adapterId) => {
       if (adapterId !== "acp") return;
-      logErr("ACP auth required during query; starting OAuth flow before retry");
-      await startAuthFlow();
+      signalProviderAuthRequired();
     },
     maxRecoverableRetries: 2,
     activeOwnerId: establishedOwnerId,

--- a/desktop/macos/agent/src/runtime/conversation-journal.ts
+++ b/desktop/macos/agent/src/runtime/conversation-journal.ts
@@ -1748,10 +1748,24 @@ function assertBackendConversationDeleteClaim(
   }
 }
 
+/**
+ * Diagnostic `last_error_code` stamped on an outbox row whose stored payload
+ * hash diverges from the canonical journal turn. Such a row is parked (see
+ * {@link drainBackendTurnOutbox}) so the pump can keep draining; the same code
+ * lets an operator spot the quarantine in the local store.
+ */
+export const OUTBOX_CANONICAL_HASH_MISMATCH_CODE = "canonical_hash_mismatch";
+
 /** Atomically leases completed journal rows for the backend sync adapter. */
 export function drainBackendTurnOutbox(
   store: AgentStore,
-  input: { ownerId?: string; limit?: number; nowMs?: number; leaseMs?: number } = {},
+  input: {
+    ownerId?: string;
+    limit?: number;
+    nowMs?: number;
+    leaseMs?: number;
+    onQuarantine?: (turnId: string) => void;
+  } = {},
 ): BackendTurnDelivery[] {
   const now = input.nowMs ?? Date.now();
   const leaseMs = Math.max(1, input.leaseMs ?? DEFAULT_OUTBOX_LEASE_MS);
@@ -1781,6 +1795,7 @@ export function drainBackendTurnOutbox(
     );
 
     const deliveries: BackendTurnDelivery[] = [];
+    const quarantined: string[] = [];
     for (const candidate of candidates) {
       const turnId = String(candidate.turn_id);
       const currentOutbox = requireOutboxRecord(store, turnId);
@@ -1788,7 +1803,21 @@ export function drainBackendTurnOutbox(
       const payload = backendTurnPayload(turn);
       const payloadHash = backendTurnPayloadHash(payload);
       if (payloadHash !== currentOutbox.payloadHash) {
-        throw new Error("Backend turn outbox revision does not match the canonical journal turn");
+        // Fail closed on a divergence from the canonical turn — but quarantine
+        // this one row instead of throwing. Throwing aborts the whole batch
+        // transaction, so the 1s outbox pump re-selects the same poisoned row
+        // forever, wedging delivery for every turn (observed as an app-wide
+        // stall that persists across restarts because the row is durable).
+        // Parking to 'failed' excludes it from future selection; a later
+        // `updateJournalTurn` re-stamps the hash and re-arms it to 'pending'.
+        store.execute(
+          `UPDATE backend_turn_outbox
+           SET status = 'failed', last_error_code = ?, lease_expires_at_ms = NULL, updated_at_ms = ?
+           WHERE turn_id = ?`,
+          [OUTBOX_CANONICAL_HASH_MISMATCH_CODE, now, turnId],
+        );
+        quarantined.push(turnId);
+        continue;
       }
       const journalState = requireJournalState(store, currentOutbox.conversationId);
       store.execute(
@@ -1802,6 +1831,9 @@ export function drainBackendTurnOutbox(
       );
       const outbox = requireOutboxRecord(store, turnId);
       deliveries.push({ ...outbox, clientMessageId: turnId, turn, payload });
+    }
+    if (input.onQuarantine) {
+      for (const turnId of quarantined) input.onQuarantine(turnId);
     }
     return deliveries;
   });

--- a/desktop/macos/agent/src/runtime/failures.ts
+++ b/desktop/macos/agent/src/runtime/failures.ts
@@ -1,3 +1,4 @@
+import { AcpError, isAcpProviderAuthFailure } from "../adapters/acp.js";
 import type { ProductionAdapterId } from "../adapters/interface.js";
 
 export type RuntimeFailureSource = "adapter_process" | "adapter_execution" | "runtime";
@@ -70,6 +71,17 @@ export function failureFromError(
 ): RuntimeFailure {
   if (error instanceof AdapterRuntimeError) {
     return error.failure;
+  }
+  if (error instanceof AcpError && isAcpProviderAuthFailure(error)) {
+    return normalizeRuntimeFailure({
+      code: "provider_auth_required",
+      failureCode: "authentication",
+      userMessage: "Claude sign-in is required to continue this chat.",
+      technicalMessage: messageFrom(error),
+      source: fallback.source ?? "adapter_execution",
+      adapterId: fallback.adapterId ?? "acp",
+      retryable: false,
+    });
   }
   return normalizeRuntimeFailure({
     ...fallback,

--- a/desktop/macos/agent/src/runtime/journal-pump-backoff.ts
+++ b/desktop/macos/agent/src/runtime/journal-pump-backoff.ts
@@ -1,0 +1,34 @@
+/**
+ * Backoff schedule for the journal outbox pump timer.
+ *
+ * The pump drains durable outbox rows on a timer. If a row is poisoned (its
+ * canonical hash diverges, a referenced journal row is missing, or any other
+ * `require*` throws), the drain throws and the pump makes no progress. A fixed
+ * 1s interval turns that into a hot loop that re-throws every second forever and
+ * survives restarts — the class of bug that wedged chat mid-stream. Backing the
+ * timer off on consecutive failures caps the blast radius of *any* such poison
+ * to at most one attempt (and one log line) per minute, while a single clean
+ * pump snaps the cadence straight back to base.
+ */
+
+/** Base cadence for a healthy pump. */
+export const JOURNAL_PUMP_BASE_INTERVAL_MS = 1_000;
+
+/** Upper bound on the pump interval while it keeps failing. */
+export const JOURNAL_PUMP_MAX_INTERVAL_MS = 60_000;
+
+/** Cap the doubling so the interval saturates at {@link JOURNAL_PUMP_MAX_INTERVAL_MS}. */
+const MAX_BACKOFF_EXPONENT = 6;
+
+/**
+ * Next pump delay given the count of consecutive failed pump ticks. A streak of
+ * 0 (healthy, or recovered) runs at the base cadence; each additional
+ * consecutive failure doubles the delay up to the cap.
+ */
+export function nextJournalPumpDelayMs(failureStreak: number): number {
+  if (!Number.isFinite(failureStreak) || failureStreak <= 0) {
+    return JOURNAL_PUMP_BASE_INTERVAL_MS;
+  }
+  const exponent = Math.min(Math.floor(failureStreak) - 1, MAX_BACKOFF_EXPONENT);
+  return Math.min(JOURNAL_PUMP_MAX_INTERVAL_MS, JOURNAL_PUMP_BASE_INTERVAL_MS * 2 ** exponent);
+}

--- a/desktop/macos/agent/src/runtime/jsonl-transport.ts
+++ b/desktop/macos/agent/src/runtime/jsonl-transport.ts
@@ -627,14 +627,13 @@ export class JsonlTransport {
     if (!this.isRecoverableError || !this.onRecoverableError || this.maxRecoverableRetries === 0) {
       return undefined;
     }
-    let recoveries = 0;
     return async (error) => {
-      if (recoveries >= this.maxRecoverableRetries || !this.isRecoverableError?.(error, adapterId)) {
+      if (!this.isRecoverableError?.(error, adapterId)) {
         return false;
       }
-      recoveries += 1;
       await this.onRecoverableError?.(error, adapterId);
-      return true;
+      // Provider auth is terminal for the active turn; OAuth must not block retries.
+      return false;
     };
   }
 }

--- a/desktop/macos/agent/src/stdout-line-sender.ts
+++ b/desktop/macos/agent/src/stdout-line-sender.ts
@@ -1,0 +1,49 @@
+/**
+ * Backpressure-aware JSONL line sender for the agent→parent stdout pipe.
+ *
+ * Synchronous `process.stdout.write` can block the Node event loop when the
+ * parent stops draining (full pipe). Queue lines and wait for `drain` instead
+ * of stalling kernel/event subscribers mid-turn.
+ */
+
+export type StdoutWrite = (chunk: string) => boolean;
+export type StdoutOnDrain = (listener: () => void) => void;
+export type StdoutWriteError = (error: unknown) => void;
+
+export function createStdoutLineSender(
+  write: StdoutWrite,
+  onDrain: StdoutOnDrain,
+  onWriteError: StdoutWriteError = () => {}
+): (line: string) => void {
+  const queue: string[] = [];
+  let waitingForDrain = false;
+
+  const pump = (): void => {
+    if (waitingForDrain) return;
+    while (queue.length > 0) {
+      const line = queue[0]!;
+      let ok = true;
+      try {
+        ok = write(line);
+      } catch (error) {
+        onWriteError(error);
+        queue.shift();
+        continue;
+      }
+      queue.shift();
+      if (!ok) {
+        waitingForDrain = true;
+        onDrain(() => {
+          waitingForDrain = false;
+          pump();
+        });
+        return;
+      }
+    }
+  };
+
+  return (line: string): void => {
+    queue.push(line);
+    pump();
+  };
+}

--- a/desktop/macos/agent/tests/acp-auth-terminal.test.ts
+++ b/desktop/macos/agent/tests/acp-auth-terminal.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AcpError, isAcpProviderAuthFailure } from "../src/adapters/acp.js";
+import type { OutboundMessageDraft, QueryMessage } from "../src/protocol.js";
+import { JsonlTransport } from "../src/runtime/jsonl-transport.js";
+import { createKernelHarness } from "./kernel-fakes.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+function acpAuthFixture() {
+  const root = mkdtempSync(join(tmpdir(), "omi-acp-auth-"));
+  roots.push(root);
+  const { store, adapter, kernel } = createKernelHarness(join(root, "agent.sqlite"), "acp");
+  const session = store.insertSession({
+    ownerId: "owner",
+    surfaceKind: "main_chat",
+    externalRefKind: "chat",
+    externalRefId: "default",
+    defaultAdapterId: "acp",
+    defaultCwd: "/tmp/pinned-workspace",
+    modelProfile: "pinned-model",
+  });
+  const sent: OutboundMessageDraft[] = [];
+  const logs: string[] = [];
+  let authSignals = 0;
+  let activeOwner = "owner";
+  const transport = new JsonlTransport({
+    kernel,
+    ownerId: "owner",
+    activeOwnerId: () => activeOwner,
+    send: (message) => sent.push(message),
+    log: (message) => logs.push(message),
+    defaultAdapterId: "acp",
+    isRecoverableError: (error, adapterId) =>
+      adapterId === "acp" && isAcpProviderAuthFailure(error),
+    onRecoverableError: async () => {
+      authSignals += 1;
+      sent.push({ type: "auth_required", methods: [] });
+    },
+    maxRecoverableRetries: 2,
+  });
+  return { store, adapter, session, sent, logs, transport, authSignals: () => authSignals };
+}
+
+function query(sessionId: string, overrides: Partial<QueryMessage> = {}): QueryMessage {
+  return {
+    type: "query",
+    protocolVersion: 2,
+    requestId: "request-1",
+    clientId: "client-1",
+    ownerId: "owner",
+    sessionId,
+    prompt: "hello",
+    mode: "act",
+    ...overrides,
+  };
+}
+
+describe("ACP provider auth terminalize-first (T1/T2)", () => {
+  it("T1: -32000 auth failure terminalizes immediately without OAuth retry", async () => {
+    const { store, adapter, session, sent, logs, transport, authSignals } = acpAuthFixture();
+    adapter.failNextExecutionError = new AcpError("Authentication required", -32000);
+
+    const startedAt = Date.now();
+    await transport.handleQuery(query(session.sessionId, { requestId: "request-auth-1" }));
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(elapsedMs).toBeLessThan(1_000);
+    expect(adapter.executed).toHaveLength(1);
+    expect(
+      store.allRows(
+        "SELECT attempt_no, status FROM run_attempts WHERE run_id = (SELECT run_id FROM runs WHERE request_id = ?)",
+        ["request-auth-1"],
+      ),
+    ).toEqual([{ attempt_no: 1, status: "failed" }]);
+    expect(authSignals()).toBe(1);
+    expect(logs.some((line) => line.includes("Auth flow already in progress"))).toBe(false);
+
+    const result = sent.findLast((message) => message.type === "result");
+    expect(result).toMatchObject({
+      type: "result",
+      terminalStatus: "failed",
+      failure: { failureCode: "authentication" },
+    });
+    store.close();
+  });
+
+  it("T2: a second auth failure does not join an in-band OAuth wait", async () => {
+    const { store, adapter, session, logs, transport, authSignals } = acpAuthFixture();
+    adapter.failNextExecutionError = new AcpError("Authentication required", -32000);
+    await transport.handleQuery(query(session.sessionId, { requestId: "request-auth-a" }));
+
+    adapter.failNextExecutionError = new AcpError("Authentication required", -32000);
+    await transport.handleQuery(query(session.sessionId, { requestId: "request-auth-b" }));
+
+    expect(authSignals()).toBe(2);
+    expect(logs.filter((line) => line.includes("Auth flow already in progress"))).toEqual([]);
+    expect(store.getRow("SELECT COUNT(*) AS count FROM run_attempts").count).toBe(2);
+    store.close();
+  });
+});

--- a/desktop/macos/agent/tests/conversation-journal.test.ts
+++ b/desktop/macos/agent/tests/conversation-journal.test.ts
@@ -22,6 +22,7 @@ import {
   journalTurnChangedWakes,
   listJournalTurns,
   migrateJournalConversation,
+  OUTBOX_CANONICAL_HASH_MISMATCH_CODE,
   recordJournalExchange,
   recordJournalTurn,
   settleClearedBackendTurnClaim,
@@ -1272,6 +1273,64 @@ describe("kernel conversation journal", () => {
       attemptCount: 1,
       turn: { turnId: "turn-pending", status: "completed", contentBlocks: blocks, resources },
     });
+    fixture.store.close();
+  });
+
+  it("quarantines a canonical-hash-mismatched outbox row instead of wedging the pump", () => {
+    const fixture = newSurface("main_chat", "chat", "default");
+    // Two completed turns → two pending outbox rows.
+    recordCompletedTextTurn(fixture, "turn-poisoned", "First answer", 10);
+    recordCompletedTextTurn(fixture, "turn-healthy", "Second answer", 20);
+
+    // Simulate the durable corruption seen in the field: the stored outbox
+    // payload hash diverges from the canonical journal turn. Previously this
+    // threw out of the batch transaction, so the 1s pump re-selected the same
+    // row forever and never delivered any turn.
+    fixture.store.execute(
+      "UPDATE backend_turn_outbox SET payload_hash = ? WHERE turn_id = ?",
+      ["stale-divergent-hash", "turn-poisoned"],
+    );
+
+    const quarantined: string[] = [];
+    const deliveries = drainBackendTurnOutbox(fixture.store, {
+      nowMs: 30,
+      onQuarantine: (turnId) => quarantined.push(turnId),
+    });
+
+    // The healthy turn still delivers; the poisoned row is parked, not thrown.
+    expect(deliveries.map((d) => d.turnId)).toEqual(["turn-healthy"]);
+    expect(quarantined).toEqual(["turn-poisoned"]);
+    const parked = fixture.store.getRow(
+      "SELECT status, last_error_code FROM backend_turn_outbox WHERE turn_id = ?",
+      ["turn-poisoned"],
+    );
+    expect(parked).toMatchObject({
+      status: "failed",
+      last_error_code: OUTBOX_CANONICAL_HASH_MISMATCH_CODE,
+    });
+
+    // Re-draining does not re-select the parked row: the pump makes progress and
+    // stops hot-looping (no second quarantine, no throw).
+    const secondQuarantine: string[] = [];
+    const secondPass = drainBackendTurnOutbox(fixture.store, {
+      nowMs: 60,
+      onQuarantine: (turnId) => secondQuarantine.push(turnId),
+    });
+    expect(secondPass).toEqual([]);
+    expect(secondQuarantine).toEqual([]);
+
+    // A later legitimate mutation re-stamps the hash and re-arms delivery.
+    updateJournalTurn(fixture.store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      turnId: "turn-poisoned",
+      content: "First answer, revised",
+      contentBlocks: [{ type: "text", id: "turn-poisoned:text", text: "First answer, revised" }],
+      status: "completed",
+      nowMs: 70,
+    });
+    const rearmed = drainBackendTurnOutbox(fixture.store, { nowMs: 80 });
+    expect(rearmed.map((d) => d.turnId)).toEqual(["turn-poisoned"]);
     fixture.store.close();
   });
 

--- a/desktop/macos/agent/tests/journal-pump-backoff.test.ts
+++ b/desktop/macos/agent/tests/journal-pump-backoff.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  JOURNAL_PUMP_BASE_INTERVAL_MS,
+  JOURNAL_PUMP_MAX_INTERVAL_MS,
+  nextJournalPumpDelayMs,
+} from "../src/runtime/journal-pump-backoff.js";
+
+describe("nextJournalPumpDelayMs", () => {
+  it("runs at base cadence while healthy (streak 0)", () => {
+    expect(nextJournalPumpDelayMs(0)).toBe(JOURNAL_PUMP_BASE_INTERVAL_MS);
+  });
+
+  it("doubles the delay on each consecutive failure", () => {
+    expect(nextJournalPumpDelayMs(1)).toBe(1_000);
+    expect(nextJournalPumpDelayMs(2)).toBe(2_000);
+    expect(nextJournalPumpDelayMs(3)).toBe(4_000);
+    expect(nextJournalPumpDelayMs(4)).toBe(8_000);
+  });
+
+  it("saturates at the cap so a durable poison throttles to ~1/min, not 60/min", () => {
+    expect(nextJournalPumpDelayMs(7)).toBe(JOURNAL_PUMP_MAX_INTERVAL_MS);
+    expect(nextJournalPumpDelayMs(100)).toBe(JOURNAL_PUMP_MAX_INTERVAL_MS);
+    expect(nextJournalPumpDelayMs(Number.POSITIVE_INFINITY)).toBe(JOURNAL_PUMP_BASE_INTERVAL_MS);
+  });
+
+  it("treats a reset/negative/non-integer streak as healthy base cadence", () => {
+    expect(nextJournalPumpDelayMs(-3)).toBe(JOURNAL_PUMP_BASE_INTERVAL_MS);
+    expect(nextJournalPumpDelayMs(Number.NaN)).toBe(JOURNAL_PUMP_BASE_INTERVAL_MS);
+    // A fractional streak floors to the lower step rather than over-delaying.
+    expect(nextJournalPumpDelayMs(2.9)).toBe(2_000);
+  });
+});

--- a/desktop/macos/agent/tests/stdout-line-sender.test.ts
+++ b/desktop/macos/agent/tests/stdout-line-sender.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { createStdoutLineSender } from "../src/stdout-line-sender.js";
+
+describe("createStdoutLineSender", () => {
+  it("writes queued lines immediately while the pipe accepts data", () => {
+    const written: string[] = [];
+    const send = createStdoutLineSender(
+      (chunk) => {
+        written.push(chunk);
+        return true;
+      },
+      () => {
+        throw new Error("drain should not be needed");
+      }
+    );
+
+    send("a\n");
+    send("b\n");
+    expect(written).toEqual(["a\n", "b\n"]);
+  });
+
+  it("waits for drain when write signals backpressure, then flushes the rest", () => {
+    const written: string[] = [];
+    let drainListener: (() => void) | undefined;
+    let accept = false;
+    const send = createStdoutLineSender(
+      (chunk) => {
+        written.push(chunk);
+        return accept;
+      },
+      (listener) => {
+        drainListener = listener;
+      }
+    );
+
+    send("one\n");
+    send("two\n");
+    send("three\n");
+    expect(written).toEqual(["one\n"]);
+    expect(drainListener).toBeTypeOf("function");
+
+    accept = true;
+    drainListener?.();
+    expect(written).toEqual(["one\n", "two\n", "three\n"]);
+  });
+
+  it("continues after a write error instead of wedging the queue", () => {
+    const written: string[] = [];
+    const errors: unknown[] = [];
+    let calls = 0;
+    const send = createStdoutLineSender(
+      (chunk) => {
+        calls += 1;
+        if (calls === 1) throw new Error("EPIPE");
+        written.push(chunk);
+        return true;
+      },
+      () => {},
+      (error) => {
+        errors.push(error);
+      }
+    );
+
+    send("bad\n");
+    send("good\n");
+    expect(errors).toHaveLength(1);
+    expect(written).toEqual(["good\n"]);
+  });
+});

--- a/desktop/macos/changelog/unreleased/20260723-acp-auth-terminalize-first.json
+++ b/desktop/macos/changelog/unreleased/20260723-acp-auth-terminalize-first.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed chat freezes when a Claude-backed session needs sign-in: the app now stops the turn immediately with a clear message instead of spinning for a minute or showing the Pro upgrade sheet"
+}

--- a/desktop/macos/changelog/unreleased/20260723-chat-outbox-pump-wedge.json
+++ b/desktop/macos/changelog/unreleased/20260723-chat-outbox-pump-wedge.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a chat freeze where a single corrupt sync record could wedge the agent forever, leaving replies stuck mid-stream with a spinning loader"
+}

--- a/desktop/macos/changelog/unreleased/20260723-stdout-pipe-drain-deadlock.json
+++ b/desktop/macos/changelog/unreleased/20260723-stdout-pipe-drain-deadlock.json
@@ -1,4 +1,3 @@
 {
-  "summary": "Prevent chat freezes when the agent stdout pipe backs up: Node queues JSONL lines on drain instead of blocking, and Swift keeps reading while the agent process is still alive.",
-  "release_note": true
+  "change": "Prevent chat freezes when the agent stdout pipe backs up: the agent queues JSONL on drain instead of blocking, and the app keeps reading while the agent process is still alive"
 }

--- a/desktop/macos/changelog/unreleased/20260723-stdout-pipe-drain-deadlock.json
+++ b/desktop/macos/changelog/unreleased/20260723-stdout-pipe-drain-deadlock.json
@@ -1,0 +1,4 @@
+{
+  "summary": "Prevent chat freezes when the agent stdout pipe backs up: Node queues JSONL lines on drain instead of blocking, and Swift keeps reading while the agent process is still alive.",
+  "release_note": true
+}


### PR DESCRIPTION
## Summary
- Quarantine canonical-hash-mismatched journal outbox rows and back off the outbox pump so one poison row cannot wedge chat mid-stream.
- Terminalize ACP `Authentication required` on the active turn (no in-turn OAuth wait); leave reconnect out-of-band.
- Drain agent→Swift JSONL under stdout backpressure and keep the Swift reader alive while the child process runs so a full pipe cannot deadlock the turn.

## Product invariants affected
- INV-AGENT-*
- INV-AUTH-1
- INV-CHAT-1

## How it was verified
- Agent hermetic suite including new `tests/journal-pump-backoff.test.ts` (node suite green at commit time).
- Named QA bundle `omi-auth-stall-qa` rebuilt and exercised; chat send path no longer stuck after the auth/pipe scenarios under test.
- Line-count baselines updated for AgentBridge / AgentRuntimeProcess / ChatProvider.
- Pre-push local gate passed (SwiftLint clean; bounded desktop/agent checks).

## Test plan
- [x] Agent hermetic: journal pump backoff + related suite
- [x] Named QA bundle `omi-auth-stall-qa` exercised locally
- [ ] CI desktop Swift / agent checks green
- [ ] Spot-check: unauthenticated Claude/ACP session fails closed with authentication disposition (no forever spinner)
- [ ] Spot-check: long tool-heavy turn still completes (stdout drain)

## Failure class (fixes)

Failure-Class: none

No registered failure class covers this chat-stall cluster yet. Minting registry classes is deferred to a separate PR per AGENTS.md (instance-fix PRs must not mutate `.github/failure-classes/`).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

