### PR TITLE
Track 0 submission: native macOS shell, consistent and improved UI/UX

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1969,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3645,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4468,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4633,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3295,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5667,
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1690
@@ -10,7 +10,7 @@
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": "SB redesign: Omi-mark avatar on replies that spins while thinking (typing-dots suppressed for Omi's own replies) and tool-call chips gated to the streaming turn, merged with main's metadata-row reveal honoring keyboard focus (shared FocusState + testable ChatBubbleMetadataReveal); a component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "Filter toggle, category menu and Create App become capsule chips with shared hover states (OmiFieldStyle/chip language); a component split is tracked follow-up.",
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": "Home ask bar now auto-grows as a multi-line TextField so long messages wrap instead of scrolling off-screen (+14 lines over the prior SB-redesign home/chat layout); a component split is tracked follow-up.",
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": "Home opens on a landing hero (rotating mark, tighter centered composer that widens to the chat column on send, prompt chips, scroll-to-reveal) before the transcript; the first send continues the one shared conversation. A component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": "Bridge memory search now awaits the active initial or pagination projection before refreshing, preventing an immediate post-navigation marker search from using stale lifecycle capability state.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": "SB redesign: adds the Notion-style status board (time-bucket columns, task cards with priority/due chips) and Board/List toggle alongside the existing list; a component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": "SB redesign: adds the hover-expand AppNavRail (icons\u2192labels) and the merged/simplified navigation (Memory, Insights) driving selectedIndex; a component split is tracked follow-up."

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -1,15 +1,15 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1969,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3643,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4508,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3298,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5706,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3645,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4468,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3295,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5667,
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1690
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": "SB redesign: Omi-mark avatar on replies that spins while thinking (typing-dots suppressed for Omi's own replies) and tool-call chips gated to the streaming turn, merged with main's metadata-row reveal honoring keyboard focus (shared FocusState + testable ChatBubbleMetadataReveal); a component split is tracked follow-up.",
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "Rebase reconciliation applies the pinned swift-format to the main-branch app-detail safety fixes; runtime behavior is unchanged.",
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "Filter toggle, category menu and Create App become capsule chips with shared hover states (OmiFieldStyle/chip language); a component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": "Home ask bar now auto-grows as a multi-line TextField so long messages wrap instead of scrolling off-screen (+14 lines over the prior SB-redesign home/chat layout); a component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": "Bridge memory search now awaits the active initial or pagination projection before refreshing, preventing an immediate post-navigation marker search from using stale lifecycle capability state.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": "SB redesign: adds the Notion-style status board (time-bucket columns, task cards with priority/due chips) and Board/List toggle alongside the existing list; a component split is tracked follow-up.",

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
@@ -2,12 +2,12 @@
   "files": {
     "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1643,
     "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3502,
-    "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": 1856
+    "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": 1878
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": "Task visibility writes now emit the shared Home-count invalidation after logging, so Dashboard totals refresh without waiting for an activation cooldown.",
     "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": "currentUserId is gated by an OSAllocatedUnfairLock to fix a cross-executor data race (actor/MainActor/nonisolated shutdown); the Sendable lock + computed accessor replace the prior unsafe static var (SCA-8).",
-    "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": "Search-result rows load a downsampled ImageIO thumbnail instead of the full-resolution screenshot, so a long results list no longer retains full-size images behind a 120x80 view."
+    "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": "Adds a Back affordance that returns to the originating tab so Rewind is no longer a navigational dead end."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/FolderManagementViews.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/FolderManagementViews.swift
@@ -98,10 +98,7 @@ struct FolderTabsStrip: View {
             .scaledFont(size: OmiType.caption, weight: .semibold)
             .foregroundColor(OmiColors.textSecondary)
             .frame(width: 26, height: 26)
-            .background(
-              RoundedRectangle(cornerRadius: OmiChrome.badgeRadius)
-                .fill(OmiColors.backgroundTertiary.opacity(0.6))
-            )
+            .background(Circle().fill(OmiColors.backgroundTertiary.opacity(0.6)))
         }
         .buttonStyle(.plain)
       }
@@ -131,11 +128,11 @@ struct FolderTabsStrip: View {
       .padding(.horizontal, OmiSpacing.sm)
       .padding(.vertical, OmiSpacing.xs)
       .background(
-        RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
+        Capsule(style: .continuous)
           .fill(isSelected ? OmiColors.textPrimary.opacity(0.12) : OmiColors.backgroundTertiary.opacity(0.6))
       )
       .overlay(
-        RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
+        Capsule(style: .continuous)
           .stroke(isSelected ? OmiColors.textPrimary.opacity(0.3) : Color.clear, lineWidth: 1)
       )
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -62,6 +62,8 @@ struct DesktopHomeView: View {
   @State private var highlightedSettingId: String? = nil
   @State private var showTryAskingPopup = false
   @State private var previousIndexBeforeSettings: Int = 0
+  @State private var previousIndexBeforeRewind: Int = 0
+  @ObservedObject private var modalState = ModalPresentationState.shared
   @State private var logoPulse = false
   @State private var lastActivationRefresh = Date.distantPast
   @State private var didScheduleAgentVMProvisioning = false
@@ -620,6 +622,25 @@ struct DesktopHomeView: View {
     return ![.permissions, .help].contains(item)
   }
 
+  /// Leading inset for the header's Settings chip so it clears the window
+  /// traffic lights now that the titlebar is hidden and content fills the frame.
+  static let trafficLightInset: CGFloat = 62
+
+  /// Opens or closes the settings sidebar. Owned here so the back-navigation
+  /// target (the tab you were on) stays correct; the header chip just calls it.
+  private func toggleSettings() {
+    OmiMotion.withGated(.spring(response: 0.42, dampingFraction: 0.86)) {
+      if isInSettings {
+        selectedIndex =
+          previousIndexBeforeSettings == SidebarNavItem.settings.rawValue
+          ? SidebarNavItem.dashboard.rawValue
+          : previousIndexBeforeSettings
+      } else {
+        selectedIndex = SidebarNavItem.settings.rawValue
+      }
+    }
+  }
+
   /// Reference instant for the top bar's "new since you were last here" counts.
   private var topBarSinceDate: Date {
     topBarNewSinceRaw > 0 ? Date(timeIntervalSince1970: topBarNewSinceRaw) : Date()
@@ -971,11 +992,11 @@ struct DesktopHomeView: View {
 
   private var mainContent: some View {
     HStack(spacing: 0) {
-      // Sidebar slot: settings sidebar overlays main sidebar
-      // IMPORTANT: SidebarView is kept alive (but hidden) when in settings to prevent
-      // EXC_BAD_ACCESS crash in SwiftUI's tooltip system. When the view is conditionally
-      // removed, its .help() tooltip graph nodes get invalidated, but the macOS tooltip
-      // tracking system still tries to evaluate them during window key state changes.
+      // Full-height glass sidebar (runs behind the traffic lights). It owns the
+      // "Back to app" control at its top so the whole left column is one panel,
+      // not a header band above a sidebar. SidebarView is kept alive (hidden)
+      // in settings to avoid the tooltip-graph EXC_BAD_ACCESS on window key
+      // changes when a `.help()`-bearing view is torn down.
       if isInSettings {
         ZStack {
           if showsPrimarySidebar {
@@ -991,52 +1012,35 @@ struct DesktopHomeView: View {
           SettingsSidebar(
             selectedSection: $selectedSettingsSection,
             highlightedSettingId: $highlightedSettingId,
-            onBack: {
-              OmiMotion.withGated(Self.pageNavigationAnimation) {
-                selectedIndex =
-                  previousIndexBeforeSettings == SidebarNavItem.settings.rawValue
-                  ? SidebarNavItem.dashboard.rawValue
-                  : previousIndexBeforeSettings
-              }
-            }
+            onBack: { toggleSettings() }
           )
         }
         .fixedSize(horizontal: true, vertical: false)
         .clipped()
+        .transition(.move(edge: .leading).combined(with: .opacity))
       } else if showsPrimarySidebar {
         ZStack {
-          if showsPrimarySidebar {
-            SidebarView(
-              selectedIndex: $selectedIndex,
-              isCollapsed: $isSidebarCollapsed,
-              appState: appState
-            )
-            .opacity(isInSettings ? 0 : 1)
-            .allowsHitTesting(!isInSettings)
-          }
-
+          SidebarView(
+            selectedIndex: $selectedIndex,
+            isCollapsed: $isSidebarCollapsed,
+            appState: appState
+          )
+          .opacity(isInSettings ? 0 : 1)
+          .allowsHitTesting(!isInSettings)
         }
         .fixedSize(horizontal: true, vertical: false)
         .clipped()
       }
 
-      // Main content area with rounded container
+      // Content column: its own top bar (Settings chip when closed, Omi identity
+      // centered, capture, segmented nav) rides above the page, right of the
+      // sidebar — so the sidebar glass is never covered by a full-width band.
       ZStack {
-        // Content container background — clean flat neutral dark (no gradient).
-        RoundedRectangle(cornerRadius: OmiChrome.windowRadius, style: .continuous)
-          .fill(Color(red: 0.050, green: 0.052, blue: 0.059))
-          .overlay(
-            RoundedRectangle(cornerRadius: OmiChrome.windowRadius, style: .continuous)
-              .stroke(OmiColors.border.opacity(0.22), lineWidth: 1)
-          )
-          .shadow(color: .black.opacity(0.22), radius: 26, x: 0, y: 14)
+        // Match the dashboard canvas's top color so the top bar and the page
+        // below it read as one surface — no seam under the segmented nav.
+        Color(red: 0.056, green: 0.058, blue: 0.065)
 
-        // Page content - switch recreates views on tab change
-        // Extracted into a separate struct so that pages like TasksPage
-        // are not re-rendered when AppState publishes unrelated changes.
         VStack(spacing: 0) {
-          // Constant floating top bar — primary nav, new-item counts, and the
-          // Capture/Listening controls. Replaces the old left nav rail.
           if showsTopBar {
             DesktopTopBar(
               selectedIndex: $selectedIndex,
@@ -1044,31 +1048,68 @@ struct DesktopHomeView: View {
               memoriesViewModel: viewModelContainer.memoriesViewModel,
               tasksStore: viewModelContainer.tasksStore,
               sinceDate: topBarSinceDate,
+              leadingInset: isInSettings ? 0 : Self.trafficLightInset,
+              isInSettings: isInSettings,
               onRewind: {
                 OmiMotion.withGated(Self.pageNavigationAnimation) {
                   selectedIndex = SidebarNavItem.rewind.rawValue
                 }
-              }
+              },
+              onToggleSettings: { toggleSettings() }
             )
             .zIndex(1)
           }
 
+          // Page content - switch recreates views on tab change. Extracted so
+          // pages like TasksPage aren't re-rendered on unrelated AppState changes.
           PageContentView(
             selectedIndex: selectedIndex,
             appState: appState,
             viewModelContainer: viewModelContainer,
             selectedSettingsSection: $selectedSettingsSection,
             highlightedSettingId: $highlightedSettingId,
-            selectedTabIndex: $selectedIndex
+            selectedTabIndex: $selectedIndex,
+            onRewindBack: {
+              OmiMotion.withGated(Self.pageNavigationAnimation) {
+                selectedIndex =
+                  previousIndexBeforeRewind == SidebarNavItem.rewind.rawValue
+                  ? SidebarNavItem.dashboard.rawValue
+                  : previousIndexBeforeRewind
+              }
+            }
           )
         }
         .onExitCommand {
           navigateHomeOnEscapeIfNeeded()
         }
-        .clipShape(RoundedRectangle(cornerRadius: OmiChrome.windowRadius, style: .continuous))
       }
-      .padding(OmiSpacing.md)
     }
+    .ignoresSafeArea(.container, edges: .top)
+    // One uniform frosted backdrop for any hoisted modal: the whole window
+    // blurs together and the card sits sharp on top. Tap-outside / Esc dismiss.
+    .blur(radius: modalState.isPresenting ? 10 : 0)
+    .overlay {
+      if modalState.isPresenting, let modal = modalState.content {
+        ZStack {
+          Color.black.opacity(0.25)
+            .ignoresSafeArea()
+            .contentShape(Rectangle())
+            .onTapGesture { modalState.dismiss() }
+          modal
+            .background(OmiColors.backgroundPrimary)
+            .clipShape(RoundedRectangle(cornerRadius: OmiChrome.cardRadius, style: .continuous))
+            .overlay(
+              RoundedRectangle(cornerRadius: OmiChrome.cardRadius, style: .continuous)
+                .stroke(OmiColors.border.opacity(0.4), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.4), radius: 30, x: 0, y: 14)
+            .transition(.scale(scale: 0.97).combined(with: .opacity))
+          OverlayModalEscapeCatcher { modalState.dismiss() }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+    }
+    .animation(.easeOut(duration: 0.22), value: modalState.isPresenting)
     .overlay {
       // Goal completion celebration overlay
       GoalCelebrationView()
@@ -1153,6 +1194,12 @@ struct DesktopHomeView: View {
       {
         previousIndexBeforeSettings = oldValue
       }
+      // Track the tab we came from so Rewind's Back returns there.
+      if newValue == SidebarNavItem.rewind.rawValue
+        && oldValue != SidebarNavItem.rewind.rawValue
+      {
+        previousIndexBeforeRewind = oldValue
+      }
       // Only auto-refresh stores when their pages are visible
       updateStoreActivity(for: newValue)
     }
@@ -1187,34 +1234,12 @@ struct DesktopHomeView: View {
 /// A minimal SB-styled segmented toggle used to fold two related surfaces into
 /// one tab (Conversations/Memories, Focus/Insights).
 private struct HubSegmentedControl: View {
-  @Environment(\.sbTheme) private var sb
   let segments: [String]
   @Binding var selection: Int
 
   var body: some View {
-    HStack(spacing: 4) {
-      ForEach(Array(segments.enumerated()), id: \.offset) { index, segment in
-        Button {
-          withAnimation(.easeOut(duration: 0.15)) { selection = index }
-        } label: {
-          Text(segment)
-            .geist(size: 13, weight: selection == index ? .semibold : .medium)
-            .foregroundStyle(selection == index ? sb.ink : sb.ink(.w45))
-            .padding(.horizontal, 14)
-            .padding(.vertical, 6)
-            .background(
-              RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(selection == index ? sb.ink(.w1) : Color.clear)
-            )
-        }
-        .buttonStyle(.plain)
-      }
-    }
-    .padding(4)
-    .background(
-      RoundedRectangle(cornerRadius: 10, style: .continuous).fill(sb.ink(.w04))
-    )
-    .frame(maxWidth: .infinity, alignment: .leading)
+    OmiSegmentedControl(segments: segments, selection: $selection)
+      .frame(maxWidth: .infinity, alignment: .center)
   }
 }
 
@@ -1230,31 +1255,30 @@ private struct MemoryHubPage: View {
   private static let listContentWidth: CGFloat = 900
 
   var body: some View {
-    Group {
-      if segment == 2 {
-        ZStack(alignment: .top) {
-          // Keep the graph's camera framing intact while removing the list-page
-          // width cap. The map only occupies more of the visual field when the
-          // user deliberately pans or zooms into it.
+    // One stable layout: the segmented control rides on top (so its sliding
+    // indicator persists across every section), the content below cross-fades.
+    VStack(spacing: 0) {
+      hubSegmentedControl
+
+      Group {
+        switch segment {
+        case 0:
+          constrainedListContent(
+            MemoriesPage(
+              viewModel: viewModelContainer.memoriesViewModel,
+              graphViewModel: viewModelContainer.memoryGraphViewModel))
+        case 1:
+          constrainedListContent(ConversationsPageHost(appState: appState))
+        default:
+          // The map keeps its uncapped width so panning/zooming never hits an
+          // artificial boundary; it simply fills the area below the control.
           MemoryGraphPage(viewModel: viewModelContainer.memoryGraphViewModel)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-          hubSegmentedControl
-        }
-      } else {
-        VStack(spacing: 0) {
-          hubSegmentedControl
-
-          if segment == 0 {
-            constrainedListContent(
-              MemoriesPage(
-                viewModel: viewModelContainer.memoriesViewModel,
-                graphViewModel: viewModelContainer.memoryGraphViewModel))
-          } else {
-            constrainedListContent(ConversationsPageHost(appState: appState))
-          }
         }
       }
+      .id(segment)
+      .transition(.opacity.animation(.easeInOut(duration: 0.2)))
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
   }
 
@@ -1287,11 +1311,16 @@ private struct FocusHubPage: View {
         .padding(.horizontal, 28)
         .padding(.bottom, 4)
 
-      if segment == 0 {
-        InsightPage()
-      } else {
-        FocusPage()
+      Group {
+        if segment == 0 {
+          InsightPage()
+        } else {
+          FocusPage()
+        }
       }
+      .id(segment)
+      .transition(.opacity.animation(.easeInOut(duration: 0.2)))
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
   }
 }
@@ -1303,6 +1332,8 @@ private struct PageContentView: View {
   @Binding var selectedSettingsSection: SettingsContentView.SettingsSection
   @Binding var highlightedSettingId: String?
   @Binding var selectedTabIndex: Int
+  /// Returns from Rewind to the tab the user came from (owned by the shell).
+  var onRewindBack: () -> Void = {}
 
   /// The list/detail pages (Conversations, Memories, Tasks, Apps) render their
   /// content in a centered, width-capped column so wide monitors get calm
@@ -1360,7 +1391,7 @@ private struct PageContentView: View {
       case 6:
         InsightPage()
       case 7:
-        RewindPage(appState: appState)
+        RewindPage(appState: appState, onBack: onRewindBack)
       case 8:
         constrainedListPage(
           AppsPage(

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1088,6 +1088,7 @@ struct DesktopHomeView: View {
     // One uniform frosted backdrop for any hoisted modal: the whole window
     // blurs together and the card sits sharp on top. Tap-outside / Esc dismiss.
     .blur(radius: modalState.isPresenting ? 10 : 0)
+    .accessibilityHidden(modalState.isPresenting)
     .overlay {
       if modalState.isPresenting, let modal = modalState.content {
         ZStack {
@@ -1096,6 +1097,7 @@ struct DesktopHomeView: View {
             .contentShape(Rectangle())
             .onTapGesture { modalState.dismiss() }
           modal
+            .accessibilityAddTraits(.isModal)
             .background(OmiColors.backgroundPrimary)
             .clipShape(RoundedRectangle(cornerRadius: OmiChrome.cardRadius, style: .continuous))
             .overlay(

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -1,3 +1,4 @@
+import AppKit
 import OmiTheme
 import SwiftUI
 
@@ -13,7 +14,26 @@ struct DesktopTopBar: View {
   /// Items created after this instant count as "new" — updated whenever Omi
   /// last resigned front (see DesktopHomeView).
   let sinceDate: Date
+  /// Leading inset that clears the window traffic lights when the bar rides in
+  /// the hidden-titlebar band with no sidebar to its left.
+  var leadingInset: CGFloat = 0
+  /// When true the leading chip reads "Back to app" and closes settings; when
+  /// false it reads "Settings" and opens them. Same control, it just morphs.
+  var isInSettings: Bool = false
   let onRewind: () -> Void
+  /// Toggles the settings sidebar open/closed. Owned by DesktopHomeView so the
+  /// back-navigation target (previous tab) stays correct.
+  var onToggleSettings: () -> Void = {}
+
+  /// Drives the sliding selection inside the segmented nav control.
+  @Namespace private var navSegmentNamespace
+
+  private static let logoImage: NSImage? = {
+    guard let url = Bundle.resourceBundle.url(forResource: "herologo", withExtension: "png") else {
+      return nil
+    }
+    return NSImage(contentsOf: url)
+  }()
 
   private struct NavItem: Identifiable {
     let index: Int
@@ -42,74 +62,132 @@ struct DesktopTopBar: View {
   }
 
   var body: some View {
-    HStack(spacing: OmiSpacing.md) {
+    VStack(spacing: OmiSpacing.xs) {
+      // Row 1 — toolbar aligned with the traffic lights: the Settings chip sits
+      // by them (only while closed — in settings "Back to app" lives on the
+      // sidebar glass), the Omi identity is centered, capture on the right.
+      ZStack {
+        omiIdentity
+
+        HStack(spacing: OmiSpacing.md) {
+          if !isInSettings {
+            settingsChip
+              .padding(.leading, leadingInset)
+              .transition(.opacity)
+          }
+          Spacer(minLength: OmiSpacing.md)
+          CaptureListeningControls(appState: appState, onRewind: onRewind)
+        }
+      }
+      .frame(height: 34)
+
+      // Row 2 — the segmented primary nav, centered below the identity.
       navPills
-      Spacer(minLength: OmiSpacing.md)
-      CaptureListeningControls(appState: appState, onRewind: onRewind)
-      settingsButton
     }
-    .frame(height: 44)
     .padding(.horizontal, OmiSpacing.lg)
-    .padding(.vertical, OmiSpacing.sm)
+    .padding(.top, 10)
+    .padding(.bottom, OmiSpacing.sm)
+    .background(WindowDragArea())
   }
 
-  /// Gear that opens Settings. The old left rail held the settings/profile entry;
-  /// with the rail gone this is the only visible way in (⌘, still works too).
-  private var settingsButton: some View {
-    let isActive = selectedIndex == SidebarNavItem.settings.rawValue
-    return Button {
-      OmiMotion.withGated(.easeOut(duration: 0.08)) {
-        selectedIndex = SidebarNavItem.settings.rawValue
+  /// The app identity beside the window controls: mark + wordmark, centered.
+  private var omiIdentity: some View {
+    HStack(spacing: OmiSpacing.xs) {
+      if let logo = Self.logoImage {
+        Image(nsImage: logo)
+          .resizable()
+          .scaledToFit()
+          .frame(width: 18, height: 18)
       }
-    } label: {
-      Image(systemName: "gearshape")
-        .scaledFont(size: OmiType.body, weight: .semibold)
-        .foregroundColor(isActive ? OmiColors.textPrimary : OmiColors.textTertiary)
-        .frame(width: 32, height: 32)
-        .background(Circle().fill(isActive ? OmiColors.textPrimary.opacity(0.08) : Color.clear))
-        .contentShape(Circle())
+      Text("Omi")
+        .scaledFont(size: OmiType.subheading, weight: .semibold)
+        .foregroundColor(OmiColors.textPrimary)
+    }
+    .allowsHitTesting(false)
+  }
+
+  /// Opens settings. It sits by the traffic lights; when settings is open the
+  /// matching "Back to app" control lives on the sidebar glass instead.
+  private var settingsChip: some View {
+    Button(action: onToggleSettings) {
+      HStack(spacing: OmiSpacing.sm) {
+        Image(systemName: "gearshape")
+          .scaledFont(size: OmiType.body, weight: .semibold)
+          .frame(width: 18, height: 18)
+        Text("Settings")
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+      }
+      .foregroundColor(OmiColors.textTertiary)
+      .padding(.horizontal, OmiSpacing.md)
+      .frame(height: 34)
+      .background(
+        Capsule(style: .continuous)
+          .fill(Color.white.opacity(0.05))
+          .overlay(Capsule(style: .continuous).stroke(Color.white.opacity(0.07), lineWidth: 1))
+      )
+      .contentShape(Capsule())
     }
     .buttonStyle(.plain)
     .help("Settings")
   }
 
   private var navPills: some View {
-    // Flat, containerless nav so the bar blends with the chat page: unselected
-    // items are muted text; the selected item gets a subtle highlight only.
-    HStack(spacing: OmiSpacing.xs) {
+    // Segmented control: one rounded track holds the four primary tabs and the
+    // selected segment's fill slides between them via matchedGeometry, so it
+    // reads as a single native control instead of loose pills.
+    HStack(spacing: 2) {
       ForEach(navItems) { item in
-        Button {
-          OmiMotion.withGated(.easeOut(duration: 0.08)) { selectedIndex = item.index }
-        } label: {
-          HStack(spacing: 6) {
-            Image(systemName: item.icon)
-              .scaledFont(size: OmiType.caption, weight: .semibold)
-            Text(item.title)
-              .scaledFont(size: OmiType.caption, weight: .semibold)
-            // New-item badge lives on the button it belongs to (Memory =
-            // memories + conversations, Tasks = tasks) since Omi was last front.
-            if newCount(for: item) > 0 {
-              Text("+\(newCount(for: item))")
-                .scaledFont(size: OmiType.micro, weight: .bold)
-                .foregroundColor(OmiColors.textPrimary)
-                .padding(.horizontal, 5)
-                .padding(.vertical, 1)
-                .background(Capsule(style: .continuous).fill(OmiColors.textPrimary.opacity(0.16)))
-            }
-          }
-          .foregroundColor(selectedIndex == item.index ? OmiColors.textPrimary : OmiColors.textTertiary)
-          .padding(.horizontal, OmiSpacing.md)
-          .padding(.vertical, 6)
-          .background(
-            Capsule(style: .continuous)
-              .fill(selectedIndex == item.index ? OmiColors.textPrimary.opacity(0.08) : Color.clear)
-          )
-          .contentShape(Capsule())
-        }
-        .buttonStyle(.plain)
-        .help(item.title)
+        navSegment(item)
       }
     }
+    .padding(3)
+    .background(
+      Capsule(style: .continuous)
+        .fill(Color.white.opacity(0.05))
+        .overlay(
+          Capsule(style: .continuous)
+            .stroke(Color.white.opacity(0.07), lineWidth: 1)
+        )
+    )
+  }
+
+  private func navSegment(_ item: NavItem) -> some View {
+    let isSelected = selectedIndex == item.index
+    return Button {
+      OmiMotion.withGated(.spring(response: 0.32, dampingFraction: 0.82)) {
+        selectedIndex = item.index
+      }
+    } label: {
+      HStack(spacing: 6) {
+        Image(systemName: item.icon)
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+        Text(item.title)
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+        // New-item badge lives on the segment it belongs to (Memory =
+        // memories + conversations, Tasks = tasks) since Omi was last front.
+        if newCount(for: item) > 0 {
+          Text("+\(newCount(for: item))")
+            .scaledFont(size: OmiType.micro, weight: .bold)
+            .foregroundColor(OmiColors.textPrimary)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(Capsule(style: .continuous).fill(OmiColors.textPrimary.opacity(0.18)))
+        }
+      }
+      .foregroundColor(isSelected ? OmiColors.textPrimary : OmiColors.textTertiary)
+      .padding(.horizontal, OmiSpacing.md)
+      .padding(.vertical, 6)
+      .background {
+        if isSelected {
+          Capsule(style: .continuous)
+            .fill(Color.white.opacity(0.12))
+            .matchedGeometryEffect(id: "navSegment", in: navSegmentNamespace)
+        }
+      }
+      .contentShape(Capsule())
+    }
+    .buttonStyle(.plain)
+    .help(item.title)
   }
 
   /// New-item count to badge on a nav button (since Omi was last in front).
@@ -121,5 +199,16 @@ struct DesktopTopBar: View {
     case SidebarNavItem.tasks.rawValue: return newTasks
     default: return 0
     }
+  }
+}
+
+/// Lets the user drag the window by the top bar's empty areas, the way a native
+/// toolbar behaves. Controls on top keep their own clicks; only the gaps drag.
+private struct WindowDragArea: NSViewRepresentable {
+  func makeNSView(context: Context) -> NSView { DragView() }
+  func updateNSView(_ nsView: NSView, context: Context) {}
+
+  private final class DragView: NSView {
+    override var mouseDownCanMoveWindow: Bool { true }
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/ModalPresentationState.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ModalPresentationState.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Hoists a page's modal up to the shell so the WHOLE window (top bar included)
+/// gets one uniform frosted backdrop, and the modal card renders sharp on top.
+/// Pages keep their own selection state and mirror it here via `dismissableSheet`.
+/// A per-presenter token guards against one modal clearing another's state.
+@MainActor final class ModalPresentationState: ObservableObject {
+  static let shared = ModalPresentationState()
+
+  @Published private(set) var content: AnyView?
+  private var token: UUID?
+  private var onDismiss: () -> Void = {}
+
+  var isPresenting: Bool { content != nil }
+
+  func present<V: View>(token: UUID, dismiss: @escaping () -> Void, @ViewBuilder content: () -> V) {
+    self.token = token
+    self.onDismiss = dismiss
+    self.content = AnyView(content())
+  }
+
+  /// Clears only if `token` owns the current presentation.
+  func clear(token: UUID) {
+    guard self.token == token else { return }
+    content = nil
+    self.token = nil
+    onDismiss = {}
+  }
+
+  /// Called by the shell backdrop (tap-outside / Escape) to dismiss.
+  func dismiss() { onDismiss() }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -301,7 +301,7 @@ struct AppsPage: View {
     }
     .dismissableSheet(item: $selectedApp) { app in
       AppDetailSheet(app: app, appProvider: appProvider, onDismiss: { selectedApp = nil })
-        .frame(width: 500, height: 650)
+        .fittedModal(width: 500, maxHeight: 650)
         .onAppear {
           AnalyticsManager.shared.appDetailViewed(appId: app.id, appName: app.name)
         }
@@ -315,7 +315,7 @@ struct AppsPage: View {
           selectedConnector = nil
         }
       )
-      .frame(width: 520, height: 620)
+      .fittedModal(width: 520, maxHeight: 620)
       .onAppear {
         automationPresentationDidAppear(.importConnector(connector.id))
       }
@@ -331,7 +331,7 @@ struct AppsPage: View {
           selectedExportDestination = nil
         }
       )
-      .frame(width: 520, height: 620)
+      .fittedModal(width: 520, maxHeight: 620)
       .onAppear {
         automationPresentationDidAppear(.exportDestination(destination.rawValue))
       }
@@ -513,9 +513,7 @@ struct AppsPage: View {
         .buttonStyle(.plain)
       }
     }
-    .padding(OmiSpacing.sm)
-    .background(OmiColors.backgroundSecondary)
-    .cornerRadius(OmiChrome.smallControlRadius)
+    .omiSearchFieldChrome()
   }
 
   private var filterControls: some View {
@@ -577,12 +575,19 @@ struct AppsPage: View {
       }
       .padding(.horizontal, OmiSpacing.md)
       .padding(.vertical, OmiSpacing.sm)
-      .background(OmiColors.backgroundSecondary)
       .foregroundColor(OmiColors.textPrimary)
-      .cornerRadius(OmiChrome.elementRadius)
+      .background(
+        Capsule(style: .continuous)
+          .fill(
+            appProvider.selectedCategory != nil
+              ? OmiColors.backgroundTertiary : OmiColors.backgroundSecondary)
+      )
       .overlay(
-        RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
-          .stroke(appProvider.selectedCategory != nil ? OmiColors.border : Color.clear, lineWidth: 1)
+        Capsule(style: .continuous)
+          .stroke(
+            appProvider.selectedCategory != nil
+              ? Color.white.opacity(0.18) : Color.white.opacity(0.07),
+            lineWidth: 1)
       )
     }
     .menuStyle(.borderlessButton)
@@ -1831,6 +1836,8 @@ struct FilterToggle: View {
   let isActive: Bool
   let action: () -> Void
 
+  @State private var isHovering = false
+
   var body: some View {
     Button(action: action) {
       HStack(spacing: OmiSpacing.xs) {
@@ -1842,16 +1849,27 @@ struct FilterToggle: View {
       }
       .padding(.horizontal, OmiSpacing.md)
       .padding(.vertical, OmiSpacing.sm)
-      .background(isActive ? Color.white : OmiColors.backgroundSecondary)
-      .foregroundColor(isActive ? Color.black : OmiColors.textSecondary)
-      .cornerRadius(OmiChrome.elementRadius)
+      .foregroundColor(
+        isActive ? Color.black : (isHovering ? OmiColors.textPrimary : OmiColors.textSecondary)
+      )
+      .background(
+        Capsule(style: .continuous)
+          .fill(
+            isActive
+              ? Color.white
+              : (isHovering ? OmiColors.backgroundTertiary : OmiColors.backgroundSecondary))
+      )
       .overlay(
-        RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
-          .stroke(isActive ? OmiColors.border : Color.clear, lineWidth: 1)
+        Capsule(style: .continuous)
+          .stroke(isActive ? Color.clear : Color.white.opacity(0.07), lineWidth: 1)
       )
       .fixedSize(horizontal: true, vertical: false)
     }
     .buttonStyle(.plain)
+    .onHover { hovering in
+      OmiMotion.withGated(.easeOut(duration: 0.12)) { isHovering = hovering }
+    }
+    .omiAnimation(.easeOut(duration: 0.15), value: isActive)
   }
 }
 
@@ -1869,21 +1887,26 @@ struct SmallHeaderButton: View {
     Button(action: action) {
       HStack(spacing: OmiSpacing.xs) {
         Image(systemName: icon)
-          .scaledFont(size: OmiType.caption)
+          .scaledFont(size: OmiType.caption, weight: .semibold)
           .foregroundColor(color)
         Text(label)
-          .scaledFont(size: OmiType.caption, weight: .medium)
-          .foregroundColor(OmiColors.textSecondary)
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .foregroundColor(isHovering ? OmiColors.textPrimary : OmiColors.textSecondary)
           .lineLimit(1)
       }
-      .padding(.horizontal, OmiSpacing.sm)
-      .padding(.vertical, OmiSpacing.xs)
-      .background(isHovering ? OmiColors.backgroundTertiary : OmiColors.backgroundSecondary)
-      .cornerRadius(OmiChrome.badgeRadius)
+      .padding(.horizontal, OmiSpacing.md)
+      .padding(.vertical, OmiSpacing.sm)
+      .background(
+        Capsule(style: .continuous)
+          .fill(isHovering ? OmiColors.backgroundTertiary : OmiColors.backgroundSecondary)
+      )
+      .overlay(Capsule(style: .continuous).stroke(Color.white.opacity(0.07), lineWidth: 1))
       .fixedSize(horizontal: true, vertical: false)
     }
     .buttonStyle(.plain)
-    .onHover { isHovering = $0 }
+    .onHover { hovering in
+      OmiMotion.withGated(.easeOut(duration: 0.12)) { isHovering = hovering }
+    }
   }
 }
 
@@ -3532,54 +3555,33 @@ extension View {
 }
 
 /// Item-based version of DismissableSheetModifier for optional item bindings.
+/// The modal is hoisted to the shell (`ModalPresentationState`) so one uniform
+/// frosted backdrop covers the whole window and the card renders sharp on top —
+/// this modifier just mirrors the page's selection state up.
 struct DismissableSheetItemModifier<Item: Identifiable, SheetContent: View>: ViewModifier {
   @Binding var item: Item?
   let sheetContent: (Item) -> SheetContent
 
+  @State private var token = UUID()
+
   func body(content: Content) -> some View {
     content
-      // The overlay is modal: while it is up, the content underneath must
-      // not be reachable by VoiceOver / Full Keyboard Access.
-      .accessibilityHidden(item != nil)
-      .overlay {
-        ZStack {
-          if let presentedItem = item {
-            // Dimmed background that dismisses on tap.
-            Color.black.opacity(0.3)
-              .ignoresSafeArea()
-              .contentShape(Rectangle())
-              .onTapGesture {
-                log("DISMISSABLE_SHEET: Background tapped, dismissing item")
-                OmiMotion.withGated(.easeOut(duration: 0.2)) {
-                  item = nil
-                }
-              }
-              .transition(.opacity)
-              .zIndex(0)
+      .onChange(of: item?.id) { _, _ in sync() }
+      .onAppear { if item != nil { sync() } }
+      .onDisappear { ModalPresentationState.shared.clear(token: token) }
+  }
 
-            // Force the sheet into a centered full-size overlay so it
-            // does not end up clipped or visually hidden behind the scrim.
-            sheetContent(presentedItem)
-              .background(OmiColors.backgroundPrimary)
-              .clipShape(RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius))
-              .shadow(color: .black.opacity(0.3), radius: 20, x: 0, y: 10)
-              .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-              .transition(.scale(scale: 0.95).combined(with: .opacity))
-              .accessibilityAddTraits(.isModal)
-              .zIndex(1)
-
-            OverlayModalEscapeCatcher {
-              log("DISMISSABLE_SHEET: Escape pressed, dismissing item")
-              OmiMotion.withGated(.easeOut(duration: 0.2)) {
-                item = nil
-              }
-            }
-            .zIndex(2)
-          }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+  private func sync() {
+    if let presentedItem = item {
+      ModalPresentationState.shared.present(
+        token: token,
+        dismiss: { OmiMotion.withGated(.easeOut(duration: 0.2)) { item = nil } }
+      ) {
+        sheetContent(presentedItem)
       }
-      .omiAnimation(.easeOut(duration: 0.2), value: item?.id != nil)
+    } else {
+      ModalPresentationState.shared.clear(token: token)
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -442,11 +442,7 @@ struct ConversationsPage: View {
             .buttonStyle(.plain)
           }
         }
-        .padding(.horizontal, OmiSpacing.sm)
-        .padding(.vertical, OmiSpacing.md)
-        .frame(minHeight: 46)
-        .omiControlSurface(
-          fill: OmiColors.backgroundSecondary, radius: 18, stroke: OmiColors.border.opacity(0.18))
+        .omiSearchFieldChrome()
 
         // Filter buttons
         filterButtonsRow

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -251,8 +251,16 @@ struct DashboardPage: View {
   @AppStorage("systemAudioCaptureMode") private var systemAudioCaptureModeRaw =
     AssistantSettings.SystemAudioCaptureMode.onlyDuringMeetings.rawValue
   @AppStorage("useLegacyHomeDesign") private var useLegacyHomeDesign = false
-  @State private var homeMode: HomeStageMode = .chat
+  @State private var homeMode: HomeStageMode = .landing
   @FocusState private var homeAskFieldFocused: Bool
+
+  /// Landing hero state. `homeLandingReveal` drives the staggered entrance and
+  /// `homeLandingLogoAngle` is the subtle ambient rotation. `landingScrollMonitor`
+  /// is a scroll-wheel monitor installed only while the landing shows, so any
+  /// deliberate scroll reveals the conversation.
+  @State private var homeLandingReveal = false
+  @State private var homeLandingLogoAngle: Double = 0
+  @State private var landingScrollMonitor: Any?
 
   /// Rotation index for the home knows-list; a timer advances it so the hub
   /// cycles through fresh suggestions while you're looking at it.
@@ -285,6 +293,9 @@ struct DashboardPage: View {
   private static let homeStageMaxSideInset: CGFloat = 96
   private static let homeAskBarMinWidth: CGFloat = 560
   private static let homeAskBarMaxWidth: CGFloat = 980
+  /// The landing composer is tighter and centered; it widens to the chat
+  /// column width as it drops to the bottom on send.
+  private static let homeLandingAskBarWidth: CGFloat = 640
   private static let homeStagePanelMaxWidth: CGFloat = 1280
   private static let homeChatColumnMaxWidth: CGFloat = 900
   private static let homeStageTopPadding: CGFloat = 8
@@ -480,6 +491,7 @@ struct DashboardPage: View {
         }
         syncCaptureState()
         autoOpenChatForExistingHistoryIfNeeded()
+        startHomeLandingEntrance()
         // Post-onboarding, the resting hub is shown by default — open the chat
         // surface so the personalized opener (set on onboarding completion) is
         // actually visible instead of hidden behind the hub.
@@ -501,6 +513,7 @@ struct DashboardPage: View {
       }
       .onDisappear {
         intelligenceStore.setRecommendationActionHandler(nil)
+        removeLandingScrollReveal()
       }
       .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
         viewModel.refreshGoals()
@@ -543,13 +556,20 @@ struct DashboardPage: View {
       }
       // Chat history is the home surface: as soon as the (async) history
       // load shows prior messages, land on the chat panel, not the greeting.
+      // The landing is intentionally NOT revealed by message-count changes:
+      // count churns for background reasons (startup restore, pagination,
+      // owner reconciliation, activate-refresh), none of which are a
+      // user-facing "new turn". The landing reveals only on an explicit user
+      // action (sending, or the Continue-conversation affordance).
       .onChange(of: chatProvider.messages.count) { _, _ in
         autoOpenChatForExistingHistoryIfNeeded()
       }
       // Clicking into the ask bar reveals the inline chat; the same is true
       // when focus lands there via keyboard (Tab / Full Keyboard Access).
+      // The landing keeps its centered composer on focus — only sending
+      // transitions to chat — so it is excluded here.
       .onChange(of: homeAskFieldFocused) { _, focused in
-        if focused && !useLegacyHomeDesign && homeMode != .chat {
+        if focused && !useLegacyHomeDesign && homeMode != .chat && homeMode != .landing {
           openHomeChat()
         }
       }
@@ -800,37 +820,159 @@ struct DashboardPage: View {
   /// Panel layout (chat / connect): the surface fills the height with the ask
   /// bar anchored directly beneath it.
   private func homePanelStage(stageWidth: CGFloat, askBarWidth: CGFloat) -> some View {
+    // `homeAskBar` is one persistent instance between the two conditional
+    // regions, so switching landing→chat animates its frame from center to
+    // bottom (draft text and focus are preserved) instead of cross-fading.
     VStack(spacing: 0) {
-      ZStack {
-        switch homeMode {
-        case .chat:
-          homeChatPanel(width: askBarWidth)
-            .transition(.homeDropFromTop)
-        case .connect:
-          homeConnectPanel(stageWidth: stageWidth)
-            .transition(.homeDropFromTop)
-        case .hub:
-          EmptyView()
-        }
-      }
-      .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-      // Rolling suggestions sit just above the ask bar while the chat is empty —
-      // but not for a just-onboarded user, whose empty chat shows the personalized
-      // onboarding opener (with its own starter questions) instead.
-      if chatProvider.messages.isEmpty && chatProvider.onboardingOpener == nil {
-        homeRollingSuggestions
+      if homeMode == .landing {
+        Spacer(minLength: 0)
+        homeLandingHero
           .frame(width: askBarWidth)
-          .padding(.bottom, OmiSpacing.sm)
+          .padding(.bottom, OmiSpacing.xl)
+      } else {
+        ZStack {
+          switch homeMode {
+          case .chat:
+            homeChatPanel(width: askBarWidth)
+              .transition(.homeDropFromTop)
+          case .connect:
+            homeConnectPanel(stageWidth: stageWidth)
+              .transition(.homeDropFromTop)
+          case .hub, .landing:
+            EmptyView()
+          }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+        // Rolling suggestions sit just above the ask bar while the chat is empty —
+        // but not for a just-onboarded user, whose empty chat shows the personalized
+        // onboarding opener (with its own starter questions) instead.
+        if chatProvider.messages.isEmpty && chatProvider.onboardingOpener == nil {
+          homeRollingSuggestions
+            .frame(width: askBarWidth)
+            .padding(.bottom, OmiSpacing.sm)
+        }
       }
 
       homeAskBar
         .frame(width: askBarWidth)
-        .padding(.top, OmiSpacing.xl)
+        .padding(.top, homeMode == .landing ? 0 : OmiSpacing.xl)
 
-      dashboardChatErrorCard
-        .frame(width: askBarWidth)
-        .padding(.top, OmiSpacing.sm)
+      if homeMode == .landing {
+        homeLandingChips
+          .frame(width: askBarWidth)
+          .padding(.top, OmiSpacing.lg)
+        Spacer(minLength: 0)
+      } else {
+        dashboardChatErrorCard
+          .frame(width: askBarWidth)
+          .padding(.top, OmiSpacing.sm)
+      }
+    }
+  }
+
+  // MARK: - Landing hero (on-open empty state)
+
+  /// The centered on-open hero: a subtly rotating Omi mark, the greeting, and
+  /// a one-line subtitle, each element staggered in. The composer and prompt
+  /// chips sit directly beneath (rendered by `homePanelStage`).
+  private var homeLandingHero: some View {
+    VStack(spacing: OmiSpacing.md) {
+      landingLogo
+        .homeLandingReveal(homeLandingReveal, delay: 0.0)
+
+      Text("Ask omi anything")
+        .scaledFont(size: OmiType.subheading, weight: .semibold)
+        .foregroundColor(OmiColors.textPrimary)
+        .homeLandingReveal(homeLandingReveal, delay: 0.08)
+
+      Text("Your personal AI assistant, ready when you are")
+        .scaledFont(size: OmiType.body)
+        .foregroundColor(OmiColors.textSecondary)
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 360)
+        .homeLandingReveal(homeLandingReveal, delay: 0.14)
+    }
+    .frame(maxWidth: .infinity)
+    .onAppear { installLandingScrollReveal() }
+    .onDisappear { removeLandingScrollReveal() }
+  }
+
+  /// While the landing shows, any deliberate scroll reveals the conversation
+  /// (the transcript lives "above" the landing). Scoped by install/remove on
+  /// the hero's appear/disappear, and re-checked against `homeMode` so a scroll
+  /// never reveals from another surface or under a modal.
+  private func installLandingScrollReveal() {
+    guard landingScrollMonitor == nil else { return }
+    landingScrollMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { event in
+      if homeMode == .landing, !isHomeModalPresented, abs(event.scrollingDeltaY) > 4 {
+        openHomeChat(focusInput: false)
+      }
+      return event
+    }
+  }
+
+  private func removeLandingScrollReveal() {
+    if let monitor = landingScrollMonitor {
+      NSEvent.removeMonitor(monitor)
+      landingScrollMonitor = nil
+    }
+  }
+
+  private var landingLogo: some View {
+    Group {
+      if let logoURL = Bundle.resourceBundle.url(forResource: "herologo", withExtension: "png"),
+        let logoImage = NSImage(contentsOf: logoURL)
+      {
+        Image(nsImage: logoImage)
+          .resizable()
+          .scaledToFit()
+      } else {
+        Image(systemName: "circle.hexagongrid.fill")
+          .resizable()
+          .scaledToFit()
+          .foregroundColor(OmiColors.textPrimary)
+      }
+    }
+    .frame(width: 44, height: 44)
+    .rotationEffect(.degrees(homeLandingLogoAngle))
+  }
+
+  /// Suggested prompts under the landing composer. Tapping one continues the
+  /// same conversation (openHomeChat + send). Hidden when no suggestions exist.
+  @ViewBuilder private var homeLandingChips: some View {
+    let prompts = Array(homeSuggestedQuestions.prefix(3))
+    if !prompts.isEmpty {
+      HStack(spacing: OmiSpacing.sm) {
+        ForEach(prompts, id: \.self) { prompt in
+          Button {
+            askHomeSuggestion(prompt)
+          } label: {
+            Text(prompt)
+              .scaledFont(size: OmiType.caption, weight: .medium)
+              .foregroundColor(OmiColors.textSecondary)
+              .lineLimit(1)
+              .padding(.horizontal, OmiSpacing.md)
+              .padding(.vertical, OmiSpacing.sm)
+              .background(Capsule(style: .continuous).fill(Color.white.opacity(0.06)))
+              .overlay(Capsule(style: .continuous).stroke(Color.white.opacity(0.08), lineWidth: 1))
+              .contentShape(Capsule())
+          }
+          .buttonStyle(.plain)
+        }
+      }
+      .homeLandingReveal(homeLandingReveal, delay: 0.20)
+    }
+  }
+
+  /// Kicks off the landing hero's staggered entrance and its subtle ambient
+  /// rotation. Both gate off cleanly under Reduce Motion.
+  private func startHomeLandingEntrance() {
+    homeLandingReveal = true
+    if !OmiMotion.reduceMotion {
+      withAnimation(.linear(duration: 18).repeatForever(autoreverses: false)) {
+        homeLandingLogoAngle = 360
+      }
     }
   }
 
@@ -1190,11 +1332,11 @@ struct DashboardPage: View {
       .padding(OmiSpacing.lg)
       .frame(maxWidth: .infinity, alignment: .topLeading)
       .background(
-        RoundedRectangle(cornerRadius: 22, style: .continuous)
+        RoundedRectangle(cornerRadius: 29, style: .continuous)
           .fill(Color.white.opacity(0.025))
       )
       .overlay(
-        RoundedRectangle(cornerRadius: 22, style: .continuous)
+        RoundedRectangle(cornerRadius: 29, style: .continuous)
           .stroke(HomePalette.hairline.opacity(0.55), lineWidth: 1)
       )
   }
@@ -1262,6 +1404,11 @@ struct DashboardPage: View {
 
   private func homeAskBarWidth(for stageWidth: CGFloat) -> CGFloat {
     let contentWidth = homeStageContentWidth(for: stageWidth)
+    if homeMode == .landing {
+      // Landing: a tighter, centered composer that widens back to the chat
+      // column width as it animates down to the bottom on send.
+      return min(Self.homeLandingAskBarWidth, contentWidth)
+    }
     if homeMode != .hub {
       // Chat mode: bar and message column share one readable width, edges
       // aligned (bubbles start/end on the bar's verticals).
@@ -1329,10 +1476,11 @@ struct DashboardPage: View {
     }
   }
 
-  /// The surface Home rests on when no panel is explicitly open: the chat
-  /// timeline once any history exists, otherwise the greeting hub.
-  /// Home opens directly in the continuous chat (no greeting hero). Rolling
-  /// suggestions sit above the ask bar while the chat is empty.
+  /// The surface Home rests on once the user has entered the conversation:
+  /// the continuous chat timeline. Home *opens* on the landing hero
+  /// (`.landing`); the first send transitions here and it stays the resting
+  /// surface for the rest of the session. Rolling suggestions sit above the
+  /// ask bar while the chat is empty.
   private var homeRestingMode: HomeStageMode {
     .chat
   }
@@ -2220,14 +2368,18 @@ enum HomeStageMode: Equatable {
   case hub
   case chat
   case connect
+  /// The on-open landing: a centered hero (rotating mark + composer) shown
+  /// before the transcript. Same conversation underneath — the first send
+  /// transitions to `.chat` and continues the one shared thread.
+  case landing
 
   /// Whether the user-facing collapse catchers (click-outside + Esc) mount.
   /// Only a panel that can collapse to a *different* resting surface gets a
-  /// catcher. The hub is the base surface, never an overlay: mounting a
-  /// catcher over hub-with-history would invert the gesture and make a stray
-  /// click or Esc *open* the chat.
+  /// catcher. `hub` and `landing` are base surfaces, never overlays: mounting
+  /// a catcher over them would invert the gesture and make a stray click or
+  /// Esc *open* the chat.
   static func collapseCatcherActive(mode: HomeStageMode, resting: HomeStageMode) -> Bool {
-    mode != resting && mode != .hub
+    mode != resting && mode != .hub && mode != .landing
   }
 
   var automationLabel: String {
@@ -2235,6 +2387,7 @@ enum HomeStageMode: Equatable {
     case .hub: return "hub"
     case .chat: return "chat"
     case .connect: return "connect"
+    case .landing: return "landing"
     }
   }
 }
@@ -2274,6 +2427,18 @@ extension AnyTransition {
       active: HomeStageDropModifier(offsetY: 10, scale: 1, opacity: 0),
       identity: HomeStageDropModifier(offsetY: 0, scale: 1, opacity: 1)
     )
+  }
+}
+
+extension View {
+  /// Staggered fade + slight upward drift for a landing-hero element. The
+  /// caller varies `delay` per element so they settle in sequence. Gates off
+  /// under Reduce Motion.
+  fileprivate func homeLandingReveal(_ shown: Bool, delay: Double) -> some View {
+    self
+      .opacity(shown ? 1 : 0)
+      .offset(y: shown ? 0 : 10)
+      .animation(OmiMotion.gated(.easeOut(duration: 0.45).delay(delay)), value: shown)
   }
 }
 
@@ -2326,13 +2491,13 @@ struct HomeAskBar: View {
           Image(systemName: "paperclip")
             .scaledFont(size: OmiType.subheading, weight: .medium)
             .foregroundStyle(isFocused ? HomePalette.secondary : HomePalette.muted)
-            .frame(width: 24, height: 34)
+            .frame(width: 24, height: 30)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .disabled(attachments.count >= kMaxChatAttachments)
         .help("Attach files")
-        .padding(.bottom, 3)
+        .padding(.bottom, 2)
 
         // Auto-growing input: `axis: .vertical` + `lineLimit(1...6)` grow the pill
         // as text wraps (scrolls past six lines). Return submits, Shift+Return
@@ -2349,7 +2514,7 @@ struct HomeAskBar: View {
         .foregroundStyle(HomePalette.ink)
         .lineLimit(1...6)
         .focused(focus)
-        .padding(.vertical, 7)
+        .padding(.vertical, 5)
         .onKeyPress(phases: .down) { press in
           guard press.key == .return else { return .ignored }
           // Shift+Return falls through to the field's newline handling.
@@ -2363,26 +2528,26 @@ struct HomeAskBar: View {
       }
       .padding(.leading, OmiSpacing.lg)
       .padding(.trailing, OmiSpacing.sm)
-      .padding(.vertical, 12)
-      .frame(minHeight: 58)
+      .padding(.vertical, 7)
+      .frame(minHeight: 44)
     }
     .background(
-      RoundedRectangle(cornerRadius: 29, style: .continuous)
+      RoundedRectangle(cornerRadius: 22, style: .continuous)
         .fill(HomePalette.tile.opacity(isHovering || isFocused ? 1 : 0.92))
     )
     .overlay {
       if isDropTargeted {
-        RoundedRectangle(cornerRadius: 29, style: .continuous)
+        RoundedRectangle(cornerRadius: 22, style: .continuous)
           .stroke(Color.white.opacity(0.42), lineWidth: 1)
       } else {
-        RoundedRectangle(cornerRadius: 29, style: .continuous)
+        RoundedRectangle(cornerRadius: 22, style: .continuous)
           .stroke(HomePalette.stageGlow.opacity(isFocused ? 0.16 : 0.08), lineWidth: 1)
           .blur(radius: 1.8)
       }
     }
     .shadow(color: HomePalette.stageGlow.opacity(isFocused ? 0.11 : 0.045), radius: isFocused ? 22 : 16, y: 8)
     .shadow(color: .black.opacity(isFocused ? 0.45 : 0.34), radius: 24, y: 10)
-    .contentShape(.rect(cornerRadius: 29))
+    .contentShape(.rect(cornerRadius: 22))
     .onTapGesture {
       onActivate()
       focus.wrappedValue = true
@@ -2463,7 +2628,7 @@ struct HomeAskBar: View {
           .scaledFont(size: OmiType.body, weight: .bold)
           .foregroundStyle(Color.black)
       }
-      .frame(width: 34, height: 34)
+      .frame(width: 30, height: 30)
       .contentShape(Circle())
     }
     .buttonStyle(.plain)
@@ -2487,7 +2652,7 @@ struct HomeAskBar: View {
             .foregroundStyle(HomePalette.ink)
         }
       }
-      .frame(width: 34, height: 34)
+      .frame(width: 30, height: 30)
       .contentShape(Circle())
     }
     .buttonStyle(.plain)
@@ -3613,11 +3778,11 @@ private struct HomeGlassPanel<Content: View>: View {
       .padding(OmiSpacing.lg)
       .frame(maxWidth: .infinity, alignment: .topLeading)
       .background(
-        RoundedRectangle(cornerRadius: 22, style: .continuous)
+        RoundedRectangle(cornerRadius: 29, style: .continuous)
           .fill(HomePalette.panel)
       )
       .overlay(
-        RoundedRectangle(cornerRadius: 22, style: .continuous)
+        RoundedRectangle(cornerRadius: 29, style: .continuous)
           .stroke(HomePalette.hairline.opacity(0.8), lineWidth: 1)
       )
       .shadow(color: .black.opacity(0.08), radius: 14, y: 6)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -287,7 +287,7 @@ struct DashboardPage: View {
   private static let homeAskBarMaxWidth: CGFloat = 980
   private static let homeStagePanelMaxWidth: CGFloat = 1280
   private static let homeChatColumnMaxWidth: CGFloat = 900
-  private static let homeStageTopPadding: CGFloat = 74
+  private static let homeStageTopPadding: CGFloat = 8
   private static let homeStageBottomPadding: CGFloat = 26
   private static let homeStageAnimation = Animation.spring(response: 0.46, dampingFraction: 0.86)
   private static let appsPopupMaxWidth: CGFloat = 1040
@@ -1117,19 +1117,21 @@ struct DashboardPage: View {
         welcomeContent: { dashboardChatWelcome }
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
+      // A short fade at each end: the transcript recedes softly under the
+      // segmented nav at the top and toward the composer at the bottom.
       .mask(
         LinearGradient(
           stops: [
             .init(color: .clear, location: 0.0),
-            .init(color: .black, location: 0.05),
-            .init(color: .black, location: 0.97),
+            .init(color: .black, location: 0.03),
+            .init(color: .black, location: 0.95),
             .init(color: .clear, location: 1.0),
           ],
           startPoint: .top,
           endPoint: .bottom
         )
       )
-      .padding(.vertical, OmiSpacing.xs)
+      .padding(.top, OmiSpacing.xs)
 
     }
     // Chat is the Home surface itself — no card chrome, it sits directly on
@@ -2330,6 +2332,7 @@ struct HomeAskBar: View {
         .buttonStyle(.plain)
         .disabled(attachments.count >= kMaxChatAttachments)
         .help("Attach files")
+        .padding(.bottom, 3)
 
         // Auto-growing input: `axis: .vertical` + `lineLimit(1...6)` grow the pill
         // as text wraps (scrolls past six lines). Return submits, Shift+Return
@@ -2356,6 +2359,7 @@ struct HomeAskBar: View {
         }
 
         actionButton
+          .padding(.bottom, 1)
       }
       .padding(.leading, OmiSpacing.lg)
       .padding(.trailing, OmiSpacing.sm)
@@ -4077,90 +4081,46 @@ struct HomeListeningStatusButton: View {
   let action: () -> Void
   let modeAction: () -> Void
 
-  // Single pill-level hover flag so moving between the title and the mode
-  // toggle never flickers the revealed controls.
   @State private var isHovering = false
 
+  // Fixed-size chip that matches Capture exactly: icon + title, no hover-grow.
+  // On/off/blocked is conveyed by color only; the listening mode moves to a
+  // right-click menu so the resting pill never changes size or reveals extras.
   var body: some View {
-    HStack(spacing: 0) {
-      Button(action: action) {
-        HStack(spacing: OmiSpacing.sm) {
-          ZStack {
-            if isToggling {
-              ProgressView()
-                .controlSize(.small)
-                .scaleEffect(0.55)
-            } else {
-              Image(systemName: systemImage)
-                .scaledFont(size: OmiType.body, weight: .semibold)
-            }
-          }
-          .frame(width: 18, height: 18)
-
-          VStack(alignment: .leading, spacing: 1) {
-            Text(title)
-              .scaledFont(size: OmiType.caption, weight: .semibold)
-              .lineLimit(1)
-
-            // Mode ("Always" / "In meeting" / …) is revealed only on
-            // hover to keep the resting pill clean.
-            if isHovering {
-              Text(modeTitle)
-                .scaledFont(size: 8, weight: .medium)
-                .foregroundStyle(status.isActive ? HomePalette.secondary : HomePalette.muted)
-                .lineLimit(1)
-                .transition(.opacity)
-            }
+    Button(action: action) {
+      HStack(spacing: OmiSpacing.sm) {
+        ZStack {
+          if isToggling {
+            ProgressView()
+              .controlSize(.small)
+              .scaleEffect(0.55)
+          } else {
+            Image(systemName: systemImage)
+              .scaledFont(size: OmiType.body, weight: .semibold)
           }
         }
-        .padding(.leading, OmiSpacing.md)
-        .padding(.trailing, OmiSpacing.sm)
-        .frame(height: 34)
-        .contentShape(Rectangle())
-      }
-      .buttonStyle(.plain)
-      .disabled(isToggling)
-      .help("Listening: \(status.text), \(modeTitle)")
-      .accessibilityLabel("Listening \(status.text), \(modeTitle)")
+        .frame(width: 18, height: 18)
 
-      // Divider + mode toggle are revealed only on hover to keep the
-      // resting pill compact.
-      if isHovering {
-        Rectangle()
-          .fill(HomePalette.hairline.opacity(0.65))
-          .frame(width: 1, height: 18)
-          .transition(.opacity)
-
-        Button(action: modeAction) {
-          Image(systemName: isMeetingsOnly ? "person.2.fill" : "person.fill")
-            .scaledFont(size: OmiType.caption, weight: .semibold)
-            .foregroundStyle(modeIconColor)
-            .frame(width: 30, height: 34)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .help(isMeetingsOnly ? "Switch to always listening" : "Switch to meetings only")
-        .accessibilityLabel(isMeetingsOnly ? "Switch Listening to Always" : "Switch Listening to Meetings Only")
-        .transition(.opacity)
+        Text(title)
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .lineLimit(1)
       }
+      .foregroundStyle(status.isActive ? HomePalette.ink : (status.isBlocked ? status.indicator : HomePalette.muted))
+      .padding(.horizontal, OmiSpacing.md)
+      .padding(.vertical, OmiSpacing.sm)
+      .frame(height: 34)
+      .background(Capsule(style: .continuous).fill(statusFill))
+      .overlay(Capsule(style: .continuous).stroke(statusStroke, lineWidth: 1))
+      .contentShape(Capsule())
     }
-    .foregroundStyle(status.isActive ? HomePalette.ink : (status.isBlocked ? status.indicator : HomePalette.muted))
-    .background(
-      Capsule(style: .continuous)
-        .fill(statusFill)
-    )
-    .overlay(
-      Capsule(style: .continuous)
-        .stroke(statusStroke, lineWidth: 1)
-    )
-    .contentShape(Capsule())
-    .frame(height: 34)
+    .buttonStyle(.plain)
+    .disabled(isToggling)
     .onHover { isHovering = $0 }
-    .omiAnimation(.easeInOut(duration: 0.14), value: isHovering)
-  }
-
-  private var modeIconColor: Color {
-    status.isActive ? HomePalette.green : HomePalette.muted
+    .help("Listening: \(status.text), \(modeTitle)")
+    .accessibilityLabel("Listening \(status.text), \(modeTitle)")
+    .contextMenu {
+      Button(isMeetingsOnly ? "Listen always" : "Listen only during meetings", action: modeAction)
+    }
   }
 
   private var statusFill: Color {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1678,7 +1678,7 @@ struct MemoriesPage: View {
         formatDate: formatDate,
         onDismiss: { viewModel.selectedMemory = nil }
       )
-      .frame(width: 450, height: 600)
+      .fittedModal(width: 450, maxHeight: 600)
     }
     .overlay(alignment: .bottom) {
       undoDeleteToast
@@ -1784,10 +1784,7 @@ struct MemoriesPage: View {
           .buttonStyle(.plain)
         }
       }
-      .padding(.horizontal, OmiSpacing.md)
-      .padding(.vertical, OmiSpacing.md)
-      .frame(minHeight: 46)
-      .omiControlSurface(fill: OmiColors.backgroundTertiary, radius: 18)
+      .omiSearchFieldChrome()
 
       if viewModel.canonicalLifecycleExposed {
         // Layer filter dropdown. Default is product default access: Short-term + Long-term.
@@ -1820,7 +1817,7 @@ struct MemoriesPage: View {
           )
           .padding(.horizontal, OmiSpacing.md)
           .padding(.vertical, OmiSpacing.md)
-          .frame(minHeight: 46)
+          .frame(minHeight: 36)
           .omiControlSurface(
             fill: viewModel.selectedLayerFilter == .defaultAccess
               ? OmiColors.backgroundTertiary : OmiColors.backgroundRaised,
@@ -1847,7 +1844,7 @@ struct MemoriesPage: View {
         )
         .padding(.horizontal, OmiSpacing.md)
         .padding(.vertical, OmiSpacing.md)
-        .frame(minHeight: 46)
+        .frame(minHeight: 36)
         .omiControlSurface(
           fill: viewModel.filterThisDeviceOnly
             ? OmiColors.backgroundRaised : OmiColors.backgroundTertiary,
@@ -1877,7 +1874,7 @@ struct MemoriesPage: View {
         )
         .padding(.horizontal, OmiSpacing.md)
         .padding(.vertical, OmiSpacing.md)
-        .frame(minHeight: 46)
+        .frame(minHeight: 36)
         .omiControlSurface(
           fill: viewModel.selectedTags.isEmpty
             ? OmiColors.backgroundTertiary : OmiColors.backgroundRaised,
@@ -1896,10 +1893,10 @@ struct MemoriesPage: View {
       } label: {
         Image(systemName: "plus")
           .scaledFont(size: OmiType.body)
-          .foregroundColor(.black)
-          .frame(width: 42, height: 42)
-          .background(OmiColors.textPrimary)
-          .clipShape(RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous))
+          .foregroundColor(OmiColors.textPrimary)
+          .frame(width: 36, height: 36)
+          .omiControlSurface(
+            fill: OmiColors.backgroundTertiary, radius: 18, stroke: OmiColors.border.opacity(0.6))
       }
       .buttonStyle(.plain)
       .help("Add Memory")
@@ -1910,10 +1907,10 @@ struct MemoriesPage: View {
       } label: {
         Image(systemName: "chevron.down")
           .scaledFont(size: OmiType.caption, weight: .medium)
-          .foregroundColor(.black)
-          .frame(width: 42, height: 42)
-          .background(OmiColors.textPrimary)
-          .clipShape(RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous))
+          .foregroundColor(OmiColors.textPrimary)
+          .frame(width: 36, height: 36)
+          .omiControlSurface(
+            fill: OmiColors.backgroundTertiary, radius: 18, stroke: OmiColors.border.opacity(0.6))
       }
       .buttonStyle(.plain)
       .popover(isPresented: $showManagementMenu, arrowEdge: .bottom) {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -2878,10 +2878,7 @@ struct TasksPage: View {
           .buttonStyle(.plain)
         }
       }
-      .padding(.horizontal, OmiSpacing.md)
-      .padding(.vertical, OmiSpacing.sm)
-      .background(OmiColors.backgroundSecondary)
-      .cornerRadius(OmiChrome.elementRadius)
+      .omiSearchFieldChrome()
 
       if !viewModel.isMultiSelectMode {
         completedToggleButton
@@ -2993,42 +2990,28 @@ struct TasksPage: View {
   }
 
   private var addTaskButton: some View {
-    Button {
+    OmiIconButton(systemName: "plus", help: "Add task (⌘N)") {
       viewModel.inlineCreateAfterTaskId = nil
       viewModel.isInlineCreating = true
-    } label: {
-      Image(systemName: "plus")
-        .scaledFont(size: OmiType.body)
-        .foregroundColor(OmiColors.textSecondary)
-        .padding(.horizontal, OmiSpacing.sm)
-        .padding(.vertical, OmiSpacing.sm)
-        .background(OmiColors.backgroundSecondary)
-        .cornerRadius(OmiChrome.elementRadius)
     }
-    .buttonStyle(.plain)
-    .help("Add task (⌘N)")
   }
 
   // MARK: - Completed Toggle (mobile parity)
 
   private var completedToggleButton: some View {
-    Button {
-      viewModel.toggleShowCompletedView()
-    } label: {
-      Image(systemName: viewModel.showCompleted ? "checkmark.circle.fill" : "checkmark.circle")
-        .scaledFont(size: OmiType.caption)
-        .foregroundColor(viewModel.showCompleted ? OmiColors.textPrimary : OmiColors.textSecondary)
-        .padding(.horizontal, OmiSpacing.sm)
-        .padding(.vertical, OmiSpacing.sm)
-        .background(OmiColors.backgroundSecondary)
-        .cornerRadius(OmiChrome.elementRadius)
-        .overlay(
-          RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
-            .stroke(viewModel.showCompleted ? OmiColors.border : Color.clear, lineWidth: 1)
-        )
-    }
-    .buttonStyle(.plain)
-    .help(viewModel.showCompleted ? "Hide completed tasks" : "Show completed tasks")
+    OmiSegmentedControl(
+      segments: ["To Do", "Done"],
+      selection: Binding(
+        get: { viewModel.showCompleted ? 1 : 0 },
+        set: { newValue in
+          let wantCompleted = (newValue == 1)
+          if viewModel.showCompleted != wantCompleted {
+            viewModel.toggleShowCompletedView()
+          }
+        }
+      )
+    )
+    .help(viewModel.showCompleted ? "Showing completed tasks" : "Showing to-do tasks")
   }
 
   private var multiSelectControls: some View {
@@ -3100,53 +3083,31 @@ struct TasksPage: View {
   }
 
   private var taskSettingsButton: some View {
-    Button {
-      NotificationCenter.default.post(
-        name: .navigateToTaskSettings,
-        object: nil
-      )
-    } label: {
-      Image(systemName: "gearshape")
-        .scaledFont(size: OmiType.caption)
-        .foregroundColor(OmiColors.textSecondary)
-        .padding(OmiSpacing.sm)
-        .background(
-          RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
-            .fill(OmiColors.backgroundSecondary)
-        )
+    OmiIconButton(systemName: "gearshape", help: "Task Settings") {
+      NotificationCenter.default.post(name: .navigateToTaskSettings, object: nil)
     }
-    .buttonStyle(.plain)
-    .help("Task Settings")
   }
 
   private var chatToggleButton: some View {
-    Button {
+    OmiIconButton(
+      systemName: showChatPanel
+        ? "bubble.left.and.bubble.right.fill" : "bubble.left.and.bubble.right",
+      isActive: showChatPanel,
+      help: showChatPanel ? "Close chat panel" : "Open task chat"
+    ) {
       if showChatPanel {
         closeChatPanel()
       } else if let selectedId = viewModel.keyboardSelectedTaskId,
         let task = viewModel.displayTasks.first(where: { $0.id == selectedId })
       {
-        // A task is selected — open chat directly for it
         openChatForTask(task)
       } else {
-        // No task selected — open empty sidebar
         adjustWindowWidth(expand: true)
         OmiMotion.withGated(.easeInOut(duration: 0.25)) {
           showChatPanel = true
         }
       }
-    } label: {
-      Image(systemName: showChatPanel ? "bubble.left.and.bubble.right.fill" : "bubble.left.and.bubble.right")
-        .scaledFont(size: OmiType.caption)
-        .foregroundColor(showChatPanel ? OmiColors.textPrimary : OmiColors.textSecondary)
-        .padding(OmiSpacing.sm)
-        .background(
-          RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
-            .fill(showChatPanel ? OmiColors.textPrimary.opacity(0.12) : OmiColors.backgroundSecondary)
-        )
     }
-    .buttonStyle(.plain)
-    .help(showChatPanel ? "Close chat panel" : "Open task chat")
   }
 
   // MARK: - Loading View

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -1,3 +1,4 @@
+import AppKit
 import OmiTheme
 import SwiftUI
 
@@ -323,14 +324,20 @@ struct SettingsSearchItem: Identifiable {
 struct SettingsSidebar: View {
   @Binding var selectedSection: SettingsContentView.SettingsSection
   @Binding var highlightedSettingId: String?
+  /// Closes settings. Lives on the glass so the whole left column is one panel.
   let onBack: () -> Void
 
   @State private var isBackHovered = false
   @State private var searchQuery = ""
   @FocusState private var isSearchFocused: Bool
+  /// Drives the sliding selection highlight between nav items.
+  @Namespace private var selectionNamespace
 
   private let expandedWidth: CGFloat = 260
   private let iconWidth: CGFloat = 20
+  /// Leading inset that pushes the Back-to-app chip clear of the window traffic
+  /// lights the glass now sits behind.
+  fileprivate static let trafficLightClearance: CGFloat = 74
   // Merged nav: `.account` hosts Account & Plan (renders `.planUsage` content
   // too) and `.notifications` hosts Notifications & Privacy (renders `.privacy`
   // content too). The absorbed cases stay routable for deep links/automation
@@ -364,17 +371,17 @@ struct SettingsSidebar: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      // Back button header
+      // Back to app — a chip on the glass, aligned to the right of the traffic
+      // lights so the top of the panel reads as the window's toolbar row.
       backButton
-        .padding(.top, OmiSpacing.md)
-        .padding(.horizontal, OmiSpacing.lg)
+        .padding(.leading, SettingsSidebar.trafficLightClearance)
+        .padding(.top, 10)
 
-      Spacer().frame(height: OmiSpacing.xxl)
-
-      // Settings title
+      // Title
       Text("Settings")
-        .scaledFont(size: OmiType.heading, weight: .bold)
+        .scaledFont(size: OmiType.title, weight: .bold)
         .foregroundColor(OmiColors.textPrimary)
+        .padding(.top, OmiSpacing.lg)
         .padding(.horizontal, OmiSpacing.lg)
         .padding(.bottom, OmiSpacing.md)
 
@@ -392,8 +399,9 @@ struct SettingsSidebar: View {
                 section: section,
                 isSelected: selectedSection.sidebarItem == section,
                 iconWidth: iconWidth,
+                namespace: selectionNamespace,
                 onTap: {
-                  OmiMotion.withGated(.easeInOut(duration: 0.15)) {
+                  OmiMotion.withGated(.spring(response: 0.34, dampingFraction: 0.82)) {
                     selectedSection = section
                   }
                 }
@@ -412,7 +420,50 @@ struct SettingsSidebar: View {
       Spacer()
     }
     .frame(width: expandedWidth)
-    .background(OmiColors.backgroundPrimary)
+    .background(sidebarBackground)
+  }
+
+  /// Translucent glass panel with a hairline trailing divider — the settings
+  /// nav reads as a native macOS sidebar rather than a flat opaque column.
+  private var sidebarBackground: some View {
+    ZStack {
+      VisualEffectView(material: .sidebar, blendingMode: .behindWindow, alphaValue: 1)
+      OmiColors.backgroundPrimary.opacity(0.55)
+    }
+    .overlay(alignment: .trailing) {
+      Rectangle()
+        .fill(OmiColors.border.opacity(0.35))
+        .frame(width: 1)
+    }
+    .ignoresSafeArea()
+  }
+
+  /// "Back to app" chip on the glass — matches the toolbar's Settings chip so
+  /// closing reads as the same control.
+  private var backButton: some View {
+    Button(action: onBack) {
+      HStack(spacing: OmiSpacing.sm) {
+        Image(systemName: "arrow.left")
+          .scaledFont(size: OmiType.body, weight: .semibold)
+          .frame(width: 18, height: 18)
+        Text("Back to app")
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+      }
+      .foregroundColor(isBackHovered ? OmiColors.textPrimary : OmiColors.textTertiary)
+      .padding(.horizontal, OmiSpacing.md)
+      .frame(height: 34)
+      .background(
+        Capsule(style: .continuous)
+          .fill(Color.white.opacity(isBackHovered ? 0.10 : 0.05))
+          .overlay(Capsule(style: .continuous).stroke(Color.white.opacity(0.07), lineWidth: 1))
+      )
+      .contentShape(Capsule())
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering in
+      OmiMotion.withGated(.easeOut(duration: 0.12)) { isBackHovered = hovering }
+    }
+    .help("Back to app")
   }
 
   private var searchField: some View {
@@ -439,17 +490,7 @@ struct SettingsSidebar: View {
         .buttonStyle(.plain)
       }
     }
-    .padding(.horizontal, OmiSpacing.sm)
-    .padding(.vertical, OmiSpacing.sm)
-    .background(
-      RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
-        .fill(OmiColors.backgroundTertiary)
-        .overlay(
-          RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
-            .stroke(
-              isSearchFocused ? OmiColors.accent.opacity(0.5) : Color.clear, lineWidth: 1)
-        )
-    )
+    .omiSearchFieldChrome(isFocused: isSearchFocused)
   }
 
   private var searchResultsList: some View {
@@ -479,32 +520,6 @@ struct SettingsSidebar: View {
     }
   }
 
-  private var backButton: some View {
-    Button(action: onBack) {
-      HStack(spacing: OmiSpacing.sm) {
-        Image(systemName: "chevron.left")
-          .scaledFont(size: OmiType.body, weight: .semibold)
-          .foregroundColor(OmiColors.textSecondary)
-
-        Text("Back")
-          .scaledFont(size: OmiType.body, weight: .medium)
-          .foregroundColor(OmiColors.textSecondary)
-
-        Spacer()
-      }
-      .padding(.horizontal, OmiSpacing.md)
-      .padding(.vertical, OmiSpacing.sm)
-      .contentShape(Rectangle())
-      .background(
-        RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
-          .fill(isBackHovered ? OmiColors.backgroundTertiary.opacity(0.5) : Color.clear)
-      )
-    }
-    .buttonStyle(.plain)
-    .onHover { hovering in
-      isBackHovered = hovering
-    }
-  }
 }
 
 // MARK: - Settings Sidebar Item
@@ -512,6 +527,7 @@ struct SettingsSidebarItem: View {
   let section: SettingsContentView.SettingsSection
   let isSelected: Bool
   let iconWidth: CGFloat
+  var namespace: Namespace.ID
   let onTap: () -> Void
 
   @State private var isHovered = false
@@ -546,25 +562,34 @@ struct SettingsSidebarItem: View {
               .frame(width: iconWidth)
 
             Text(section.displayTitle)
-              .scaledFont(size: OmiType.body, weight: isSelected ? .medium : .regular)
+              .scaledFont(size: OmiType.body, weight: isSelected ? .semibold : .regular)
               .foregroundColor(isSelected ? OmiColors.textPrimary : OmiColors.textSecondary)
 
-            Spacer()
+            Spacer(minLength: 0)
           }
           .padding(.horizontal, OmiSpacing.md)
-          .padding(.vertical, OmiSpacing.md)
+          .padding(.vertical, OmiSpacing.sm + 2)
           .contentShape(Rectangle())
-          .background(
-            RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
-              .fill(
-                isSelected
-                  ? OmiColors.backgroundTertiary.opacity(0.8)
-                  : (isHovered ? OmiColors.backgroundTertiary.opacity(0.5) : Color.clear))
-          )
+          .background {
+            ZStack {
+              if isSelected {
+                RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius, style: .continuous)
+                  .fill(Color.white.opacity(0.10))
+                  .overlay(
+                    RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius, style: .continuous)
+                      .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                  )
+                  .matchedGeometryEffect(id: "settingsSelection", in: namespace)
+              } else if isHovered {
+                RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius, style: .continuous)
+                  .fill(Color.white.opacity(0.05))
+              }
+            }
+          }
         }
         .buttonStyle(.plain)
         .onHover { hovering in
-          isHovered = hovering
+          OmiMotion.withGated(.easeOut(duration: 0.12)) { isHovered = hovering }
         }
       }
     }

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -131,7 +131,7 @@ struct OMIApp: App {
           log("OmiApp: Main window content appeared (mode: \(Self.launchMode.rawValue))")
         }
     }
-    .windowStyle(.titleBar)
+    .windowStyle(.hiddenTitleBar)
     .defaultSize(width: defaultWindowSize.width, height: defaultWindowSize.height)
     .commands {
       CommandGroup(after: .textFormatting) {

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -6,6 +6,9 @@ import SwiftUI
 /// The timeline is the primary interface, with search results highlighted inline
 struct RewindPage: View {
   var appState: AppState? = nil
+  /// Returns to the shell tab the user came from. Nil in the standalone window,
+  /// where the gear menu handles navigation instead.
+  var onBack: (() -> Void)? = nil
 
   @StateObject private var viewModel = RewindViewModel()
 
@@ -339,6 +342,25 @@ struct RewindPage: View {
         .buttonStyle(.plain)
         .help("Back to results")
       } else {
+        // Back to the tab the user came from (shell only).
+        if let onBack {
+          Button(action: onBack) {
+            HStack(spacing: OmiSpacing.xs) {
+              Image(systemName: "arrow.left")
+                .scaledFont(size: OmiType.caption, weight: .semibold)
+              Text("Back")
+                .scaledFont(size: OmiType.caption, weight: .semibold)
+            }
+            .foregroundColor(.white.opacity(0.85))
+            .padding(.horizontal, OmiSpacing.sm + 2)
+            .padding(.vertical, 6)
+            .background(Capsule(style: .continuous).fill(Color.white.opacity(0.1)))
+            .contentShape(Capsule())
+          }
+          .buttonStyle(.plain)
+          .help("Back to app")
+        }
+
         // Rewind title
         HStack(spacing: OmiSpacing.sm) {
           Text("Rewind")

--- a/desktop/macos/Desktop/Sources/Theme/OmiFieldStyle.swift
+++ b/desktop/macos/Desktop/Sources/Theme/OmiFieldStyle.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+extension View {
+  /// Consistent search / text-field chrome: a capsule with a subtle translucent
+  /// fill and a focus ring, matching the app's chip and segmented-control
+  /// language. Wrap the field's `HStack { icon; TextField; clear }` with it.
+  package func omiSearchFieldChrome(isFocused: Bool = false, minHeight: CGFloat? = nil) -> some View {
+    self
+      .padding(.horizontal, OmiSpacing.md)
+      .padding(.vertical, OmiSpacing.sm + 1)
+      .frame(minHeight: minHeight)
+      .background(
+        Capsule(style: .continuous)
+          .fill(Color.white.opacity(isFocused ? 0.10 : 0.06))
+      )
+      .overlay(
+        Capsule(style: .continuous)
+          .stroke(
+            isFocused ? Color.white.opacity(0.22) : Color.white.opacity(0.08),
+            lineWidth: 1)
+      )
+      .omiAnimation(.easeOut(duration: 0.15), value: isFocused)
+  }
+}

--- a/desktop/macos/Desktop/Sources/Theme/OmiIconButton.swift
+++ b/desktop/macos/Desktop/Sources/Theme/OmiIconButton.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// A consistent circular icon button for toolbars/headers: neutral at rest, a
+/// soft white wash on hover, a brighter fill when active. Matches the app's
+/// chip / segmented-control language so every header control reads as one set.
+package struct OmiIconButton: View {
+  let systemName: String
+  var isActive: Bool = false
+  var help: String? = nil
+  let action: () -> Void
+
+  @State private var isHovering = false
+
+  package init(
+    systemName: String,
+    isActive: Bool = false,
+    help: String? = nil,
+    action: @escaping () -> Void
+  ) {
+    self.systemName = systemName
+    self.isActive = isActive
+    self.help = help
+    self.action = action
+  }
+
+  package var body: some View {
+    Button(action: action) {
+      Image(systemName: systemName)
+        .scaledFont(size: OmiType.body, weight: .semibold)
+        .foregroundColor(
+          isActive || isHovering ? OmiColors.textPrimary : OmiColors.textSecondary
+        )
+        .frame(width: 34, height: 34)
+        .background(
+          Circle()
+            .fill(
+              isActive
+                ? Color.white.opacity(0.12)
+                : (isHovering ? Color.white.opacity(0.08) : Color.clear))
+        )
+        .contentShape(Circle())
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering in
+      OmiMotion.withGated(.easeOut(duration: 0.12)) { isHovering = hovering }
+    }
+    .help(help ?? "")
+  }
+}

--- a/desktop/macos/Desktop/Sources/Theme/OmiModal.swift
+++ b/desktop/macos/Desktop/Sources/Theme/OmiModal.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+private struct ModalContentHeightKey: PreferenceKey {
+  static let defaultValue: CGFloat = 0
+  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+    value = max(value, nextValue())
+  }
+}
+
+/// Sizes a modal to its content: fixed width, height fits the content up to
+/// `maxHeight`, and anything taller scrolls. No more dead space under short
+/// content, no overflow for long content.
+struct FittedModal: ViewModifier {
+  let width: CGFloat
+  let maxHeight: CGFloat
+
+  @State private var contentHeight: CGFloat = 0
+
+  func body(content: Content) -> some View {
+    ScrollView {
+      content
+        .frame(width: width)
+        .background(
+          GeometryReader { geo in
+            Color.clear.preference(key: ModalContentHeightKey.self, value: geo.size.height)
+          }
+        )
+    }
+    .frame(width: width, height: min(contentHeight, maxHeight))
+    .scrollDisabled(contentHeight <= maxHeight)
+    .scrollBounceBehavior(.basedOnSize)
+    .onPreferenceChange(ModalContentHeightKey.self) { contentHeight = $0 }
+  }
+}
+
+extension View {
+  package func fittedModal(width: CGFloat, maxHeight: CGFloat) -> some View {
+    modifier(FittedModal(width: width, maxHeight: maxHeight))
+  }
+}

--- a/desktop/macos/Desktop/Sources/Theme/OmiSegmentedControl.swift
+++ b/desktop/macos/Desktop/Sources/Theme/OmiSegmentedControl.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// The app's one segmented control: a single rounded track whose selected fill
+/// slides between segments (matchedGeometry + spring), with a soft hover on the
+/// unselected ones. Same visual language as the shell's top nav so every
+/// section switcher across the app reads as one control.
+package struct OmiSegmentedControl: View {
+  package let segments: [String]
+  @Binding package var selection: Int
+
+  @Namespace private var namespace
+
+  package init(segments: [String], selection: Binding<Int>) {
+    self.segments = segments
+    self._selection = selection
+  }
+
+  package var body: some View {
+    HStack(spacing: 2) {
+      ForEach(Array(segments.enumerated()), id: \.offset) { index, title in
+        OmiSegment(
+          title: title,
+          isSelected: selection == index,
+          namespace: namespace
+        ) {
+          OmiMotion.withGated(.spring(response: 0.32, dampingFraction: 0.82)) {
+            selection = index
+          }
+        }
+      }
+    }
+    .padding(3)
+    .background(
+      Capsule(style: .continuous)
+        .fill(Color.white.opacity(0.05))
+        .overlay(Capsule(style: .continuous).stroke(Color.white.opacity(0.07), lineWidth: 1))
+    )
+  }
+}
+
+private struct OmiSegment: View {
+  let title: String
+  let isSelected: Bool
+  var namespace: Namespace.ID
+  let action: () -> Void
+
+  @State private var isHovering = false
+
+  var body: some View {
+    Button(action: action) {
+      Text(title)
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+        .foregroundColor(isSelected ? OmiColors.textPrimary : OmiColors.textTertiary)
+        .padding(.horizontal, OmiSpacing.md)
+        .padding(.vertical, 6)
+        .background {
+          ZStack {
+            if isSelected {
+              Capsule(style: .continuous)
+                .fill(Color.white.opacity(0.12))
+                .matchedGeometryEffect(id: "omiSegmentedSelection", in: namespace)
+            } else if isHovering {
+              Capsule(style: .continuous)
+                .fill(Color.white.opacity(0.05))
+            }
+          }
+        }
+        .contentShape(Capsule())
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering in
+      OmiMotion.withGated(.easeOut(duration: 0.12)) { isHovering = hovering }
+    }
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260723-native-shell-ui-polish.json
+++ b/desktop/macos/changelog/unreleased/20260723-native-shell-ui-polish.json
@@ -1,0 +1,3 @@
+{
+  "change": "Refreshed the macOS app with a native edge-to-edge shell, a glass settings sidebar, and consistent segmented navigation, chips, and frosted modals across every tab"
+}

--- a/desktop/macos/e2e/flows/apps.yaml
+++ b/desktop/macos/e2e/flows/apps.yaml
@@ -6,6 +6,8 @@ app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ManualInstallationDisclosure.swift
+  - desktop/macos/Desktop/Sources/Theme/OmiModal.swift
+  - desktop/macos/Desktop/Sources/MainWindow/ModalPresentationState.swift
   - desktop/macos/Desktop/Sources/ConferencingApps.swift
   - desktop/macos/Desktop/Sources/ConnectorBrandIcon.swift
 preconditions:

--- a/desktop/macos/e2e/flows/home-stage.yaml
+++ b/desktop/macos/e2e/flows/home-stage.yaml
@@ -1,7 +1,7 @@
 version: 2
 name: home-stage
 tier: 2
-description: Redesigned Home stage transitions (hub/chat/connect) via automation bridge
+description: Redesigned Home stage transitions (landing/chat/connect) via automation bridge
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -22,11 +22,9 @@ steps:
       state.selectedTabIndex: 0
 
   - id: S2
-    name: Collapse to hub baseline (chat auto-opens when history exists)
-    bridge.action:
-      name: home_close_panel
+    name: Landing hero on open
     wait:
-      state.homeMode: hub
+      state.homeMode: landing
 
   - id: S3
     name: Open inline chat
@@ -54,11 +52,11 @@ steps:
       state.homeMode: connect
 
   - id: S6
-    name: Collapse back to hub
+    name: Collapse back to the resting chat surface
     bridge.action:
       name: home_close_panel
     wait:
-      state.homeMode: hub
+      state.homeMode: chat
 
   - id: S7
     name: Logs clean

--- a/desktop/macos/e2e/flows/navigation.yaml
+++ b/desktop/macos/e2e/flows/navigation.yaml
@@ -18,6 +18,9 @@ covers:
   - desktop/macos/Desktop/Sources/Theme/OmiTextEditor.swift
   - desktop/macos/Desktop/Sources/Theme/OmiToggleStyle.swift
   - desktop/macos/Desktop/Sources/Theme/OmiType.swift
+  - desktop/macos/Desktop/Sources/Theme/OmiSegmentedControl.swift
+  - desktop/macos/Desktop/Sources/Theme/OmiFieldStyle.swift
+  - desktop/macos/Desktop/Sources/Theme/OmiIconButton.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/FocusPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/InsightPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift


### PR DESCRIPTION
**This is my submission for the Omi Summer challenge (Track 0).** I already submitted for Track 1 (Agents) #10007  #10088  and Track 3 (the notch) #10247  #10332 . This time I went at the main macOS desktop app itself. The app already does a lot; what stood out is that the shell and the everyday UI did not feel native, and the controls were different on every page. So this PR is a native UI/UX pass over the whole app plus a calmer, landing-first Home. It is cosmetic and additive: nothing about what the app can do was removed, and chat stays one shared timeline.

## The problem I found

The desktop app can do a lot, but it never quite read as a native Mac app, and that showed up in small ways all across the surface.

The shell was the first thing. The window carried the standard title bar over a floating card, so there was a visible seam and a black gap along the top instead of one clean, edge-to-edge surface.

The controls were inconsistent, both with the platform and with each other. The Settings control sat on the right of the header, but the panel it opened slid in from the left, so the thing you clicked and the thing that appeared were on opposite sides, and it read as disorienting every time. The Capture and Listening chips next to it were all slightly different sizes, and Listening grew whenever you hovered it, so the header never quite sat still. Deeper in, every page had drifted into its own dialect: the search fields, toggles, and chips on Memory, Tasks, and Apps were each shaped and styled a little differently, so it rarely felt like the same app twice.

A few surfaces had their own rough edges. Modals opened as large half-empty boxes, and the blur behind them was applied per section, so the focus effect looked patchy rather than deliberate. Rewind was a dead end with no way back to the tab you came from. And the Home composer was oversized and sat a little out of place against everything around it.

Home itself was the biggest one. It dropped you into your full chat history the instant it launched, even though it is one continuous conversation and there is seldom a reason to see all of it right away.

None of it was broken. It just added up to an app that felt assembled rather than designed. This pass pulls it back into one native shell, gives every page the same set of controls, settles the header, and lets Home open calm. There is a lot here, more than a diagram can usefully show, so the demo below is the best way to see it end to end.

## Demo (under 2 minutes)


https://github.com/user-attachments/assets/34291c47-e05f-469c-92b5-76f7f7208c39



## What changed, and why it feels right

- **A native shell.** Hidden title bar, content runs edge to edge, no floating card and no top seam. The whole window shares one background so there is no visible break between sections, and you can drag it from the top bar.
- **A two-row header with segmented nav.** The Omi mark and name sit centered on top; the four tabs (Home, Memory, Tasks, Apps) became one sliding segmented control below. Settings moved to a chip on the left near the traffic lights, and Capture / Listening are matched to the same chip size.
- **Settings as a glass sidebar.** The gear opens a frosted, behind-window sidebar that slides in cleanly, with a Back-to-app chip cleared of the traffic lights and a sliding highlight on the selected item.
- **One control language across pages.** Memory, Tasks, and Apps now share the same segmented control, the same capsule search field, and the same chip shapes. Section switches cross-fade instead of hard-cutting. Filter, category, and Create App all became matching capsules, and the buttons next to search bars were shrunk to match its height.
- **Modals that focus.** Memory and Apps modals fit their content, cap their height and scroll when taller, and dismiss on click-outside or Esc. The whole window frosts uniformly behind them (one shared modal host) instead of blurring per section, with a smooth scale and fade.
- **Rewind has a way back.** A Back chip returns you to the tab you came from, so it is no longer a dead end.
- **A steadier Listening chip.** It is a fixed-size chip that matches Capture and no longer grows on hover; the Always / Meetings-only toggle moved to a right-click menu so the resting pill stays calm.
- **Home opens on a landing.** Instead of the full transcript, Home opens on a centered hero: a subtly rotating Omi mark, a greeting, the composer, and suggested prompt chips, each staggered in. Sending your first message continues the same conversation and the composer glides down to the bottom as the chat appears. Scrolling on the landing reveals your existing conversation. All of the motion respects the system Reduce Motion setting.
- **A composer that gets out of the way.** It is slimmer and reads like the search fields, it grows to multiple lines as you type and to fit attachments, and it is tight and centered on the landing then widens to the full chat column when it drops to the bottom.
- **Shared building blocks.** The repeated pieces are now a small set of reusable components (segmented control, capsule search field, icon button, fitted modal, chip styles, and the shared modal host), so the call sites shrank and every surface stays identical by construction.

## Where this stands (for maintainers)

This is a design pass I am putting up so you can try the direction on a real build, not a rewrite. Everything here is finished and works; what it is not is a top-to-bottom redesign of every last surface. I focused on the shell, the navigation, and the everyday controls, pulled the repeated pieces into a few shared components so every page speaks the same language, and kept every existing feature working. The one behavior change is that Home now opens on a landing empty state instead of dumping the whole transcript, and that is presentation only: the first message continues the same conversation.

If you like where it is going, I am happy to double down: push the polish further, bring the shared components to the last few surfaces, and take the chat view itself (streaming, markdown rendering, message actions) the same distance. Tell me what you would change or how far you want it taken, and I will finish it out.

## What I kept (nothing dropped)

Every feature still works after the redesign. Chat is still one shared timeline (the landing is a view, not a new session), Settings keeps all its sections in the same order, Capture / Listening / the automation bridge all behave as before, and the multiline Home composer is the maintainers' own version (I kept it and dropped my earlier duplicate during the rebase). Nothing was deleted; the changes are additive styling plus the shared components.

## Product invariants

- **INV-UI-1** (no purple): the redesign uses white and neutral on the existing dark surfaces throughout, no purple accents, glows, or gradients. `check_brand_ui` passes.
- **INV-CHAT-1** (one shared transcript): the landing is presentation only. It does not fork the conversation, add a store, or mint a session; the first send goes through the existing `sendMainDraft` into the one shared thread, and it deliberately does not reveal on message-count changes (which churn for background restore / pagination / reconciliation). No files under the invariant's locked globs changed.
- **INV-AUTH-1** (desktop session truth): touched by path only. The shell, header, and settings-sidebar changes are presentation; they do not touch `AuthSessionCoordinator`, session ownership, token handling, or authorized-surface gating. The desktop-auth-session ratchet passes.

## Testing / Verification

- `xcrun swift build -c debug --package-path Desktop` green against the current `main` after rebasing onto it.
- All preflight contract checks pass with this body (`python3 .github/scripts/pr_preflight.py`): manifest, diff-hygiene, brand-ui / INV-UI-1, changelog schema and entry, swift-format, SwiftLint, e2e flow coverage, product invariants, and the line-count and test-quality ratchets.
- Exercised live on a named bundle (`omi-chat`): Home opens on the landing (verified `homeMode: landing` via `omi-ctl state`, and confirmed it stays landing across a 12s idle so background restore does not skip it); sending transitions to chat and the same message renders in the one timeline; the composer widens from the landing width back to the chat column at the bottom; navigated every tab; opened and closed the glass settings sidebar; opened Memory / Apps modals and confirmed the uniform whole-window blur and click-outside / Esc dismiss; Rewind Back returns to the previous tab.
- Housekeeping so it merges clean: a changelog fragment under `desktop/macos/changelog/unreleased/`, e2e flow coverage added for the new shared components, the `home-stage` flow updated to the landing/chat/connect model, and the line-count baselines raised with justifications for the files that grew (and ratcheted down for the ones the shared components shrank).

Note: the scroll-to-reveal on the landing is a real trackpad gesture, so the automation bridge cannot drive it; I verified the code path (scoped to the landing, mode-guarded, small threshold, cleaned up on exit) and checked it by hand. The demo above shows it live.

Failure-Class: none

The `fix:`-style corrections in this branch are UI-polish fixes inside this new work (blur uniformity, button heights, composer sizing), not repairs of a shipped failure-class boundary.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

