### PR TITLE
perf(chat): reuse Anthropic context prefixes

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2216,
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4330
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4304
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": "deleteBackend flag threaded through both clearJournalTurns variants so a reset is local-only",

--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -23,6 +23,11 @@ DELETE_MESSAGES_BATCH_LIMIT = 200  # Leaves room for one session-counter write p
 DELETE_MESSAGES_CONFLICT_RETRIES = 3
 CHAT_HISTORY_BASE_VISIBLE_MESSAGES = 10
 CHAT_HISTORY_APPEND_EPOCH_MESSAGES = 8
+# Maximum number of reported (hidden) rows to over-fetch per raw Firestore
+# query when reading cache-aligned history. Keeps the raw read bounded even
+# when a user has thousands of lifetime reported messages; the newest page
+# rarely contains more reported rows than this cap.
+CHAT_HISTORY_REPORTED_RAW_SCAN_CAP = 50
 
 
 class ClientMessageIdPayloadConflict(ValueError):
@@ -323,7 +328,12 @@ def get_cache_aligned_messages(
     if visible_limit == 0:
         return []
 
-    raw_limit = min(total, visible_limit + reported)
+    # Cap the raw Firestore read so a large lifetime reported count cannot
+    # cause unbounded document reads on every chat send. The over-fetch only
+    # needs to cover reported rows that fall inside the newest raw page, not
+    # the lifetime total.
+    reported_overfetch = min(reported, CHAT_HISTORY_REPORTED_RAW_SCAN_CAP)
+    raw_limit = min(total, visible_limit + reported_overfetch)
     return get_messages(
         uid,
         limit=raw_limit,

--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 BATCH_LIMIT = 500  # Firestore hard limit
 DELETE_MESSAGES_BATCH_LIMIT = 200  # Leaves room for one session-counter write per deleted message.
 DELETE_MESSAGES_CONFLICT_RETRIES = 3
+CHAT_HISTORY_BASE_VISIBLE_MESSAGES = 10
+CHAT_HISTORY_APPEND_EPOCH_MESSAGES = 8
 
 
 class ClientMessageIdPayloadConflict(ValueError):
@@ -273,6 +275,61 @@ def get_messages(
         message['files'] = [files[file_id] for file_id in message.get('files_id', []) if file_id in files]
 
     return messages
+
+
+def cache_aligned_history_limit(total_visible_messages: int) -> int:
+    """Return a bounded history size whose start moves only at epoch boundaries.
+
+    A fixed newest-N window changes at the front on every chat turn, invalidating
+    Anthropic's cumulative message-prefix cache. This policy keeps at least the
+    existing ten-message continuity window and lets it grow append-only for eight
+    messages before resetting to ten. The request therefore carries 10..17
+    messages, never less history than before and never an unbounded transcript.
+    """
+    if total_visible_messages < 0:
+        raise ValueError('total_visible_messages must be non-negative')
+    if total_visible_messages <= CHAT_HISTORY_BASE_VISIBLE_MESSAGES:
+        return total_visible_messages
+    return CHAT_HISTORY_BASE_VISIBLE_MESSAGES + (
+        (total_visible_messages - CHAT_HISTORY_BASE_VISIBLE_MESSAGES) % CHAT_HISTORY_APPEND_EPOCH_MESSAGES
+    )
+
+
+def get_cache_aligned_messages(
+    uid: str,
+    *,
+    app_id: Optional[str] = None,
+    chat_session_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Read a cache-aligned, scope-safe chat history in newest-first order.
+
+    Reported messages are excluded from the visible count and read. Over-fetching
+    by the scoped reported count guarantees the target number of visible messages
+    even when hidden records fall inside the selected raw Firestore page.
+    """
+    user_ref = db.collection('users').document(uid)
+    scoped_ref = user_ref.collection('messages')
+    if chat_session_id:
+        scoped_ref = scoped_ref.where(filter=FieldFilter('chat_session_id', '==', chat_session_id))
+    else:
+        scoped_ref = scoped_ref.where(filter=FieldFilter('plugin_id', '==', app_id))
+
+    total_result = scoped_ref.count().get()
+    total = int(total_result[0][0].value) if total_result and total_result[0] else 0
+    reported_result = scoped_ref.where(filter=FieldFilter('reported', '==', True)).count().get()
+    reported = int(reported_result[0][0].value) if reported_result and reported_result[0] else 0
+    visible_total = max(0, total - reported)
+    visible_limit = cache_aligned_history_limit(visible_total)
+    if visible_limit == 0:
+        return []
+
+    raw_limit = min(total, visible_limit + reported)
+    return get_messages(
+        uid,
+        limit=raw_limit,
+        app_id=app_id,
+        chat_session_id=chat_session_id,
+    )[:visible_limit]
 
 
 @prepare_for_read(decrypt_func=_prepare_message_for_read)

--- a/backend/llm_gateway/gateway/accounting.py
+++ b/backend/llm_gateway/gateway/accounting.py
@@ -435,11 +435,11 @@ def cache_requested_for_openai_request(request: Mapping[str, Any]) -> bool:
 
 
 def cache_requested_for_anthropic_request(request: Mapping[str, Any]) -> bool:
-    return any(_contains_cache_control(request.get(field)) for field in ('system', 'messages', 'tools'))
+    return _contains_cache_control(request)
 
 
 def cache_write_ttl_for_anthropic_request(request: Mapping[str, Any]) -> str | None:
-    ttls = _cache_control_ttls([request.get(field) for field in ('system', 'messages', 'tools')])
+    ttls = _cache_control_ttls(request)
     if len(ttls) == 1:
         return next(iter(ttls))
     return 'mixed' if ttls else None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,7 +6,7 @@ aiosignal==1.4.0
 aiostream==0.5.2
 alembic==1.13.2
 altair==5.5.0
-anthropic>=0.52.0
+anthropic>=0.111.0
 annotated-types==0.7.0
 antlr4-python3-runtime==4.9.3
 anyio==4.4.0

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -373,7 +373,7 @@ def send_message(
     messages = list(
         reversed(
             Message.deserialize_many_safe(
-                chat_db.get_messages(uid, limit=10, app_id=compat_app_id),
+                chat_db.get_cache_aligned_messages(uid, app_id=compat_app_id, chat_session_id=message.chat_session_id),
                 on_error=lambda record, exc: logger.warning(
                     'Skipping malformed chat message %s for uid=%s: %s',
                     record.get('id') if isinstance(record, dict) else None,

--- a/backend/tests/unit/_chat_router_test_harness.py
+++ b/backend/tests/unit/_chat_router_test_harness.py
@@ -81,6 +81,7 @@ def wire_common_stubs(install) -> SimpleNamespace:
     chat_db = install('database.chat')
     chat_db.get_chat_session = MagicMock(return_value=None)
     chat_db.get_messages = MagicMock(return_value=[])
+    chat_db.get_cache_aligned_messages = MagicMock(return_value=[])
     chat_db.add_message = MagicMock(side_effect=lambda uid, message_data: message_data)
     chat_db.add_message_to_chat_session = MagicMock()
     install('database.conversations')

--- a/backend/tests/unit/test_chat_message_count.py
+++ b/backend/tests/unit/test_chat_message_count.py
@@ -56,3 +56,72 @@ def test_message_count_never_negative():
 
     with patch.object(chat_db, "db", fake_db):
         assert chat_db.get_message_count("u1") == 0
+
+
+def test_cache_aligned_history_limit_grows_then_resets_without_shrinking_below_previous_window():
+    assert [chat_db.cache_aligned_history_limit(total) for total in range(0, 19)] == [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        10,
+    ]
+    assert chat_db.cache_aligned_history_limit(25) == 17
+    assert chat_db.cache_aligned_history_limit(26) == 10
+
+
+def test_cache_aligned_history_read_is_scoped_and_overfetches_hidden_records():
+    fake_db = MagicMock()
+    messages_ref = _messages_ref(fake_db)
+    messages_ref.where.return_value = messages_ref
+    messages_ref.count.return_value.get.side_effect = [_count(21), _count(2)]
+    visible_messages = [{"id": f"m{i}"} for i in range(13)]
+
+    with patch.object(chat_db, "db", fake_db), patch.object(
+        chat_db, "get_messages", return_value=visible_messages
+    ) as get_messages:
+        result = chat_db.get_cache_aligned_messages("u1", app_id="app-1", chat_session_id="session-1")
+
+    # 21 raw - 2 reported = 19 visible; the 10+8 epoch has grown to 11.
+    assert result == visible_messages[:11]
+    get_messages.assert_called_once_with(
+        "u1",
+        limit=13,
+        app_id="app-1",
+        chat_session_id="session-1",
+    )
+    scoped_filters = [call.kwargs["filter"] for call in messages_ref.where.call_args_list]
+    assert [(filter_.field_path, filter_.value) for filter_ in scoped_filters] == [
+        ("chat_session_id", "session-1"),
+        ("reported", True),
+    ]
+
+
+def test_cache_aligned_history_without_session_is_scoped_to_app():
+    fake_db = MagicMock()
+    messages_ref = _messages_ref(fake_db)
+    messages_ref.where.return_value = messages_ref
+    messages_ref.count.return_value.get.side_effect = [_count(1), _count(0)]
+
+    with patch.object(chat_db, "db", fake_db), patch.object(chat_db, "get_messages", return_value=[{"id": "m1"}]):
+        assert chat_db.get_cache_aligned_messages("u1", app_id="app-1") == [{"id": "m1"}]
+
+    scoped_filters = [call.kwargs["filter"] for call in messages_ref.where.call_args_list]
+    assert [(filter_.field_path, filter_.value) for filter_ in scoped_filters] == [
+        ("plugin_id", "app-1"),
+        ("reported", True),
+    ]

--- a/backend/tests/unit/test_chat_message_count.py
+++ b/backend/tests/unit/test_chat_message_count.py
@@ -111,6 +111,35 @@ def test_cache_aligned_history_read_is_scoped_and_overfetches_hidden_records():
     ]
 
 
+def test_cache_aligned_history_caps_reported_overfetch_for_large_lifetime_count():
+    """A large lifetime reported count must not cause unbounded Firestore reads.
+
+    A user with hundreds or thousands of old reported messages should not stream
+    all of them on every chat send. The raw read is capped to
+    CHAT_HISTORY_REPORTED_RAW_SCAN_CAP plus the visible limit.
+    """
+    fake_db = MagicMock()
+    messages_ref = _messages_ref(fake_db)
+    messages_ref.where.return_value = messages_ref
+    # 500 total, 300 reported → 200 visible; visible_limit = 10 + (190 % 8) = 10 + 6 = 16
+    messages_ref.count.return_value.get.side_effect = [_count(500), _count(300)]
+    visible_messages = [{"id": f"m{i}"} for i in range(66)]
+
+    with patch.object(chat_db, "db", fake_db), patch.object(
+        chat_db, "get_messages", return_value=visible_messages
+    ) as get_messages:
+        result = chat_db.get_cache_aligned_messages("u1", app_id="app-1")
+
+    expected_raw_limit = 16 + chat_db.CHAT_HISTORY_REPORTED_RAW_SCAN_CAP  # 16 + 50 = 66
+    get_messages.assert_called_once_with(
+        "u1",
+        limit=min(500, expected_raw_limit),
+        app_id="app-1",
+        chat_session_id=None,
+    )
+    assert result == visible_messages[:16]
+
+
 def test_cache_aligned_history_without_session_is_scoped_to_app():
     fake_db = MagicMock()
     messages_ref = _messages_ref(fake_db)

--- a/backend/tests/unit/test_llm_gateway_accounting.py
+++ b/backend/tests/unit/test_llm_gateway_accounting.py
@@ -159,6 +159,14 @@ def test_anthropic_tool_cache_control_marks_an_explicit_cache_attempt() -> None:
     assert cache_write_ttl_for_anthropic_request(request) == '1h'
 
 
+def test_anthropic_automatic_cache_control_is_accounted() -> None:
+    from llm_gateway.gateway.accounting import cache_requested_for_anthropic_request
+
+    request = {'cache_control': {'type': 'ephemeral', 'ttl': '1h'}, 'messages': []}
+    assert cache_requested_for_anthropic_request(request)
+    assert cache_write_ttl_for_anthropic_request(request) == '1h'
+
+
 def test_rate_card_estimate_uses_cached_input_price_and_never_priceless_unknowns() -> None:
     context = _context()
     trace = AttemptTrace()

--- a/backend/tests/unit/test_llm_gateway_anthropic_passthrough.py
+++ b/backend/tests/unit/test_llm_gateway_anthropic_passthrough.py
@@ -96,6 +96,7 @@ def _agentic_request(**overrides: Any) -> dict[str, Any]:
         ],
         'messages': [{'role': 'user', 'content': 'hello'}],
         'tools': [{'name': 'get_memories_tool', 'description': 'Get memories', 'input_schema': {'type': 'object'}}],
+        'cache_control': {'type': 'ephemeral', 'ttl': '1h'},
         'stream': False,
     }
     body.update(overrides)
@@ -165,6 +166,7 @@ def test_anthropic_messages_passthrough_preserves_cache_control(_reset_anthropic
     assert forwarded['model'] == 'claude-sonnet-5'
     assert 'effort' not in forwarded
     assert forwarded['system'][0]['cache_control'] == {'type': 'ephemeral', 'ttl': '1h'}
+    assert forwarded['cache_control'] == {'type': 'ephemeral', 'ttl': '1h'}
     assert forwarded['tools'][0]['name'] == 'get_memories_tool'
     assert fake.post_calls[0]['headers']['x-api-key'] == 'anthropic-test-key'
 

--- a/backend/tests/unit/test_prompt_cache_integration.py
+++ b/backend/tests/unit/test_prompt_cache_integration.py
@@ -12,6 +12,7 @@ actually import and call the real production functions to verify:
 6. Dynamic sections actually vary per user (otherwise the split is pointless)
 """
 
+import asyncio
 import os
 import sys
 import types
@@ -19,7 +20,7 @@ import importlib
 import importlib.util
 from datetime import timedelta, timezone
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 os.environ.setdefault(
     "ENCRYPTION_SECRET",
@@ -853,6 +854,74 @@ def test_anthropic_cache_control_not_5min_default():
         # Must NOT be the bare {"type": "ephemeral"} form
         if '"type": "ephemeral"' in line or "'type': 'ephemeral'" in line:
             assert "ttl" in line, f"cache_control line missing ttl field: {line.strip()}"
+
+
+async def test_anthropic_agent_loop_moves_automatic_cache_breakpoint_across_tool_iterations():
+    """The production loop asks Anthropic to cache the latest cacheable message on every call."""
+    agentic_mod = _get_agentic_module()
+    calls = []
+    responses = [
+        types.SimpleNamespace(
+            stop_reason="tool_use",
+            content=[
+                types.SimpleNamespace(
+                    type="tool_use",
+                    id="tool-1",
+                    name="lookup",
+                    input={"query": "omi"},
+                )
+            ],
+        ),
+        types.SimpleNamespace(stop_reason="end_turn", content=[]),
+    ]
+
+    class FakeStream:
+        def __init__(self, response):
+            self.response = response
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def __aiter__(self):
+            async def events():
+                if False:
+                    yield None
+
+            return events()
+
+        async def get_final_message(self):
+            return self.response
+
+    def stream(**kwargs):
+        calls.append(kwargs)
+        return FakeStream(responses[len(calls) - 1])
+
+    callback = agentic_mod.AsyncStreamingCallback()
+    safety_guard = MagicMock()
+    safety_guard.should_warn_user.return_value = None
+    safety_guard.get_stats.return_value = {}
+
+    with patch.object(agentic_mod.anthropic_client.messages, "stream", side_effect=stream), patch.object(
+        agentic_mod, "_execute_tool", new=AsyncMock(return_value="tool result")
+    ):
+        await agentic_mod._run_anthropic_agent_stream(
+            "SYSTEM",
+            [{"role": "user", "content": "question"}],
+            [],
+            {"lookup": MagicMock()},
+            callback,
+            [],
+            safety_guard,
+            {},
+        )
+
+    assert len(calls) == 2
+    assert all(call["cache_control"] == {"type": "ephemeral", "ttl": "1h"} for call in calls)
+    assert calls[0]["system"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    assert calls[1]["messages"][-1]["content"][0]["type"] == "tool_result"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -464,6 +464,11 @@ async def _run_anthropic_agent_stream(
                 messages=messages,
                 tools=tool_schemas,
                 max_tokens=8192,
+                # Anthropic moves this breakpoint to the last cacheable message
+                # block on every request. That incrementally caches both the
+                # append-only inter-turn history epoch and each agentic tool-loop
+                # iteration while the explicit system breakpoint remains stable.
+                cache_control={"type": "ephemeral", "ttl": "1h"},
             ) as stream:
                 async for event in stream:
                     # Stream text tokens

--- a/desktop/macos/Backend-Rust/src/routes/chat/request_translation.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/request_translation.rs
@@ -48,10 +48,14 @@ impl ReasoningEffort {
         }
     }
 }
-/// Anthropic server-side web search tool type (same version the Python
-/// backend's agentic chat uses). Executed entirely upstream by Anthropic —
-/// the OpenAI-side client never sees or executes it.
-const WEB_SEARCH_TOOL_TYPE: &str = "web_search_20260209";
+/// Anthropic's direct server-side web search tool. Executed entirely upstream
+/// by Anthropic — the OpenAI-side client never sees or executes it.
+///
+/// Keep this on the basic-search version while the gateway's response parser
+/// owns only the direct `server_tool_use` + `web_search_tool_result` contract.
+/// `web_search_20260209` defaults to code-execution callers and cannot safely
+/// be selected as the direct tool this compatibility route requires.
+const WEB_SEARCH_TOOL_TYPE: &str = "web_search_20250305";
 
 /// Max web searches per request (matches the Python backend's agentic chat).
 const WEB_SEARCH_MAX_USES: u32 = 5;
@@ -64,15 +68,8 @@ fn web_search_tool_def() -> AnthropicToolDef {
         "type": WEB_SEARCH_TOOL_TYPE,
         "name": "web_search",
         "max_uses": WEB_SEARCH_MAX_USES,
-        // Force direct execution. As of web_search_20260209, `allowed_callers`
-        // defaults to ["code_execution_20260120"]: on a programmatic-tool-calling
-        // model (sonnet-4-6 / opus-4-6, the only models we route web search to)
-        // Anthropic runs the search *inside* code execution and returns
-        // `code_execution_tool_result` blocks. Our AnthropicContentBlock enum has
-        // no variant (and no serde(other)) for those, so `receive_anthropic_response`
-        // fails to deserialize and 502s the whole turn. "direct" keeps the search a
-        // plain server tool that returns the `server_tool_use` + `web_search_tool_result`
-        // blocks the parser already handles.
+        // Make the parser contract explicit. The basic tool supports direct
+        // execution and returns the server-tool blocks handled below.
         "allowed_callers": ["direct"],
     }))
 }

--- a/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
@@ -984,14 +984,11 @@ fn test_translate_request_forces_required_web_search_without_client_tools() {
 }
 
 #[test]
-fn test_injected_web_search_tool_forces_direct_caller() {
-    // Regression: web_search_20260209 defaults allowed_callers to
-    // ["code_execution_20260120"] on programmatic-tool-calling models
-    // (sonnet-4-6 / opus-4-6). Under that default Anthropic returns
-    // code_execution_tool_result blocks our AnthropicContentBlock enum can't
-    // deserialize, so every forced web-search turn 502s. The injected tool must
-    // pin the direct caller so the search returns server_tool_use +
-    // web_search_tool_result blocks the parser already handles.
+fn test_injected_web_search_tool_uses_direct_compatible_version() {
+    // Regression: web_search_20260209 only allowed code-execution callers in
+    // the live provider route, so selecting web_search directly returned 400
+    // before the model could answer. The gateway parser owns the basic direct
+    // server-tool contract, so keep its definition on that compatible version.
     let req = test_request(vec![user_message("search the web for HumanPost")]);
 
     let result = translate_request_inner(
@@ -1005,12 +1002,11 @@ fn test_injected_web_search_tool_forces_direct_caller() {
     let tools = result.tools.unwrap();
     let web_search = serde_json::to_value(&tools[0]).unwrap();
     assert_eq!(web_search["name"], "web_search");
-    assert_eq!(web_search["type"], "web_search_20260209");
+    assert_eq!(web_search["type"], "web_search_20250305");
     assert_eq!(
         web_search["allowed_callers"],
         json!(["direct"]),
-        "web_search must pin the direct caller; the default code-execution caller \
-         returns blocks the response parser cannot deserialize (502s the turn)"
+        "web_search must stay on the direct server-tool path the parser handles"
     );
 }
 

--- a/desktop/macos/Backend-Rust/src/routes/retrieval_policy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/retrieval_policy.rs
@@ -142,11 +142,17 @@ const EXPLICIT_PRIVATE_PHRASES: &[&str] = &[
     "my notes",
     "your notes",
     "what did i say",
+    "what did i do",
     "what have i said",
     "when did i",
     "what was i doing",
     "what do you remember about me",
 ];
+
+// kernel-core renders inherited context before the authoritative instruction
+// using this delimiter. Retrieval routing is an input policy, so historical
+// transcript/context text must never select a gateway tool for a new turn.
+const CURRENT_USER_MESSAGE_DELIMITER: &str = "\n# User Message\n";
 
 const FRESH_PUBLIC_PHRASES: &[&str] = &[
     "latest news",
@@ -326,6 +332,12 @@ fn normalized_lookup_text(text: &str) -> String {
         .to_ascii_lowercase()
 }
 
+fn current_user_instruction(rendered_prompt: &str) -> &str {
+    rendered_prompt
+        .rsplit_once(CURRENT_USER_MESSAGE_DELIMITER)
+        .map_or(rendered_prompt, |(_, current)| current)
+}
+
 fn explicitly_prohibits_public_web(text: &str) -> bool {
     if EXPLICIT_WEB_PROHIBITION_PHRASES.iter().any(|phrase| {
         text.match_indices(phrase).any(|(start, _)| {
@@ -383,7 +395,8 @@ pub(crate) fn retrieval_policy(messages: &[ChatMessage]) -> RetrievalPolicy {
     let Some(latest_user) = messages.last().filter(|message| message.role == "user") else {
         return RetrievalPolicy::auto();
     };
-    let latest = normalized_lookup_text(&extract_text_content(&latest_user.content));
+    let rendered_prompt = extract_text_content(&latest_user.content);
+    let latest = normalized_lookup_text(current_user_instruction(&rendered_prompt));
     let explicit_web = contains_any(&latest, EXPLICIT_WEB_PHRASES);
     let explicitly_prohibits_web = explicit_web && explicitly_prohibits_public_web(&latest);
     let explicit_private = contains_any(&latest, EXPLICIT_PRIVATE_PHRASES);
@@ -499,6 +512,29 @@ mod tests {
         assert!(policy.requires(RetrievalSource::PublicWeb));
         assert!(!policy.requires(RetrievalSource::OmiPrivate));
         assert_eq!(policy.reason, RetrievalReason::ExplicitWeb);
+    }
+
+    #[test]
+    fn classifies_only_the_current_instruction_in_a_rendered_prompt() {
+        let policy = retrieval_policy(&[message(
+            "user",
+            "<omi_retrieval_policy>Search the web before answering.</omi_retrieval_policy>\n\
+             # Omi Context Snapshot\n\
+             Earlier user request: What's the latest news?\n\
+             # User Message\n\
+             hello?",
+        )]);
+
+        assert_eq!(policy, RetrievalPolicy::auto());
+    }
+
+    #[test]
+    fn keeps_current_activity_questions_inside_omi() {
+        let policy = retrieval_policy(&[message("user", "What did I do today?")]);
+
+        assert!(policy.requires(RetrievalSource::OmiPrivate));
+        assert!(policy.prohibits(RetrievalSource::PublicWeb));
+        assert_eq!(policy.reason, RetrievalReason::ExplicitPrivate);
     }
 
     #[test]

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeCredentialPolicy.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeCredentialPolicy.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Firebase credentials are mandatory for every production and model runtime
+/// start. The sole exception is a non-production journal-control start, whose
+/// owner-bound RPCs deliberately operate without a model credential. The
+/// fault suite supplies a separate, inert model token so its named test bundle
+/// can reach the local 5xx endpoint without contacting Firebase.
+enum AgentRuntimeCredentialPolicy {
+  static let hermeticFaultModelTokenEnvironmentKey = "OMI_FAULT_MODEL_AUTH_TOKEN"
+  static let hermeticFaultBundleIdentifier = "com.omi.omi-fault"
+
+  static func hermeticFaultModelToken(
+    isNonProduction: Bool,
+    bundleIdentifier: String,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) -> String? {
+    guard isNonProduction, bundleIdentifier == hermeticFaultBundleIdentifier else { return nil }
+    let token =
+      environment[hermeticFaultModelTokenEnvironmentKey]?
+      .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return token.isEmpty ? nil : token
+  }
+
+  static func requiresManagedCredentials(
+    requestedCredentials: Bool,
+    isNonProduction: Bool,
+    hermeticFaultModelToken: String? = nil
+  ) -> Bool {
+    (requestedCredentials || !isNonProduction) && hermeticFaultModelToken == nil
+  }
+
+  /// Named QA bundles have a valid owner-bound token seeded from another app,
+  /// but intentionally lack that app's Firebase SDK session. Let AuthService
+  /// reuse the token until its normal expiry path refreshes it.
+  static func shouldForceRefreshAtStartup(
+    isNonProduction: Bool,
+    isDesktopLocalProfile: Bool
+  ) -> Bool {
+    !isNonProduction && !isDesktopLocalProfile
+  }
+}

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -82,36 +82,6 @@ enum AgentRuntimeStartupAdmission {
   }
 }
 
-/// Firebase credentials are mandatory for every production and model runtime
-/// start. The sole exception is a non-production journal-control start, whose
-/// owner-bound RPCs deliberately operate without a model credential. The
-/// fault suite supplies a separate, inert model token so its named test bundle
-/// can reach the local 5xx endpoint without contacting Firebase.
-enum AgentRuntimeCredentialPolicy {
-  static let hermeticFaultModelTokenEnvironmentKey = "OMI_FAULT_MODEL_AUTH_TOKEN"
-  static let hermeticFaultBundleIdentifier = "com.omi.omi-fault"
-
-  static func hermeticFaultModelToken(
-    isNonProduction: Bool,
-    bundleIdentifier: String,
-    environment: [String: String] = ProcessInfo.processInfo.environment
-  ) -> String? {
-    guard isNonProduction, bundleIdentifier == hermeticFaultBundleIdentifier else { return nil }
-    let token =
-      environment[hermeticFaultModelTokenEnvironmentKey]?
-      .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    return token.isEmpty ? nil : token
-  }
-
-  static func requiresManagedCredentials(
-    requestedCredentials: Bool,
-    isNonProduction: Bool,
-    hermeticFaultModelToken: String? = nil
-  ) -> Bool {
-    (requestedCredentials || !isNonProduction) && hermeticFaultModelToken == nil
-  }
-}
-
 /// Serializes the pipe read and sequence assignment performed by Foundation's
 /// readability callback. The callback may be re-entered on different threads;
 /// sequencing only after `availableData` would still allow a later read to be
@@ -2629,7 +2599,11 @@ actor AgentRuntimeProcess {
         isNonProduction: AppBuild.isNonProduction,
         hermeticFaultModelToken: hermeticFaultModelToken)
     let authService = await MainActor.run { AuthService.shared }
-    let forceRefreshToken = preferredAdapterId == .piMono && !DesktopLocalProfile.isEnabled
+    let forceRefreshToken =
+      preferredAdapterId == .piMono
+      && AgentRuntimeCredentialPolicy.shouldForceRefreshAtStartup(
+        isNonProduction: AppBuild.isNonProduction,
+        isDesktopLocalProfile: DesktopLocalProfile.isEnabled)
     let authHeader = try? await Self.startupAuthHeader(
       requiresCredentials: requiresPiMonoCredentials,
       fetchAuthHeader: {

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -205,6 +205,24 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertEqual(snapshot.ownerSynchronizations, 1)
   }
 
+  func testNamedBundleStartupUsesValidSeededCredentialWithoutForcedRefresh() {
+    XCTAssertFalse(
+      AgentRuntimeCredentialPolicy.shouldForceRefreshAtStartup(
+        isNonProduction: true,
+        isDesktopLocalProfile: false),
+      "a named bundle has no Firebase SDK session to satisfy a forced refresh")
+    XCTAssertFalse(
+      AgentRuntimeCredentialPolicy.shouldForceRefreshAtStartup(
+        isNonProduction: true,
+        isDesktopLocalProfile: true),
+      "the local harness owns its credential lifecycle")
+    XCTAssertTrue(
+      AgentRuntimeCredentialPolicy.shouldForceRefreshAtStartup(
+        isNonProduction: false,
+        isDesktopLocalProfile: false),
+      "production and Beta starts must continue forcing a fresh credential")
+  }
+
   func testKernelJournalMutationClosesTheRuntimeReplayBoundary() async throws {
     let runtime = AgentRuntimeProcess()
     let turn = try XCTUnwrap(

--- a/desktop/macos/agent/src/adapters/pi-mono.ts
+++ b/desktop/macos/agent/src/adapters/pi-mono.ts
@@ -285,7 +285,7 @@ const EXPLICIT_PRIVATE_CONTEXT = [
   "my screen history", "my screen activity", "my calendar", "your calendar",
   "my email", "your email", "my files", "your files", "my tasks", "your tasks",
   "my action items", "my notes", "your notes", "what did i say", "what have i said",
-  "when did i", "what was i doing", "what do you remember about me",
+  "what did i do", "when did i", "what was i doing", "what do you remember about me",
 ];
 
 const PUBLIC_WEB_ACCESS_DENIAL = /\b(?:I\s+)?(?:do\s+not|don't|cannot|can't|can not)\s+(?:(?:have\s+)?(?:direct\s+)?(?:access\s+to\s+)?(?:the\s+)?(?:internet|web(?:[ -]?search)?|browser|real[- ]time(?:\s+\w+){0,2}(?:\s+data)?)(?:\s+(?:or|and)\s+(?:the\s+)?(?:internet|web(?:[ -]?search)?|browser|real[- ]time(?:\s+\w+){0,2}(?:\s+data)?))*|(?:have\s+)?(?:direct\s+)?(?:internet|web(?:[ -]?search)?|browser)\s+access|(?:browse|search)\s+(?:the\s+)?(?:web|internet))/i;

--- a/desktop/macos/agent/src/runtime/context-snapshot.ts
+++ b/desktop/macos/agent/src/runtime/context-snapshot.ts
@@ -528,6 +528,59 @@ export function renderContextSnapshot(
   ].join("\n");
 }
 
+export interface ContextDeliveryCursor {
+  conversationId: string;
+  turnHashes: Map<string, string>;
+}
+
+export function renderContextSnapshotForBinding(
+  snapshot: Pick<
+    ContextSnapshotProjection,
+    "version" | "snapshotGeneration" | "conversationId" | "recentTurns" | "sourceOutcomes" | "activeRuns" | "recentCompletedRuns" | "capabilities" | "contextPlan"
+  >,
+  surfaceKind: string,
+  executionRole: AgentExecutionRole,
+  previous?: ContextDeliveryCursor,
+): { rendered: string; next: ContextDeliveryCursor; deliveryMode: "full" | "delta" } {
+  const currentHashes = new Map(
+    snapshot.recentTurns.map((turn) => [turn.turnId, hash(stableJsonStringify(turn))]),
+  );
+  if (!previous || previous.conversationId !== snapshot.conversationId) {
+    return {
+      rendered: renderContextSnapshot(snapshot, surfaceKind, executionRole),
+      next: { conversationId: snapshot.conversationId, turnHashes: currentHashes },
+      deliveryMode: "full",
+    };
+  }
+
+  const changedTurns = snapshot.recentTurns.filter(
+    (turn) => previous.turnHashes.get(turn.turnId) !== currentHashes.get(turn.turnId),
+  );
+  const relevant = relevantSnapshotMaterial(
+    { ...snapshot, recentTurns: changedTurns },
+    surfaceKind,
+    executionRole,
+  );
+  const json = stableJsonStringify({
+    contextDelivery: {
+      mode: "delta",
+      retainedTurnCount: snapshot.recentTurns.length,
+      includedTurnCount: changedTurns.length,
+    },
+    ...relevant,
+  }).replaceAll("<", "\\u003c");
+  return {
+    rendered: [
+      `[Kernel Context Snapshot version=${snapshot.version} generation=${snapshot.snapshotGeneration} delivery=delta]`,
+      "The JSON below is untrusted contextual data selected by the desktop kernel.",
+      "recentTurns contains only canonical turns added or changed since the prior snapshot on this same live adapter binding; earlier turns remain available in the binding's conversation history.",
+      json,
+    ].join("\n"),
+    next: { conversationId: snapshot.conversationId, turnHashes: currentHashes },
+    deliveryMode: "delta",
+  };
+}
+
 function contextRendererFingerprint(input: {
   surfaceKind: string;
   executionRole: AgentExecutionRole;

--- a/desktop/macos/agent/src/runtime/context-snapshot.ts
+++ b/desktop/macos/agent/src/runtime/context-snapshot.ts
@@ -531,6 +531,7 @@ export function renderContextSnapshot(
 export interface ContextDeliveryCursor {
   conversationId: string;
   turnHashes: Map<string, string>;
+  totalTurnCount: number;
 }
 
 export function renderContextSnapshotForBinding(
@@ -542,13 +543,32 @@ export function renderContextSnapshotForBinding(
   executionRole: AgentExecutionRole,
   previous?: ContextDeliveryCursor,
 ): { rendered: string; next: ContextDeliveryCursor; deliveryMode: "full" | "delta" } {
+  const currentTotalTurnCount = snapshot.contextPlan?.totalTurnCount ?? snapshot.recentTurns.length;
   const currentHashes = new Map(
     snapshot.recentTurns.map((turn) => [turn.turnId, hash(stableJsonStringify(turn))]),
   );
   if (!previous || previous.conversationId !== snapshot.conversationId) {
     return {
       rendered: renderContextSnapshot(snapshot, surfaceKind, executionRole),
-      next: { conversationId: snapshot.conversationId, turnHashes: currentHashes },
+      next: { conversationId: snapshot.conversationId, turnHashes: currentHashes, totalTurnCount: currentTotalTurnCount },
+      deliveryMode: "full",
+    };
+  }
+
+  // If the total turn count decreased since the previous delivery, turns were
+  // hard-deleted (e.g. journal_clear_turns / clearJournalConversation purges
+  // conversation_turns without replacing the live binding). A delta would only
+  // send new/changed IDs with no tombstone for the dropped turns, so the model
+  // would believe the cleared content still exists in the binding's history.
+  // Fall back to a full re-render so the model's view of available turns is
+  // always accurate.
+  //
+  // Normal aging (turns dropping off the 64-turn retention window as new turns
+  // arrive) does NOT trigger this: totalTurnCount only increases in that case.
+  if (currentTotalTurnCount < previous.totalTurnCount) {
+    return {
+      rendered: renderContextSnapshot(snapshot, surfaceKind, executionRole),
+      next: { conversationId: snapshot.conversationId, turnHashes: currentHashes, totalTurnCount: currentTotalTurnCount },
       deliveryMode: "full",
     };
   }
@@ -576,7 +596,7 @@ export function renderContextSnapshotForBinding(
       "recentTurns contains only canonical turns added or changed since the prior snapshot on this same live adapter binding; earlier turns remain available in the binding's conversation history.",
       json,
     ].join("\n"),
-    next: { conversationId: snapshot.conversationId, turnHashes: currentHashes },
+    next: { conversationId: snapshot.conversationId, turnHashes: currentHashes, totalTurnCount: currentTotalTurnCount },
     deliveryMode: "delta",
   };
 }

--- a/desktop/macos/agent/src/runtime/kernel-core.ts
+++ b/desktop/macos/agent/src/runtime/kernel-core.ts
@@ -24,6 +24,8 @@ import {
   inheritContextSnapshotForSession,
   kernelSystemPolicy,
   renderContextSnapshot,
+  renderContextSnapshotForBinding,
+  type ContextDeliveryCursor,
 } from "./context-snapshot.js";
 import { repairPersistedAgentSpawnJournals } from "./agent-spawn-journal.js";
 import {
@@ -172,6 +174,7 @@ export class KernelCore {
   protected readonly subscribers = new Set<KernelEventSubscriber>();
   protected readonly activeExecutions = new Map<string, ActiveExecution>();
   protected readonly bindingResolutionLocks = new Map<string, Promise<void>>();
+  protected readonly contextDeliveryByBinding = new Map<string, ContextDeliveryCursor>();
   protected readonly toolCapabilities: RunToolCapabilityBroker;
   private transactionDepth = 0;
   private pendingSubscriberEvents: AgentEvent[] = [];
@@ -992,17 +995,30 @@ export class KernelCore {
 
       let effectivePrompt = attemptInput.prompt;
       let effectivePromptBlocks = attemptInput.promptBlocks;
+      let nextContextDelivery: ContextDeliveryCursor | undefined;
       if (surfaceRef) {
         const snapshot = attemptInput.admittedContextSnapshot;
         if (!snapshot) throw new Error("Run is missing its admitted context snapshot");
         const attachments = input.attachments?.length
           ? `\n\n# Attachments\n${stableJsonStringify(input.attachments)}`
           : "";
-        effectivePrompt = `${renderContextSnapshot(
-          snapshot,
-          accepted.session.surfaceKind,
-          accepted.session.executionRole,
-        )}${attachments}\n\n# User Message\n${input.prompt}`;
+        const renderedContext = adapterId === "pi-mono" && handle.bindingId
+          ? renderContextSnapshotForBinding(
+              snapshot,
+              accepted.session.surfaceKind,
+              accepted.session.executionRole,
+              this.contextDeliveryByBinding.get(handle.bindingId),
+            )
+          : {
+              rendered: renderContextSnapshot(
+                snapshot,
+                accepted.session.surfaceKind,
+                accepted.session.executionRole,
+              ),
+              next: undefined,
+            };
+        nextContextDelivery = renderedContext.next;
+        effectivePrompt = `${renderedContext.rendered}${attachments}\n\n# User Message\n${input.prompt}`;
         effectivePromptBlocks = attemptInput.promptBlocks
           ? attemptInput.promptBlocks.map((block) =>
               block.type === "text" ? { ...block, text: effectivePrompt } : block,
@@ -1056,6 +1072,9 @@ export class KernelCore {
         });
         this.activeExecutions.delete(accepted.run.runId);
         assertExecutionAuthority();
+        if (handle.bindingId && nextContextDelivery) {
+          this.contextDeliveryByBinding.set(handle.bindingId, nextContextDelivery);
+        }
         if (
           (
             this.runStatus(accepted.run.runId) === "cancelling"
@@ -2114,6 +2133,7 @@ export class KernelCore {
   }
 
   protected markBindingStale(binding: AdapterBinding, attempt: RunAttempt, reason: string): void {
+    this.contextDeliveryByBinding.delete(binding.bindingId);
     const run = this.readRun(attempt.runId);
     this.withTransaction(() => {
       this.updateBinding(binding.bindingId, {
@@ -2132,6 +2152,7 @@ export class KernelCore {
   }
 
   protected markEvictedBindingStale(bindingId: string, reason: string): void {
+    this.contextDeliveryByBinding.delete(bindingId);
     const binding = this.readBinding(bindingId);
     this.withTransaction(() => {
       this.updateBinding(binding.bindingId, {

--- a/desktop/macos/agent/tests/context-cache-delivery.test.ts
+++ b/desktop/macos/agent/tests/context-cache-delivery.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { recordJournalTurn } from "../src/runtime/conversation-journal.js";
+import { resolveSurfaceSession } from "../src/runtime/surface-session.js";
+import { createKernelHarness } from "./kernel-fakes.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+describe("pi-mono context cache delivery", () => {
+  it("hydrates a binding once and sends later history as a delta", async () => {
+    const root = mkdtempSync(join(tmpdir(), "omi-context-cache-"));
+    roots.push(root);
+    const { store, adapter, kernel } = createKernelHarness(
+      join(root, "agent.sqlite"),
+      "pi-mono",
+      1,
+    );
+    const surface = resolveSurfaceSession(store, {
+      ownerId: "owner-cache",
+      surfaceRef: { surfaceKind: "main_chat", externalRefKind: "chat", externalRefId: "default" },
+      defaultAdapterId: "pi-mono",
+    }, () => 1);
+    for (let sequence = 1; sequence <= 64; sequence += 1) {
+      recordJournalTurn(store, {
+        ownerId: "owner-cache",
+        conversationId: surface.conversationId,
+        turnId: `cache-turn-${sequence}`,
+        role: sequence % 2 ? "user" : "assistant",
+        surfaceKind: "main_chat",
+        origin: "typed_chat",
+        status: "completed",
+        content: `cache canonical turn ${sequence}`,
+        contentBlocks: [],
+        createdAtMs: sequence,
+      });
+    }
+
+    const common = {
+      sessionId: surface.agentSessionId,
+      ownerId: "owner-cache",
+      surfaceKind: "main_chat",
+      externalRefKind: "chat",
+      externalRefId: "default",
+      defaultAdapterId: "pi-mono",
+      adapterId: "pi-mono",
+      clientId: "cache-test",
+      cwd: root,
+    } as const;
+    await kernel.executeRun({ ...common, requestId: "cache-request-1", prompt: "first question" });
+
+    recordJournalTurn(store, {
+      ownerId: "owner-cache",
+      conversationId: surface.conversationId,
+      turnId: "cache-turn-65",
+      role: "user",
+      surfaceKind: "main_chat",
+      origin: "typed_chat",
+      status: "completed",
+      content: "cache canonical turn 65",
+      contentBlocks: [],
+      createdAtMs: 65,
+    });
+    await kernel.executeRun({ ...common, requestId: "cache-request-2", prompt: "second question" });
+
+    expect(adapter.executed).toHaveLength(2);
+    const firstPrompt = adapter.executed[0].prompt
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n");
+    const secondPrompt = adapter.executed[1].prompt
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n");
+    expect(firstPrompt).toContain("cache canonical turn 1");
+    expect(firstPrompt).toContain("cache canonical turn 64");
+    expect(secondPrompt).toContain("delivery=delta");
+    expect(secondPrompt).toContain("cache canonical turn 65");
+    expect(secondPrompt).not.toContain("cache canonical turn 2");
+    expect(secondPrompt).toContain("# User Message\nsecond question");
+    store.close();
+  });
+});

--- a/desktop/macos/agent/tests/context-snapshot.test.ts
+++ b/desktop/macos/agent/tests/context-snapshot.test.ts
@@ -10,6 +10,7 @@ import {
   inheritContextSnapshotForSession,
   kernelSystemPolicy,
   renderContextSnapshot,
+  renderContextSnapshotForBinding,
   updateContextSource,
 } from "../src/runtime/context-snapshot.js";
 import {
@@ -92,6 +93,67 @@ describe("kernel ContextSnapshot", () => {
     expect(cacheBoundedPolicy).not.toContain(at65!.contextPlan.dynamicContextIdentity);
     expect(renderContextSnapshot(at65!, "main_chat", "coordinator"))
       .toContain(at65!.contextPlan.dynamicContextIdentity);
+    store.close();
+  });
+
+  it("delivers full history once per binding, then only new or changed canonical turns", () => {
+    const { store } = fixture();
+    const surface = resolveSurfaceSession(store, {
+      ownerId: "owner-delta",
+      surfaceRef: { surfaceKind: "main_chat", externalRefKind: "chat", externalRefId: "delta" },
+      defaultAdapterId: "pi-mono",
+    }, () => 1);
+    for (let sequence = 1; sequence <= 64; sequence += 1) {
+      recordJournalTurn(store, {
+        ownerId: "owner-delta",
+        conversationId: surface.conversationId,
+        turnId: `delta-turn-${sequence}`,
+        role: sequence % 2 ? "user" : "assistant",
+        surfaceKind: "main_chat",
+        origin: "typed_chat",
+        status: "completed",
+        content: `delta canonical turn ${sequence}`,
+        contentBlocks: [],
+        createdAtMs: sequence,
+      });
+    }
+
+    const first = buildContextSnapshot(store, surface.agentSessionId, "owner-delta", 64);
+    const full = renderContextSnapshotForBinding(first, "main_chat", "coordinator");
+    expect(full.deliveryMode).toBe("full");
+    expect(full.rendered).toContain("delta canonical turn 1");
+    expect(full.rendered).toContain("delta canonical turn 64");
+
+    recordJournalTurn(store, {
+      ownerId: "owner-delta",
+      conversationId: surface.conversationId,
+      turnId: "delta-turn-65",
+      role: "user",
+      surfaceKind: "main_chat",
+      origin: "typed_chat",
+      status: "completed",
+      content: "delta canonical turn 65",
+      contentBlocks: [],
+      createdAtMs: 65,
+    });
+    const second = buildContextSnapshot(store, surface.agentSessionId, "owner-delta", 65);
+    const delta = renderContextSnapshotForBinding(second, "main_chat", "coordinator", full.next);
+    expect(delta.deliveryMode).toBe("delta");
+    expect(delta.rendered).toContain('"includedTurnCount":1');
+    expect(delta.rendered).toContain("delta canonical turn 65");
+    expect(delta.rendered).not.toContain("delta canonical turn 2");
+
+    updateJournalTurn(store, {
+      ownerId: "owner-delta",
+      conversationId: surface.conversationId,
+      turnId: "delta-turn-65",
+      content: "delta canonical turn 65 corrected",
+      status: "completed",
+    });
+    const corrected = buildContextSnapshot(store, surface.agentSessionId, "owner-delta", 66);
+    const correction = renderContextSnapshotForBinding(corrected, "main_chat", "coordinator", delta.next);
+    expect(correction.rendered).toContain('"includedTurnCount":1');
+    expect(correction.rendered).toContain("delta canonical turn 65 corrected");
     store.close();
   });
 

--- a/desktop/macos/agent/tests/context-snapshot.test.ts
+++ b/desktop/macos/agent/tests/context-snapshot.test.ts
@@ -157,6 +157,65 @@ describe("kernel ContextSnapshot", () => {
     store.close();
   });
 
+  it("falls back to full delivery when previously retained turns disappear", () => {
+    const { store } = fixture();
+    const surface = resolveSurfaceSession(store, {
+      ownerId: "owner-shrink",
+      surfaceRef: { surfaceKind: "main_chat", externalRefKind: "chat", externalRefId: "shrink" },
+      defaultAdapterId: "pi-mono",
+    }, () => 1);
+    for (let sequence = 1; sequence <= 5; sequence += 1) {
+      recordJournalTurn(store, {
+        ownerId: "owner-shrink",
+        conversationId: surface.conversationId,
+        turnId: `shrink-turn-${sequence}`,
+        role: sequence % 2 ? "user" : "assistant",
+        surfaceKind: "main_chat",
+        origin: "typed_chat",
+        status: "completed",
+        content: `shrink canonical turn ${sequence}`,
+        contentBlocks: [],
+        createdAtMs: sequence,
+      });
+    }
+
+    const first = buildContextSnapshot(store, surface.agentSessionId, "owner-shrink", 5);
+    const full = renderContextSnapshotForBinding(first, "main_chat", "coordinator");
+    expect(full.deliveryMode).toBe("full");
+
+    // Simulate journal_clear_turns: delete some turns so the retained set shrinks.
+    store.execute(
+      "DELETE FROM conversation_turns WHERE conversation_id = ? AND turn_id IN (?, ?)",
+      [surface.conversationId, "shrink-turn-1", "shrink-turn-2"],
+    );
+
+    // New turn arrives after the clear.
+    recordJournalTurn(store, {
+      ownerId: "owner-shrink",
+      conversationId: surface.conversationId,
+      turnId: "shrink-turn-6",
+      role: "user",
+      surfaceKind: "main_chat",
+      origin: "typed_chat",
+      status: "completed",
+      content: "shrink canonical turn 6",
+      contentBlocks: [],
+      createdAtMs: 6,
+    });
+
+    const afterShrink = buildContextSnapshot(store, surface.agentSessionId, "owner-shrink", 7);
+    const result = renderContextSnapshotForBinding(afterShrink, "main_chat", "coordinator", full.next);
+    // Must be a full re-render, not a delta, so the model knows turns 1 and 2
+    // are gone. A delta with no tombstone would let the model believe they still
+    // exist in the binding's conversation history.
+    expect(result.deliveryMode).toBe("full");
+    expect(result.rendered).not.toContain("delivery=delta");
+    expect(result.rendered).toContain("shrink canonical turn 3");
+    expect(result.rendered).toContain("shrink canonical turn 6");
+    expect(result.rendered).not.toContain("shrink canonical turn 1");
+    store.close();
+  });
+
   it("requires direct conversational recall from canonical recent turns", () => {
     const policy = kernelSystemPolicy("realtime_voice", "coordinator");
 

--- a/desktop/macos/agent/tests/pi-mono-adapter.test.ts
+++ b/desktop/macos/agent/tests/pi-mono-adapter.test.ts
@@ -183,6 +183,7 @@ describe("PiMonoAdapter prompt correlation", () => {
     for (const message of [
       "search my calendar for weather in NYC",
       "what did I say today about the current weather?",
+      "what did I do today?",
     ]) {
       expect(routePromptForPublicWeb(message)).toBe(message);
     }

--- a/desktop/macos/changelog/unreleased/20260723-chat-current-turn-web-routing.json
+++ b/desktop/macos/changelog/unreleased/20260723-chat-current-turn-web-routing.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed typed chat getting stuck after a previous web lookup and restored responses to personal-history questions"
+}

--- a/desktop/macos/changelog/unreleased/20260723-context-cache-efficiency.json
+++ b/desktop/macos/changelog/unreleased/20260723-context-cache-efficiency.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved response speed and efficiency in long desktop chats by reusing conversation context across turns"
+}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -50,6 +50,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/SelectableMarkdown.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ChatErrorCard.swift
+  - desktop/macos/Desktop/Sources/Chat/AgentRuntimeCredentialPolicy.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
   - desktop/macos/Desktop/Sources/Chat/AgentClient.swift
   - desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift

--- a/docs/superpowers/specs/2026-07-23-context-cache-efficiency-design.md
+++ b/docs/superpowers/specs/2026-07-23-context-cache-efficiency-design.md
@@ -1,0 +1,182 @@
+# Context Cache Efficiency Audit and Implementation
+
+Issue: [#10418](https://github.com/BasedHardware/omi/issues/10418)
+
+## Outcome
+
+This change adds two complementary cache-safe history strategies:
+
+1. Desktop Pi bindings receive the full canonical retained history once, then receive only turns that are new or whose canonical representation changed. A new/replaced binding always receives a full snapshot.
+2. Backend agentic chat uses Anthropic's automatic moving message breakpoint and a bounded append-only history epoch. History grows from 10 through 17 visible messages, then resets to the newest 10.
+
+Neither path summarizes, mutates, or drops content that was previously available. There is no cache pre-warming request.
+
+## Cache audit
+
+### Desktop kernel
+
+The context plan is assembled in `desktop/macos/agent/src/runtime/context-snapshot.ts`.
+
+- `RECENT_TURN_LIMIT` is 64.
+- Turns are selected newest-first from `conversation_turns`, then reversed into chronological order.
+- `olderHistoryStrategy` is `none` until the retained limit is exceeded, then `truncated`.
+- `stableCacheIdentity` hashes semantic guidance and the capability version. It does **not** hash profile, memories, tasks, or goals.
+- `dynamicContextIdentity` hashes the conversation identity, retained turn IDs, and omitted count.
+- `renderContextSnapshot` serializes recent turns, semantic source outcomes, run state, capabilities, and the context plan into one stable JSON payload.
+
+Before this change, `kernel-core.ts` prepended that entire rendered payload to every user turn. In the Anthropic translation:
+
+- one explicit 1-hour breakpoint followed the stable system policy;
+- one explicit 1-hour breakpoint was placed on the latest user/tool-result message;
+- no independently reusable breakpoint existed inside the serialized 64-turn JSON.
+
+The latest-message breakpoint already cached the growing Pi conversation and agentic tool loops. It could not independently cache repeated old turns embedded later inside each new snapshot because Anthropic cache hashes are cumulative over `tools → system → messages`.
+
+### Backend agentic chat
+
+Before this change:
+
+- `backend/routers/chat.py` always loaded the newest 10 stored messages;
+- the window moved at the front every turn;
+- `_run_anthropic_agent_stream` marked only the system block;
+- tool-loop history and the cross-turn message history had no message breakpoint.
+
+The gateway already persisted `cache_read_input_tokens` and `cache_creation_input_tokens` for every Anthropic attempt. This change extends cache-attempt and TTL classification to Anthropic's top-level automatic `cache_control` shape as well as explicit block markers.
+
+### Stable-prefix staleness
+
+No per-turn stable-prefix invalidation defect was found.
+
+- The desktop stable identity intentionally covers only semantic guidance and capabilities.
+- Profile, memory, goal, task, screen, and surface payloads live in the dynamic snapshot.
+- Semantic source projection omits transport-only revision/capture metadata, so an identical payload poll does not change the renderer fingerprint merely because it was re-fetched.
+
+Candidate C therefore does not justify a staleness patch in this pass.
+
+## Baseline
+
+### Production backend sample from issue #10418
+
+The issue's telemetry sample covered 749 Anthropic attempts:
+
+- 526 cache reads and 223 explicit 1-hour misses/writes;
+- median cached input: about 25.3K tokens;
+- median uncached input: about 1.2K tokens;
+- p90 uncached input: about 27.5K tokens;
+- p95 uncached input: about 331K tokens;
+- 62 attempts exceeded 300K uncached tokens;
+- the top 10% of attempts represented about 94% of uncached input and 61% of estimated cost.
+
+### Local 64-turn desktop sample
+
+A long local desktop session supplied an exact retained-window baseline:
+
+- 64 retained turns, 6 omitted;
+- rendered context: 68,757 characters;
+- provider input: 20,403 uncached tokens plus 29,983 cache-read tokens;
+- effective cache-read share: 59.5%;
+- total provider input footprint: about 50.4K tokens.
+
+Across eight non-tool local turns with positive token telemetry, the aggregate cache-read share was 53.1% and the median per-turn share was 59.5%. Restarting the Pi binding reset the cache read from roughly 30K to 8.8K, confirming that the existing hit was the growing provider conversation prefix, not reuse within the newly serialized context snapshot.
+
+The 64-turn fixture's `recentTurns` payload was 47,166 characters. The oldest 56 turns accounted for 45,051 characters; the latest eight accounted for 2,116.
+
+## Design decisions
+
+### Desktop: binding-scoped delta hydration
+
+`renderContextSnapshotForBinding` records a privacy-local hash per delivered canonical turn.
+
+- First delivery or conversation mismatch: send the complete retained snapshot.
+- Same live Pi binding: send only turns with a new ID or changed canonical hash.
+- Binding replacement, eviction, or daemon restart: discard the cursor and send a complete snapshot.
+- Dynamic sources, run state, capabilities, and the full context-plan metadata continue to be sent every turn.
+
+The cursor is in-memory and keyed by Omi's binding ID. It is committed only after the adapter returns, so a pre-dispatch failure cannot falsely claim hydration. A changed turn is additive in the next delta; existing provider conversation content is never rewritten.
+
+This is the workable form of Candidate A for the actual architecture. Placing a marker “N turns back” inside each repeated JSON string would not create an independent cache segment, and after front truncation its cumulative prefix would miss every mature turn.
+
+### Backend: automatic breakpoint plus bounded append-only epochs
+
+Anthropic automatic caching moves a single breakpoint to the last cacheable block as a conversation grows. The explicit 1-hour system breakpoint remains.
+
+The history selector uses:
+
+- base continuity window: 10 visible messages;
+- append epoch: 8 messages;
+- maximum transmitted history: 17 visible messages;
+- reset: newest 10 at each eight-message boundary.
+
+For totals 10 through 18, selected lengths are `10, 11, …, 17, 10`. Reported messages are excluded from the visible count and over-fetched so they cannot reduce the selected continuity window. Reads are scoped to the active chat session when one exists, otherwise to the active app.
+
+This bounds history, preserves at least the previous 10-message behavior, and gives several append-only turns between deliberate cache resets.
+
+## Candidate assessment
+
+| Candidate | Decision | Savings/impact | Complexity and risk |
+|---|---|---|---|
+| A: mid-history checkpoint | Implemented as desktop delta hydration and backend automatic moving breakpoint | Highest steady-state savings | A literal marker inside repeated JSON would not work; delivery shape had to change |
+| B: compaction summary | Defer | Improves continuity beyond the 64-turn boundary | Requires a canonical additive summary lifecycle and quality evaluation |
+| C: stable-prefix scope | No code change | No free hit-rate gain found | Current identity is stable for its actual scope |
+| D: tighter filtering | Do not blanket-filter | Possible small token reduction | Failed/streaming turns can carry continuity or retry evidence; dropping them is correctness-sensitive |
+| E: adaptive sizing | Backend uses cache-aware bounded epochs; desktop remains 64-turn on first hydration | More predictable cache behavior without reducing continuity | Token-aware compaction can follow after canonical summarization exists |
+
+## Estimated savings
+
+### Desktop
+
+Using the measured 64-turn sample, removing the repeated oldest-56 payload from steady-state turns saves about 13.4K uncached tokens per turn. Estimated uncached input falls from about 20.4K to about 7.0K, a 66% reduction. If the cached prefix remains near 30K tokens, the cache-read share rises from about 59.5% to roughly 81%.
+
+At Claude Sonnet 4.6 rates used by the desktop cost model, converting that repeated slice from regular input to an already-present cached conversation prefix is worth about $0.036 per mature turn before cache-write amortization.
+
+### Backend
+
+For the stable base portion of a four-user-turn history epoch, the 1-hour cache cost multiplier is approximately `2.0 + 0.1 + 0.1 + 0.1 = 2.3` instead of four regular-input passes. That is a 42.5% reduction on the reusable history slice, while newly appended messages remain ordinary incremental input. Tool loops gain the same moving breakpoint without waiting for another user turn.
+
+Actual savings should be compared after deployment using the existing gateway attempt traces:
+
+- cache-read share: `cache_read_input_tokens / total_input_tokens`;
+- cache-write share and reset cadence;
+- p50/p75/p90/p95 uncached input;
+- attempts over 300K uncached tokens;
+- first-token latency split by cache hit/miss.
+
+## Implementation ticket pack
+
+### TICKET-01 — Desktop binding delta hydration
+
+Status: implemented.
+
+Acceptance:
+
+- full 64-turn retained history on a new binding;
+- only new/changed turns on the next live Pi turn;
+- changed canonical turns are re-delivered;
+- new/replaced bindings fail safe to a full snapshot;
+- source payloads and context-plan metadata remain present;
+- behavioral kernel and renderer tests pass.
+
+### TICKET-02 — Backend history and tool-loop caching
+
+Status: implemented.
+
+Acceptance:
+
+- history is chronological after the existing reversal and is scoped by session/app;
+- selected visible history is 0–17 messages and never below the previous 10-message window once available;
+- a deterministic reset occurs every eight stored visible messages;
+- automatic 1-hour caching is present on every agent-loop request;
+- explicit stable-system caching remains;
+- gateway passthrough and cache accounting recognize both breakpoint forms;
+- behavioral database, agent-loop, and gateway tests pass.
+
+### TICKET-03 — Post-deploy measurement
+
+Status: operational verification.
+
+Compare a seven-day post-deploy cohort with issue #10418's baseline. The issue can be closed by this PR because all required fields already exist in gateway attempt telemetry; no new user-visible or production state is required. If p95 uncached input remains dominated by large tool outputs, open a separate problem issue for bounded tool-result projection rather than silently truncating results in this change.
+
+## References
+
+- [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)
+- [Anthropic tool use with prompt caching](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-use-with-prompt-caching)


### PR DESCRIPTION
## Summary

- hydrate each live desktop Pi binding with the full canonical retained context once, then deliver only new or changed turns while continuing to refresh dynamic sources and context-plan metadata
- replace the backend's moving newest-10 window with a bounded 10–17 message append epoch and enable Anthropic's automatic 1-hour message breakpoint for cross-turn history and agentic tool loops
- teach gateway accounting to recognize top-level Anthropic cache controls and document the code audit, measured baseline, candidate decisions, implementation tickets, and savings estimate
- restore typed desktop chat by routing on only the current `# User Message`, keeping personal-activity prompts on private Omi retrieval, and using Anthropic's direct-compatible web-search tool version
- let non-production named QA bundles reuse a valid owner-checked seeded token at startup while preserving production/Beta's forced Firebase refresh behavior

## Typed chat root cause and fix

Local Omi Beta logs showed typed turns failing quickly with Anthropic HTTP 400: the selected `web_search` tool was not callable through the configured direct path. PTT stayed healthy because it uses the separate Gemini Live `RealtimeHub` / `VoiceTurnCoordinator` path.

The failure had two coupled causes:

1. Pi's rendered prompt includes retained history plus a final `# User Message`. Retrieval policy classified the entire rendered prompt, so an older turn's web-required instruction could leak into later private or ordinary turns.
2. The gateway emitted `web_search_20260209` for direct named selection. That dynamic-filtering tool version permits the code-execution caller in the live Anthropic contract, while the current parser and routing path expect direct `server_tool_use` / `web_search_tool_result` blocks.

The fix isolates classification to the current user section, recognizes “what did I do” as private-context intent in both Rust and Pi, and pins the direct-compatible `web_search_20250305` request shape. Regression coverage exercises stale inherited web policy, personal activity, and the provider request shape.

The QA run also exposed a named-bundle-only startup issue: the bundle had a valid seeded Keychain token but attempted a source-app Firebase refresh that cannot exist under a distinct bundle ID. The new credential policy reuses the valid owner-checked token only for non-production named bundles; normal Omi and Omi Beta behavior is unchanged.

## Cache audit and expected impact

- Desktop already used explicit 1-hour breakpoints after the stable system policy and on the latest user/tool-result message. A literal midpoint marker inside the repeated snapshot would not be independently reusable because Anthropic hashes cumulative `tools → system → messages` prefixes.
- A measured mature 64-turn desktop request used 20,403 uncached plus 29,983 cache-read tokens (59.5% cache-read share). The repeated old-history slice is approximately 13.4K tokens per turn.
- Steady-state desktop uncached input is therefore estimated to fall from about 20.4K to 7.0K tokens (66%), with cache-read share rising to roughly 81% while the same live binding remains healthy.
- The backend epoch preserves at least the previous 10 visible messages, remains bounded at 17, resets deterministically every eight messages, and is scoped to the active session or app.
- No stable-prefix staleness defect was found: the desktop stable identity is constant for its intentional semantic-guidance/capability scope, while profile, memory, tasks, goals, and other live sources are dynamic.

Full audit and ticket pack: `docs/superpowers/specs/2026-07-23-context-cache-efficiency-design.md`

## Verification

- backend focused cache/gateway tests — 71 passed
- desktop Rust suite — 398 passed
- Pi adapter policy tests — 36 passed; full agent suite passed
- `xcrun swift test --package-path Desktop --filter AgentRuntimeProcessTests` — passed
- `./scripts/agent-logic-harness.sh --cross-surface-smoke` — all four stages passed
- named bundle `/Applications/omi-context-cache.app` — Swift/Rust/agent build, ad-hoc signing, install, launch, exact bundle identity, automation health, authenticated protocol-v2 runtime, and dev-backend configuration passed
- exact named-bundle repros: `hello?` completed with no error/stuck sending state; `What did I do today?` stayed on private Omi context and completed with no error/stuck sending state
- `scripts/pr-preflight --pr-body-file /tmp/pr-10422-preflight.md` — passed
- bounded pre-push acceptance gate — passed twice, including Swift compile, desktop tool surfaces (53 files / 597 tests), focused backend tests, product invariant checks, formatting, lint, and Rust compile

## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1

The change preserves canonical kernel ownership, binding replacement/reset boundaries, recent-turn continuity, and additive context delivery. It does not summarize, mutate, or remove canonical turn content. Production Omi/Omi Beta startup auth behavior remains fail-closed and unchanged.

Closes #10418

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

Failure-Class: none
