### PR TITLE
feat(desktop): outcome-based, build-attributable macOS release-health telemetry (#10425)

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -4,7 +4,8 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2639,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4849,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2584,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1500,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1509,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift": 1507,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1584
   },
   "raise_justifications": {
@@ -12,7 +13,8 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": "The Second Brain onboarding, reach-error, and notch-moment UI keeps the hover menu agent-only and routes idle notch taps through main chat.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": "Second Brain continuous-chat routing shares window geometry with agent-only hover sizing and canonical idle-notch chat ownership.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": "The owning turn manager carries privacy-bounded push-to-talk capture-lifecycle diagnostics wiring alongside strict concurrency, response-critical batch STT, and parallel screen-context capture.",
-    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": "Adds an owner-scope guard so the persistence-fence retry loop stops instead of busy-looping agent-bridge startup when signed out; the decision logic lives in RealtimeHubSessionPolicies.",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": "Adds an optional mint_attempt_id correlation key to the token-mint failure helper and the two failover methods so a mint failure joins its recovered/degraded/exhausted outcome; telemetry-only, no lifecycle change (#10425).",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift": "Threads mint_attempt_id through the warm and barge-in token-mint failure catches and their correlated failover calls for release-health attribution; telemetry-only, no lifecycle change (#10425).",
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior."
   },
   "threshold": 1500

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -4,13 +4,13 @@
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4256,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1593,
-    "desktop/macos/Desktop/Sources/OmiApp.swift": 1635
+    "desktop/macos/Desktop/Sources/OmiApp.swift": 1651
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/AuthService.swift": "Apple first-auth name capture signals observers (authNameDidUpdate) and persists the name to Firebase so it survives reinstalls.",
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": "present_onboarding_opener QA action renders the real post-onboarding opener in-process for verification.",
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": "Adds cloudOAuthGrantClientIDs so ChatGPT directory grants (always omi-chatgpt-prod) verify on dev/Beta builds, fixing the connector chip never flipping to connected.",
-    "desktop/macos/Desktop/Sources/OmiApp.swift": "Current main already contains 1693 lines after the menu-bar summon and chat-landing additions; this PR changes the Firebase-missing launch branch without increasing that count."
+    "desktop/macos/Desktop/Sources/OmiApp.swift": "Sets Sentry options.releaseName/options.dist and a global update_channel/bundle_id scope tag so native crash/app-hang/watchdog events are build-attributable; telemetry-only init, no lifecycle change (#10425)."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -1945,7 +1945,7 @@ class AuthService {
   private func recordTokenStorageFallback(reason: String) {
     guard tokenStorageHooks.recordsFallbackTelemetry else { return }
     DesktopDiagnosticsManager.shared.recordFallback(
-      area: "other",
+      area: "auth_storage",
       from: "keychain",
       to: "user_defaults",
       reason: "other",

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -3402,7 +3402,7 @@ actor AgentRuntimeProcess {
         case .succeeded = executionResult
       {
         DesktopDiagnosticsManager.shared.recordFallback(
-          area: "other",
+          area: "agent_runtime",
           from: "spawn_agent",
           to: command.canonicalToolName,
           reason: "other",

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -670,7 +670,8 @@ final class DesktopDiagnosticsManager {
     // so a release-regression rollup can exclude normal idle teardown / planned
     // session rotation without enumerating the two `realtime_provider_expected_*`
     // event names (#10425). Expected lifecycle stays inspectable, never an error.
-    let expectedLifecycle = event == .realtimeProviderExpectedIdleTeardown
+    let expectedLifecycle =
+      event == .realtimeProviderExpectedIdleTeardown
       || event == .realtimeProviderExpectedSessionRotation
     var properties: [String: Any] = [
       "provider": safeProvider(provider),

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -771,8 +771,9 @@ final class DesktopDiagnosticsManager {
   /// listed and survive the filter.
   private static let contentBearingPropertyKeys: Set<String> = [
     "transcript", "transcript_text", "audio", "audio_data", "pcm", "prompt", "prompt_text",
-    "response", "response_text", "message", "error_message", "localized_description",
-    "content", "title", "notification_title", "window_title", "screen_title",
+    "response", "response_text", "message", "error_message", "error_description", "error_desc",
+    "localized_description", "description", "detail", "detail_reason", "detail_message",
+    "reason_detail", "content", "title", "notification_title", "window_title", "screen_title",
   ]
 
   func writeDiagnosticsAttachment() -> URL? {

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -404,17 +404,20 @@ final class DesktopDiagnosticsManager {
   }
   /// Record one bounded PTT attempt lifecycle snapshot (see
   /// `PTTAttemptLifecycleRecorder`). Routes through the shared ring buffer + Sentry
-  /// attachment path; the event is remote (PostHog) only for non-committed
-  /// terminations so successful turns stay local-only (matching
-  /// `recordPTTStarted` / `recordPTTCommitted`). This is the causal-correlation
-  /// complement to the late `recordPTTSilentTurn` snapshot: same attempt context,
-  /// but with the capture-start / first-audio / first-usable-frame / recovery
-  /// boundaries that the silent-turn snapshot cannot see.
+  /// attachment path. Emitted remotely (PostHog) for EVERY terminal disposition —
+  /// including `failureClass == .committed` — so a release-health query has the
+  /// full attempt denominator (success + the causally distinct excluded/failure
+  /// classes), not only classified failures. Short tap / quiet discard / user
+  /// cancel are bounded `failure_class` values distinct from `capture_never_operational`,
+  /// so they cannot inflate a capture-failure rate. This is the authoritative,
+  /// privacy-bounded PTT terminal-outcome funnel (#10425); the ambiguous
+  /// `floating_bar_ptt_ended` `had_transcript` event is retained only for backward
+  /// compatibility and must not be read as a success/failure denominator.
   func recordPTTAttemptLifecycle(_ snapshot: PTTAttemptLifecycleRecorder.Snapshot) {
     record(
       .pttAudioCaptureLifecycle,
       properties: snapshot.properties,
-      trackRemotely: snapshot.failureClass != .committed)
+      trackRemotely: true)
   }
 
   /// Records a typed chat failure as a fleet-health metric. The existing bounded
@@ -592,6 +595,13 @@ final class DesktopDiagnosticsManager {
     record(.fallbackTriggered, properties: properties, trackRemotely: true)
   }
 
+  /// Realtime token-mint failure. `phase` is bucketed to a closed set (`warm` =
+  /// background pre-warm vs `barge_in_replacement` = replacement during an active
+  /// turn) so a release-health query has a bounded warm-vs-active dimension (#10425).
+  /// `outcome`/`mintAttemptId` are optional: a mint failure is point-in-time, so its
+  /// terminal fate (recovered/degraded/exhausted) is carried by the correlated
+  /// `fallback_triggered`{area=realtime_hub} event; `mint_attempt_id` lets a query
+  /// join the two without provider/time heuristics.
   func recordRealtimeTokenMintFailed(
     provider: String,
     reason: String,
@@ -600,12 +610,14 @@ final class DesktopDiagnosticsManager {
     backendRoute: String? = nil,
     upstreamStatusCode: Int? = nil,
     providerCode: String? = nil,
-    retryable: Bool? = nil
+    retryable: Bool? = nil,
+    outcome: DesktopFallbackOutcome? = nil,
+    mintAttemptId: String? = nil
   ) {
     var properties: [String: Any] = [
       "provider": safeProvider(provider),
       "reason": reason,
-      "phase": phase,
+      "phase": bucketRealtimePhase(phase),
     ]
     if let httpStatusCode {
       properties["http_status_code"] = httpStatusCode
@@ -621,6 +633,12 @@ final class DesktopDiagnosticsManager {
     }
     if let retryable {
       properties["retryable"] = retryable
+    }
+    if let outcome {
+      properties["outcome"] = outcome.rawValue
+    }
+    if let mintAttemptId, !mintAttemptId.isEmpty {
+      properties["mint_attempt_id"] = mintAttemptId
     }
     record(
       .realtimeTokenMintFailed,
@@ -648,11 +666,19 @@ final class DesktopDiagnosticsManager {
     default:
       event = .realtimeProviderSessionError
     }
+    // Bounded release-health dimension: a single `expected` flag + `lifecycle_class`
+    // so a release-regression rollup can exclude normal idle teardown / planned
+    // session rotation without enumerating the two `realtime_provider_expected_*`
+    // event names (#10425). Expected lifecycle stays inspectable, never an error.
+    let expectedLifecycle = event == .realtimeProviderExpectedIdleTeardown
+      || event == .realtimeProviderExpectedSessionRotation
     var properties: [String: Any] = [
       "provider": safeProvider(provider),
       "category": normalizedCategory,
       "alive_for_seconds": Int(aliveFor),
       "active_turn": activeTurn,
+      "expected": expectedLifecycle,
+      "lifecycle_class": expectedLifecycle ? "expected" : "error",
     ]
     if normalizedCategory == RealtimeHubCloseCategory.expectedSessionRotation.rawValue {
       properties["recovery_action"] = "rotate_realtime_session"
@@ -738,6 +764,15 @@ final class DesktopDiagnosticsManager {
     "input_route_class", "input_route_source", "route_changed_during_attempt",
     "recovery_triggered", "recovery_attempt_id", "recovery_outcome_of_next_turn",
     "judgeable", "telemetry_schema_version",
+  ]
+  /// Exact-match property keys that must never appear on a health snapshot
+  /// (local ring buffer or remote PostHog). Bounded cousins like
+  /// `transcript_length`, `failure_class`, or `error_code` are intentionally NOT
+  /// listed and survive the filter.
+  private static let contentBearingPropertyKeys: Set<String> = [
+    "transcript", "transcript_text", "audio", "audio_data", "pcm", "prompt", "prompt_text",
+    "response", "response_text", "message", "error_message", "localized_description",
+    "content", "title", "notification_title", "window_title", "screen_title",
   ]
 
   func writeDiagnosticsAttachment() -> URL? {
@@ -1046,10 +1081,17 @@ final class DesktopDiagnosticsManager {
     properties: [String: Any],
     trackRemotely: Bool = true
   ) {
+    // Defense-in-depth privacy guard (#10425): no health snapshot — local ring buffer
+    // or remote PostHog `desktop_health_event` — may carry raw transcript/audio/
+    // prompt/response/free-form text. Drop any content-bearing key a caller might
+    // accidentally thread through `extra`. Exact-match only so bounded keys like
+    // `transcript_length` survive; this is the single chokepoint for every emit.
+    let safeProperties = commonProperties().merging(sanitized(properties)) { _, new in new }
+      .filter { !DesktopDiagnosticsManager.contentBearingPropertyKeys.contains($0.key) }
     let snapshot = DesktopHealthSnapshot(
       timestamp: Date(),
       event: event,
-      properties: commonProperties().merging(sanitized(properties)) { _, new in new })
+      properties: safeProperties)
 
     lock.lock()
     snapshots.append(snapshot)
@@ -1232,6 +1274,17 @@ final class DesktopDiagnosticsManager {
     "automation_bridge",
     "transcription_retry",
     "task_reconcile",
+    // Named owners for paths that previously collapsed into `area=other` (#10425):
+    // screen-capture health flap, memory device-scope, desktop update policy,
+    // out-of-turn TTS, task workflow control, and auth-token storage. Keeping them
+    // out of `other` lets a release-health query separate a benign screen-capture
+    // flap from a genuinely degraded path.
+    "screen_capture",
+    "memory_scope",
+    "desktop_update",
+    "tts_fallback",
+    "task_workflow",
+    "auth_storage",
     "other",
   ]
 
@@ -1273,6 +1326,19 @@ final class DesktopDiagnosticsManager {
   private func bucketFallbackReason(_ reason: String) -> String {
     let label = safeFallbackLabel(reason, default: "other")
     return Self.allowedFallbackReasons.contains(label) ? label : "other"
+  }
+  /// Closed set for the realtime token-mint `phase` dimension (#10425): a release
+  /// query can rely on `warm` (background pre-warm) vs `barge_in_replacement`
+  /// (socket replacement during an active turn) instead of an open string.
+  private static let allowedRealtimeMintPhases: Set<String> = [
+    "warm",
+    "barge_in_replacement",
+    "other",
+  ]
+
+  private func bucketRealtimePhase(_ phase: String) -> String {
+    let label = safeFallbackLabel(phase, default: "other")
+    return Self.allowedRealtimeMintPhases.contains(label) ? label : "other"
   }
 
   private func safeFallbackLabel(_ value: String, default defaultValue: String) -> String {

--- a/desktop/macos/Desktop/Sources/DesktopUpdatePolicyManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopUpdatePolicyManager.swift
@@ -65,7 +65,7 @@ final class DesktopUpdatePolicyManager: ObservableObject {
       policy = nil
       log("DesktopUpdatePolicy: unavailable error_type=\(String(reflecting: type(of: error)))")
       DesktopDiagnosticsManager.shared.recordFallback(
-        area: "other",
+        area: "desktop_update",
         from: "desktop_update_policy",
         to: "desktop_update_appcast",
         reason: "other",

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -573,7 +573,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
     outcome: DesktopFallbackOutcome
   ) {
     DesktopDiagnosticsManager.shared.recordFallback(
-      area: activePTTLease == nil ? "other" : "ptt_cascade",
+      area: activePTTLease == nil ? "tts_fallback" : "ptt_cascade",
       from: "openai_tts",
       to: to,
       reason: reason,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PTTAttemptLifecycleRecorder.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PTTAttemptLifecycleRecorder.swift
@@ -424,7 +424,7 @@ final class PTTAttemptLifecycleRecorder {
       rms: rms,
       isNearZero: isNearZero,
       judgeable: judgeable,
-      telemetrySchemaVersion: 1)
+      telemetrySchemaVersion: 2)
 
     emit(snapshot)
     return snapshot

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
@@ -296,7 +296,8 @@ extension RealtimeHubController {
         if error.healthError.failureClass.isAccountWide {
           log("RealtimeHub: account credential failure during mint — staying on cascade")
         } else if !self.failoverToAlternateProvider(
-          reason: self.failoverReason(for: error.healthError.failureClass))
+          reason: self.failoverReason(for: error.healthError.failureClass),
+          mintAttemptId: String(mintGeneration))
         {
           log("⚠️ RealtimeHub: ephemeral mint failed on both providers — staying on cascade")
         }
@@ -318,7 +319,8 @@ extension RealtimeHubController {
         if error.failureClass.isAccountWide {
           log("RealtimeHub: account credential failure during mint — staying on cascade")
         } else if !self.failoverToAlternateProvider(
-          reason: self.failoverReason(for: error.failureClass))
+          reason: self.failoverReason(for: error.failureClass),
+          mintAttemptId: String(mintGeneration))
         {
           log("⚠️ RealtimeHub: ephemeral mint failed on both providers — staying on cascade")
         }
@@ -338,7 +340,7 @@ extension RealtimeHubController {
           reason: "backend_transient",
           phase: "warm",
           mintAttemptId: String(mintGeneration))
-        if !self.failoverToAlternateProvider() {
+        if !self.failoverToAlternateProvider(mintAttemptId: String(mintGeneration)) {
           log("⚠️ RealtimeHub: ephemeral mint failed on both providers — staying on cascade")
         }
         return
@@ -1251,6 +1253,7 @@ extension RealtimeHubController {
           return
         }
         guard self.releaseMint(generation: mintGeneration, ownerScope: ownerScope) else { return }
+        CredentialHealthManager.shared.record(error, context: "realtime_barge_in_mint")
         DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
           provider: providerParam,
           reason: error.failureClass.logValue,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
@@ -291,7 +291,8 @@ extension RealtimeHubController {
         else { return }
         _ = self.releaseMint(generation: mintGeneration, ownerScope: ownerScope)
         self.recordRealtimeMintFailure(
-          error, provider: providerParam, phase: "warm", context: "realtime_mint")
+          error, provider: providerParam, phase: "warm", context: "realtime_mint",
+          mintAttemptId: String(mintGeneration))
         if error.healthError.failureClass.isAccountWide {
           log("RealtimeHub: account credential failure during mint — staying on cascade")
         } else if !self.failoverToAlternateProvider(
@@ -312,7 +313,8 @@ extension RealtimeHubController {
           provider: providerParam,
           reason: error.failureClass.logValue,
           phase: "warm",
-          httpStatusCode: error.failureClass.httpStatusCode)
+          httpStatusCode: error.failureClass.httpStatusCode,
+          mintAttemptId: String(mintGeneration))
         if error.failureClass.isAccountWide {
           log("RealtimeHub: account credential failure during mint — staying on cascade")
         } else if !self.failoverToAlternateProvider(
@@ -334,7 +336,8 @@ extension RealtimeHubController {
         DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
           provider: providerParam,
           reason: "backend_transient",
-          phase: "warm")
+          phase: "warm",
+          mintAttemptId: String(mintGeneration))
         if !self.failoverToAlternateProvider() {
           log("⚠️ RealtimeHub: ephemeral mint failed on both providers — staying on cascade")
         }
@@ -1224,11 +1227,13 @@ extension RealtimeHubController {
           error,
           provider: providerParam,
           phase: "barge_in_replacement",
-          context: "realtime_barge_in_mint")
+          context: "realtime_barge_in_mint",
+          mintAttemptId: String(mintGeneration))
         if self.shouldFailoverToAlternate(for: error.healthError.failureClass),
           self.failoverBargeInReplacement(
             from: provider,
-            reason: self.failoverReason(for: error.healthError.failureClass))
+            reason: self.failoverReason(for: error.healthError.failureClass),
+            mintAttemptId: String(mintGeneration))
         {
           return
         }
@@ -1246,16 +1251,17 @@ extension RealtimeHubController {
           return
         }
         guard self.releaseMint(generation: mintGeneration, ownerScope: ownerScope) else { return }
-        CredentialHealthManager.shared.record(error, context: "realtime_barge_in_mint")
         DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
           provider: providerParam,
           reason: error.failureClass.logValue,
           phase: "barge_in_replacement",
-          httpStatusCode: error.failureClass.httpStatusCode)
+          httpStatusCode: error.failureClass.httpStatusCode,
+          mintAttemptId: String(mintGeneration))
         if self.shouldFailoverToAlternate(for: error.failureClass),
           self.failoverBargeInReplacement(
             from: provider,
-            reason: self.failoverReason(for: error.failureClass))
+            reason: self.failoverReason(for: error.failureClass),
+            mintAttemptId: String(mintGeneration))
         {
           return
         }
@@ -1276,8 +1282,9 @@ extension RealtimeHubController {
         DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
           provider: providerParam,
           reason: "backend_transient",
-          phase: "barge_in_replacement")
-        if self.failoverBargeInReplacement(from: provider, reason: "other") {
+          phase: "barge_in_replacement",
+          mintAttemptId: String(mintGeneration))
+        if self.failoverBargeInReplacement(from: provider, reason: "other", mintAttemptId: String(mintGeneration)) {
           return
         }
         self.failBargeInReplacement(provider: provider, reason: error.localizedDescription)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -671,27 +671,31 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   /// Returns true if a failover was started. Only fires once per chain (primary →
   /// alternate); if the alternate also fails we stop and let PTT use the Claude cascade.
   @discardableResult
-  func failoverToAlternateProvider(reason: String = "other") -> Bool {
+  func failoverToAlternateProvider(reason: String = "other", mintAttemptId: String? = nil) -> Bool {
     guard fallbackProvider == nil else {
+      var exhaustedExtra: [String: Any] = ["user_visible": false]
+      if let mintAttemptId { exhaustedExtra["mint_attempt_id"] = mintAttemptId }
       DesktopDiagnosticsManager.shared.recordFallback(
         area: "realtime_hub",
         from: effectiveProvider.rawValue,
         to: "cascade",
         reason: reason,
         outcome: .exhausted,
-        extra: ["user_visible": false])
+        extra: exhaustedExtra)
       return false  // already on the alternate → cascade
     }
     let primary = RealtimeHubSettings.shared.provider
     fallbackProvider = primary.alternate
     pendingFailoverReason = reason
+    var degradedExtra: [String: Any] = ["user_visible": false]
+    if let mintAttemptId { degradedExtra["mint_attempt_id"] = mintAttemptId }
     DesktopDiagnosticsManager.shared.recordFallback(
       area: "realtime_hub",
       from: primary.rawValue,
       to: primary.alternate.rawValue,
       reason: reason,
       outcome: .degraded,
-      extra: ["user_visible": false])
+      extra: degradedExtra)
     log(
       "RealtimeHub: \(primary.displayName) unavailable — failing over to \(primary.alternate.displayName)"
     )
@@ -714,7 +718,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   @discardableResult
   func failoverBargeInReplacement(
     from provider: RealtimeHubProvider,
-    reason: String
+    reason: String,
+    mintAttemptId: String? = nil
   ) -> Bool {
     guard fallbackProvider == nil,
       let pendingTurn = replacementAudioBuffer,
@@ -726,13 +731,15 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     let alternate = provider.alternate
     fallbackProvider = alternate
     pendingFailoverReason = reason
+    var degradedExtra: [String: Any] = ["user_visible": false]
+    if let mintAttemptId { degradedExtra["mint_attempt_id"] = mintAttemptId }
     DesktopDiagnosticsManager.shared.recordFallback(
       area: "realtime_hub",
       from: provider.rawValue,
       to: alternate.rawValue,
       reason: reason,
       outcome: .degraded,
-      extra: ["user_visible": false])
+      extra: degradedExtra)
     log(
       "RealtimeHub: preserving barge-in turn while failing over "
         + "\(provider.displayName) → \(alternate.displayName)")
@@ -781,7 +788,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     _ error: RealtimeTokenMintError,
     provider providerParam: String,
     phase: String,
-    context: String
+    context: String,
+    mintAttemptId: String? = nil
   ) {
     CredentialHealthManager.shared.record(error.healthError, context: context)
     DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
@@ -792,7 +800,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       backendRoute: error.payload?.backendRoute,
       upstreamStatusCode: error.payload?.upstreamStatusCode,
       providerCode: error.payload?.code,
-      retryable: error.payload?.retryable)
+      retryable: error.payload?.retryable,
+      mintAttemptId: mintAttemptId)
   }
 
   /// PTT must distinguish a merely authenticated socket from a session that can

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -848,7 +848,7 @@ class MemoriesViewModel: ObservableObject {
       // Backend rejected device_scope for a non-canonical user — retry unscoped.
       log("MemoriesViewModel: device_scope unsupported by backend, retrying unscoped")
       DesktopDiagnosticsManager.shared.recordFallback(
-        area: "other",
+        area: "memory_scope",
         from: "device_scoped",
         to: "unscoped",
         reason: "capability_mismatch",

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -400,6 +400,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
       options.enableAppHangTracking = !isDev
       options.enableWatchdogTerminationTracking = !isDev
       options.environment = isDev ? "development" : "production"
+      // Build-attributable native events (#10425): bind every native crash / app-hang /
+      // watchdog event to the exact version+build (`v{version}+{build}-macos`, the same
+      // tag Codemagic publishes) and the release channel (`stable`/`beta`). Without these,
+      // Sentry's Release/Build filters return nothing for native events and beta+stable
+      // are indistinguishable (both report environment="production").
+      if let releaseTag = AppBuild.releaseTag {
+        options.releaseName = releaseTag
+      }
+      options.dist = AppBuild.currentUpdateChannel
       // Disable automatic HTTP client error capture — the SDK creates noisy events
       // for every 4xx/5xx response (e.g. Cloud Run 503 cold starts on /v1/crisp/unread).
       // App code already handles HTTP errors and reports meaningful ones explicitly.
@@ -421,6 +430,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
           exceptions: (event.exceptions ?? []).map { (type: $0.type, value: $0.value) })
         return drop ? nil : event
       }
+    }
+    // Tag every Sentry event (including native crashes, which bypass app code) with
+    // the release channel and bundle identity so a release cohort can be sliced without
+    // relying on `dist` alone (#10425).
+    SentrySDK.configureScope { scope in
+      scope.setTag(value: AppBuild.currentUpdateChannel, key: "update_channel")
+      scope.setTag(value: AppBuild.bundleIdentifier, key: "bundle_id")
     }
     log(
       "Sentry initialized (environment: \(isDev ? "development" : "production"), nativeHandlers=\(!isDev))"

--- a/desktop/macos/Desktop/Sources/PostHogManager.swift
+++ b/desktop/macos/Desktop/Sources/PostHogManager.swift
@@ -34,6 +34,18 @@ class PostHogManager {
 
     PostHogSDK.shared.setup(config)
 
+    // Release-identity super-properties (#10425): every captured event carries the
+    // app version + build + release channel, so PostHog (including
+    // `floating_bar_ptt_ended` and other per-event tracks that previously carried no
+    // identity) can be sliced by release cohort without per-event plumbing. These
+    // persist across sessions.
+    PostHogSDK.shared.register([
+      "platform": "macos",
+      "app_version": Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown",
+      "app_build": Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown",
+      "update_channel": AppBuild.currentUpdateChannel,
+    ])
+
     isInitialized = true
     log("PostHog: Initialized successfully")
   }
@@ -69,6 +81,8 @@ class PostHogManager {
     var properties: [String: Any] = [
       "platform": "macos",
       "app_version": Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown",
+      "app_build": Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown",
+      "update_channel": AppBuild.currentUpdateChannel,
     ]
 
     if let email = email {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -669,7 +669,7 @@ actor TaskAssistant: ProactiveAssistant {
 
       guard TaskCaptureModePolicy.usesLegacyStaging(mode) else {
         DesktopDiagnosticsManager.shared.recordFallback(
-          area: "other",
+          area: "task_workflow",
           from: "workflow_control",
           to: "capture_deferred",
           reason: "other",

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
@@ -34,7 +34,7 @@ actor TaskPromotionService {
             return false
           }
           DesktopDiagnosticsManager.shared.recordFallback(
-            area: "other",
+            area: "task_workflow",
             from: "workflow_control",
             to: "promotion_disabled",
             reason: "other",

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+ScreenCaptureHealth.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+ScreenCaptureHealth.swift
@@ -10,7 +10,7 @@ extension ProactiveAssistantsPlugin {
     switch (previous, health) {
     case (.active, .temporarilyUnavailable):
       DesktopDiagnosticsManager.shared.recordFallback(
-        area: "other",
+        area: "screen_capture",
         from: "screen_capture",
         to: "capture_paused",
         reason: "capability_mismatch",
@@ -23,7 +23,7 @@ extension ProactiveAssistantsPlugin {
       )
     case (.active, .recovering), (.temporarilyUnavailable, .recovering):
       DesktopDiagnosticsManager.shared.recordFallback(
-        area: "other",
+        area: "screen_capture",
         from: "screen_capture",
         to: "recovery_poll",
         reason: "other",
@@ -36,7 +36,7 @@ extension ProactiveAssistantsPlugin {
       )
     case (.temporarilyUnavailable, .active), (.recovering, .active):
       DesktopDiagnosticsManager.shared.recordFallback(
-        area: "other",
+        area: "screen_capture",
         from: "capture_paused",
         to: "screen_capture",
         reason: "capability_mismatch",

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -604,6 +604,19 @@ import XCTest
       // The bounded cousin (a length, not content) survives.
       XCTAssertEqual(snapshot["transcript_length"] as? Int, 42)
     }
+    func testWalUploadFailureStripsFreeFormDetailReason() throws {
+      // A real caller (WALService.uploadWalToCloud) pipes String(describing: error)
+      // into detail_reason; the emit chokepoint must strip that free-form text while
+      // keeping the bounded failure_class + area.
+      DesktopDiagnosticsManager.shared.recordWalUploadFailed(
+        walId: "wal-1",
+        reason: "backend returned a customer-specific private transcript snippet")
+      let snapshot = try latestSnapshot()
+      XCTAssertEqual(snapshot["event"] as? String, "fallback_triggered")
+      XCTAssertEqual(snapshot["area"] as? String, "wal_upload")
+      XCTAssertEqual(snapshot["failure_class"] as? String, "wal_upload_failed")
+      XCTAssertNil(snapshot["detail_reason"])
+    }
     private func assertLatestHealthSnapshot(
       event: DesktopHealthEventName,
       contains expected: [String: Any] = [:],

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -573,7 +573,8 @@ import XCTest
     }
 
     func testFallbackNamedAreasAreNotCollapsedToOther() throws {
-      for area in ["screen_capture", "memory_scope", "desktop_update", "tts_fallback", "task_workflow", "auth_storage"] {
+      for area in ["screen_capture", "memory_scope", "desktop_update", "tts_fallback", "task_workflow", "auth_storage"]
+      {
         DesktopDiagnosticsManager.shared.resetForTests()
         DesktopDiagnosticsManager.shared.recordFallback(
           area: area, from: "a", to: "b", reason: "capability_mismatch", outcome: .degraded)

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -519,6 +519,91 @@ import XCTest
       XCTAssertNil(snapshot["device_description"])
     }
 
+    // MARK: - Release-health telemetry contract (#10425)
+
+    @MainActor
+    func testPTTCommittedLifecycleRecordsSuccessDenominator() throws {
+      // Success (`failure_class = committed`) is part of the remote funnel so a
+      // release-health query has a success denominator, not only classified failures.
+      let snapshot = PTTAttemptLifecycleRecorder.Snapshot(
+        attemptId: "1", failureClass: .committed, captureStartOutcome: .accepted,
+        captureStartStatusClass: .ok, msToFirstAudioBucket: .lt100,
+        msToFirstUsableFrameBucket: .lt200, firstChunksEnergyBucket: .audible,
+        turnDisposition: .committed, inputRouteClass: .builtIn, inputRouteSource: .default,
+        routeChangedDuringAttempt: false, recoveryTriggered: false, recoveryAction: .none,
+        recoveryAttemptId: nil, recoveryOutcomeOfNextTurn: .none, mode: "hold", source: "hub",
+        hubActive: true, micPermissionGranted: true, turnAudioSeconds: 2.0,
+        voicedAudioSeconds: 1.5, peak: 1200, rms: 300, isNearZero: false, judgeable: true,
+        telemetrySchemaVersion: 2)
+      DesktopDiagnosticsManager.shared.recordPTTAttemptLifecycle(snapshot)
+      try assertLatestHealthSnapshot(
+        event: .pttAudioCaptureLifecycle,
+        contains: ["failure_class": "committed", "turn_disposition": "committed", "telemetry_schema_version": 2])
+    }
+
+    func testRealtimeMintPhaseBucketedAndCarriesOutcomeAndMintAttemptId() throws {
+      DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
+        provider: "openai", reason: "backend_transient", phase: "warm",
+        outcome: .degraded, mintAttemptId: "42")
+      try assertLatestHealthSnapshot(
+        event: .realtimeTokenMintFailed,
+        contains: ["provider": "openai", "phase": "warm", "outcome": "degraded", "mint_attempt_id": "42"])
+
+      // An unknown phase collapses to the closed set's `other` (warm-vs-active is bounded).
+      DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
+        provider: "gemini", reason: "provider_5xx", phase: "totally-new-thing")
+      try assertLatestHealthSnapshot(event: .realtimeTokenMintFailed, contains: ["phase": "other"])
+    }
+
+    func testRealtimeProviderCloseMarksExpectedLifecycle() throws {
+      DesktopDiagnosticsManager.shared.recordRealtimeProviderClose(
+        provider: "gemini",
+        category: RealtimeHubCloseCategory.expectedIdleTeardown.rawValue,
+        aliveFor: 180, activeTurn: false, authMode: .managed, failureClass: nil)
+      try assertLatestHealthSnapshot(
+        event: .realtimeProviderExpectedIdleTeardown,
+        contains: ["expected": true, "lifecycle_class": "expected"])
+
+      DesktopDiagnosticsManager.shared.recordRealtimeProviderClose(
+        provider: "openai", category: nil, aliveFor: 7, activeTurn: true,
+        authMode: .managed, failureClass: nil)
+      try assertLatestHealthSnapshot(
+        event: .realtimeProviderSessionError,
+        contains: ["expected": false, "lifecycle_class": "error"])
+    }
+
+    func testFallbackNamedAreasAreNotCollapsedToOther() throws {
+      for area in ["screen_capture", "memory_scope", "desktop_update", "tts_fallback", "task_workflow", "auth_storage"] {
+        DesktopDiagnosticsManager.shared.resetForTests()
+        DesktopDiagnosticsManager.shared.recordFallback(
+          area: area, from: "a", to: "b", reason: "capability_mismatch", outcome: .degraded)
+        try assertLatestHealthSnapshot(
+          event: .fallbackTriggered, contains: ["area": area, "outcome": "degraded"])
+      }
+    }
+
+    func testHealthEventsStripContentBearingKeysButKeepBoundedCousins() throws {
+      DesktopDiagnosticsManager.shared.recordFallback(
+        area: "realtime_hub", from: "openai", to: "gemini", reason: "other", outcome: .recovered,
+        extra: [
+          "transcript": "the user said a secret",
+          "prompt": "secret prompt",
+          "audio": "base64-audio",
+          "response": "secret response",
+          "message": "free-form local error detail",
+          "transcript_length": 42,
+        ])
+      let snapshot = try latestSnapshot()
+      XCTAssertEqual(snapshot["event"] as? String, "fallback_triggered")
+      // Content-bearing keys are stripped at the single emit chokepoint (#10425 privacy).
+      XCTAssertNil(snapshot["transcript"])
+      XCTAssertNil(snapshot["prompt"])
+      XCTAssertNil(snapshot["audio"])
+      XCTAssertNil(snapshot["response"])
+      XCTAssertNil(snapshot["message"])
+      // The bounded cousin (a length, not content) survives.
+      XCTAssertEqual(snapshot["transcript_length"] as? Int, 42)
+    }
     private func assertLatestHealthSnapshot(
       event: DesktopHealthEventName,
       contains expected: [String: Any] = [:],

--- a/desktop/macos/Desktop/Tests/RealtimeHubSessionHandoffPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSessionHandoffPolicyTests.swift
@@ -203,6 +203,7 @@ final class RealtimeHubSessionHandoffPolicyTests: XCTestCase {
   }
 
   @MainActor
+  @MainActor
   func testBargeInFailoverExhaustedWhenAlternateProviderAlreadyActive() {
     DesktopDiagnosticsManager.shared.resetForTests()
     defer { DesktopDiagnosticsManager.shared.resetForTests() }

--- a/desktop/macos/changelog/unreleased/20260723-release-health-telemetry.json
+++ b/desktop/macos/changelog/unreleased/20260723-release-health-telemetry.json
@@ -1,0 +1,3 @@
+{
+  "change": "Release-health diagnostics are now attributed to the exact app version/build and distinguish normal lifecycle (short taps, quiet discards, expected session rotation) from real issues, so a stability signal reflects an actual regression rather than healthy behavior"
+}

--- a/desktop/macos/docs/release-health-metrics.md
+++ b/desktop/macos/docs/release-health-metrics.md
@@ -14,7 +14,7 @@ Release identity is uniform across surfaces (Sentry + PostHog):
 | Dimension | PostHog key | Sentry | Source |
 |-----------|-------------|--------|--------|
 | App version | `app_version` | `release` (`v{ver}+{build}-macos`) | `CFBundleShortVersionString` |
-| App build | `app_build` | `release` (same tag) / `dist` | `CFBundleVersion` |
+| App build | `app_build` | `release` (same tag) | `CFBundleVersion` |
 | Release channel | `update_channel` (`stable`/`beta`) | `dist` + `update_channel` tag | `AppBuild.currentUpdateChannel` |
 | Bundle id | — | `bundle_id` tag | `AppBuild.bundleIdentifier` |
 

--- a/desktop/macos/docs/release-health-metrics.md
+++ b/desktop/macos/docs/release-health-metrics.md
@@ -1,0 +1,164 @@
+# macOS Release-Health Metric Specification
+
+**Status:** active · **Schema version:** 1 · **Owner:** desktop/macos · **Tracking:** [#10425](https://github.com/BasedHardware/omi/issues/10425)
+
+This is the **authoritative query contract** for macOS release-health telemetry. It
+defines, per signal, the exact numerator, denominator, time window, minimum cohort,
+unknown/missing-data behavior, and release-comparison rule so that intermediate
+lifecycle events and expected noise **cannot** be read as a customer-visible
+regression. It is the long form of the "Product analytics integrity" and "Fallback /
+resilience telemetry" sections of `desktop/macos/AGENTS.md`.
+
+Release identity is uniform across surfaces (Sentry + PostHog):
+
+| Dimension | PostHog key | Sentry | Source |
+|-----------|-------------|--------|--------|
+| App version | `app_version` | `release` (`v{ver}+{build}-macos`) | `CFBundleShortVersionString` |
+| App build | `app_build` | `release` (same tag) / `dist` | `CFBundleVersion` |
+| Release channel | `update_channel` (`stable`/`beta`) | `dist` + `update_channel` tag | `AppBuild.currentUpdateChannel` |
+| Bundle id | — | `bundle_id` tag | `AppBuild.bundleIdentifier` |
+
+PostHog `app_version`/`app_build`/`update_channel` are registered as super-properties
+(`PostHogManager.register`) so **every** event — including `floating_bar_ptt_ended` —
+carries release identity. Sentry native crash/app-hang/watchdog events are
+build-attributable via `options.releaseName`/`options.dist` set at `SentrySDK.start`.
+
+## Cross-cutting rules
+
+- **Intermediate events are not failures.** A metric's numerator is a *terminal,
+  bounded outcome*, never an intermediate lifecycle transition. If a signal has no
+  explicit outcome field, it is a building block, not a release-health metric.
+- **Expected lifecycle is excluded from error rollups.** Realtime events with
+  `expected = true` (`lifecycle_class = "expected"`) — idle teardown and planned
+  session rotation — are inspectable but MUST be filtered out of realtime error and
+  release-regression rates. Error rate uses `expected = false` only.
+- **Minimum cohort.** A rate is `unknown` (not `100%`/`0%`) below the minimum sample.
+  Comparisons across releases require both sides to meet the minimum.
+- **Comparison basis.** Build-vs-build and beta-vs-stable use the same window and
+  denominator definition; a delta is a regression only if both cohorts meet the
+  minimum sample and the direction is adverse for the outcome of interest.
+- **Privacy.** Numerators/denominators are bounded dimensions only. No transcript,
+  audio, prompt, device identifier, or free-form local error text is emitted to
+  PostHog or Sentry tags (enforced by `DesktopDiagnosticsManagerTests` /
+  `TelemetryPrivacyBoundaryTests`).
+
+## Metrics
+
+Each metric below maps to a `desktop_release_doctor_report.METRIC_CONTRACTS` name
+where one exists; desktop-outcome metrics without a doctor entry are client inputs
+the release-evidence layer (`#9523`) will consume.
+
+### PTT terminal-outcome funnel — `ptt_audio_capture_lifecycle`
+
+- **Source event:** `desktop_health_event` with `event = ptt_audio_capture_lifecycle`
+  (`telemetry_schema_version >= 2`).
+- **Denominator (attempts):** all `ptt_audio_capture_lifecycle` events in the window,
+  grouped by `failure_class`. Every terminal disposition — including success — is
+  emitted remotely, so the denominator is queryable.
+- **Numerator (capture failure):** `failure_class IN
+  (capture_never_operational)`. Recovery outcomes
+  (`recovery_outcome_recovered`/`_still_silent`/`_not_judgeable`) are joined on
+  `recovery_attempt_id`, not counted as fresh failures.
+- **Excluded from the failure numerator (NOT regressions):**
+  `committed` (success), `released_before_usable_audio` / `too_short_audible`
+  (short tap / released early), `cancelled` (user cancel), and
+  `zero_or_near_zero_samples` with `turn_disposition = silent_rejected` (quiet
+  discard / no speech). `first_chunks_energy_bucket` + `turn_disposition` separate a
+  true zero-sample capture failure from a deliberate quiet discard.
+- **Deprecated event:** `floating_bar_ptt_ended` (`had_transcript`) collapses all
+  four outcomes above into one boolean and MUST NOT be read as a PTT
+  success/failure denominator. It is retained only for backward compatibility.
+- **Window:** PT24H rolling. **Minimum cohort:** 50 judgeable attempts per build.
+  **Missing data:** if no `ptt_audio_capture_lifecycle` events for a build → `unknown`.
+
+### Realtime token-mint — `realtime_token_mint_failed`
+
+- **Source event:** `desktop_health_event` with `event = realtime_token_mint_failed`.
+- **Phase (warm vs active):** `phase` is a closed set — `warm` (background pre-warm)
+  vs `barge_in_replacement` (socket replacement during an active turn); any other
+  value is bucketed to `other`. This is the warm-vs-active dimension.
+- **Outcome (recovered/degraded/exhausted):** a mint failure is point-in-time; its
+  terminal fate is the correlated `fallback_triggered`{`area = realtime_hub`} event
+  (`outcome` = `recovered`/`degraded`/`exhausted`). Join on `mint_attempt_id` (present
+  on both when a mint triggered the failover), then `provider` + bounded time window.
+- **Numerator (mint-exhausted, user-impacting):** mint failures joined to a
+  `realtime_hub` fallback with `outcome = exhausted` (fell through to the cascade
+  with no acceptable path). `degraded` (failed over to the alternate provider) is
+  recoverable and is **not** a terminal failure numerator.
+- **Window:** PT24H. **Minimum cohort:** 30 mint-attempting users per build.
+  **Missing data:** `unknown` if no mint events.
+
+### Realtime provider session health — `realtime_provider_*`
+
+- **Source events:** `realtime_provider_expected_idle_teardown`,
+  `realtime_provider_expected_session_rotation` (both `expected = true`),
+  `realtime_provider_policy_close`, `realtime_provider_session_error`
+  (both `expected = false`).
+- **Error rate numerator:** `realtime_provider_session_error` +
+  `realtime_provider_policy_close` (`expected = false`). **Denominator:** active
+  realtime sessions (proxy: distinct sessions emitting any `realtime_provider_*`).
+- **Excluded:** the two `expected_*` events (`expected = true`) — normal idle teardown
+  and planned 60-min OpenAI session rotation. They remain separately inspectable but
+  MUST NOT inflate the realtime error or release-regression rate.
+- **Window:** PT24H. **Minimum cohort:** 40 active-session users per build.
+
+### Fallback outcomes — `fallback_triggered`  · doctor metric `fallback_outcomes`
+
+- **Source event:** `desktop_health_event` with `event = fallback_triggered`.
+- **Dimensions (all closed enums):** `area`, `reason`, `from`, `to`, `outcome`
+  (`recovered`/`degraded`/`exhausted`). Unknown `area`/`reason` bucket to `other`.
+- **Release-health numerator (customer-visible degradation):** `outcome IN
+  (degraded, exhausted)`, grouped by `(area, reason, from, to)`. `recovered` is a
+  silent UX heal and is **not** a failure.
+- **Known-benign flap:** `area = screen_capture`, `reason = capability_mismatch`,
+  `from/to` ∈ {`screen_capture`, `capture_paused`, `recovery_poll`} is the
+  ProactiveAssistants screen-capture health flap (target temporarily unavailable then
+  restored). It is an expected capability flap — alert on its *rate*, never page on
+  absolute counts or on the `recovered` leg.
+- **`area = other` policy:** remaining `other` collapses only genuinely-unclassified
+  paths; a non-trivial `other` rate is an instrumentation defect to triage, not a
+  product regression. Named owners (`screen_capture`, `memory_scope`,
+  `desktop_update`, `tts_fallback`, `task_workflow`, `auth_storage`, `realtime_hub`,
+  `ptt_cascade`, …) keep known paths out of `other`.
+- **Window:** PT24H. **Minimum cohort:** 50 fallback-emitting users per build.
+
+### Crash-free sessions — doctor metric `crash_free_sessions`
+
+- **Source:** Sentry release health (auto session tracking) keyed by
+  `releaseName`/`dist`.
+- **Numerator:** sessions with a hard crash. **Denominator:** total started sessions
+  for the release. Filter by `release` (version+build) and `update_channel`; native
+  crashes are now build-attributable via `options.releaseName`/`options.dist`.
+- **Window:** PT24H. **Minimum cohort:** 100 sessions per build.
+- **Privacy:** native events carry only `update_channel`/`bundle_id` tags +
+  `diagnostic_area`/`failure_class`; no user content.
+
+### Updater delivery — doctor metric `updater_delivery`
+
+- **Source:** PostHog updater events (`source_app_version`, `source_app_build`,
+  `update_channel`, `target_version`, `target_build`).
+- **Numerator:** successful installs (`update_installed`). **Denominator:** started
+  update attempts. **Window:** PT24H. **Minimum cohort:** 30 attempts per build.
+
+### Recording & memory (client inputs)
+
+- **Recording:** `recording_error` PostHog events carry `error_class` only (no audio).
+  Numerator = errors; denominator = recording sessions. Below minimum → `unknown`.
+- **Memory:** memory-operations reliability is tracked via `memory_scope` fallback
+  outcomes (device-scope rejection) and memory-extract counts; no memory *content* is
+  emitted. Out of scope for a numeric spec until a backend denominator exists —
+  client supplies the `memory_scope` degradation signal only.
+
+### Feature path success — doctor metric `feature_path_success` · backend error rate — doctor metric `backend_error_rate`
+
+Owned by the doctor report and backend respectively; this spec only requires that the
+desktop client feeds (chat terminal outcomes, PTT funnel, fallback outcomes) use the
+outcome semantics above so the doctor's `feature_path_success` numerator is never an
+intermediate event.
+
+## Versioning
+
+Bump `Schema version` and call out the change here when any numerator/denominator
+definition, closed enum, or field name changes. `telemetry_schema_version` on the
+PTT lifecycle snapshot and the `expected`/`outcome`/`mint_attempt_id`/`phase` fields
+are the machine-readable companions to this document.


### PR DESCRIPTION
# macOS release-health telemetry: outcome-based, build-attributable, privacy-safe

Closes #10425

Makes macOS desktop release-health telemetry **outcome-based, build-attributable, and
safe to use for release decisions**. Observability-contract only — no product behavior,
provider, PTT UX, release-promotion, or backend change.

## Product invariants affected

Path globs are touched by telemetry-only edits (labels, correlation keys, init) — no
lifecycle state machine, auth-session, or chat-continuity behavior change:

- INV-AUTH-1 — `AuthService.swift` (fallback area label), `OmiApp.swift` (Sentry init).
- INV-CHAT-1 — `AgentRuntimeProcess.swift`, `FloatingBarVoicePlaybackService.swift`,
  `PTTAttemptLifecycleRecorder.swift`, `RealtimeHubController*.swift` (telemetry keys/labels).
- INV-VOICE-1 — `RealtimeHubController.swift`, `FloatingBarVoicePlaybackService.swift`
  (optional `mint_attempt_id` correlation + a fallback area label; no new lifecycle owner).

## Root cause

Several high-volume desktop signals were intermediate lifecycle events or ambiguous
terminal states, so a healthy path could resemble a user-visible regression:

- `floating_bar_ptt_ended` collapsed four causally distinct PTT outcomes (accidental
  tap, deliberate quiet discard, dead-mic capture failure, empty-after-commit) into one
  `had_transcript` boolean; the classified `ptt_audio_capture_lifecycle` funnel
  suppressed success remotely, so there was no queryable success denominator.
- `realtime_token_mint_failed` had no terminal outcome and no correlation key, so a
  mint failure that **recovered** could not be told apart from one that **exhausted** to
  the cascade; `phase` was an open string.
- `fallback_triggered` reported `area=other, reason=capability_mismatch` for 32/255
  users — the benign ProactiveAssistants screen-capture flap mixed with genuinely
  degraded paths under one `other` bucket.
- Expected realtime idle teardown / session rotation were separate events but had no
  single field excluding them from error rollups.
- Sentry never set `options.release`/`options.dist`; native crash/hang/watchdog events
  were unfilterable by version/build, and beta+stable were indistinguishable
  (`environment=production`). PostHog registered no global identity, so most events
  (incl. `floating_bar_ptt_ended`) carried no release cohort.
- No versioned release-health metric spec existed.

## What changed (one authoritative owner, bounded schemas, no second state machine)

- **PTT funnel** (`ptt_audio_capture_lifecycle`, schema v2): emit every terminal
  disposition remotely — including committed success — so the success denominator is
  queryable. `failure_class` separates `capture_never_operational` (real failure) from
  `released_before_usable_audio`/`too_short_audible` (short tap), `cancelled`, and
  `zero_or_near_zero_samples`+`silent_rejected` (quiet discard). `floating_bar_ptt_ended`
  is deprecated as a denominator (retained for backward compatibility).
- **Realtime mint**: bucket `phase` to a closed set (`warm` vs `barge_in_replacement`);
  add optional `outcome` + `mint_attempt_id` so a mint failure joins its
  recovered/degraded/exhausted fate on the correlated `realtime_hub` fallback event
  (wired on all 3 warm + 3 barge-in mint paths).
- **Realtime provider close**: add bounded `expected` + `lifecycle_class` so expected
  idle teardown / planned session rotation are excluded from error rollups but stay
  inspectable (they remain non-Sentry).
- **Fallback**: add named owners (`screen_capture`, `memory_scope`, `desktop_update`,
  `tts_fallback`, `task_workflow`, `auth_storage`) and update callers so known paths
  stop collapsing into `area=other`. `recovered` stays distinct from `degraded`/`exhausted`.
- **Release attribution**: Sentry `options.releaseName = AppBuild.releaseTag`
  (`v{ver}+{build}-macos`), `options.dist = currentUpdateChannel`, plus global
  `update_channel`/`bundle_id` scope tags; PostHog registers
  `app_version`/`app_build`/`update_channel` super-properties (and mirrors them onto
  `identify()`), so every event is release-attributable.
- **Privacy guard**: a content-bearing-key blocklist at the single `record()` emit
  chokepoint strips `transcript`/`audio`/`prompt`/`response`/`message`/`detail_reason`/
  error-text keys; bounded cousins (`transcript_length`, `failure_class`) survive.
- **Spec**: `desktop/macos/docs/release-health-metrics.md` — versioned query contract
  (numerator, denominator, window, minimum cohort, missing-data, comparison) for PTT,
  realtime, fallback, crash, updater, recording, memory, aligned to
  `desktop_release_doctor_report.METRIC_CONTRACTS`.

## Recurrence / similar-case audit

A parallel Phase-A discovery swarm (4 read-only scouts) mapped every producer/consumer
of PTT, realtime, fallback, and Sentry/PostHog telemetry, then a refutation pass
discarded disproven/duplicate/out-of-scope candidates. The auditor confirmed the only
remaining `area=other`+`capability_mismatch` path is the benign screen-capture flap (now
its own area), and that `realtime_hub` capability-mismatch paths already stay in-area.

## Durable guard

The `record()` content-key blocklist is the single chokepoint every health snapshot
(local ring buffer + remote PostHog) flows through, so a future caller that threads a
content-bearing key through `extra` is stripped by construction — defended by
`testHealthEventsStripContentBearingKeysButKeepBoundedCousins` and
`testWalUploadFailureStripsFreeFormDetailReason` (the latter targets the real
`String(describing: error)` provenance).

## Source ownership

`DesktopDiagnosticsManager` remains the one health-event owner; no second enum, state
machine, or analytics path is introduced. INV-VOICE-1: the only changes to
`RealtimeHubController.swift` / `FloatingBarVoicePlaybackService.swift` add telemetry
correlation keys (`mint_attempt_id`) and a fallback-area label — no lifecycle state,
current-turn variable, or timer.

## Privacy boundary

Only bounded dimensions/strings are emitted. No transcript, audio, prompt, device
identifier, or free-form local error text reaches PostHog properties or Sentry
tags/contexts (content-key blocklist + the existing `allowedIncidentExtraKeys`
allowlist for Sentry incidents). Tests prove it.

## Tests

New contract tests in `DesktopDiagnosticsManagerTests`: PTT committed success
denominator (schema v2), realtime phase bucketing + outcome/mint_attempt_id, expected
lifecycle flag, named fallback areas, content-key stripping (+ bounded cousin
survival), and WAL free-form `detail_reason` stripping.

## Verification evidence

- `swift build` clean (executable + test target, strict concurrency / warnings-as-errors).
- `DesktopDiagnosticsManagerTests` 28/28, `PTTAttemptLifecycleRecorderTests` 18/18,
  `RealtimeHubSessionHandoffPolicyTests` 20/20.
- `make preflight`: 9/9 checks pass (incl. product-invariants, failure-class-protocol,
  deferred-work-markers).
- **Real user-facing path:** the changed telemetry is `isDevBuild`-gated (remote
  PostHog/Sentry and native handlers are disabled for dev bundles), and triggering a
  real mint failure / fallback / native crash needs a non-dev build plus live realtime
  providers and physical PTT — an interactive real path is genuinely impractical to
  observe here. Per the issue's allowance, behavioral production-seam tests exercising
  the real `DesktopDiagnosticsManager.record*` paths are retained instead. `AppBuild.releaseTag`
  format matches the Codemagic `v{ver}+{build}-macos` tag, and Sentry dSYM upload is
  UUID-based, so `options.releaseName` cannot break symbolication.

## Review / critic outcomes

- **Adversarial critic** (REQUEST-CHANGES → fixed): (A) privacy blocklist missed
  `detail_reason` (free-form WAL error text) — extended + test; (B) warm-mint failovers
  omitted `mint_attempt_id`, breaking the majority-path join — wired; (C) an off-by-2
  edit had dropped a `CredentialHealthManager.record` call in the barge-in catch —
  restored. Re-verified green.
- **Independent code reviewer**: APPROVE (correctness: correct). One P3 doc nit (Sentry
  `dist` mislabeled as build carrier) — fixed.

## Deliberate deferrals (not in scope)

- Rust `fallback::record_fallback` is referenced by `docs/agents/fallback-telemetry.md`
  but unimplemented in `sdks/rust/` — backend/SDK contract-doc gap, not macOS.
- PostHog/Sentry dashboard provisioning, Sentry-server config, backend release-evidence
  doctor wiring (`#9523`), beta auth/release-channel taxonomy (`#9160`), and the concrete
  `.113` Sentry/memory/hang/Gemini fixes (`#10420`) are owned by their own issues; this
  PR supplies only the client-side outcome/attribution contract they consume.
- Cross-namespace join (PTT lifecycle int `attempt_id` ↔ realtime `voice_turn_terminal`
  UUID) is documented as follow-up — not required by the acceptance criteria.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

