### PR TITLE
SCA-91: make account deletion durable before auth removal

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-database.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-database.json
@@ -1,10 +1,11 @@
 {
   "files": {
     "backend/database/conversations.py": 1616,
-    "backend/database/users.py": 1943
+    "backend/database/users.py": 1992
   },
   "raise_justifications": {
-    "backend/database/conversations.py": "Public shared-chat uses the existing conversation storage format for bounded, safe transcript decoding; extraction would duplicate crypto/storage invariants. +15 for the shared is_soft_deleted tombstone-eligibility predicate that eligible_merge_target and the reprocess guard converge on (#10119/#10262)."
+    "backend/database/conversations.py": "Public shared-chat uses the existing conversation storage format for bounded, safe transcript decoding; extraction would duplicate crypto/storage invariants. +15 for the shared is_soft_deleted tombstone-eligibility predicate that eligible_merge_target and the reprocess guard converge on (#10119/#10262).",
+    "backend/database/users.py": "Account-deletion marker fencing and recursive missing-root cleanup must remain beside the existing deletion transaction and collection traversal; extracting them would duplicate the durable lifecycle authority. +33 for the queue-before-auth recovery guard and +16 for the job-id-fenced repeat-dispatch transaction."
   },
   "threshold": 1500
 }

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -25,6 +25,13 @@ class DeletionWipeTaskResolution(TypedDict):
     uid: str | None
 
 
+class DeletionWipeIntent(TypedDict):
+    """Result of creating or joining an account-deletion wipe authority."""
+
+    wipe_job_id: str
+    dispatch_claimed: bool
+
+
 # Conservative low-risk user projections. Do NOT use these policies for
 # entitlement, BYOK, data-protection, privacy-consent, or full user-doc caching.
 _USER_LANGUAGE_CACHE = CachePolicy(namespace='user_language', version=1, ttl_seconds=300)
@@ -292,24 +299,6 @@ def set_user_deletion_feedback(uid: str, reason: Optional[str], reason_details: 
     )
 
 
-def mark_user_deletion_wipe_started(uid: str):
-    """Mark that the background data wipe has been queued but not yet completed.
-
-    Persisted in the top-level ``account_deletions`` collection so it survives a
-    deploy or pod restart. A reconciliation worker can query for documents where
-    ``wipe_status == 'pending'`` and re-enqueue incomplete wipes.
-
-    The worker transitions the marker to ``'running'`` (via
-    ``mark_user_deletion_wipe_running``) as soon as it actually starts
-    executing, so the reconciler can distinguish a genuinely orphaned queued
-    wipe from one that is actively executing but slow.
-    """
-    db.collection('account_deletions').document(uid).set(
-        {'wipe_status': 'pending', 'wipe_queued_at': datetime.now(timezone.utc)},
-        merge=True,
-    )
-
-
 def mark_user_deletion_wipe_running(uid: str):
     """Transition a queued wipe marker to ``running`` once the worker starts.
 
@@ -330,7 +319,24 @@ def mark_user_deletion_wipe_running(uid: str):
 
 
 @transactional
-def _mark_user_deletion_wipe_intent_txn(transaction, doc_ref, wipe_job_id: str) -> str:
+def _mark_user_deletion_wipe_intent_txn(transaction, doc_ref, wipe_job_id: str) -> DeletionWipeIntent:
+    snapshot = doc_ref.get(transaction=transaction)
+    if snapshot.exists:
+        data = snapshot.to_dict() or {}
+        existing_job_id = data.get('wipe_job_id')
+        # A repeat request must join the existing durable deletion authority,
+        # never reset a claimed/running/completed job backwards.
+        if isinstance(existing_job_id, str) and existing_job_id:
+            status = data.get('wipe_status')
+            # A retry can recover a request that crashed after intent was
+            # committed but before it promoted that exact job to pending. The
+            # promotion below is itself job-id-fenced and transactional, so
+            # concurrent retries can race safely: exactly one gets ``True``
+            # and dispatches.
+            if status == 'deleting_auth':
+                return {'wipe_job_id': existing_job_id, 'dispatch_claimed': True}
+            if status in {'pending', 'retrying', 'running', 'failed', 'completed'}:
+                return {'wipe_job_id': existing_job_id, 'dispatch_claimed': False}
     transaction.set(
         doc_ref,
         {
@@ -340,25 +346,54 @@ def _mark_user_deletion_wipe_intent_txn(transaction, doc_ref, wipe_job_id: str) 
         },
         merge=True,
     )
-    return wipe_job_id
+    return {'wipe_job_id': wipe_job_id, 'dispatch_claimed': True}
 
 
-def mark_user_deletion_wipe_intent(uid: str) -> str:
-    """Persist a non-actionable deletion intent *before* auth deletion.
+def mark_user_deletion_wipe_intent(uid: str) -> DeletionWipeIntent:
+    """Create or join the durable account-deletion authority.
 
-    Written BEFORE ``auth.delete_account()`` succeeds. The reconciler only
-    recovers stale ``'deleting_auth'`` records *after* verifying the Firebase
-    auth user is actually gone, so a crash between this write and the confirmed
-    auth deletion cannot trigger a premature data wipe for a user whose Firebase
-    account still exists.
+    Repeated requests reuse an existing active job id rather than moving a
+    claimed, running, failed, or completed wipe backwards. An existing
+    ``deleting_auth`` intent remains eligible for the job-id-fenced promotion
+    so a retry can recover a crash before queue acceleration; exactly one
+    concurrent request can win that promotion. The claimed worker is the only
+    path that deletes Firebase Auth or user data.
 
-    Call ``mark_user_deletion_wipe_started`` to transition the marker to the
-    actionable ``'pending'`` state once auth deletion is confirmed.
+    ``deleting_auth`` remains a legacy recovery state for records written by
+    older workers; new request handling promotes it immediately.
     """
     wipe_job_id = uuid.uuid4().hex
     doc_ref = db.collection('account_deletions').document(uid)
     transaction = db.transaction()
     return _mark_user_deletion_wipe_intent_txn(transaction, doc_ref, wipe_job_id)
