### PR TITLE
fix(backend): name the surface in the OpenAPI regenerate hint

### DIFF
--- a/backend/scripts/export_openapi.py
+++ b/backend/scripts/export_openapi.py
@@ -989,12 +989,23 @@ def write_spec(path: Path, generated: str) -> None:
     path.write_text(generated)
 
 
-def check_spec(path: Path, generated: str) -> None:
+def regenerate_hint(path: Path, surface: str) -> str:
+    """The exact command that regenerates `path`.
+
+    `--surface` has to be explicit: it defaults to `public`, so a hint that omits it
+    sends the reader to overwrite a non-public contract with the public surface, which
+    quietly guts the file instead of refreshing it (#10217).
+    """
+    return f'backend/scripts/export_openapi.py --surface {surface} --write {path}'
+
+
+def check_spec(path: Path, generated: str, *, surface: str) -> None:
+    hint = regenerate_hint(path, surface)
     if not path.exists():
-        raise OpenAPIContractError(f'{path} does not exist; run export_openapi.py --write {path}')
+        raise OpenAPIContractError(f'{path} does not exist; run {hint}')
     current = path.read_text()
     if current != generated:
-        raise OpenAPIContractError(f'{path} is stale; run backend/scripts/export_openapi.py --write {path}')
+        raise OpenAPIContractError(f'{path} is stale; run {hint}')
 
 
 def parse_args() -> argparse.Namespace:
@@ -1047,7 +1058,7 @@ def main() -> int:
             print(f'wrote {path}')
         elif args.check is not None:
             path = resolve_spec_path(args.surface, args.check)
-            check_spec(path, generated)
+            check_spec(path, generated, surface=args.surface)
             print(f'{path} is up to date')
         return 0
     except OpenAPIContractError as e:

--- a/backend/scripts/export_openapi.py
+++ b/backend/scripts/export_openapi.py
@@ -999,7 +999,10 @@ def regenerate_hint(path: Path, surface: str) -> str:
     return f'backend/scripts/export_openapi.py --surface {surface} --write {path}'
 
 
-def check_spec(path: Path, generated: str, *, surface: str) -> None:
+def check_spec(path: Path, generated: str, *, surface: str = 'public') -> None:
+    # Default matches the --surface default so existing callers (and the public
+    # contract test) stay valid; the production caller passes surface explicitly
+    # so a non-public surface never silently gets the public regenerate hint.
     hint = regenerate_hint(path, surface)
     if not path.exists():
         raise OpenAPIContractError(f'{path} does not exist; run {hint}')

