### PR TITLE
fix: reduce backend 504 read amplification

### DIFF
--- a/app/lib/backend/http/api/action_items.dart
+++ b/app/lib/backend/http/api/action_items.dart
@@ -49,7 +49,13 @@ Future<ActionItemsResponse?> tryGetActionItems({
     url += '&end_date=${endDate.toUtc().toIso8601String()}';
   }
 
-  var response = await makeApiCall(url: url, headers: {}, method: 'GET', body: '');
+  var response = await makeApiCall(
+    url: url,
+    headers: {},
+    method: 'GET',
+    body: '',
+    retries: 0,
+  );
 
   if (response == null) return null;
 

--- a/app/lib/backend/http/api/knowledge_graph_api.dart
+++ b/app/lib/backend/http/api/knowledge_graph_api.dart
@@ -14,7 +14,7 @@ class KnowledgeGraphApi {
       body: '',
       method: 'GET',
       timeout: const Duration(seconds: 60),
-      retries: 2,
+      retries: 0,
     );
 
     if (response != null && response.statusCode == 200) {

--- a/app/test/unit/http_pool_manager_retry_test.dart
+++ b/app/test/unit/http_pool_manager_retry_test.dart
@@ -1,0 +1,125 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/http/api/action_items.dart' as action_items_api;
+import 'package:omi/backend/http/api/knowledge_graph_api.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/env/env.dart';
+import 'package:omi/utils/platform/platform_manager.dart';
+
+void main() {
+  final env = _TestEnvFields();
+
+  setUpAll(() async {
+    Env.init(env);
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    PackageInfo.setMockInitialValues(
+      appName: 'Omi Test',
+      packageName: 'com.omi.test',
+      version: '1.0.0',
+      buildNumber: '1',
+      buildSignature: '',
+    );
+    await PlatformManager.initializeServices();
+  });
+
+  group('expensive read retry policy', () {
+    late HttpServer server;
+
+    setUp(() async {
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      env.routeNextRequestTo(
+        'http://${server.address.host}:${server.port}/',
+      );
+    });
+
+    tearDown(() async {
+      await server.close(force: true);
+    });
+
+    test('tryGetActionItems makes one request when the backend returns 504', () async {
+      var attempts = 0;
+      server.listen((request) async {
+        attempts++;
+        expect(request.uri.path, '/v1/action-items');
+        request.response.statusCode = HttpStatus.gatewayTimeout;
+        await request.response.close();
+      });
+
+      final response = await action_items_api.tryGetActionItems();
+
+      expect(response, isNull);
+      expect(attempts, 1);
+    });
+
+    test('getKnowledgeGraph makes one request when the backend returns 504', () async {
+      var attempts = 0;
+      server.listen((request) async {
+        attempts++;
+        expect(request.uri.path, '/v1/knowledge-graph');
+        request.response.statusCode = HttpStatus.gatewayTimeout;
+        await request.response.close();
+      });
+
+      await expectLater(
+        KnowledgeGraphApi.getKnowledgeGraph(),
+        throwsA(isA<Exception>()),
+      );
+
+      expect(attempts, 1);
+    });
+  });
+}
+
+class _TestEnvFields implements EnvFields {
+  String _requestBaseUrl = '';
+  var _apiBaseUrlReads = 0;
+
+  void routeNextRequestTo(String baseUrl) {
+    _requestBaseUrl = baseUrl;
+    _apiBaseUrlReads = 0;
+  }
+
+  @override
+  String? get apiBaseUrl {
+    _apiBaseUrlReads++;
+    // The production API uses the first read to build the request URL and the
+    // second to decide whether auth is required. Returning a distinct base on
+    // the second read keeps this loopback test focused on retry behavior.
+    return _apiBaseUrlReads.isOdd ? _requestBaseUrl : 'https://auth-not-required.invalid/';
+  }
+
+  @override
+  String? get googleClientId => null;
+
+  @override
+  String? get googleClientSecret => null;
+
+  @override
+  String? get googleMapsApiKey => null;
+
+  @override
+  String? get intercomAppId => null;
+
+  @override
+  String? get intercomIOSApiKey => null;
+
+  @override
+  String? get intercomAndroidApiKey => null;
+
+  @override
+  String? get openAIAPIKey => null;
+
+  @override
+  String? get posthogApiKey => null;
+
+  @override
+  bool? get useAuthCustomToken => false;
+
+  @override
+  bool? get useWebAuth => false;
+}

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -360,9 +360,12 @@ def get_action_items(
         end_date=end_date,
         due_start_date=due_start_date,
         due_end_date=due_end_date,
-        limit=limit,
+        limit=limit + 1,
         offset=offset,
     )
+
+    has_more = len(action_items) > limit
+    action_items = action_items[:limit]
 
     for item in action_items:
         if item.get('is_locked', False):
@@ -370,21 +373,6 @@ def get_action_items(
             item['description'] = (description[:70] + '...') if len(description) > 70 else description
 
     response_items = _safe_action_item_responses(action_items, uid=uid)
-
-    has_more = len(action_items) == limit
-    if has_more:
-        next_batch = action_items_db.get_action_items(
-            uid=uid,
-            conversation_id=conversation_id,
-            completed=completed,
-            start_date=start_date,
-            end_date=end_date,
-            due_start_date=due_start_date,
-            due_end_date=due_end_date,
-            limit=1,
-            offset=offset + limit,
-        )
-        has_more = len(next_batch) > 0
 
     return {"action_items": response_items, "has_more": has_more}
 

--- a/backend/testing/e2e/test_canonical_memory_pipeline.py
+++ b/backend/testing/e2e/test_canonical_memory_pipeline.py
@@ -414,7 +414,7 @@ def _invoke_surface_reader(surface_name, *, uid, db, rollout, policy, now):
             now=now,
         ).memories
     if surface_name == "agent_tools":
-        return tool_memories_service.get_memories_text(uid=uid, limit=50)
+        return tool_memories_service.get_memories_text(uid=uid, limit=50, now=now)
     if surface_name == "mcp":
         return MemoryService(db_client=db).search_mcp(uid, "coffee", limit=10)
     if surface_name == "product_search":

--- a/backend/tests/unit/test_action_items_router_pagination.py
+++ b/backend/tests/unit/test_action_items_router_pagination.py
@@ -1,0 +1,69 @@
+"""Router pagination uses one database call with a one-row lookahead."""
+
+from unittest.mock import patch
+
+import pytest
+
+import routers.action_items as action_items_router
+
+
+def _item(item_id: str, *, locked: bool = False, description: str = 'Do a thing') -> dict:
+    return {
+        'id': item_id,
+        'description': description,
+        'completed': False,
+        'is_locked': locked,
+    }
+
+
+def _call(*, limit: int = 2, offset: int = 0):
+    return action_items_router.get_action_items(
+        limit=limit,
+        offset=offset,
+        completed=None,
+        conversation_id=None,
+        start_date=None,
+        end_date=None,
+        due_start_date=None,
+        due_end_date=None,
+        uid='user-1',
+    )
+
+
+@pytest.mark.parametrize(
+    ('rows', 'expected_ids', 'expected_has_more'),
+    [
+        ([_item('one'), _item('two'), _item('three')], ['one', 'two'], True),
+        ([_item('one'), _item('two')], ['one', 'two'], False),
+        ([_item('one')], ['one'], False),
+    ],
+)
+def test_page_uses_one_row_lookahead(rows, expected_ids, expected_has_more):
+    with patch.object(action_items_router.action_items_db, 'get_action_items', return_value=rows) as get_items:
+        response = _call(limit=2, offset=7)
+
+    get_items.assert_called_once_with(
+        uid='user-1',
+        conversation_id=None,
+        completed=None,
+        start_date=None,
+        end_date=None,
+        due_start_date=None,
+        due_end_date=None,
+        limit=3,
+        offset=7,
+    )
+    assert [item.id for item in response['action_items']] == expected_ids
+    assert response['has_more'] is expected_has_more
+
+
+def test_lookahead_row_is_trimmed_before_locked_item_redaction():
+    extra_description = 'x' * 80
+    rows = [_item('one'), _item('two'), _item('lookahead', locked=True, description=extra_description)]
+
+    with patch.object(action_items_router.action_items_db, 'get_action_items', return_value=rows):
+        response = _call(limit=2)
+
+    assert [item.id for item in response['action_items']] == ['one', 'two']
+    assert response['has_more'] is True
+    assert rows[2]['description'] == extra_description

--- a/backend/tests/unit/test_memory_service_parity.py
+++ b/backend/tests/unit/test_memory_service_parity.py
@@ -459,6 +459,22 @@ class TestMemoryServiceParity:
         assert len(result) == 1
         assert result[0].id == "mem-1"
 
+    @pytest.mark.parametrize("canonical_enabled", [False, True])
+    def test_memory_service_forwards_read_clock_to_selected_backend(self, monkeypatch, canonical_enabled):
+        service_mod = _load_memory_service(monkeypatch)
+        monkeypatch.setattr(service_mod, "canonical_read_enabled", lambda *args, **kwargs: canonical_enabled)
+        service = service_mod.MemoryService(db_client=_FirestoreFake())
+        service._legacy.read = MagicMock(return_value=[])
+        service._canonical.read = MagicMock(return_value=[])
+        read_time = datetime(2040, 1, 15, 12, 0, tzinfo=timezone.utc)
+
+        assert service.read("uid-test", now=read_time) == []
+
+        selected = service._canonical.read if canonical_enabled else service._legacy.read
+        unselected = service._legacy.read if canonical_enabled else service._canonical.read
+        assert selected.call_args.kwargs["now"] == read_time
+        unselected.assert_not_called()
+
     def test_legacy_backend_strips_canonical_lifecycle_fields_on_read(self, monkeypatch):
         service_mod = _load_memory_service(monkeypatch)
         memories = [_sample_tiered_memory_dict()]

--- a/backend/tests/unit/test_ws_b_short_term_lifecycle.py
+++ b/backend/tests/unit/test_ws_b_short_term_lifecycle.py
@@ -460,6 +460,32 @@ def test_expired_short_term_hidden_from_default_reads(monkeypatch):
     assert read_canonical_memories(uid, db_client=db) == []
 
 
+def test_canonical_read_uses_explicit_time_for_short_term_visibility(monkeypatch):
+    uid = "uid-canonical-read-clock"
+    _set_canonical_cohort(monkeypatch, uid)
+    db = _canonical_db_with_control(uid)
+    memory_id = _seed_canonical_short_term(
+        db,
+        uid=uid,
+        conversation_id="conv-read-clock",
+        content="Time-bounded note",
+        monkeypatch=monkeypatch,
+    )
+    path = f"users/{uid}/memory_items/{memory_id}"
+    read_time = datetime(2040, 1, 15, 12, 0, tzinfo=timezone.utc)
+    db.docs[path] |= {
+        "captured_at": (read_time - timedelta(days=1)).isoformat(),
+        "updated_at": (read_time - timedelta(days=1)).isoformat(),
+        "expires_at": (read_time + timedelta(hours=1)).isoformat(),
+    }
+
+    visible = read_canonical_memories(uid, db_client=db, now=read_time)
+    expired = read_canonical_memories(uid, db_client=db, now=read_time + timedelta(hours=1))
+
+    assert [memory.id for memory in visible] == [memory_id]
+    assert expired == []
+
+
 def test_legacy_uid_promotion_and_lifecycle_are_noop(monkeypatch):
     uid = "uid-legacy"
     assert resolve_memory_system(uid, db_client=_PromotionFakeDb()) == MemorySystem.LEGACY

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -205,6 +205,7 @@ def read_canonical_memories(
     db_client: Any = None,
     device_scope_request: Optional[DeviceScopeRequest] = None,
     include_pending_processing: bool = False,
+    now: Optional[datetime] = None,
 ) -> List[MemoryDB]:
     """Read canonical items, optionally exposing explicit pending submissions.
 
@@ -216,9 +217,9 @@ def read_canonical_memories(
     device_scope = device_scope_request.device_scope if device_scope_request else "all"
     client_device_id = device_scope_request.client_device_id if device_scope_request else None
     items = fetch_authoritative_product_memory_items(uid=uid, db_client=client)
-    now = datetime.now(timezone.utc)
+    current_time = now or datetime.now(timezone.utc)
     policy = MemoryAccessPolicy.for_omi_chat(archive_capability=False)
-    visible = filter_canonical_default_visible_items(items, policy=policy, now=now)
+    visible = filter_canonical_default_visible_items(items, policy=policy, now=current_time)
     if include_pending_processing:
         visible_by_id = {item.memory_id: item for item in visible}
         for item in items:

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -2,6 +2,7 @@
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Dict, List, Optional, cast
 
 from fastapi import HTTPException
@@ -290,6 +291,7 @@ class LegacyMemoryBackend:
         offset: int = 0,
         device_scope_request: Optional[DeviceScopeRequest] = None,
         include_pending_processing: bool = False,
+        now: Optional[datetime] = None,
     ) -> List[MemoryDB]:
         _reject_legacy_device_scope(device_scope_request)
         return _legacy_read_memories(uid, limit=limit, offset=offset)
@@ -359,6 +361,7 @@ class CanonicalMemoryBackend:
         offset: int = 0,
         device_scope_request: Optional[DeviceScopeRequest] = None,
         include_pending_processing: bool = False,
+        now: Optional[datetime] = None,
     ) -> List[MemoryDB]:
         return read_canonical_memories(
             uid,
@@ -367,6 +370,7 @@ class CanonicalMemoryBackend:
             db_client=self._db_client,
             device_scope_request=device_scope_request,
             include_pending_processing=include_pending_processing,
+            now=now,
         )
 
     def search(
@@ -466,6 +470,7 @@ class MemoryService:
         offset: int = 0,
         device_scope_request: Optional[DeviceScopeRequest] = None,
         include_pending_processing: bool = False,
+        now: Optional[datetime] = None,
     ) -> List[MemoryDB]:
         backend = self._canonical if canonical_read_enabled(uid, db_client=self._db_client) else self._legacy
         return backend.read(
@@ -474,6 +479,7 @@ class MemoryService:
             offset=offset,
             device_scope_request=device_scope_request,
             include_pending_processing=include_pending_processing,
+            now=now,
         )
 
     def search(

--- a/backend/utils/retrieval/tool_services/memories.py
+++ b/backend/utils/retrieval/tool_services/memories.py
@@ -3,7 +3,7 @@ Shared service functions for memory retrieval.
 Used by both LangChain tools (mobile chat) and REST router (desktop/web).
 """
 
-from datetime import timezone
+from datetime import datetime, timezone
 from typing import Optional, Any, Dict, List, cast
 
 import database.memories as memory_db
@@ -32,6 +32,7 @@ def get_memories_text(
     offset: int = 0,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
+    now: Optional[datetime] = None,
 ) -> str:
     """Fetch user memories/facts and format as LLM-ready text."""
     logger.info(f"get_memories_text - uid: {uid}, limit: {limit}, offset: {offset}")
@@ -55,7 +56,7 @@ def get_memories_text(
 
     memory_system = pin_memory_system(uid, db_client=firestore_db)
     if memory_system == MemorySystem.CANONICAL:
-        memories = MemoryService(db_client=firestore_db).read(uid, limit=limit, offset=offset)
+        memories = MemoryService(db_client=firestore_db).read(uid, limit=limit, offset=offset, now=now)
         if start_dt or end_dt:
             filtered: List[MemoryDB] = []
             for memory in memories:


### PR DESCRIPTION
## What changed and why

Production was still returning 30-second 504s on the expensive Action Items and Knowledge Graph GETs. This PR removes the second Action Items database invocation used only to compute `has_more`, and disables all automatic retries for those two mobile GET call sites so one failed read does not immediately repeat the same work.

This is a scoped read/retry-amplification mitigation. The remaining Action Items database invocation still streams and sorts the full matching collection, Knowledge Graph still returns the full graph, and the Memories route is unchanged. It does not claim a proven root cause or bounded Firestore reads.

The PR also repairs a date-dependent hermetic memory test exposed by CI. Canonical list reads now accept one optional explicit read instant, threaded through the real agent-tools call path; production callers omit it and retain UTC wall-clock behavior.

## Product invariants affected

INV-MEM-1 — the three-tier/default-access behavior is unchanged; the hermetic default-access matrix now evaluates its fixed fixtures against the same fixed instant.

## How it was verified

- Refreshed read-only production evidence at 2026-07-23 22:04:48 UTC: the active backend revision was still returning only 30-35 second 504s in the sampled windows (77 in 15 minutes: 61 Action Items, 11 Knowledge Graph, 4 Memories, 1 development Action Items; 29 in 5 minutes: 23 Action Items, 5 Knowledge Graph, 1 development Action Items).
- `backend/.venv/bin/python -m pytest -q tests/unit/test_action_items_router_pagination.py tests/unit/test_action_items_pagination_order.py tests/unit/test_action_item_canonical_contract.py tests/unit/test_timeout_middleware.py` — 47 passed.
- `backend/.venv/bin/python scripts/scan_async_blockers.py --dirs routers utils` — 0 selected blocking findings.
- `backend/test-preflight.sh` — 17 checks passed, 0 failed, 9 optional environment warnings.
- `/Users/dazheng/fvm/versions/3.44.6/bin/flutter test test/unit/http_pool_manager_retry_test.dart` — 2 passed against a loopback 504 server through the real API call sites.
- Focused Flutter analysis found no new diagnostics. It reports one pre-existing `avoid_print` info on an untouched line in `knowledge_graph_api.dart`.
- `backend/.venv/bin/python -m pytest -q tests/unit/test_memory_service_parity.py tests/unit/test_ws_b_short_term_lifecycle.py` — 56 passed, including exact-expiry and canonical/legacy clock propagation.
- `pyright` on the three changed production memory modules — 0 errors, 0 warnings.
- The official macOS hermetic E2E runner hit its existing 120-second local startup timeout before producing test output. The Linux GitHub Actions hermetic job remains the full-harness authority.
- The full `backend/test.sh` runner was attempted but did not complete cleanly: three untouched tests exceeded the 0.12-second CPU guard under the broad parallel run, and one untouched memory-runtime adapter test remained stuck for about 11 minutes before the runner was interrupted. The affected-path suites above are green.

## Tests

- `backend/tests/unit/test_action_items_router_pagination.py` fails on the old two-call pagination implementation and covers full, exact, and underfilled pages plus trimming before locked-item redaction.
- `app/test/unit/http_pool_manager_retry_test.dart` exercises `tryGetActionItems` and `KnowledgeGraphApi.getKnowledgeGraph` through a loopback 504 server. It observes one request now; the old call sites would make two and three requests respectively.
- `backend/tests/unit/test_ws_b_short_term_lifecycle.py` proves a short-term item is visible before its supplied expiry and hidden exactly at expiry.
- `backend/tests/unit/test_memory_service_parity.py` proves the selected canonical or legacy backend receives the same explicit read instant.
- `backend/testing/e2e/test_canonical_memory_pipeline.py` passes its fixture clock through the real agent-tools list surface instead of mixing it with wall time.

## Failure class (fixes)

Failure-Class: none

No existing registered class describes duplicated expensive reads after an application timeout; failure-class lifecycle work belongs in a separate PR.