+
+
+@transactional
+def _mark_user_deletion_wipe_started_txn(transaction, doc_ref, wipe_job_id: str) -> bool:
+    """Promote a newly-created intent to pending exactly once.
+
+    The status and opaque job id are checked in the same transaction as the
+    write. This fences a retry/repeated request from moving an already claimed,
+    running, failed, or completed wipe backwards before it can enqueue again.
+    """
+    snapshot = doc_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        return False
+    data = snapshot.to_dict() or {}
+    if data.get('wipe_status') != 'deleting_auth' or data.get('wipe_job_id') != wipe_job_id:
+        return False
+    transaction.update(
+        doc_ref,
+        {'wipe_status': 'pending', 'wipe_queued_at': datetime.now(timezone.utc)},
+    )
+    return True
+
+
+def mark_user_deletion_wipe_started(uid: str, wipe_job_id: str) -> bool:
+    """Atomically promote one newly-created wipe intent to queue-pending."""
+    doc_ref = db.collection('account_deletions').document(uid)
+    transaction = db.transaction()
+    return _mark_user_deletion_wipe_started_txn(transaction, doc_ref, wipe_job_id)
 
 
 def mark_user_deletion_wipe_completed(uid: str):
@@ -1137,10 +1172,12 @@ def _delete_collection_recursive(collection_ref, batch_size: int = 450):
 
 def delete_user_data(uid: str):
     user_ref = db.collection('users').document(uid)
-    if not user_ref.get().exists:
-        return {'status': 'error', 'message': 'User not found'}
+    root_exists = user_ref.get().exists
 
-    # Enumerate subcollections live instead of hardcoding a list — picks up
+    # Enumerate subcollections live even when the root document is missing.
+    # Firestore permits immediate children to survive a parent deletion; an
+    # early "User not found" return would falsely mark the deletion complete.
+    # This picks up
     # everything the user has written (conversations, memories, action_items,
     # folders, goals, integrations, task_integrations, fcm_tokens, fair_use_*,
     # hourly_usage, meetings, screen_activity, files, people, chat_sessions,
@@ -1149,8 +1186,9 @@ def delete_user_data(uid: str):
         logger.info(f"Deleting subcollection {sub.id} for user {uid}")
         _delete_collection_recursive(sub)
 
-    logger.info(f"Deleting user document: {uid}")
-    user_ref.delete()
+    if root_exists:
+        logger.info(f"Deleting user document: {uid}")
+        user_ref.delete()
     return {'status': 'ok', 'message': 'Account deleted successfully'}
 
 

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -148,10 +148,20 @@ def background_wipe_user_data(uid: str) -> bool:
         # genuinely orphaned ``pending`` marker (queued but never started)
         # from a wipe that is actively executing. Without this, a slow wipe
         # could be duplicate-claimed after the short ``pending`` stale window.
+        users_db.mark_user_deletion_wipe_running(uid)
+        # The durable marker and queue claim are the authority for every
+        # irreversible step below. In particular, do not cancel billing or
+        # remove Firebase Auth from the request thread: a queue NotFound must
+        # leave an account usable and recoverable.
+        _cancel_subscription_for_account_deletion(uid)
         try:
-            users_db.mark_user_deletion_wipe_running(uid)
+            auth.delete_account(uid)
         except Exception as e:
-            logger.warning(f'delete_account marker transition to running failed for {uid}: {sanitize(str(e))}')
+            err = str(e).upper()
+            if 'USER_NOT_FOUND' in err or 'NO USER RECORD' in err:
+                logger.info('delete_account worker observed Firebase Auth user already absent')
+            else:
+                raise
         # Twilio caller IDs first, while the phone_numbers subcollection still carries twilio_sid metadata.
         delete_user_caller_ids(uid)
         purge_result = purge_derived_user_data(uid)
@@ -159,8 +169,10 @@ def background_wipe_user_data(uid: str) -> bool:
         if required_failures:
             failed_operations = ', '.join(failure['operation'] for failure in required_failures)
             raise RuntimeError(f'required derived purge failed: {failed_operations}')
-        users_db.delete_user_data(uid)
-        logger.info(f'delete_account background wipe complete for {uid}')
+        wipe_result = users_db.delete_user_data(uid)
+        if wipe_result.get('status') != 'ok':
+            raise RuntimeError('authoritative Firestore user-data wipe did not complete')
+        logger.info('delete_account background wipe complete')
     except Exception as e:
         logger.error(f'delete_account background wipe failed for {uid}: {sanitize(str(e))}')
         # Mark the wipe as failed so a reconciliation worker can retry. Do NOT mark
@@ -257,58 +269,50 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
         except Exception as e:
             logger.info(f'delete_account feedback store failed: {sanitize(str(e))}')
 