--- a/backend/tests/unit/test_export_openapi_hint.py
+++ b/backend/tests/unit/test_export_openapi_hint.py
@@ -1,0 +1,56 @@
+"""The stale-contract hint must name the surface it regenerates (#10217).
+
+`--surface` defaults to `public`, so a hint that prints only `--write <path>` sends the
+reader to overwrite a NON-public contract with the public surface. Following it verbatim
+does not refresh that file, it guts it — the app-client spec lost ~53k lines exactly that
+way. These pin the surface into every regenerate hint the checker emits.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "export_openapi.py"
+_spec = importlib.util.spec_from_file_location("export_openapi_under_test", SCRIPT)
+assert _spec is not None and _spec.loader is not None
+export_openapi = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(export_openapi)
+
+SURFACES = ("public", "app-client", "integration-public")
+
+
+@pytest.mark.parametrize("surface", SURFACES)
+def test_hint_names_its_own_surface_and_path(surface):
+    path = export_openapi.default_spec_path(surface)
+    hint = export_openapi.regenerate_hint(path, surface)
+
+    assert f"--surface {surface}" in hint
+    assert str(path) in hint
+
+
+@pytest.mark.parametrize("surface", SURFACES)
+def test_missing_and_stale_errors_both_carry_the_surface(tmp_path, surface):
+    path = tmp_path / "contract.json"
+
+    with pytest.raises(export_openapi.OpenAPIContractError) as missing:
+        export_openapi.check_spec(path, "{}\n", surface=surface)
+    assert f"--surface {surface}" in str(missing.value)
+
+    path.write_text("{}\n")
+    with pytest.raises(export_openapi.OpenAPIContractError) as stale:
+        export_openapi.check_spec(path, '{"different": true}\n', surface=surface)
+    assert f"--surface {surface}" in str(stale.value)
+
+
+def test_a_non_public_hint_is_never_the_bare_public_default():
+    """The regression itself: the app-client hint must not be a command that writes public.
+
+    Before the fix the hint was `--write <app-client path>`, and because --surface defaults
+    to public, running it produced the public surface in the app-client file.
+    """
+    app_client_path = export_openapi.default_spec_path("app-client")
+    hint = export_openapi.regenerate_hint(app_client_path, "app-client")
+
+    assert "--surface public" not in hint
+    assert hint != f"backend/scripts/export_openapi.py --write {app_client_path}"

--- a/backend/tests/unit/test_export_openapi_hint.py
+++ b/backend/tests/unit/test_export_openapi_hint.py
@@ -43,6 +43,23 @@ def test_missing_and_stale_errors_both_carry_the_surface(tmp_path, surface):
     assert f"--surface {surface}" in str(stale.value)
 
 
+def test_check_spec_stays_callable_without_surface(tmp_path):
+    """Backward compatibility: check_spec must remain callable without `surface`.
+
+    Making `surface` keyword-only-required broke existing callers
+    (test_openapi_contract.py::test_check_spec_detects_stale_file) with a
+    TypeError. It defaults to 'public' — matching the --surface default — while
+    the production caller still passes surface explicitly.
+    """
+    path = tmp_path / "openapi.json"
+    path.write_text("stale\n")
+
+    with pytest.raises(export_openapi.OpenAPIContractError) as stale:
+        export_openapi.check_spec(path, "fresh\n")  # no surface kwarg
+    assert "is stale" in str(stale.value)
+    assert "--surface public" in str(stale.value)
+
+
 def test_a_non_public_hint_is_never_the_bare_public_default():
     """The regression itself: the app-client hint must not be a command that writes public.
 


### PR DESCRIPTION
## What

The OpenAPI contract checker tells you how to fix a stale contract, and the command it prints is wrong for every non-public surface.

Fixes #10217.

## Why it matters

`check_spec` printed:

```
<path> is stale; run backend/scripts/export_openapi.py --write <path>
```

`--surface` **defaults to `public`**. So running that hint verbatim against the app-client contract exports the *public* surface into the app-client file — it doesn't refresh the contract, it guts it (~53k lines). The hint actively causes the damage it claims to repair.

I hit this myself regenerating contracts today: you have to already know to pass `--surface app-client`, which is precisely what the error message exists to tell you.

## Fix

Thread the surface into `check_spec` and build both the missing- and stale-file messages from one `regenerate_hint` helper, so the printed command is exactly the command that regenerates that path:

```
<path> is stale; run backend/scripts/export_openapi.py --surface app-client --write <path>
```

Verified live by making the app-client contract stale and running the checker (contract restored afterwards, not part of the diff):

```
OpenAPI contract check failed: .../app-client-openapi.json is stale;
run backend/scripts/export_openapi.py --surface app-client --write .../app-client-openapi.json
```

## Tests

`backend/tests/unit/test_export_openapi_hint.py` — 7 cases:
- every surface's hint names that surface and its own path
- both the missing-file and stale-file errors carry the surface
- the regression itself: the app-client hint is never the bare `--write <path>` form that defaults to public

## Note on prior attempts

#10255 and #10294 both targeted this and were closed unmerged, so the issue is still live on `main` — I verified the surface-less hint is still there before writing anything.

## Product invariants affected

none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

