### PR TITLE
Fix desktop chat copy output and code blocks

### DIFF
--- a/.github/failure-classes/FC-selection-overlay-layout-loop.json
+++ b/.github/failure-classes/FC-selection-overlay-layout-loop.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "FC-selection-overlay-layout-loop",
+  "violated_contract": "Transient parent or chrome state must not rebuild unchanged AppKit-backed selectable chat content; doing so can make SelectionOverlay repeatedly set fonts, invalidate intrinsic size, and re-enter AttributeGraph layout until the main thread is pinned.",
+  "canonical_prevention": "Place selectable message content behind an Equatable render boundary whose inputs include every content-affecting value, and keep transient feedback state such as copy confirmation in leaf controls below that boundary.",
+  "evidence_prs": [9267],
+  "scope_hints": ["desktop/macos/Desktop/Sources/**"],
+  "status": "open"
+}

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6300,
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6280,
     "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2861
   },
   "raise_justifications": {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
@@ -397,12 +397,13 @@ struct AIResponseView: View {
         .padding(.horizontal, OmiSpacing.xxs)
         .padding(.bottom, OmiSpacing.xs)
         .contextMenu {
+          let finalOutput = message.copyableText
           Button("Copy") {
             NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(message.text, forType: .string)
+            NSPasteboard.general.setString(finalOutput, forType: .string)
           }
           Button("Copy Question & Answer") {
-            let combined = "Q: \(userInput)\n\nA: \(message.text)"
+            let combined = "Q: \(userInput)\n\nA: \(finalOutput)"
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(combined, forType: .string)
           }
@@ -571,7 +572,7 @@ struct MessageHoverOverlay<Content: View>: View {
     // Capture the message's value-type fields once per body evaluation so every
     // button action operates on the exact message the user sees — not whatever
     // `self.message` happens to point to when the click is dispatched.
-    let messageText = message.text
+    let finalOutput = message.copyableText
     let currentRating = message.rating
     return HStack(alignment: .top, spacing: OmiSpacing.xs) {
       Spacer(minLength: 0)
@@ -616,10 +617,10 @@ struct MessageHoverOverlay<Content: View>: View {
             lastSubmittedRating = newValue
           }
 
-          // Copy — captures `messageText` explicitly so we always copy the
+          // Copy — captures `finalOutput` explicitly so we always copy the
           // message this button was drawn for, even if SwiftUI reuses the
           // overlay view across re-renders.
-          Button(action: { [messageText] in copyText(messageText) }) {
+          Button(action: { [finalOutput] in copyText(finalOutput) }) {
             Image(systemName: showCopied ? "checkmark" : "doc.on.doc")
               .scaledFont(size: OmiType.caption)
               .foregroundColor(showCopied ? .green : .secondary)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -2061,9 +2061,9 @@ private struct AgentMainChatView: View {
     } else {
       let trimmed = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
       if !trimmed.isEmpty {
-        Markdown(trimmed)
-          .markdownTheme(.aiMessage(scale: 0.88))
+        SelectableMarkdown(text: trimmed, sender: .ai)
           .textSelection(.enabled)
+          .environment(\.fontScale, 0.88)
           .fixedSize(horizontal: false, vertical: true)
           .frame(maxWidth: .infinity, alignment: .leading)
       }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/SelectableMarkdown.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/SelectableMarkdown.swift
@@ -18,6 +18,25 @@ struct SelectableMarkdown: View {
   let sender: ChatSender
   @Environment(\.fontScale) private var fontScale
 
+  var body: some View {
+    SelectableMarkdownContent(text: text, sender: sender, fontScale: fontScale)
+      .equatable()
+  }
+
+  static func containsGFMTable(_ content: String) -> Bool {
+    SelectableMarkdownContent.containsGFMTable(content)
+  }
+}
+
+/// Keeps parent-only UI feedback (copy checkmarks, hover chrome, ratings) from
+/// rebuilding SwiftUI's AppKit-backed SelectionOverlay for unchanged message
+/// content. SelectionOverlay can otherwise enter a setFont → intrinsic-size →
+/// AttributeGraph update loop and pin the main thread.
+struct SelectableMarkdownContent: View, Equatable {
+  let text: String
+  let sender: ChatSender
+  let fontScale: CGFloat
+
   // Cached parsed segments — pre-computed on init, recomputed only when text changes.
   // Avoids running splitSegments() on every SwiftUI layout pass.
   @State private var cachedSegments: [Segment]
@@ -27,12 +46,16 @@ struct SelectableMarkdown: View {
   @State private var attrCache: [String: AttributedString?] = [:]
   // Font scale at time of caching — used to invalidate when scale changes.
   @State private var cachedFontScale: CGFloat = 0
-  @State private var copiedCodeBlockID: Int?
 
-  init(text: String, sender: ChatSender) {
+  init(text: String, sender: ChatSender, fontScale: CGFloat) {
     self.text = text
     self.sender = sender
+    self.fontScale = fontScale
     self._cachedSegments = State(initialValue: Self.splitSegments(text))
+  }
+
+  nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.text == rhs.text && lhs.sender == rhs.sender && lhs.fontScale == rhs.fontScale
   }
 
   var body: some View {
@@ -47,7 +70,7 @@ struct SelectableMarkdown: View {
             case .text:
               textSegmentView(segment.content)
             case .codeBlock(let language):
-              codeBlockView(segment.content, language: language, id: segment.id)
+              codeBlockView(segment.content, language: language)
             }
           }
         }
@@ -128,7 +151,7 @@ struct SelectableMarkdown: View {
   // MARK: - Code Block (boxed, monospace)
 
   @ViewBuilder
-  private func codeBlockView(_ code: String, language: String?, id: Int) -> some View {
+  private func codeBlockView(_ code: String, language: String?) -> some View {
     let codeFontSize = round(13 * fontScale)
     let bgColor =
       sender == .user
@@ -143,23 +166,7 @@ struct SelectableMarkdown: View {
             .foregroundColor(sender == .user ? .white.opacity(0.7) : OmiColors.textTertiary)
         }
         Spacer(minLength: 0)
-        Button {
-          NSPasteboard.general.clearContents()
-          NSPasteboard.general.setString(code, forType: .string)
-          copiedCodeBlockID = id
-          DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-            if copiedCodeBlockID == id {
-              copiedCodeBlockID = nil
-            }
-          }
-        } label: {
-          Image(systemName: copiedCodeBlockID == id ? "checkmark" : "doc.on.doc")
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(copiedCodeBlockID == id ? .green : OmiColors.textTertiary)
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Copy code")
-        .help("Copy code")
+        CodeBlockCopyButton(code: code)
       }
 
       ScrollView(.horizontal, showsIndicators: false) {
@@ -377,5 +384,30 @@ struct SelectableMarkdown: View {
     }
 
     return segments
+  }
+}
+
+/// Owns transient copy feedback below the selectable-message render boundary.
+/// Updating this leaf must not invalidate the surrounding SelectionOverlay.
+private struct CodeBlockCopyButton: View {
+  let code: String
+  @State private var copied = false
+
+  var body: some View {
+    Button {
+      NSPasteboard.general.clearContents()
+      NSPasteboard.general.setString(code, forType: .string)
+      copied = true
+      DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+        copied = false
+      }
+    } label: {
+      Image(systemName: copied ? "checkmark" : "doc.on.doc")
+        .scaledFont(size: OmiType.caption)
+        .foregroundColor(copied ? .green : OmiColors.textTertiary)
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("Copy code")
+    .help("Copy code")
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/SelectableMarkdown.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/SelectableMarkdown.swift
@@ -1,3 +1,4 @@
+import AppKit
 @preconcurrency import Foundation
 @preconcurrency import MarkdownUI
 import OmiTheme
@@ -26,6 +27,7 @@ struct SelectableMarkdown: View {
   @State private var attrCache: [String: AttributedString?] = [:]
   // Font scale at time of caching — used to invalidate when scale changes.
   @State private var cachedFontScale: CGFloat = 0
+  @State private var copiedCodeBlockID: Int?
 
   init(text: String, sender: ChatSender) {
     self.text = text
@@ -44,8 +46,8 @@ struct SelectableMarkdown: View {
             switch segment.kind {
             case .text:
               textSegmentView(segment.content)
-            case .codeBlock:
-              codeBlockView(segment.content)
+            case .codeBlock(let language):
+              codeBlockView(segment.content, language: language, id: segment.id)
             }
           }
         }
@@ -126,18 +128,46 @@ struct SelectableMarkdown: View {
   // MARK: - Code Block (boxed, monospace)
 
   @ViewBuilder
-  private func codeBlockView(_ code: String) -> some View {
+  private func codeBlockView(_ code: String, language: String?, id: Int) -> some View {
     let codeFontSize = round(13 * fontScale)
     let bgColor =
       sender == .user
       ? Color.white.opacity(0.15)
       : OmiColors.backgroundTertiary
 
-    ScrollView(.horizontal, showsIndicators: false) {
-      Text(code)
-        .font(.system(size: codeFontSize, design: .monospaced))
-        .foregroundColor(sender == .user ? .white : OmiColors.textPrimary)
-        .if_available_writingToolsNone()
+    VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+      HStack(spacing: OmiSpacing.xs) {
+        if let language {
+          Text(language)
+            .scaledFont(size: OmiType.micro, weight: .medium)
+            .foregroundColor(sender == .user ? .white.opacity(0.7) : OmiColors.textTertiary)
+        }
+        Spacer(minLength: 0)
+        Button {
+          NSPasteboard.general.clearContents()
+          NSPasteboard.general.setString(code, forType: .string)
+          copiedCodeBlockID = id
+          DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            if copiedCodeBlockID == id {
+              copiedCodeBlockID = nil
+            }
+          }
+        } label: {
+          Image(systemName: copiedCodeBlockID == id ? "checkmark" : "doc.on.doc")
+            .scaledFont(size: OmiType.caption)
+            .foregroundColor(copiedCodeBlockID == id ? .green : OmiColors.textTertiary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Copy code")
+        .help("Copy code")
+      }
+
+      ScrollView(.horizontal, showsIndicators: false) {
+        Text(code)
+          .font(.system(size: codeFontSize, design: .monospaced))
+          .foregroundColor(sender == .user ? .white : OmiColors.textPrimary)
+          .if_available_writingToolsNone()
+      }
     }
     .padding(OmiSpacing.md)
     .background(bgColor)

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -860,13 +860,20 @@ struct ChatMessage: Identifiable {
 
 extension ChatMessage {
   var copyableText: String {
-    let structuredText =
+    // A completed assistant turn can contain internal reasoning and transient
+    // tool/lifecycle blocks alongside its user-visible answer. The message
+    // copy affordance promises the answer, so retain only final text blocks.
+    let finalOutput =
       contentBlocks
-      .compactMap(\.copyableText)
+      .compactMap { block -> String? in
+        guard case .text(_, let text) = block else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+      }
       .joined(separator: "\n")
       .trimmingCharacters(in: .whitespacesAndNewlines)
-    if !structuredText.isEmpty {
-      return structuredText
+    if !finalOutput.isEmpty {
+      return finalOutput
     }
     return text.trimmingCharacters(in: .whitespacesAndNewlines)
   }
@@ -876,33 +883,6 @@ extension ChatMessage {
       return resources
     }
     return attachments.map(ChatResource.attachment)
-  }
-}
-
-extension ChatContentBlock {
-  var copyableText: String? {
-    switch self {
-    case .text(_, let text):
-      let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-      return trimmed.isEmpty ? nil : trimmed
-    case .thinking(_, let text):
-      let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-      return trimmed.isEmpty ? nil : "Thinking:\n\(trimmed)"
-    case .discoveryCard(_, let title, _, let fullText):
-      let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
-      return trimmed.isEmpty ? title : "\(title)\n\(trimmed)"
-    case .agentSpawn(_, _, _, _, let title, let objective, _):
-      let trimmed = objective.trimmingCharacters(in: .whitespacesAndNewlines)
-      return trimmed.isEmpty ? title : "\(title)\n\(trimmed)"
-    case .agentCompletion(_, _, _, _, let title, let promptSnippet, let output, _):
-      let body = [promptSnippet, output]
-        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-        .filter { !$0.isEmpty }
-        .joined(separator: "\n")
-      return body.isEmpty ? title : "\(title)\n\(body)"
-    case .toolCall:
-      return nil
-    }
   }
 }
 

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -1612,6 +1612,16 @@ import XCTest
     XCTAssertTrue(chatBubbleSource.contains(".markdownTableBackgroundStyle"))
   }
 
+  func testSelectableMarkdownProvidesAnIndependentCodeCopyControl() throws {
+    // omi-test-quality: source-inspection -- static contract: the reusable SwiftUI code-block
+    // renderer owns its copy affordance; clipboard writes are exercised manually in the app.
+    let source = try selectableMarkdownSource()
+
+    XCTAssertTrue(source.contains("private func codeBlockView(_ code: String, language: String?, id: Int)"))
+    XCTAssertTrue(source.contains("NSPasteboard.general.setString(code, forType: .string)"))
+    XCTAssertTrue(source.contains(".help(\"Copy code\")"))
+  }
+
   func testNonProductionBundlesDoNotInstallNativeSentryHandlers() throws {
     let source = try omiAppSource()
     let loggerSource = try loggerSource()

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -390,8 +390,8 @@ import XCTest
     XCTAssertTrue(source.contains("private func groupedContentBlocks(for message: ChatMessage) -> [ContentBlockGroup]"))
     XCTAssertTrue(source.contains("ToolCallsGroup(calls: calls, compact: true)"))
     XCTAssertTrue(source.contains("ThinkingBlock(text: text)"))
-    XCTAssertTrue(source.contains("Markdown(trimmed)"))
-    XCTAssertTrue(source.contains(".markdownTheme(.aiMessage(scale: 0.88))"))
+    XCTAssertTrue(source.contains("SelectableMarkdown(text: trimmed, sender: .ai)"))
+    XCTAssertTrue(source.contains(".environment(\\.fontScale, 0.88)"))
     XCTAssertTrue(source.contains(".frame(width: 36, height: 36)"))
     XCTAssertTrue(source.contains(".contentShape(Rectangle())"))
     XCTAssertTrue(source.contains("let onBackToAgentRows: () -> Void"))
@@ -1612,12 +1612,36 @@ import XCTest
     XCTAssertTrue(chatBubbleSource.contains(".markdownTableBackgroundStyle"))
   }
 
+  func testSelectableMarkdownRenderBoundarySkipsParentOnlyFeedbackUpdates() {
+    let baseline = SelectableMarkdownContent(text: "Final answer", sender: .ai, fontScale: 1)
+
+    XCTAssertEqual(
+      baseline,
+      SelectableMarkdownContent(text: "Final answer", sender: .ai, fontScale: 1),
+      "unchanged message inputs must not rebuild SelectionOverlay when parent copy feedback changes"
+    )
+    XCTAssertNotEqual(
+      baseline,
+      SelectableMarkdownContent(text: "Updated answer", sender: .ai, fontScale: 1)
+    )
+    XCTAssertNotEqual(
+      baseline,
+      SelectableMarkdownContent(text: "Final answer", sender: .user, fontScale: 1)
+    )
+    XCTAssertNotEqual(
+      baseline,
+      SelectableMarkdownContent(text: "Final answer", sender: .ai, fontScale: 1.1)
+    )
+  }
+
   func testSelectableMarkdownProvidesAnIndependentCodeCopyControl() throws {
     // omi-test-quality: source-inspection -- static contract: the reusable SwiftUI code-block
-    // renderer owns its copy affordance; clipboard writes are exercised manually in the app.
+    // renderer owns a leaf-state copy affordance; clipboard writes are exercised manually in the app.
     let source = try selectableMarkdownSource()
 
-    XCTAssertTrue(source.contains("private func codeBlockView(_ code: String, language: String?, id: Int)"))
+    XCTAssertTrue(source.contains("private func codeBlockView(_ code: String, language: String?)"))
+    XCTAssertTrue(source.contains("private struct CodeBlockCopyButton: View"))
+    XCTAssertTrue(source.contains("@State private var copied = false"))
     XCTAssertTrue(source.contains("NSPasteboard.general.setString(code, forType: .string)"))
     XCTAssertTrue(source.contains(".help(\"Copy code\")"))
   }

--- a/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
@@ -533,7 +533,7 @@ final class ChatQueryTelemetryTests: XCTestCase {
       eventSink: { browserEvents.append($0) }
     )
     XCTAssertTrue(browserAttempt.finish(stopReason: .browserExtensionMissing))
-    guard case .failed(_, _, let errorClass, _) = browserEvents.last else {
+    guard case .failed(_, _, let errorClass, _, _) = browserEvents.last else {
       return XCTFail("expected browser precondition failure")
     }
     XCTAssertEqual(errorClass, .browserExtensionMissing)

--- a/desktop/macos/Desktop/Tests/ChatTimelineContinuityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatTimelineContinuityTests.swift
@@ -81,6 +81,46 @@ final class ChatTimelineContinuityTests: XCTestCase {
     XCTAssertFalse(settled.contains(where: isToolCalls))
   }
 
+  func testCopyableTextIncludesOnlyFinalAssistantOutput() {
+    let message = ChatMessage(
+      text: "Fallback answer",
+      sender: .ai,
+      contentBlocks: [
+        .thinking(id: "thinking_1", text: "Internal reasoning"),
+        .toolCall(id: "tool_1", name: "search", status: .completed, output: "Raw tool result"),
+        .text(id: "answer_1", text: "Visible final answer"),
+        .agentCompletion(
+          id: "agent_1",
+          pillId: nil,
+          sessionId: nil,
+          runId: nil,
+          title: "Background agent",
+          promptSnippet: "Internal agent prompt",
+          output: "Agent-only result",
+          status: "completed"
+        ),
+      ]
+    )
+
+    XCTAssertEqual(message.copyableText, "Visible final answer")
+  }
+
+  func testFloatingResponseCopiesTheSharedFinalOutputProjection() throws {
+    let root = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    // omi-test-quality: source-inspection -- static contract: floating copy controls use ChatMessage.copyableText.
+    let source = try String(
+      contentsOf: root.appendingPathComponent("Sources/FloatingControlBar/AIResponseView.swift"),
+      encoding: .utf8
+    )
+
+    XCTAssertTrue(source.contains("let finalOutput = message.copyableText"))
+    XCTAssertTrue(source.contains("A: \\(finalOutput)"))
+    XCTAssertTrue(source.contains("Button(action: { [finalOutput] in copyText(finalOutput) })"))
+    XCTAssertFalse(source.contains("setString(message.text, forType: .string)"))
+  }
+
   private func isToolCalls(_ group: ContentBlockGroup) -> Bool {
     if case .toolCalls = group { return true }
     return false

--- a/desktop/macos/changelog/unreleased/20260723-chat-copy-visible-output.json
+++ b/desktop/macos/changelog/unreleased/20260723-chat-copy-visible-output.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed chat copying so it excludes hidden reasoning, and added one-click copy buttons to code blocks"
+}

--- a/desktop/macos/changelog/unreleased/20260723-chat-copy-visible-output.json
+++ b/desktop/macos/changelog/unreleased/20260723-chat-copy-visible-output.json
@@ -1,3 +1,3 @@
 {
-  "change": "Fixed chat copying so it excludes hidden reasoning, and added one-click copy buttons to code blocks"
+  "change": "Fixed chat copying so it excludes hidden reasoning, avoids hangs in selectable messages, and adds one-click copy buttons to code blocks"
 }


### PR DESCRIPTION
## Summary

- Copy only the visible final assistant text from main and floating chat responses.
- Add an accessible one-click copy control to each rendered fenced code block.
- Prevent Copy feedback from rebuilding unchanged selectable Markdown and pinning the main thread in SwiftUI `SelectionOverlay`.
- Repair stale desktop test expectations on this branch so the Swift test target compiles.

## Product invariants

- INV-AGENT-* — agent-card and floating-chat rendering continue to use the shared selectable Markdown surface.
- INV-AUTH-1 — no authentication/session behavior changed.
- INV-CHAT-1 — preserved the shared canonical transcript and the same final-output copy projection in main and floating chat.
- INV-VOICE-1 — no voice-turn behavior changed.
- INV-MEM-1 — no memory behavior changed.

## Failure class

Failure-Class: new

Transient copy confirmation state rebuilt unchanged AppKit-backed selectable chat content. SwiftUI's `SelectionOverlay` then repeatedly called `setFont`, invalidated intrinsic size, and re-entered AttributeGraph layout until the main thread was pinned. `FC-selection-overlay-layout-loop` records the contract and the reusable prevention boundary.

## Verification

- `xcrun swift test --package-path Desktop --filter AgentPillLifecycleTests` — 77 tests passed.
- `xcrun swift test --package-path Desktop --skip-build --filter ChatQueryTelemetryTests` — 25 tests passed.
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed.
- `desktop/macos/scripts/swift-format-wrapper.sh format -i ...` and `git diff --check` — passed.
- Built and launched `/Applications/omi-pr-10421.app` (`com.omi.omi-pr-10421`) against the dev backend on automation port 47921. Clicked the actual macOS Accessibility `Copy` control in a signed-in main chat; clipboard updated, the bridge remained responsive with a fresh snapshot, and the app settled at 1.8% CPU/sleeping instead of the reproduced ~100% SelectionOverlay loop.
- `./scripts/agent-logic-harness.sh --cross-surface-smoke` — passed in the original PR verification.

## Review

- Root cause confirmed from a live stable-app sample: the main thread was looping through `SelectionOverlay.updateNSView`, `NSControl.setFont`, intrinsic-size invalidation, and AttributeGraph after Copy toggled parent feedback state.
- Prior merged PR #9267 fixed the same layout-loop class on agent-card chrome; this PR adds the reusable Equatable message-render boundary and a behavioral regression test.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