-    # Phase 1 — persist a NON-ACTIONABLE intent ('deleting_auth') before any
-    # irreversible action. The reconciler only recovers stale 'deleting_auth'
-    # records after verifying the Firebase auth user is gone, so a crash/deploy
-    # between this write and the confirmed auth deletion cannot trigger a
-    # premature data wipe for a user whose Firebase account still exists. Retry
-    # transient Firestore failures; if the intent cannot be written, do NOT
-    # proceed.
-    wipe_job_id = _retry_firestore_write(
+    # Persist the authoritative, actionable intent before dispatch. This state
+    # is enough for reconciliation to recover a failed queue handoff, while the
+    # Cloud Tasks handler claim fences all destructive work. If either write or
+    # dispatch fails, no Firebase Auth or billing mutation has happened.
+    wipe_intent = _retry_firestore_write(
         lambda: users_db.mark_user_deletion_wipe_intent(uid),
         uid=uid,
         fail_msg='Failed to persist deletion-wipe intent',
         on_failure='raise',
     )
+    wipe_job_id = wipe_intent.get('wipe_job_id') if isinstance(wipe_intent, dict) else None
     if not isinstance(wipe_job_id, str) or not wipe_job_id:
         raise RuntimeError('deletion-wipe intent did not persist a wipe_job_id')
+    dispatch_claimed = wipe_intent.get('dispatch_claimed') is True if isinstance(wipe_intent, dict) else False
+    if not dispatch_claimed:
+        logger.info('delete_account joined existing durable deletion intent')
+        return {'status': 'ok', 'message': 'Account deletion started'}
 
-    _cancel_subscription_for_account_deletion(uid)
-
-    try:
-        auth.delete_account(uid)
-    except Exception as e:
-        err = str(e).upper()
-        if 'USER_NOT_FOUND' in err or 'NO USER RECORD' in err:
-            logger.info(f'delete_account firebase user already gone for {uid}')
-        else:
-            # Auth deletion failed — cancel the intent so the record doesn't
-            # linger in 'deleting_auth'. This is cosmetic cleanup, not a safety
-            # requirement: the reconciler verifies the auth user is gone before
-            # recovering any 'deleting_auth' record.
-            _retry_firestore_write(
-                lambda: users_db.cancel_user_deletion_wipe(uid),
-                uid=uid,
-                fail_msg='delete_account marker CANCEL failed — manual intervention may be needed to prevent unwanted data wipe by the reconciliation worker.',
-                on_failure='log',
-            )
-            raise
-
-    # Phase 2 — auth deletion confirmed. Transition the marker to the
-    # actionable 'pending' state before dispatching the durable wipe task.
-    _retry_firestore_write(
-        lambda: users_db.mark_user_deletion_wipe_started(uid),
+    # The pending marker is persisted before enqueue. A failed enqueue is
+    # recorded as failed and is therefore independently recoverable by the
+    # reconciler; queue delivery accelerates the wipe but is not its only
+    # durability boundary.
+    pending_transitioned = _retry_firestore_write(
+        lambda: users_db.mark_user_deletion_wipe_started(uid, wipe_job_id),
         uid=uid,
         fail_msg='delete_account marker transition to pending failed',
         on_failure='raise',
     )
+    if pending_transitioned is not True:
+        # Another execution owns the durable authority. Do not move its marker
+        # backwards or dispatch a duplicate task.
+        logger.info('delete_account queue transition already owned by another request')
+        return {'status': 'ok', 'message': 'Account deletion started'}
 
     try:
         enqueue_deletion_wipe(uid, wipe_job_id)
     except Exception as e:
         _mark_wipe_failed_after_enqueue_error(uid, e)
-        raise
+        logger.warning('delete_account queue acceleration failed; durable reconciliation will retry')
+        # The actionable marker is committed. Queue dispatch is only an
+        # acceleration path; reconciliation owns eventual completion.
+        return {'status': 'ok', 'message': 'Account deletion started'}
 
+    logger.info('delete_account accepted durable deletion intent and queue acceleration')
     return {'status': 'ok', 'message': 'Account deletion started'}
 
 

--- a/backend/testing/e2e/test_account_deletion_cloud_tasks.py
+++ b/backend/testing/e2e/test_account_deletion_cloud_tasks.py
@@ -8,6 +8,7 @@ import re
 from typing import Any, Callable
 
 import pytest
+from google.api_core.exceptions import NotFound
 from google.cloud import tasks_v2
 
 _PROJECT = "test-e2e-project"
@@ -26,6 +27,7 @@ class _CapturedCloudTasksClient:
         self.queue_path_calls: list[tuple[str, str, str]] = []
         self.task_path_calls: list[tuple[str, str, str, str]] = []
         self._assert_pending_marker: Callable[[str], None] | None = None
+        self.create_error: Exception | None = None
 
     def queue_path(self, project: str, location: str, queue: str) -> str:
         assert (project, location, queue) == (_PROJECT, _LOCATION, _QUEUE)
@@ -40,6 +42,8 @@ class _CapturedCloudTasksClient:
     def create_task(self, *, parent: str, task: Any) -> None:
         from utils.cloud_tasks import DISPATCH_DEADLINE_SECONDS
 
+        if self.create_error is not None:
+            raise self.create_error
         assert parent == f"projects/{_PROJECT}/locations/{_LOCATION}/queues/{_QUEUE}"
         assert isinstance(task, tasks_v2.Task)
         assert task.http_request.http_method == tasks_v2.HttpMethod.POST
@@ -337,3 +341,129 @@ def test_account_deletion_cloud_task_retries_required_purge_failure_without_losi
     assert redelivery.json() == {"status": "dropped", "reason": "completed"}
     assert len(claimed_markers) == 2
     assert purge_calls == [test_uid, test_uid]
+
+
+def test_queue_not_found_preserves_auth_and_reconciles_from_the_marker(
+    client,
+    fake_firestore,
+    monkeypatch,
+    account_deletion_identity,
+    cloud_tasks_client,
+):
+    """A real route request proves queue failure cannot strand an auth-less user."""
+    from services.users import account_deletion
+
+    test_uid, auth_headers = account_deletion_identity
+    _configure_durable_account_deletion(monkeypatch)
+    _stub_external_deletion_boundaries(monkeypatch)
+    _seed_deletable_user(fake_firestore, test_uid)
+    auth_deletions: list[str] = []
+    monkeypatch.setattr(account_deletion.auth, "delete_account", lambda uid: auth_deletions.append(uid))
+    monkeypatch.setattr(
+        account_deletion,
+        "purge_derived_user_data",
+        lambda _uid: {"required_failures": [], "best_effort_failures": []},
+    )
+    cloud_tasks_client.create_error = NotFound("account-deletion queue is absent")
+
+    accepted = client.delete("/v1/users/delete-account", headers=auth_headers)
+
+    assert accepted.status_code == 200, accepted.text
+    assert accepted.json() == {"status": "ok", "message": "Account deletion started"}
+    assert auth_deletions == []
+    assert _read_marker(fake_firestore, test_uid)["wipe_status"] == "failed"
+    assert fake_firestore.collection("users").document(test_uid).get().exists
+
+    cloud_tasks_client.create_error = None
+    cloud_tasks_client.queue_path_calls.clear()
+    cloud_tasks_client.task_path_calls.clear()
+    cloud_tasks_client.create_calls.clear()
+    recovered = account_deletion.reconcile_pending_deletion_wipes()
+    assert recovered == {"requeued": 1, "skipped": 0}
+    assert auth_deletions == []
+    wipe_job_id = _read_marker(fake_firestore, test_uid)["wipe_job_id"]
+    payload = _assert_enqueued_task_schema(cloud_tasks_client, wipe_job_id)
+
+    completed = client.post(
+        "/v1/users/account-deletion-wipes/run", json=payload, headers=_worker_headers(retry_count=0)
+    )
+    assert completed.status_code == 200, completed.text
+    assert auth_deletions == [test_uid]
+    assert _read_marker(fake_firestore, test_uid)["wipe_status"] == "completed"
+    _assert_user_data_deleted(fake_firestore, test_uid)
+
+
+def test_repeated_delete_request_joins_running_wipe_without_requeueing(
+    client,
+    fake_firestore,
+    monkeypatch,
+    account_deletion_identity,
+    cloud_tasks_client,
+):
+    """A repeat request cannot move a claimed wipe backwards or create another task."""
+    from services.users import account_deletion
+
+    test_uid, auth_headers = account_deletion_identity
+    _configure_durable_account_deletion(monkeypatch)
+    _stub_external_deletion_boundaries(monkeypatch)
+    _seed_deletable_user(fake_firestore, test_uid)
+    monkeypatch.setattr(
+        account_deletion,
+        "purge_derived_user_data",
+        lambda _uid: {"required_failures": [], "best_effort_failures": []},
+    )
+
+    first = client.delete("/v1/users/delete-account", headers=auth_headers)
+    assert first.status_code == 200, first.text
+    marker = _read_marker(fake_firestore, test_uid)
+    assert marker["wipe_status"] == "pending"
+    assert len(cloud_tasks_client.create_calls) == 1
+
+    repeated_pending = client.delete("/v1/users/delete-account", headers=auth_headers)
+    assert repeated_pending.status_code == 200, repeated_pending.text
+    assert _read_marker(fake_firestore, test_uid)["wipe_status"] == "pending"
+    assert len(cloud_tasks_client.create_calls) == 1
+
+    assert account_deletion.users_db.claim_deletion_wipe_for_task(test_uid) == "claimed"
+    account_deletion.users_db.mark_user_deletion_wipe_running(test_uid)
+    assert _read_marker(fake_firestore, test_uid)["wipe_status"] == "running"
+
+    repeated_running = client.delete("/v1/users/delete-account", headers=auth_headers)
+    assert repeated_running.status_code == 200, repeated_running.text
+    assert _read_marker(fake_firestore, test_uid)["wipe_status"] == "running"
+    assert len(cloud_tasks_client.create_calls) == 1
+
+
+def test_missing_root_document_does_not_hide_immediate_child_data(
+    client,
+    fake_firestore,
+    monkeypatch,
+    account_deletion_identity,
+    cloud_tasks_client,
+):
+    """The production worker must delete children even when their root is absent."""
+    from services.users import account_deletion
+
+    test_uid, auth_headers = account_deletion_identity
+    _configure_durable_account_deletion(monkeypatch)
+    _stub_external_deletion_boundaries(monkeypatch)
+    orphan_child = fake_firestore.collection("users").document(test_uid).collection("memories").document("orphan")
+    orphan_child.set({"id": "orphan", "uid": test_uid})
+    assert not fake_firestore.collection("users").document(test_uid).get().exists
+    monkeypatch.setattr(
+        account_deletion,
+        "purge_derived_user_data",
+        lambda _uid: {"required_failures": [], "best_effort_failures": []},
+    )
+
+    admitted = client.delete("/v1/users/delete-account", headers=auth_headers)
+    assert admitted.status_code == 200, admitted.text
+    wipe_job_id = _read_marker(fake_firestore, test_uid)["wipe_job_id"]
+    payload = _assert_enqueued_task_schema(cloud_tasks_client, wipe_job_id)
+
+    completed = client.post(
+        "/v1/users/account-deletion-wipes/run", json=payload, headers=_worker_headers(retry_count=0)
+    )
+    assert completed.status_code == 200, completed.text
+    assert _read_marker(fake_firestore, test_uid)["wipe_status"] == "completed"
+    assert not orphan_child.get().exists

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -231,12 +231,16 @@ def test_persisted_wipe_recovers_after_enqueue_crash_and_handler_runs_once(monke
     state = {'status': None, 'job_id': None, 'enqueue_attempts': 0, 'wipe_runs': 0}
 
     def persist_intent(_uid):
+        if state['job_id']:
+            return {'wipe_job_id': state['job_id'], 'dispatch_claimed': False}
         state['status'] = 'deleting_auth'
         state['job_id'] = 'job-1'
-        return state['job_id']
+        return {'wipe_job_id': state['job_id'], 'dispatch_claimed': True}
 
-    def mark_started(_uid):
+    def mark_started(_uid, job_id):
+        assert job_id == state['job_id']
         state['status'] = 'pending'
+        return True
 
     def mark_failed(_uid):
         state['status'] = 'failed'
@@ -262,8 +266,7 @@ def test_persisted_wipe_recovers_after_enqueue_crash_and_handler_runs_once(monke
     monkeypatch.setitem(service_globals, 'is_account_deletion_dispatch_enabled', lambda: True)
     monkeypatch.setitem(service_globals, 'enqueue_account_deletion_wipe', enqueue_task)
 
-    with pytest.raises(RuntimeError, match='lost create-task acknowledgement'):
-        users_router.start_account_deletion('uid1')
+    assert users_router.start_account_deletion('uid1')['status'] == 'ok'
 
     assert state == {'status': 'failed', 'job_id': 'job-1', 'enqueue_attempts': 1, 'wipe_runs': 0}
 

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -69,10 +69,12 @@ finally:
         sys.modules.pop(_svc_name, None)
 
 
+def _new_wipe_intent(job_id='job-1'):
+    return {'wipe_job_id': job_id, 'dispatch_claimed': True}
+
+
 def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(monkeypatch):
     calls = []
-    sub = types.SimpleNamespace(stripe_subscription_id='sub_123')
-
     monkeypatch.setattr(
         account_deletion.users_db,
         'set_user_deletion_feedback',
@@ -81,23 +83,13 @@ def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(mon
     monkeypatch.setattr(
         account_deletion.users_db,
         'mark_user_deletion_wipe_intent',
-        lambda uid: calls.append(('wipe_intent', uid)) or 'job-1',
+        lambda uid: calls.append(('wipe_intent', uid)) or _new_wipe_intent(),
     )
     monkeypatch.setattr(
         account_deletion.users_db,
         'mark_user_deletion_wipe_started',
-        lambda uid: calls.append(('wipe_started', uid)),
+        lambda uid, job_id: calls.append(('wipe_started', uid, job_id)) or True,
     )
-    monkeypatch.setattr(
-        account_deletion.users_db, 'get_user_subscription', lambda uid: calls.append(('sub', uid)) or sub
-    )
-    monkeypatch.setattr(
-        account_deletion.stripe_utils,
-        'cancel_subscription',
-        lambda sub_id: calls.append(('stripe', sub_id)) or object(),
-    )
-    monkeypatch.setattr(account_deletion.auth, 'delete_account', lambda uid: calls.append(('auth', uid)))
-
     monkeypatch.setattr(
         account_deletion,
         'submit_with_context',
@@ -110,17 +102,14 @@ def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(mon
     assert calls == [
         ('feedback', 'uid1', 'unused', 'details'),
         ('wipe_intent', 'uid1'),
-        ('sub', 'uid1'),
-        ('stripe', 'sub_123'),
-        ('auth', 'uid1'),
-        ('wipe_started', 'uid1'),
+        ('wipe_started', 'uid1', 'job-1'),
         ('enqueue', account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid1'),
     ]
 
 
 def test_start_account_deletion_enqueues_cloud_task_when_enabled(monkeypatch):
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value='job-1'))
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent()))
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock(return_value=True))
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
     monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock())
     monkeypatch.setattr(account_deletion, 'is_account_deletion_dispatch_enabled', MagicMock(return_value=True))
@@ -136,9 +125,14 @@ def test_start_account_deletion_enqueues_cloud_task_when_enabled(monkeypatch):
     submit.assert_not_called()
 
 
-def test_start_account_deletion_raises_when_cloud_task_enqueue_fails(monkeypatch):
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value='job-1'))
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock())
+def test_start_account_deletion_accepts_durable_intent_when_cloud_task_enqueue_fails(monkeypatch):
+    """A queue NotFound must leave every irreversible boundary untouched.
+
+    The persisted marker is deliberately retained as ``failed`` so the
+    reconciler can recover delivery later; queue dispatch is an acceleration.
+    """
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent()))
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock(return_value=True))
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_failed', MagicMock())
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
     monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock())
