### PR TITLE
fix(desktop): reveal PTT while floating bar is snoozed

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2375,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2639,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4849,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4829,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2584,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1534,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1584

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarLaunchPolicy.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarLaunchPolicy.swift
@@ -16,6 +16,28 @@ enum FloatingBarLaunchPresentation: Equatable {
   case deferUntilFirstPushToTalk
 }
 
+/// A temporary snooze silences passive floating-bar presentation, but it must
+/// never swallow a direct request to talk. Settings-hidden and snoozed bars
+/// therefore share the same Push-to-Talk reveal behavior.
+enum FloatingBarPresentationRequest {
+  case explicitUserAction
+  case background
+}
+
+enum FloatingBarPresentationPolicy {
+  static func shouldPresent(
+    request: FloatingBarPresentationRequest,
+    isSnoozed: Bool
+  ) -> Bool {
+    switch request {
+    case .explicitUserAction:
+      true
+    case .background:
+      !isSnoozed
+    }
+  }
+}
+
 struct FloatingBarLaunchPolicy {
   static func presentation(
     isEnabled: Bool,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
@@ -35,8 +35,12 @@ extension FloatingControlBarManager {
 
     // Auto-focus input if AI conversation is open.
     if let window, window.state.showingAIConversation && !window.state.showingAIResponse {
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-        window.focusInputField()
+      if !window.focusInputField() {
+        // SwiftUI may still be attaching the text view. Retry on its next
+        // layout pass rather than relying on a fixed wall-clock delay.
+        DispatchQueue.main.async { [weak window] in
+          window?.focusInputField()
+        }
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Shared reveal implementation for persistent settings, temporary snoozes,
+/// and direct Push-to-Talk presentation.
+extension FloatingControlBarManager {
+  /// Applies the saved launch preference without overriding a temporary
+  /// notification snooze. Push-to-Talk and Settings call `show()` instead.
+  func showForLaunch() {
+    present(.background, persistEnabledPreference: false)
+  }
+
+  func present(
+    _ request: FloatingBarPresentationRequest,
+    persistEnabledPreference: Bool
+  ) {
+    log("FloatingControlBarManager: show() called, window=\(window != nil), isVisible=\(window?.isVisible ?? false)")
+    if persistEnabledPreference {
+      isEnabled = true
+    }
+    guard FloatingBarPresentationPolicy.shouldPresent(request: request, isSnoozed: isSnoozed) else {
+      return
+    }
+    // Reveal on every hidden→present transition (not just once per session):
+    // the island should always grow out of the notch instead of popping in.
+    let shouldPlayNotchReveal =
+      window?.usesNotchIslandForCurrentScreen == true
+      && (window?.isVisible != true || !hasRevealedNotchThisSession)
+    hasRevealedNotchThisSession = true
+    window?.normalizeForTemporaryShow()
+    window?.makeKeyAndOrderFront(nil)
+    if shouldPlayNotchReveal {
+      window?.playNotchRevealAnimation()
+    }
+    log("FloatingControlBarManager: show() done, frame=\(window?.frame ?? .zero)")
+
+    // Auto-focus input if AI conversation is open.
+    if let window, window.state.showingAIConversation && !window.state.showingAIResponse {
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        window.focusInputField()
+      }
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2543,10 +2543,10 @@ class FloatingControlBarManager {
     let context: FloatingBarNotificationContext?
   }
 
-  private var window: FloatingControlBarWindow?
+  var window: FloatingControlBarWindow?
   /// Tracks whether the deferred notch reveal has happened this session for
   /// explicit opt-in contexts such as onboarding/demo/minimal mode.
-  private var hasRevealedNotchThisSession = false
+  var hasRevealedNotchThisSession = false
   private var snoozeTimer: Timer?
   private var recordingCancellable: AnyCancellable?
   private var durationCancellable: AnyCancellable?
@@ -3137,7 +3137,7 @@ class FloatingControlBarManager {
     case .hidden:
       return
     case .showImmediately:
-      show()
+      showForLaunch()
     case .deferUntilFirstPushToTalk:
       showDeferredUntilFirstPushToTalk()
     }
@@ -3151,37 +3151,12 @@ class FloatingControlBarManager {
       log("FloatingControlBarManager: showDeferredUntilFirstPushToTalk() — notch hidden until first Push-to-Talk")
       return
     }
-    show()
+    showForLaunch()
   }
 
   /// Show the floating bar and persist the preference.
   func show() {
-    log("FloatingControlBarManager: show() called, window=\(window != nil), isVisible=\(window?.isVisible ?? false)")
-    isEnabled = true
-    if isSnoozed {
-      log(
-        "FloatingControlBarManager: show() suppressed because bar is snoozed until \(snoozedUntil?.description ?? "?")")
-      return
-    }
-    // Reveal on every hidden→present transition (not just once per session):
-    // the island should always grow out of the notch instead of popping in.
-    let shouldPlayNotchReveal =
-      window?.usesNotchIslandForCurrentScreen == true
-      && (window?.isVisible != true || !hasRevealedNotchThisSession)
-    hasRevealedNotchThisSession = true
-    window?.normalizeForTemporaryShow()
-    window?.makeKeyAndOrderFront(nil)
-    if shouldPlayNotchReveal {
-      window?.playNotchRevealAnimation()
-    }
-    log("FloatingControlBarManager: show() done, frame=\(window?.frame ?? .zero)")
-
-    // Auto-focus input if AI conversation is open
-    if let window = window, window.state.showingAIConversation && !window.state.showingAIResponse {
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-        window.focusInputField()
-      }
-    }
+    present(.explicitUserAction, persistEnabledPreference: true)
   }
 
   /// Hide the floating bar and persist the preference.
@@ -3206,7 +3181,12 @@ class FloatingControlBarManager {
       log("FloatingControlBarManager: showTemporarily() suppressed because bar is disabled")
       return
     }
-    if isSnoozed {
+    guard
+      FloatingBarPresentationPolicy.shouldPresent(
+        request: .background,
+        isSnoozed: isSnoozed
+      )
+    else {
       log("FloatingControlBarManager: showTemporarily() suppressed because bar is snoozed")
       return
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2282,11 +2282,11 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     UserDefaults.standard.removeObject(forKey: FloatingControlBarWindow.positionKey)
     centerOnMainScreen()
   }
-
-  /// Called when monitors are connected/disconnected. Re-center if the bar is no longer
-  /// fully visible on any screen.
+  /// Called when monitors are connected/disconnected. Re-center if the bar is no longer fully visible on any screen.
   private func scheduleStartupDisplayRevalidation() {
-    startupDisplayRevalidationWorkItems.forEach { $0.cancel() }
+    for workItem in startupDisplayRevalidationWorkItems {
+      workItem.cancel()
+    }
     startupDisplayRevalidationWorkItems = Self.startupDisplayRevalidationDelays.map { delay in
       let workItem = DispatchWorkItem { [weak self] in
         Task { @MainActor in

--- a/desktop/macos/Desktop/Tests/FloatingBarLaunchPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarLaunchPolicyTests.swift
@@ -3,6 +3,33 @@ import XCTest
 @testable import Omi_Computer
 
 final class FloatingBarLaunchPolicyTests: XCTestCase {
+  func testExplicitUserActionRevealsSnoozedFloatingBar() {
+    XCTAssertTrue(
+      FloatingBarPresentationPolicy.shouldPresent(
+        request: .explicitUserAction,
+        isSnoozed: true
+      )
+    )
+  }
+
+  func testBackgroundPresentationRemainsSuppressedWhileSnoozed() {
+    XCTAssertFalse(
+      FloatingBarPresentationPolicy.shouldPresent(
+        request: .background,
+        isSnoozed: true
+      )
+    )
+  }
+
+  func testBackgroundPresentationIsAllowedWhenNotSnoozed() {
+    XCTAssertTrue(
+      FloatingBarPresentationPolicy.shouldPresent(
+        request: .background,
+        isSnoozed: false
+      )
+    )
+  }
+
   func testNormalSignedInLaunchShowsEnabledFloatingBarEvenOnNotchedDisplays() {
     XCTAssertEqual(
       FloatingBarLaunchPolicy.presentation(

--- a/desktop/macos/changelog/unreleased/20260724-floating-bar-ptt-snooze.json
+++ b/desktop/macos/changelog/unreleased/20260724-floating-bar-ptt-snooze.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Push-to-Talk so it still reveals the floating bar while the bar is snoozed"
+}

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -11,6 +11,7 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/DelayedActionScheduler.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarLaunchPolicy.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift


### PR DESCRIPTION
## Summary

- Route explicit Push-to-Talk presentation through the same reveal behavior whether the floating bar was hidden in Settings or snoozed from the notch menu.
- Keep the two-hour snooze effective for passive launch, browser-tool, and notification presentation.
- Add policy coverage for explicit and background presentation while snoozed.

## Verification

- `xcrun swift build --package-path Desktop --product 'Omi Computer'` ✅
- `./scripts/swift-format-wrapper.sh lint Desktop/Sources/FloatingControlBar/FloatingBarLaunchPolicy.swift Desktop/Tests/FloatingBarLaunchPolicyTests.swift` ✅
- `xcrun swift test --package-path Desktop --filter FloatingBarLaunchPolicyTests` ⚠️ blocked by unrelated existing compile errors in `RealtimeHubSessionHandoffPolicyTests` and `RealtimeVoiceContextSingleFlightTests`.

## Product invariants affected

- INV-CHAT-1

## Failure class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

