### PR TITLE
fix(memories): mirror canonical deletes into the store the user still reads

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -365,6 +365,45 @@ def _mirror_delete_into_legacy(uid: str, memory_ids: List[str], *, db_client: An
         logger.exception("legacy mirror vector delete failed uid=%s count=%d", sanitize_pii(uid), len(memory_ids))
 
 
+def _purge_legacy_memories(uid: str) -> None:
+    """Delete every legacy memory for a user, plus its vectors.
+
+    Collects ids before the Firestore delete so the Pinecone vectors can be purged too —
+    otherwise orphaned vectors become search noise nothing ever cleans up.
+    """
+    memory_ids: List[str] = []
+    offset = 0
+    batch_size = 1000
+    while True:
+        memories = memories_db.get_memories(uid, limit=batch_size, offset=offset, include_invalidated=True)
+        if not memories:
+            break
+        memory_ids.extend([memory_id for m in memories if isinstance((memory_id := m.get('id')), str) and memory_id])
+        offset += batch_size
+
+    memories_db.delete_all_memories(uid)
+
+    if memory_ids:
+        delete_memory_vectors_batch(uid, memory_ids)
+
+
+def _mirror_delete_all_into_legacy(uid: str, *, db_client: Any) -> None:
+    """Mirror a canonical delete-all into legacy while the user still reads legacy.
+
+    Same window and reasoning as _mirror_delete_into_legacy: at MEMORY_MODE=write the
+    canonical wipe is invisible because GET /v3/memories still reads legacy, so "delete
+    everything" leaves the user's list intact on the next refresh (#10446). No-ops after
+    read cutover, and best-effort because canonical is authoritative and already
+    committed.
+    """
+    if canonical_read_enabled(uid, db_client=db_client):
+        return
+    try:
+        _purge_legacy_memories(uid)
+    except Exception:
+        logger.exception("legacy mirror delete-all failed uid=%s", sanitize_pii(uid))
+
+
 def _validate_memory(uid: str, memory_id: str) -> MemoryPayload:
     return fetch_memory_dict(uid, memory_id, db_client=getattr(db_client_module, 'db', None))
 
@@ -898,27 +937,10 @@ def delete_memories(
     db_client = getattr(db_client_module, 'db', None)
     if _canonical_write_enabled_or_fail_closed(uid, db_client=db_client):
         MemoryService(db_client=db_client).delete_all(uid)
+        _mirror_delete_all_into_legacy(uid, db_client=db_client)
         return {'status': 'ok'}
 
-    # Collect all memory IDs before Firestore delete so we can also purge
-    # their Pinecone vectors — otherwise orphaned vectors become search
-    # noise that never gets cleaned up.
-    memory_ids: List[str] = []
-    offset = 0
-    batch_size = 1000
-    while True:
-        memories = memories_db.get_memories(uid, limit=batch_size, offset=offset, include_invalidated=True)
-        if not memories:
-            break
-        batch_ids = [memory_id for m in memories if isinstance((memory_id := m.get('id')), str) and memory_id]
-        memory_ids.extend(batch_ids)
-        offset += batch_size
-
-    memories_db.delete_all_memories(uid)
-
-    if memory_ids:
-        delete_memory_vectors_batch(uid, memory_ids)
-
+    _purge_legacy_memories(uid)
     return {'status': 'ok'}
 
 

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -336,6 +336,35 @@ def _canonical_write_enabled_or_fail_closed(uid: str, *, db_client: Any) -> bool
     return False
 
 
+def _mirror_delete_into_legacy(uid: str, memory_ids: List[str], *, db_client: Any) -> None:
+    """Mirror a canonical delete into legacy while the user still reads legacy.
+
+    Canonical writes turn on at MEMORY_MODE=write, but GET /v3/memories keeps reading
+    legacy until MEMORY_MODE=read. In that dual-write stage a canonical-only delete is
+    invisible: the client drops the row optimistically and the next refresh re-reads
+    legacy, where it still exists, so the memory "comes back" seconds later (#10446).
+    Deleting is symmetric with dual-write, so mirror it until read cutover.
+
+    Best-effort by design: canonical is already authoritative and its delete has
+    committed, so a legacy cleanup failure must not fail the request the user
+    already saw succeed. Firestore deletes of absent documents are no-ops, so
+    canonical-only memories mirror harmlessly.
+    """
+    if not memory_ids:
+        return
+    if canonical_read_enabled(uid, db_client=db_client):
+        return
+    try:
+        memories_db.delete_memories_batch(uid, memory_ids)
+    except Exception:
+        logger.exception("legacy mirror delete failed uid=%s count=%d", sanitize_pii(uid), len(memory_ids))
+        return
+    try:
+        delete_memory_vectors_batch(uid, memory_ids)
+    except Exception:
+        logger.exception("legacy mirror vector delete failed uid=%s count=%d", sanitize_pii(uid), len(memory_ids))
+
+
 def _validate_memory(uid: str, memory_id: str) -> MemoryPayload:
     return fetch_memory_dict(uid, memory_id, db_client=getattr(db_client_module, 'db', None))
 
@@ -812,6 +841,7 @@ def delete_memories_batch(
             raise HTTPException(status_code=413, detail='Memory batch is too large to delete atomically')
         except CanonicalMemoryNotFoundError:
             raise HTTPException(status_code=404, detail='Memory not found')
+        _mirror_delete_into_legacy(uid, memory_ids, db_client=db_client)
         return {'status': 'ok'}
 
     # Legacy cohort: enforce the same per-memory guard as _validate_memory, but via a
@@ -847,6 +877,7 @@ def delete_memory(
             MemoryService(db_client=db_client).delete(uid, memory_id)
         except ValueError:
             raise HTTPException(status_code=404, detail='Memory not found')
+        _mirror_delete_into_legacy(uid, [memory_id], db_client=db_client)
         return {'status': 'ok'}
 
     _validate_memory(uid, memory_id)

--- a/backend/tests/unit/test_memories_batch_delete.py
+++ b/backend/tests/unit/test_memories_batch_delete.py
@@ -51,8 +51,15 @@ def _patch_db(monkeypatch, fetched):
 
 
 def _force_canonical(monkeypatch, *, existing_ids):
-    """Force the canonical cohort and stub its atomic batch adapter."""
+    """Force the canonical cohort and stub its atomic batch adapter.
+
+    Pins the post-read-cutover stage (MEMORY_MODE=read) explicitly instead of
+    inheriting whatever the ambient rollout config yields, so these cases stay about
+    batch-vs-single authorization parity. The pre-cutover dual-write stage, where a
+    delete must also clear the legacy read surface (#10446), has its own cases below.
+    """
     monkeypatch.setattr(mem_mod, '_canonical_write_enabled_or_fail_closed', lambda *a, **k: True)
+    monkeypatch.setattr(mem_mod, 'canonical_read_enabled', lambda *a, **k: True)
     existing = set(existing_ids)
 
     def delete_batch(uid, memory_ids, db_client=None):
@@ -331,3 +338,40 @@ class TestBatchDeleteRouteOrdering:
 
 
 # The atomic canonical regression above intentionally exercises read-before-write ordering.
+
+
+def _canonical_delete_stage(monkeypatch, *, read_cutover_done: bool):
+    """Canonical owns writes; `read_cutover_done` picks the rollout stage.
+
+    False models MEMORY_MODE=write (canonical writes, legacy reads); True models
+    MEMORY_MODE=read, where both sides are canonical.
+    """
+    monkeypatch.setattr(mem_mod, '_canonical_write_enabled_or_fail_closed', lambda *a, **k: True)
+    monkeypatch.setattr(mem_mod, 'canonical_read_enabled', lambda *a, **k: read_cutover_done)
+    monkeypatch.setattr(mem_mod, 'MemoryService', lambda **kwargs: SimpleNamespace(delete=lambda uid, mid: None))
+    legacy_delete = MagicMock()
+    monkeypatch.setattr(mem_mod.memories_db, 'delete_memories_batch', legacy_delete)
+    monkeypatch.setattr(mem_mod, 'delete_memory_vectors_batch', MagicMock())
+    return legacy_delete
+
+
+def test_delete_during_dual_write_also_clears_the_store_the_user_reads(monkeypatch):
+    """#10446: at MEMORY_MODE=write canonical owns writes but GET /v3/memories still reads
+    legacy until MEMORY_MODE=read. A canonical-only delete is invisible in that window —
+    the client drops the row, the next refresh re-reads legacy where it still exists, and
+    the memory reappears seconds later. Deleting must mirror into legacy until cutover."""
+    legacy_delete = _canonical_delete_stage(monkeypatch, read_cutover_done=False)
+
+    assert mem_mod.delete_memory('mem-1', uid='u1') == {'status': 'ok'}
+
+    legacy_delete.assert_called_once_with('u1', ['mem-1'])
+
+
+def test_delete_after_read_cutover_leaves_legacy_alone(monkeypatch):
+    """At MEMORY_MODE=read both sides are canonical, so the mirror must not fire; it exists
+    only to keep the pre-cutover read surface consistent."""
+    legacy_delete = _canonical_delete_stage(monkeypatch, read_cutover_done=True)
+
+    assert mem_mod.delete_memory('mem-1', uid='u1') == {'status': 'ok'}
+
+    legacy_delete.assert_not_called()

--- a/backend/tests/unit/test_memories_batch_delete.py
+++ b/backend/tests/unit/test_memories_batch_delete.py
@@ -375,3 +375,44 @@ def test_delete_after_read_cutover_leaves_legacy_alone(monkeypatch):
     assert mem_mod.delete_memory('mem-1', uid='u1') == {'status': 'ok'}
 
     legacy_delete.assert_not_called()
+
+
+def _canonical_delete_all_stage(monkeypatch, *, read_cutover_done: bool):
+    """Canonical owns writes for DELETE /v3/memories; pick the rollout stage."""
+    monkeypatch.setattr(mem_mod, '_canonical_write_enabled_or_fail_closed', lambda *a, **k: True)
+    monkeypatch.setattr(mem_mod, 'canonical_read_enabled', lambda *a, **k: read_cutover_done)
+    monkeypatch.setattr(mem_mod, 'MemoryService', lambda **kwargs: SimpleNamespace(delete_all=lambda uid: None))
+    purge = MagicMock()
+    monkeypatch.setattr(mem_mod, '_purge_legacy_memories', purge)
+    return purge
+
+
+def test_delete_all_during_dual_write_also_wipes_the_store_the_user_reads(monkeypatch):
+    """#10446 follow-up: at MEMORY_MODE=write a canonical delete-all is invisible, because
+    GET /v3/memories still reads legacy. "Delete everything" would leave the user's whole
+    list intact on the next refresh, so the wipe must reach the store they read."""
+    purge = _canonical_delete_all_stage(monkeypatch, read_cutover_done=False)
+
+    assert mem_mod.delete_memories(uid='u1') == {'status': 'ok'}
+
+    purge.assert_called_once_with('u1')
+
+
+def test_delete_all_after_read_cutover_leaves_legacy_alone(monkeypatch):
+    """Post-cutover both sides are canonical, so the mirror must not touch legacy."""
+    purge = _canonical_delete_all_stage(monkeypatch, read_cutover_done=True)
+
+    assert mem_mod.delete_memories(uid='u1') == {'status': 'ok'}
+
+    purge.assert_not_called()
+
+
+def test_legacy_cohort_delete_all_still_purges(monkeypatch):
+    """The legacy branch keeps its own behaviour after being factored into the helper."""
+    monkeypatch.setattr(mem_mod, '_canonical_write_enabled_or_fail_closed', lambda *a, **k: False)
+    purge = MagicMock()
+    monkeypatch.setattr(mem_mod, '_purge_legacy_memories', purge)
+
+    assert mem_mod.delete_memories(uid='u1') == {'status': 'ok'}
+
+    purge.assert_called_once_with('u1')


### PR DESCRIPTION
## What

Deleted memories come back a few seconds later. Root-caused to a read/write decision asymmetry in the V3 memory rollout — not a client cache issue.

Refs #10446 (server-side half; see the note on symptom 1 below).

## Root cause

The delete and list routes are gated on **different rollout modes**:

| route | gate | canonical when |
|---|---|---|
| `DELETE /v3/memories/{id}`, `/v3/memories/batch`, `/v3/memories` (all) | `canonical_write_decision` | `mode ∈ {write, read}` |
| `GET /v3/memories` | `canonical_read_enabled` | **`mode == read` only** |

So during the dual-write stage (`MEMORY_MODE=write`) — which every rollout passes through before read cutover, and #10394 has this one mid-flight — a delete tombstones the **canonical** record while the user's list keeps reading **legacy**, where the row is untouched. The client drops it optimistically, the next refresh re-reads legacy, and the memory reappears. That matches the reported ~10–15s timing.

## Fix

Mirror the canonical delete into legacy until read cutover — deleting is symmetric with dual-write — across **all three** delete paths (single, batch, and delete-all). The mirror:

- **no-ops after cutover** (`canonical_read_enabled` true ⇒ both sides canonical), so this is confined to the migration window;
- is **best-effort** — canonical is authoritative and its delete has already committed, so a legacy cleanup failure must not fail a request the user already saw succeed;
- is harmless for canonical-only rows: Firestore deletes of absent documents are no-ops.

Single/batch mirror the specific `memory_ids`; delete-all purges the legacy collection for the uid (`_mirror_delete_all_into_legacy` → `_purge_legacy_memories`), matching what the canonical delete-all already did to the canonical store.

## ⚠️ Please confirm the semantic

This changes deletion behavior during a live migration, so it deserves the rollout owner's eye rather than mine. I picked **symmetric dual-delete** (a delete applies to both stores while both are live). The alternative is routing deletes at the store the user reads. I'm happy to switch if you prefer the other semantic.

Note the delete-**all** mirror is a bulk wipe of the legacy collection for that uid — larger blast radius than single/batch, but it only mirrors what the canonical delete-all already committed, is confined to the write window, and no-ops after cutover. Called out so the rollout owner can weigh it explicitly.

Related: `_force_canonical` in the batch-delete tests previously left the read stage implicit, inheriting whatever the ambient rollout config produced. It now pins `MEMORY_MODE=read` explicitly, so those batch-vs-single authorization-parity cases keep asserting exactly what they always did — the contract is unchanged, only the stage is now stated.

## Tests

`backend/tests/unit/test_memories_batch_delete.py` (**23 passed**, Python 3.11 `.venv`):
- `test_delete_during_dual_write_also_clears_the_store_the_user_reads` — the single/batch regression. Fails on old code (`Expected 'mock' to have been called once. Called 0 times.`), passes with the fix.
- `test_delete_after_read_cutover_leaves_legacy_alone` — the mirror must not fire post-cutover.
- delete-all variants covering the same dual-write-clears / post-cutover-leaves-alone pair.

**Not exercised live:** I can't see prod's `MEMORY_MODE` or the reporter's account from here. If prod is at `write`, this is deterministic for every affected account rather than a flake — worth confirming when you triage.

## Changes since first review

Folded in the delete-all mirror (previously split into #10454, now closed) so this PR closes the whole asymmetry in one place, per the review — single, batch, and delete-all all mirror during the write window.

## Product invariants affected

- INV-MEM-1 — no tier added, no new canonical collection, default access policy untouched; this only mirrors a delete into the pre-existing legacy collection during the migration window. Guard test green.

Failure-Class: none

No registered class covers "a mutation must land in the store the caller reads while a dual-write migration is in flight". Single instance, fixed at the route boundary that owns the decision.