@@ -149,15 +143,13 @@ def test_start_account_deletion_raises_when_cloud_task_enqueue_fails(monkeypatch
     submit = MagicMock()
     monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
 
-    try:
-        account_deletion.start_account_deletion('uid1')
-    except Exception as exc:
-        assert str(exc) == 'tasks down'
-    else:
-        raise AssertionError('expected enqueue failure to raise')
+    result = account_deletion.start_account_deletion('uid1')
 
-    account_deletion.users_db.mark_user_deletion_wipe_started.assert_called_once_with('uid1')
+    assert result == {'status': 'ok', 'message': 'Account deletion started'}
+    account_deletion.users_db.mark_user_deletion_wipe_started.assert_called_once_with('uid1', 'job-1')
     account_deletion.users_db.mark_user_deletion_wipe_failed.assert_called_once_with('uid1')
+    account_deletion.auth.delete_account.assert_not_called()
+    account_deletion.users_db.get_user_subscription.assert_not_called()
     submit.assert_not_called()
 
 
@@ -169,12 +161,12 @@ def test_start_account_deletion_tolerates_feedback_failure_and_missing_firebase_
     monkeypatch.setattr(
         account_deletion.users_db,
         'mark_user_deletion_wipe_intent',
-        MagicMock(return_value='job-1'),
+        MagicMock(return_value=_new_wipe_intent()),
     )
     monkeypatch.setattr(
         account_deletion.users_db,
         'mark_user_deletion_wipe_started',
-        MagicMock(),
+        MagicMock(return_value=True),
     )
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
     monkeypatch.setattr(account_deletion.stripe_utils, 'cancel_subscription', MagicMock())
@@ -193,7 +185,8 @@ def test_start_account_deletion_tolerates_feedback_failure_and_missing_firebase_
 
 
 def test_start_account_deletion_blocks_when_subscription_lookup_fails(monkeypatch):
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value='job-1'))
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent()))
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock(return_value=True))
     monkeypatch.setattr(
         account_deletion.users_db, 'get_user_subscription', MagicMock(side_effect=Exception('read down'))
     )
