### PR TITLE
fix(desktop): isolate onboarding state from normal product data

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6280,
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6268,
     "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2861
   },
   "raise_justifications": {

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -4,13 +4,13 @@
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4256,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1593,
-    "desktop/macos/Desktop/Sources/OmiApp.swift": 1651
+    "desktop/macos/Desktop/Sources/OmiApp.swift": 1596
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/AuthService.swift": "Apple first-auth name capture signals observers (authNameDidUpdate) and persists the name to Firebase so it survives reinstalls.",
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": "present_onboarding_opener QA action renders the real post-onboarding opener in-process for verification.",
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": "Adds cloudOAuthGrantClientIDs so ChatGPT directory grants (always omi-chatgpt-prod) verify on dev/Beta builds, fixing the connector chip never flipping to connected.",
-    "desktop/macos/Desktop/Sources/OmiApp.swift": "Sets Sentry options.releaseName/options.dist and a global update_channel/bundle_id scope tag so native crash/app-hang/watchdog events are build-attributable; telemetry-only init, no lifecycle change (#10425)."
+    "desktop/macos/Desktop/Sources/OmiApp.swift": "Extracts onboarding journal lifecycle and removes startup maintenance while retaining newer main additions."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
@@ -139,7 +139,6 @@ extension AppState {
   /// This clears onboarding state without touching production data or system permissions.
   nonisolated func resetOnboardingAndRestart() {
     log("Resetting onboarding state for current app...")
-    let graphAuthorizationSnapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot()
 
     // Update live @AppStorage-backed state on the main thread *before* clearing
     // UserDefaults. DesktopHomeView handles .resetOnboardingRequested by setting
@@ -169,40 +168,16 @@ extension AppState {
     log("Cleared onboarding chat persistence")
 
     Task { @MainActor [self] in
-      // Clear knowledge graph (local + server) so the onboarding chart starts fresh
-      if let graphAuthorizationSnapshot {
-        let authorization = LocalMutationAuthorization {
-          RuntimeOwnerIdentity.isAuthorizationCurrent(graphAuthorizationSnapshot)
-        }
-        do {
-          try await KnowledgeGraphStorage.shared.clearAll(authorization: authorization)
-          log("Cleared local knowledge graph storage")
-        } catch LocalMutationAuthorizationError.revoked {
-          log("Skipped stale-owner local knowledge graph reset")
-        } catch {
-          logError("Failed to clear local knowledge graph during onboarding reset", error: error)
-        }
-      } else {
-        log("Skipped local knowledge graph reset without an authenticated owner")
-      }
-      do {
-        try await APIClient.shared.deleteKnowledgeGraph()
-        log("Cleared server knowledge graph")
-      } catch {
-        logError("Failed to clear server knowledge graph during onboarding reset", error: error)
-      }
-
-      // Clear the default stream through the kernel journal's durable,
-      // generation-fenced delete outbox. No UI surface may write or delete
-      // backend chat state directly.
+      // Clear only setup-owned local conversation state. A re-walkthrough must
+      // never mutate the user's normal local or backend chat history.
       if let chatProvider = ChatProvider.mainInstance {
-        if await chatProvider.clearDefaultJournalForOnboardingReset() {
-          log("Queued default chat reset through kernel journal")
+        if await chatProvider.clearOnboardingJournal() {
+          log("Cleared onboarding journal")
         } else {
-          log("Failed to queue default chat reset through kernel journal")
+          log("Failed to clear onboarding journal")
         }
       } else {
-        log("Default chat reset deferred: main chat provider unavailable")
+        log("Onboarding journal reset deferred: main chat provider unavailable")
       }
 
       try? await Task.sleep(nanoseconds: 150_000_000)
@@ -394,12 +369,36 @@ extension AppState {
     hasSystemAudioPermission = status == .granted
   }
 
-  /// Check system audio permission support and keep the last observed tap result fresh.
+  /// Prime the same Core Audio tap used by real capture and reconcile its
+  /// observed outcome into the shared permission state.
+  func primeSystemAudioPermission() async -> Bool {
+    guard #available(macOS 14.4, *) else {
+      recordSystemAudioCaptureOutcome(.unsupported)
+      return false
+    }
+
+    return await reconcileSystemAudioPermission {
+      await SystemAudioCaptureService.primePermission()
+    }
+  }
+
+  /// Injectable production seam for reconciling a real tap attempt. Keeping
+  /// this at AppState makes onboarding and normal capture share one owner.
+  func reconcileSystemAudioPermission(
+    testPermission: @escaping @Sendable () async -> Bool
+  ) async -> Bool {
+    let granted = await testPermission()
+    recordSystemAudioCaptureOutcome(granted ? .granted : .denied)
+    return granted
+  }
+
+  /// Check system audio support and retain the last observed tap result.
   ///
   /// Core Audio process taps (macOS 14.4+) do not provide a preflight API. Unlike
   /// Screen Recording, the truthful product state comes from a real tap outcome.
-  /// If no tap is currently running, a previously granted outcome is no longer a
-  /// fresh assertion, so refreshes return to unknown until the next tap succeeds.
+  /// An idle refresh cannot produce newer evidence, so it must not erase the
+  /// successful prime performed during onboarding. A later real tap failure
+  /// replaces this state through `recordSystemAudioCaptureOutcome`.
   func checkSystemAudioPermission() {
     guard #available(macOS 14.4, *) else {
       recordSystemAudioCaptureOutcome(.unsupported)
@@ -408,8 +407,6 @@ extension AppState {
 
     if let service = systemAudioCaptureService as? SystemAudioCaptureService, service.capturing {
       recordSystemAudioCaptureOutcome(.granted)
-    } else if systemAudioPermissionStatus == .granted {
-      recordSystemAudioCaptureOutcome(.unknown)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
+++ b/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
@@ -305,6 +305,9 @@ final class KernelTurnProjection {
 
     repeat {
       guard isCurrent(lease) else { return false }
+      // A queued request is a fresh attempt. Its outcome supersedes an earlier
+      // failed pass once the accumulated replacement snapshot is complete.
+      refreshSucceeded = true
       if refreshRequestedSurfaceEpochs[surfaceKey] == lease.epoch {
         refreshRequestedSurfaceEpochs.removeValue(forKey: surfaceKey)
       }

--- a/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
+++ b/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
@@ -270,17 +270,22 @@ final class KernelTurnProjection {
 
   /// Ordered replay. A gap never advances the checkpoint: the next page starts
   /// from the last contiguous turnSeq, so out-of-order wakeups cannot drop data.
-  func refresh(surface: AgentSurfaceReference) async {
-    guard let lease = captureOwnerLease() else { return }
-    await refresh(surface: surface, lease: lease)
+  @discardableResult
+  func refresh(surface: AgentSurfaceReference) async -> Bool {
+    guard let lease = captureOwnerLease() else { return false }
+    return await refresh(surface: surface, lease: lease, publishPartialResults: true)
   }
 
-  private func refresh(surface: AgentSurfaceReference, lease: OwnerLease) async {
-    guard isCurrent(lease), let client else { return }
+  private func refresh(
+    surface: AgentSurfaceReference,
+    lease: OwnerLease,
+    publishPartialResults: Bool
+  ) async -> Bool {
+    guard isCurrent(lease), let client else { return false }
     let surfaceKey = surface.key
     if refreshingSurfaceEpochs[surfaceKey] == lease.epoch {
       refreshRequestedSurfaceEpochs[surfaceKey] = lease.epoch
-      return
+      return true
     }
     refreshingSurfaceEpochs[surfaceKey] = lease.epoch
     defer {
@@ -296,15 +301,16 @@ final class KernelTurnProjection {
     // history arrive in real time, and causes the chat viewport to chase it.
     var pendingProjectionTurns: [KernelJournalTurn] = []
     var shouldResetProjection = false
+    var refreshSucceeded = true
 
     repeat {
-      guard isCurrent(lease) else { return }
+      guard isCurrent(lease) else { return false }
       if refreshRequestedSurfaceEpochs[surfaceKey] == lease.epoch {
         refreshRequestedSurfaceEpochs.removeValue(forKey: surfaceKey)
       }
       var shouldContinue = true
       while shouldContinue {
-        guard isCurrent(lease) else { return }
+        guard isCurrent(lease) else { return false }
         let knownConversation = conversationBySurface[surfaceKey]
         let knownCheckpoint = knownConversation.map {
           checkpointKeyFor(conversationId: $0, surface: surface)
@@ -318,7 +324,7 @@ final class KernelTurnProjection {
             afterTurnSeq: after,
             limit: 100
           )
-          guard isCurrent(lease) else { return }
+          guard isCurrent(lease) else { return false }
           let conversationId = page.conversationId
           guard !conversationId.isEmpty else {
             shouldContinue = false
@@ -330,7 +336,7 @@ final class KernelTurnProjection {
           if currentGeneration != page.conversationGeneration {
             highWaterByConversation[checkpointKey] = page.generationBaseTurnSeq
             generationByConversation[checkpointKey] = page.conversationGeneration
-            guard isCurrent(lease) else { return }
+            guard isCurrent(lease) else { return false }
             // A newer generation invalidates every accumulated row from the
             // prior one. Keep the reset and its replacement snapshot atomic.
             pendingProjectionTurns.removeAll()
@@ -343,7 +349,7 @@ final class KernelTurnProjection {
             after: contiguous
           )
           for turn in contiguousPage {
-            guard isCurrent(lease) else { return }
+            guard isCurrent(lease) else { return false }
             pendingProjectionTurns.append(turn)
             contiguous = turn.turnSeq
             highWaterByConversation[checkpointKey] = contiguous
@@ -368,29 +374,67 @@ final class KernelTurnProjection {
           if isCurrent(lease) {
             log("KernelTurnProjection: journal replay failed (code=journal_range_fetch_failed)")
           }
+          refreshSucceeded = false
           shouldContinue = false
         }
       }
     } while isCurrent(lease) && refreshRequestedSurfaceEpochs[surfaceKey] == lease.epoch
 
-    guard isCurrent(lease) else { return }
+    guard isCurrent(lease) else { return false }
+    if !refreshSucceeded, !publishPartialResults {
+      return false
+    }
     if shouldResetProjection {
       host?.resetJournalProjection(surface: surface)
     }
     host?.projectJournalTurns(pendingProjectionTurns)
+    return refreshSucceeded
   }
 
-  func reload(surface: AgentSurfaceReference) async {
-    guard let lease = captureOwnerLease(), isCurrent(lease) else { return }
+  @discardableResult
+  func reload(surface: AgentSurfaceReference) async -> Bool {
+    guard let lease = captureOwnerLease(), isCurrent(lease) else { return false }
     let surfaceKey = surface.key
-    if let conversationId = conversationBySurface.removeValue(forKey: surfaceKey) {
+    if refreshingSurfaceEpochs[surfaceKey] == lease.epoch {
+      refreshRequestedSurfaceEpochs[surfaceKey] = lease.epoch
+      return false
+    }
+    let previousConversationId = conversationBySurface.removeValue(forKey: surfaceKey)
+    let previousCheckpointKey = previousConversationId.map {
+      checkpointKeyFor(conversationId: $0, surface: surface)
+    }
+    let previousHighWater = previousCheckpointKey.flatMap { highWaterByConversation[$0] }
+    let previousGeneration = previousCheckpointKey.flatMap { generationByConversation[$0] }
+    if let conversationId = previousConversationId {
       let key = checkpointKeyFor(conversationId: conversationId, surface: surface)
       highWaterByConversation.removeValue(forKey: key)
       generationByConversation.removeValue(forKey: key)
     }
-    guard isCurrent(lease) else { return }
-    host?.resetJournalProjection(surface: surface)
-    await refresh(surface: surface, lease: lease)
+    guard isCurrent(lease) else { return false }
+    // The refresh builds a complete replacement snapshot and publishes it
+    // atomically. Keep the current projection visible if fetching fails.
+    let reloaded = await refresh(
+      surface: surface,
+      lease: lease,
+      publishPartialResults: false
+    )
+    guard !reloaded, isCurrent(lease) else { return reloaded }
+
+    if let failedConversationId = conversationBySurface.removeValue(forKey: surfaceKey) {
+      let failedKey = checkpointKeyFor(conversationId: failedConversationId, surface: surface)
+      highWaterByConversation.removeValue(forKey: failedKey)
+      generationByConversation.removeValue(forKey: failedKey)
+    }
+    if let previousConversationId, let previousCheckpointKey {
+      conversationBySurface[surfaceKey] = previousConversationId
+      if let previousHighWater {
+        highWaterByConversation[previousCheckpointKey] = previousHighWater
+      }
+      if let previousGeneration {
+        generationByConversation[previousCheckpointKey] = previousGeneration
+      }
+    }
+    return false
   }
 
   @discardableResult
@@ -421,7 +465,7 @@ final class KernelTurnProjection {
         )
       )
       guard isCurrent(lease) else { return nil }
-      await refresh(surface: surface, lease: lease)
+      _ = await refresh(surface: surface, lease: lease, publishPartialResults: true)
       guard isCurrent(lease) else { return nil }
       return turn
     } catch {
@@ -446,7 +490,7 @@ final class KernelTurnProjection {
         update: message.journalUpdate(status: status)
       )
       guard isCurrent(lease) else { return nil }
-      await refresh(surface: surface, lease: lease)
+      _ = await refresh(surface: surface, lease: lease, publishPartialResults: true)
       guard isCurrent(lease) else { return nil }
       return turn
     } catch {
@@ -492,7 +536,7 @@ final class KernelTurnProjection {
         terminalization: terminalization
       )
       guard isCurrent(lease) else { return nil }
-      await refresh(surface: surface, lease: lease)
+      _ = await refresh(surface: surface, lease: lease, publishPartialResults: true)
       return isCurrent(lease) ? turn : nil
     } catch {
       log("KernelTurnProjection: journal terminalization failed (code=journal_terminalize_failed)")
@@ -541,7 +585,7 @@ final class KernelTurnProjection {
         update: .statusOnly(turnId: turnId, status: status)
       )
       guard isCurrent(lease) else { return nil }
-      await refresh(surface: surface, lease: lease)
+      _ = await refresh(surface: surface, lease: lease, publishPartialResults: true)
       guard isCurrent(lease) else { return nil }
       return turn
     } catch {
@@ -724,7 +768,7 @@ final class KernelTurnProjection {
             update: KernelAgentLifecycleMutation.atomicAppendUpdate(mutation)
           )
           guard isCurrent(lease) else { return nil }
-          await refresh(surface: surface, lease: lease)
+          _ = await refresh(surface: surface, lease: lease, publishPartialResults: true)
           guard isCurrent(lease) else { return nil }
           return turn
         }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -128,7 +128,10 @@ struct DesktopHomeView: View {
           }
         } else {
           SBOnboardingView(
-            appState: appState, chatProvider: viewModelContainer.chatProvider, onComplete: nil
+            appState: appState,
+            chatProvider: viewModelContainer.chatProvider,
+            importConnectorStatusStore: viewModelContainer.homeStatusStore.connectorStatusStore,
+            onComplete: nil
           )
           .onAppear {
             log("DesktopHomeView: Showing SBOnboardingView (signed in, not onboarded)")

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -309,10 +309,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
     LocalAgentAPIServer.shared.startIfNeeded()
     publishNamedBundleRuntimeManifest()
 
-    // Strip com.apple.provenance xattrs that macOS adds when Sparkle extracts updates.
-    // These break the code signature seal, causing the NEXT update to fail with
-    // "An error occurred while running the updater."
-    stripProvenanceXattrs()
+    runStartupSystemMaintenance()
 
     log("AppDelegate: applicationDidFinishLaunching started (mode: \(OMIApp.launchMode.rawValue))")
     log("AppDelegate: AuthState.isSignedIn=\(AuthState.shared.isSignedIn)")
@@ -365,16 +362,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
       icon.draw(in: contentRect)
       maskedIcon.unlockFocus()
       NSApp.applicationIconImage = maskedIcon
-      if let cfURL = Bundle.main.bundleURL as CFURL? {
-        LSRegisterURL(cfURL, true)
-      }
       log("AppDelegate: Set application icon with squircle mask")
     }
-
-    // One-time icon cache reset: forces macOS to pick up the new squircle icon.
-    // Without this, users who had the old square icon see it cached indefinitely
-    // in the Dock, notifications, and Sparkle updater.
-    resetIconCacheIfNeeded()
 
     // Initialize NotificationService early to set up UNUserNotificationCenterDelegate
     // This ensures notifications display properly when app is in foreground
@@ -733,65 +722,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
     MainActor.assumeIsolated { window.title.lowercased().hasPrefix("omi") }
   }
 
-  /// Strip com.apple.provenance extended attributes from our own bundle.
-  /// macOS adds these when Sparkle extracts the update ZIP, which breaks the code
-  /// signature seal and causes subsequent updates to fail.
-  private func stripProvenanceXattrs() {
+  /// Run the narrow, bundle-local maintenance required for update integrity.
+  /// Startup must never restart shared macOS services or mutate global caches.
+  private func runStartupSystemMaintenance() {
     let bundlePath = Bundle.main.bundlePath
+    let commands = StartupSystemMaintenancePolicy.commands(bundlePath: bundlePath)
     DispatchQueue.global(qos: .utility).async {
-      // A silent failure here breaks the code-signature seal and causes future
-      // Sparkle updates to fail, so surface it (BL-022) instead of dropping it.
-      SystemCommand.runLogging(
-        "AppDelegate: strip provenance xattrs",
-        executable: "/usr/bin/xattr", arguments: ["-cr", bundlePath])
-    }
-  }
-
-  /// One-time icon cache reset to force macOS to pick up the new squircle icon.
-  /// Runs lsregister unregister/register + kills iconservicesagent (auto-restarts).
-  /// Includes a safety net to restart the Dock if it crashes during the reset.
-  private func resetIconCacheIfNeeded() {
-    let key = "hasResetIconCache_v2"
-    guard !UserDefaults.standard.bool(forKey: key) else { return }
-    UserDefaults.standard.set(true, forKey: key)
-    log("AppDelegate: Running one-time icon cache reset")
-
-    let appPath = Bundle.main.bundlePath
-    let lsregister =
-      "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
-
-    DispatchQueue.global(qos: .utility).async {
-      // Best-effort cosmetic maintenance. Capture each step's outcome instead of
-      // dropping it with `try?`, but keep it at info level — some steps exit
-      // non-zero benignly (e.g. killall when the agent isn't running), so this is
-      // not routed through the failure path (BL-022).
-      log(
-        "Icon cache: lsregister unregister \(SystemCommand.run(executable: lsregister, arguments: ["-u", appPath]).summary)"
-      )
-      log(
-        "Icon cache: lsregister register \(SystemCommand.run(executable: lsregister, arguments: ["-f", appPath]).summary)"
-      )
-      log(
-        "Icon cache: kill iconservicesagent \(SystemCommand.run(executable: "/usr/bin/killall", arguments: ["iconservicesagent"]).summary)"
-      )
-
-      // Safety net: verify the Dock is still running after 2 seconds.
-      // iconservicesagent restart can occasionally crash the Dock. pgrep exits
-      // non-zero when Dock isn't found, which is the signal we branch on.
-      Thread.sleep(forTimeInterval: 2.0)
-      let dockRunning = SystemCommand.run(
-        executable: "/usr/bin/pgrep", arguments: ["-x", "Dock"]
-      ).isSuccess
-
-      if !dockRunning {
-        // Dock is not running — restart it
-        log("AppDelegate: Dock not running after icon cache reset, restarting")
-        log(
-          "Icon cache: restart Dock \(SystemCommand.run(executable: "/usr/bin/open", arguments: ["-a", "Dock"]).summary)"
+      for command in commands {
+        // A silent failure here can break future update integrity, so surface it
+        // instead of dropping it.
+        SystemCommand.runLogging(
+          command.label,
+          executable: command.executable,
+          arguments: command.arguments
         )
       }
-
-      log("AppDelegate: Icon cache reset complete")
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -643,7 +643,7 @@ struct OnboardingChatView: View {
     )
 
     // Mark as onboarding so analytics and prompts use onboarding mode
-    chatProvider.isOnboarding = true
+    chatProvider.beginOnboardingJournal()
 
     // Check if we're resuming after a mid-onboarding restart (e.g. screen recording permission)
     if OnboardingChatPersistence.isMidOnboarding {

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
@@ -633,7 +633,6 @@ struct OnboardingView: View {
       OnboardingPromptSuggestionBuilder.build(from: introCoordinator))
 
     // Clean up onboarding state and persisted chat data
-    chatProvider.isOnboarding = false
     ChatToolExecutor.onboardingAppState = nil
     OnboardingChatPersistence.clear()
     ChatDraftStore.shared.clear(.onboardingMain)
@@ -644,9 +643,9 @@ struct OnboardingView: View {
       onComplete()
     }
 
-    // Transition UI FIRST — service failures must never block the UI.
-    // Setting this synchronously crashes in Button.body.getter, so defer it.
-    DispatchQueue.main.async {
+    // Restore the real chat projection before revealing the product UI.
+    Task {
+      await chatProvider.finishOnboardingJournal()
       appState.hasCompletedOnboarding = true
     }
 
@@ -665,20 +664,6 @@ struct OnboardingView: View {
     } else {
       startMonitoringIfNeeded()
       appState.startTranscription()
-    }
-
-    // Create welcome task
-    Task {
-      let welcomeDescription = "Run omi for two days to start receiving helpful insights"
-      let alreadyExists = await ActionItemStorage.shared.actionItemExists(
-        description: welcomeDescription)
-      if !alreadyExists {
-        await TasksStore.shared.createTask(
-          description: welcomeDescription,
-          dueAt: Date(),
-          priority: "low"
-        )
-      }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -13,11 +13,13 @@ extension SBOnboardingModel {
       appState.requestMicrophonePermission()
       pollPermission(key)
     case "system_audio":
-      // System-audio capture (Core Audio process tap) has no prompt of its own —
-      // macOS gates it behind Screen Recording TCC. Requesting/reading screen
-      // recording is the only thing that actually prompts + reliably detects.
+      // A Core Audio process tap has its own consent in addition to Screen
+      // Recording TCC. Wait for Screen Recording, then reconcile a real tap
+      // attempt before marking this permission granted.
       sysState = .waiting
-      ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()
+      if !appState.hasScreenRecordingPermission {
+        ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()
+      }
       pollPermission(key)
     case "screen_recording":
       scrState = .waiting
@@ -73,6 +75,12 @@ extension SBOnboardingModel {
     // Cancel only this key's prior poll — never a sibling permission's, so the
     // "both" mic+system-audio step can poll two grants at once.
     pollTasks[key]?.cancel()
+
+    if key == "system_audio" {
+      pollSystemAudioPermission()
+      return
+    }
+
     pollTasks[key] = Task { [weak self] in
       for _ in 0..<40 {  // ~20s
         try? await Task.sleep(nanoseconds: 500_000_000)
@@ -80,16 +88,6 @@ extension SBOnboardingModel {
         self.refreshPermCheck(key)
         if self.isGranted(key) {
           self.setPermOn(key)
-          // System audio needs a SEPARATE Core Audio tap consent (the "bypass the
-          // private window picker … screen and audio" prompt) beyond the Screen
-          // Recording TCC this step grants. Prime it here — in-context on this step,
-          // and awaited BEFORE we advance — so the modal surfaces on the system-audio
-          // step (not a later one) and the real capture path never re-prompts after
-          // onboarding. Screen Recording (which the tap requires) is granted now.
-          if key == "system_audio", #available(macOS 14.4, *) {
-            _ = await SystemAudioCaptureService.primePermission()
-            guard !Task.isCancelled else { return }
-          }
           // Auto-advance once the grant lands — the user shouldn't have to click
           // Continue after granting. Brief pause so the ✓ is visible, then only
           // advance if they're still on this permission's step (a late poll for a
@@ -108,11 +106,49 @@ extension SBOnboardingModel {
     }
   }
 
+  /// Screen Recording TCC is only a prerequisite for system audio. The
+  /// authoritative grant is a successful Core Audio tap attempt.
+  private func pollSystemAudioPermission() {
+    // A precheck and an Allow click can race to start this poll. Preserve one
+    // authoritative consent attempt so an older task cannot advance the flow
+    // after the replacement has already reconciled a newer result.
+    pollTasks["system_audio"]?.cancel()
+    pollTasks["system_audio"] = Task { [weak self] in
+      for _ in 0..<40 {  // ~20s
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        guard let self, !Task.isCancelled else { return }
+        // Skipping this step is an explicit choice not to surface its consent.
+        // Never let a late Screen Recording grant trigger the modal elsewhere.
+        guard self.step == .systemAudio else { return }
+        self.appState.checkScreenRecordingPermission()
+        guard self.appState.hasScreenRecordingPermission else { continue }
+
+        let granted = await self.appState.primeSystemAudioPermission()
+        guard !Task.isCancelled else { return }
+        guard granted else {
+          self.resetPermToAsk("system_audio")
+          return
+        }
+
+        self.setPermOn("system_audio")
+        try? await Task.sleep(nanoseconds: 600_000_000)
+        guard !Task.isCancelled else { return }
+        self.autoAdvanceIfCurrent("system_audio")
+        return
+      }
+
+      guard let self, !Task.isCancelled else { return }
+      self.resetPermToAsk("system_audio")
+    }
+  }
+
   /// Re-probe a single permission (each check writes the matching AppState flag).
   private func refreshPermCheck(_ key: String) {
     switch key {
     case "microphone": appState.checkMicrophonePermission()
-    case "system_audio": appState.checkScreenRecordingPermission()  // shares Screen Recording TCC
+    case "system_audio":
+      appState.checkScreenRecordingPermission()
+      appState.checkSystemAudioPermission()
     case "screen_recording": appState.checkScreenRecordingPermission()
     case "full_disk_access": appState.checkFullDiskAccess()
     case "accessibility": appState.checkAccessibilityPermission()
@@ -127,20 +163,21 @@ extension SBOnboardingModel {
     refreshPermCheck(key)
     if isGranted(key) {
       setPermOn(key)
-      // If the user lands on the system-audio step already holding Screen Recording,
-      // prime the separate Core Audio tap consent here (in-context) so it isn't
-      // deferred to the first capture after onboarding. precheck doesn't advance, so
-      // fire-and-forget is fine — the modal shows while this step is on screen.
-      if key == "system_audio", #available(macOS 14.4, *) {
-        Task.detached { _ = await SystemAudioCaptureService.primePermission() }
-      }
+    } else if key == "system_audio", appState.hasScreenRecordingPermission,
+      appState.systemAudioPermissionStatus == .unknown
+    {
+      // Already holding Screen Recording must not skip this separate consent.
+      // Prime while its own onboarding step is visible and reconcile the result.
+      sysState = .waiting
+      pollSystemAudioPermission()
     }
   }
 
   func isGranted(_ key: String) -> Bool {
     switch key {
     case "microphone": return appState.hasMicrophonePermission
-    case "system_audio": return appState.hasScreenRecordingPermission  // shares Screen Recording TCC
+    case "system_audio":
+      return appState.hasSystemAudioPermission || appState.systemAudioPermissionStatus == .unsupported
     case "screen_recording": return appState.hasScreenRecordingPermission
     case "full_disk_access": return appState.hasFullDiskAccess
     case "accessibility": return appState.hasAccessibilityPermission && !appState.isAccessibilityBroken
@@ -543,6 +580,17 @@ extension SBOnboardingModel {
 // MARK: - Context (connect what I can see)
 
 extension SBOnboardingModel {
+  enum ContextConnectionRoute: Equatable {
+    case importConnector(String)
+    case direct
+  }
+
+  struct GoogleContextResolution: Equatable {
+    let state: String
+    let detail: String?
+    let shouldOpenSignIn: Bool
+  }
+
   var contextRows: [(id: String, name: String, detail: String)] {
     [
       ("calendar", "Calendar", "meetings + prep"),
@@ -558,15 +606,6 @@ extension SBOnboardingModel {
     if appState.hasFullDiskAccess { contextStates["files"] = "on" }
     Task { [weak self] in
       guard let self else { return }
-      for id in ["chatgpt", "claude"] {
-        let dest: MemoryExportDestination = id == "chatgpt" ? .chatgpt : .claude
-        // OAuth for these completes in the browser, so only the backend grant
-        // list knows the truth — a local status check would never flip the chip.
-        let connected = await MemoryExportService.shared.refreshCloudGrantConnectionStatus(for: dest).hasConnection
-        if let resolved = Self.cloudContextState(current: self.contextStates[id], connected: connected) {
-          self.contextStates[id] = resolved
-        }
-      }
       // Apple Notes rides the same Full Disk Access grant that powers Files, so a
       // readable NoteStore should show "✓ on" up front — not a "Connect" button
       // that would only flip to on for nothing (this precheck was missing, which
@@ -577,19 +616,47 @@ extension SBOnboardingModel {
         self.contextStates["applenotes"] = "on"
       }
       let cal = await CalendarReaderService.shared.verifyConnection()
-      if cal.isConnected { self.contextStates["calendar"] = "on" }
+      if cal.isConnected { self.markContextConnected("calendar") }
       let gmail = await GmailReaderService.shared.verifyConnection()
-      if gmail.isConnected { self.contextStates["gmail"] = "on" }
+      if gmail.isConnected { self.markContextConnected("gmail") }
     }
   }
 
-  /// Chip state for a cloud OAuth connector (ChatGPT/Claude) after a backend
-  /// grant refresh: connected always wins; an unfinished "connecting" (the user
-  /// came back without completing OAuth) resolves to "idle" so the Connect
-  /// button returns; anything else is left unchanged (nil).
-  nonisolated static func cloudContextState(current: String?, connected: Bool) -> String? {
-    if connected { return "on" }
-    return current == "connecting" ? "idle" : nil
+  func markContextConnected(_ id: String) {
+    contextStates[id] = "on"
+    contextDetails[id] = nil
+  }
+
+  /// ChatGPT and Claude on this surface mean importing existing memories into
+  /// Omi. Live MCP exports are a separate Apps > Exports action and must never
+  /// be substituted here.
+  nonisolated static func contextConnectionRoute(for id: String) -> ContextConnectionRoute {
+    switch id {
+    case "chatgpt", "claude":
+      return .importConnector(id)
+    default:
+      return .direct
+    }
+  }
+
+  nonisolated static func googleContextResolution(
+    connectorID: String,
+    connected: Bool,
+    needsSignIn: Bool
+  ) -> GoogleContextResolution {
+    if connected {
+      return GoogleContextResolution(state: "on", detail: nil, shouldOpenSignIn: false)
+    }
+    let name = connectorID == "gmail" ? "Gmail" : "Google Calendar"
+    let detail =
+      needsSignIn
+      ? "Open \(name) in Chrome, Arc, Brave, or Edge, sign in, then retry."
+      : "Couldn't verify \(name). Check your browser session and connection, then retry."
+    return GoogleContextResolution(
+      state: needsSignIn ? "needsSignIn" : "error",
+      detail: detail,
+      shouldOpenSignIn: needsSignIn
+    )
   }
 
   /// Resolve a cookie-based Google connector (Calendar, Gmail). These don't OAuth —
@@ -597,32 +664,67 @@ extension SBOnboardingModel {
   /// isn't an error to shrug at: OPEN the Google page so the user can actually sign
   /// in, then Retry picks up the new session. (An `.error`, e.g. a not-yet-loaded
   /// API key, just leaves a Retry button — opening Google wouldn't help.)
-  private func resolveGoogleConnect(_ id: String, connected: Bool, needsSignIn: Bool, signInURL: String) {
-    if connected {
-      contextStates[id] = "on"
-      return
+  private func resolveGoogleConnect(
+    _ id: String,
+    connected: Bool,
+    needsSignIn: Bool,
+    signInURL: String
+  ) {
+    let resolution = Self.googleContextResolution(
+      connectorID: id,
+      connected: connected,
+      needsSignIn: needsSignIn
+    )
+    contextStates[id] = resolution.state
+    contextDetails[id] = resolution.detail
+    if resolution.shouldOpenSignIn, let url = URL(string: signInURL) {
+      NSWorkspace.shared.open(url)
     }
-    contextStates[id] = "needsSignIn"
-    if needsSignIn, let url = URL(string: signInURL) { NSWorkspace.shared.open(url) }
   }
 
   func connectContext(_ id: String) {
     guard contextStates[id] != "connecting", contextStates[id] != "on" else { return }
+    // The view owns import-sheet presentation. Keep this guard so another
+    // caller cannot accidentally route a memory import into the MCP exporter.
+    guard Self.contextConnectionRoute(for: id) == .direct else { return }
     contextStates[id] = "connecting"
+    contextDetails[id] = nil
     switch id {
     case "calendar":
       Task { [weak self] in
         let s = await CalendarReaderService.shared.verifyConnection()
-        let needsSignIn = { if case .needsSignIn = s { return true } else { return false } }()
+        let needsSignIn = {
+          switch s {
+          case .connected, .error:
+            return false
+          case .needsSignIn:
+            return true
+          }
+        }()
         self?.resolveGoogleConnect(
-          "calendar", connected: s.isConnected, needsSignIn: needsSignIn, signInURL: "https://calendar.google.com")
+          "calendar",
+          connected: s.isConnected,
+          needsSignIn: needsSignIn,
+          signInURL: "https://calendar.google.com"
+        )
       }
     case "gmail":
       Task { [weak self] in
         let s = await GmailReaderService.shared.verifyConnection()
-        let needsSignIn = { if case .needsSignIn = s { return true } else { return false } }()
+        let needsSignIn = {
+          switch s {
+          case .connected, .error:
+            return false
+          case .needsSignIn:
+            return true
+          }
+        }()
         self?.resolveGoogleConnect(
-          "gmail", connected: s.isConnected, needsSignIn: needsSignIn, signInURL: "https://mail.google.com")
+          "gmail",
+          connected: s.isConnected,
+          needsSignIn: needsSignIn,
+          signInURL: "https://mail.google.com"
+        )
       }
     case "applenotes":
       Task { [weak self] in
@@ -665,25 +767,14 @@ extension SBOnboardingModel {
         requestFullDiskAccess()
         contextStates["files"] = "idle"
       }
-    case "chatgpt", "claude":
-      let dest: MemoryExportDestination = id == "chatgpt" ? .chatgpt : .claude
-      Task { [weak self] in
-        let outcome: MemoryExportExecutor.Outcome
-        do {
-          outcome = try await MemoryExportExecutor.run(dest)
-        } catch {
-          self?.contextStates[id] = "unavailable"
-          return
-        }
-        // Assisted/directory flows finish in the browser — checking now would
-        // always read "not connected" and reset the chip. Keep it "connecting";
-        // the app-activation refresh resolves it when the user comes back.
-        guard outcome.mode == .completed else { return }
-        let connected = await MemoryExportService.shared.status(for: dest).hasConnection
-        self?.contextStates[id] = connected ? "on" : "idle"
-      }
     default: break
     }
+  }
+
+  func markContextImportConnected(_ connectorID: String) {
+    guard Self.contextConnectionRoute(for: connectorID) == .importConnector(connectorID) else { return }
+    contextStates[connectorID] = "on"
+    contextDetails[connectorID] = nil
   }
 
   func answerContext() { advance(userAnswer: "Continue", to: .capture) }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -84,6 +84,10 @@ final class SBOnboardingModel: ObservableObject {
   // ("idle" | "connecting" | "on" | "unavailable" | "needsSignIn").
   @Published var agentStates: [String: String] = [:]
   @Published var contextStates: [String: String] = [:]
+  /// Actionable connector detail replaces the generic row subtitle after a
+  /// failed functional probe. Values use bounded product copy; raw cookie,
+  /// response, and exception data never reaches this projection.
+  @Published var contextDetails: [String: String] = [:]
 
   unowned let appState: AppState
   let chatProvider: ChatProvider
@@ -108,7 +112,7 @@ final class SBOnboardingModel: ObservableObject {
     // Isolate any onboarding chat/voice turns to the throwaway `.onboarding()`
     // journal surface so they never pollute the real Chat tab. Cleared on
     // complete()/skip(), after which the Chat tab reloads the clean default surface.
-    chatProvider.isOnboarding = true
+    chatProvider.beginOnboardingJournal()
     // Detect the user's real name automatically (mirrors the legacy paged intro):
     // seed the editable field from what we already know, kick a backend fetch if we
     // don't have it yet, and adopt an async arrival — so onboarding greets by name
@@ -391,7 +395,6 @@ final class SBOnboardingModel: ObservableObject {
     chatProvider.stopAgent(owner: .mainChat)
     UserDefaults.standard.set(true, forKey: DefaultsKey.onboardingJustCompleted)
     UserDefaults.standard.removeObject(forKey: Self.resumeStepKey)
-    chatProvider.isOnboarding = false
     // Greet the user in the Home chat with the personalized opener + starters.
     chatProvider.presentOnboardingOpener()
     ChatToolExecutor.onboardingAppState = nil
@@ -399,12 +402,9 @@ final class SBOnboardingModel: ObservableObject {
     ChatDraftStore.shared.clear(.onboardingMain)
     ChatDraftStore.shared.clear(.onboardingFloating)
     onComplete?()
-    // Wipe the default main-chat journal so the Chat tab opens clean (any stray
-    // demo turns lived on the .onboarding() surface; this clears the default
-    // surface the tab actually loads) before we reveal it.
     Task { [weak self] in
       guard let self else { return }
-      _ = await self.chatProvider.clearDefaultJournalForOnboardingReset()
+      await self.chatProvider.finishOnboardingJournal()
       self.appState.hasCompletedOnboarding = true
     }
   }
@@ -419,7 +419,6 @@ final class SBOnboardingModel: ObservableObject {
     if !AppBuild.usesLazyDevPermissions {
       UserDefaults.standard.set(true, forKey: DefaultsKey.hasCompletedFileIndexing)
     }
-    chatProvider.isOnboarding = false
     // Greet the user in the Home chat with the personalized opener + starters.
     chatProvider.presentOnboardingOpener()
     ChatToolExecutor.onboardingAppState = nil
@@ -428,10 +427,9 @@ final class SBOnboardingModel: ObservableObject {
     ChatDraftStore.shared.clear(.onboardingFloating)
 
     onComplete?()
-    // Wipe the default main-chat journal so the Chat tab opens clean before reveal.
     Task { [weak self] in
       guard let self else { return }
-      _ = await self.chatProvider.clearDefaultJournalForOnboardingReset()
+      await self.chatProvider.finishOnboardingJournal()
       self.appState.hasCompletedOnboarding = true
     }
 
@@ -452,13 +450,6 @@ final class SBOnboardingModel: ObservableObject {
     Task { [appState] in
       if startListening { appState.startTranscription() }
       await appState.reconcileCapture()
-    }
-    Task {
-      let welcome = "Run omi for two days to start receiving helpful insights"
-      let exists = await ActionItemStorage.shared.actionItemExists(description: welcome)
-      if !exists {
-        _ = await TasksStore.shared.createTask(description: welcome, dueAt: Date(), priority: "low")
-      }
     }
   }
 
@@ -482,7 +473,9 @@ final class SBOnboardingModel: ObservableObject {
   /// Cancel every live task/monitor this model owns. Safe to call repeatedly.
   private func teardownAll() {
     streamTask?.cancel()
-    pollTasks.values.forEach { $0.cancel() }
+    for pollTask in pollTasks.values {
+      pollTask.cancel()
+    }
     pollTasks.removeAll()
     disarmShortcutSummon()
     teardownVoiceDemo()

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -11,6 +11,8 @@ enum SBOnboardingRepository {
 struct SBOnboardingView: View {
   @Environment(\.sbTheme) private var sb
   @StateObject private var model: SBOnboardingModel
+  @ObservedObject private var importConnectorStatusStore: ImportConnectorStatusStore
+  @State private var selectedImportConnector: ImportConnector?
   /// Language step: false shows the detected default + Continue; true reveals the picker.
   @State private var languageChanging = false
 
@@ -20,9 +22,15 @@ struct SBOnboardingView: View {
     return NSImage(contentsOf: url)
   }()
 
-  init(appState: AppState, chatProvider: ChatProvider, onComplete: (() -> Void)?) {
+  init(
+    appState: AppState,
+    chatProvider: ChatProvider,
+    importConnectorStatusStore: ImportConnectorStatusStore,
+    onComplete: (() -> Void)?
+  ) {
     _model = StateObject(
       wrappedValue: SBOnboardingModel(appState: appState, chatProvider: chatProvider, onComplete: onComplete))
+    _importConnectorStatusStore = ObservedObject(wrappedValue: importConnectorStatusStore)
   }
 
   var body: some View {
@@ -62,10 +70,23 @@ struct SBOnboardingView: View {
       .padding(.top, 20).padding(.trailing, 24)
     }
     .onAppear { model.begin() }
-    // ChatGPT/Claude OAuth finishes in the browser — re-check the grants when
-    // the user comes back so their chip actually flips to "✓ on".
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-      if model.step == .context { model.refreshContextStates() }
+      if model.step == .context { refreshContextStates() }
+    }
+    .onChange(of: model.step) { _, step in
+      if step == .context { refreshContextStates() }
+    }
+    .onReceive(importConnectorStatusStore.connectorDidSync) { connectorID in
+      model.markContextImportConnected(connectorID)
+    }
+    .dismissableSheet(item: $selectedImportConnector) { connector in
+      ImportConnectorSheet(
+        connector: connector,
+        appState: nil,
+        statusStore: importConnectorStatusStore,
+        onDismiss: { selectedImportConnector = nil }
+      )
+      .frame(width: 520, height: 620)
     }
     // Safety net: the `.shortcut` step suspends global hotkeys and nulls the main
     // menu (restored only via the advance/skip/complete buttons). If the view is
@@ -510,8 +531,13 @@ struct SBOnboardingView: View {
     VStack(alignment: .leading, spacing: 12) {
       VStack(spacing: 0) {
         ForEach(Array(model.contextRows.enumerated()), id: \.element.id) { i, row in
-          connectRow(id: row.id, row.name, row.detail, state: model.contextStates[row.id] ?? "idle") {
-            model.connectContext(row.id)
+          connectRow(
+            id: row.id,
+            row.name,
+            model.contextDetails[row.id] ?? row.detail,
+            state: model.contextStates[row.id] ?? "idle"
+          ) {
+            connectContext(row.id)
           }
           if i < model.contextRows.count - 1 { Divider().overlay(sb.ink(.w08)) }
         }
@@ -521,6 +547,27 @@ struct SBOnboardingView: View {
       SBInkButton(title: "Continue") { model.answerContext() }
     }
     .frame(maxWidth: 380, alignment: .leading)
+  }
+
+  private func connectContext(_ id: String) {
+    switch SBOnboardingModel.contextConnectionRoute(for: id) {
+    case .importConnector(let connectorID):
+      selectedImportConnector = ImportConnector.all.first { $0.id == connectorID }
+    case .direct:
+      model.connectContext(id)
+    }
+  }
+
+  private func refreshContextStates() {
+    model.refreshContextStates()
+    importConnectorStatusStore.refreshPersistedManualImportMetrics()
+    for connectorID in ["chatgpt", "claude"] {
+      guard
+        let connector = ImportConnector.all.first(where: { $0.id == connectorID }),
+        importConnectorStatusStore.snapshot(for: connector).isConnected
+      else { continue }
+      model.markContextImportConnected(connectorID)
+    }
   }
 
   private func connectRow(id: String, _ name: String, _ detail: String, state: String, action: @escaping () -> Void)
@@ -552,6 +599,13 @@ struct SBOnboardingView: View {
     case "connecting": Text("…").geistMono(size: 13).foregroundStyle(sb.ink(.w4))
     case "checking": Text("checking…").geist(size: 12).foregroundStyle(sb.ink(.w35))
     case "unavailable": Text("not installed").geist(size: 12).foregroundStyle(sb.ink(.w35))
+    case "error":
+      Button(action: action) {
+        Text("Retry").geist(size: 13, weight: .semibold).foregroundStyle(sb.inkInverted)
+          .padding(.horizontal, 12).padding(.vertical, 4)
+          .background(RoundedRectangle(cornerRadius: 7).fill(sb.ink))
+      }
+      .buttonStyle(.plain)
     default:
       Button(action: action) {
         Text(state == "needsSignIn" ? "Retry" : "Connect").geist(size: 13, weight: .semibold).foregroundStyle(

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+OnboardingJournal.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+OnboardingJournal.swift
@@ -1,0 +1,30 @@
+extension ChatProvider {
+  func beginOnboardingJournal() {
+    guard !isOnboarding else { return }
+    preOnboardingMainMessages = messages
+    isOnboarding = true
+  }
+
+  /// Delete only setup-owned conversation state. Onboarding is a local-only
+  /// journal surface, so this can never enqueue a backend chat deletion or
+  /// mutate the user's normal main-chat history.
+  func clearOnboardingJournal() async -> Bool {
+    let surface = AgentSurfaceReference.onboarding()
+    AgentRuntimeStatusStore.shared.clear(surface: surface)
+    return await kernelTurnProjection.clear(surface: surface, deleteBackend: false)
+  }
+
+  /// Leave the setup-only chat surface, purge its local transcript, and restore
+  /// the authoritative main-chat projection before the product UI is revealed.
+  func finishOnboardingJournal() async {
+    let fallbackMessages = preOnboardingMainMessages ?? []
+    _ = await clearOnboardingJournal()
+    isOnboarding = false
+    let reloaded = await kernelTurnProjection.reload(surface: mainChatSurfaceReference())
+    if !reloaded {
+      messages = fallbackMessages
+      resetMessagesPagination()
+    }
+    preOnboardingMainMessages = nil
+  }
+}

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1127,7 +1127,7 @@ class ChatProvider: ObservableObject {
 
   /// Set to true during onboarding so the ACP session ID is persisted for restart recovery.
   var isOnboarding = false
-  private var preOnboardingMainMessages: [ChatMessage]?
+  var preOnboardingMainMessages: [ChatMessage]?
   @Published var sessionsLoadError: String?
   @Published var selectedAppId: String? {
     didSet { restoreDraftForCurrentContextIfNeeded() }
@@ -5922,35 +5922,6 @@ class ChatProvider: ObservableObject {
   }
 
   // MARK: - Clear Chat
-
-  func beginOnboardingJournal() {
-    guard !isOnboarding else { return }
-    preOnboardingMainMessages = messages
-    isOnboarding = true
-  }
-
-  /// Delete only setup-owned conversation state. Onboarding is a local-only
-  /// journal surface, so this can never enqueue a backend chat deletion or
-  /// mutate the user's normal main-chat history.
-  func clearOnboardingJournal() async -> Bool {
-    let surface = AgentSurfaceReference.onboarding()
-    AgentRuntimeStatusStore.shared.clear(surface: surface)
-    return await kernelTurnProjection.clear(surface: surface, deleteBackend: false)
-  }
-
-  /// Leave the setup-only chat surface, purge its local transcript, and restore
-  /// the authoritative main-chat projection before the product UI is revealed.
-  func finishOnboardingJournal() async {
-    let fallbackMessages = preOnboardingMainMessages ?? []
-    _ = await clearOnboardingJournal()
-    isOnboarding = false
-    let reloaded = await kernelTurnProjection.reload(surface: mainChatSurfaceReference())
-    if !reloaded {
-      messages = fallbackMessages
-      resetMessagesPagination()
-    }
-    preOnboardingMainMessages = nil
-  }
 
   /// Clear current session messages (delete and create new)
   func clearChat() async {

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1127,6 +1127,7 @@ class ChatProvider: ObservableObject {
 
   /// Set to true during onboarding so the ACP session ID is persisted for restart recovery.
   var isOnboarding = false
+  private var preOnboardingMainMessages: [ChatMessage]?
   @Published var sessionsLoadError: String?
   @Published var selectedAppId: String? {
     didSet { restoreDraftForCurrentContextIfNeeded() }
@@ -5922,17 +5923,33 @@ class ChatProvider: ObservableObject {
 
   // MARK: - Clear Chat
 
-  /// Reset onboarding's legacy default backend stream through the same
-  /// generation-fenced journal deletion path as every other chat clear.
-  /// The app may restart before the physical DELETE returns; the daemon's
-  /// durable outbox resumes that exact operation on the next launch.
-  func clearDefaultJournalForOnboardingReset() async -> Bool {
-    let surface = AgentSurfaceReference.mainChat(chatId: "default")
+  func beginOnboardingJournal() {
+    guard !isOnboarding else { return }
+    preOnboardingMainMessages = messages
+    isOnboarding = true
+  }
+
+  /// Delete only setup-owned conversation state. Onboarding is a local-only
+  /// journal surface, so this can never enqueue a backend chat deletion or
+  /// mutate the user's normal main-chat history.
+  func clearOnboardingJournal() async -> Bool {
+    let surface = AgentSurfaceReference.onboarding()
     AgentRuntimeStatusStore.shared.clear(surface: surface)
-    // Local-only: an onboarding re-walkthrough resets the local chat view but
-    // must never hard-delete the user's server-side chat history. The backend
-    // stays authoritative and rehydrates the thread via reconcile.
     return await kernelTurnProjection.clear(surface: surface, deleteBackend: false)
+  }
+
+  /// Leave the setup-only chat surface, purge its local transcript, and restore
+  /// the authoritative main-chat projection before the product UI is revealed.
+  func finishOnboardingJournal() async {
+    let fallbackMessages = preOnboardingMainMessages ?? []
+    _ = await clearOnboardingJournal()
+    isOnboarding = false
+    let reloaded = await kernelTurnProjection.reload(surface: mainChatSurfaceReference())
+    if !reloaded {
+      messages = fallbackMessages
+      resetMessagesPagination()
+    }
+    preOnboardingMainMessages = nil
   }
 
   /// Clear current session messages (delete and create new)

--- a/desktop/macos/Desktop/Sources/Startup/StartupSystemMaintenancePolicy.swift
+++ b/desktop/macos/Desktop/Sources/Startup/StartupSystemMaintenancePolicy.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct StartupSystemMaintenanceCommand: Equatable, Sendable {
+  let label: String
+  let executable: String
+  let arguments: [String]
+}
+
+/// System commands allowed during normal app startup.
+///
+/// Keep this list bundle-local. Launching Omi must not mutate shared macOS
+/// services such as the Dock or icon cache agents.
+enum StartupSystemMaintenancePolicy {
+  static func commands(bundlePath: String) -> [StartupSystemMaintenanceCommand] {
+    [
+      StartupSystemMaintenanceCommand(
+        label: "AppDelegate: strip provenance xattrs",
+        executable: "/usr/bin/xattr",
+        arguments: ["-cr", bundlePath]
+      )
+    ]
+  }
+}

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -1026,11 +1026,16 @@ final class AgentRuntimeProcessTests: XCTestCase {
       .deletingLastPathComponent()
       .appendingPathComponent("Sources/Chat/AgentRuntimeProcess.swift")
     let source = try String(contentsOf: sourceURL, encoding: .utf8)
+    let whitespaceNormalizedSource = source.split(whereSeparator: \.isWhitespace).joined(separator: " ")
 
     XCTAssertTrue(source.contains("Self.removeInheritedBYOKEnvironment(from: &env)"))
     XCTAssertTrue(source.contains("let byok = await Self.usableBYOKEnvironment()"))
     XCTAssertTrue(
-      source.contains("let forceRefreshToken = preferredAdapterId == .piMono && !DesktopLocalProfile.isEnabled"))
+      whitespaceNormalizedSource.contains(
+        "let forceRefreshToken = preferredAdapterId == .piMono "
+          + "&& AgentRuntimeCredentialPolicy.shouldForceRefreshAtStartup("
+      ))
+    XCTAssertTrue(source.contains("isDesktopLocalProfile: DesktopLocalProfile.isEnabled"))
     XCTAssertTrue(source.contains("getAuthHeader("))
     XCTAssertTrue(source.contains("forceRefresh: forceRefreshToken"))
     XCTAssertTrue(source.contains("expectedUserId: authorizationSnapshot.ownerID"))

--- a/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
+++ b/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
@@ -50,7 +50,7 @@ final class FailLoudConfigTests: XCTestCase {
   // MARK: BL-047 — system audio permission truth
 
   /// Core Audio process taps do not expose a preflight API. The app must not
-  /// proxy this through Screen Recording; it reports the last real tap outcome.
+  /// proxy this through Screen Recording; it retains the last real tap outcome.
   func testCheckSystemAudioPermissionUsesObservedTapOutcome() throws {
     let src = try source(relativePath: "Sources/AppState/AppState+SystemActions.swift")
 
@@ -74,9 +74,9 @@ final class FailLoudConfigTests: XCTestCase {
     XCTAssertTrue(
       body.contains("service.capturing"),
       "active system audio capture should preserve a granted state")
-    XCTAssertTrue(
+    XCTAssertFalse(
       body.contains("recordSystemAudioCaptureOutcome(.unknown)"),
-      "refreshes without an active tap must not keep stale granted state")
+      "an idle refresh has no new evidence and must not erase onboarding's successful tap")
   }
 
   func testSystemAudioCaptureOutcomesUpdatePermissionState() throws {
@@ -114,9 +114,9 @@ final class FailLoudConfigTests: XCTestCase {
   }
 
   @MainActor
-  func testSystemAudioOutcomeMappingAndIdleDowngrade() {
+  func testSystemAudioOutcomeMappingAndIdleReconciliation() {
     // Behavioral contract (BL-047): status follows OBSERVED tap outcomes and
-    // never claims granted while idle.
+    // an idle refresh cannot discard the last real observation.
     let state = AppState()
     state.recordSystemAudioCaptureOutcome(.granted)
     XCTAssertEqual(state.systemAudioPermissionStatus, .granted)
@@ -126,13 +126,12 @@ final class FailLoudConfigTests: XCTestCase {
     XCTAssertEqual(state.systemAudioPermissionStatus, .denied)
     XCTAssertFalse(state.hasSystemAudioPermission)
 
-    // A stale granted (no live capture) must downgrade to unknown on re-check,
-    // never persist as granted — and idle unknown must not count as a missing
-    // permission (it would permanently suppress the all-granted banner).
+    // A successful onboarding prime remains authoritative across the transition
+    // to the main app. There is no idle preflight that can contradict it.
     state.recordSystemAudioCaptureOutcome(.granted)
     state.checkSystemAudioPermission()
-    XCTAssertEqual(state.systemAudioPermissionStatus, .unknown)
-    XCTAssertFalse(state.hasSystemAudioPermission)
+    XCTAssertEqual(state.systemAudioPermissionStatus, .granted)
+    XCTAssertTrue(state.hasSystemAudioPermission)
     XCTAssertFalse(state.missingPermissions.contains("System Audio"))
 
     // A proven denial DOES count as missing, and persists through re-checks
@@ -142,6 +141,21 @@ final class FailLoudConfigTests: XCTestCase {
     state.checkSystemAudioPermission()
     XCTAssertEqual(state.systemAudioPermissionStatus, .denied)
     XCTAssertTrue(state.missingPermissions.contains("System Audio"))
+  }
+
+  @MainActor
+  func testSystemAudioPrimeReconcilesSuccessAndFailureThroughSharedState() async {
+    let state = AppState()
+
+    let granted = await state.reconcileSystemAudioPermission { true }
+    XCTAssertTrue(granted)
+    XCTAssertEqual(state.systemAudioPermissionStatus, .granted)
+    XCTAssertTrue(state.hasSystemAudioPermission)
+
+    let denied = await state.reconcileSystemAudioPermission { false }
+    XCTAssertFalse(denied)
+    XCTAssertEqual(state.systemAudioPermissionStatus, .denied)
+    XCTAssertFalse(state.hasSystemAudioPermission)
   }
 
   @available(macOS 14.4, *)

--- a/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
@@ -367,7 +367,7 @@ import XCTest
       projection.invalidateOwnerState()
       await projection.refresh(surface: surface)
       await gate.releaseOwnerA(with: ownerAPage)
-      await ownerARefresh.value
+      _ = await ownerARefresh.value
 
       XCTAssertEqual(provider.messages.map(\.id), ["owner-b-turn"])
       XCTAssertEqual(provider.messages.map(\.text), ["Owner B history"])
@@ -460,14 +460,17 @@ import XCTest
       XCTAssertEqual(clearCalls.map(\.generation), [7])
     }
 
-    func testOnboardingResetClearsLocalJournalWithoutDeletingBackendChat() async {
+    func testOnboardingResetClearsOnlyLocalOnboardingJournal() async {
       let provider = ChatProvider()
+      var listedSurfaces: [AgentSurfaceReference] = []
+      var clearedSurfaces: [AgentSurfaceReference] = []
       var deleteBackendCalls: [Bool] = []
       provider.kernelTurnProjection = KernelTurnProjection(
         host: provider,
         client: AgentClient.Session(harnessMode: "piMono"),
         ownerIDProvider: { "onboarding-reset-owner" },
-        journalListOperation: { _, _, _, afterTurnSeq, limit in
+        journalListOperation: { _, surface, _, afterTurnSeq, limit in
+          listedSurfaces.append(surface)
           XCTAssertEqual(afterTurnSeq, 0)
           XCTAssertEqual(limit, 1)
           return self.journalPage(
@@ -476,18 +479,19 @@ import XCTest
             generation: 4
           )
         },
-        journalClearOperation: { _, _, _, _, deleteBackend in
+        journalClearOperation: { _, surface, _, _, deleteBackend in
+          clearedSurfaces.append(surface)
           deleteBackendCalls.append(deleteBackend)
           return 0
         },
         kernelReadyOperation: { true }
       )
 
-      let cleared = await provider.clearDefaultJournalForOnboardingReset()
+      let cleared = await provider.clearOnboardingJournal()
 
-      // The onboarding reset still clears the local journal, but must NOT delete
-      // the user's server-side chat history — the reset is local-only.
       XCTAssertTrue(cleared)
+      XCTAssertEqual(listedSurfaces, [.onboarding()])
+      XCTAssertEqual(clearedSurfaces, [.onboarding()])
       XCTAssertEqual(deleteBackendCalls, [false])
     }
 
@@ -757,6 +761,79 @@ import XCTest
       XCTAssertFalse(cleared)
       XCTAssertEqual(clearCallCount, 0)
       XCTAssertEqual(provider.messages.map(\.id), ["owner-b-visible"])
+    }
+
+    func testReloadFailureKeepsTheExistingProjectionVisible() async throws {
+      struct ReloadFailure: Error {}
+
+      let provider = ChatProvider()
+      let surface = provider.mainChatSurfaceReference()
+      provider.projectJournalTurn(
+        try turn(
+          surface: surface,
+          turnId: "existing-main-turn",
+          turnSeq: 1,
+          content: "Keep the existing main chat visible"
+        ))
+      let projection = KernelTurnProjection(
+        host: provider,
+        client: AgentClient.Session(harnessMode: "piMono"),
+        ownerIDProvider: { "owner-b" },
+        journalListOperation: { _, _, _, _, _ in throw ReloadFailure() },
+        kernelReadyOperation: { true }
+      )
+
+      let reloaded = await projection.reload(surface: surface)
+
+      XCTAssertFalse(reloaded)
+      XCTAssertEqual(provider.messages.map(\.id), ["existing-main-turn"])
+    }
+
+    func testReloadSecondPageFailureDoesNotPublishAPartialReplacement() async throws {
+      struct ReloadFailure: Error {}
+
+      let provider = ChatProvider()
+      let surface = provider.mainChatSurfaceReference()
+      provider.projectJournalTurn(
+        try turn(
+          surface: surface,
+          turnId: "existing-main-turn",
+          turnSeq: 1,
+          content: "Keep the complete existing chat"
+        ))
+      var listCalls = 0
+      let replacement = try turn(
+        surface: surface,
+        turnId: "replacement-first-page",
+        turnSeq: 1,
+        content: "Do not publish this partial page"
+      )
+      let projection = KernelTurnProjection(
+        host: provider,
+        client: AgentClient.Session(harnessMode: "piMono"),
+        ownerIDProvider: { "owner-b" },
+        journalListOperation: { _, _, _, _, _ in
+          listCalls += 1
+          guard listCalls == 1 else { throw ReloadFailure() }
+          return AgentRuntimeProcess.JournalOperationResult(
+            operation: "list",
+            conversationId: "replacement-conversation",
+            turn: nil,
+            turns: [replacement],
+            clearedCount: 0,
+            highWaterTurnSeq: 2,
+            conversationGeneration: 1,
+            generationBaseTurnSeq: 0
+          )
+        },
+        kernelReadyOperation: { true }
+      )
+
+      let reloaded = await projection.reload(surface: surface)
+
+      XCTAssertFalse(reloaded)
+      XCTAssertEqual(listCalls, 2)
+      XCTAssertEqual(provider.messages.map(\.id), ["existing-main-turn"])
     }
 
     func testRuntimeOwnerNotificationSynchronouslyInvalidatesVisibleProjection() throws {

--- a/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
@@ -836,6 +836,56 @@ import XCTest
       XCTAssertEqual(provider.messages.map(\.id), ["existing-main-turn"])
     }
 
+    func testQueuedReloadSuccessSupersedesAnEarlierFailedPass() async throws {
+      struct FirstPassFailure: Error {}
+
+      let provider = ChatProvider()
+      let surface = provider.mainChatSurfaceReference()
+      provider.projectJournalTurn(
+        try turn(
+          surface: surface,
+          turnId: "existing-main-turn",
+          turnSeq: 1,
+          content: "Replace this stale transcript"
+        ))
+      let replacement = try turn(
+        surface: surface,
+        turnId: "replacement-turn",
+        turnSeq: 1,
+        content: "Fresh complete transcript"
+      )
+      let projectionBox = Box<KernelTurnProjection?>(nil)
+      var listCalls = 0
+      let projection = KernelTurnProjection(
+        host: provider,
+        client: AgentClient.Session(harnessMode: "piMono"),
+        ownerIDProvider: { "owner-b" },
+        journalListOperation: { _, _, _, _, _ in
+          listCalls += 1
+          if listCalls == 1 {
+            guard let nestedProjection = projectionBox.value else {
+              throw FirstPassFailure()
+            }
+            _ = await nestedProjection.refresh(surface: surface)
+            throw FirstPassFailure()
+          }
+          return self.journalPage(
+            conversationId: "replacement-conversation",
+            turns: [replacement]
+          )
+        },
+        kernelReadyOperation: { true }
+      )
+      projectionBox.value = projection
+
+      let reloaded = await projection.reload(surface: surface)
+
+      XCTAssertTrue(reloaded)
+      XCTAssertEqual(listCalls, 2)
+      XCTAssertEqual(provider.messages.map(\.id), ["replacement-turn"])
+      XCTAssertEqual(provider.messages.map(\.text), ["Fresh complete transcript"])
+    }
+
     func testRuntimeOwnerNotificationSynchronouslyInvalidatesVisibleProjection() throws {
       let provider = ChatProvider()
       let surface = provider.mainChatSurfaceReference()

--- a/desktop/macos/Desktop/Tests/OnboardingPermissionToolTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPermissionToolTests.swift
@@ -59,16 +59,16 @@ final class OnboardingPermissionToolTests: XCTestCase {
   }
 
   @MainActor
-  func testRepeatedSystemAudioPollingCancelsTheOlderConsentTask() {
+  func testRepeatedSystemAudioPollingCancelsTheOlderConsentTask() throws {
     let model = SBOnboardingModel(
       appState: AppState(),
       chatProvider: ChatProvider(),
       onComplete: nil)
 
     model.pollPermission("system_audio")
-    let first = model.pollTasks["system_audio"]!
+    let first = try XCTUnwrap(model.pollTasks["system_audio"])
     model.pollPermission("system_audio")
-    let second = model.pollTasks["system_audio"]!
+    let second = try XCTUnwrap(model.pollTasks["system_audio"])
     defer { second.cancel() }
 
     XCTAssertTrue(first.isCancelled)

--- a/desktop/macos/Desktop/Tests/OnboardingPermissionToolTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPermissionToolTests.swift
@@ -32,4 +32,46 @@ final class OnboardingPermissionToolTests: XCTestCase {
         "full_disk_access",
       ])
   }
+
+  @MainActor
+  func testPregrantedScreenRecordingDoesNotSkipSeparateSystemAudioConsent() {
+    let appState = AppState()
+    appState.hasScreenRecordingPermission = true
+    appState.recordSystemAudioCaptureOutcome(.unknown)
+    let model = SBOnboardingModel(
+      appState: appState,
+      chatProvider: ChatProvider(),
+      onComplete: nil)
+
+    XCTAssertFalse(
+      model.isGranted("system_audio"),
+      "Screen Recording alone must never be reported as a system-audio grant")
+    XCTAssertEqual(
+      model.firstUnaskedStep(from: .systemAudio),
+      .systemAudio,
+      "Screen Recording is only a prerequisite; it cannot stand in for a successful Core Audio tap")
+
+    appState.recordSystemAudioCaptureOutcome(.denied)
+    XCTAssertEqual(
+      model.firstUnaskedStep(from: .systemAudio),
+      .systemAudio,
+      "a real denied tap must keep the system-audio permission step visible")
+  }
+
+  @MainActor
+  func testRepeatedSystemAudioPollingCancelsTheOlderConsentTask() {
+    let model = SBOnboardingModel(
+      appState: AppState(),
+      chatProvider: ChatProvider(),
+      onComplete: nil)
+
+    model.pollPermission("system_audio")
+    let first = model.pollTasks["system_audio"]!
+    model.pollPermission("system_audio")
+    let second = model.pollTasks["system_audio"]!
+    defer { second.cancel() }
+
+    XCTAssertTrue(first.isCancelled)
+    XCTAssertFalse(second.isCancelled)
+  }
 }

--- a/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
@@ -93,5 +93,11 @@ final class OnboardingPersistenceClearingTests: XCTestCase {
     XCTAssertNil(
       tail.range(of: "removeObject(forKey: \"onboardingStep\")"),
       "resetOnboardingAndRestart() must not keep a hand-rolled onboarding key list")
+    XCTAssertNil(
+      tail.range(of: "deleteKnowledgeGraph"),
+      "resetting onboarding must not delete the user's server knowledge graph")
+    XCTAssertNil(
+      tail.range(of: "KnowledgeGraphStorage.shared.clearAll"),
+      "resetting onboarding must not clear the user's local knowledge graph")
   }
 }

--- a/desktop/macos/Desktop/Tests/RealtimeHubSessionHandoffPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSessionHandoffPolicyTests.swift
@@ -16,8 +16,10 @@ final class RealtimeHubSessionHandoffPolicyTests: XCTestCase {
       gate.replace(
         stop: {
           events.append("stop")
-          stopEntered.fulfill()
-          await withCheckedContinuation { releaseStop = $0 }
+          await withCheckedContinuation {
+            releaseStop = $0
+            stopEntered.fulfill()
+          }
           events.append("drained")
         },
         start: {
@@ -49,8 +51,10 @@ final class RealtimeHubSessionHandoffPolicyTests: XCTestCase {
     XCTAssertTrue(
       gate.replace(
         stop: {
-          stopEntered.fulfill()
-          await withCheckedContinuation { releaseStop = $0 }
+          await withCheckedContinuation {
+            releaseStop = $0
+            stopEntered.fulfill()
+          }
         },
         start: { startCount += 1 }))
     await fulfillment(of: [stopEntered], timeout: 1)

--- a/desktop/macos/Desktop/Tests/RealtimeHubSessionHandoffPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSessionHandoffPolicyTests.swift
@@ -203,7 +203,6 @@ final class RealtimeHubSessionHandoffPolicyTests: XCTestCase {
   }
 
   @MainActor
-  @MainActor
   func testBargeInFailoverExhaustedWhenAlternateProviderAlreadyActive() {
     DesktopDiagnosticsManager.shared.resetForTests()
     defer { DesktopDiagnosticsManager.shared.resetForTests() }

--- a/desktop/macos/Desktop/Tests/RealtimeVoiceContextSingleFlightTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeVoiceContextSingleFlightTests.swift
@@ -34,6 +34,27 @@ final class RealtimeVoiceContextSingleFlightTests: XCTestCase {
     }
   }
 
+  @MainActor
+  private final class Signal {
+    private var didFire = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func fire() {
+      didFire = true
+      for waiter in waiters {
+        waiter.resume()
+      }
+      waiters.removeAll()
+    }
+
+    func wait() async {
+      guard !didFire else { return }
+      await withCheckedContinuation { continuation in
+        waiters.append(continuation)
+      }
+    }
+  }
+
   private func waitUntilStarted(_ gate: Gate) async {
     await gate.waitUntilStarted()
   }
@@ -41,10 +62,16 @@ final class RealtimeVoiceContextSingleFlightTests: XCTestCase {
   func testCancelledTurnWaiterDoesNotCancelSharedReadiness() async {
     let singleFlight = RealtimeVoiceContextSingleFlight()
     let gate = Gate()
+    let turnWaiterJoined = Signal()
 
     let speculative = singleFlight.joinOrStart { await gate.run() }
-    let turnWaiter = Task { await singleFlight.joinOrStart { await gate.run() }.value }
+    let turnWaiter = Task {
+      let sharedReadiness = singleFlight.joinOrStart { await gate.run() }
+      turnWaiterJoined.fire()
+      return await sharedReadiness.value
+    }
     await waitUntilStarted(gate)
+    await turnWaiterJoined.wait()
 
     XCTAssertEqual(gate.startCount, 1)
     XCTAssertTrue(singleFlight.isRunning)

--- a/desktop/macos/Desktop/Tests/RealtimeVoiceContextSingleFlightTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeVoiceContextSingleFlightTests.swift
@@ -4,14 +4,27 @@ import XCTest
 
 @MainActor
 final class RealtimeVoiceContextSingleFlightTests: XCTestCase {
+  @MainActor
   private final class Gate {
     var startCount = 0
     var continuation: CheckedContinuation<Bool, Never>?
+    var startedWaiters: [CheckedContinuation<Void, Never>] = []
 
     func run() async -> Bool {
       startCount += 1
+      for waiter in startedWaiters {
+        waiter.resume()
+      }
+      startedWaiters.removeAll()
       return await withCheckedContinuation { continuation in
         self.continuation = continuation
+      }
+    }
+
+    func waitUntilStarted() async {
+      guard startCount == 0 else { return }
+      await withCheckedContinuation { continuation in
+        startedWaiters.append(continuation)
       }
     }
 
@@ -22,9 +35,7 @@ final class RealtimeVoiceContextSingleFlightTests: XCTestCase {
   }
 
   private func waitUntilStarted(_ gate: Gate) async {
-    for _ in 0..<100 where gate.startCount == 0 {
-      await Task.yield()
-    }
+    await gate.waitUntilStarted()
   }
 
   func testCancelledTurnWaiterDoesNotCancelSharedReadiness() async {

--- a/desktop/macos/Desktop/Tests/RealtimeVoiceContextSingleFlightTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeVoiceContextSingleFlightTests.swift
@@ -11,13 +11,13 @@ final class RealtimeVoiceContextSingleFlightTests: XCTestCase {
     var startedWaiters: [CheckedContinuation<Void, Never>] = []
 
     func run() async -> Bool {
-      startCount += 1
-      for waiter in startedWaiters {
-        waiter.resume()
-      }
-      startedWaiters.removeAll()
       return await withCheckedContinuation { continuation in
         self.continuation = continuation
+        startCount += 1
+        for waiter in startedWaiters {
+          waiter.resume()
+        }
+        startedWaiters.removeAll()
       }
     }
 

--- a/desktop/macos/Desktop/Tests/SBOnboardingCloudContextStateTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingCloudContextStateTests.swift
@@ -2,29 +2,80 @@ import XCTest
 
 @testable import Omi_Computer
 
-/// Regression coverage for the onboarding ChatGPT/Claude connect chip (#new-onboarding).
+/// Regression coverage for context-connector routing and failure projection.
 ///
-/// The connect flow opens the provider's OAuth page in the browser and used to
-/// check the local connection status immediately after — which always read "not
-/// connected" (OAuth hadn't happened yet) and silently reset the chip to
-/// "Connect", never flipping to "✓ on" even after a successful authorization.
-/// Resolution now happens through a backend grant refresh when the app becomes
-/// active again, mapped through `cloudContextState`.
+/// Memory import and live MCP export are different product operations. The
+/// context rows must use the same importer as Apps > Imports, while Google
+/// functional-probe failures retain sanitized, actionable copy.
 final class SBOnboardingCloudContextStateTests: XCTestCase {
 
-  func testConnectedFlipsChipOnFromAnyState() {
-    for current in [nil, "idle", "connecting", "needsSignIn", "on"] {
-      XCTAssertEqual(SBOnboardingModel.cloudContextState(current: current, connected: true), "on")
+  func testMemoryContextRowsRouteToCanonicalImportConnectors() {
+    XCTAssertEqual(SBOnboardingModel.contextConnectionRoute(for: "chatgpt"), .importConnector("chatgpt"))
+    XCTAssertEqual(SBOnboardingModel.contextConnectionRoute(for: "claude"), .importConnector("claude"))
+    XCTAssertEqual(SBOnboardingModel.contextConnectionRoute(for: "calendar"), .direct)
+    XCTAssertEqual(SBOnboardingModel.contextConnectionRoute(for: "gmail"), .direct)
+
+    for connectorID in ["chatgpt", "claude"] {
+      let connector = ImportConnector.all.first(where: { $0.id == connectorID })
+      XCTAssertEqual(connector?.subtitle, "Memory import")
+      XCTAssertEqual(connector?.description, "Paste a memory export into Omi.")
     }
   }
 
-  func testUnfinishedConnectingResolvesToIdleSoConnectButtonReturns() {
-    XCTAssertEqual(SBOnboardingModel.cloudContextState(current: "connecting", connected: false), "idle")
+  func testGoogleSignInFailurePreservesActionableMessage() {
+    let resolution = SBOnboardingModel.googleContextResolution(
+      connectorID: "gmail",
+      connected: false,
+      needsSignIn: true
+    )
+
+    XCTAssertEqual(resolution.state, "needsSignIn")
+    XCTAssertEqual(
+      resolution.detail,
+      "Open Gmail in Chrome, Arc, Brave, or Edge, sign in, then retry."
+    )
+    XCTAssertTrue(resolution.shouldOpenSignIn)
   }
 
-  func testNotConnectedLeavesNonConnectingStatesUntouched() {
-    for current in [nil, "idle", "on", "unavailable"] {
-      XCTAssertNil(SBOnboardingModel.cloudContextState(current: current, connected: false))
-    }
+  func testGoogleOperationalFailureUsesBoundedCopyAndDoesNotOpenSignIn() {
+    let resolution = SBOnboardingModel.googleContextResolution(
+      connectorID: "calendar",
+      connected: false,
+      needsSignIn: false
+    )
+
+    XCTAssertEqual(resolution.state, "error")
+    XCTAssertEqual(
+      resolution.detail,
+      "Couldn't verify Google Calendar. Check your browser session and connection, then retry."
+    )
+    XCTAssertFalse(resolution.shouldOpenSignIn)
+  }
+
+  func testGoogleSuccessClearsOldFailureDetail() {
+    let resolution = SBOnboardingModel.googleContextResolution(
+      connectorID: "gmail",
+      connected: true,
+      needsSignIn: false
+    )
+
+    XCTAssertEqual(resolution.state, "on")
+    XCTAssertNil(resolution.detail)
+    XCTAssertFalse(resolution.shouldOpenSignIn)
+  }
+
+  @MainActor
+  func testPassiveGoogleRecoveryClearsThePreviouslyProjectedFailure() {
+    let model = SBOnboardingModel(
+      appState: AppState(),
+      chatProvider: ChatProvider(),
+      onComplete: nil)
+    model.contextStates["calendar"] = "error"
+    model.contextDetails["calendar"] = "Couldn't verify Google Calendar."
+
+    model.markContextConnected("calendar")
+
+    XCTAssertEqual(model.contextStates["calendar"], "on")
+    XCTAssertNil(model.contextDetails["calendar"])
   }
 }

--- a/desktop/macos/Desktop/Tests/StartupSystemMaintenancePolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupSystemMaintenancePolicyTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class StartupSystemMaintenancePolicyTests: XCTestCase {
+  func testStartupMaintenanceIsRestrictedToTheAppBundle() {
+    let bundlePath = "/Applications/omi.app"
+
+    let commands = StartupSystemMaintenancePolicy.commands(bundlePath: bundlePath)
+
+    XCTAssertEqual(
+      commands,
+      [
+        StartupSystemMaintenanceCommand(
+          label: "AppDelegate: strip provenance xattrs",
+          executable: "/usr/bin/xattr",
+          arguments: ["-cr", bundlePath]
+        )
+      ]
+    )
+  }
+
+  func testStartupMaintenanceNeverRestartsSharedMacOSServices() {
+    let commands = StartupSystemMaintenancePolicy.commands(bundlePath: "/Applications/omi.app")
+
+    XCTAssertFalse(commands.contains { $0.executable == "/usr/bin/killall" })
+    XCTAssertFalse(commands.contains { $0.arguments.contains("Dock") })
+    XCTAssertFalse(commands.contains { $0.arguments.contains("iconservicesagent") })
+  }
+}

--- a/desktop/macos/Desktop/Tests/TaskChatLegacyAcpMigrationTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskChatLegacyAcpMigrationTests.swift
@@ -370,6 +370,15 @@ final class TaskChatKernelIdentityTests: XCTestCase {
     XCTAssertFalse(app.contains("RecurringTaskScheduler.shared.start()"))
   }
 
+  func testAppStartupDoesNotMutateSharedLaunchServicesOrSystemProcesses() throws {
+    // omi-test-quality: source-inspection -- static startup boundary prevents
+    // direct macOS-global mutations from bypassing the command policy.
+    let app = try sourceFile("OmiApp.swift")
+    XCTAssertFalse(app.contains("LSRegisterURL("))
+    XCTAssertFalse(app.contains("iconservicesagent"))
+    XCTAssertFalse(app.contains("\"/usr/bin/killall\""))
+  }
+
   private func sourceFile(_ relativePath: String) throws -> String {
     let sourceURL = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()

--- a/desktop/macos/agent/src/runtime/conversation-journal.ts
+++ b/desktop/macos/agent/src/runtime/conversation-journal.ts
@@ -39,7 +39,7 @@ const DELETE_OUTBOX_COLUMNS = `
   created_at_ms, updated_at_ms, delivered_at_ms
 `;
 
-const LOCAL_ONLY_SURFACES = new Set(["task_chat", "workstream"]);
+const LOCAL_ONLY_SURFACES = new Set(["onboarding", "task_chat", "workstream"]);
 const DEFAULT_OUTBOX_LEASE_MS = 30_000;
 const MAX_DRAIN_BATCH = 100;
 const BACKEND_RECONCILE_PAGE_LIMIT = 100;
@@ -1154,8 +1154,11 @@ export function clearJournalConversation(
        WHERE conversation_id = ?`,
       [generation, now, input.conversationId],
     );
+    const deleteBackend =
+      canonicalJournalDelivery(store, input.ownerId, input.conversationId) === "backend"
+      && input.deleteBackend !== false;
     const backendDeleteOperationId =
-      input.deleteBackend === false
+      !deleteBackend
         ? null
         : enqueueBackendConversationDelete(store, {
             ownerId: input.ownerId,

--- a/desktop/macos/agent/src/runtime/sqlite-store.ts
+++ b/desktop/macos/agent/src/runtime/sqlite-store.ts
@@ -75,6 +75,7 @@ const CLEARED_BACKEND_TURN_CLAIMS_MIGRATION_VERSION = 24;
 const CONTEXT_SOURCE_SURFACE_SCOPE_MIGRATION_VERSION = 25;
 const BACKEND_RECONCILE_CURSOR_MIGRATION_VERSION = 26;
 const JOURNAL_PRODUCING_ATTEMPT_MIGRATION_VERSION = 27;
+const LOCAL_ONLY_JOURNAL_DELIVERY_MIGRATION_VERSION = 28;
 
 const ACTIVE_ATTEMPT_STATUSES = ["queued", "starting", "running", "waiting_input", "waiting_approval", "cancelling"] as const;
 const TERMINAL_ATTEMPT_STATUSES = ["succeeded", "failed", "cancelled", "timed_out", "orphaned"] as const;
@@ -379,8 +380,14 @@ export function probeNodeSqliteRuntime(options: NodeSqliteProbeOptions = {}): vo
     runToolInvocationLedgerMigration(db, Date.now());
     runKernelContextAuthorityMigration(db, Date.now());
     runJournalGenerationBaseMigration(db, Date.now());
+    runOwnerContextSnapshotMigration(db, Date.now());
+    runBackendConversationDeleteOutboxMigration(db, Date.now());
+    runBackendReconcileStateMigration(db, Date.now());
+    runClearedBackendTurnClaimsMigration(db, Date.now());
     runContextSourceSurfaceScopeMigration(db, Date.now());
+    runBackendReconcileCursorMigration(db, Date.now());
     runJournalProducingAttemptMigration(db, Date.now());
+    runLocalOnlyJournalDeliveryMigration(db, Date.now());
     runTransaction(db, () => {
       db?.prepare("INSERT INTO sessions (session_id, owner_id, status, surface_kind, default_adapter_id, created_at_ms, updated_at_ms, last_activity_at_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(
         "ses_probe",
@@ -512,6 +519,9 @@ export class SqliteAgentStore implements AgentStore {
     }
     if (!this.hasMigration(JOURNAL_PRODUCING_ATTEMPT_MIGRATION_VERSION)) {
       runJournalProducingAttemptMigration(this.db, this.nowMs());
+    }
+    if (!this.hasMigration(LOCAL_ONLY_JOURNAL_DELIVERY_MIGRATION_VERSION)) {
+      runLocalOnlyJournalDeliveryMigration(this.db, this.nowMs());
     }
   }
 
@@ -3192,6 +3202,55 @@ function runJournalProducingAttemptMigration(
     `);
     db.prepare("INSERT INTO schema_migrations (version, applied_at_ms) VALUES (?, ?)").run(
       JOURNAL_PRODUCING_ATTEMPT_MIGRATION_VERSION,
+      appliedAtMs,
+    );
+  });
+}
+
+function runLocalOnlyJournalDeliveryMigration(
+  db: Pick<DatabaseSync, "exec" | "prepare" | "isTransaction">,
+  appliedAtMs: number,
+): void {
+  runTransaction(db, () => {
+    // Canonical surface ownership is the delivery authority. Remove only rows
+    // whose owner and conversation both resolve to a local-only surface so an
+    // upgrade cannot flush previously queued onboarding/task data to backend.
+    db.exec(`
+      DELETE FROM backend_turn_outbox
+      WHERE EXISTS (
+        SELECT 1
+        FROM surface_conversations
+        WHERE surface_conversations.conversation_id = backend_turn_outbox.conversation_id
+          AND surface_conversations.owner_id = backend_turn_outbox.owner_id
+          AND surface_conversations.surface_kind IN ('onboarding', 'task_chat', 'workstream')
+      );
+      DELETE FROM backend_conversation_delete_outbox
+      WHERE EXISTS (
+        SELECT 1
+        FROM surface_conversations
+        WHERE surface_conversations.conversation_id = backend_conversation_delete_outbox.conversation_id
+          AND surface_conversations.owner_id = backend_conversation_delete_outbox.owner_id
+          AND surface_conversations.surface_kind IN ('onboarding', 'task_chat', 'workstream')
+      );
+      DELETE FROM backend_reconcile_state
+      WHERE EXISTS (
+        SELECT 1
+        FROM surface_conversations
+        WHERE surface_conversations.conversation_id = backend_reconcile_state.conversation_id
+          AND surface_conversations.owner_id = backend_reconcile_state.owner_id
+          AND surface_conversations.surface_kind IN ('onboarding', 'task_chat', 'workstream')
+      );
+      DELETE FROM cleared_backend_turn_claims
+      WHERE EXISTS (
+        SELECT 1
+        FROM surface_conversations
+        WHERE surface_conversations.conversation_id = cleared_backend_turn_claims.conversation_id
+          AND surface_conversations.owner_id = cleared_backend_turn_claims.owner_id
+          AND surface_conversations.surface_kind IN ('onboarding', 'task_chat', 'workstream')
+      );
+    `);
+    db.prepare("INSERT INTO schema_migrations (version, applied_at_ms) VALUES (?, ?)").run(
+      LOCAL_ONLY_JOURNAL_DELIVERY_MIGRATION_VERSION,
       appliedAtMs,
     );
   });

--- a/desktop/macos/agent/tests/conversation-journal.test.ts
+++ b/desktop/macos/agent/tests/conversation-journal.test.ts
@@ -112,6 +112,7 @@ describe("kernel conversation journal", () => {
   it("derives delivery from the canonical conversation and rejects surface spoofing", () => {
     const store = new SqliteAgentStore({ stateDir: newStateDir(), reconcileOnOpen: false });
     const main = insertSurface(store, "main_chat", "chat", "canonical-main");
+    const onboarding = insertSurface(store, "onboarding", "session", "canonical-onboarding");
     const task = insertSurface(store, "task_chat", "task", "canonical-task");
     const base = {
       ownerId: main.ownerId,
@@ -136,6 +137,12 @@ describe("kernel conversation journal", () => {
       surfaceKind: "task_chat",
       origin: "task_chat",
     })).toMatchObject({ created: true, outboxStatus: null });
+    expect(recordJournalTurn(store, {
+      ...base,
+      conversationId: onboarding.conversationId,
+      turnId: "turn-onboarding",
+      surfaceKind: "onboarding",
+    })).toMatchObject({ created: true, outboxStatus: null });
     expect(() => recordJournalTurn(store, {
       ...base,
       conversationId: main.conversationId,
@@ -144,10 +151,10 @@ describe("kernel conversation journal", () => {
       origin: "task_chat",
     })).toThrow(/canonical conversation delivery boundary/i);
 
-    expect(store.getRow("SELECT COUNT(*) AS count FROM conversation_turns").count).toBe(2);
-    expect(store.getRow("SELECT COUNT(*) AS count FROM conversation_turn_revisions").count).toBe(2);
+    expect(store.getRow("SELECT COUNT(*) AS count FROM conversation_turns").count).toBe(3);
+    expect(store.getRow("SELECT COUNT(*) AS count FROM conversation_turn_revisions").count).toBe(3);
     expect(store.getRow("SELECT COUNT(*) AS count FROM backend_turn_outbox").count).toBe(1);
-    expect(store.getRow("SELECT COUNT(*) AS count FROM conversation_journal_state").count).toBe(2);
+    expect(store.getRow("SELECT COUNT(*) AS count FROM conversation_journal_state").count).toBe(3);
     store.close();
   });
 
@@ -2744,6 +2751,37 @@ describe("kernel conversation journal", () => {
       ownerId: fixture.ownerId,
       nowMs: 91,
     })).toHaveLength(0);
+    fixture.store.close();
+  });
+
+  it("canonical local-only ownership suppresses backend deletion even when a caller requests it", () => {
+    const fixture = newSurface("onboarding", "session", "default");
+    recordJournalTurn(fixture.store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      turnId: "turn-local-onboarding",
+      role: "assistant",
+      surfaceKind: "onboarding",
+      origin: "agent_runtime",
+      status: "completed",
+      content: "setup only",
+      contentBlocks: [{ type: "text", id: "setup:text", text: "setup only" }],
+      createdAtMs: 10,
+    });
+    const cleared = clearJournalConversation(fixture.store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      expectedGeneration: 1,
+      nowMs: 90,
+      deleteBackend: true,
+    });
+
+    expect(cleared.deletedTurns).toBe(1);
+    expect(cleared.backendDeleteOperationId).toBeNull();
+    expect(drainBackendConversationDeleteOutbox(fixture.store, {
+      ownerId: fixture.ownerId,
+      nowMs: 91,
+    })).toEqual([]);
     fixture.store.close();
   });
 

--- a/desktop/macos/agent/tests/sqlite-store.test.ts
+++ b/desktop/macos/agent/tests/sqlite-store.test.ts
@@ -21,7 +21,7 @@ describe("SqliteAgentStore", () => {
     store.migrate();
     store.migrate();
 
-    expect(store.getRow("SELECT COUNT(*) AS count FROM schema_migrations").count).toBe(27);
+    expect(store.getRow("SELECT COUNT(*) AS count FROM schema_migrations").count).toBe(28);
     expect(tableNames(store)).toEqual([
       "adapter_bindings",
       "artifacts",
@@ -205,6 +205,67 @@ describe("SqliteAgentStore", () => {
     })).toThrow();
 
     store.close();
+  });
+
+  it("drops queued backend delivery when an upgraded conversation is canonically local-only", () => {
+    const databasePath = newDatabasePath();
+    const store = new SqliteAgentStore({ databasePath, reconcileOnOpen: false });
+    const session = store.insertSession({
+      ownerId: "owner",
+      surfaceKind: "main_chat",
+      defaultAdapterId: "acp",
+    });
+    store.insertSurfaceConversation({
+      ownerId: "owner",
+      surfaceKind: "main_chat",
+      externalRefKind: "chat",
+      externalRefId: "upgrade-local-only",
+      conversationId: "conv-upgrade-local-only",
+      agentSessionId: session.sessionId,
+      createdAtMs: 1,
+      lastActiveAtMs: 1,
+    });
+    store.execute(
+      `INSERT INTO conversation_turns(
+         turn_id, conversation_id, role, surface_kind, origin, status,
+         content, content_blocks_json, resources_json, metadata_json, created_at_ms,
+         updated_at_ms, turn_seq
+       ) VALUES (
+         'turn-upgrade-local-only', 'conv-upgrade-local-only', 'user',
+         'main_chat', 'typed_chat', 'completed', 'setup transcript', '[]', '[]',
+         '{}', 2, 2, 1
+       )`,
+    );
+    store.execute(
+      `INSERT INTO backend_turn_outbox(
+         turn_id, conversation_id, owner_id, client_message_id, status, attempt_count,
+         delivery_generation, conversation_generation, payload_hash,
+         available_at_ms, created_at_ms, updated_at_ms
+       ) VALUES (
+         'turn-upgrade-local-only', 'conv-upgrade-local-only', 'owner',
+         'turn-upgrade-local-only', 'pending',
+         0, 0, 1, 'sha256:upgrade-local-only', 2, 2, 2
+       )`,
+    );
+    store.execute(
+      `UPDATE surface_conversations
+       SET surface_kind = 'onboarding'
+       WHERE conversation_id = 'conv-upgrade-local-only' AND owner_id = 'owner'`,
+    );
+    store.execute("DELETE FROM schema_migrations WHERE version = 28");
+    store.close();
+
+    const upgraded = new SqliteAgentStore({ databasePath, reconcileOnOpen: false });
+    expect(upgraded.getRow(
+      "SELECT COUNT(*) AS count FROM backend_turn_outbox WHERE conversation_id = 'conv-upgrade-local-only'",
+    ).count).toBe(0);
+    expect(upgraded.getRow(
+      "SELECT COUNT(*) AS count FROM conversation_turns WHERE conversation_id = 'conv-upgrade-local-only'",
+    ).count).toBe(1);
+    expect(upgraded.getRow(
+      "SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 28",
+    ).count).toBe(1);
+    upgraded.close();
   });
 
   it("persists desktop coordinator records and rejects invalid JSON", () => {

--- a/desktop/macos/agent/tests/workstream-continuity.test.ts
+++ b/desktop/macos/agent/tests/workstream-continuity.test.ts
@@ -119,7 +119,7 @@ describe("workstream continuity", () => {
       delivery_status: "blocked",
       status: "rejected",
     });
-    expect(store.getRow("SELECT COUNT(*) AS count FROM schema_migrations").count).toBe(27);
+    expect(store.getRow("SELECT COUNT(*) AS count FROM schema_migrations").count).toBe(28);
     store.close();
   });
 

--- a/desktop/macos/changelog/unreleased/20260724-first-launch-performance.json
+++ b/desktop/macos/changelog/unreleased/20260724-first-launch-performance.json
@@ -1,0 +1,3 @@
+{
+  "change": "Reduced first-launch disruption by removing system-wide icon cache maintenance"
+}

--- a/desktop/macos/changelog/unreleased/20260724-onboarding-connectors.json
+++ b/desktop/macos/changelog/unreleased/20260724-onboarding-connectors.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed ChatGPT memory import routing and made Google connector failures actionable"
+}

--- a/desktop/macos/changelog/unreleased/20260724-onboarding-data-isolation.json
+++ b/desktop/macos/changelog/unreleased/20260724-onboarding-data-isolation.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed setup conversations and sample tasks appearing in normal chat and task history"
+}

--- a/desktop/macos/changelog/unreleased/20260724-system-audio-permission-reconciliation.json
+++ b/desktop/macos/changelog/unreleased/20260724-system-audio-permission-reconciliation.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed system audio permission being requested again after setup"
+}

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -37,6 +37,7 @@ covers:
   - desktop/macos/Desktop/Sources/ViewExporter.swift
   - desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
   - desktop/macos/Desktop/Sources/Startup/OmiFontRegistration.swift
+  - desktop/macos/Desktop/Sources/Startup/StartupSystemMaintenancePolicy.swift
 preconditions:
   - automation_bridge_ready
 

--- a/desktop/macos/e2e/flows/onboarding-smoke.yaml
+++ b/desktop/macos/e2e/flows/onboarding-smoke.yaml
@@ -9,6 +9,7 @@ covers:
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift
+  - desktop/macos/Desktop/Sources/Providers/ChatProvider+OnboardingJournal.swift
 preconditions:
   - automation_bridge_ready
   - auth_ready


### PR DESCRIPTION
## What changed and why

Isolate onboarding-owned conversations, permissions, connectors, and reset behavior from normal product state after a user interview exposed setup data leaking into chat/tasks and system-audio consent being requested again. Remove first-launch maintenance that mutated LaunchServices and shared macOS icon/Dock processes.

## Product invariants affected

- INV-AGENT-*
- INV-AUTH-1
- INV-CHAT-1

## How it was verified

- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm test` — 599 agent-runtime tests passed
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run build` — agent TypeScript build passed
- `xcrun swift build` — production macOS app compiled and linked successfully
- `./scripts/swift-test-suites.sh` — all 374 desktop Swift suites passed in isolated processes with four workers
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — desktop test-quality ratchets passed
- `PATH=backend/.venv/bin:/opt/homebrew/opt/node@22/bin:$PATH desktop/macos/scripts/desktop-core-harness.sh --self-check --skip-backend-contracts` — flow lint and desktop static E2E contracts passed
- `make preflight` and the bounded pre-push gate passed
- Built and launched the isolated `com.omi.omi-onboarding-boundaries` bundle; the automation bridge reported the expected bundle and its startup log contained only bundle-local provenance cleanup, with no LaunchServices, Dock, or icon-service mutation

## Tests

- Added journal delivery and upgrade tests proving onboarding/task/workstream surfaces remain local-only and cannot enqueue backend deletion
- Added projection tests proving failed or partially failed main-chat reloads retain the complete visible transcript, while a successful queued refresh supersedes an earlier failed pass
- Added system-audio reconciliation and duplicate-poll cancellation tests
- Added connector routing, bounded Google failure, and passive recovery tests
- Added startup maintenance allowlist and direct global-mutation tripwires
- Replaced a timing-sensitive single-flight test gate with deterministic continuation signaling

## Failure class (fixes)

Failure-Class: FC-split-mutation-authority

## Scoped cleanups

- Extracted onboarding journal lifecycle from the oversized chat provider and ratcheted the provider and app-root line-count ceilings downward


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

