### PR TITLE
fix(desktop): force direct caller for chat web_search tool (fixes web search 502/timeout)

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/chat/request_translation.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/request_translation.rs
@@ -64,6 +64,16 @@ fn web_search_tool_def() -> AnthropicToolDef {
         "type": WEB_SEARCH_TOOL_TYPE,
         "name": "web_search",
         "max_uses": WEB_SEARCH_MAX_USES,
+        // Force direct execution. As of web_search_20260209, `allowed_callers`
+        // defaults to ["code_execution_20260120"]: on a programmatic-tool-calling
+        // model (sonnet-4-6 / opus-4-6, the only models we route web search to)
+        // Anthropic runs the search *inside* code execution and returns
+        // `code_execution_tool_result` blocks. Our AnthropicContentBlock enum has
+        // no variant (and no serde(other)) for those, so `receive_anthropic_response`
+        // fails to deserialize and 502s the whole turn. "direct" keeps the search a
+        // plain server tool that returns the `server_tool_use` + `web_search_tool_result`
+        // blocks the parser already handles.
+        "allowed_callers": ["direct"],
     }))
 }
 

--- a/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
@@ -984,6 +984,37 @@ fn test_translate_request_forces_required_web_search_without_client_tools() {
 }
 
 #[test]
+fn test_injected_web_search_tool_forces_direct_caller() {
+    // Regression: web_search_20260209 defaults allowed_callers to
+    // ["code_execution_20260120"] on programmatic-tool-calling models
+    // (sonnet-4-6 / opus-4-6). Under that default Anthropic returns
+    // code_execution_tool_result blocks our AnthropicContentBlock enum can't
+    // deserialize, so every forced web-search turn 502s. The injected tool must
+    // pin the direct caller so the search returns server_tool_use +
+    // web_search_tool_result blocks the parser already handles.
+    let req = test_request(vec![user_message("search the web for HumanPost")]);
+
+    let result = translate_request_inner(
+        &req,
+        "claude-sonnet-4-6",
+        true,
+        ReasoningEffort::Unspecified,
+    )
+    .unwrap();
+
+    let tools = result.tools.unwrap();
+    let web_search = serde_json::to_value(&tools[0]).unwrap();
+    assert_eq!(web_search["name"], "web_search");
+    assert_eq!(web_search["type"], "web_search_20260209");
+    assert_eq!(
+        web_search["allowed_callers"],
+        json!(["direct"]),
+        "web_search must pin the direct caller; the default code-execution caller \
+         returns blocks the response parser cannot deserialize (502s the turn)"
+    );
+}
+
+#[test]
 fn test_translate_request_forces_web_search_for_location_qualified_weather() {
     // This is the same gateway request shape used by both the main
     // pi-mono session and default delegated pi-mono child sessions. The

--- a/desktop/macos/changelog/unreleased/20260723-chat-web-search-direct-caller.json
+++ b/desktop/macos/changelog/unreleased/20260723-chat-web-search-direct-caller.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed chat web searches failing when the assistant tried to look something up online"
+}


### PR DESCRIPTION
## Problem

Desktop chat's server-side web search **hard-fails every time it actually runs**. When a turn triggers web search, the assistant either errors out or (as users see it) "times out" — the turn ends with `status: "failed"`.

Real user session showing the symptom (the assistant self-reporting that web search runs *inside the code-execution sandbox* and the turn "just hung and died"):

> "The web search tool … is an async function injected into the `code_execution` sandbox … The prior attempt shows `status: "failed"` … The turn just… hung and died."

## Root cause

`web_search_tool_def()` requests `web_search_20260209` **without** an `allowed_callers` field. As of that tool version, `allowed_callers` **defaults to `["code_execution_20260120"]`** ([Anthropic docs](https://platform.claude.com/docs/en/docs/agents-and-tools/tool-use/web-search-tool)). On the programmatic-tool-calling models desktop chat routes web search to (`claude-sonnet-4-6` / `claude-opus-4-6`), Anthropic then runs the search **inside code execution** (dynamic filtering) and returns `code_execution_tool_result` / `bash_code_execution_tool_result` content blocks.

Our `AnthropicContentBlock` is a closed `#[serde(tag = "type")]` enum (`text`, `tool_use`, `server_tool_use`, `web_search_tool_result`, `thinking`, `redacted_thinking`) with **no variant and no `#[serde(other)]`** for code-execution blocks. So `receive_anthropic_response` fails to deserialize the whole response and returns `502 BAD_GATEWAY`. Both the non-streaming and server-tool streaming paths funnel through this strict aggregation (`complete_anthropic_server_tool_turn` forces `stream=false`), so **every** forced-web-search turn fails.

## Fix

Pin `"allowed_callers": ["direct"]` on the web_search tool so the search runs as a plain server tool and returns the `server_tool_use` + `web_search_tool_result` blocks the parser already handles (and whose response shape existing tests already cover). One-line behavioral change; no parser rewrite.

Tradeoff: direct mode forgoes dynamic filtering (search results load fully into context → marginally higher token cost on search-heavy turns). Acceptable — the alternative is the current 502. Regaining dynamic filtering by adding a `code_execution_tool_result` variant + `#[serde(other)]` is a larger, separate change.

## Verification

- **New regression test** `test_injected_web_search_tool_forces_direct_caller` runs real `translate_request_inner(...)` and asserts the injected tool carries `allowed_callers=["direct"]`. **Proven**: reverting the fix makes it panic on the assertion; with the fix it passes.
- `cargo test --bin omi-desktop-backend routes::chat::tests` → **91 passed, 0 failed**. `rustfmt --check` clean, `cargo build` clean.
- **Independent agent code review**: APPROVE — confirmed `["direct"]` is documented/valid, the parser fully covers the direct response shape (citations are nested inside text blocks; unknown fields are tolerated since no `deny_unknown_fields`), and no other block type a direct turn emits is left unhandled.
- **Convergent field evidence**: the production session above shows web search running via code execution and failing — exactly this defect.
- Not yet run: a live search through a locally-built backend (needs a server Anthropic key). The response-parse side is covered by existing hermetic tests, and the request-side change is covered by the new one.

## Scope / follow-ups

- **Not in this PR (tracked separately):** the retrieval-policy keyword classifier (`retrieval_policy.rs`) only injects web search when the message matches ~16 fixed phrases, so natural requests like "find out who X is and everything about them online" get no web tool at all. Issue: https://github.com/BasedHardware/omi/issues/10429
- **Parity follow-up:** `backend/utils/retrieval/agentic.py` `WEB_SEARCH_TOOL` has the same missing `allowed_callers`. The Python path tolerates unknown blocks (SDK `if/elif` filtering, no 502) but still silently runs in code-execution mode — worth confirming it surfaces citations.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