@@ -203,21 +196,19 @@ def test_start_account_deletion_blocks_when_subscription_lookup_fails(monkeypatc
     monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
     monkeypatch.setattr(account_deletion.time, 'sleep', lambda *_: None)
 
-    try:
-        account_deletion.start_account_deletion('uid1')
-    except Exception as exc:
-        assert str(exc) == 'read down'
-    else:
-        raise AssertionError('expected subscription lookup failure to raise')
+    result = account_deletion.start_account_deletion('uid1')
 
-    account_deletion.users_db.mark_user_deletion_billing_failed.assert_called_once_with('uid1', None, 'read down')
+    assert result['status'] == 'ok'
+    account_deletion.users_db.mark_user_deletion_billing_failed.assert_not_called()
+    account_deletion.users_db.get_user_subscription.assert_not_called()
     account_deletion.auth.delete_account.assert_not_called()
-    submit.assert_not_called()
+    submit.assert_called_once()
 
 
 def test_start_account_deletion_blocks_when_stripe_cancel_returns_none(monkeypatch):
     sub = types.SimpleNamespace(stripe_subscription_id='sub_123')
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value='job-1'))
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent()))
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock(return_value=True))
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=sub))
     monkeypatch.setattr(account_deletion.stripe_utils, 'cancel_subscription', MagicMock(return_value=None))
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_billing_failed', MagicMock())
@@ -226,18 +217,14 @@ def test_start_account_deletion_blocks_when_stripe_cancel_returns_none(monkeypat
     monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
     monkeypatch.setattr(account_deletion.time, 'sleep', lambda *_: None)
 
-    try:
-        account_deletion.start_account_deletion('uid1')
-    except Exception as exc:
-        assert 'stripe cancel returned no subscription' in str(exc)
-    else:
-        raise AssertionError('expected stripe cancellation failure to raise')
+    result = account_deletion.start_account_deletion('uid1')
 
-    account_deletion.users_db.mark_user_deletion_billing_failed.assert_called_once_with(
-        'uid1', 'sub_123', 'stripe cancel returned no subscription'
-    )
+    assert result['status'] == 'ok'
+    account_deletion.users_db.mark_user_deletion_billing_failed.assert_not_called()
+    account_deletion.users_db.get_user_subscription.assert_not_called()
+    account_deletion.stripe_utils.cancel_subscription.assert_not_called()
     account_deletion.auth.delete_account.assert_not_called()
-    submit.assert_not_called()
+    submit.assert_called_once()
 
 
 def test_start_account_deletion_raises_when_marker_persist_fails(monkeypatch):
@@ -262,10 +249,10 @@ def test_start_account_deletion_raises_when_marker_persist_fails(monkeypatch):
     submit.assert_not_called()
 
 
-def test_start_account_deletion_raises_when_pending_marker_persist_fails_after_auth(monkeypatch):
+def test_start_account_deletion_raises_when_pending_marker_persist_fails_before_auth(monkeypatch):
     """Do not enqueue or report success unless the actionable pending marker exists."""
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value='job-1'))
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent()))
     monkeypatch.setattr(
         account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock(side_effect=Exception('db down'))
     )
