### PR TITLE
fix(listen): recover a taught person's lost speaker embedding

### DIFF
--- a/backend/routers/listen/speakers.py
+++ b/backend/routers/listen/speakers.py
@@ -13,6 +13,7 @@ import numpy as np
 from utils.audio import AudioRingBuffer
 from utils.executors import storage_executor, sync_executor, run_blocking
 from utils.other.storage import get_profile_audio_if_exists
+from utils.speaker_sample import download_sample_audio
 from utils.speaker_sample_migration import maybe_migrate_person_samples
 from utils.stt.speaker_embedding import SPEAKER_MATCH_THRESHOLD, compare_embeddings, extract_embedding_from_bytes
 from utils.transcribe_decisions import USER_SELF_PERSON_ID, should_spawn_speaker_match
@@ -69,12 +70,16 @@ class SpeakerMatcher:
             for person in people:
                 if person.get('speech_samples'):
                     person = await maybe_migrate_person_samples(self.host.request.uid, person)
-                embedding = person.get('speaker_embedding')
-                if embedding and person.get('speech_samples') and person.get('speech_samples_version', 1) >= 3:
-                    self.person_embeddings[person['id']] = {
-                        'embedding': np.array(embedding, dtype=np.float32).reshape(1, -1),
-                        'name': person['name'],
-                    }
+                stored = person.get('speaker_embedding')
+                verified_samples = bool(person.get('speech_samples')) and (person.get('speech_samples_version', 1) >= 3)
+                vector: Optional[Any] = None
+                if verified_samples:
+                    if stored:
+                        vector = np.array(stored, dtype=np.float32).reshape(1, -1)
+                    else:
+                        vector = await self._recover_person_embedding(person)
+                if vector is not None:
+                    self.person_embeddings[person['id']] = {'embedding': vector, 'name': person['name']}
         except Exception as error:
             logger.error('Speaker ID embeddings load failed type=%s', type(error).__name__)
             state.speaker_id_done.set()
@@ -99,6 +104,39 @@ class SpeakerMatcher:
                 self.tasks.add(task)
                 task.add_done_callback(self.tasks.discard)
         state.speaker_id_done.set()
+
+    async def _recover_person_embedding(self, person: Dict[str, Any]) -> Optional[Any]:
+        """Rebuild a taught person's missing embedding from their stored samples.
+
+        The teach path extracts the embedding inside a try/except that only logs, so a
+        failed extraction leaves a person holding samples with no embedding, and nothing
+        ever recomputes it. That person is then skipped here on every later session and
+        can never be matched no matter how many times the user teaches them (#10434) —
+        while the user's own profile self-heals through exactly this fallback above.
+
+        Only reached for `speech_samples_version >= 3` samples, which already passed
+        verify_and_transcribe_sample when they were stored, so this restores a lost
+        embedding without reopening the quality gate that deliberately drops bad samples.
+        """
+        person_id = person.get('id')
+        samples = person.get('speech_samples') or []
+        if not samples:
+            return None
+        try:
+            audio = await run_blocking(storage_executor, download_sample_audio, samples[0])
+            if not audio:
+                return None
+            vector = await run_blocking(sync_executor, cast(Any, extract_embedding_from_bytes), audio, 'sample.wav')
+            await self.host.persistence.call(
+                user_db.set_person_speaker_embedding, self.host.request.uid, person_id, vector.flatten().tolist()
+            )
+            logger.info('Speaker ID recovered missing person embedding person=%s', person_id)
+            return vector
+        except Exception as error:
+            logger.error(
+                'Speaker ID person embedding recovery failed person=%s type=%s', person_id, type(error).__name__
+            )
+            return None
 
     async def match(self, speaker_id: int, segment: dict[str, Any]) -> None:
         try:

--- a/backend/tests/unit/test_speaker_person_embedding_recovery.py
+++ b/backend/tests/unit/test_speaker_person_embedding_recovery.py
@@ -1,0 +1,102 @@
+"""A taught person whose stored embedding was lost must be recoverable (#10434).
+
+extract_speaker_samples stores a person's speech sample, then extracts the speaker
+embedding inside a try/except that only logs. When that extraction fails the person
+keeps quality-verified samples with no embedding, and nothing ever recomputes it — so
+the listen session skips them on every later session and they can never be matched,
+however many times the user teaches them. The user's own profile already self-heals
+through the same fallback; these pin the person side of that behaviour.
+
+Recovery is deliberately limited to speech_samples_version >= 3 samples, which passed
+verify_and_transcribe_sample when they were stored, so it restores a lost embedding
+without reopening the quality gate that intentionally drops bad samples.
+"""
+
+import os
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+import asyncio  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+
+import numpy as np  # noqa: E402
+
+import routers.listen.speakers as speakers_mod  # noqa: E402
+
+
+class _Persistence:
+    """Run persistence work inline and record it, like the real host's serialized queue."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def call(self, fn, *args, **kwargs):
+        self.calls.append((getattr(fn, "__name__", str(fn)), args))
+        return fn(*args, **kwargs)
+
+
+def _matcher(uid: str = "u1") -> speakers_mod.SpeakerMatcher:
+    host = SimpleNamespace(request=SimpleNamespace(uid=uid), persistence=_Persistence())
+    return speakers_mod.SpeakerMatcher(host)
+
+
+def _v3_person() -> dict:
+    return {"id": "p1", "name": "Sarah", "speech_samples": ["people/u1/p1/a.wav"], "speech_samples_version": 3}
+
+
+def test_recovers_a_taught_person_whose_embedding_was_lost(monkeypatch):
+    vector = np.full((1, 512), 0.25, dtype=np.float32)
+    monkeypatch.setattr(speakers_mod, "download_sample_audio", lambda path: b"RIFFfake-wav")
+    monkeypatch.setattr(speakers_mod, "extract_embedding_from_bytes", lambda audio, name: vector)
+
+    persisted: dict[str, list] = {}
+
+    def _persist(uid, person_id, embedding):
+        persisted[person_id] = embedding
+        return True
+
+    monkeypatch.setattr(speakers_mod.user_db, "set_person_speaker_embedding", _persist)
+
+    matcher = _matcher()
+    recovered = asyncio.run(matcher._recover_person_embedding(_v3_person()))
+
+    assert recovered is not None
+    assert np.array_equal(recovered, vector)
+    # Written back, so the next session matches from storage instead of paying for
+    # extraction again — and the person stops being invisible permanently.
+    assert persisted["p1"] == vector.flatten().tolist()
+
+
+def test_recovered_embedding_is_usable_for_matching(monkeypatch):
+    """The recovered vector must be shaped for compare_embeddings, not just non-None."""
+    vector = np.full((1, 512), 0.25, dtype=np.float32)
+    monkeypatch.setattr(speakers_mod, "download_sample_audio", lambda path: b"RIFFfake-wav")
+    monkeypatch.setattr(speakers_mod, "extract_embedding_from_bytes", lambda audio, name: vector)
+    monkeypatch.setattr(speakers_mod.user_db, "set_person_speaker_embedding", lambda *a, **k: True)
+
+    recovered = asyncio.run(_matcher()._recover_person_embedding(_v3_person()))
+
+    assert speakers_mod.compare_embeddings(recovered, vector) < speakers_mod.SPEAKER_MATCH_THRESHOLD
+
+
+def test_person_without_samples_is_not_recovered(monkeypatch):
+    """No samples means nothing to rebuild from — return None rather than reach storage."""
+    reached = []
+    monkeypatch.setattr(speakers_mod, "download_sample_audio", lambda path: reached.append(path) or b"x")
+
+    person = {"id": "p2", "name": "Alex", "speech_samples": [], "speech_samples_version": 3}
+
+    assert asyncio.run(_matcher()._recover_person_embedding(person)) is None
+    assert reached == []
+
+
+def test_recovery_failure_is_contained(monkeypatch):
+    """A storage/extraction failure must not break loading the other speakers."""
+
+    def _boom(path):
+        raise RuntimeError("storage unavailable")
+
+    monkeypatch.setattr(speakers_mod, "download_sample_audio", _boom)
+
+    assert asyncio.run(_matcher()._recover_person_embedding(_v3_person())) is None


### PR DESCRIPTION
## What

A taught person can become permanently unmatchable, so the user sees only their own voice recognised — no matter how many times they teach anyone else.

Refs #10434.

## Root cause

`extract_speaker_samples` stores the sample, then extracts the speaker embedding inside a `try/except` that **only logs**:

```python
try:
    embedding = await run_blocking(sync_executor, extract_embedding_from_bytes, wav_bytes, "sample.wav")
    await run_blocking(db_executor, users_db.set_person_speaker_embedding, uid, person_id, embedding_list)
except Exception as emb_err:
    logger.error(f"Failed to extract/store speaker embedding: {emb_err} ...")
```

When that fails, the person keeps their (quality-verified) samples with **no embedding**, and nothing ever recomputes it. The listen loader requires a stored embedding, so it skips that person on every later session — and `maybe_migrate_person_samples` returns early for anyone already at v3, so re-teaching doesn't rescue them either.

**The asymmetry that makes the symptom so lopsided:** the user's *own* profile already self-heals from exactly this state — if its stored embedding is missing it re-extracts from the profile audio and writes it back (`speakers.py`, the `has_speech_profile` branch). People had no equivalent. Hence: own voice always recognised, everyone else never.

## Fix

Give people the same fallback. When a person has samples but no stored embedding, rebuild it from their first stored sample and persist it.

**Deliberately scoped so it does not reopen the quality gate.** Recovery only runs for `speech_samples_version >= 3`. Those samples already passed `verify_and_transcribe_sample` when stored (the transcript that gates v3 is produced by that verification), so this restores a *lost* embedding rather than resurrecting a *rejected* one. The migrations intentionally drop embeddings for samples that fail quality, and that behaviour is untouched — which matters, because the failure mode of getting this wrong is **mis**identification, worse than non-identification.

Failures stay contained: one unreadable sample returns `None` and the remaining speakers still load.

## Tests

`backend/tests/unit/test_speaker_person_embedding_recovery.py`:
- recovers a v3 person whose embedding was lost, **and persists it** so the next session matches from storage instead of re-extracting
- the recovered vector is shaped for `compare_embeddings` (matches under `SPEAKER_MATCH_THRESHOLD`), not merely non-`None`
- a person with no samples is not recovered and storage is never touched
- a storage/extraction failure is contained

Suites: `test_speaker_id_pipeline.py` + the new file → **112 passed**.

## Scope, honestly

This closes one deterministic path to the reported symptom — the one I could establish from the code. I can't see the reporter's account state, so I can't confirm it's the only contributor. A person can also stay unmatchable if migration fails repeatedly (`maybe_migrate_person_samples` returns the person unchanged on failure), which is a separate question about whether quality-rejected samples should ever be retried — a product call I've deliberately not made here.

## Product invariants affected

none (verified with `scripts/pr-preflight --suggest`)

Failure-Class: none

No registered class covers "a derived artifact is lost by a swallowed exception and never rebuilt"; the durable guard is the recovery path plus its tests.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

