### PR TITLE
fix(windows): simplify post-onboarding controls

### DIFF
--- a/desktop/windows/src/renderer/src/App.tsx
+++ b/desktop/windows/src/renderer/src/App.tsx
@@ -69,8 +69,8 @@ function AppShellInner(): React.JSX.Element {
     window.omi?.setTitleBarSurface?.(isHome)
   }, [isHome])
 
-  // Honor a one-shot destination requested by onboarding (e.g. the final
-  // "Take me to my tasks" button). The shell mounts at /home after the
+  // Honor the one-shot destination requested when onboarding completes. The
+  // shell mounts at /home after the
   // onboarding gate redirects; we consume the pending route here and jump to it.
   useEffect(() => {
     const dest = consumePendingRoute()

--- a/desktop/windows/src/renderer/src/components/settings/tabs/GeneralTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/GeneralTab.tsx
@@ -7,7 +7,8 @@ import {
   Monitor,
   Power,
   Presentation,
-  ScanEye
+  ScanEye,
+  Zap
 } from 'lucide-react'
 import type { MeetingMode, RewindSettings } from '../../../../../shared/types'
 import { getPreferences, onPreferencesChange, setPreferences } from '../../../lib/preferences'
@@ -23,6 +24,7 @@ export function GeneralTab(): React.JSX.Element {
       {/* macOS General leads with the capture-status cards (spec §3.1). */}
       <ScreenCaptureRow />
       <AudioRecordingRow />
+      <ActionAutomationRow />
       <ScreenAnalysisRow />
       <SettingRow
         icon={MessagesSquare}
@@ -54,6 +56,39 @@ export function GeneralTab(): React.JSX.Element {
       <LaunchAtLoginRow />
       <FontSizeCard />
     </>
+  )
+}
+
+function ActionAutomationRow(): React.JSX.Element {
+  const automationAvailable = window.omi.automationEnabled
+  const [autoConsent, setAutoConsent] = useState<boolean>(!!getPreferences().automationConsentedAt)
+  const toggleAutomation = (on: boolean): void => {
+    setAutoConsent(on)
+    setPreferences({ automationConsentedAt: on ? Date.now() : undefined })
+  }
+
+  return (
+    <SettingRow
+      icon={Zap}
+      dot={automationAvailable && autoConsent ? 'on' : 'off'}
+      title="Let Omi take actions"
+      subtitle={
+        !automationAvailable
+          ? 'Disabled in this build.'
+          : autoConsent
+            ? 'Omi can click and type in your apps when you ask.'
+            : 'Turn on to let Omi act in your apps when you ask.'
+      }
+      keywords="automation actions desktop control agent take action flaui approve"
+      control={
+        <Toggle
+          on={automationAvailable && autoConsent}
+          onChange={toggleAutomation}
+          disabled={!automationAvailable}
+          label="Let Omi take actions"
+        />
+      }
+    />
   )
 }
 

--- a/desktop/windows/src/renderer/src/components/settings/tabs/PrivacyTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/PrivacyTab.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Activity, EyeOff, Monitor, ShieldCheck, Zap } from 'lucide-react'
-import { getPreferences, setPreferences } from '../../../lib/preferences'
+import { Activity, EyeOff, Monitor, ShieldCheck } from 'lucide-react'
 import { SettingRow } from '../SettingRow'
 import { Toggle } from '../Toggle'
 import type { UsageSettings } from '../../../../../shared/types'
@@ -23,18 +22,6 @@ export function PrivacyTab(): React.JSX.Element {
   }, [])
   const saveUsage = async (next: UsageSettings): Promise<void> => {
     setUsage(await window.omi.usageSetSettings(next))
-  }
-
-  // Desktop-automation opt-in. The toggle writes the same `automationConsentedAt`
-  // preference the onboarding Automation step sets; useChat gates its action
-  // planner on it. `OMI_AUTOMATION=0` is a hard build kill-switch (exposed as
-  // automationEnabled) — when off, the feature can't run, so the toggle is shown
-  // disabled regardless of consent.
-  const automationAvailable = window.omi.automationEnabled
-  const [autoConsent, setAutoConsent] = useState<boolean>(!!getPreferences().automationConsentedAt)
-  const toggleAutomation = (on: boolean): void => {
-    setAutoConsent(on)
-    setPreferences({ automationConsentedAt: on ? Date.now() : undefined })
   }
 
   // Bar/HUD screen-share privacy: exclude the top-edge bar from captures