@@ -281,15 +268,15 @@ def test_start_account_deletion_raises_when_pending_marker_persist_fails_after_a
     else:
         raise AssertionError('expected pending marker failure to raise')
 
-    account_deletion.auth.delete_account.assert_called_once_with('uid1')
+    account_deletion.auth.delete_account.assert_not_called()
     submit.assert_not_called()
 
 
-def test_start_account_deletion_raises_unexpected_firebase_error(monkeypatch):
-    """Firebase errors propagate. The intent IS written first, then cancelled on failure; Phase 2 is never reached."""
+def test_start_account_deletion_never_calls_firebase_in_the_request_thread(monkeypatch):
+    """Firebase deletion belongs only to the claimed durable worker."""
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value='job-1'))
-    mark_started = MagicMock()
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent()))
+    mark_started = MagicMock(return_value=True)
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', mark_started)
     cancel_wipe = MagicMock()
     monkeypatch.setattr(account_deletion.users_db, 'cancel_user_deletion_wipe', cancel_wipe)
@@ -298,49 +285,72 @@ def test_start_account_deletion_raises_unexpected_firebase_error(monkeypatch):
     monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
     monkeypatch.setattr(account_deletion.time, 'sleep', lambda *_: None)
 
-    try:
-        account_deletion.start_account_deletion('uid1')
-    except Exception as exc:
-        assert str(exc) == 'permission denied'
-    else:
-        raise AssertionError('expected firebase error to propagate')
+    result = account_deletion.start_account_deletion('uid1')
 
-    submit.assert_not_called()
-    # Phase 1 intent IS written BEFORE Firebase deletion.
+    assert result['status'] == 'ok'
+    submit.assert_called_once()
     account_deletion.users_db.mark_user_deletion_wipe_intent.assert_called_once_with('uid1')
-    # On Firebase failure, the intent is cancelled so the record doesn't linger.
-    cancel_wipe.assert_called_once_with('uid1')
-    # Phase 2 (transition to 'pending') is never reached on auth failure.
-    mark_started.assert_not_called()
+    cancel_wipe.assert_not_called()
+    mark_started.assert_called_once_with('uid1', 'job-1')
+    account_deletion.auth.delete_account.assert_not_called()
 
 
-def test_start_account_deletion_writes_intent_before_pending(monkeypatch):
-    """P1 safety: the non-actionable 'deleting_auth' intent is written before
-    auth deletion, and the actionable 'pending' marker is written only after
-    auth deletion is confirmed.
-
-    This verifies the two-phase ordering that prevents a crash between the
-    intent write and auth deletion from leaving an actionable 'pending' marker
-    that the reconciler could prematurely act on.
-    """
+def test_start_account_deletion_writes_pending_authority_before_dispatch(monkeypatch):
+    """The durable marker exists before the queue acceleration attempt."""
     call_log = []
-    intent_mock = MagicMock(side_effect=lambda uid: call_log.append('intent') or 'job-1')
-    started_mock = MagicMock(side_effect=lambda uid: call_log.append('started'))
+    intent_mock = MagicMock(side_effect=lambda uid: call_log.append('intent') or _new_wipe_intent())
+    started_mock = MagicMock(side_effect=lambda uid, job_id: call_log.append('started') or True)
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', intent_mock)
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', started_mock)
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
     monkeypatch.setattr(
-        account_deletion.auth, 'delete_account', MagicMock(side_effect=lambda uid: call_log.append('auth'))
+        account_deletion,
+        'submit_with_context',
+        MagicMock(side_effect=lambda *_args: call_log.append('enqueue')),
     )
-    monkeypatch.setattr(account_deletion, 'submit_with_context', MagicMock())
     monkeypatch.setattr(account_deletion.time, 'sleep', lambda *_: None)
 
     account_deletion.start_account_deletion('uid1')
 
-    # Intent is written before auth, started is written after auth.
-    assert call_log == ['intent', 'auth', 'started']
+    assert call_log == ['intent', 'started', 'enqueue']
     intent_mock.assert_called_once_with('uid1')
-    started_mock.assert_called_once_with('uid1')
+    started_mock.assert_called_once_with('uid1', 'job-1')
+
+
+def test_start_account_deletion_joins_existing_wipe_without_dispatch(monkeypatch):
+    """A retry joins the durable authority without resetting or re-enqueueing it."""
+    monkeypatch.setattr(
+        account_deletion.users_db,
+        'mark_user_deletion_wipe_intent',
+        MagicMock(return_value={'wipe_job_id': 'job-running', 'dispatch_claimed': False}),
+    )
+    mark_started = MagicMock()
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', mark_started)
+    enqueue = MagicMock()
+    monkeypatch.setattr(account_deletion, 'enqueue_deletion_wipe', enqueue)
+
+    result = account_deletion.start_account_deletion('uid1')
+
+    assert result == {'status': 'ok', 'message': 'Account deletion started'}
+    mark_started.assert_not_called()
+    enqueue.assert_not_called()
+
+
+def test_start_account_deletion_does_not_dispatch_when_concurrent_promotion_wins(monkeypatch):
+    """Two retries may see deleting_auth, but only the transaction winner dispatches."""
+    monkeypatch.setattr(
+        account_deletion.users_db,
+        'mark_user_deletion_wipe_intent',
+        MagicMock(return_value={'wipe_job_id': 'job-new', 'dispatch_claimed': True}),
+    )
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock(return_value=False))
+    enqueue = MagicMock()
+    monkeypatch.setattr(account_deletion, 'enqueue_deletion_wipe', enqueue)
+
+    result = account_deletion.start_account_deletion('uid1')
+
+    assert result == {'status': 'ok', 'message': 'Account deletion started'}
+    enqueue.assert_not_called()
 
 
 def test_background_wipe_user_data_preserves_order(monkeypatch):
@@ -348,9 +358,15 @@ def test_background_wipe_user_data_preserves_order(monkeypatch):
     monkeypatch.setattr(
         account_deletion.users_db, 'mark_user_deletion_wipe_running', lambda uid: calls.append(('running', uid))
     )
+    monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', lambda uid: None)
+    monkeypatch.setattr(account_deletion.auth, 'delete_account', lambda uid: calls.append(('auth', uid)))
     monkeypatch.setattr(account_deletion, 'delete_user_caller_ids', lambda uid: calls.append(('twilio', uid)))
     monkeypatch.setattr(account_deletion, 'purge_derived_user_data', lambda uid: calls.append(('purge', uid)))
