### PR TITLE
fix(backend): restore GPT-5.6 conversation prompt caching

### DIFF
--- a/backend/llm_gateway/config/cost_rate_cards.yaml
+++ b/backend/llm_gateway/config/cost_rate_cards.yaml
@@ -25,6 +25,7 @@ rate_cards:
     input_micro_usd_per_million: 1000000
     cached_input_micro_usd_per_million: 100000
     output_micro_usd_per_million: 6000000
+    cache_write_micro_usd_per_million: 1250000
 
   - rate_card_id: vertex.gemini-2.5-flash.2026-07-17
     provider: gemini

--- a/backend/llm_gateway/gateway/accounting.py
+++ b/backend/llm_gateway/gateway/accounting.py
@@ -538,7 +538,9 @@ def _openai_usage(raw: Mapping[str, Any], *, cache_requested: bool) -> ProviderU
     return ProviderUsage(
         prompt_tokens=prompt,
         cached_input_tokens=cached,
-        uncached_input_tokens=max(prompt - cached, 0),
+        # OpenAI includes explicit cache-write tokens in prompt_tokens; their
+        # write rate replaces the ordinary uncached-input rate for those units.
+        uncached_input_tokens=max(prompt - cached - cache_write, 0),
         output_tokens=output,
         reasoning_tokens=reasoning,
         output_tokens_include_reasoning=True,

--- a/backend/llm_gateway/gateway/accounting.py
+++ b/backend/llm_gateway/gateway/accounting.py
@@ -431,7 +431,28 @@ def image_usage(*, count: int, size: object, quality: object) -> ProviderUsage:
 
 def cache_requested_for_openai_request(request: Mapping[str, Any]) -> bool:
     prompt_cache_key = request.get('prompt_cache_key')
-    return isinstance(prompt_cache_key, str) and bool(prompt_cache_key.strip())
+    if not isinstance(prompt_cache_key, str) or not prompt_cache_key.strip():
+        return False
+    # Pre-5.6 callers use implicit caching with only a routing key.  Explicit
+    # GPT-5.6 requests without a marker deliberately opt out of cache writes.
+    if request.get('prompt_cache_options') == {'mode': 'explicit', 'ttl': '30m'}:
+        return _has_openai_cache_breakpoint(request.get('messages'))
+    return True
+
+
+def _has_openai_cache_breakpoint(messages: object) -> bool:
+    if not isinstance(messages, list):
+        return False
+    for message in messages:
+        if not isinstance(message, Mapping):
+            continue
+        content = message.get('content')
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if isinstance(part, Mapping) and part.get('prompt_cache_breakpoint') == {'mode': 'explicit'}:
+                return True
+    return False
 
 
 def cache_requested_for_anthropic_request(request: Mapping[str, Any]) -> bool:
@@ -506,6 +527,7 @@ def _openai_usage(raw: Mapping[str, Any], *, cache_requested: bool) -> ProviderU
     details = raw.get('prompt_tokens_details', raw.get('input_tokens_details'))
     cached = _nonnegative_int(details.get('cached_tokens')) if isinstance(details, Mapping) else 0
     cached = min(prompt, cached)
+    cache_write = _nonnegative_int(details.get('cache_write_tokens')) if isinstance(details, Mapping) else 0
     completion_details = raw.get('completion_tokens_details', raw.get('output_tokens_details'))
     reasoning = (
         _nonnegative_int(completion_details.get('reasoning_tokens')) if isinstance(completion_details, Mapping) else 0
@@ -520,6 +542,8 @@ def _openai_usage(raw: Mapping[str, Any], *, cache_requested: bool) -> ProviderU
         output_tokens=output,
         reasoning_tokens=reasoning,
         output_tokens_include_reasoning=True,
+        cache_write_tokens=cache_write,
+        cache_write_ttl='30m' if cache_write else None,
         total_tokens=total,
         cache_status=_cache_status(
             prompt_tokens=prompt,

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -359,9 +359,37 @@ def _provider_request(
     if resolved_route.validated_request.response_format is not None:
         provider_request['response_format'] = dict(resolved_route.validated_request.response_format)
     provider_request.update(dict(resolved_route.validated_request.forwarded_params))
+    if not provider_ref.model.startswith('gpt-5.6'):
+        _remove_gpt56_cache_fields(provider_request)
     if apply_budget:
         provider_request, _ = apply_output_budget(provider_request, route.output_budget)
     return provider_request
+
+
+def _remove_gpt56_cache_fields(provider_request: dict[str, Any]) -> None:
+    """Keep GPT-5.6 explicit-cache fields off a legacy route or fallback."""
+    provider_request.pop('prompt_cache_options', None)
+    raw_messages = provider_request.get('messages')
+    if not isinstance(raw_messages, list):
+        return
+    sanitized_messages: list[Any] = []
+    for message in raw_messages:
+        if not isinstance(message, Mapping):
+            sanitized_messages.append(message)
+            continue
+        sanitized_message = dict(message)
+        content = sanitized_message.get('content')
+        if isinstance(content, list):
+            sanitized_message['content'] = [
+                (
+                    {key: value for key, value in part.items() if key != 'prompt_cache_breakpoint'}
+                    if isinstance(part, Mapping)
+                    else part
+                )
+                for part in content
+            ]
+        sanitized_messages.append(sanitized_message)
+    provider_request['messages'] = sanitized_messages
 
 
 def _apply_provider_options(provider_request: dict[str, Any], provider_options: Mapping[str, Any]) -> None:

--- a/backend/llm_gateway/gateway/validator.py
+++ b/backend/llm_gateway/gateway/validator.py
@@ -27,6 +27,7 @@ FORWARDED_CHAT_COMPLETION_PARAMS = frozenset(
         'max_tokens',
         'n',
         'presence_penalty',
+        'prompt_cache_options',
         'prompt_cache_key',
         'seed',
         'stop',
@@ -105,7 +106,11 @@ def _is_text_content_part(part: object) -> bool:
     if not isinstance(part, Mapping):
         return False
     typed_part = cast(Mapping[str, object], part)
-    return typed_part.get('type') == 'text' and isinstance(typed_part.get('text'), str)
+    if typed_part.get('type') != 'text' or not isinstance(typed_part.get('text'), str):
+        return False
+    if 'prompt_cache_breakpoint' in typed_part:
+        _validate_prompt_cache_breakpoint(typed_part['prompt_cache_breakpoint'])
+    return True
 
 
 def _validate_response_format(value: object, lane: LaneConfig) -> Mapping[str, Any] | None:
@@ -158,10 +163,30 @@ def _validate_forwarded_params(request: Mapping[str, Any]) -> Mapping[str, Any]:
         )
     forwarded = {key: request[key] for key in FORWARDED_CHAT_COMPLETION_PARAMS if key in request}
     _validate_output_limit_aliases(forwarded)
+    if 'prompt_cache_options' in forwarded:
+        _validate_prompt_cache_options(forwarded['prompt_cache_options'])
     for key in ('tools', 'tool_choice', 'stream'):
         if key in request:
             forwarded[key] = request[key]
     return forwarded
+
+
+def _validate_prompt_cache_options(value: object) -> None:
+    if not isinstance(value, Mapping):
+        raise GatewayInvalidRequestError('prompt_cache_options must be an object', param='prompt_cache_options')
+    if set(value) != {'mode', 'ttl'} or value.get('mode') != 'explicit' or value.get('ttl') != '30m':
+        raise GatewayInvalidRequestError(
+            'prompt_cache_options must be {"mode": "explicit", "ttl": "30m"}',
+            param='prompt_cache_options',
+        )
+
+
+def _validate_prompt_cache_breakpoint(value: object) -> None:
+    if not isinstance(value, Mapping) or dict(value) != {'mode': 'explicit'}:
+        raise GatewayInvalidRequestError(
+            'prompt_cache_breakpoint must be {"mode": "explicit"}',
+            param='prompt_cache_breakpoint',
+        )
 
 
 def _validate_output_limit_aliases(forwarded: Mapping[str, Any]) -> None:

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -81,6 +81,8 @@ sys.modules["database.auth"].get_user_name = MagicMock(return_value="Test User")
 _stub_package("langchain_core")
 langchain_output_parsers = _stub_module("langchain_core.output_parsers")
 langchain_output_parsers.PydanticOutputParser = MagicMock()
+langchain_messages = _stub_module("langchain_core.messages")
+langchain_messages.SystemMessage = MagicMock()
 langchain_prompts = _stub_module("langchain_core.prompts")
 langchain_prompts.ChatPromptTemplate = MagicMock()
 

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -305,3 +305,16 @@ class TestStructureFunctionsTimezone:
             assert "do not re-interpret this timestamp as UTC" in text
             # The old buggy instruction asking the model to convert must be gone.
             assert "respond in user local timezone" not in text
+
+
+def test_gpt56_cache_buckets_are_fixed_and_never_include_request_content():
+    keys = {conv_proc._cache_bucket_key('omi-transcript-structure', now=offset * 15) for offset in range(8)}
+
+    assert keys == {
+        'omi-transcript-structure-v1-b0',
+        'omi-transcript-structure-v1-b1',
+        'omi-transcript-structure-v1-b2',
+        'omi-transcript-structure-v1-b3',
+    }
+    assert conv_proc._has_gpt56_cacheable_static_prefix('static ' * 1_100)
+    assert not conv_proc._has_gpt56_cacheable_static_prefix('short prefix')

--- a/backend/tests/unit/test_gateway_serving_streaming.py
+++ b/backend/tests/unit/test_gateway_serving_streaming.py
@@ -7,7 +7,7 @@ import httpx
 import pytest
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from pydantic import Field
 
@@ -73,6 +73,29 @@ class _StreamChatModel(BaseChatModel):
             yield ChatGeneration(message=AIMessage(content=chunk))
         if self.fail_after_chunks:
             raise httpx.ReadError('stream reset')
+
+
+def test_legacy_fallback_strips_gpt56_only_cache_fields_without_changing_text_content():
+    messages, kwargs = gateway_serving._legacy_cache_compatible_call(
+        [
+            HumanMessage(
+                content=[
+                    {
+                        'type': 'text',
+                        'text': 'Stable instructions.',
+                        'prompt_cache_breakpoint': {'mode': 'explicit'},
+                    }
+                ]
+            )
+        ],
+        {
+            'prompt_cache_key': 'omi-extract-actions-v1-b0',
+            'prompt_cache_options': {'mode': 'explicit', 'ttl': '30m'},
+        },
+    )
+
+    assert messages[0].content == [{'type': 'text', 'text': 'Stable instructions.'}]
+    assert kwargs == {'prompt_cache_key': 'omi-extract-actions-v1-b0'}
 
 
 def test_gateway_serving_stream_records_serving_mode_on_success(monkeypatch):

--- a/backend/tests/unit/test_llm_gateway_accounting.py
+++ b/backend/tests/unit/test_llm_gateway_accounting.py
@@ -65,6 +65,40 @@ def test_openai_usage_distinguishes_cache_hit_miss_and_unobserved_cache() -> Non
     assert no_cache_read is not None and no_cache_read.cache_status == CacheStatus.NO_CACHE_READ_OBSERVED
 
 
+def test_openai_usage_parses_cache_writes_and_prices_luna_write_tokens() -> None:
+    usage = openai_usage_from_response(
+        {
+            'id': 'chatcmpl-write',
+            'usage': {
+                'prompt_tokens': 1_000_000,
+                'completion_tokens': 1_000_000,
+                'prompt_tokens_details': {'cached_tokens': 200_000, 'cache_write_tokens': 400_000},
+            },
+        },
+        cache_requested=True,
+    ).usage
+    assert usage is not None
+    assert usage.cache_write_tokens == 400_000
+    assert usage.cache_write_ttl == '30m'
+
+    trace = AttemptTrace()
+    attempt = trace.record(
+        provider='openai',
+        configured_model='gpt-5.6-luna',
+        route_artifact_id='route.conv_action_items.model_config.001',
+        fallback_reason=None,
+        retry_ordinal=1,
+        outcome='success',
+        error_class='none',
+        metadata=ProviderResponseMetadata(usage=usage),
+    )
+    event = build_accounting_event(_context(), attempt)
+
+    assert event.cache_write_tokens == 400_000
+    assert event.estimated_cost_micro_usd == 7_320_000
+    assert event.rate_card_id == 'openai.gpt-5.6-luna.2026-07-17'
+
+
 def test_empty_usage_object_is_unreported_not_a_zero_cost_completion() -> None:
     metadata = openai_usage_from_response({'id': 'chatcmpl-empty', 'model': 'gpt-5.4-nano', 'usage': {}})
     trace = AttemptTrace()

--- a/backend/tests/unit/test_llm_gateway_accounting.py
+++ b/backend/tests/unit/test_llm_gateway_accounting.py
@@ -80,6 +80,7 @@ def test_openai_usage_parses_cache_writes_and_prices_luna_write_tokens() -> None
     assert usage is not None
     assert usage.cache_write_tokens == 400_000
     assert usage.cache_write_ttl == '30m'
+    assert usage.uncached_input_tokens == 400_000
 
     trace = AttemptTrace()
     attempt = trace.record(
@@ -95,7 +96,7 @@ def test_openai_usage_parses_cache_writes_and_prices_luna_write_tokens() -> None
     event = build_accounting_event(_context(), attempt)
 
     assert event.cache_write_tokens == 400_000
-    assert event.estimated_cost_micro_usd == 7_320_000
+    assert event.estimated_cost_micro_usd == 6_920_000
     assert event.rate_card_id == 'openai.gpt-5.6-luna.2026-07-17'
 
 

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -11,10 +11,10 @@ from starlette.requests import Request
 from llm_gateway.gateway.auth import ServiceCaller
 from llm_gateway.gateway.config_loader import load_gateway_config
 from llm_gateway.gateway.credentials import build_omi_managed_credential_context
-from llm_gateway.gateway.executor import ProviderRegistry
+from llm_gateway.gateway.executor import ProviderRegistry, provider_request_for
 from llm_gateway.gateway.providers import FakeChatCompletionProvider, ProviderFailure
 from llm_gateway.gateway.resolver import resolve_chat_completion_route
-from llm_gateway.gateway.schemas import FailureClass
+from llm_gateway.gateway.schemas import FailureClass, ProviderRef
 from llm_gateway.main import app
 from llm_gateway.routers import dependencies, openai_compatible
 from models.structured_extraction import ActionItemsExtraction, ConversationStructureExtraction
@@ -133,6 +133,58 @@ def test_chat_completions_persists_cache_aware_attempt_with_authenticated_attrib
     assert trace.attempts[0].usage is not None
     assert trace.attempts[0].usage.cached_input_tokens == 40
     assert trace.attempts[0].usage.cache_status.value == 'partial_hit'
+
+
+def test_gateway_provider_body_forwards_validated_gpt56_cache_fields_unchanged():
+    request = valid_request(
+        prompt_cache_key='omi-extract-actions-v1-b0',
+        prompt_cache_options={'mode': 'explicit', 'ttl': '30m'},
+        messages=[
+            {
+                'role': 'system',
+                'content': [
+                    {
+                        'type': 'text',
+                        'text': 'Stable instructions.',
+                        'prompt_cache_breakpoint': {'mode': 'explicit'},
+                    }
+                ],
+            },
+            {'role': 'user', 'content': 'Dynamic content.'},
+        ],
+    )
+    resolved = resolve_chat_completion_route(load_gateway_config(prod_mode=True), request)
+    forwarded = provider_request_for(resolved, ProviderRef(provider='openai', model='gpt-5.6-luna'))
+
+    assert forwarded['prompt_cache_key'] == 'omi-extract-actions-v1-b0'
+    assert forwarded['prompt_cache_options'] == {'mode': 'explicit', 'ttl': '30m'}
+    assert forwarded['messages'] == request['messages']
+
+
+def test_gateway_provider_body_strips_gpt56_cache_fields_for_legacy_route():
+    request = valid_request(
+        prompt_cache_key='omi-extract-actions-v1-b0',
+        prompt_cache_options={'mode': 'explicit', 'ttl': '30m'},
+        messages=[
+            {
+                'role': 'system',
+                'content': [
+                    {
+                        'type': 'text',
+                        'text': 'Stable instructions.',
+                        'prompt_cache_breakpoint': {'mode': 'explicit'},
+                    }
+                ],
+            },
+            {'role': 'user', 'content': 'Dynamic content.'},
+        ],
+    )
+    resolved = resolve_chat_completion_route(load_gateway_config(prod_mode=True), request)
+    forwarded = provider_request_for(resolved, ProviderRef(provider='openai', model='gpt-5.4-nano'))
+
+    assert forwarded['prompt_cache_key'] == 'omi-extract-actions-v1-b0'
+    assert 'prompt_cache_options' not in forwarded
+    assert forwarded['messages'][0]['content'] == [{'type': 'text', 'text': 'Stable instructions.'}]
 
 
 def test_metadata_feature_never_enters_the_accounting_context(monkeypatch):

--- a/backend/tests/unit/test_llm_gateway_validator.py
+++ b/backend/tests/unit/test_llm_gateway_validator.py
@@ -40,6 +40,64 @@ def test_forwards_prompt_cache_key():
     assert validated.forwarded_params['prompt_cache_key'] == 'omi-extract-actions'
 
 
+def test_forwards_explicit_gpt56_cache_contract_on_a_text_content_block():
+    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    request = valid_request(
+        prompt_cache_key='omi-extract-actions-v1-b0',
+        prompt_cache_options={'mode': 'explicit', 'ttl': '30m'},
+        messages=[
+            {
+                'role': 'system',
+                'content': [
+                    {
+                        'type': 'text',
+                        'text': 'Stable instructions.',
+                        'prompt_cache_breakpoint': {'mode': 'explicit'},
+                    }
+                ],
+            },
+            {'role': 'user', 'content': 'Dynamic content.'},
+        ],
+    )
+
+    validated = validate_chat_completion_request(request, lane)
+
+    assert validated.messages == tuple(request['messages'])
+    assert validated.forwarded_params['prompt_cache_options'] == {'mode': 'explicit', 'ttl': '30m'}
+
+
+@pytest.mark.parametrize(
+    'prompt_cache_options',
+    [None, {}, {'mode': 'implicit', 'ttl': '30m'}, {'mode': 'explicit'}, {'mode': 'explicit', 'ttl': '24h'}],
+)
+def test_rejects_invalid_gpt56_cache_options(prompt_cache_options):
+    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+
+    with pytest.raises(GatewayInvalidRequestError, match='prompt_cache_options'):
+        validate_chat_completion_request(valid_request(prompt_cache_options=prompt_cache_options), lane)
+
+
+def test_rejects_invalid_cache_breakpoint_shape():
+    lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
+    request = valid_request(
+        messages=[
+            {
+                'role': 'system',
+                'content': [
+                    {
+                        'type': 'text',
+                        'text': 'Stable instructions.',
+                        'prompt_cache_breakpoint': {'mode': 'implicit'},
+                    }
+                ],
+            }
+        ]
+    )
+
+    with pytest.raises(GatewayInvalidRequestError, match='prompt_cache_breakpoint'):
+        validate_chat_completion_request(request, lane)
+
+
 def test_accepts_matching_output_limit_aliases():
     lane = load_gateway_config(prod_mode=True).lanes[LANE_ID]
 

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -746,9 +746,9 @@ def test_llm_calls_use_omi_qos_tier_system():
     conv_proc_path = Path(__file__).resolve().parent.parent.parent / "utils" / "llm" / "conversation_processing.py"
     conv_proc_source = conv_proc_path.read_text(encoding="utf-8")
 
-    # get_transcript_structure should use get_llm('conv_structure', cache_key=...)
+    # get_transcript_structure should use the conv_structure QoS lane.
     struct_match = re.search(
-        r'def get_transcript_structure.*?chain = prompt \| get_llm\([\'"](\w+)[\'"]\s*,\s*cache_key=',
+        r'def get_transcript_structure.*?get_llm\([\'"](\w+)[\'"]\s*,\s*cache_key=',
         conv_proc_source,
         re.DOTALL,
     )
@@ -757,9 +757,9 @@ def test_llm_calls_use_omi_qos_tier_system():
         struct_match.group(1) == "conv_structure"
     ), f"Expected get_llm('conv_structure') for structure, got {struct_match.group(1)}"
 
-    # get_app_result should use get_llm('conv_app_result', cache_key=...)
+    # get_app_result should use the conv_app_result QoS lane.
     app_match = re.search(
-        r'def get_app_result.*?response = get_llm\([\'"](\w+)[\'"]\s*,\s*cache_key=',
+        r'def get_app_result.*?get_llm\([\'"](\w+)[\'"]\s*,\s*cache_key=',
         conv_proc_source,
         re.DOTALL,
     )
@@ -768,9 +768,9 @@ def test_llm_calls_use_omi_qos_tier_system():
         app_match.group(1) == "conv_app_result"
     ), f"Expected get_llm('conv_app_result') for app result, got {app_match.group(1)}"
 
-    # extract_action_items should use get_llm('conv_action_items', cache_key=...)
+    # extract_action_items should use the conv_action_items QoS lane.
     action_match = re.search(
-        r'def extract_action_items.*?chain = prompt \| get_llm\([\'"](\w+)[\'"]\s*,\s*cache_key=',
+        r'def extract_action_items.*?get_llm\([\'"](\w+)[\'"]\s*,\s*cache_key=',
         conv_proc_source,
         re.DOTALL,
     )
@@ -780,9 +780,9 @@ def test_llm_calls_use_omi_qos_tier_system():
     ), f"Expected get_llm('conv_action_items') for action items, got {action_match.group(1)}"
 
     # Verify cache keys are passed through get_llm's cache_key param (model-safe)
-    assert "cache_key='omi-extract-actions'" in conv_proc_source, "Missing cache_key for action items"
-    assert "cache_key='omi-transcript-structure'" in conv_proc_source, "Missing cache_key for structure"
-    assert "cache_key='omi-app-result'" in conv_proc_source, "Missing cache_key for app result"
+    assert "_cache_bucket_key('omi-extract-actions')" in conv_proc_source, "Missing cache key for action items"
+    assert "_cache_bucket_key('omi-transcript-structure')" in conv_proc_source, "Missing cache key for structure"
+    assert "else 'omi-app-result'" in conv_proc_source, "Missing cache_key for app result"
     assert "cache_key='omi-daily-summary'" in conv_proc_source, "Missing cache_key for daily summary"
 
 

--- a/backend/tests/unit/test_prompt_caching.py
+++ b/backend/tests/unit/test_prompt_caching.py
@@ -15,6 +15,7 @@ from models.calendar_context import CalendarMeetingContext, MeetingParticipant
 from models.conversation_photo import ConversationPhoto
 from utils.llm.conversation_processing import (
     _build_conversation_context,
+    _gpt56_cacheable_system_message,
     extract_action_items,
     get_transcript_structure,
 )
@@ -183,15 +184,16 @@ class TestPromptMessageOrdering:
     def _get_from_messages_calls(self, func):
         """Extract ChatPromptTemplate.from_messages call patterns from function source."""
         source = inspect.getsource(func)
-        return re.findall(r'from_messages\(\[(.*?)\]\)', source, re.DOTALL)
+        return re.findall(r'from_messages\(\s*\[(.*?)\]\s*\)', source, re.DOTALL)
 
     def test_get_transcript_structure_instructions_first(self):
         """Static instructions must be the first system message for cross-conversation caching."""
         calls = self._get_from_messages_calls(get_transcript_structure)
         assert len(calls) == 1, "Expected exactly one from_messages call"
         args = calls[0].strip()
-        # instructions_text should come before context_message
-        instructions_pos = args.index('instructions_text')
+        # The cached prefix is a concrete message so parser-schema braces are
+        # never treated as ChatPromptTemplate variables.
+        instructions_pos = args.index('_gpt56_cacheable_system_message(instructions_text')
         context_pos = args.index('context_message')
         assert instructions_pos < context_pos, "instructions_text must come before context_message"
 
@@ -200,7 +202,7 @@ class TestPromptMessageOrdering:
         calls = self._get_from_messages_calls(extract_action_items)
         assert len(calls) == 1, "Expected exactly one from_messages call"
         args = calls[0].strip()
-        instructions_pos = args.index('instructions_text')
+        instructions_pos = args.index('_gpt56_cacheable_system_message(instructions_text')
         context_pos = args.index('context_message')
         assert instructions_pos < context_pos, "instructions_text must come before context_message"
 
@@ -209,9 +211,8 @@ class TestPromptMessageOrdering:
         for func in [get_transcript_structure, extract_action_items]:
             calls = self._get_from_messages_calls(func)
             assert len(calls) == 1, f"{func.__name__}: expected one from_messages call"
-            # Count 'system' occurrences in the call
-            system_count = calls[0].count("'system'")
-            assert system_count == 2, f"{func.__name__}: expected 2 system messages, got {system_count}"
+            assert calls[0].count('_gpt56_cacheable_system_message(') == 1
+            assert calls[0].count("('system', context_message)") == 1
 
     def test_existing_items_context_not_in_instructions(self):
         """existing_items_context must be in the context message, not the instructions."""
@@ -224,7 +225,7 @@ class TestPromptMessageOrdering:
             '{existing_items_context}' not in instructions_content
         ), "existing_items_context should not be in instructions_text (breaks static prefix caching)"
         # Verify it IS in the context_message
-        context_match = re.search(r"context_message\s*=\s*['\"](.+?)['\"]", source)
+        context_match = re.search(r"context_message\s*=\s*'''(.*?)'''", source, re.DOTALL)
         assert context_match, "Could not find context_message definition"
         assert 'existing_items_context' in context_match.group(1), "existing_items_context should be in context_message"
 
@@ -237,7 +238,7 @@ class TestPromptMessageOrdering:
         assert (
             '{language_code}' not in instructions_content
         ), "language_code should not be in instructions_text (breaks static prefix caching for non-English)"
-        context_match = re.search(r"context_message\s*=\s*['\"](.+?)['\"]", source)
+        context_match = re.search(r"context_message\s*=\s*'''(.*?)'''", source, re.DOTALL)
         assert context_match, "Could not find context_message definition"
         assert 'language_code' in context_match.group(1), "language_code should be in context_message"
 
@@ -297,24 +298,42 @@ class TestPromptCacheRetention:
             assert 'prompt_cache_retention' not in block, f"prompt_cache_retention must not be in model_kwargs: {block}"
 
     def test_prompt_cache_key_in_structure_function(self):
-        """get_transcript_structure must pass cache_key='omi-transcript-structure' via get_llm."""
+        """The structure path keeps a fixed, non-user-derived cache routing key."""
         source = inspect.getsource(get_transcript_structure)
-        assert (
-            "cache_key='omi-transcript-structure'" in source
-        ), "get_transcript_structure missing cache_key in get_llm call"
+        assert "_cache_bucket_key('omi-transcript-structure')" in source
+        assert "cache_key = 'omi-transcript-structure'" in source
 
     def test_prompt_cache_key_in_action_items_function(self):
-        """extract_action_items must pass cache_key='omi-extract-actions' via get_llm."""
+        """The action-items path keeps a fixed, non-user-derived cache routing key."""
         source = inspect.getsource(extract_action_items)
-        assert "cache_key='omi-extract-actions'" in source, "extract_action_items missing cache_key in get_llm call"
+        assert "_cache_bucket_key('omi-extract-actions')" in source
+        assert "cache_key = 'omi-extract-actions'" in source
 
     def test_distinct_cache_keys_per_function(self):
         """Each function must have a distinct cache_key to avoid cache conflation."""
         source_structure = inspect.getsource(get_transcript_structure)
         source_actions = inspect.getsource(extract_action_items)
-        key_structure = re.search(r"cache_key='([^']+)'", source_structure)
-        key_actions = re.search(r"cache_key='([^']+)'", source_actions)
+        key_structure = re.search(r"_cache_bucket_key\('([^']+)'\)", source_structure)
+        key_actions = re.search(r"_cache_bucket_key\('([^']+)'\)", source_actions)
         assert key_structure and key_actions, "Both functions must have cache_key"
         assert key_structure.group(1) != key_actions.group(
             1
         ), f"Cache keys must be distinct: structure={key_structure.group(1)}, actions={key_actions.group(1)}"
+
+
+def test_explicit_cache_system_message_preserves_parser_schema_braces():
+    """A cached system message must bypass ChatPromptTemplate variable parsing."""
+    from langchain_core.prompts import ChatPromptTemplate
+
+    system_message = _gpt56_cacheable_system_message('{"title": "string"}', cache_enabled=True)
+    prompt = ChatPromptTemplate.from_messages([system_message, ('system', 'Content: {conversation_context}')])
+
+    messages = prompt.format_messages(conversation_context='Transcript: hello')
+
+    assert messages[0].content == [
+        {
+            'type': 'text',
+            'text': '{"title": "string"}',
+            'prompt_cache_breakpoint': {'mode': 'explicit'},
+        }
+    ]

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -449,7 +449,12 @@ def _get_or_create_openrouter_llm(
     return get_or_create_openai_compatible_llm('openrouter', model_name, streaming, options)
 
 
-def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = None) -> BaseChatModel:
+def get_llm(
+    feature: str,
+    streaming: bool = False,
+    cache_key: Optional[str] = None,
+    prompt_cache_options: Optional[dict[str, str]] = None,
+) -> BaseChatModel:
     """Get the LLM client for a feature based on the active Model QoS profile.
 
     Works for OpenAI, Gemini, OpenRouter, and other registered OpenAI-compatible
@@ -547,8 +552,15 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
         legacy_model=result,
     )
 
+    cache_params: Dict[str, Any] = {}
     if cache_key and supports_prompt_cache(model):
-        return result.bind(prompt_cache_key=cache_key)
+        cache_params['prompt_cache_key'] = cache_key
+    # The direct route can still resolve to a pre-5.6 model.  Only the
+    # gateway's GPT-5.6 lanes receive the explicit-cache API fields.
+    if prompt_cache_options and gateway_feature_mode:
+        cache_params['prompt_cache_options'] = prompt_cache_options
+    if cache_params:
+        return result.bind(**cache_params)
     return result
 
 

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -1,11 +1,14 @@
 import hashlib
+import logging
 import os
+import time
 import unicodedata
 from datetime import datetime, timedelta, timezone
 from difflib import SequenceMatcher
 from zoneinfo import ZoneInfo
 from typing import Any, Dict, List, Optional, Tuple, cast
 
+import tiktoken
 from langchain_core.output_parsers import PydanticOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel, Field
@@ -20,7 +23,14 @@ from .clients import get_llm, get_llm_gateway_chat_structured, parser
 from utils.byok import has_byok_keys
 from utils.llm.gateway_client import record_chat_extraction_gateway_result
 from utils.llm.gateway_observability import record_gateway_shadow_comparison
-import logging
+
+try:
+    from utils.llm.gateway_client import should_route_features_through_gateway
+except ImportError:  # pragma: no cover - isolated legacy tests provide only the shadow seam
+
+    def should_route_features_through_gateway() -> bool:
+        return False
+
 
 logger = logging.getLogger(__name__)
 CONVERSATION_STRUCTURE_SHADOW_FEATURE = 'conversation_structure.extract.shadow'
@@ -29,6 +39,42 @@ CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_ST
 CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE = 'conversation_action_items.extract.shadow'
 CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED'
 CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE'
+GPT56_EXPLICIT_CACHE_OPTIONS = {'mode': 'explicit', 'ttl': '30m'}
+CONVERSATION_CACHE_BUCKET_COUNT = 4
+CONVERSATION_CACHE_BUCKET_SECONDS = 15
+GPT56_CACHE_MINIMUM_TOKENS = 1024
+
+
+def _cache_bucket_key(prefix: str, *, now: float | None = None) -> str:
+    """Return a fixed, opaque cache-routing bucket without user-derived input."""
+    slot = int(time.time() if now is None else now) // CONVERSATION_CACHE_BUCKET_SECONDS
+    return f'{prefix}-v1-b{slot % CONVERSATION_CACHE_BUCKET_COUNT}'
+
+
+def _gpt56_cacheable_system_message(content: str, *, cache_enabled: bool) -> tuple[str, Any]:
+    """Mark a static system prefix only when the request uses the GPT-5.6 gateway."""
+    if not cache_enabled:
+        return ('system', content)
+    return (
+        'system',
+        [
+            {
+                'type': 'text',
+                'text': content,
+                'prompt_cache_breakpoint': {'mode': 'explicit'},
+            }
+        ],
+    )
+
+
+def _has_gpt56_cacheable_static_prefix(content: str) -> bool:
+    """Use the model-family tokenizer as a conservative preflight for a cache write."""
+    try:
+        return len(tiktoken.get_encoding('o200k_base').encode(content)) >= GPT56_CACHE_MINIMUM_TOKENS
+    except AttributeError:
+        # Do not make a cache write merely because an optional tokenizer dependency is unavailable.
+        return len(content) >= GPT56_CACHE_MINIMUM_TOKENS * 4
+
 
 # =============================================
 #            FOLDER ASSIGNMENT
@@ -911,8 +957,34 @@ def extract_action_items(
     action_items_parser = PydanticOutputParser(pydantic_object=ActionItemsExtraction)
     # Second system message: conversation context + existing items (dynamic, per-conversation)
     context_message = 'The content language is {language_code}. You MUST respond entirely in {response_language}.\n\nContent:\n{conversation_context}{existing_items_context}'
-    prompt = cast(Any, ChatPromptTemplate).from_messages([('system', instructions_text), ('system', context_message)])
-    chain = prompt | get_llm('conv_action_items', cache_key='omi-extract-actions') | action_items_parser
+    gateway_mode_enabled = should_route_features_through_gateway()
+    if gateway_mode_enabled:
+        instructions_text = instructions_text.format(
+            format_instructions=action_items_parser.get_format_instructions(),
+            commitment_capture_rules=commitment_capture_rules,
+            workflow_filter_rules=workflow_filter_rules,
+            live_work_exclusion_rules=live_work_exclusion_rules,
+            completion_targeting_rule=completion_targeting_rule,
+            quality_threshold_rules=quality_threshold_rules,
+            strict_filter_intro=strict_filter_intro,
+            timing_importance_rules=timing_importance_rules,
+        )
+    gateway_cache_enabled = gateway_mode_enabled and _has_gpt56_cacheable_static_prefix(instructions_text)
+    prompt = cast(Any, ChatPromptTemplate).from_messages(
+        [
+            _gpt56_cacheable_system_message(instructions_text, cache_enabled=gateway_cache_enabled),
+            ('system', context_message),
+        ]
+    )
+    if gateway_cache_enabled:
+        cache_key = _cache_bucket_key('omi-extract-actions')
+    elif gateway_mode_enabled:
+        cache_key = None
+    else:
+        cache_key = 'omi-extract-actions'
+    cache_options = GPT56_EXPLICIT_CACHE_OPTIONS if gateway_cache_enabled else None
+    action_items_llm = get_llm('conv_action_items', cache_key=cache_key, prompt_cache_options=cache_options)
+    chain = prompt | action_items_llm | action_items_parser
 
     current_time = datetime.now(timezone.utc)
 
@@ -931,21 +1003,26 @@ def extract_action_items(
     current_time_local = current_time.astimezone(user_tz)
     prompt_values = {
         'conversation_context': conversation_context,
-        'format_instructions': action_items_parser.get_format_instructions(),
         'language_code': language_code,
         'response_language': response_language,
         'started_at_local': started_at_local.replace(tzinfo=None).isoformat(),
         'current_time_local': current_time_local.replace(tzinfo=None).isoformat(),
         'tz': tz or 'UTC',
         'existing_items_context': existing_items_context,
-        'commitment_capture_rules': commitment_capture_rules,
-        'workflow_filter_rules': workflow_filter_rules,
-        'live_work_exclusion_rules': live_work_exclusion_rules,
-        'completion_targeting_rule': completion_targeting_rule,
-        'quality_threshold_rules': quality_threshold_rules,
-        'strict_filter_intro': strict_filter_intro,
-        'timing_importance_rules': timing_importance_rules,
     }
+    if not gateway_cache_enabled:
+        prompt_values.update(
+            {
+                'format_instructions': action_items_parser.get_format_instructions(),
+                'commitment_capture_rules': commitment_capture_rules,
+                'workflow_filter_rules': workflow_filter_rules,
+                'live_work_exclusion_rules': live_work_exclusion_rules,
+                'completion_targeting_rule': completion_targeting_rule,
+                'quality_threshold_rules': quality_threshold_rules,
+                'strict_filter_intro': strict_filter_intro,
+                'timing_importance_rules': timing_importance_rules,
+            }
+        )
 
     try:
         response = chain.invoke(prompt_values)
@@ -1045,26 +1122,47 @@ def get_transcript_structure(
     • Vague suggestions ("let's grab coffee soon")
     • Hypothetical scenarios ("if we meet Tuesday...")
 
-    For date context, this content was captured at {started_at}, which is already the user's local time ({tz}). Interpret it as-is and describe times of day in the title and overview accordingly; do not re-interpret this timestamp as UTC.
-
     {format_instructions}'''.replace(
         '    ', ''
     ).strip()
 
-    # Second system message: conversation context (dynamic, per-conversation)
-    context_message = 'The content language is {language_code}. You MUST respond entirely in {response_language}.\n\nContent:\n{conversation_context}'
-    prompt = cast(Any, ChatPromptTemplate).from_messages([('system', instructions_text), ('system', context_message)])
+    # Second system message contains every per-conversation value, including timestamp.
+    context_message = (
+        'The content language is {language_code}. You MUST respond entirely in {response_language}.\n\n'
+        'For date context, this content was captured at {started_at}, which is already the user\'s local time ({tz}). '
+        'Interpret it as-is and describe times of day in the title and overview accordingly; do not re-interpret this '
+        'timestamp as UTC.\n\nContent:\n{conversation_context}'
+    )
+    gateway_mode_enabled = should_route_features_through_gateway()
+    if gateway_mode_enabled:
+        instructions_text = instructions_text.format(format_instructions=parser.get_format_instructions())
+    gateway_cache_enabled = gateway_mode_enabled and _has_gpt56_cacheable_static_prefix(instructions_text)
+    prompt = cast(Any, ChatPromptTemplate).from_messages(
+        [
+            _gpt56_cacheable_system_message(instructions_text, cache_enabled=gateway_cache_enabled),
+            ('system', context_message),
+        ]
+    )
     legacy_prompt_values = {
         'conversation_context': conversation_context,
-        'format_instructions': parser.get_format_instructions(),
         'language_code': language_code,
         'response_language': response_language,
         'started_at': _local_started_at_iso(started_at, tz),
         'tz': tz or 'UTC',
     }
+    if not gateway_cache_enabled:
+        legacy_prompt_values['format_instructions'] = parser.get_format_instructions()
 
     with track_usage(uid, Features.CONVERSATION_STRUCTURE):
-        chain = prompt | get_llm('conv_structure', cache_key='omi-transcript-structure') | parser
+        if gateway_cache_enabled:
+            cache_key = _cache_bucket_key('omi-transcript-structure')
+        elif gateway_mode_enabled:
+            cache_key = None
+        else:
+            cache_key = 'omi-transcript-structure'
+        cache_options = GPT56_EXPLICIT_CACHE_OPTIONS if gateway_cache_enabled else None
+        structure_llm = get_llm('conv_structure', cache_key=cache_key, prompt_cache_options=cache_options)
+        chain = prompt | structure_llm | parser
         response = _coerce_structured(chain.invoke(legacy_prompt_values))
     if _should_run_conversation_structure_shadow(uid, started_at, conversation_context):
         _submit_conversation_structure_shadow(
@@ -1144,7 +1242,13 @@ def get_reprocess_transcript_structure(
     ).strip()
 
     prompt = cast(Any, ChatPromptTemplate).from_messages([('system', prompt_text)])
-    chain = prompt | get_llm('conv_structure', cache_key='omi-transcript-structure') | parser
+    gateway_cache_enabled = should_route_features_through_gateway()
+    # Reprocessing has no eligible static prefix, so explicit mode avoids both
+    # cache reads and billable cache writes on the GPT-5.6 route.
+    cache_key = None if gateway_cache_enabled else 'omi-transcript-structure'
+    cache_options = GPT56_EXPLICIT_CACHE_OPTIONS if gateway_cache_enabled else None
+    structure_llm = get_llm('conv_structure', cache_key=cache_key, prompt_cache_options=cache_options)
+    chain = prompt | structure_llm | parser
 
     response = _coerce_structured(
         chain.invoke(
@@ -1195,7 +1299,13 @@ def get_app_result(transcript: str, photos: List[ConversationPhoto], app: App, l
     {full_context}
     '''
 
-    response = get_llm('conv_app_result', cache_key='omi-app-result').invoke(prompt)
+    gateway_cache_enabled = should_route_features_through_gateway()
+    # App-specific instructions vary at the start of the prompt. Explicit mode
+    # without a breakpoint keeps this route out of GPT-5.6's billable cache.
+    cache_key = None if gateway_cache_enabled else 'omi-app-result'
+    cache_options = GPT56_EXPLICIT_CACHE_OPTIONS if gateway_cache_enabled else None
+    app_result_llm = get_llm('conv_app_result', cache_key=cache_key, prompt_cache_options=cache_options)
+    response = app_result_llm.invoke(prompt)
     content = _content_str(response).replace('```json', '').replace('```', '')
     return content
 

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 
 import tiktoken
 from langchain_core.output_parsers import PydanticOutputParser
+from langchain_core.messages import SystemMessage
 from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel, Field
 
@@ -51,19 +52,20 @@ def _cache_bucket_key(prefix: str, *, now: float | None = None) -> str:
     return f'{prefix}-v1-b{slot % CONVERSATION_CACHE_BUCKET_COUNT}'
 
 
-def _gpt56_cacheable_system_message(content: str, *, cache_enabled: bool) -> tuple[str, Any]:
+def _gpt56_cacheable_system_message(content: str, *, cache_enabled: bool) -> Any:
     """Mark a static system prefix only when the request uses the GPT-5.6 gateway."""
     if not cache_enabled:
         return ('system', content)
-    return (
-        'system',
-        [
+    # A concrete message prevents ChatPromptTemplate from treating literal JSON
+    # braces in parser instructions as template variables.
+    return SystemMessage(
+        content=[
             {
                 'type': 'text',
                 'text': content,
                 'prompt_cache_breakpoint': {'mode': 'explicit'},
             }
-        ],
+        ]
     )
 
 
@@ -936,19 +938,6 @@ def extract_action_items(
     DUE DATE EXTRACTION:
     Resolve each due date in the user's LOCAL time. NEVER produce a past date.
 
-    REFERENCE_TIME (user's local time): If {started_at_local} is >7 days before {current_time_local}, use {current_time_local} (historical reprocessing). Otherwise use {started_at_local}.
-
-    Date resolution: "today" → REFERENCE_TIME date, "tomorrow" → next day, weekday names → next occurrence, "next week" → +7 days.
-    Time resolution: "morning" → 9AM, "afternoon" → 2PM, "evening" → 6PM, "noon" → 12PM, "end of day"/"midnight" → 11:59PM, no time → 11:59PM. "urgent"/"ASAP" → 2h from REFERENCE_TIME.
-    Output the resolved value as the user's LOCAL wall-clock time in ISO 8601 with NO timezone suffix or offset (no 'Z', no '+05:30') — the server converts it to UTC. Verify it is in the future relative to REFERENCE_TIME; if past, omit due_at.
-
-    Example: REFERENCE_TIME "2025-10-03T13:25:00", "tomorrow before 10am" → "2025-10-04T10:00:00"
-    Format: naive local ISO 8601, no suffix (e.g., "2025-10-04T10:00:00").
-
-    Conversation started at (local): {started_at_local}
-    Current time (local): {current_time_local}
-    User timezone: {tz}
-
     {format_instructions}'''.replace(
         '    ', ''
     ).strip()
@@ -956,7 +945,21 @@ def extract_action_items(
     response_language = output_language_code or language_code
     action_items_parser = PydanticOutputParser(pydantic_object=ActionItemsExtraction)
     # Second system message: conversation context + existing items (dynamic, per-conversation)
-    context_message = 'The content language is {language_code}. You MUST respond entirely in {response_language}.\n\nContent:\n{conversation_context}{existing_items_context}'
+    context_message = '''The content language is {language_code}. You MUST respond entirely in {response_language}.
+
+    DUE DATE EXTRACTION:
+    REFERENCE_TIME (user's local time): If {started_at_local} is >7 days before {current_time_local}, use {current_time_local} (historical reprocessing). Otherwise use {started_at_local}.
+    Date resolution: "today" → REFERENCE_TIME date, "tomorrow" → next day, weekday names → next occurrence, "next week" → +7 days.
+    Time resolution: "morning" → 9AM, "afternoon" → 2PM, "evening" → 6PM, "noon" → 12PM, "end of day"/"midnight" → 11:59PM, no time → 11:59PM. "urgent"/"ASAP" → 2h from REFERENCE_TIME.
+    Output the resolved value as the user's LOCAL wall-clock time in ISO 8601 with NO timezone suffix or offset (no 'Z', no '+05:30') — the server converts it to UTC. Verify it is in the future relative to REFERENCE_TIME; if past, omit due_at.
+    Example: REFERENCE_TIME "2025-10-03T13:25:00", "tomorrow before 10am" → "2025-10-04T10:00:00"
+    Format: naive local ISO 8601, no suffix (e.g., "2025-10-04T10:00:00").
+    Conversation started at (local): {started_at_local}
+    Current time (local): {current_time_local}
+    User timezone: {tz}
+
+    Content:
+    {conversation_context}{existing_items_context}'''
     gateway_mode_enabled = should_route_features_through_gateway()
     if gateway_mode_enabled:
         instructions_text = instructions_text.format(

--- a/backend/utils/llm/gateway_serving.py
+++ b/backend/utils/llm/gateway_serving.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 import time
 import uuid
@@ -427,6 +428,41 @@ def _gateway_call_kwargs(kwargs: Mapping[str, Any]) -> tuple[dict[str, Any], str
     return gateway_kwargs, request_id
 
 
+def _legacy_cache_compatible_call(
+    messages: list[BaseMessage], kwargs: Mapping[str, Any]
+) -> tuple[list[BaseMessage], dict[str, Any]]:
+    """Remove GPT-5.6-only cache fields before the pre-5.6 recovery path."""
+    legacy_messages: list[BaseMessage] = []
+    for message in messages:
+        content = getattr(message, 'content', None)
+        if not isinstance(content, list):
+            legacy_messages.append(message)
+            continue
+        cleaned_content: list[Any] = []
+        changed = False
+        for part in content:
+            if isinstance(part, Mapping) and 'prompt_cache_breakpoint' in part:
+                cleaned_part = dict(part)
+                cleaned_part.pop('prompt_cache_breakpoint')
+                cleaned_content.append(cleaned_part)
+                changed = True
+            else:
+                cleaned_content.append(part)
+        if not changed:
+            legacy_messages.append(message)
+            continue
+        if hasattr(message, 'model_copy'):
+            legacy_messages.append(message.model_copy(update={'content': cleaned_content}))
+        else:  # pragma: no cover - compatibility for older LangChain message objects
+            copied_message = copy.copy(message)
+            copied_message.content = cleaned_content
+            legacy_messages.append(copied_message)
+
+    legacy_kwargs = dict(kwargs)
+    legacy_kwargs.pop('prompt_cache_options', None)
+    return legacy_messages, legacy_kwargs
+
+
 def _canonical_request_id(value: object) -> str:
     if isinstance(value, str):
         try:
@@ -456,11 +492,14 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
         **kwargs: Any,
     ) -> ChatResult:
         gateway_kwargs, request_id = _gateway_call_kwargs(kwargs)
+        legacy_messages, legacy_kwargs = _legacy_cache_compatible_call(messages, kwargs)
         if not gateway_circuit.allow_request():
             return _run_legacy_fallback(
                 feature=self.feature,
                 gateway_reason='circuit_open',
-                call=lambda: self.legacy_model._generate(messages, stop=stop, run_manager=run_manager, **kwargs),
+                call=lambda: self.legacy_model._generate(
+                    legacy_messages, stop=stop, run_manager=run_manager, **legacy_kwargs
+                ),
                 request_id=request_id,
                 credential_source=self.credential_source,
             )
@@ -483,7 +522,9 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
             return _run_legacy_fallback(
                 feature=self.feature,
                 gateway_reason=_fallback_reason(exc),
-                call=lambda: self.legacy_model._generate(messages, stop=stop, run_manager=run_manager, **kwargs),
+                call=lambda: self.legacy_model._generate(
+                    legacy_messages, stop=stop, run_manager=run_manager, **legacy_kwargs
+                ),
                 request_id=request_id,
                 credential_source=self.credential_source,
             )
@@ -508,11 +549,14 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
         **kwargs: Any,
     ) -> ChatResult:
         gateway_kwargs, request_id = _gateway_call_kwargs(kwargs)
+        legacy_messages, legacy_kwargs = _legacy_cache_compatible_call(messages, kwargs)
         if not gateway_circuit.allow_request():
             return await _run_legacy_fallback_async(
                 feature=self.feature,
                 gateway_reason='circuit_open',
-                call=lambda: self.legacy_model._agenerate(messages, stop=stop, run_manager=run_manager, **kwargs),
+                call=lambda: self.legacy_model._agenerate(
+                    legacy_messages, stop=stop, run_manager=run_manager, **legacy_kwargs
+                ),
                 request_id=request_id,
                 credential_source=self.credential_source,
             )
@@ -545,7 +589,9 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
             return await _run_legacy_fallback_async(
                 feature=self.feature,
                 gateway_reason=_fallback_reason(exc),
-                call=lambda: self.legacy_model._agenerate(messages, stop=stop, run_manager=run_manager, **kwargs),
+                call=lambda: self.legacy_model._agenerate(
+                    legacy_messages, stop=stop, run_manager=run_manager, **legacy_kwargs
+                ),
                 request_id=request_id,
                 credential_source=self.credential_source,
             )
@@ -572,11 +618,12 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
         yielded = False
         stream = None
         gateway_kwargs, request_id = _gateway_call_kwargs(kwargs)
+        legacy_messages, legacy_kwargs = _legacy_cache_compatible_call(messages, kwargs)
         if not gateway_circuit.allow_request():
             yield from _iter_legacy_fallback(
                 feature=self.feature,
                 gateway_reason='circuit_open',
-                stream=self.legacy_model._stream(messages, stop=stop, run_manager=run_manager, **kwargs),
+                stream=self.legacy_model._stream(legacy_messages, stop=stop, run_manager=run_manager, **legacy_kwargs),
                 request_id=request_id,
                 credential_source=self.credential_source,
             )
@@ -642,7 +689,7 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
         yield from _iter_legacy_fallback(
             feature=self.feature,
             gateway_reason=gateway_reason,
-            stream=self.legacy_model._stream(messages, stop=stop, run_manager=run_manager, **kwargs),
+            stream=self.legacy_model._stream(legacy_messages, stop=stop, run_manager=run_manager, **legacy_kwargs),
             request_id=request_id,
             credential_source=self.credential_source,
         )
@@ -657,11 +704,12 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
         yielded = False
         stream = None
         gateway_kwargs, request_id = _gateway_call_kwargs(kwargs)
+        legacy_messages, legacy_kwargs = _legacy_cache_compatible_call(messages, kwargs)
         if not gateway_circuit.allow_request():
             legacy_stream = _aiter_legacy_fallback(
                 feature=self.feature,
                 gateway_reason='circuit_open',
-                stream=self.legacy_model._astream(messages, stop=stop, run_manager=run_manager, **kwargs),
+                stream=self.legacy_model._astream(legacy_messages, stop=stop, run_manager=run_manager, **legacy_kwargs),
                 request_id=request_id,
                 credential_source=self.credential_source,
             )
@@ -732,7 +780,7 @@ class GatewayWithLegacyFallbackChatModel(BaseChatModel):
         legacy_stream = _aiter_legacy_fallback(
             feature=self.feature,
             gateway_reason=gateway_reason,
-            stream=self.legacy_model._astream(messages, stop=stop, run_manager=run_manager, **kwargs),
+            stream=self.legacy_model._astream(legacy_messages, stop=stop, run_manager=run_manager, **legacy_kwargs),
             request_id=request_id,
             credential_source=self.credential_source,
         )


### PR DESCRIPTION
## Summary

- Restore explicit GPT-5.6 prompt caching for action-item and transcript-structure extraction through the LLM gateway.
- Validate and forward the supported cache contract, account for cache writes at the GPT-5.6 rate, and keep legacy fallback routes compatible.
- Keep dynamic and app/reprocess prompts out of the billable explicit cache path, with fixed non-user-derived routing buckets for eligible static prefixes.

Closes #10445

## Verification

- `BACKEND_UNIT_TEST_FILE_LIST=.focused-test-files BACKEND_PYTEST_WORKERS=1 bash test.sh` from `backend/` (7 focused unit test files; 100% passed)
- `python3 -m compileall -q backend/llm_gateway/gateway backend/utils/llm`
- `git diff --check`
- `make preflight`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