@@ -69,27 +56,6 @@ export function PrivacyTab(): React.JSX.Element {
 
   return (
     <>
-      <SettingRow
-        icon={Zap}
-        dot={automationAvailable && autoConsent ? 'on' : 'off'}
-        title="Let Omi take actions"
-        subtitle={
-          !automationAvailable
-            ? 'Disabled in this build.'
-            : autoConsent
-              ? 'Omi can click and type in your apps when you ask — you approve each action first.'
-              : 'Turn on to let Omi act in your apps when you ask (you approve each action first).'
-        }
-        keywords="automation actions desktop control agent take action flaui approve"
-        control={
-          <Toggle
-            on={automationAvailable && autoConsent}
-            onChange={toggleAutomation}
-            disabled={!automationAvailable}
-            label="Let Omi take actions"
-          />
-        }
-      />
       <SettingRow
         icon={Activity}
         dot={usage?.enabled ? 'on' : 'off'}

--- a/desktop/windows/src/renderer/src/pages/Onboarding.tsx
+++ b/desktop/windows/src/renderer/src/pages/Onboarding.tsx
@@ -24,7 +24,6 @@ import { VoiceIntroStep } from '../components/onboarding/VoiceIntroStep'
 import { AskDemoStep } from '../components/onboarding/AskDemoStep'
 import { DataSourcesStep } from '../components/onboarding/DataSourcesStep'
 import { GoalStep } from '../components/onboarding/GoalStep'
-import { AutoCreatedTasksStep } from '../components/onboarding/AutoCreatedTasksStep'
 import { createGoal } from '../lib/goals'
 // Import BrainGraph DIRECTLY (not via LazyBrainGraph) for onboarding — matches
 // the f42497b version that rendered reliably. The lazy wrapper's Suspense +
@@ -39,7 +38,7 @@ import {
   useOnboardingGraph
 } from '../lib/onboardingGraph'
 
-const TOTAL_STEPS = 15
+const TOTAL_STEPS = 14
 
 export function Onboarding(): React.JSX.Element {
   // Resume where the user left off if they quit mid-onboarding. Clamped in case
@@ -101,22 +100,19 @@ export function Onboarding(): React.JSX.Element {
     next()
   }
 
+  const finishToChat = (): void => {
+    setPendingRoute('/chat')
+    completeOnboarding()
+  }
+
   const handleGoal = (goal: string): void => {
     setPreferences({ goal })
     // Best-effort sync to the Omi goals backend — never block onboarding on the
-    // network. Advance to the final "auto-created tasks" screen.
+    // network or delay the transition into Chat.
     void createGoal(goal).catch(() => {
       toast('Saved locally — goal sync will retry later', { tone: 'warn' })
     })
-    next()
-  }
-
-  // Finish onboarding and land on the Tasks tab. We record the destination
-  // first, then flip the gate flag — the app shell consumes the pending route on
-  // mount (navigating from here directly races the gate's redirect to /home).
-  const finishToTasks = (): void => {
-    setPendingRoute('/tasks')
-    completeOnboarding()
+    finishToChat()
   }
 
   // App names already revealed in the brain map (id prefix `app_`), used to
@@ -255,20 +251,15 @@ export function Onboarding(): React.JSX.Element {
         />
       )
     }
-    if (step === 13) {
-      return (
-        <GoalStep
-          stepIndex={step}
-          totalSteps={TOTAL_STEPS}
-          apps={appNames}
-          onContinue={handleGoal}
-          onSkip={next}
-        />
-      )
-    }
-    // Final screen: a preview of the auto-created tasks feature. Its button both
-    // completes onboarding and routes straight to the Tasks tab.
-    return <AutoCreatedTasksStep onFinish={finishToTasks} />
+    return (
+      <GoalStep
+        stepIndex={step}
+        totalSteps={TOTAL_STEPS}
+        apps={appNames}
+        onContinue={handleGoal}
+        onSkip={finishToChat}
+      />
+    )
   }
 
   // Persistent two-pane shell: omi logo + the swapping step card on the left, the


### PR DESCRIPTION
## Summary

- move the existing **Let Omi take actions** toggle from Privacy to General without changing its behavior
- remove the inaccurate “approve each action first” promise from the Windows automation copy
- make Goal the final onboarding step
- open Chat immediately after the user selects or skips a goal

## Verification

- `pnpm run build`
- `pnpm run typecheck:web`
- `git diff --check`
- manually replayed onboarding using the real Windows profile

## Failure class (fixes)

Failure-Class: none
