### PR TITLE
fix(desktop): trigger web search for implicit research asks (#10429)

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/retrieval_policy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/retrieval_policy.rs
@@ -17,6 +17,7 @@ enum RetrievalReason {
     ExplicitWeb,
     Freshness,
     AnaphoricLookup,
+    ResearchIntent,
     ExplicitPrivate,
     Mixed,
     Auto,
@@ -28,6 +29,7 @@ impl RetrievalReason {
             Self::ExplicitWeb => "explicit_web",
             Self::Freshness => "freshness",
             Self::AnaphoricLookup => "anaphoric_lookup",
+            Self::ResearchIntent => "research_intent",
             Self::ExplicitPrivate => "explicit_private",
             Self::Mixed => "mixed",
             Self::Auto => "auto",
@@ -61,9 +63,9 @@ impl RetrievalPolicy {
 
     /// True only when the user asked for the public web in so many words.
     ///
-    /// Everything else (`Freshness`, `AnaphoricLookup`) is a heuristic guess, so
-    /// it may steer a turn but must never fail one: a route that cannot search
-    /// the web still owes the user an answer.
+    /// Everything else (`Freshness`, `AnaphoricLookup`, `ResearchIntent`) is a
+    /// heuristic guess, so it may steer a turn but must never fail one: a route
+    /// that cannot search the web still owes the user an answer.
     pub(crate) fn web_requirement_is_explicit(&self) -> bool {
         matches!(
             self.reason,
@@ -190,6 +192,33 @@ const ANAPHORIC_LOOKUP_PHRASES: &[&str] = &[
     "find out",
 ];
 
+/// Implicit web-research asks pair a lookup verb with a public-web locus
+/// ("find out who X is ... online", "look him up on the web", "research X on the
+/// internet"). They carry none of the fixed `EXPLICIT_WEB_PHRASES`, so they fell
+/// through to `auto` and the model was handed no web tool — users saw "I can't
+/// search the web" even though the capability exists. Requiring both a research
+/// verb and an explicit online/web locus keeps this high-precision; it is still
+/// a non-explicit guess, so a web-unavailable route degrades to model knowledge
+/// instead of failing the turn.
+const RESEARCH_INTENT_VERBS: &[&str] = &[
+    "find out",
+    "look up",
+    "look him up",
+    "look her up",
+    "look them up",
+    "research",
+    "tell me about",
+    "everything about",
+    "everything on",
+    "all about",
+    "information about",
+    "information on",
+    "who is",
+    "who's",
+];
+
+const PUBLIC_WEB_LOCUS: &[&str] = &["online", "on the web", "on the internet"];
+
 /// The generic qualifier+subject pairing describes a short conversational ask
 /// ("who is playing today?"). Service synthesis prompts, pasted documents and
 /// agent instructions are long and hit these common words by accident, so they
@@ -229,6 +258,16 @@ fn is_fresh_public_lookup(text: &str) -> bool {
         || (text.len() <= MAX_GENERIC_LOOKUP_CHARS
             && contains_any_word(text, FRESH_PUBLIC_TEMPORAL_QUALIFIERS)
             && contains_any_word(text, FRESH_PUBLIC_LOOKUP_TERMS))
+}
+
+/// A lookup verb paired with an explicit online/web locus, on a short turn.
+/// Locus matches on word boundaries so "on the web" does not read out of "on the
+/// webinar"; the length cap keeps long machine-written prompts (which never name
+/// a web locus about a subject anyway) out of the heuristic.
+fn is_research_intent_lookup(text: &str) -> bool {
+    text.len() <= MAX_GENERIC_LOOKUP_CHARS
+        && contains_any_word(text, PUBLIC_WEB_LOCUS)
+        && contains_any(text, RESEARCH_INTENT_VERBS)
 }
 
 pub(crate) fn caller_disabled_tools(req: &ChatCompletionRequest) -> bool {
@@ -323,6 +362,13 @@ pub(crate) fn retrieval_policy(messages: &[ChatMessage]) -> RetrievalPolicy {
             required_sources: vec![RetrievalSource::PublicWeb],
             prohibited_sources: Vec::new(),
             reason: RetrievalReason::AnaphoricLookup,
+        };
+    }
+    if is_research_intent_lookup(&latest) {
+        return RetrievalPolicy {
+            required_sources: vec![RetrievalSource::PublicWeb],
+            prohibited_sources: Vec::new(),
+            reason: RetrievalReason::ResearchIntent,
         };
     }
 
@@ -479,6 +525,71 @@ mod tests {
         let asked = retrieval_policy(&[message("user", "Search the web for the World Cup final")]);
         assert!(asked.requires(RetrievalSource::PublicWeb));
         assert!(asked.web_requirement_is_explicit());
+    }
+
+    #[test]
+    fn requires_web_for_implicit_research_with_a_web_locus() {
+        // The reported repro: no fixed trigger phrase, but a lookup verb plus an
+        // explicit "online" locus. Previously fell through to auto and the model
+        // was handed no web tool, so it told the user it couldn't search.
+        let policy = retrieval_policy(&[message(
+            "user",
+            "Find out who David Zhang is and get every piece of information \
+             available on him online.",
+        )]);
+        assert!(policy.requires(RetrievalSource::PublicWeb));
+        assert!(!policy.prohibits(RetrievalSource::PublicWeb));
+        assert_eq!(policy.reason, RetrievalReason::ResearchIntent);
+    }
+
+    #[test]
+    fn research_intent_is_a_guess_not_a_strict_requirement() {
+        // A guess must degrade (answer from model knowledge) on a web-unavailable
+        // route rather than fail the turn.
+        let policy = retrieval_policy(&[message("user", "look him up on the web")]);
+        assert!(policy.requires(RetrievalSource::PublicWeb));
+        assert!(!policy.web_requirement_is_explicit());
+    }
+
+    #[test]
+    fn research_intent_requires_both_a_verb_and_a_web_locus() {
+        // A lookup verb with no online/web locus stays on auto (the model may
+        // still choose its own tools); a locus with no research verb likewise.
+        assert_eq!(
+            retrieval_policy(&[message("user", "Find out who David Zhang is")]),
+            RetrievalPolicy::auto()
+        );
+        assert_eq!(
+            retrieval_policy(&[message("user", "The team standup is online today")]),
+            RetrievalPolicy::auto()
+        );
+    }
+
+    #[test]
+    fn private_context_still_wins_over_a_research_web_locus() {
+        // "what did i say" is an explicit private phrase; the trailing "online"
+        // must not flip the turn onto the public web.
+        let policy = retrieval_policy(&[message(
+            "user",
+            "What did I say about the pricing I found online?",
+        )]);
+        assert!(policy.prohibits(RetrievalSource::PublicWeb));
+        assert_eq!(policy.reason, RetrievalReason::ExplicitPrivate);
+    }
+
+    #[test]
+    fn leaves_a_long_prompt_that_mentions_research_and_online_on_auto() {
+        // A machine-written synthesis prompt can contain "research" and "online"
+        // by accident; the length cap keeps it off the forced-search path.
+        let policy = retrieval_policy(&[message(
+            "user",
+            "Analyze these calendar events and extract a profile.\n\
+             Today's date: 2026-07-23\n\
+             - Extract 10-15 memories about their role, recurring meetings, \
+             online research habits, relationships, routines, interests, and \
+             the way they schedule collaborative work across time zones.",
+        )]);
+        assert_eq!(policy, RetrievalPolicy::auto());
     }
 
     #[test]

--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Chat now searches the web for natural research requests like \"find out who X is online\" or \"look them up on the web\", not just explicit \"search the web\" phrasings."
+  ],
   "releases": [
     {
       "version": "0.12.94",


### PR DESCRIPTION
## Bug (#10429)

Desktop chat only injected Anthropic's server-side `web_search` tool when `retrieval_policy()` matched one of ~16 fixed `EXPLICIT_WEB_PHRASES` (or the freshness/anaphoric heuristics). Natural web-research asks that name a public-web locus but no literal trigger phrase fell through to `auto`, so the model got **no web tool** and replied it couldn't search the web.

Real repro from the issue:
> "find out who David Zhang is ... every piece of information available on him online ..."

`requires(PublicWeb)=false, reason=auto` → no `web_search` tool → assistant says it can't browse.

## Root cause

The trigger classifier caught explicit phrasings ("search the web", "google it") but missed the more common implicit research asks ("find out who X is ... online", "look them up on the web").

## Fix

Add a guarded research-intent heuristic (issue Option 1): a lookup verb (`find out`, `look up`, `research`, `who is`, `information about`, ...) paired with an explicit online/web **locus** (`online`, `on the web`, `on the internet`), on a turn under the existing 240-char cap.

- Locus matches on **word boundaries** so "on the web" doesn't read out of "on the webinar".
- The **length cap** keeps long machine-written synthesis prompts (which never name a web locus about a subject) off the forced-search path.
- Explicit **private-context precedence preserved** — private phrases return before this branch, so "what did I say about the pricing I found online?" stays inside Omi.
- Classified as a **non-explicit guess** (like Freshness/AnaphoricLookup): `web_requirement_is_explicit()` stays false, so a route without web search (haiku / kill switch) degrades to model knowledge instead of failing the turn.

## Tested

- 5 regression tests: repro requires web (`reason=research_intent`); guess-not-strict; verb+locus both required; private precedence; long synthesis prompt stays `auto`.
- Proved the repro test **fails on the pre-fix classifier** and passes after.
- `cargo test --bin omi-desktop-backend`: **393 passed, 0 failed**.
- `cargo clippy --bin omi-desktop-backend -- -D warnings`: clean. `cargo fmt --check`: clean.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

