### PR TITLE
Enable Return for onboarding proceed actions

### DIFF
--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexingView.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexingView.swift
@@ -215,6 +215,7 @@ struct FileIndexingView: View {
             .shadow(color: OmiColors.accent.opacity(0.4), radius: 16, x: 0, y: 4)
         }
         .buttonStyle(.plain)
+        .keyboardShortcut(.defaultAction)
         .padding(.bottom, OmiSpacing.page)
       }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/SecondBrain/SBComponents.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SecondBrain/SBComponents.swift
@@ -91,6 +91,7 @@ struct SBInkButton: View {
   var size: CGFloat = 14
   var horizontalPadding: CGFloat = 18
   var verticalPadding: CGFloat = 9
+  var isDefaultAction = false
   let action: () -> Void
 
   var body: some View {
@@ -105,6 +106,20 @@ struct SBInkButton: View {
         )
     }
     .buttonStyle(.plain)
+    .modifier(SBDefaultActionKeyboardShortcut(enabled: isDefaultAction))
+  }
+}
+
+private struct SBDefaultActionKeyboardShortcut: ViewModifier {
+  let enabled: Bool
+
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if enabled {
+      content.keyboardShortcut(.defaultAction)
+    } else {
+      content
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -336,7 +336,7 @@ struct OnboardingChatView: View {
                   .background(OmiColors.accent)
                   .cornerRadius(OmiChrome.smallControlRadius)
               }
-              .buttonStyle(.plain)
+              .buttonStyle(.plain).keyboardShortcut(.defaultAction)
               .padding(.top, OmiSpacing.md)
             }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -198,7 +198,7 @@ struct SBOnboardingView: View {
         trustRow("YOURS") { Text("Pause me from the notch. Delete anything, forever.") }
       }
       .overlay(RoundedRectangle(cornerRadius: 13).stroke(sb.ink(.w1), lineWidth: 1))
-      SBInkButton(title: "Set up Omi →") { model.answerPromise() }
+      SBInkButton(title: "Set up Omi →", isDefaultAction: true) { model.answerPromise() }
     }
   }
 
@@ -241,7 +241,7 @@ struct SBOnboardingView: View {
           Text(draft).geist(size: 17, weight: .medium).foregroundStyle(sb.ink)
           Text("· detected").geist(size: 12.5).foregroundStyle(sb.ink(.w4))
         }