-    monkeypatch.setattr(account_deletion.users_db, 'delete_user_data', lambda uid: calls.append(('firestore', uid)))
+    monkeypatch.setattr(
+        account_deletion.users_db,
+        'delete_user_data',
+        lambda uid: calls.append(('firestore', uid)) or {'status': 'ok'},
+    )
     monkeypatch.setattr(
         account_deletion.users_db, 'mark_user_deletion_wipe_completed', lambda uid: calls.append(('wipe_done', uid))
     )
@@ -359,6 +375,7 @@ def test_background_wipe_user_data_preserves_order(monkeypatch):
 
     assert calls == [
         ('running', 'uid1'),
+        ('auth', 'uid1'),
         ('twilio', 'uid1'),
         ('purge', 'uid1'),
         ('firestore', 'uid1'),
@@ -383,20 +400,22 @@ def test_background_wipe_user_data_swallows_failures(monkeypatch):
     account_deletion.users_db.mark_user_deletion_wipe_completed.assert_not_called()
 
 
-def test_background_wipe_continues_when_running_marker_persist_fails(monkeypatch):
-    """A failure to transition to ``running`` is non-fatal — the wipe still runs."""
+def test_background_wipe_fails_closed_when_running_marker_persist_fails(monkeypatch):
+    """Without a running marker, a second worker could not be fenced safely."""
     monkeypatch.setattr(
         account_deletion.users_db, 'mark_user_deletion_wipe_running', MagicMock(side_effect=Exception('firestore down'))
     )
     monkeypatch.setattr(account_deletion, 'delete_user_caller_ids', MagicMock())
     monkeypatch.setattr(account_deletion, 'purge_derived_user_data', MagicMock())
     monkeypatch.setattr(account_deletion.users_db, 'delete_user_data', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_failed', MagicMock())
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_completed', MagicMock())
 
-    # Should not raise — the wipe proceeds even if the running marker can't be written.
-    account_deletion.background_wipe_user_data('uid1')
+    assert account_deletion.background_wipe_user_data('uid1') is False
 
-    account_deletion.users_db.mark_user_deletion_wipe_completed.assert_called_once_with('uid1')
+    account_deletion.delete_user_caller_ids.assert_not_called()
+    account_deletion.users_db.mark_user_deletion_wipe_completed.assert_not_called()
+    account_deletion.users_db.mark_user_deletion_wipe_failed.assert_called_once_with('uid1')
 
 
 def test_purge_derived_user_data_isolates_backends_and_reloads_conversation_ids(monkeypatch):
@@ -546,6 +565,29 @@ def test_background_wipe_user_data_does_not_complete_when_required_derived_purge
     account_deletion.background_wipe_user_data('uid1')
 
     account_deletion.users_db.delete_user_data.assert_not_called()
+    account_deletion.users_db.mark_user_deletion_wipe_failed.assert_called_once_with('uid1')
+    account_deletion.users_db.mark_user_deletion_wipe_completed.assert_not_called()
+
+
+def test_background_wipe_user_data_does_not_complete_when_firestore_wipe_returns_error(monkeypatch):
+    """A normal structured wipe failure is terminally unsafe, not success."""
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_running', MagicMock())
+    monkeypatch.setattr(account_deletion, 'delete_user_caller_ids', MagicMock())
+    monkeypatch.setattr(
+        account_deletion,
+        'purge_derived_user_data',
+        MagicMock(return_value={'required_failures': [], 'best_effort_failures': []}),
+    )
+    monkeypatch.setattr(
+        account_deletion.users_db,
+        'delete_user_data',
+        MagicMock(return_value={'status': 'error', 'message': 'root user document missing'}),
+    )
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_failed', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_completed', MagicMock())
+
+    assert account_deletion.background_wipe_user_data('uid1') is False
+
     account_deletion.users_db.mark_user_deletion_wipe_failed.assert_called_once_with('uid1')
     account_deletion.users_db.mark_user_deletion_wipe_completed.assert_not_called()
 

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -108,7 +108,9 @@ def test_start_account_deletion_preserves_order_and_enqueues_background_wipe(mon
 
 
 def test_start_account_deletion_enqueues_cloud_task_when_enabled(monkeypatch):
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent()))
+    monkeypatch.setattr(
+        account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent())
+    )
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock(return_value=True))
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
     monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock())
