### PR TITLE
fix(ci): repair the release-guard self-suite and run it in a lane

### DIFF
--- a/.github/scripts/test_check_release_process_guards.py
+++ b/.github/scripts/test_check_release_process_guards.py
@@ -46,6 +46,28 @@ def _assert_contract_rejects(errors: list[str]) -> None:
     assert any("contract" in error or "fixture" in error for error in errors), errors
 
 
+# The reviewed parent is a deliberately frozen snapshot of the guard, but it is run
+# against the CURRENT codemagic.yaml. Any parent check that counts things the pipeline
+# legitimately grows therefore drifts the moment the pipeline changes — the approved
+# script-step count did exactly that when INV-BETA-1 added the "Create Omi Beta variant"
+# step after this parent was pinned, silently failing 9 of these tests (#10351).
+#
+# That drift is not what these tests demonstrate. Their subject is which *publisher
+# bypasses* the parent's narrower lock accepted, so drop the parent's stale count
+# complaints instead of letting ordinary pipeline growth break the suite. A real
+# publisher/lock finding is never filtered.
+_PARENT_STALE_DRIFT_MARKERS = ("approved script steps",)
+
+
+def _parent_publisher_errors(parent) -> list[str]:
+    """Parent-guard publisher errors, minus complaints caused by its own staleness."""
+    return [
+        error
+        for error in parent.check_codemagic_release_publishers()
+        if not any(marker in error for marker in _PARENT_STALE_DRIFT_MARKERS)
+    ]
+
+
 def _load_parent_guard(tmp_path: Path, revision: str = REVIEWED_PARENT):
     """Load the reviewed parent to prove its narrower lock accepted known bypasses."""
     parent_script = tmp_path / "parent-guard.py"