-        SBInkButton(title: "Continue") {
+        SBInkButton(title: "Continue", isDefaultAction: true) {
           if let m = all.first(where: { $0.name.lowercased() == draft.lowercased() }) {
             model.pickLanguage(code: m.code, name: m.name)
           } else {
@@ -338,6 +338,7 @@ struct SBOnboardingView: View {
           .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .keyboardShortcut(.defaultAction)
       } else {
         Button {
           if state == .ask { model.requestPerm(key) }
@@ -439,7 +440,9 @@ struct SBOnboardingView: View {
       // just a quiet Skip so the user is never stuck.
       Group {
         if model.shortcutPressed {
-          SBInkButton(title: "Continue") { isTalk ? model.answerShortcutTalk() : model.answerShortcutOpen() }
+          SBInkButton(title: "Continue", isDefaultAction: true) {
+            isTalk ? model.answerShortcutTalk() : model.answerShortcutOpen()
+          }
         } else {
           Button {
             isTalk ? model.answerShortcutTalk() : model.answerShortcutOpen()
@@ -472,7 +475,7 @@ struct SBOnboardingView: View {
       // that, a quiet "Skip for now" so the user doesn't blow past the live demo.
       Group {
         if model.screenDemoDone {
-          SBInkButton(title: "Continue") { model.answerScreenDemo() }
+          SBInkButton(title: "Continue", isDefaultAction: true) { model.answerScreenDemo() }
         } else {
           Button {
             model.answerScreenDemo()
@@ -501,7 +504,7 @@ struct SBOnboardingView: View {
       }
       .padding(.horizontal, 14)
       .overlay(RoundedRectangle(cornerRadius: 13).stroke(sb.ink(.w1), lineWidth: 1))
-      SBInkButton(title: "Continue") { model.answerAgents() }
+      SBInkButton(title: "Continue", isDefaultAction: true) { model.answerAgents() }
     }
     .frame(maxWidth: 380, alignment: .leading)
   }
@@ -518,7 +521,7 @@ struct SBOnboardingView: View {
       }
       .padding(.horizontal, 14)
       .overlay(RoundedRectangle(cornerRadius: 13).stroke(sb.ink(.w1), lineWidth: 1))
-      SBInkButton(title: "Continue") { model.answerContext() }
+      SBInkButton(title: "Continue", isDefaultAction: true) { model.answerContext() }
     }
     .frame(maxWidth: 380, alignment: .leading)
   }

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -387,6 +387,44 @@ final class OnboardingFlowTests: XCTestCase {
     }
   }
 
+  /// Static tripwire: keyboard shortcut registration is a SwiftUI wiring
+  /// contract, so assert every visible onboarding proceed action remains the
+  /// default action without trying to synthesize AppKit key events in a unit test.
+  func testOnboardingProceedActionsUseDefaultActionKeyboardShortcut() throws {
+    // omi-test-quality: source-inspection -- static contract: verifies SwiftUI default-action wiring on every visible onboarding proceed control
+    let chatSource = try desktopSourceFile("Onboarding/OnboardingChatView.swift")
+    XCTAssertTrue(
+      chatSource.contains("handleOnboardingComplete()\n              })")
+        && chatSource.contains(".keyboardShortcut(.defaultAction)\n              .padding(.top"),
+      "the conversational onboarding Continue button must accept Return")
+
+    let fileIndexingSource = try desktopSourceFile("FileIndexing/FileIndexingView.swift")
+    XCTAssertTrue(
+      fileIndexingSource.contains("onComplete(totalFilesScanned)")
+        && fileIndexingSource.contains(".keyboardShortcut(.defaultAction)\n        .padding(.bottom"),
+      "the file-index onboarding Continue button must accept Return")
+
+    let secondBrainSource = try desktopSourceFile("Onboarding/SecondBrain/SBOnboardingView.swift")
+    for title in ["Set up Omi →", "Continue"] {
+      XCTAssertTrue(
+        secondBrainSource.contains("SBInkButton(title: \"\\(title)\", isDefaultAction: true)"),
+        "the second-brain \(title) action must accept Return")
+    }
+    XCTAssertEqual(
+      secondBrainSource.components(separatedBy: "isDefaultAction: true").count - 1,
+      6,
+      "every visible second-brain proceed action must register Return")
+    XCTAssertTrue(
+      secondBrainSource.contains("Text(\"Continue →\")")
+        && secondBrainSource.contains(".keyboardShortcut(.defaultAction)\n      } else {"),
+      "the granted-permission Continue action must accept Return")
+
+    let componentsSource = try desktopSourceFile("MainWindow/SecondBrain/SBComponents.swift")
+    XCTAssertTrue(
+      componentsSource.contains("content.keyboardShortcut(.defaultAction)"),
+      "SBInkButton must wire opted-in proceed actions to Return")
+  }
+
   // Regression: arrow navigation must be computed from persisted step state and
   // applied by the mounted view — the NSEvent monitor's captured view copy drops
   // @AppStorage writes on some macOS versions. These cover the extracted
@@ -440,11 +478,15 @@ final class OnboardingFlowTests: XCTestCase {
   }
 
   private func onboardingSourceFile(_ name: String) throws -> String {
+    try desktopSourceFile("Onboarding/\(name)")
+  }
+
+  private func desktopSourceFile(_ relativePath: String) throws -> String {
     let sourceURL = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()
       .deletingLastPathComponent()
-      .appendingPathComponent("Sources/Onboarding")
-      .appendingPathComponent(name)
+      .appendingPathComponent("Sources")
+      .appendingPathComponent(relativePath)
     // omi-test-quality: source-inspection -- static contract: forbids uncancellable deferred-advance patterns in step views
     return try String(contentsOf: sourceURL, encoding: .utf8)
   }

--- a/desktop/macos/changelog/unreleased/20260724-onboarding-return-continue.json
+++ b/desktop/macos/changelog/unreleased/20260724-onboarding-return-continue.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added Return-key support for onboarding Continue and setup actions"
+}


### PR DESCRIPTION
## What changed and why

Made Return the default action for visible onboarding setup and Continue controls, including the active Second Brain flow, legacy conversational onboarding, and file-index completion.

## Product invariants affected

none

## How it was verified

- `xcrun swift build -c debug --package-path Desktop --scratch-path /tmp/omi-onboarding-return-build.dFb1iG` — passed.
- `./scripts/swiftlint-wrapper.sh lint` — passed with 0 violations.
- `./scripts/swift-format-wrapper.sh lint` on the five changed Swift files — passed.
- `python3 scripts/check_desktop_test_quality.py` — passed.
- Built and launched the isolated ad-hoc signed bundle `/Applications/omi-onboarding-return.app`; its automation bridge responded on port 47817. The copied profile was signed out, so onboarding could not be driven without interactive sign-in.
- `xcrun swift test --package-path Desktop --scratch-path /tmp/omi-onboarding-return-build.dFb1iG --filter OnboardingFlowTests` is blocked before execution by unrelated existing test-target compilation errors in `RealtimeHubSessionHandoffPolicyTests` and `RealtimeVoiceContextSingleFlightTests`.

## Tests

Added `OnboardingFlowTests.testOnboardingProceedActionsUseDefaultActionKeyboardShortcut`, a static SwiftUI wiring tripwire for every onboarding proceed action.

## Failure class (fixes)

Failure-Class: none

## New guards (only when adding a check or ratchet)

The regression tripwire is tied to this user-reported onboarding failure. It is not a shared primitive because it verifies a finite set of onboarding-specific controls, including dynamically shown Continue actions.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