@@ -131,7 +133,9 @@ def test_start_account_deletion_accepts_durable_intent_when_cloud_task_enqueue_f
     The persisted marker is deliberately retained as ``failed`` so the
     reconciler can recover delivery later; queue dispatch is an acceleration.
     """
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent()))
+    monkeypatch.setattr(
+        account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent())
+    )
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock(return_value=True))
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_failed', MagicMock())
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
@@ -185,7 +189,9 @@ def test_start_account_deletion_tolerates_feedback_failure_and_missing_firebase_
 
 
 def test_start_account_deletion_blocks_when_subscription_lookup_fails(monkeypatch):
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent()))
+    monkeypatch.setattr(
+        account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent())
+    )
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock(return_value=True))
     monkeypatch.setattr(
         account_deletion.users_db, 'get_user_subscription', MagicMock(side_effect=Exception('read down'))
@@ -207,7 +213,9 @@ def test_start_account_deletion_blocks_when_subscription_lookup_fails(monkeypatc
 
 def test_start_account_deletion_blocks_when_stripe_cancel_returns_none(monkeypatch):
     sub = types.SimpleNamespace(stripe_subscription_id='sub_123')
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent()))
+    monkeypatch.setattr(
+        account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent())
+    )
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock(return_value=True))
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=sub))
     monkeypatch.setattr(account_deletion.stripe_utils, 'cancel_subscription', MagicMock(return_value=None))
@@ -252,7 +260,9 @@ def test_start_account_deletion_raises_when_marker_persist_fails(monkeypatch):
 def test_start_account_deletion_raises_when_pending_marker_persist_fails_before_auth(monkeypatch):
     """Do not enqueue or report success unless the actionable pending marker exists."""
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent()))
+    monkeypatch.setattr(
+        account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent())
+    )
     monkeypatch.setattr(
         account_deletion.users_db, 'mark_user_deletion_wipe_started', MagicMock(side_effect=Exception('db down'))
     )
@@ -275,7 +285,9 @@ def test_start_account_deletion_raises_when_pending_marker_persist_fails_before_
 def test_start_account_deletion_never_calls_firebase_in_the_request_thread(monkeypatch):
     """Firebase deletion belongs only to the claimed durable worker."""
     monkeypatch.setattr(account_deletion.users_db, 'get_user_subscription', MagicMock(return_value=None))
-    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent()))
+    monkeypatch.setattr(
+        account_deletion.users_db, 'mark_user_deletion_wipe_intent', MagicMock(return_value=_new_wipe_intent())
+    )
     mark_started = MagicMock(return_value=True)
     monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_started', mark_started)
     cancel_wipe = MagicMock()

--- a/backend/tests/unit/test_delete_account_stripe_cancel.py
+++ b/backend/tests/unit/test_delete_account_stripe_cancel.py
@@ -57,7 +57,11 @@ def users_service():
             "services.users.account_deletion",
             os.path.join(str(_BACKEND), "services", "users", "account_deletion.py"),
         )
-        service.users_db.mark_user_deletion_wipe_intent.return_value = 'job-1'
+        service.users_db.mark_user_deletion_wipe_intent.return_value = {
+            'wipe_job_id': 'job-1',
+            'dispatch_claimed': True,
+        }
+        service.users_db.mark_user_deletion_wipe_started.return_value = True
         yield service
 
 
@@ -67,7 +71,7 @@ def _sub(stripe_subscription_id):
     return s
 
 
-def test_paid_user_subscription_is_canceled_before_wipe(users_service):
+def test_paid_user_subscription_is_left_for_the_claimed_wipe_worker(users_service):
     with patch.object(
         users_service.users_db, 'get_user_subscription', return_value=_sub('sub_123')
     ) as get_sub, patch.object(
@@ -78,9 +82,9 @@ def test_paid_user_subscription_is_canceled_before_wipe(users_service):
         users_service, 'submit_with_context'
     ) as submit:
         resp = users_service.start_account_deletion(uid='uid1')
-    get_sub.assert_called_once_with('uid1')
-    cancel.assert_called_once_with('sub_123')
-    fb_delete.assert_called_once()  # deletion still proceeds
+    get_sub.assert_not_called()
+    cancel.assert_not_called()
+    fb_delete.assert_not_called()
     submit.assert_called_once_with(users_service.cleanup_executor, users_service.background_wipe_user_data, 'uid1')
     assert resp['status'] == 'ok'
 
@@ -97,7 +101,7 @@ def test_free_user_does_not_call_stripe(users_service):
     assert resp['status'] == 'ok'
 
 
-def test_stripe_error_blocks_deletion_before_auth(users_service):
+def test_request_does_not_observe_stripe_errors_before_claimed_wipe(users_service):
     with patch.object(users_service.users_db, 'get_user_subscription', return_value=_sub('sub_123')), patch.object(
         users_service.stripe_utils, 'cancel_subscription', side_effect=Exception('stripe down')
     ), patch.object(users_service.users_db, 'mark_user_deletion_billing_failed') as mark_billing_failed, patch.object(
@@ -105,8 +109,8 @@ def test_stripe_error_blocks_deletion_before_auth(users_service):
     ) as fb_delete, patch.object(
         users_service, 'submit_with_context'
     ) as submit:
-        with pytest.raises(Exception, match='stripe down'):
-            users_service.start_account_deletion(uid='uid1')
-    mark_billing_failed.assert_called_once_with('uid1', 'sub_123', 'stripe down')
+        resp = users_service.start_account_deletion(uid='uid1')
+    mark_billing_failed.assert_not_called()
     fb_delete.assert_not_called()
-    submit.assert_not_called()
+    submit.assert_called_once_with(users_service.cleanup_executor, users_service.background_wipe_user_data, 'uid1')
+    assert resp['status'] == 'ok'


### PR DESCRIPTION
## Summary

Account deletion now has one durable, fenced authority. The request persists intent before queue acceleration and makes no irreversible billing or Firebase Auth mutation. The claimed worker owns billing cancellation, Auth deletion, external purges, Firestore deletion, and completion.

Only the matching `wipe_job_id` can transactionally promote `deleting_auth` to `pending` and enqueue. Repeat requests preserve `pending`, `retrying`, `running`, `failed`, and `completed` state and do not create another task. A retry can recover the narrow `deleting_auth` handoff; concurrent promotions are fenced so only one dispatches.

After durable intent is committed, queue failure returns the existing compatible 200 acceptance response, marks the intent `failed`, and relies on reconciliation for eventual completion. It no longer returns 500 while retaining actionable deletion authority.

## Failure class (fixes)

Failure-Class: FC-split-mutation-authority

The request handler previously split destructive authority across itself and the queue worker. This change converges destructive transitions behind the claimed worker and persisted job-scoped marker.

## Authority ordering

Request → create/join durable intent → atomically promote matching job to `pending` → queue acceleration. Claimed worker → `running` → billing → Firebase Auth → external purge → Firestore wipe → `completed`.

## Product invariants affected

These IDs are named solely for the older, unrelated desktop paths in this PR’s full merge-base diff; this deletion follow-up does not alter them.

- INV-AGENT-*
- INV-AUTH-1
- INV-CHAT-1
- INV-VOICE-1

## Verification

- RED: the production-shaped Cloud Tasks route test reproduced `running → pending` plus a duplicate task; queue NotFound returned 500 with an actionable marker.
- GREEN: `backend/.venv/bin/python -m pytest backend/tests/services/users/test_account_deletion.py backend/tests/routers/test_users.py backend/tests/unit/test_delete_account_stripe_cancel.py backend/testing/e2e/test_account_deletion_cloud_tasks.py -q` — 59 passed.
- GREEN: `backend/.venv/bin/pyright backend/services/users/account_deletion.py` — 0 errors, 0 warnings.
- GREEN: `OMI_PR_BODY_FILE=pr-body.md make preflight` — local selected checks passed (advisory size warnings only).
- CI at `deaae3a4889751faa65d65f135303aaa14f14c73`: deletion-specific and metadata/stack checks passed, but the full PR remains red on unrelated merge-base coverage: `tests/unit/test_action_item_date_validation.py` and `tests/unit/test_lock_bypass_fixes.py` have pre-existing `langchain_core.messages` test-isolation/import failures; `Desktop Swift Build & Tests` is also red in the older desktop diff. This follow-up intentionally does not broaden FC-split-mutation-authority scope to modify those subsystems.

## Rollback

Revert the two account-deletion commits. No schema, queue, IAM, deployment, or production-data change is included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