@@ -277,7 +299,7 @@ def test_reviewed_parent_accepts_constructed_release_and_api_bypasses(tmp_path, 
     parent = _load_parent_guard(tmp_path, RAW_SCANNER_PARENT)
     (tmp_path / "codemagic.yaml").write_text(_parent_bypass_workflow(bypass), encoding="utf-8")
     parent.ROOT = tmp_path
-    assert parent.check_codemagic_release_publishers() == [], bypass
+    assert _parent_publisher_errors(parent) == [], bypass
 
 
 @pytest.mark.parametrize(
@@ -295,14 +317,14 @@ def test_reviewed_parent_accepts_suppressed_or_shadowed_reservations(tmp_path, r
     )
     (tmp_path / "codemagic.yaml").write_text(workflow, encoding="utf-8")
     parent.ROOT = tmp_path
-    assert parent.check_codemagic_release_publishers() == [], replacement
+    assert _parent_publisher_errors(parent) == [], replacement
 
 
 def test_reviewed_parent_accepts_preview_alias_without_early_exit(tmp_path):
     parent = _load_parent_guard(tmp_path, RAW_SCANNER_PARENT)
     (tmp_path / "codemagic.yaml").write_text(_parent_bypass_workflow("echo harmless"), encoding="utf-8")
     parent.ROOT = tmp_path
-    assert parent.check_codemagic_release_publishers() == []
+    assert _parent_publisher_errors(parent) == []
 
 
 def test_codemagic_workflow_contract_accepts_current_production_configuration():
@@ -453,7 +475,7 @@ def test_reviewed_parent_accepts_unreviewed_publisher_bypasses_but_global_lock_r
 
     parent = _load_parent_guard(tmp_path)
     parent.ROOT = tmp_path
-    assert parent.check_codemagic_release_publishers() == [], script
+    assert _parent_publisher_errors(parent) == [], script
 
     errors = GUARDS.check_codemagic_release_publishers()
     assert any("entire document" in error for error in errors), errors
@@ -470,7 +492,7 @@ def test_reviewed_parent_accepts_unknown_credential_group_with_publisher_but_glo
 
     parent = _load_parent_guard(tmp_path)
     parent.ROOT = tmp_path
-    assert parent.check_codemagic_release_publishers() == []
+    assert _parent_publisher_errors(parent) == []
 
     errors = GUARDS.check_codemagic_release_publishers()
     assert any("entire document" in error for error in errors), errors
@@ -511,7 +533,7 @@ def test_global_document_lock_rejects_every_codemagic_mutation(tmp_path, monkeyp
     parent = _load_parent_guard(tmp_path)
     _restore_parent_preview_credential_shape(codemagic)
     parent.ROOT = tmp_path
-    parent_errors = parent.check_codemagic_release_publishers()
+    parent_errors = _parent_publisher_errors(parent)
     assert (parent_errors == []) is parent_accepts, parent_errors
 
     errors = GUARDS.check_codemagic_release_publishers()
@@ -532,7 +554,7 @@ def test_global_document_raw_lock_rejects_semantically_equivalent_yaml_rewrite(t
     parent = _load_parent_guard(tmp_path)
     _restore_parent_preview_credential_shape(codemagic)
     parent.ROOT = tmp_path
-    assert parent.check_codemagic_release_publishers() == []
+    assert _parent_publisher_errors(parent) == []
 
     _mutate(
         codemagic,

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -154,6 +154,18 @@ jobs:
       - name: Check release process guards
         run: bash scripts/run-release-process-guards.sh
 
+      # The guard passing says nothing about its own self-suite, which asserts WHICH
+      # bypasses the lock rejects. That suite ran in no lane, so 9 of its 87 cases
+      # failed silently on main while the guard itself stayed green (#10351). Run it
+      # beside the guard so the two can never drift apart again.
+      - name: Test release process guards
+        run: |
+          pip install -q pyyaml pytest
+          # --noconftest: pytest runs from the repo root, where it would otherwise collect
+          # backend/tests/unit/conftest.py and fail importing backend-only dependencies
+          # this lane does not install. The suite needs no conftest fixtures.
+          python3 -m pytest .github/scripts/test_check_release_process_guards.py -q --noconftest
+
       - name: Check GitHub Actions workflows
         if: needs.changes.outputs.has_workflows == 'true'
         run: |


### PR DESCRIPTION
## What

`.github/scripts/test_check_release_process_guards.py` had **9 of 87 cases failing on `main`**, and the suite ran in **no CI lane** — not in `checks-manifest.yaml`, not in any workflow — so the failures accumulated silently while the guard itself stayed green in repo-checks.

Fixes #10351.

## Why they failed

The tests load a **deliberately frozen** parent guard (`REVIEWED_PARENT`) and run it against the **current** `codemagic.yaml`, to demonstrate which publisher bypasses that older, narrower lock accepted.

Any parent check that counts something the pipeline legitimately grows drifts the moment the pipeline changes. INV-BETA-1's "Create Omi Beta variant" step pushed the approved script-step count past what the pinned parent knows, so the parent started reporting:

```
canonical workflow must retain exactly 21 approved script steps
```

…and every "the parent accepted this baseline" assertion broke. The tests were failing on the parent's own staleness, not on anything about the lock.

## Fix

1. **Filter the parent's stale count complaints.** Their subject is which *publisher bypasses* the old lock accepted, not how many steps the pipeline has today.

   Scoped deliberately: the filter is applied **only to the frozen parent snapshot**. The current guard's step-count check still runs unfiltered — in these same tests and in repo-checks — so a real regression cannot hide behind it.

2. **Run the suite in a lane.** Added a "Test release process guards" step directly beside the existing "Check release process guards" step in `repo-checks.yml`, so the guard and its self-suite can never drift apart silently again. (Per AGENTS.md, a check that runs in no blocking lane is a dead check.)

The manifest wasn't the right home: every entry there invokes `python3 <script>` directly and none uses pytest, while this suite is pytest-based. Putting it next to the guard keeps them in one place with one dependency install.

## Verification

- Suite before: `9 failed, 78 passed` (reproduced on `bdd0d5d0`, matching the issue)
- Suite after: **87 passed**
- Guard itself: still exits 0 (untouched)
- `repo-checks.yml` parses as valid YAML

## Product invariants affected

none (verified with `scripts/pr-preflight --suggest`)

Failure-Class: none

No registered class covers "a guard's self-suite runs in no lane and rots"; the durable fix is the lane wiring in this PR, not a new class.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

