### PR TITLE
fix(test): bind the hermetic agent-tools memory case to its fake datastore

### DIFF
--- a/backend/testing/e2e/test_canonical_memory_pipeline.py
+++ b/backend/testing/e2e/test_canonical_memory_pipeline.py
@@ -457,6 +457,12 @@ class TestSurfaceDefaultAccessMatrix:
 
             install_vector_search_fakes(monkeypatch, vector_db)
         db = fake_firestore
+        if surface_name == "agent_tools":
+            # get_memories_text reads through the client this module captured at import
+            # time, so bind it explicitly here. Without this the case only passes when an
+            # earlier test's fixture happened to rebind it, and standalone it reaches for
+            # real Firestore (#10423).
+            monkeypatch.setattr(tool_memories_service, "firestore_db", db)
         _seed_apply_control(db, uid)
         _seed_rollout_readiness(db, uid, grant_consumer=grant_consumer)
 


### PR DESCRIPTION
## What

Fixes the order dependency in `TestSurfaceDefaultAccessMatrix::test_surface_excludes_archive_and_respects_grants[agent_tools]`, the case failing the **Backend Hermetic E2E** job (and therefore the **Backend Hermetic Merge Gate**) across several open PRs.

Fixes #10423.

## Root cause

The agent-tools case reads through `utils.retrieval.tool_services.memories.get_memories_text`, which resolves the Firestore client that module captured at import time (`from database._client import db as firestore_db`). The case never bound that name, so it only passed when an earlier test's fixture happened to rebind it.

Run on its own it reaches for **real Firestore**:

```
pytest 'testing/e2e/test_canonical_memory_pipeline.py::TestSurfaceDefaultAccessMatrix::test_surface_excludes_archive_and_respects_grants'
→ 1 failed, 5 passed
   PermissionDenied: Cloud Firestore API has not been used in project test-e2e-project
```

That's both an order dependency and a hermeticity hole — a "hermetic" case escaping to a real service.

## Fix

Bind the module's client to the case's `fake_firestore` explicitly. Six added lines, test-only.

## On the clock half of #10423

The issue also suspected the reader evaluated short-term expiry against the wall clock. **That part is already resolved on current `main`** — the clock is injected end to end:

`get_memories_text(now=)` → `MemoryService.read(now=)` → `read_canonical_memories(now=)` → `filter_canonical_default_visible_items(now=)`

I verified it rather than assuming: re-ran the matrix with the fixture clock moved **18 months** into the past (`NOW = 2025-01-15`) — **6 passed**. If the wall clock still leaked, the `fresh-short` fixture would have been filtered. So after this change the case is both **date- and order-independent**.

## Verification

- Case standalone (the failing repro): **6 passed** (was 1 failed, 5 passed)
- Whole file, CI-like ordering: **8 passed**
- Date-independence probe (`NOW` −18 months): **6 passed**

## Product invariants affected

none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

