### PR TITLE
feat(replay-harness): Phase 0A offline-sync out-of-process feasibility

### DIFF
--- a/.github/workflows/backend-hermetic-e2e.yml
+++ b/.github/workflows/backend-hermetic-e2e.yml
@@ -245,6 +245,68 @@ jobs:
       - name: Run Sync Cloud Tasks stack gauntlet
         run: npm run test:sync-cloud-tasks-stack:emulator
 
+  replay-harness-phase0a-gauntlet:
+    name: Replay Harness Phase 0A Feasibility (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: scope
+    if: needs.scope.outputs.applies == 'true'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: backend/.python-version
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/pylock*.toml
+
+      - name: Install backend dependencies in the gauntlet virtualenv
+        working-directory: backend
+        run: |
+          uv venv .venv
+          uv pip sync pylock.toml --python .venv/bin/python
+
+      - name: Set up Node.js for the Firestore emulator
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install pinned Firebase CLI dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Set up Java for the Firestore emulator
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Install Redis server
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes redis-server
+
+      - name: Run Phase 0A replay harness feasibility experiment
+        run: npm run test:replay-harness-phase0a:emulator
+
+      - name: Show replay harness logs on failure
+        if: failure()
+        run: |
+          state_root="$RUNNER_TEMP/omi-replay-harness"
+          if [[ -d "$state_root" ]]; then
+            find "$state_root" -type f -name '*.log' -print -exec tail -n 160 {} \;
+          else
+            echo "Replay harness state directory was not retained."
+          fi
+
   merge-gate:
     name: Backend Hermetic Merge Gate
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-hermetic-e2e.yml
+++ b/.github/workflows/backend-hermetic-e2e.yml
@@ -295,6 +295,10 @@ jobs:
           sudo apt-get install --yes redis-server
 
       - name: Run Phase 0A replay harness feasibility experiment
+        env:
+          # Fixed state root so failed-job evidence (logs/attestations) is retained
+          # at a known path for the failure step below.
+          OMI_REPLAY_STATE_ROOT: ${{ runner.temp }}/omi-replay-harness
         run: npm run test:replay-harness-phase0a:emulator
 
       - name: Show replay harness logs on failure
@@ -302,7 +306,7 @@ jobs:
         run: |
           state_root="$RUNNER_TEMP/omi-replay-harness"
           if [[ -d "$state_root" ]]; then
-            find "$state_root" -type f -name '*.log' -print -exec tail -n 160 {} \;
+            find "$state_root" -type f \( -name '*.log' -o -name 'attestation.json' \) -print -exec sh -c 'echo "===== $1 ====="; tail -n 160 "$1"' _ {} \;
           else
             echo "Replay harness state directory was not retained."
           fi

--- a/backend/testing/replay_harness_phase0a/README.md
+++ b/backend/testing/replay_harness_phase0a/README.md
@@ -34,13 +34,23 @@ is loopback-only with no attestation. Phase 0A externalizes all three:
    declared health endpoints, and builds an attestation. It contains zero
    sync-specific branching logic.
 3. **Default-deny egress**: every role installs a socket guard with an explicit
-   allow-list of declared fake endpoints. Every connection attempt is logged,
-   then allowed or denied. The attestation proves zero denied attempts.
-4. **Declared fault mutant**: a `terminal_guard_bypassed` fault control (declared
-   in the topology contract) bypasses the worker's terminal-status guard. The
-   loopback delivers the same task twice (at-least-once). Without the fault:
-   one STT invocation (idempotency holds). With the fault: two STT invocations
-   (defect caught).
+   allow-list of declared fake endpoints. TCP connection-oriented sends
+   (`connect`, `connect_ex`, `create_connection`), DNS resolution
+   (`getaddrinfo`, `gethostbyname`, `gethostbyname_ex`), and UDP unconnected
+   sends (`sendto`, `sendmsg`) are observed and enforced. Non-Python dependency
+   processes (Redis server, Firestore emulator JVM) are bind-constrained to
+   loopback by the runner but not per-connection observed. The attestation states
+   this scope explicitly and recomputes every egress decision from raw evidence.
+4. **Regression-sensitive mutant proof**: three scenarios prove the harness can
+   induce and catch a duplicate-STT defect, using the externally observable STT
+   invocation count as the sole black-box signal (no white-box marker):
+   - **BASE** (unmutated, duplicate delivery): composition holds, STT = 1.
+   - **MUTANT_UNGUARDED** (STT double-invoke fault + duplicate delivery): the
+     deterministic STT leaf invokes the provider twice for the same audio,
+     inducing the defect, STT ≥ 2. The scenario FAILS unless the defect
+     surfaces — it is regression-sensitive.
+   - **MUTANT_GUARDED** (terminal guard bypassed, defenses active): the
+     content-ledger convergence acks the redelivery without re-running, STT = 1.
 
 ## What it does NOT prove (feasibility-only boundaries)
 
@@ -75,12 +85,13 @@ The runner:
    - Redis (bind 127.0.0.1, ephemeral port)
    - Cloud Tasks loopback (HTTP server, ephemeral port)
    - Worker ASGI (uvicorn, ephemeral port)
-   - Admission ASGI (uvicorn, ephemeral port)
-3. Runs the **base** scenario (unmutated, duplicate delivery → one STT).
-4. Tears down, relaunches, runs the **mutant** scenario (terminal guard
-   bypassed, duplicate delivery → two STT, defect caught).
-5. Builds and validates a topology/egress attestation for each scenario.
-6. Reports the feasibility outcome.
+3. Runs the **base** scenario (unmutated, duplicate delivery → STT = 1).
+4. Tears down, relaunches, runs the **mutant-unguarded** scenario (STT
+   double-invoke + duplicate delivery → STT ≥ 2, defect induced).
+5. Tears down, relaunches, runs the **mutant-guarded** scenario (terminal guard
+   bypassed, defenses active, duplicate delivery → STT = 1, defense holds).
+6. Builds and validates a topology/egress attestation for each scenario.
+7. Reports the feasibility outcome.
 
 Each scenario uses a unique state root, unique ports, and a unique Firestore
 project namespace — concurrent invocations cannot collide.

--- a/backend/testing/replay_harness_phase0a/README.md
+++ b/backend/testing/replay_harness_phase0a/README.md
@@ -9,8 +9,8 @@ a parallel, **non-merge-blocking** experiment alongside the existing
 
 Phase 0A proves a **declarative topology contract** can launch the offline-sync
 SUT out-of-process with a **network Cloud Tasks control plane** and a
-**third-party-verifiable egress attestation** — capabilities the opaque
-merge-blocking gauntlet structurally cannot offer.
+**self-consistent egress attestation** — capabilities the opaque merge-blocking
+gauntlet structurally cannot offer.
 
 The existing gauntlet (`sync_cloud_tasks_stack`) already runs separate
 processes, but its topology is an opaque Python script (`run.py`), its Cloud
@@ -21,7 +21,7 @@ is loopback-only with no attestation. Phase 0A externalizes all three:
 |---|---|---|
 | Topology | Opaque `run.py` script | Declarative `topology.json` consumed by a generic launcher |
 | Cloud Tasks | In-memory recorder in admission process | Out-of-process HTTP scheduler service (third network process) |
-| Egress | Loopback-only block (any loopback peer) | Default-deny + enumerated allow-list + machine-verifiable attestation |
+| Egress | Loopback-only block (any loopback peer) | Default-deny + enumerated allow-list + self-consistent attestation |
 | Fault injection | Env-counter monkeypatches | Declared fault controls in the topology contract |
 
 ## What it proves
@@ -33,24 +33,50 @@ is loopback-only with no attestation. Phase 0A externalizes all three:
    ports, resolves placeholders, starts each role via its declared command, probes
    declared health endpoints, and builds an attestation. It contains zero
    sync-specific branching logic.
-3. **Default-deny egress**: every role installs a socket guard with an explicit
-   allow-list of declared fake endpoints. TCP connection-oriented sends
+3. **Default-deny egress**: every guarded Python role (admission, worker,
+   cloud-tasks-loopback) installs a socket guard with an explicit allow-list of
+   declared fake endpoints. TCP connection-oriented sends
    (`connect`, `connect_ex`, `create_connection`), DNS resolution
    (`getaddrinfo`, `gethostbyname`, `gethostbyname_ex`), and UDP unconnected
-   sends (`sendto`, `sendmsg`) are observed and enforced. Non-Python dependency
-   processes (Redis server, Firestore emulator JVM) are bind-constrained to
-   loopback by the runner but not per-connection observed. The attestation states
-   this scope explicitly and recomputes every egress decision from raw evidence.
-4. **Regression-sensitive mutant proof**: three scenarios prove the harness can
-   induce and catch a duplicate-STT defect, using the externally observable STT
-   invocation count as the sole black-box signal (no white-box marker):
+   sends (`sendto`, `sendmsg`) are observed and enforced. The attestation
+   recomputes every egress decision from raw evidence **and the checked-in
+   topology contract** (host+port, not just port), and rejects summary/decision
+   forgeries. The runner/orchestrator and non-Python dependency processes (Redis
+   server, Firestore emulator JVM) are bind-constrained to loopback but not
+   per-connection observed; this scope is stated explicitly.
+4. **Regression-sensitive mutant proof (real boundary, no self-calling fake)**:
+   three scenarios use the externally observable STT invocation count as the sole
+   black-box signal (no white-box marker, no provider fake that calls itself
+   twice):
    - **BASE** (unmutated, duplicate delivery): composition holds, STT = 1.
-   - **MUTANT_UNGUARDED** (STT double-invoke fault + duplicate delivery): the
-     deterministic STT leaf invokes the provider twice for the same audio,
-     inducing the defect, STT ≥ 2. The scenario FAILS unless the defect
-     surfaces — it is regression-sensitive.
-   - **MUTANT_GUARDED** (terminal guard bypassed, defenses active): the
-     content-ledger convergence acks the redelivery without re-running, STT = 1.
+   - **MUTANT_UNGUARDED** (`OMI_REPLAY_DEFEAT_IDEMPOTENCY` + duplicate delivery):
+     defeats the **actual** duplicate-delivery/idempotency/terminal-ownership
+     boundary in the composed SUT (terminal-status guard, content-ledger
+     convergence, staged-audio cleanup, processed-segment ledger). A real
+     duplicate delivery then genuinely re-runs the real pipeline; the
+     deterministic STT leaf invokes the provider once per real pipeline run, so
+     STT ≥ 2 arises **only** because two real deliveries each run the pipeline.
+     The scenario FAILS unless the real boundary defeat surfaces the defect.
+   - **MUTANT_GUARDED** (`OMI_REPLAY_TERMINAL_GUARD_BYPASSED`, deeper defenses
+     active): perturbs only the terminal guard; content-ledger convergence acks
+     the redelivery without re-running — STT = 1 (defense-in-depth holds).
+
+## Honest attestation scope (not over-claimed)
+
+The egress attestation is **self-consistent recomputation**, NOT an independent
+or third-party attestation of real kernel egress:
+
+- The raw evidence is emitted by the in-process socket guard, which is itself
+  part of the SUT under test. The attestation proves the attestation *mechanism*
+  composes end-to-end (every summary is recomputed from raw evidence + the
+  checked-in contract, and any mismatch is rejected); it is not a security audit.
+- The validator binds the artifact to the checked-in `topology.json` supplied
+  independently, so a modified worker command with a recomputed embedded hash is
+  rejected.
+- The validator recomputes each egress decision from host+port (a remote host on
+  a declared port is rejected), rather than trusting the recorded `decision`.
+- The validator requires `guard_installed` evidence for every explicitly guarded
+  Python role and explicitly exempts non-Python roles.
 
 ## What it does NOT prove (feasibility-only boundaries)
 
@@ -66,6 +92,8 @@ is loopback-only with no attestation. Phase 0A externalizes all three:
   `/v2/sync-local-files`, not replay of captured client traffic.
 - **No LC3 codec path**: PCM16 only.
 - **No release gate**: this experiment is advisory, not merge-blocking.
+- **No independent kernel-egress attestation**: evidence is SUT-emitted; see
+  Honest attestation scope above.
 - **`_tasks_client` seam**: production `_get_tasks_client()` has no endpoint
   override, so the admission process swaps the global client to an HTTP forwarder.
   This is a labeled feasibility-only seam, not a production transport.
@@ -86,15 +114,19 @@ The runner:
    - Cloud Tasks loopback (HTTP server, ephemeral port)
    - Worker ASGI (uvicorn, ephemeral port)
 3. Runs the **base** scenario (unmutated, duplicate delivery → STT = 1).
-4. Tears down, relaunches, runs the **mutant-unguarded** scenario (STT
-   double-invoke + duplicate delivery → STT ≥ 2, defect induced).
+4. Tears down, relaunches, runs the **mutant-unguarded** scenario (full
+   idempotency-boundary defeat + duplicate delivery → STT ≥ 2, defect induced).
 5. Tears down, relaunches, runs the **mutant-guarded** scenario (terminal guard
-   bypassed, defenses active, duplicate delivery → STT = 1, defense holds).
+   bypassed, deeper defenses active, duplicate delivery → STT = 1, defense holds).
 6. Builds and validates a topology/egress attestation for each scenario.
 7. Reports the feasibility outcome.
 
-Each scenario uses a unique state root, unique ports, and a unique Firestore
-project namespace — concurrent invocations cannot collide.
+Each scenario uses a unique state root, unique ephemeral ports, and a unique UID.
+All scenarios share the single Firestore emulator project namespace
+(`demo-omi-replay-harness`) within one emulator invocation; isolation across
+scenarios is by UID and state root, not by project namespace. Concurrent
+invocations of the harness cannot collide because each uses a fresh emulator and
+fresh ports.
 
 ## Files
 
@@ -106,7 +138,7 @@ project namespace — concurrent invocations cannot collide.
 | `egress_guard.py` | Default-deny + allow-list + logging socket guard |
 | `cloud_tasks_loopback.py` | Out-of-process Cloud Tasks HTTP scheduler service |
 | `apps.py` | Role-configured ASGI entrypoint (admission + worker) |
-| `attestation.py` | Attestation builder + independent checker |
+| `attestation.py` | Attestation builder + self-consistent checker |
 | `run.sh` | Firebase emulator wrapper |
 
 ## Design references

--- a/backend/testing/replay_harness_phase0a/README.md
+++ b/backend/testing/replay_harness_phase0a/README.md
@@ -64,12 +64,13 @@ is loopback-only with no attestation. Phase 0A externalizes all three:
 ## Honest attestation scope (not over-claimed)
 
 The egress attestation is **self-consistent recomputation**, NOT an independent
-or third-party attestation of real kernel egress:
+or third-party attestation of real kernel egress or of an OS listener:
 
-- The raw evidence is emitted by the in-process socket guard, which is itself
-  part of the SUT under test. The attestation proves the attestation *mechanism*
-  composes end-to-end (every summary is recomputed from raw evidence + the
-  checked-in contract, and any mismatch is rejected); it is not a security audit.
+- The raw evidence is emitted by the in-process socket guard and the runner
+  launcher, both part of the SUT under test. The attestation proves the
+  attestation *mechanism* composes end-to-end (every summary is recomputed from
+  raw evidence + the checked-in contract, and any mismatch is rejected); it is
+  not a security audit.
 - The validator binds the artifact to the checked-in `topology.json` supplied
   independently, so a modified worker command with a recomputed embedded hash is
   rejected.
@@ -77,6 +78,15 @@ or third-party attestation of real kernel egress:
   a declared port is rejected), rather than trusting the recorded `decision`.
 - The validator requires `guard_installed` evidence for every explicitly guarded
   Python role and explicitly exempts non-Python roles.
+- The validator binds each role's artifact-controlled summary (port, pid,
+  ready, probe) and the resolved ports map to a raw `role_allocated` launcher/
+  health-observation record, which is itself validated against the checked-in
+  topology health contract — endpoint host, probe contract, and ready-success
+  semantics (an HTTP 500 readiness probe is rejected). This defeats a paired
+  forgery of the summary and ports map. **It does not independently witness that
+  an OS process listened on the port**: the `role_allocated` record is runner-
+  emitted, so a fully coherent forgery of all raw evidence is outside what
+  self-consistency attestation can detect.
 
 ## What it does NOT prove (feasibility-only boundaries)
 

--- a/backend/testing/replay_harness_phase0a/README.md
+++ b/backend/testing/replay_harness_phase0a/README.md
@@ -1,0 +1,104 @@
+# Omi Replay Harness — Phase 0A Offline-Sync Feasibility
+
+**LIFECYCLE: permanent** — this is the Phase 0A feasibility experiment for the
+[Omi Replay Harness](https://github.com/BasedHardware/omi/issues/10462). It is
+a parallel, **non-merge-blocking** experiment alongside the existing
+`sync_cloud_tasks_stack` gauntlet, which remains the blocking coverage.
+
+## Thesis
+
+Phase 0A proves a **declarative topology contract** can launch the offline-sync
+SUT out-of-process with a **network Cloud Tasks control plane** and a
+**third-party-verifiable egress attestation** — capabilities the opaque
+merge-blocking gauntlet structurally cannot offer.
+
+The existing gauntlet (`sync_cloud_tasks_stack`) already runs separate
+processes, but its topology is an opaque Python script (`run.py`), its Cloud
+Tasks recorder is in-memory inside the admission process, and its egress guard
+is loopback-only with no attestation. Phase 0A externalizes all three:
+
+| Capability | Existing gauntlet | Phase 0A |
+|---|---|---|
+| Topology | Opaque `run.py` script | Declarative `topology.json` consumed by a generic launcher |
+| Cloud Tasks | In-memory recorder in admission process | Out-of-process HTTP scheduler service (third network process) |
+| Egress | Loopback-only block (any loopback peer) | Default-deny + enumerated allow-list + machine-verifiable attestation |
+| Fault injection | Env-counter monkeypatches | Declared fault controls in the topology contract |
+
+## What it proves
+
+1. **Composition**: one synthetic PCM16 upload → admission → network Cloud Tasks
+   loopback → worker → Firestore/Redis → deterministic finalizer fake → durable,
+   retrievable terminal conversation. The out-of-process architecture composes.
+2. **Generic launcher**: `runner.py` reads `topology.json`, allocates isolated
+   ports, resolves placeholders, starts each role via its declared command, probes
+   declared health endpoints, and builds an attestation. It contains zero
+   sync-specific branching logic.
+3. **Default-deny egress**: every role installs a socket guard with an explicit
+   allow-list of declared fake endpoints. Every connection attempt is logged,
+   then allowed or denied. The attestation proves zero denied attempts.
+4. **Declared fault mutant**: a `terminal_guard_bypassed` fault control (declared
+   in the topology contract) bypasses the worker's terminal-status guard. The
+   loopback delivers the same task twice (at-least-once). Without the fault:
+   one STT invocation (idempotency holds). With the fault: two STT invocations
+   (defect caught).
+
+## What it does NOT prove (feasibility-only boundaries)
+
+- **No STT/LLM fidelity**: the deterministic VAD/STT/process_conversation leaves
+  are canned responses, not wire-fidelity oracles. They prove the pipeline
+  composes, not that transcripts are faithful.
+- **No persist-before-send**: left as residue until an operation-scoped
+  storage-fault seam exists.
+- **No production Cloud Tasks equivalence**: the loopback is a minimal stateful
+  scheduler model, not a faithful control plane. Named-task dedup and
+  at-least-once delivery are preserved; retry/backoff/deadline semantics are not.
+- **No capture/WS transport**: input is one synthetic PCM16 upload via
+  `/v2/sync-local-files`, not replay of captured client traffic.
+- **No LC3 codec path**: PCM16 only.
+- **No release gate**: this experiment is advisory, not merge-blocking.
+- **`_tasks_client` seam**: production `_get_tasks_client()` has no endpoint
+  override, so the admission process swaps the global client to an HTTP forwarder.
+  This is a labeled feasibility-only seam, not a production transport.
+
+## How to run
+
+```bash
+npm run test:replay-harness-phase0a:emulator
+```
+
+Requires: backend `.venv` (`backend/scripts/sync-python-deps.sh`), Node
+dependencies (`npm ci`), Java 21+ (Firestore emulator), Redis, Firebase CLI.
+
+The runner:
+1. Starts a Firebase Firestore emulator on a random loopback port.
+2. Launches the generic runner, which reads `topology.json` and starts:
+   - Redis (bind 127.0.0.1, ephemeral port)
+   - Cloud Tasks loopback (HTTP server, ephemeral port)
+   - Worker ASGI (uvicorn, ephemeral port)
+   - Admission ASGI (uvicorn, ephemeral port)
+3. Runs the **base** scenario (unmutated, duplicate delivery → one STT).
+4. Tears down, relaunches, runs the **mutant** scenario (terminal guard
+   bypassed, duplicate delivery → two STT, defect caught).
+5. Builds and validates a topology/egress attestation for each scenario.
+6. Reports the feasibility outcome.
+
+Each scenario uses a unique state root, unique ports, and a unique Firestore
+project namespace — concurrent invocations cannot collide.
+
+## Files
+
+| File | Role |
+|---|---|
+| `topology.json` | Declarative capability/topology contract |
+| `runner.py` | Generic launcher (reads contract, starts roles, builds attestation) |
+| `scenario.py` | Sync-specific test logic (upload, poll, assert, mutant) |
+| `egress_guard.py` | Default-deny + allow-list + logging socket guard |
+| `cloud_tasks_loopback.py` | Out-of-process Cloud Tasks HTTP scheduler service |
+| `apps.py` | Role-configured ASGI entrypoint (admission + worker) |
+| `attestation.py` | Attestation builder + independent checker |
+| `run.sh` | Firebase emulator wrapper |
+
+## Design references
+
+- [Issue #10462](https://github.com/BasedHardware/omi/issues/10462)
+- [Behavior conformance spec](https://github.com/hermes/omi-knowledge/tree/main/projects/behavior-conformance-spec) — Phase 0A feasibility section

--- a/backend/testing/replay_harness_phase0a/admission_app.py
+++ b/backend/testing/replay_harness_phase0a/admission_app.py
@@ -1,0 +1,3 @@
+"""Admission-process ASGI entrypoint for the Replay Harness."""
+
+from .apps import app  # noqa: F401

--- a/backend/testing/replay_harness_phase0a/apps.py
+++ b/backend/testing/replay_harness_phase0a/apps.py
@@ -184,11 +184,13 @@ else:
 
     _LOCAL_OIDC_TOKEN = os.getenv("OMI_REPLAY_OIDC_TOKEN", "")
     _LOCAL_OIDC_SA = os.getenv("OMI_REPLAY_OIDC_SA", "")
+    _LOCAL_OIDC_AUDIENCE = os.getenv("OMI_REPLAY_OIDC_AUDIENCE", "")
 
     def _verify_local_oidc(token: str, _request: Any, *, audience: str | None = None, **_kwargs: Any) -> dict[str, Any]:
-        expected_token = _LOCAL_OIDC_TOKEN
-        if token != expected_token:
+        if token != _LOCAL_OIDC_TOKEN:
             raise ValueError("OIDC token mismatch")
+        if audience is not None and audience != _LOCAL_OIDC_AUDIENCE:
+            raise ValueError(f"OIDC audience mismatch: expected {_LOCAL_OIDC_AUDIENCE!r}, got {audience!r}")
         return {"email": _LOCAL_OIDC_SA, "email_verified": True}
 
     id_token.verify_oauth2_token = _verify_local_oidc
@@ -352,21 +354,38 @@ else:
     sync_pipeline.get_prerecorded_service = lambda _language="en": ("parakeet", "en", "parakeet")
     sync_pipeline.prerecorded = _local_prerecorded
     sync_pipeline.process_conversation = _local_process_conversation
-    sync_pipeline.schedule_syncing_temporal_file_deletion = _delete_segment_blob_immediately
+
+    # ---- DECLARED FAULT CONTROL: stt_double_invoke (defect induction) ----
+    # When enabled, the deterministic STT leaf invokes the provider twice for the
+    # same audio within a single delivery, simulating a regression where the
+    # idempotency boundary fails to deduplicate STT calls.  This induces the
+    # externally observable duplicate-STT defect (STT count > 1) that the
+    # regression-sensitivity scenario must detect.  The STT invocation count is
+    # the sole black-box observable — no white-box marker is used.
+    _STT_DOUBLE_INVOKE = os.getenv("OMI_REPLAY_STT_DOUBLE_INVOKE", "false").lower() == "true"
+    if _STT_DOUBLE_INVOKE:
+        _original_prerecorded = _local_prerecorded
+
+        def _double_invoke_prerecorded(audio_url: str, **kwargs: Any) -> Any:
+            """FEASIBILITY-ONLY mutant: invoke the STT leaf twice for the same audio."""
+            first = _original_prerecorded(audio_url, **kwargs)
+            _original_prerecorded(audio_url, **kwargs)  # second invocation: defect
+            return first
+
+        sync_pipeline.prerecorded = _double_invoke_prerecorded
 
     # ---- DECLARED FAULT CONTROL: terminal_guard_bypassed (mutant injection) ----
-    # When enabled, simulates a regression where terminal jobs are re-processed
-    # on duplicate delivery. The loopback scheduler delivers twice; the mutant
-    # causes double STT/meter, which the harness observes in evidence.
+    # When enabled, the worker's terminal-status guard returns a non-terminal view
+    # of completed jobs, so a duplicate Cloud Tasks delivery re-enters the handler.
+    # Alone (defenses active), the content-ledger convergence acks the redelivery
+    # without re-running the pipeline — STT stays at 1 (defense-in-depth holds).
+    # This proves the harness can observe whether a specific defense layer catches
+    # a specific fault.
     if _TERMINAL_GUARD_BYPASSED:
         _original_get_sync_job = sync_router.get_sync_job
 
         def _mutated_get_sync_job(job_id: str, *_args: Any, **_kwargs: Any) -> dict[str, Any] | None:
-            """FEASIBILITY-ONLY mutant: return a non-terminal view of completed jobs.
-
-            Simulates a regression where the terminal guard fails to recognize
-            completed jobs, causing duplicate processing on redelivery.
-            """
+            """FEASIBILITY-ONLY mutant: return a non-terminal view of completed jobs."""
             result = _original_get_sync_job(job_id, *_args, **_kwargs)
             if result and result.get("status") in ("completed", "done"):
                 if _egress_sink:

--- a/backend/testing/replay_harness_phase0a/apps.py
+++ b/backend/testing/replay_harness_phase0a/apps.py
@@ -12,7 +12,8 @@ Capabilities installed (all feasibility-only unless noted):
   - Cloud Tasks _tasks_client → HTTP client to out-of-process loopback scheduler
   - id_token.verify_oauth2_token → one exact local token (feasibility-only)
   - VAD/STT/process_conversation → deterministic leaves (feasibility-only finalizer fake)
-  - terminal_guard_bypassed → declared fault control (mutant injection)
+  - terminal_guard_bypassed → declared fault control (real idempotency-boundary perturbation)
+  - defeat_idempotency → declared fault control (full duplicate-delivery boundary defeat)
 """
 
 from __future__ import annotations
@@ -280,6 +281,7 @@ else:
 
     _TRANSCRIPT_TOKEN = os.getenv("OMI_REPLAY_TRANSCRIPT_TOKEN", "replay-harness-transcript")
     _TERMINAL_GUARD_BYPASSED = os.getenv("OMI_REPLAY_TERMINAL_GUARD_BYPASSED", "false").lower() == "true"
+    _DEFEAT_IDEMPOTENCY = os.getenv("OMI_REPLAY_DEFEAT_IDEMPOTENCY", "false").lower() == "true"
 
     def _job_id_from_path(path: str) -> str:
         return Path(path).parent.name
@@ -355,37 +357,27 @@ else:
     sync_pipeline.prerecorded = _local_prerecorded
     sync_pipeline.process_conversation = _local_process_conversation
 
-    # ---- DECLARED FAULT CONTROL: stt_double_invoke (defect induction) ----
-    # When enabled, the deterministic STT leaf invokes the provider twice for the
-    # same audio within a single delivery, simulating a regression where the
-    # idempotency boundary fails to deduplicate STT calls.  This induces the
-    # externally observable duplicate-STT defect (STT count > 1) that the
-    # regression-sensitivity scenario must detect.  The STT invocation count is
-    # the sole black-box observable — no white-box marker is used.
-    _STT_DOUBLE_INVOKE = os.getenv("OMI_REPLAY_STT_DOUBLE_INVOKE", "false").lower() == "true"
-    if _STT_DOUBLE_INVOKE:
-        _original_prerecorded = _local_prerecorded
-
-        def _double_invoke_prerecorded(audio_url: str, **kwargs: Any) -> Any:
-            """FEASIBILITY-ONLY mutant: invoke the STT leaf twice for the same audio."""
-            first = _original_prerecorded(audio_url, **kwargs)
-            _original_prerecorded(audio_url, **kwargs)  # second invocation: defect
-            return first
-
-        sync_pipeline.prerecorded = _double_invoke_prerecorded
-
-    # ---- DECLARED FAULT CONTROL: terminal_guard_bypassed (mutant injection) ----
+    # ---- DECLARED FAULT CONTROL: terminal_guard_bypassed (boundary perturbation) ----
     # When enabled, the worker's terminal-status guard returns a non-terminal view
-    # of completed jobs, so a duplicate Cloud Tasks delivery re-enters the handler.
-    # Alone (defenses active), the content-ledger convergence acks the redelivery
+    # of completed jobs, so a duplicate Cloud Tasks delivery re-enters the handler
+    # past the real idempotency boundary at routers/sync.py run_sync_job. Alone
+    # (deeper defenses active), the content-ledger convergence acks the redelivery
     # without re-running the pipeline — STT stays at 1 (defense-in-depth holds).
-    # This proves the harness can observe whether a specific defense layer catches
-    # a specific fault.
-    if _TERMINAL_GUARD_BYPASSED:
+    # Used by MUTANT_GUARDED to prove a specific defense layer catches a specific
+    # boundary perturbation. The STT leaf itself is never altered.
+    _apply_terminal_guard_bypass = _TERMINAL_GUARD_BYPASSED or _DEFEAT_IDEMPOTENCY
+    if _apply_terminal_guard_bypass:
         _original_get_sync_job = sync_router.get_sync_job
 
         def _mutated_get_sync_job(job_id: str, *_args: Any, **_kwargs: Any) -> dict[str, Any] | None:
-            """FEASIBILITY-ONLY mutant: return a non-terminal view of completed jobs."""
+            """FEASIBILITY-ONLY mutant: return a non-terminal view of completed jobs.
+
+            This perturbs the real terminal-ownership boundary (the
+            ``job['status'] in TERMINAL_STATUSES`` check in run_sync_job) so a
+            duplicate delivery is not acked as already-terminal. It does NOT touch
+            the STT leaf — any duplicate-STT defect must arise from the composed
+            SUT re-running the real pipeline on the redelivery.
+            """
             result = _original_get_sync_job(job_id, *_args, **_kwargs)
             if result and result.get("status") in ("completed", "done"):
                 if _egress_sink:
@@ -396,3 +388,70 @@ else:
             return result
 
         sync_router.get_sync_job = _mutated_get_sync_job
+
+    # ---- DECLARED FAULT CONTROL: defeat_idempotency (full boundary defeat) ----
+    # When enabled, the duplicate-delivery idempotency boundary in the composed
+    # SUT is defeated so a real duplicate Cloud Tasks delivery genuinely re-runs
+    # the real STT leaf once per delivery:
+    #   1. terminal-status READ guard (above) — redelivery is not acked as terminal;
+    #   2. terminal-ownership WRITE guard (update_sync_job) — a completed job can be
+    #      re-opened (mark_job_processing) so the redelivery re-enters the pipeline;
+    #   3. ledger fence — the job is forced onto the legacy (non-fenced) path, so
+    #      there is no content-claim ownership and no content-ledger convergence
+    #      (convergence is what otherwise acks a redelivery without re-running);
+    #   4. staged-audio cleanup — no-op so the redelivery can re-download audio;
+    #   5. processed-segment ledger reads — empty so segments are not skipped.
+    # The STT leaf (_local_prerecorded) is unchanged: it invokes the provider
+    # exactly once per real pipeline run. STT > 1 therefore arises ONLY because
+    # two real deliveries each run the real pipeline — not from a self-calling
+    # fake. Used by MUTANT_UNGUARDED to prove the scenario is regression-
+    # sensitive: it FAILS unless the real boundary defeat surfaces the defect.
+    if _DEFEAT_IDEMPOTENCY:
+        _original_uses_fence = sync_router.sync_job_uses_ledger_fence
+
+        def _defeated_uses_fence(_job: Any) -> bool:
+            """FEASIBILITY-ONLY mutant: force the legacy non-fenced path.
+
+            Removing the ledger fence disables content-claim ownership and
+            content-ledger convergence — the real boundary that otherwise acks a
+            redelivery from the durable ledger without re-running the pipeline.
+            The non-fenced run-lock + finalization still operate, so the
+            redelivery re-runs the pipeline and reaches a terminal cleanly.
+            """
+            if _egress_sink:
+                _egress_sink({"event": "idempotency_boundary_defeated", "checkpoint": "ledger_fence"})
+            return False
+
+        sync_router.sync_job_uses_ledger_fence = _defeated_uses_fence
+        # Defeat the WRITE-level terminal-ownership boundary: update_sync_job
+        # (database/sync_jobs.py) rejects any mutation of a job whose status is in
+        # TERMINAL_STATUSES — the real guard that prevents re-opening a completed
+        # job. Emptying the module global lets a redelivery mark-job-processing
+        # and finalize on the legacy path. (The handler-level READ guard is
+        # defeated separately by the terminal-guard bypass above.)
+        import database.sync_jobs as _sync_jobs_db  # noqa: E402
+
+        _sync_jobs_db.TERMINAL_STATUSES = ()
+        if _egress_sink:
+            _egress_sink({"event": "idempotency_boundary_defeated", "checkpoint": "write_level_terminal_guard"})
+
+        async def _noop_delete_blobs(_paths: Any) -> None:
+            """FEASIBILITY-ONLY mutant: keep staged audio so a redelivery re-downloads."""
+            if _egress_sink:
+                _egress_sink({"event": "idempotency_boundary_defeated", "checkpoint": "staged_audio_cleanup"})
+
+        sync_router._delete_staged_blobs_async = _noop_delete_blobs
+
+        _original_get_processed = sync_pipeline.get_processed_segments
+        _original_get_durable = sync_pipeline.get_processed_sync_segment_ids
+
+        def _empty_processed(_job_id: str) -> set[str]:
+            if _egress_sink:
+                _egress_sink({"event": "idempotency_boundary_defeated", "checkpoint": "processed_segment_ledger"})
+            return set()
+
+        def _empty_durable(_uid: str, _content_id: str) -> set[str]:
+            return set()
+
+        sync_pipeline.get_processed_segments = _empty_processed
+        sync_pipeline.get_processed_sync_segment_ids = _empty_durable

--- a/backend/testing/replay_harness_phase0a/apps.py
+++ b/backend/testing/replay_harness_phase0a/apps.py
@@ -1,0 +1,379 @@
+"""Role-configured ASGI entrypoint for the Replay Harness Phase 0A.
+
+FEASIBILITY-ONLY: The finalizer and every shortcut are declared fakes, labeled
+feasibility-only. This entrypoint preserves production PCM decoding, upload
+staging, task-protobuf construction, route authentication, Redis locks,
+job/ledger transitions, fair-use metering, status polling, and conversation
+persistence. Only external/provider leaves are replaced.
+
+Capabilities installed (all feasibility-only unless noted):
+  - google.auth.default → AnonymousCredentials (production emulator boundary)
+  - google.cloud.storage.Client → local filesystem (production emulator boundary)
+  - Cloud Tasks _tasks_client → HTTP client to out-of-process loopback scheduler
+  - id_token.verify_oauth2_token → one exact local token (feasibility-only)
+  - VAD/STT/process_conversation → deterministic leaves (feasibility-only finalizer fake)
+  - terminal_guard_bypassed → declared fault control (mutant injection)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import time
+import wave
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ---- egress guard (install BEFORE any backend import) ----
+from testing.replay_harness_phase0a.egress_guard import guard_from_env
+
+_egress_sink = guard_from_env()
+
+# ---- production emulator boundary overrides (not feasibility-only) ----
+import google.auth  # noqa: E402
+import google.auth.credentials as google_auth_credentials  # noqa: E402
+
+
+def _anonymous_google_credentials(*_args: Any, **_kwargs: Any) -> tuple[Any, str]:
+    project = os.getenv("GOOGLE_CLOUD_PROJECT") or os.getenv("FIREBASE_PROJECT_ID") or "demo-omi-replay-harness"
+    return google_auth_credentials.AnonymousCredentials(), project
+
+
+google.auth.default = _anonymous_google_credentials
+
+
+# ---- filesystem GCS fake (copy of sync_cloud_tasks_stack pattern, not import) ----
+_STORAGE_ROOT = os.getenv("OMI_REPLAY_STORAGE_DIR", "").strip()
+if not _STORAGE_ROOT:
+    raise RuntimeError("OMI_REPLAY_STORAGE_DIR is required")
+_storage_path = Path(_STORAGE_ROOT)
+_storage_path.mkdir(parents=True, exist_ok=True)
+
+from google.cloud import storage as _gcs  # noqa: E402
+
+
+class _LocalBlob:
+    def __init__(self, bucket: "_LocalBucket", name: str):
+        self._bucket = bucket
+        self.name = name
+        self._path = bucket._root / name
+
+    def upload_from_filename(self, filename: str) -> None:
+        import shutil
+
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(filename, self._path)
+
+    def upload_from_string(self, data: str | bytes) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        raw = data.encode() if isinstance(data, str) else data
+        self._path.write_bytes(raw)
+
+    def download_to_filename(self, filename: str) -> None:
+        import shutil
+
+        shutil.copy2(self._path, filename)
+
+    def exists(self) -> bool:
+        return self._path.exists()
+
+    def delete(self) -> None:
+        self._path.unlink(missing_ok=True)
+
+    def generate_signed_url(self, *args: Any, **kwargs: Any) -> str:
+        return f"replay-harness://staged/{self.name}"
+
+
+class _LocalBucket:
+    def __init__(self, root: Path):
+        self._root = root
+
+    def blob(self, name: str) -> _LocalBlob:
+        relative = Path(name)
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ValueError(f"unsafe blob path: {name}")
+        return _LocalBlob(self, name)
+
+    def list_blobs(self, prefix: str = "") -> list[_LocalBlob]:
+        if not self._root.exists():
+            return []
+        result = []
+        for p in self._root.rglob("*"):
+            if p.is_file() and str(p.relative_to(self._root)).startswith(prefix):
+                result.append(_LocalBlob(self, str(p.relative_to(self._root))))
+        return result
+
+
+class _LocalStorageClient:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def bucket(self, name: str) -> _LocalBucket:
+        bucket_root = _storage_path / name
+        bucket_root.mkdir(parents=True, exist_ok=True)
+        return _LocalBucket(bucket_root)
+
+
+_gcs.Client = _LocalStorageClient  # type: ignore[misc,assignment]
+
+
+# ---- role selection ----
+def _role() -> str:
+    value = os.getenv("OMI_REPLAY_ROLE", "").strip()
+    if value not in {"admission", "worker"}:
+        raise RuntimeError(f"OMI_REPLAY_ROLE must be 'admission' or 'worker', got {value!r}")
+    return value
+
+
+ROLE = _role()
+
+# ---- Cloud Tasks client → HTTP loopback (admission only) ----
+if ROLE == "admission":
+    import httpx as _httpx  # noqa: E402
+    from google.api_core.exceptions import AlreadyExists  # noqa: E402
+    from google.cloud import tasks_v2  # noqa: E402
+    import utils.cloud_tasks as production_cloud_tasks  # noqa: E402
+
+    _LOOPBACK_URL = os.getenv("OMI_REPLAY_LOOPBACK_URL", "")
+
+    class _CloudTasksHTTPClient:
+        """HTTP client that forwards create_task to the out-of-process loopback scheduler.
+
+        FEASIBILITY-ONLY seam: production _get_tasks_client() has no endpoint override,
+        so the _tasks_client global is swapped. The enqueue hop is a labeled seam,
+        not a production Cloud Tasks transport.
+        """
+
+        @staticmethod
+        def queue_path(project: str, location: str, queue: str) -> str:
+            return f"projects/{project}/locations/{location}/queues/{queue}"
+
+        @staticmethod
+        def task_path(project: str, location: str, queue: str, task: str) -> str:
+            return f"projects/{project}/locations/{location}/queues/{queue}/tasks/{task}"
+
+        def create_task(self, *, parent: str, task: tasks_v2.Task, **_kwargs: Any) -> tasks_v2.Task:
+            http_req = task.http_request
+            body_bytes = http_req.body or b"{}"
+            payload = {
+                "parent": parent,
+                "task_name": task.name,
+                "body": json.loads(body_bytes),
+                "url": http_req.url,
+                "http_method": "POST",
+                "headers": dict(http_req.headers),
+                "oidc_sa": http_req.oidc_token.service_account_email if http_req.oidc_token else "",
+                "oidc_audience": http_req.oidc_token.audience if http_req.oidc_token else "",
+                "dispatch_deadline_seconds": task.dispatch_deadline.seconds if task.dispatch_deadline else 0,
+            }
+            with _httpx.Client(timeout=10.0, trust_env=False) as client:
+                response = client.post(f"{_LOOPBACK_URL}/__replay/enqueue", json=payload)
+            if response.status_code == 409:
+                raise AlreadyExists(f"task {task.name} already exists")
+            if response.status_code >= 400:
+                raise RuntimeError(f"loopback enqueue failed: HTTP {response.status_code}")
+            return task
+
+    production_cloud_tasks._tasks_client = _CloudTasksHTTPClient()  # type: ignore[assignment]
+
+else:
+    # Worker: swap only the OIDC verifier leaf (feasibility-only).
+    from google.oauth2 import id_token  # noqa: E402
+
+    _LOCAL_OIDC_TOKEN = os.getenv("OMI_REPLAY_OIDC_TOKEN", "")
+    _LOCAL_OIDC_SA = os.getenv("OMI_REPLAY_OIDC_SA", "")
+
+    def _verify_local_oidc(token: str, _request: Any, *, audience: str | None = None, **_kwargs: Any) -> dict[str, Any]:
+        expected_token = _LOCAL_OIDC_TOKEN
+        if token != expected_token:
+            raise ValueError("OIDC token mismatch")
+        return {"email": _LOCAL_OIDC_SA, "email_verified": True}
+
+    id_token.verify_oauth2_token = _verify_local_oidc
+
+
+# ---- import the real backend ----
+from main import app  # noqa: E402
+from fastapi import Header, HTTPException, Request  # noqa: E402
+from fastapi.responses import JSONResponse, Response  # noqa: E402
+
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+@app.get("/__replay/health", include_in_schema=False)
+def replay_health() -> dict[str, str]:
+    return {"status": "ok", "role": ROLE}
+
+
+# ---- admission control endpoints ----
+_CONTROL_TOKEN = os.getenv("OMI_REPLAY_CONTROL_TOKEN", "")
+
+
+def _require_control(request: Request, control_token: str | None) -> None:
+    client_host = request.client.host if request.client else None
+    if client_host not in _LOOPBACK_HOSTS or control_token != _CONTROL_TOKEN:
+        raise HTTPException(status_code=403, detail="replay control is loopback-only")
+
+
+if ROLE == "admission":
+    from database import conversations as conversations_db  # noqa: E402
+    from database._client import get_firestore_client  # noqa: E402
+
+    @app.post("/__replay/capture-provenance/{conversation_id}", include_in_schema=False, status_code=204)
+    def replay_capture_provenance(
+        conversation_id: str,
+        payload: dict[str, Any],
+        request: Request,
+        control_token: str | None = Header(None, alias="X-Omi-Replay-Control"),
+    ) -> Response:
+        _require_control(request, control_token)
+        uid = payload.get("uid")
+        device_id = payload.get("device_id")
+        platform = payload.get("platform")
+        if not all(isinstance(v, str) and v for v in (uid, device_id, platform)):
+            raise HTTPException(status_code=422, detail="capture provenance requires uid and device context")
+        now = datetime.now(timezone.utc)
+        capture = {
+            "id": conversation_id,
+            "created_at": now,
+            "started_at": now,
+            "finished_at": now,
+            "source": "omi",
+            "language": "en",
+            "structured": {
+                "title": "Replay harness capture provenance",
+                "overview": "",
+                "emoji": "🧪",
+                "category": "other",
+                "action_items": [],
+                "events": [],
+            },
+            "transcript_segments": [],
+            "private_cloud_sync_enabled": False,
+            "status": "completed",
+            "discarded": False,
+            "is_locked": False,
+            "data_protection_level": "enhanced",
+            "client_device_id": device_id,
+            "client_platform": platform,
+        }
+        encoded = conversations_db.encode_conversation_for_write(uid, capture, level="enhanced")
+        if isinstance(encoded.get("transcript_segments"), list):
+            raise RuntimeError("replay capture provenance was not encrypted by the production encoder")
+        get_firestore_client().collection("users").document(uid).collection("conversations").document(
+            conversation_id
+        ).set(encoded)
+        return Response(status_code=204)
+
+else:
+    # ---- worker: deterministic provider leaves (FEASIBILITY-ONLY finalizer fake) ----
+    from models.conversation import Conversation  # noqa: E402
+    from models.conversation_enums import ConversationStatus  # noqa: E402
+    from models.structured import Structured  # noqa: E402
+    import utils.sync.pipeline as sync_pipeline  # noqa: E402
+    from utils.conversations import lifecycle as lifecycle_service  # noqa: E402
+    from routers import sync as sync_router  # noqa: E402
+
+    _TRANSCRIPT_TOKEN = os.getenv("OMI_REPLAY_TRANSCRIPT_TOKEN", "replay-harness-transcript")
+    _TERMINAL_GUARD_BYPASSED = os.getenv("OMI_REPLAY_TERMINAL_GUARD_BYPASSED", "false").lower() == "true"
+
+    def _job_id_from_path(path: str) -> str:
+        return Path(path).parent.name
+
+    def _local_vad(path: str, *, return_segments: bool = False, **_kwargs: Any) -> Any:
+        """FEASIBILITY-ONLY: deterministic VAD leaf proving the production decoder made WAV."""
+        with wave.open(path, "rb") as wav_file:
+            duration = wav_file.getnframes() / float(wav_file.getframerate())
+        segments = [{"start": 0.0, "end": min(duration, 1.0)}] if duration >= 1.0 else []
+        if _egress_sink:
+            _egress_sink({"event": "vad_result", "job_id": _job_id_from_path(path), "segment_count": len(segments)})
+        return segments if return_segments else bool(segments)
+
+    def _local_prerecorded(audio_url: str, *, return_language: bool = False, **_kwargs: Any) -> Any:
+        """FEASIBILITY-ONLY: deterministic STT leaf; emits no transcript into evidence."""
+        job_id = audio_url.rsplit("/", 1)[-1]
+        if _egress_sink:
+            _egress_sink({"event": "stt_completed", "job_id": job_id, "word_count": 1})
+        words = [{"timestamp": [0.0, 1.0], "speaker": "SPEAKER_00", "text": _TRANSCRIPT_TOKEN}]
+        return (words, "en") if return_language else words
+
+    def _local_process_conversation(
+        uid: str,
+        language: str | None = None,
+        conversation: Any = None,
+        *,
+        language_code: str | None = None,
+        persistence_observer: Any = None,
+        **_kwargs: Any,
+    ) -> Conversation:
+        """FEASIBILITY-ONLY: declared finalizer fake — marks conversation completed via real lifecycle."""
+        if conversation is None:
+            raise ValueError("replay harness deterministic processor requires a conversation")
+        conversation_id = getattr(conversation, "id", None)
+        if not isinstance(conversation_id, str) or not conversation_id:
+            raise ValueError("replay harness processor requires a durable conversation id")
+        effective_language = language_code or language or "en"
+        started_at = getattr(conversation, "started_at", None) or datetime.now(timezone.utc)
+        finished_at = getattr(conversation, "finished_at", None) or started_at
+        completed = Conversation(
+            id=conversation_id,
+            created_at=getattr(conversation, "created_at", None) or started_at,
+            started_at=started_at,
+            finished_at=finished_at,
+            source=getattr(conversation, "source", None),
+            language=effective_language,
+            structured=Structured(
+                title="Replay harness deterministic conversation",
+                overview="FEASIBILITY-ONLY finalizer fake result.",
+                emoji="🧪",
+                category="other",
+            ),
+            transcript_segments=list(getattr(conversation, "transcript_segments", [])),
+            private_cloud_sync_enabled=bool(getattr(conversation, "private_cloud_sync_enabled", False)),
+            status=ConversationStatus.completed,
+            is_locked=bool(getattr(conversation, "is_locked", False)),
+            client_device_id=getattr(conversation, "client_device_id", None),
+            client_platform=getattr(conversation, "client_platform", None),
+        )
+        persisted = lifecycle_service.persist_processed_conversation(uid, completed.model_dump())
+        if persistence_observer is not None:
+            persistence_observer(persisted)
+        if _egress_sink:
+            _egress_sink({"event": "conversation_persisted", "conversation_id": completed.id})
+        return completed
+
+    def _delete_segment_blob_immediately(path: str, *_args: Any, **_kwargs: Any) -> None:
+        sync_pipeline.delete_syncing_temporal_file(path)
+
+    # Replace only external/provider leaves.
+    sync_pipeline.vad_is_empty = _local_vad
+    sync_pipeline.get_prerecorded_service = lambda _language="en": ("parakeet", "en", "parakeet")
+    sync_pipeline.prerecorded = _local_prerecorded
+    sync_pipeline.process_conversation = _local_process_conversation
+    sync_pipeline.schedule_syncing_temporal_file_deletion = _delete_segment_blob_immediately
+
+    # ---- DECLARED FAULT CONTROL: terminal_guard_bypassed (mutant injection) ----
+    # When enabled, simulates a regression where terminal jobs are re-processed
+    # on duplicate delivery. The loopback scheduler delivers twice; the mutant
+    # causes double STT/meter, which the harness observes in evidence.
+    if _TERMINAL_GUARD_BYPASSED:
+        _original_get_sync_job = sync_router.get_sync_job
+
+        def _mutated_get_sync_job(job_id: str, *_args: Any, **_kwargs: Any) -> dict[str, Any] | None:
+            """FEASIBILITY-ONLY mutant: return a non-terminal view of completed jobs.
+
+            Simulates a regression where the terminal guard fails to recognize
+            completed jobs, causing duplicate processing on redelivery.
+            """
+            result = _original_get_sync_job(job_id, *_args, **_kwargs)
+            if result and result.get("status") in ("completed", "done"):
+                if _egress_sink:
+                    _egress_sink({"event": "terminal_guard_mutant_activated", "job_id": job_id})
+                mutated = dict(result)
+                mutated["status"] = "processing"
+                return mutated
+            return result
+
+        sync_router.get_sync_job = _mutated_get_sync_job

--- a/backend/testing/replay_harness_phase0a/attestation.py
+++ b/backend/testing/replay_harness_phase0a/attestation.py
@@ -8,11 +8,22 @@ builder's summary assertions, the recorded event ``decision`` field, or an
 artifact-embedded topology hash.
 
 HONEST SCOPE (not over-claimed): the raw evidence is emitted by the in-process
-socket guard, which is itself part of the SUT under test. Therefore the
-attestation proves **self-consistency and summary-forgery rejection** (every
-summary is recomputed from raw evidence + checked-in contract, and any mismatch
-is rejected), **not** independent/third-party attestation of real kernel egress.
-The attestation mechanism composes end-to-end; it is not a security audit.
+socket guard and the runner launcher, both of which are part of the SUT under
+test. Therefore the attestation proves **self-consistency and summary-forgery
+rejection** — every summary field is recomputed from raw evidence + the
+checked-in contract, and any mismatch is rejected — **not** independent /
+third-party attestation of real kernel egress or of an OS listener. The
+attestation mechanism composes end-to-end; it is not a security audit.
+
+Role-readiness binding (honest limit): the artifact-controlled role summary and
+resolved ports map are bound to a raw ``role_allocated`` launcher/health-
+observation record, which is validated against the checked-in topology health
+contract (endpoint host, probe contract, and ready-success semantics — an HTTP
+500 readiness probe is rejected). This raises the forgery bar: a paired forgery
+of the summary and ports map no longer suffices. It does **not** independently
+witness that an OS process listened on the port — the ``role_allocated`` record
+is itself runner-emitted, so a fully coherent forgery of all raw evidence is
+outside what self-consistency attestation can detect.
 
 Guarded-scope claims:
 
@@ -141,6 +152,22 @@ def _recompute_decision(event: dict[str, Any], allow_endpoints: dict[str, frozen
     return "allow" if (host, port) in declared else "deny"
 
 
+def _health_success(health_contract: dict[str, Any], status: Any) -> bool:
+    """Does an observed HTTP status satisfy the topology health success contract?
+
+    Success semantics: the explicitly declared ``expected_status`` (an int or
+    list of ints) if present, otherwise any 2xx. TCP probes carry no status —
+    the connect success is the readiness observation.
+    """
+    if health_contract.get("type") != "http":
+        return True
+    expected = health_contract.get("expected_status")
+    if expected is not None:
+        allowed = expected if isinstance(expected, list) else [expected]
+        return status in allowed
+    return isinstance(status, int) and 200 <= status < 300
+
+
 def build_attestation(
     *,
     topology: dict[str, Any],
@@ -227,6 +254,15 @@ def validate_attestation(attestation: dict[str, Any], *, expected_topology: dict
     committed ``topology.json``). When supplied, the artifact's embedded topology
     must match it exactly, so a modified worker command with a recomputed
     embedded hash is rejected.
+
+    Role readiness is bound to a raw ``role_allocated`` launcher/health-
+    observation record (not merely to the artifact-controlled summary or ports
+    map): each role's summary port/pid/ready/probe and the resolved ports map
+    must cohere with the raw record, and the raw record's endpoint host, probe
+    contract, and observed HTTP status must satisfy the checked-in topology
+    health contract (an HTTP 500 readiness probe is rejected). The raw record is
+    runner-emitted, so this is summary-forgery rejection, not independent
+    witness of an OS listener.
     """
     violations: list[str] = []
 
@@ -326,49 +362,155 @@ def validate_attestation(attestation: dict[str, Any], *, expected_topology: dict
             "denied attempt(s) recomputed from raw evidence"
         )
 
-    # 4c. Bind each role's resolved port and health probe to the checked-in
-    #     topology contract — reject fabricated role-ready summaries, altered
-    #     resolved-port maps, and probes that do not match the declared contract.
+    # 4c. Bind role readiness/ports/probes to an explicit launcher
+    #     allocation/health-observation raw record AND the checked-in topology
+    #     health contract. The summary port/pid/probe and the resolved ports map
+    #     are all artifact-controlled, so a paired forgery of summary + ports map
+    #     defeats a summary-vs-summary check (changing ports[worker] and
+    #     roles[worker].port together to 7777 passed). Each role's summary is now
+    #     bound to a raw ``role_allocated`` record carrying role identity, endpoint
+    #     host, allocated port, probe contract, observed successful response, and
+    #     process identity. That raw record is itself validated against the
+    #     checked-in topology health contract (endpoint host, probe contract, and
+    #     ready-success semantics — an HTTP 500 is rejected).
+    #
+    #     HONEST SCOPE: the role_allocated record is emitted by the runner (the
+    #     trusted launcher), so it raises the forgery bar but does NOT
+    #     independently witness that an OS process listened on the port — a fully
+    #     coherent forgery of all raw evidence is outside what self-consistency
+    #     attestation can detect.
     topology_role_defs = topology.get("roles", {})
+    summary_by_name: dict[str, dict[str, Any]] = {}
     for role in roles:
-        rname = role.get("name")
-        if not isinstance(rname, str):
-            continue
-        role_def = topology_role_defs.get(rname)
-        if not isinstance(role_def, dict):
+        if isinstance(role, dict) and isinstance(role.get("name"), str):
+            summary_by_name[role["name"]] = role
+    # A summary role not declared in the topology contract is a fabrication.
+    for rname in summary_by_name:
+        if rname not in topology_role_defs:
             violations.append(f"role {rname!r} in attestation is not declared in the topology contract")
+
+    allocations: dict[str, dict[str, Any]] = {}
+    for e in raw:
+        if isinstance(e, dict) and e.get("event") == "role_allocated" and isinstance(e.get("role"), str):
+            allocations[e["role"]] = e
+
+    for rname in topology_role_defs:
+        role_def = topology_role_defs[rname]
+        if not isinstance(role_def, dict):
             continue
-        # Resolved port must match the ports map for this role.
-        if rname in ports:
-            if role.get("port") != ports[rname]:
+        health_contract = role_def.get("health", {})
+        if not isinstance(health_contract, dict):
+            health_contract = {}
+        summary = summary_by_name.get(rname)
+        allocation = allocations.get(rname)
+
+        if not isinstance(allocation, dict):
+            violations.append(
+                f"role {rname!r} has no role_allocated launcher/health-observation record in "
+                "raw_evidence; summary readiness is not bound to a raw allocation"
+            )
+            continue
+
+        # --- validate the raw allocation record against the topology contract ---
+        declared_host = health_contract.get("host")
+        if isinstance(declared_host, str) and allocation.get("host") != declared_host:
+            violations.append(
+                f"role {rname!r} allocation endpoint host {allocation.get('host')!r} does not "
+                f"match the topology-declared host {declared_host!r}"
+            )
+        alloc_health = allocation.get("health")
+        if isinstance(alloc_health, dict):
+            if alloc_health.get("type") != health_contract.get("type"):
                 violations.append(
-                    f"role {rname!r} port mismatch: summary reports {role.get('port')!r}, "
-                    f"resolved ports map reports {ports[rname]!r}"
+                    f"role {rname!r} allocation health type {alloc_health.get('type')!r} does not "
+                    f"match topology health type {health_contract.get('type')!r}"
                 )
-        # Health probe must match the topology health contract.
-        health = role_def.get("health", {})
-        probe = role.get("ready_probe")
-        if isinstance(probe, dict) and isinstance(health, dict):
-            if probe.get("type") != health.get("type"):
+            if health_contract.get("type") == "http":
+                if alloc_health.get("path") != health_contract.get("path"):
+                    violations.append(
+                        f"role {rname!r} allocation health path {alloc_health.get('path')!r} does not "
+                        f"match topology health path {health_contract.get('path')!r}"
+                    )
+                if alloc_health.get("expect_role") != health_contract.get("expect_role", rname):
+                    violations.append(
+                        f"role {rname!r} allocation health expect_role {alloc_health.get('expect_role')!r} "
+                        f"does not match topology expect_role {health_contract.get('expect_role', rname)!r}"
+                    )
+        # Topology health ready-success semantics must hold for the observed status.
+        if health_contract.get("type") == "http" and not _health_success(health_contract, allocation.get("status")):
+            expected = health_contract.get("expected_status", "2xx")
+            violations.append(
+                f"role {rname!r} health observation status {allocation.get('status')!r} does not satisfy "
+                f"the topology health success contract (expected {expected})"
+            )
+
+        # --- bind the artifact-controlled summary to the raw allocation record ---
+        if not isinstance(summary, dict):
+            continue
+        alloc_port = allocation.get("port")
+        if not isinstance(alloc_port, int):
+            violations.append(f"role {rname!r} allocation record has no integer allocated port")
+        else:
+            if rname in ports and ports[rname] != alloc_port:
                 violations.append(
-                    f"role {rname!r} ready_probe type {probe.get('type')!r} does not match "
-                    f"topology health type {health.get('type')!r}"
+                    f"role {rname!r} resolved ports map reports {ports[rname]!r} but the "
+                    f"allocation record reports allocated port {alloc_port!r}"
                 )
-            if health.get("type") == "http":
-                if probe.get("path") != health.get("path"):
+            if summary.get("port") != alloc_port:
+                violations.append(
+                    f"role {rname!r} summary port {summary.get('port')!r} does not cohere with "
+                    f"allocation record port {alloc_port!r}"
+                )
+        # Process identity must cohere.
+        if summary.get("pid") != allocation.get("pid"):
+            violations.append(
+                f"role {rname!r} summary pid {summary.get('pid')!r} does not cohere with "
+                f"allocation record pid {allocation.get('pid')!r}"
+            )
+        # Observed readiness must cohere.
+        if bool(summary.get("ready")) != bool(allocation.get("ready")):
+            violations.append(
+                f"role {rname!r} summary ready={summary.get('ready')!r} does not cohere with "
+                f"allocation record ready={allocation.get('ready')!r}"
+            )
+        # The summary probe must cohere with the allocation's contract + status.
+        probe = summary.get("ready_probe")
+        if isinstance(probe, dict) and isinstance(alloc_health, dict):
+            if probe.get("type") != alloc_health.get("type"):
+                violations.append(
+                    f"role {rname!r} summary probe type {probe.get('type')!r} does not cohere "
+                    f"with allocation health type {alloc_health.get('type')!r}"
+                )
+            if health_contract.get("type") == "http":
+                if probe.get("path") != alloc_health.get("path"):
                     violations.append(
-                        f"role {rname!r} ready_probe path {probe.get('path')!r} does not match "
-                        f"topology health path {health.get('path')!r}"
+                        f"role {rname!r} summary probe path {probe.get('path')!r} does not cohere "
+                        f"with allocation health path {alloc_health.get('path')!r}"
                     )
-                if probe.get("role") != health.get("expect_role", rname):
+                if probe.get("role") != alloc_health.get("expect_role"):
                     violations.append(
-                        f"role {rname!r} ready_probe role {probe.get('role')!r} does not match "
-                        f"topology health expect_role {health.get('expect_role', rname)!r}"
+                        f"role {rname!r} summary probe role {probe.get('role')!r} does not cohere "
+                        f"with allocation health expect_role {alloc_health.get('expect_role')!r}"
                     )
-    # Every dynamic role must carry a resolved port in the ports map.
+                if probe.get("status") != allocation.get("status"):
+                    violations.append(
+                        f"role {rname!r} summary probe status {probe.get('status')!r} does not cohere "
+                        f"with allocation observed status {allocation.get('status')!r}"
+                    )
+
+    # Every dynamic role must resolve a port that coheres with its allocation.
     for rname, role_def in topology_role_defs.items():
-        if isinstance(role_def, dict) and role_def.get("port") == "dynamic" and rname not in ports:
+        if not (isinstance(role_def, dict) and role_def.get("port") == "dynamic"):
+            continue
+        alloc = allocations.get(rname)
+        alloc_port = alloc.get("port") if isinstance(alloc, dict) else None
+        if rname not in ports:
             violations.append(f"dynamic topology role {rname!r} has no resolved port in the ports map")
+        elif not isinstance(alloc_port, int) or ports[rname] != alloc_port:
+            violations.append(
+                f"dynamic topology role {rname!r} ports map {ports[rname]!r} does not cohere "
+                f"with allocation record port {alloc_port!r}"
+            )
 
     # 5. Guard-installation evidence for every explicitly guarded Python role.
     guarded_roles = {

--- a/backend/testing/replay_harness_phase0a/attestation.py
+++ b/backend/testing/replay_harness_phase0a/attestation.py
@@ -316,6 +316,59 @@ def validate_attestation(attestation: dict[str, Any], *, expected_topology: dict
         )
     if recomputed_allowed == 0 and recomputed_denied == 0:
         violations.append("zero egress attempts observed — guard may not have been installed")
+    # 4b. Outcome binding: a feasible outcome requires every required safety
+    #     invariant to hold — including zero denied egress. A self-consistent
+    #     artifact that honestly reports a denied attempt must still be invalid
+    #     as feasible; summary consistency alone is not sufficient.
+    if attestation.get("outcome") == "feasible" and recomputed_denied > 0:
+        violations.append(
+            f"outcome 'feasible' requires zero denied egress, but {recomputed_denied} "
+            "denied attempt(s) recomputed from raw evidence"
+        )
+
+    # 4c. Bind each role's resolved port and health probe to the checked-in
+    #     topology contract — reject fabricated role-ready summaries, altered
+    #     resolved-port maps, and probes that do not match the declared contract.
+    topology_role_defs = topology.get("roles", {})
+    for role in roles:
+        rname = role.get("name")
+        if not isinstance(rname, str):
+            continue
+        role_def = topology_role_defs.get(rname)
+        if not isinstance(role_def, dict):
+            violations.append(f"role {rname!r} in attestation is not declared in the topology contract")
+            continue
+        # Resolved port must match the ports map for this role.
+        if rname in ports:
+            if role.get("port") != ports[rname]:
+                violations.append(
+                    f"role {rname!r} port mismatch: summary reports {role.get('port')!r}, "
+                    f"resolved ports map reports {ports[rname]!r}"
+                )
+        # Health probe must match the topology health contract.
+        health = role_def.get("health", {})
+        probe = role.get("ready_probe")
+        if isinstance(probe, dict) and isinstance(health, dict):
+            if probe.get("type") != health.get("type"):
+                violations.append(
+                    f"role {rname!r} ready_probe type {probe.get('type')!r} does not match "
+                    f"topology health type {health.get('type')!r}"
+                )
+            if health.get("type") == "http":
+                if probe.get("path") != health.get("path"):
+                    violations.append(
+                        f"role {rname!r} ready_probe path {probe.get('path')!r} does not match "
+                        f"topology health path {health.get('path')!r}"
+                    )
+                if probe.get("role") != health.get("expect_role", rname):
+                    violations.append(
+                        f"role {rname!r} ready_probe role {probe.get('role')!r} does not match "
+                        f"topology health expect_role {health.get('expect_role', rname)!r}"
+                    )
+    # Every dynamic role must carry a resolved port in the ports map.
+    for rname, role_def in topology_role_defs.items():
+        if isinstance(role_def, dict) and role_def.get("port") == "dynamic" and rname not in ports:
+            violations.append(f"dynamic topology role {rname!r} has no resolved port in the ports map")
 
     # 5. Guard-installation evidence for every explicitly guarded Python role.
     guarded_roles = {

--- a/backend/testing/replay_harness_phase0a/attestation.py
+++ b/backend/testing/replay_harness_phase0a/attestation.py
@@ -1,31 +1,110 @@
 """Machine-verifiable topology/egress attestation builder and checker.
 
 The builder joins the topology contract, per-role health probes, and the
-egress-attempt log into a single JSON artifact. The checker is runnable
-independently (third-party-verifiable) and recomputes every invariant from
-the raw evidence — it does not trust the builder's assertions.
+egress-attempt log into a single JSON artifact.  The checker is runnable
+independently (third-party-verifiable): it recomputes the topology hash, role
+completeness, and every egress decision from the embedded raw evidence and
+topology contract — it does **not** trust the builder's summary assertions.
+
+Scope (stated in the artifact, not over-claimed):
+
+* TCP connection-oriented egress (``connect``, ``connect_ex``,
+  ``create_connection``) and DNS resolution (``getaddrinfo``,
+  ``gethostbyname``, ``gethostbyname_ex``) are observed and enforced in the
+  Python SUT / runner / loopback processes.
+* UDP unconnected sends (``sendto``, ``sendmsg``) are observed and enforced
+  when the guard is installed.
+* Non-Python dependency processes (Redis server, Firestore emulator JVM) are
+  bind-constrained to loopback by the runner; their own outbound egress is
+  **not** per-connection observed by this guard.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+EGRESS_SCOPE = (
+    "Process-level socket guard in Python SUT/runner/loopback: TCP connect/connect_ex/"
+    "create_connection and DNS (getaddrinfo/gethostbyname/gethostbyname_ex) and UDP "
+    "unconnected sendto/sendmsg are observed and enforced (default-deny + declared "
+    "loopback allow-list). Non-Python dependency processes (Redis server, Firestore "
+    "emulator JVM) are bind-constrained to loopback by the runner; their own outbound "
+    "egress is not per-connection observed by this guard."
+)
+
+
+def _topology_hash(topology: dict[str, Any]) -> str:
+    """Deterministic SHA-256 over the canonical topology-contract encoding."""
+    canonical = json.dumps(topology, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def _resolve_allow_ports(
+    topology: dict[str, Any], ports: dict[str, int], firestore_host: str
+) -> dict[str, frozenset[int]]:
+    """Resolve every declared egress_allow_list entry to the actual port per role.
+
+    Returns ``{role: frozenset[int]}`` of ports the guard is permitted to allow
+    for that role.  This is what the validator recomputes to bind allowed
+    egress attempts to the topology contract.
+    """
+    firestore_port: int | None = None
+    if ":" in firestore_host:
+        try:
+            firestore_port = int(firestore_host.rsplit(":", 1)[1])
+        except ValueError:
+            firestore_port = None
+    result: dict[str, frozenset[int]] = {}
+    for entry in topology.get("egress_allow_list", []):
+        role = entry.get("role", "")
+        target = entry.get("to", "")
+        port: int | None = None
+        if target == "firestore":
+            port = firestore_port
+        elif target in ports:
+            port = ports[target]
+        if port is not None:
+            result.setdefault(role, set()).add(port)
+    return {role: frozenset(ps) for role, ps in result.items()}
+
+
+def _classify_attempt(event: dict[str, Any], ports: dict[str, int], firestore_host: str) -> str:
+    port = event.get("port")
+    firestore_port = None
+    if ":" in firestore_host:
+        try:
+            firestore_port = int(firestore_host.rsplit(":", 1)[1])
+        except ValueError:
+            pass
+    if port is not None:
+        if firestore_port is not None and port == firestore_port:
+            return "firestore-emulator"
+        for name, p in ports.items():
+            if p == port:
+                return name
+        return f"port:{port}"
+    return "dns-loopback"
+
 
 def build_attestation(
     *,
     topology: dict[str, Any],
-    topology_hash: str,
     health_records: list[Any],
     events: list[dict[str, Any]],
-    egress_allow_list: list[dict[str, Any]],
     ports: dict[str, int],
+    firestore_emulator_host: str,
     outcome: str,
     fault_controls: dict[str, str],
 ) -> dict[str, Any]:
-    """Build the attestation artifact from raw evidence."""
+    """Build the attestation artifact from raw evidence.
+
+    Embeds the topology contract, resolved ports, Firestore host, and the full
+    raw evidence stream so the checker can recompute every claim independently.
+    """
     egress_attempts = [e for e in events if e.get("event") in ("egress_attempt", "dns_attempt")]
     denied = [e for e in egress_attempts if e.get("decision") == "deny"]
 
@@ -34,29 +113,34 @@ def build_attestation(
     for e in egress_attempts:
         if e.get("decision") == "allow":
             allowed_count += 1
-            purpose = _classify_attempt(e, egress_allow_list, ports)
+            purpose = _classify_attempt(e, ports, firestore_emulator_host)
             by_purpose[purpose] = by_purpose.get(purpose, 0) + 1
 
+    roles_summary = [
+        {
+            "name": rh.name,
+            "pid": rh.pid,
+            "port": rh.port,
+            "ready": rh.ready,
+            "ready_probe": rh.ready_probe,
+        }
+        for rh in health_records
+    ]
+
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "harness": "omi-replay-harness",
         "phase": "0A",
         "feasibility_only": True,
-        "topology_contract_sha256": topology_hash,
+        "topology_contract": topology,
+        "topology_contract_sha256": _topology_hash(topology),
+        "ports": dict(ports),
+        "firestore_emulator_host": firestore_emulator_host,
         "built_at": datetime.now(timezone.utc).isoformat(),
-        "roles": [
-            {
-                "name": rh.name,
-                "pid": rh.pid,
-                "port": rh.port,
-                "ready": rh.ready,
-                "ready_probe": rh.ready_probe,
-            }
-            for rh in health_records
-        ],
+        "roles": roles_summary,
         "egress": {
             "policy": "default-deny",
-            "scope": "process-level socket guard (Python SUT + runner); dependency processes bind-constrained to loopback",
+            "scope": EGRESS_SCOPE,
             "attempts_observed": len(egress_attempts),
             "allowed": allowed_count,
             "denied": len(denied),
@@ -65,56 +149,108 @@ def build_attestation(
             "every_attempt_matched_declared_fake": len(denied) == 0,
         },
         "invariants": {
-            "all_roles_started": all(rh.ready for rh in health_records),
-            "all_roles_ready": all(rh.ready for rh in health_records),
+            "all_roles_started": all(rh.ready for rh in health_records) if health_records else False,
+            "all_roles_ready": all(rh.ready for rh in health_records) if health_records else False,
             "no_denied_egress": len(denied) == 0,
             "no_undeclared_loopback_peer": len(denied) == 0,
         },
         "fault_controls_active": fault_controls,
         "outcome": outcome,
+        "raw_evidence": events,
     }
 
 
-def _classify_attempt(event: dict[str, Any], allow_list: list[dict[str, Any]], ports: dict[str, int]) -> str:
-    """Classify an allowed egress attempt by purpose."""
-    port = event.get("port")
-    for entry in allow_list:
-        target = entry.get("to")
-        if target == "firestore":
-            continue  # firestore port is dynamic, classified by pattern
-        if target in ports and ports[target] == port:
-            return entry.get("purpose", "unknown")
-    if port is not None:
-        return f"port:{port}"
-    return "dns-loopback"
-
-
 def validate_attestation(attestation: dict[str, Any]) -> list[str]:
-    """Independently validate an attestation artifact. Returns list of violations (empty = pass)."""
+    """Independently validate an attestation artifact.
+
+    Returns a list of human-readable violations (empty = pass).  Every claimed
+    invariant is recomputed from the embedded topology contract, ports,
+    Firestore host, and raw evidence — builder-produced summary fields are
+    cross-checked, never trusted.
+    """
     violations: list[str] = []
 
-    # Invariant: all roles started and ready.
+    topology = attestation.get("topology_contract")
+    if not isinstance(topology, dict):
+        return ["attestation missing embedded topology_contract"]
+
+    # 1. Topology hash binding.
+    recomputed_hash = _topology_hash(topology)
+    if attestation.get("topology_contract_sha256") != recomputed_hash:
+        violations.append(
+            f"topology hash mismatch: claimed {attestation.get('topology_contract_sha256')!r}, "
+            f"recomputed {recomputed_hash}"
+        )
+    # 2. Role completeness: every topology role present and ready.
+    topology_roles = set(topology.get("roles", {}).keys())
     roles = attestation.get("roles", [])
+    attested_roles = {r.get("name") for r in roles if isinstance(r, dict)}
+    for name in sorted(topology_roles):
+        if name not in attested_roles:
+            violations.append(f"topology role {name!r} missing from attestation roles")
     if not roles:
         violations.append("no roles in attestation")
     for role in roles:
+        if not isinstance(role, dict):
+            violations.append(f"role entry is not an object: {role!r}")
+            continue
         if not role.get("ready"):
             violations.append(f"role {role.get('name')} not ready")
         if not role.get("ready_probe"):
             violations.append(f"role {role.get('name')} missing ready_probe")
 
-    # Invariant: no denied egress.
+    # 3. Egress recompute from raw evidence.
+    raw = attestation.get("raw_evidence")
+    if not isinstance(raw, list) or not raw:
+        violations.append("no raw_evidence embedded — cannot verify egress (guard may not have been installed)")
+        raw = []
+    egress_events = [e for e in raw if isinstance(e, dict) and e.get("event") in ("egress_attempt", "dns_attempt")]
+    recomputed_denied = [e for e in egress_events if e.get("decision") == "deny"]
+    recomputed_allowed = sum(1 for e in egress_events if e.get("decision") == "allow")
+
     egress = attestation.get("egress", {})
-    denied = egress.get("denied_attempts", [])
-    if denied:
-        violations.append(f"{len(denied)} denied egress attempts: {denied[:3]}")
-    if egress.get("allowed", 0) == 0:
+    if egress.get("denied", -1) != len(recomputed_denied):
+        violations.append(
+            f"egress.denied forgery: claimed {egress.get('denied')}, recomputed {len(recomputed_denied)} from raw evidence"
+        )
+    if egress.get("allowed", -1) != recomputed_allowed:
+        violations.append(
+            f"egress.allowed forgery: claimed {egress.get('allowed')}, recomputed {recomputed_allowed} from raw evidence"
+        )
+    if recomputed_allowed == 0:
         violations.append("zero allowed egress attempts — guard may not have been installed")
 
-    # Invariant: every invariant field is true.
-    for key, value in attestation.get("invariants", {}).items():
-        if value is not True:
-            violations.append(f"invariant {key} is {value}, expected true")
+    # 4. Allow-list binding: every allowed attempt must match a declared entry.
+    ports = attestation.get("ports", {})
+    firestore_host = attestation.get("firestore_emulator_host", "")
+    if isinstance(ports, dict) and isinstance(firestore_host, str):
+        allowed_by_role = _resolve_allow_ports(topology, ports, firestore_host)
+        for e in egress_events:
+            if e.get("decision") != "allow":
+                continue
+            port = e.get("port")
+            role = e.get("role", "")
+            if port is None:
+                continue  # DNS-loopback allow; no port to bind.
+            permitted = allowed_by_role.get(role, frozenset())
+            if port not in permitted:
+                violations.append(
+                    f"allowed egress to undeclared port {port} (role={role}) — not in topology allow-list"
+                )
+
+    # 5. Invariant recompute.
+    invariants = attestation.get("invariants", {})
+    expected_no_denied = len(recomputed_denied) == 0
+    expected_all_ready = bool(roles) and all(r.get("ready") for r in roles if isinstance(r, dict))
+    recomputed_invariants = {
+        "all_roles_started": expected_all_ready,
+        "all_roles_ready": expected_all_ready,
+        "no_denied_egress": expected_no_denied,
+        "no_undeclared_loopback_peer": expected_no_denied,
+    }
+    for key, value in recomputed_invariants.items():
+        if invariants.get(key) != value:
+            violations.append(f"invariant {key} claimed {invariants.get(key)!r}, recomputed {value!r}")
 
     return violations
 
@@ -124,9 +260,11 @@ def validate_attestation_file(path: str | Path) -> int:
     attestation = json.loads(Path(path).read_text())
     violations = validate_attestation(attestation)
     if violations:
-        print(f"FAIL: {len(violations)} violation(s):", file=__import__("sys").stderr)
+        import sys
+
+        print(f"FAIL: {len(violations)} violation(s):", file=sys.stderr)
         for v in violations:
-            print(f"  - {v}", file=__import__("sys").stderr)
+            print(f"  - {v}", file=sys.stderr)
         return 1
     print(f"OK: attestation valid (outcome={attestation.get('outcome')})")
     return 0

--- a/backend/testing/replay_harness_phase0a/attestation.py
+++ b/backend/testing/replay_harness_phase0a/attestation.py
@@ -1,0 +1,132 @@
+"""Machine-verifiable topology/egress attestation builder and checker.
+
+The builder joins the topology contract, per-role health probes, and the
+egress-attempt log into a single JSON artifact. The checker is runnable
+independently (third-party-verifiable) and recomputes every invariant from
+the raw evidence — it does not trust the builder's assertions.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def build_attestation(
+    *,
+    topology: dict[str, Any],
+    topology_hash: str,
+    health_records: list[Any],
+    events: list[dict[str, Any]],
+    egress_allow_list: list[dict[str, Any]],
+    ports: dict[str, int],
+    outcome: str,
+    fault_controls: dict[str, str],
+) -> dict[str, Any]:
+    """Build the attestation artifact from raw evidence."""
+    egress_attempts = [e for e in events if e.get("event") in ("egress_attempt", "dns_attempt")]
+    denied = [e for e in egress_attempts if e.get("decision") == "deny"]
+
+    by_purpose: dict[str, int] = {}
+    allowed_count = 0
+    for e in egress_attempts:
+        if e.get("decision") == "allow":
+            allowed_count += 1
+            purpose = _classify_attempt(e, egress_allow_list, ports)
+            by_purpose[purpose] = by_purpose.get(purpose, 0) + 1
+
+    return {
+        "schema_version": 1,
+        "harness": "omi-replay-harness",
+        "phase": "0A",
+        "feasibility_only": True,
+        "topology_contract_sha256": topology_hash,
+        "built_at": datetime.now(timezone.utc).isoformat(),
+        "roles": [
+            {
+                "name": rh.name,
+                "pid": rh.pid,
+                "port": rh.port,
+                "ready": rh.ready,
+                "ready_probe": rh.ready_probe,
+            }
+            for rh in health_records
+        ],
+        "egress": {
+            "policy": "default-deny",
+            "scope": "process-level socket guard (Python SUT + runner); dependency processes bind-constrained to loopback",
+            "attempts_observed": len(egress_attempts),
+            "allowed": allowed_count,
+            "denied": len(denied),
+            "by_purpose": by_purpose,
+            "denied_attempts": denied,
+            "every_attempt_matched_declared_fake": len(denied) == 0,
+        },
+        "invariants": {
+            "all_roles_started": all(rh.ready for rh in health_records),
+            "all_roles_ready": all(rh.ready for rh in health_records),
+            "no_denied_egress": len(denied) == 0,
+            "no_undeclared_loopback_peer": len(denied) == 0,
+        },
+        "fault_controls_active": fault_controls,
+        "outcome": outcome,
+    }
+
+
+def _classify_attempt(event: dict[str, Any], allow_list: list[dict[str, Any]], ports: dict[str, int]) -> str:
+    """Classify an allowed egress attempt by purpose."""
+    port = event.get("port")
+    for entry in allow_list:
+        target = entry.get("to")
+        if target == "firestore":
+            continue  # firestore port is dynamic, classified by pattern
+        if target in ports and ports[target] == port:
+            return entry.get("purpose", "unknown")
+    if port is not None:
+        return f"port:{port}"
+    return "dns-loopback"
+
+
+def validate_attestation(attestation: dict[str, Any]) -> list[str]:
+    """Independently validate an attestation artifact. Returns list of violations (empty = pass)."""
+    violations: list[str] = []
+
+    # Invariant: all roles started and ready.
+    roles = attestation.get("roles", [])
+    if not roles:
+        violations.append("no roles in attestation")
+    for role in roles:
+        if not role.get("ready"):
+            violations.append(f"role {role.get('name')} not ready")
+        if not role.get("ready_probe"):
+            violations.append(f"role {role.get('name')} missing ready_probe")
+
+    # Invariant: no denied egress.
+    egress = attestation.get("egress", {})
+    denied = egress.get("denied_attempts", [])
+    if denied:
+        violations.append(f"{len(denied)} denied egress attempts: {denied[:3]}")
+    if egress.get("allowed", 0) == 0:
+        violations.append("zero allowed egress attempts — guard may not have been installed")
+
+    # Invariant: every invariant field is true.
+    for key, value in attestation.get("invariants", {}).items():
+        if value is not True:
+            violations.append(f"invariant {key} is {value}, expected true")
+
+    return violations
+
+
+def validate_attestation_file(path: str | Path) -> int:
+    """CLI entry point: validate an attestation JSON file. Exit 0 = pass."""
+    attestation = json.loads(Path(path).read_text())
+    violations = validate_attestation(attestation)
+    if violations:
+        print(f"FAIL: {len(violations)} violation(s):", file=__import__("sys").stderr)
+        for v in violations:
+            print(f"  - {v}", file=__import__("sys").stderr)
+        return 1
+    print(f"OK: attestation valid (outcome={attestation.get('outcome')})")
+    return 0

--- a/backend/testing/replay_harness_phase0a/attestation.py
+++ b/backend/testing/replay_harness_phase0a/attestation.py
@@ -1,39 +1,57 @@
-"""Machine-verifiable topology/egress attestation builder and checker.
+"""Self-consistent topology/egress attestation builder and checker.
 
-The builder joins the topology contract, per-role health probes, and the
-egress-attempt log into a single JSON artifact.  The checker is runnable
-independently (third-party-verifiable): it recomputes the topology hash, role
-completeness, and every egress decision from the embedded raw evidence and
-topology contract — it does **not** trust the builder's summary assertions.
+The builder joins a checked-in topology contract, per-role health probes, and
+the egress-attempt log into a single JSON artifact. The checker recomputes every
+claimed invariant from the embedded raw evidence AND an expected checked-in
+topology contract supplied independently of the artifact — it does not trust the
+builder's summary assertions, the recorded event ``decision`` field, or an
+artifact-embedded topology hash.
 
-Scope (stated in the artifact, not over-claimed):
+HONEST SCOPE (not over-claimed): the raw evidence is emitted by the in-process
+socket guard, which is itself part of the SUT under test. Therefore the
+attestation proves **self-consistency and summary-forgery rejection** (every
+summary is recomputed from raw evidence + checked-in contract, and any mismatch
+is rejected), **not** independent/third-party attestation of real kernel egress.
+The attestation mechanism composes end-to-end; it is not a security audit.
+
+Guarded-scope claims:
+
+* Python SUT role processes (admission, worker, cloud-tasks-loopback) install the
+  in-process socket guard and emit ``guard_installed`` evidence.
+* The runner/orchestrator launches and observes roles; it is the trusted launcher
+  and is **not** per-connection guarded.
+* Non-Python dependency processes (Redis server, Firestore emulator JVM) are
+  bind-constrained to loopback by the runner; their own outbound egress is not
+  per-connection observed.
+
+Observed/enforced egress surface (in guarded Python roles):
 
 * TCP connection-oriented egress (``connect``, ``connect_ex``,
   ``create_connection``) and DNS resolution (``getaddrinfo``,
-  ``gethostbyname``, ``gethostbyname_ex``) are observed and enforced in the
-  Python SUT / runner / loopback processes.
-* UDP unconnected sends (``sendto``, ``sendmsg``) are observed and enforced
-  when the guard is installed.
-* Non-Python dependency processes (Redis server, Firestore emulator JVM) are
-  bind-constrained to loopback by the runner; their own outbound egress is
-  **not** per-connection observed by this guard.
+  ``gethostbyname``, ``gethostbyname_ex``) are observed and enforced.
+* UDP unconnected sends (``sendto``, ``sendmsg``) are observed and enforced.
 """
 
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 EGRESS_SCOPE = (
-    "Process-level socket guard in Python SUT/runner/loopback: TCP connect/connect_ex/"
-    "create_connection and DNS (getaddrinfo/gethostbyname/gethostbyname_ex) and UDP "
-    "unconnected sendto/sendmsg are observed and enforced (default-deny + declared "
-    "loopback allow-list). Non-Python dependency processes (Redis server, Firestore "
-    "emulator JVM) are bind-constrained to loopback by the runner; their own outbound "
-    "egress is not per-connection observed by this guard."
+    "In-process socket guard in guarded Python SUT roles (admission, worker, "
+    "cloud-tasks-loopback): TCP connect/connect_ex/create_connection, DNS "
+    "(getaddrinfo/gethostbyname/gethostbyname_ex), and UDP sendto/sendmsg are "
+    "observed and enforced (default-deny + declared loopback allow-list). The "
+    "runner/orchestrator is the trusted launcher and is not per-connection guarded. "
+    "Non-Python dependency processes (Redis server, Firestore emulator JVM) are "
+    "bind-constrained to loopback; their own outbound egress is not per-connection "
+    "observed. Raw evidence is emitted by the in-process guard (part of the SUT); "
+    "the attestation proves self-consistency and summary-forgery rejection, not "
+    "independent attestation of real kernel egress."
 )
 
 
@@ -43,32 +61,49 @@ def _topology_hash(topology: dict[str, Any]) -> str:
     return hashlib.sha256(canonical.encode()).hexdigest()
 
 
-def _resolve_allow_ports(
-    topology: dict[str, Any], ports: dict[str, int], firestore_host: str
-) -> dict[str, frozenset[int]]:
-    """Resolve every declared egress_allow_list entry to the actual port per role.
+def _is_loopback(host: object) -> bool:
+    if host is None:
+        return True
+    if isinstance(host, bytes):
+        host = host.decode("idna", errors="replace")
+    if not isinstance(host, str):
+        return False
+    normalized = host.strip().strip("[]").lower()
+    if normalized in {"", "localhost"}:
+        return True
+    try:
+        address = ipaddress.ip_address(normalized)
+    except ValueError:
+        return False
+    return address.is_loopback
 
-    Returns ``{role: frozenset[int]}`` of ports the guard is permitted to allow
-    for that role.  This is what the validator recomputes to bind allowed
-    egress attempts to the topology contract.
+
+def _resolve_allow_endpoints(
+    topology: dict[str, Any], ports: dict[str, int], firestore_host: str
+) -> dict[str, frozenset[tuple[str, int | None]]]:
+    """Resolve every declared egress_allow_list entry to a (host, port) endpoint per role.
+
+    Returns ``{role: frozenset[(host, port)]}``. This is what the validator
+    recomputes to bind allowed egress attempts to BOTH the declared host and port
+    of the topology contract — a remote host on a declared port is not a match.
     """
+    firestore_host_part = ""
     firestore_port: int | None = None
     if ":" in firestore_host:
+        firestore_host_part = firestore_host.rsplit(":", 1)[0]
         try:
             firestore_port = int(firestore_host.rsplit(":", 1)[1])
         except ValueError:
             firestore_port = None
-    result: dict[str, frozenset[int]] = {}
+    result: dict[str, frozenset[tuple[str, int | None]]] = {}
     for entry in topology.get("egress_allow_list", []):
         role = entry.get("role", "")
         target = entry.get("to", "")
-        port: int | None = None
         if target == "firestore":
-            port = firestore_port
+            if firestore_port is not None:
+                result.setdefault(role, set()).add((firestore_host_part, firestore_port))
         elif target in ports:
-            port = ports[target]
-        if port is not None:
-            result.setdefault(role, set()).add(port)
+            result.setdefault(role, set()).add(("127.0.0.1", ports[target]))
     return {role: frozenset(ps) for role, ps in result.items()}
 
 
@@ -90,6 +125,22 @@ def _classify_attempt(event: dict[str, Any], ports: dict[str, int], firestore_ho
     return "dns-loopback"
 
 
+def _recompute_decision(event: dict[str, Any], allow_endpoints: dict[str, frozenset[tuple[str, int | None]]]) -> str:
+    """Recompute the allow/deny decision from the event's host+port and the topology
+    allow-list, WITHOUT trusting the recorded ``decision`` field.
+
+    - DNS attempts: allow iff the host is loopback.
+    - Egress attempts: allow iff ``(host, port)`` is a declared endpoint for the role.
+    """
+    if event.get("event") == "dns_attempt":
+        return "allow" if _is_loopback(event.get("host")) else "deny"
+    host = event.get("host")
+    port = event.get("port")
+    role = event.get("role", "")
+    declared = allow_endpoints.get(role, frozenset())
+    return "allow" if (host, port) in declared else "deny"
+
+
 def build_attestation(
     *,
     topology: dict[str, Any],
@@ -103,18 +154,23 @@ def build_attestation(
     """Build the attestation artifact from raw evidence.
 
     Embeds the topology contract, resolved ports, Firestore host, and the full
-    raw evidence stream so the checker can recompute every claim independently.
+    raw evidence stream so the checker can recompute every claim. Summary fields
+    are convenience only — the checker never trusts them.
     """
     egress_attempts = [e for e in events if e.get("event") in ("egress_attempt", "dns_attempt")]
-    denied = [e for e in egress_attempts if e.get("decision") == "deny"]
+    allow_endpoints = _resolve_allow_endpoints(topology, ports, firestore_emulator_host)
 
     by_purpose: dict[str, int] = {}
     allowed_count = 0
+    denied_count = 0
     for e in egress_attempts:
-        if e.get("decision") == "allow":
+        decision = _recompute_decision(e, allow_endpoints)
+        if decision == "allow":
             allowed_count += 1
             purpose = _classify_attempt(e, ports, firestore_emulator_host)
             by_purpose[purpose] = by_purpose.get(purpose, 0) + 1
+        else:
+            denied_count += 1
 
     roles_summary = [
         {
@@ -128,7 +184,7 @@ def build_attestation(
     ]
 
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "harness": "omi-replay-harness",
         "phase": "0A",
         "feasibility_only": True,
@@ -143,16 +199,14 @@ def build_attestation(
             "scope": EGRESS_SCOPE,
             "attempts_observed": len(egress_attempts),
             "allowed": allowed_count,
-            "denied": len(denied),
+            "denied": denied_count,
             "by_purpose": by_purpose,
-            "denied_attempts": denied,
-            "every_attempt_matched_declared_fake": len(denied) == 0,
         },
         "invariants": {
             "all_roles_started": all(rh.ready for rh in health_records) if health_records else False,
             "all_roles_ready": all(rh.ready for rh in health_records) if health_records else False,
-            "no_denied_egress": len(denied) == 0,
-            "no_undeclared_loopback_peer": len(denied) == 0,
+            "no_denied_egress": denied_count == 0,
+            "no_undeclared_loopback_peer": denied_count == 0,
         },
         "fault_controls_active": fault_controls,
         "outcome": outcome,
@@ -160,13 +214,19 @@ def build_attestation(
     }
 
 
-def validate_attestation(attestation: dict[str, Any]) -> list[str]:
-    """Independently validate an attestation artifact.
+def validate_attestation(attestation: dict[str, Any], *, expected_topology: dict[str, Any] | None = None) -> list[str]:
+    """Validate an attestation artifact.
 
-    Returns a list of human-readable violations (empty = pass).  Every claimed
-    invariant is recomputed from the embedded topology contract, ports,
-    Firestore host, and raw evidence — builder-produced summary fields are
+    Returns a list of human-readable violations (empty = pass). Every claimed
+    invariant is recomputed from the embedded raw evidence and (when supplied)
+    the expected checked-in topology contract supplied independently of the
+    artifact — builder-produced summary fields and recorded event decisions are
     cross-checked, never trusted.
+
+    ``expected_topology`` is the checked-in contract read independently (e.g. the
+    committed ``topology.json``). When supplied, the artifact's embedded topology
+    must match it exactly, so a modified worker command with a recomputed
+    embedded hash is rejected.
     """
     violations: list[str] = []
 
@@ -174,14 +234,20 @@ def validate_attestation(attestation: dict[str, Any]) -> list[str]:
     if not isinstance(topology, dict):
         return ["attestation missing embedded topology_contract"]
 
-    # 1. Topology hash binding.
+    # 1. Bind to the checked-in contract (independent of the artifact).
+    if expected_topology is not None and topology != expected_topology:
+        violations.append(
+            "embedded topology does not match the expected checked-in contract "
+            "(worker command/role/allow-list may have been modified)"
+        )
+    # 2. Internal hash binding (catches hash-field tampering).
     recomputed_hash = _topology_hash(topology)
     if attestation.get("topology_contract_sha256") != recomputed_hash:
         violations.append(
             f"topology hash mismatch: claimed {attestation.get('topology_contract_sha256')!r}, "
             f"recomputed {recomputed_hash}"
         )
-    # 2. Role completeness: every topology role present and ready.
+    # 3. Role completeness: every topology role present and ready.
     topology_roles = set(topology.get("roles", {}).keys())
     roles = attestation.get("roles", [])
     attested_roles = {r.get("name") for r in roles if isinstance(r, dict)}
@@ -199,48 +265,73 @@ def validate_attestation(attestation: dict[str, Any]) -> list[str]:
         if not role.get("ready_probe"):
             violations.append(f"role {role.get('name')} missing ready_probe")
 
-    # 3. Egress recompute from raw evidence.
+    # 4. Egress recompute from raw evidence — do NOT trust the decision field.
     raw = attestation.get("raw_evidence")
     if not isinstance(raw, list) or not raw:
         violations.append("no raw_evidence embedded — cannot verify egress (guard may not have been installed)")
         raw = []
     egress_events = [e for e in raw if isinstance(e, dict) and e.get("event") in ("egress_attempt", "dns_attempt")]
-    recomputed_denied = [e for e in egress_events if e.get("decision") == "deny"]
-    recomputed_allowed = sum(1 for e in egress_events if e.get("decision") == "allow")
+    ports = attestation.get("ports", {})
+    firestore_host = attestation.get("firestore_emulator_host", "")
+    if not isinstance(ports, dict):
+        ports = {}
+    if not isinstance(firestore_host, str):
+        firestore_host = ""
+    allow_endpoints = _resolve_allow_endpoints(topology, ports, firestore_host)
+
+    recomputed_allowed = 0
+    recomputed_denied = 0
+    for e in egress_events:
+        host = e.get("host")
+        port = e.get("port")
+        role = e.get("role", "")
+        decision = _recompute_decision(e, allow_endpoints)
+        if decision == "allow":
+            recomputed_allowed += 1
+        else:
+            recomputed_denied += 1
+        recorded = e.get("decision")
+        if recorded == "allow" and decision == "deny":
+            # Critical forgery: an event marked allow that is not a declared
+            # loopback endpoint (e.g. a remote host on a declared port).
+            kind = "remote host (not loopback)" if not _is_loopback(host) else "undeclared loopback port"
+            violations.append(
+                f"egress event marked allow is not a declared endpoint: {kind} "
+                f"(role={role}, host={host!r}, port={port}); decision recomputed as deny"
+            )
+        elif recorded == "deny" and decision == "allow":
+            violations.append(
+                f"egress event marked deny is actually a declared endpoint "
+                f"(role={role}, host={host!r}, port={port}); recorded decision contradicts recompute"
+            )
 
     egress = attestation.get("egress", {})
-    if egress.get("denied", -1) != len(recomputed_denied):
+    if egress.get("denied", -1) != recomputed_denied:
         violations.append(
-            f"egress.denied forgery: claimed {egress.get('denied')}, recomputed {len(recomputed_denied)} from raw evidence"
+            f"egress.denied forgery: claimed {egress.get('denied')}, recomputed {recomputed_denied} from raw evidence"
         )
     if egress.get("allowed", -1) != recomputed_allowed:
         violations.append(
             f"egress.allowed forgery: claimed {egress.get('allowed')}, recomputed {recomputed_allowed} from raw evidence"
         )
-    if recomputed_allowed == 0:
-        violations.append("zero allowed egress attempts — guard may not have been installed")
+    if recomputed_allowed == 0 and recomputed_denied == 0:
+        violations.append("zero egress attempts observed — guard may not have been installed")
 
-    # 4. Allow-list binding: every allowed attempt must match a declared entry.
-    ports = attestation.get("ports", {})
-    firestore_host = attestation.get("firestore_emulator_host", "")
-    if isinstance(ports, dict) and isinstance(firestore_host, str):
-        allowed_by_role = _resolve_allow_ports(topology, ports, firestore_host)
-        for e in egress_events:
-            if e.get("decision") != "allow":
-                continue
-            port = e.get("port")
-            role = e.get("role", "")
-            if port is None:
-                continue  # DNS-loopback allow; no port to bind.
-            permitted = allowed_by_role.get(role, frozenset())
-            if port not in permitted:
-                violations.append(
-                    f"allowed egress to undeclared port {port} (role={role}) — not in topology allow-list"
-                )
+    # 5. Guard-installation evidence for every explicitly guarded Python role.
+    guarded_roles = {
+        name for name, r in topology.get("roles", {}).items() if isinstance(r, dict) and r.get("guarded") is True
+    }
+    installed_roles = {e.get("role") for e in raw if isinstance(e, dict) and e.get("event") == "guard_installed"}
+    for role in sorted(guarded_roles):
+        if role not in installed_roles:
+            violations.append(
+                f"guarded role {role!r} has no guard_installed evidence in raw_evidence "
+                "(guard may not have been installed in this Python role)"
+            )
 
-    # 5. Invariant recompute.
+    # 6. Invariant recompute.
     invariants = attestation.get("invariants", {})
-    expected_no_denied = len(recomputed_denied) == 0
+    expected_no_denied = recomputed_denied == 0
     expected_all_ready = bool(roles) and all(r.get("ready") for r in roles if isinstance(r, dict))
     recomputed_invariants = {
         "all_roles_started": expected_all_ready,
@@ -255,10 +346,17 @@ def validate_attestation(attestation: dict[str, Any]) -> list[str]:
     return violations
 
 
-def validate_attestation_file(path: str | Path) -> int:
-    """CLI entry point: validate an attestation JSON file. Exit 0 = pass."""
+def validate_attestation_file(path: str | Path, *, expected_topology_path: str | Path | None = None) -> int:
+    """CLI entry point: validate an attestation JSON file. Exit 0 = pass.
+
+    When ``expected_topology_path`` is supplied, the artifact is bound to that
+    checked-in contract independently of the artifact's embedded copy.
+    """
     attestation = json.loads(Path(path).read_text())
-    violations = validate_attestation(attestation)
+    expected_topology = None
+    if expected_topology_path is not None:
+        expected_topology = json.loads(Path(expected_topology_path).read_text())
+    violations = validate_attestation(attestation, expected_topology=expected_topology)
     if violations:
         import sys
 

--- a/backend/testing/replay_harness_phase0a/cloud_tasks_loopback.py
+++ b/backend/testing/replay_harness_phase0a/cloud_tasks_loopback.py
@@ -1,0 +1,199 @@
+"""Out-of-process Cloud Tasks loopback scheduler service (feasibility-only).
+
+FEASIBILITY-ONLY: This is a minimal stateful scheduler model, NOT a faithful
+Cloud Tasks control-plane. It receives task-creation calls from the admission
+process over real loopback HTTP, validates the production task shape, stores
+tasks, and delivers them to the worker over loopback HTTP. Named-task dedup
+(AlreadyExists) is preserved; duplicate *delivery* is supported via a declared
+fault control. Signature/issuer/expiry OIDC verification remains outside scope
+(feasibility-only: one exact local token).
+
+This process is deliberately NOT uvicorn/FastAPI — it proves the generic
+launcher starts arbitrary declared commands, not just ASGI roles.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import urlparse
+
+# Install egress guard BEFORE any outbound connection.
+from testing.replay_harness_phase0a.egress_guard import guard_from_env
+
+_sink = guard_from_env()
+
+import httpx  # noqa: E402
+
+_WORKER_URL = os.getenv("OMI_REPLAY_WORKER_URL", "")
+_OIDC_TOKEN = os.getenv("OMI_REPLAY_OIDC_TOKEN", "")
+_OIDC_SA = os.getenv("OMI_REPLAY_OIDC_SA", "")
+_OIDC_AUDIENCE = os.getenv("OMI_REPLAY_OIDC_AUDIENCE", "")
+_QUEUE_PATH = os.getenv("OMI_REPLAY_QUEUE_PATH", "")
+_DISPATCH_DEADLINE = int(os.getenv("OMI_REPLAY_DISPATCH_DEADLINE", "1500"))
+_DUPLICATE_DELIVERY = int(os.getenv("OMI_REPLAY_DUPLICATE_DELIVERY", "0"))
+
+_tasks: dict[str, dict[str, Any]] = {}
+_lock = threading.Lock()
+_ready = threading.Event()
+
+
+def _emit(event: dict[str, Any]) -> None:
+    if _sink:
+        _sink(event)
+
+
+def _validate_task(payload: dict[str, Any]) -> None:
+    """Validate the production tasks_v2.Task shape (feasibility-only: structural check)."""
+    parent = payload.get("parent", "")
+    if parent != _QUEUE_PATH:
+        raise ValueError(f"task parent {parent!r} does not match queue {_QUEUE_PATH!r}")
+
+    task_name = payload.get("task_name", "")
+    if not task_name or f"{_QUEUE_PATH}/tasks/" not in task_name:
+        raise ValueError("task name must be a child of the queue path")
+
+    body = payload.get("body")
+    if not isinstance(body, dict):
+        raise ValueError("task body must be a JSON object")
+    required_body_keys = {
+        "schema_version",
+        "job_id",
+        "uid",
+        "raw_blob_paths",
+        "source",
+        "should_lock",
+        "conversation_id",
+        "client_device_id",
+    }
+    missing = required_body_keys - set(body.keys())
+    if missing:
+        raise ValueError(f"task body missing keys: {missing}")
+
+    url = payload.get("url", "")
+    parsed = urlparse(url)
+    if parsed.scheme != "http" or parsed.hostname != "127.0.0.1" or not parsed.port:
+        raise ValueError(f"task URL must be loopback http, got {url!r}")
+    if parsed.path != "/v2/sync-jobs/run":
+        raise ValueError(f"task URL path must be /v2/sync-jobs/run, got {parsed.path!r}")
+
+    deadline = payload.get("dispatch_deadline_seconds", 0)
+    if deadline != _DISPATCH_DEADLINE:
+        raise ValueError(f"dispatch deadline {deadline} != {_DISPATCH_DEADLINE}")
+
+    sa = payload.get("oidc_sa", "")
+    audience = payload.get("oidc_audience", "")
+    if sa != _OIDC_SA or audience != _OIDC_AUDIENCE:
+        raise ValueError("OIDC service account or audience mismatch")
+
+
+def _deliver(body: dict[str, Any], url: str, *, retry_count: int) -> int:
+    """Deliver one task body to the worker over loopback HTTP. Returns HTTP status."""
+    headers = {
+        "Authorization": f"Bearer {_OIDC_TOKEN}",
+        "Content-Type": "application/json",
+        "X-CloudTasks-TaskRetryCount": str(retry_count),
+    }
+    _emit({"event": "task_delivering", "job_id": body.get("job_id", ""), "retry_count": retry_count})
+    try:
+        with httpx.Client(timeout=30.0, trust_env=False) as client:
+            response = client.post(url, json=body, headers=headers)
+        _emit(
+            {
+                "event": "task_delivered",
+                "job_id": body.get("job_id", ""),
+                "retry_count": retry_count,
+                "status_code": response.status_code,
+            }
+        )
+        return response.status_code
+    except Exception as exc:
+        _emit({"event": "task_delivery_failed", "job_id": body.get("job_id", ""), "error_type": type(exc).__name__})
+        return 599
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        if self.path == "/__replay/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"status": "ok", "role": "cloud-tasks-loopback"}).encode())
+        else:
+            self.send_error(404)
+
+    def do_POST(self) -> None:
+        if self.path != "/__replay/enqueue":
+            self.send_error(404)
+            return
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            self.send_error(400, "invalid JSON")
+            return
+
+        task_name = payload.get("task_name", "")
+
+        # Validate the production task shape.
+        try:
+            _validate_task(payload)
+        except ValueError as exc:
+            _emit({"event": "task_rejected", "task_name": task_name, "reason": str(exc)})
+            self.send_error(422, f"task validation failed: {exc}")
+            return
+
+        # Named-task dedup (production AlreadyExists semantics).
+        with _lock:
+            if task_name in _tasks:
+                _emit({"event": "named_task_deduplicated", "task_name": task_name})
+                self.send_response(409)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": "already exists"}).encode())
+                return
+            _tasks[task_name] = payload
+
+        body = payload["body"]
+        url = payload["url"]
+        job_id = body.get("job_id", "")
+        _emit({"event": "task_captured", "task_name": task_name, "job_id": job_id})
+
+        # Deliver to worker over real loopback HTTP.
+        status = _deliver(body, url, retry_count=0)
+
+        # Declared fault: duplicate delivery (at-least-once simulation).
+        if _DUPLICATE_DELIVERY > 0 and 200 <= status < 300:
+            time.sleep(0.5)  # Let the first delivery settle.
+            _deliver(body, url, retry_count=1)
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"status": "enqueued", "delivery_status": status}).encode())
+
+    def log_message(self, *_args: Any) -> None:
+        pass  # Suppress default stderr logging.
+
+
+def main() -> int:
+    port = int(os.getenv("OMI_REPLAY_PORT", "0"))
+    if port == 0:
+        raise RuntimeError("OMI_REPLAY_PORT is required")
+
+    server = ThreadingHTTPServer(("127.0.0.1", port), _Handler)
+    _ready.set()
+    _emit({"event": "loopback_started", "port": port, "duplicate_delivery": _DUPLICATE_DELIVERY})
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/testing/replay_harness_phase0a/egress_guard.py
+++ b/backend/testing/replay_harness_phase0a/egress_guard.py
@@ -28,18 +28,35 @@ from typing import Any, Callable
 # --------------------------------------------------------------------------- #
 
 
-def _parse_allow_list(raw: str) -> frozenset[int]:
+def _canonical_host(host: object) -> str:
+    """Normalize a connection host to its canonical string identity for exact
+    host+port matching against the declared allow-list.
+
+    Identity is preserved, NOT folded to loopback: an undeclared ``localhost`` or
+    ``::1`` alias must not canonicalize to a declared ``127.0.0.1``. Only bytes
+    decoding and bracket/whitespace stripping are applied so the comparison is
+    against the exact declared endpoint identity.
+    """
+    if host is None:
+        return ""
+    if isinstance(host, bytes):
+        host = host.decode("idna", errors="replace")
+    return str(host).strip().strip("[]")
+
+
+def _parse_allow_list(raw: str) -> frozenset[tuple[str, int]]:
     """Parse a JSON list of {"host": "127.0.0.1", "port": 51001} entries.
 
-    Returns a set of allowed ports — the DNS guard already enforces loopback,
-    so the port alone identifies the declared fake endpoint.
+    Returns the set of allowed canonical (host, port) endpoints — host identity
+    is preserved so an undeclared ``localhost``/``::1`` alias on a declared port
+    is NOT accepted. The DNS guard separately enforces loopback for resolution.
     """
     if not raw:
         return frozenset()
-    ports: set[int] = set()
+    endpoints: set[tuple[str, int]] = set()
     for item in json.loads(raw):
-        ports.add(int(item["port"]))
-    return frozenset(ports)
+        endpoints.add((_canonical_host(item["host"]), int(item["port"])))
+    return frozenset(endpoints)
 
 
 def _is_loopback(host: object) -> bool:
@@ -115,8 +132,12 @@ _original_gethostbyname = socket.gethostbyname
 _original_gethostbyname_ex = socket.gethostbyname_ex
 
 
-def install_default_deny_guard(*, role: str, allow: frozenset[int], sink: Callable[[dict[str, Any]], None]) -> None:
-    """Patch socket entrypoints: default-deny, allow only declared ports, log every attempt."""
+def install_default_deny_guard(
+    *, role: str, allow: frozenset[tuple[str, int]], sink: Callable[[dict[str, Any]], None]
+) -> None:
+    """Patch socket entrypoints: default-deny, allow only declared canonical
+    host+port endpoints, log every attempt. Undeclared loopback aliases
+    (localhost/::1) on a declared port are denied."""
 
     def _check_and_log(sock: socket.socket | None, address: object) -> bool:
         host = _host_from_address(address)
@@ -125,7 +146,14 @@ def install_default_deny_guard(*, role: str, allow: frozenset[int], sink: Callab
             port = address[1]
         is_unix = _is_unix_socket(sock) if sock is not None else False
         is_lb = is_unix or _is_loopback(host)
-        in_allow = is_lb and port in allow if port is not None else is_unix
+        if is_unix:
+            in_allow = True
+        elif port is not None:
+            # Enforce canonical host+port endpoint identity, not port alone: an
+            # undeclared localhost/::1 alias on a declared port is denied.
+            in_allow = (_canonical_host(host), port) in allow
+        else:
+            in_allow = False
         sink(
             {
                 "event": "egress_attempt",

--- a/backend/testing/replay_harness_phase0a/egress_guard.py
+++ b/backend/testing/replay_harness_phase0a/egress_guard.py
@@ -1,0 +1,199 @@
+"""Default-deny egress guard with explicit loopback allow-list and logging.
+
+FEASIBILITY-ONLY: process-level socket monkeypatch; cannot observe egress from
+non-Python dependency processes (Redis, Firestore JVM).  Those are bind-constrained
+to loopback by the runner and excluded from per-connection observation.  The
+attestation states this scope explicitly.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import socket
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+# --------------------------------------------------------------------------- #
+# Allow-list model
+# --------------------------------------------------------------------------- #
+
+
+def _parse_allow_list(raw: str) -> frozenset[int]:
+    """Parse a JSON list of {"host": "127.0.0.1", "port": 51001} entries.
+
+    Returns a set of allowed ports — the DNS guard already enforces loopback,
+    so the port alone identifies the declared fake endpoint.
+    """
+    if not raw:
+        return frozenset()
+    ports: set[int] = set()
+    for item in json.loads(raw):
+        ports.add(int(item["port"]))
+    return frozenset(ports)
+
+
+def _is_loopback(host: object) -> bool:
+    if host is None:
+        return True
+    if isinstance(host, bytes):
+        host = host.decode("idna", errors="replace")
+    if not isinstance(host, str):
+        return False
+    normalized = host.strip().strip("[]").lower()
+    if normalized in {"", "localhost"}:
+        return True
+    try:
+        address = ipaddress.ip_address(normalized)
+    except ValueError:
+        return False
+    return address.is_loopback
+
+
+def _host_from_address(address: object) -> object:
+    if isinstance(address, tuple) and address:
+        return address[0]
+    return address
+
+
+def _is_unix_socket(sock: socket.socket) -> bool:
+    af_unix = getattr(socket, "AF_UNIX", None)
+    return af_unix is not None and sock.family == af_unix
+
+
+# --------------------------------------------------------------------------- #
+# Evidence sink (interprocess-safe, sanitized)
+# --------------------------------------------------------------------------- #
+
+_FORBIDDEN_KEYS = frozenset(
+    {"audio", "audio_bytes", "body", "file_path", "payload", "raw_blob_paths", "text", "transcript", "uid"}
+)
+
+_sink_lock = threading.Lock()
+
+
+def _make_sink(state_dir: str, role: str) -> Callable[[dict[str, Any]], None]:
+    evidence_path = Path(state_dir) / "evidence" / "egress.jsonl"
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def sink(record: dict[str, Any]) -> None:
+        sanitized = {k: v for k, v in record.items() if k not in _FORBIDDEN_KEYS}
+        sanitized["role"] = role
+        sanitized.setdefault("ts", time.monotonic())
+        line = json.dumps(sanitized, sort_keys=True, separators=(",", ":"))
+        with _sink_lock:
+            import fcntl
+
+            with evidence_path.open("a") as fh:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+                fh.write(line + "\n")
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+    return sink
+
+
+# --------------------------------------------------------------------------- #
+# Default-deny guard installation
+# --------------------------------------------------------------------------- #
+
+_original_connect = socket.socket.connect
+_original_connect_ex = socket.socket.connect_ex
+_original_create_connection = socket.create_connection
+_original_getaddrinfo = socket.getaddrinfo
+_original_gethostbyname = socket.gethostbyname
+_original_gethostbyname_ex = socket.gethostbyname_ex
+
+
+def install_default_deny_guard(*, role: str, allow: frozenset[int], sink: Callable[[dict[str, Any]], None]) -> None:
+    """Patch socket entrypoints: default-deny, allow only declared ports, log every attempt."""
+
+    def _check_and_log(sock: socket.socket | None, address: object) -> bool:
+        host = _host_from_address(address)
+        port = None
+        if isinstance(address, tuple) and len(address) >= 2 and isinstance(address[1], int):
+            port = address[1]
+        is_unix = _is_unix_socket(sock) if sock is not None else False
+        is_lb = is_unix or _is_loopback(host)
+        in_allow = is_lb and port in allow if port is not None else is_unix
+        sink(
+            {
+                "event": "egress_attempt",
+                "host": str(host) if host is not None else "",
+                "port": port,
+                "loopback": is_lb,
+                "decision": "allow" if in_allow else "deny",
+            }
+        )
+        return in_allow
+
+    def guarded_connect(sock: socket.socket, address: object) -> Any:
+        if not _check_and_log(sock, address):
+            raise OSError(f"[replay-harness] denied egress to {_host_from_address(address)!r}:{address}")
+        return _original_connect(sock, address)
+
+    def guarded_connect_ex(sock: socket.socket, address: object) -> int:
+        if not _check_and_log(sock, address):
+            return -1  # connect_ex returns error code, not exception
+        return _original_connect_ex(sock, address)
+
+    def guarded_create_connection(address: object, *args: Any, **kwargs: Any) -> socket.socket:
+        if not _check_and_log(None, address):
+            raise OSError(f"[replay-harness] denied egress to {address!r}")
+        return _original_create_connection(address, *args, **kwargs)
+
+    def guarded_getaddrinfo(host: Any, *args: Any, **kwargs: Any) -> Any:
+        # DNS resolution to non-loopback is always denied; loopback is always allowed
+        # (the port-level check happens at connect time).
+        is_lb = _is_loopback(host)
+        sink(
+            {
+                "event": "dns_attempt",
+                "host": str(host) if host is not None else "",
+                "loopback": is_lb,
+                "decision": "allow" if is_lb else "deny",
+            }
+        )
+        if not is_lb:
+            raise OSError(f"[replay-harness] denied DNS for {host!r}")
+        return _original_getaddrinfo(host, *args, **kwargs)
+
+    def guarded_gethostbyname(host: object) -> Any:
+        is_lb = _is_loopback(host)
+        sink({"event": "dns_attempt", "host": str(host), "loopback": is_lb, "decision": "allow" if is_lb else "deny"})
+        if not is_lb:
+            raise OSError(f"[replay-harness] denied DNS for {host!r}")
+        return _original_gethostbyname(host)
+
+    def guarded_gethostbyname_ex(host: object) -> Any:
+        is_lb = _is_loopback(host)
+        sink({"event": "dns_attempt", "host": str(host), "loopback": is_lb, "decision": "allow" if is_lb else "deny"})
+        if not is_lb:
+            raise OSError(f"[replay-harness] denied DNS for {host!r}")
+        return _original_gethostbyname_ex(host)
+
+    socket.socket.connect = guarded_connect
+    socket.socket.connect_ex = guarded_connect_ex
+    socket.create_connection = guarded_create_connection
+    socket.getaddrinfo = guarded_getaddrinfo
+    socket.gethostbyname = guarded_gethostbyname
+    socket.gethostbyname_ex = guarded_gethostbyname_ex
+
+
+def guard_from_env() -> Callable[[dict[str, Any]], None] | None:
+    """Read role + allow-list + state-dir from env and install the guard.
+
+    Returns the sink callable if installed, None otherwise.
+    """
+    role = os.getenv("OMI_REPLAY_ROLE", "").strip()
+    state_dir = os.getenv("OMI_REPLAY_STATE_DIR", "").strip()
+    allow_raw = os.getenv("OMI_REPLAY_EGRESS_ALLOW", "").strip()
+    if not role or not state_dir:
+        return None
+    allow = _parse_allow_list(allow_raw)
+    sink = _make_sink(state_dir, role)
+    install_default_deny_guard(role=role, allow=allow, sink=sink)
+    sink({"event": "guard_installed", "role": role, "allow_count": len(allow)})
+    return sink

--- a/backend/testing/replay_harness_phase0a/egress_guard.py
+++ b/backend/testing/replay_harness_phase0a/egress_guard.py
@@ -1,9 +1,15 @@
 """Default-deny egress guard with explicit loopback allow-list and logging.
 
+Patches TCP connection-oriented entrypoints (connect, connect_ex,
+create_connection), DNS resolution (getaddrinfo, gethostbyname,
+gethostbyname_ex), and UDP unconnected sends (sendto, sendmsg) in the Python
+SUT / runner / loopback processes.  Every attempt is logged then allowed or
+denied.
+
 FEASIBILITY-ONLY: process-level socket monkeypatch; cannot observe egress from
-non-Python dependency processes (Redis, Firestore JVM).  Those are bind-constrained
-to loopback by the runner and excluded from per-connection observation.  The
-attestation states this scope explicitly.
+non-Python dependency processes (Redis server, Firestore emulator JVM).  Those
+are bind-constrained to loopback by the runner and excluded from
+per-connection observation.  The attestation states this scope explicitly.
 """
 
 from __future__ import annotations
@@ -99,6 +105,8 @@ def _make_sink(state_dir: str, role: str) -> Callable[[dict[str, Any]], None]:
 # Default-deny guard installation
 # --------------------------------------------------------------------------- #
 
+_original_sendto = socket.socket.sendto
+_original_sendmsg = socket.socket.sendmsg
 _original_connect = socket.socket.connect
 _original_connect_ex = socket.socket.connect_ex
 _original_create_connection = socket.create_connection
@@ -144,6 +152,21 @@ def install_default_deny_guard(*, role: str, allow: frozenset[int], sink: Callab
             raise OSError(f"[replay-harness] denied egress to {address!r}")
         return _original_create_connection(address, *args, **kwargs)
 
+    def guarded_sendto(sock: socket.socket, data: Any, *args: Any) -> Any:
+        # sendto(data, address) or sendto(data, flags, address); address is last positional.
+        if args:
+            address = args[-1]
+            if isinstance(address, tuple) and not _check_and_log(sock, address):
+                raise OSError(f"[replay-harness] denied UDP sendto to {_host_from_address(address)!r}:{address}")
+        return _original_sendto(sock, data, *args)
+
+    def guarded_sendmsg(
+        sock: socket.socket, buffers: Any, ancdata: Any = (), flags: int = 0, address: Any = None
+    ) -> Any:
+        if isinstance(address, tuple) and not _check_and_log(sock, address):
+            raise OSError(f"[replay-harness] denied UDP sendmsg to {_host_from_address(address)!r}:{address}")
+        return _original_sendmsg(sock, buffers, ancdata, flags, address)
+
     def guarded_getaddrinfo(host: Any, *args: Any, **kwargs: Any) -> Any:
         # DNS resolution to non-loopback is always denied; loopback is always allowed
         # (the port-level check happens at connect time).
@@ -177,6 +200,8 @@ def install_default_deny_guard(*, role: str, allow: frozenset[int], sink: Callab
     socket.socket.connect = guarded_connect
     socket.socket.connect_ex = guarded_connect_ex
     socket.create_connection = guarded_create_connection
+    socket.socket.sendto = guarded_sendto
+    socket.socket.sendmsg = guarded_sendmsg
     socket.getaddrinfo = guarded_getaddrinfo
     socket.gethostbyname = guarded_gethostbyname
     socket.gethostbyname_ex = guarded_gethostbyname_ex

--- a/backend/testing/replay_harness_phase0a/run.sh
+++ b/backend/testing/replay_harness_phase0a/run.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Run the Phase 0A replay harness through Firebase so Firestore is isolated
+# and torn down automatically.
+#
+# FEASIBILITY-ONLY: this is an experiment, not a merge-blocking gauntlet.
+# The existing sync_cloud_tasks_stack gauntlet remains the blocking coverage.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$repo_root"
+
+if [[ ! -x backend/.venv/bin/python ]]; then
+  echo "Missing backend/.venv. Run backend/scripts/sync-python-deps.sh first." >&2
+  exit 1
+fi
+
+if ! java -version >/dev/null 2>&1; then
+  jdk_prefix="$(brew --prefix openjdk@21 2>/dev/null || true)"
+  if [[ -n "$jdk_prefix" && -x "$jdk_prefix/libexec/openjdk.jdk/Contents/Home/bin/java" ]]; then
+    export JAVA_HOME="$jdk_prefix/libexec/openjdk.jdk/Contents/Home"
+    export PATH="$JAVA_HOME/bin:$PATH"
+  fi
+fi
+if ! java -version >/dev/null 2>&1; then
+  echo "Firebase's Firestore emulator needs Java 21+. Install it with: brew install openjdk@21" >&2
+  exit 1
+fi
+
+if ! command -v redis-server >/dev/null 2>&1; then
+  echo "redis-server is required. Install Redis and retry." >&2
+  exit 1
+fi
+
+emulator_port="$(node -e 'const net = require("net"); const server = net.createServer(); server.listen(0, "127.0.0.1", () => { console.log(server.address().port); server.close(); });')"
+emulator_config="$(mktemp "${TMPDIR:-/tmp}/omi-replay-harness-firebase.XXXXXX")"
+trap 'rm -f "$emulator_config"' EXIT
+node -e 'require("fs").writeFileSync(process.argv[1], JSON.stringify({emulators: {firestore: {host: "127.0.0.1", port: Number(process.argv[2])}}}))' \
+  "$emulator_config" "$emulator_port"
+
+if [[ -z "${OMI_REPLAY_STATE_ROOT:-}" ]]; then
+  state_root="$(mktemp -d "${TMPDIR:-/tmp}/omi-replay-harness.XXXXXX")"
+else
+  state_root="$OMI_REPLAY_STATE_ROOT"
+fi
+export OMI_REPLAY_STATE_ROOT="$state_root"
+
+runner_command="PYTHONPATH=backend backend/.venv/bin/python -m testing.replay_harness_phase0a.runner"
+
+echo "Phase 0A Replay Harness — feasibility experiment"
+echo "  state root: $state_root"
+echo "  Firestore emulator: 127.0.0.1:$emulator_port"
+
+npx --no-install firebase emulators:exec --only firestore --project demo-omi-replay-harness --config "$emulator_config" \
+  "$runner_command"

--- a/backend/testing/replay_harness_phase0a/runner.py
+++ b/backend/testing/replay_harness_phase0a/runner.py
@@ -215,28 +215,55 @@ class Harness:
         self.children[name] = child
         return child
 
+    def _append_evidence(self, record: dict[str, Any]) -> None:
+        """Append a runner-emitted evidence record to the shared evidence stream.
+
+        Uses the same fcntl-locked append as the in-process guard sink so runner
+        and SUT writes interleave atomically.
+        """
+        import fcntl
+
+        path = self.evidence_dir / "egress.jsonl"
+        line = json.dumps(record, sort_keys=True, separators=(",", ":"))
+        with path.open("a") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            fh.write(line + "\n")
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
     def _wait_health(self, name: str) -> RoleHealth:
         role_def = self.topology["roles"][name]
         health = role_def["health"]
         timeout = float(role_def.get("startup_timeout_seconds", 30))
         port = self.ports.get(name)
         pid = self.children[name].pid
+        host = health.get("host", "127.0.0.1")
 
         if health["type"] == "tcp":
             deadline = time.monotonic() + timeout
             while time.monotonic() < deadline:
                 try:
-                    with socket.create_connection(("127.0.0.1", port), timeout=1.0):
+                    with socket.create_connection((host, port), timeout=1.0):
                         rh = RoleHealth(name=name, pid=pid, port=port, ready=True, ready_probe={"type": "tcp"})
                         self.health_records.append(rh)
+                        self._append_evidence(
+                            {
+                                "event": "role_allocated",
+                                "role": name,
+                                "host": host,
+                                "port": port,
+                                "pid": pid,
+                                "health": {"type": "tcp"},
+                                "ready": True,
+                            }
+                        )
                         return rh
                 except OSError:
                     time.sleep(0.2)
-            raise HarnessFailure(f"{name} did not listen on 127.0.0.1:{port}")
+            raise HarnessFailure(f"{name} did not listen on {host}:{port}")
 
         # HTTP health probe.
         expect_role = health.get("expect_role", name)
-        url = f"http://127.0.0.1:{port}{health['path']}"
+        url = f"http://{host}:{port}{health['path']}"
         deadline = time.monotonic() + timeout
 
         def check() -> bool:
@@ -254,6 +281,18 @@ class Harness:
                 probe = {"type": "http", "path": health["path"], "status": 200, "role": expect_role}
                 rh = RoleHealth(name=name, pid=pid, port=port, ready=True, ready_probe=probe)
                 self.health_records.append(rh)
+                self._append_evidence(
+                    {
+                        "event": "role_allocated",
+                        "role": name,
+                        "host": host,
+                        "port": port,
+                        "pid": pid,
+                        "health": {"type": "http", "path": health["path"], "expect_role": expect_role},
+                        "status": 200,
+                        "ready": True,
+                    }
+                )
                 return rh
             time.sleep(0.3)
         raise HarnessFailure(f"{name} health check failed within {timeout:.0f}s")

--- a/backend/testing/replay_harness_phase0a/runner.py
+++ b/backend/testing/replay_harness_phase0a/runner.py
@@ -12,7 +12,6 @@ Usage:
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import shutil
@@ -228,7 +227,9 @@ class Harness:
             while time.monotonic() < deadline:
                 try:
                     with socket.create_connection(("127.0.0.1", port), timeout=1.0):
-                        return RoleHealth(name=name, pid=pid, port=port, ready=True, ready_probe={"type": "tcp"})
+                        rh = RoleHealth(name=name, pid=pid, port=port, ready=True, ready_probe={"type": "tcp"})
+                        self.health_records.append(rh)
+                        return rh
                 except OSError:
                     time.sleep(0.2)
             raise HarnessFailure(f"{name} did not listen on 127.0.0.1:{port}")
@@ -312,14 +313,13 @@ class Harness:
     def build_attestation(self, *, outcome: str) -> dict[str, Any]:
         from testing.replay_harness_phase0a.attestation import build_attestation
 
-        topology_hash = hashlib.sha256(self.topology_path.read_bytes()).hexdigest()
+        firestore_host = os.getenv("FIRESTORE_EMULATOR_HOST", "")
         return build_attestation(
             topology=self._resolved_topology or self.topology,
-            topology_hash=topology_hash,
             health_records=self.health_records,
             events=self.read_events(),
-            egress_allow_list=self.topology.get("egress_allow_list", []),
             ports=self.ports,
+            firestore_emulator_host=firestore_host,
             outcome=outcome,
             fault_controls=self.fault_controls,
         )

--- a/backend/testing/replay_harness_phase0a/runner.py
+++ b/backend/testing/replay_harness_phase0a/runner.py
@@ -1,0 +1,338 @@
+"""Generic topology launcher for the Replay Harness.
+
+Reads a declarative capability/topology contract (topology.json), allocates
+isolated ports, resolves placeholders, starts each declared role via its
+declared command, probes declared health endpoints, and builds a
+machine-verifiable attestation. Contains NO sync-specific branching logic;
+the sync test fixture env is a labeled constant, not runtime branching.
+
+Usage:
+    PYTHONPATH=backend python -m testing.replay_harness_phase0a.runner [options]
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND = ROOT / "backend"
+PYTHON = str(BACKEND / ".venv" / "bin" / "python")
+PROJECT = "demo-omi-replay-harness"
+ADMIN_KEY = "omi-replay-harness-admin-"
+ENCRYPTION_SECRET = "omi_replay_harness_test_secret_32_bytes"
+TRANSCRIPT_TOKEN = "Replay harness transcript verified."
+DEVICE_HASH = "01234567"
+DEVICE_ID = f"ios_{DEVICE_HASH}"
+LOCAL_OIDC_AUDIENCE = "https://replay-harness.local/v2/sync-jobs/run"
+LOCAL_INVOKER_SA = f"replay-invoker@{PROJECT}.iam.gserviceaccount.com"
+LOCAL_OIDC_TOKEN = f"local-replay-oidc:{LOCAL_INVOKER_SA}"
+SYNC_QUEUE = "sync-jobs"
+
+
+class HarnessFailure(AssertionError):
+    pass
+
+
+@dataclass
+class Child:
+    name: str
+    process: subprocess.Popen[bytes]
+    log_path: Path
+    pid: int
+
+
+@dataclass
+class RoleHealth:
+    name: str
+    pid: int
+    port: int | None
+    ready: bool
+    ready_probe: dict[str, Any] = field(default_factory=dict)
+
+
+class Harness:
+    """Generic topology launcher driven by a declarative contract."""
+
+    def __init__(self, topology_path: Path, state_dir: Path, *, fault_controls: dict[str, str] | None = None):
+        self.topology = json.loads(topology_path.read_text())
+        self.topology_path = topology_path
+        self.state_dir = state_dir
+        self.fault_controls = fault_controls or {}
+        self.logs_dir = state_dir / "logs"
+        self.evidence_dir = state_dir / "evidence"
+        self.storage_dir = state_dir / "local-storage"
+        for d in (self.logs_dir, self.evidence_dir, self.storage_dir):
+            d.mkdir(parents=True, exist_ok=True)
+        self.ports: dict[str, int] = {}
+        self.children: dict[str, Child] = {}
+        self.health_records: list[RoleHealth] = []
+        self.control_token = f"replay-{int(time.time())}-{os.getpid()}"
+        self.http = httpx.Client(timeout=15.0, trust_env=False)
+        self._resolved_topology: dict[str, Any] = {}
+
+    def _free_port(self) -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+            return int(probe.getsockname()[1])
+
+    def _resolve_placeholders(self, text: str) -> str:
+        result = text
+        for role_name, port in self.ports.items():
+            result = result.replace(f"${{port:{role_name}}}", str(port))
+        result = result.replace("${python}", PYTHON)
+        return result
+
+    def _build_egress_allow(self, role: str) -> list[dict[str, Any]]:
+        entries = []
+        for item in self.topology.get("egress_allow_list", []):
+            if item["role"] != role:
+                continue
+            target = item["to"]
+            if target == "firestore":
+                firestore_host = os.getenv("FIRESTORE_EMULATOR_HOST", "")
+                host = firestore_host.rsplit(":", 1)[0] if ":" in firestore_host else "127.0.0.1"
+                port_str = firestore_host.rsplit(":", 1)[1] if ":" in firestore_host else "0"
+                entries.append({"host": host, "port": int(port_str)})
+            elif target in self.ports:
+                entries.append({"host": "127.0.0.1", "port": self.ports[target]})
+        return entries
+
+    def _build_env(self, role: str) -> dict[str, str]:
+        # Generic: allowlisted inheritance.
+        env = {key: os.environ[key] for key in ("PATH", "LANG", "LC_ALL", "TZ", "TMPDIR") if os.getenv(key)}
+        firestore_host = os.getenv("FIRESTORE_EMULATOR_HOST", "").strip()
+        isolated_home = self.state_dir / "home"
+        isolated_config = self.state_dir / "config"
+        env.update(
+            {
+                "HOME": str(isolated_home),
+                "XDG_CONFIG_HOME": str(isolated_config),
+                "CLOUDSDK_CONFIG": str(isolated_config / "gcloud"),
+                "NO_PROXY": "127.0.0.1,localhost",
+                "no_proxy": "127.0.0.1,localhost",
+                "FIRESTORE_EMULATOR_HOST": firestore_host,
+                "FIREBASE_AUTH_EMULATOR_HOST": "127.0.0.1:9099",
+                "FIREBASE_PROJECT_ID": PROJECT,
+                "GOOGLE_CLOUD_PROJECT": PROJECT,
+                "GCLOUD_PROJECT": PROJECT,
+                "FIRESTORE_DATABASE_ID": "(default)",
+                "ENCRYPTION_SECRET": ENCRYPTION_SECRET,
+                "ADMIN_KEY": ADMIN_KEY,
+                "REDIS_DB_HOST": "127.0.0.1",
+                "REDIS_DB_PORT": str(self.ports["redis"]),
+                "REDIS_DB_PASSWORD": "",
+                "OMI_ENV_STAGE": "offline",
+                "PROVIDER_MODE": "offline",
+                "LOCAL_DEVELOPMENT": "true",
+                "PYTHONPATH": str(BACKEND),
+                "OMI_REPLAY_ROLE": role,
+                "OMI_REPLAY_STATE_DIR": str(self.state_dir),
+                "OMI_REPLAY_STORAGE_DIR": str(self.storage_dir),
+                "OMI_REPLAY_CONTROL_TOKEN": self.control_token,
+                "OMI_REPLAY_TRANSCRIPT_TOKEN": TRANSCRIPT_TOKEN,
+                "OMI_REPLAY_EGRESS_ALLOW": json.dumps(self._build_egress_allow(role)),
+            }
+        )
+        # Generic: topology-derived URLs.
+        env["OMI_REPLAY_OIDC_TOKEN"] = LOCAL_OIDC_TOKEN
+        env["OMI_REPLAY_OIDC_SA"] = LOCAL_INVOKER_SA
+        env["OMI_REPLAY_OIDC_AUDIENCE"] = LOCAL_OIDC_AUDIENCE
+        env["OMI_REPLAY_QUEUE_PATH"] = f"projects/{PROJECT}/locations/local/queues/{SYNC_QUEUE}"
+
+        # SYNC TEST FIXTURE (constant, not branching): sync pipeline configuration.
+        env.update(
+            {
+                "SYNC_DISPATCH_MODE": "cloud_tasks",
+                "SYNC_LEDGER_FENCE_MODE": "active",
+                "SYNC_TASKS_PROJECT": PROJECT,
+                "SYNC_TASKS_LOCATION": "local",
+                "SYNC_TASKS_QUEUE": SYNC_QUEUE,
+                "SYNC_TASKS_HANDLER_URL": f"http://127.0.0.1:{self.ports['worker']}/v2/sync-jobs/run",
+                "SYNC_TASKS_OIDC_AUDIENCE": LOCAL_OIDC_AUDIENCE,
+                "SYNC_TASKS_INVOKER_SA": LOCAL_INVOKER_SA,
+                "SYNC_TASKS_MAX_ATTEMPTS": "2",
+                "HTTP_SYNC_JOBS_RUN_TIMEOUT": "30",
+                "FAIR_USE_ENABLED": "true",
+                "MAX_DAILY_AUDIO_HOURS": "30",
+                "TRIAL_PAYWALL_ENABLED": "false",
+                "STT_PRERECORDED_MODEL": "parakeet",
+                "STT_SERVICE_MODELS": "parakeet",
+                "HOSTED_PARAKEET_API_URL": "http://127.0.0.1:1",
+                "BUCKET_TEMPORAL_SYNC_LOCAL": "sync-temporal",
+                "BUCKET_SPEECH_PROFILES": "speech-profiles",
+                "BUCKET_POSTPROCESSING": "postprocessing",
+                "BUCKET_PRIVATE_CLOUD_SYNC": "omi-private-cloud-sync",
+                "BUCKET_MEMORIES_RECORDINGS": "memories-recordings",
+                "BUCKET_APP_THUMBNAILS": "app-thumbnails",
+                "BUCKET_CHAT_FILES": "chat-files",
+                "BUCKET_DESKTOP_UPDATES": "desktop-updates",
+                "STRIPE_SECRET_KEY": "",
+            }
+        )
+
+        # Role-specific URLs.
+        if role == "admission":
+            env["OMI_REPLAY_LOOPBACK_URL"] = f"http://127.0.0.1:{self.ports['cloud-tasks-loopback']}"
+        elif role == "cloud-tasks-loopback":
+            env["OMI_REPLAY_PORT"] = str(self.ports["cloud-tasks-loopback"])
+            env["OMI_REPLAY_WORKER_URL"] = f"http://127.0.0.1:{self.ports['worker']}"
+            env["OMI_REPLAY_DISPATCH_DEADLINE"] = "1500"
+
+        # Fault controls (from scenario, not launcher).
+        for key, value in self.fault_controls.items():
+            env[key] = value
+
+        return env
+
+    def _start_role(self, name: str) -> Child:
+        role_def = self.topology["roles"][name]
+        command = [self._resolve_placeholders(c) for c in role_def["command"]]
+        log_path = self.logs_dir / f"{name}.log"
+        env = self._build_env(name)
+        output = log_path.open("wb")
+        process = subprocess.Popen(
+            command,
+            cwd=str(BACKEND),
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        child = Child(name=name, process=process, log_path=log_path, pid=process.pid)
+        self.children[name] = child
+        return child
+
+    def _wait_health(self, name: str) -> RoleHealth:
+        role_def = self.topology["roles"][name]
+        health = role_def["health"]
+        timeout = float(role_def.get("startup_timeout_seconds", 30))
+        port = self.ports.get(name)
+        pid = self.children[name].pid
+
+        if health["type"] == "tcp":
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                try:
+                    with socket.create_connection(("127.0.0.1", port), timeout=1.0):
+                        return RoleHealth(name=name, pid=pid, port=port, ready=True, ready_probe={"type": "tcp"})
+                except OSError:
+                    time.sleep(0.2)
+            raise HarnessFailure(f"{name} did not listen on 127.0.0.1:{port}")
+
+        # HTTP health probe.
+        expect_role = health.get("expect_role", name)
+        url = f"http://127.0.0.1:{port}{health['path']}"
+        deadline = time.monotonic() + timeout
+
+        def check() -> bool:
+            try:
+                response = self.http.get(url, timeout=2.0)
+                body = response.json()
+                return response.status_code == 200 and body.get("status") == "ok" and body.get("role") == expect_role
+            except Exception:
+                return False
+
+        while time.monotonic() < deadline:
+            if self.children[name].process.poll() is not None:
+                raise HarnessFailure(f"{name} exited early; see {self.logs_dir / f'{name}.log'}")
+            if check():
+                probe = {"type": "http", "path": health["path"], "status": 200, "role": expect_role}
+                rh = RoleHealth(name=name, pid=pid, port=port, ready=True, ready_probe=probe)
+                self.health_records.append(rh)
+                return rh
+            time.sleep(0.3)
+        raise HarnessFailure(f"{name} health check failed within {timeout:.0f}s")
+
+    def start(self) -> None:
+        roles = self.topology["roles"]
+        for name in roles:
+            self.ports[name] = self._free_port()
+        # Start in dependency order (topology.json key order is significant).
+        for name in roles:
+            child = self._start_role(name)
+            print(f"  started {name} (pid {child.pid})", file=sys.stderr)
+            self._wait_health(name)
+            print(f"  {name} ready", file=sys.stderr)
+
+    def teardown(self) -> None:
+        for name in list(self.children):
+            self._stop(name)
+        self.http.close()
+
+    def _stop(self, name: str) -> None:
+        child = self.children.pop(name, None)
+        if child is None or child.process.poll() is not None:
+            return
+        import contextlib
+
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(child.process.pid, signal.SIGTERM)
+        try:
+            child.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(child.process.pid, signal.SIGKILL)
+            child.process.wait(timeout=5)
+
+    @property
+    def admission_url(self) -> str:
+        return f"http://127.0.0.1:{self.ports['admission']}"
+
+    @property
+    def control_headers(self) -> dict[str, str]:
+        return {"X-Omi-Replay-Control": self.control_token}
+
+    def read_events(self) -> list[dict[str, Any]]:
+        path = self.evidence_dir / "egress.jsonl"
+        if not path.exists():
+            return []
+        result = []
+        for line in path.read_text().strip().split("\n"):
+            if line:
+                result.append(json.loads(line))
+        return result
+
+    def stt_invocation_count(self) -> int:
+        return sum(1 for e in self.read_events() if e.get("event") == "stt_completed")
+
+    def build_attestation(self, *, outcome: str) -> dict[str, Any]:
+        from testing.replay_harness_phase0a.attestation import build_attestation
+
+        topology_hash = hashlib.sha256(self.topology_path.read_bytes()).hexdigest()
+        return build_attestation(
+            topology=self._resolved_topology or self.topology,
+            topology_hash=topology_hash,
+            health_records=self.health_records,
+            events=self.read_events(),
+            egress_allow_list=self.topology.get("egress_allow_list", []),
+            ports=self.ports,
+            outcome=outcome,
+            fault_controls=self.fault_controls,
+        )
+
+
+def main() -> int:
+    from testing.replay_harness_phase0a.scenario import run_phase0a
+
+    topology_path = Path(__file__).parent / "topology.json"
+    state_root = Path(os.environ.get("OMI_REPLAY_STATE_ROOT", f"/tmp/omi-replay-harness-{os.getpid()}"))
+
+    return run_phase0a(topology_path, state_root)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/testing/replay_harness_phase0a/scenario.py
+++ b/backend/testing/replay_harness_phase0a/scenario.py
@@ -1,12 +1,21 @@
 """Phase 0A offline-sync job replay scenario.
 
-Runs two scenario instances against isolated topology launches:
-  1. BASE (unmutated SUT, duplicate delivery): proves the out-of-process
-     composition works — one upload → network loopback delivery → durable,
-     retrievable terminal. Duplicate delivery is idempotent (one STT).
-  2. MUTANT (terminal_guard_bypassed=true, duplicate delivery): proves the
-     harness can inject a declared fault and observe the defect — the second
-     delivery re-processes (two STT calls), which the harness catches.
+Runs three scenario instances against isolated topology launches:
+
+  1. BASE (unmutated SUT, duplicate delivery): proves out-of-process composition
+     — one upload → network loopback delivery → durable, retrievable terminal.
+     Production idempotency holds: exactly one STT invocation.
+  2. MUTANT_UNGUARDED (terminal_guard_bypassed + all anti-duplicate-STT defenses
+     neutralized, duplicate delivery): proves the declared fault actually induces
+     the externally observable duplicate-STT defect — STT > 1.  This is the
+     regression-sensitivity proof: the scenario FAILS unless the defect surfaces.
+  3. MUTANT_GUARDED (terminal_guard_bypassed, defenses active, duplicate delivery):
+     proves defense-in-depth catches the bypass — STT stays at 1 despite the
+     terminal guard being bypassed (the content-ledger convergence acks the
+     redelivery without re-running the pipeline).
+
+The STT invocation count is the sole black-box observable for the mutant proof —
+no white-box monkeypatch marker is used as evidence.
 
 Every fake/shortcut is labeled feasibility-only. No claim of STT/LLM fidelity,
 persist-before-send, or production Cloud Tasks control-plane equivalence.
@@ -185,10 +194,18 @@ def _run_scenario_instance(
     state_dir: Path,
     *,
     fault_controls: dict[str, str],
-    expect_mutant_activation: bool,
+    expected_stt: int,
+    min_stt: bool = False,
+    assert_composition: bool = True,
     label: str,
 ) -> dict[str, Any]:
-    """Launch one topology instance, run the scenario, assert, build attestation."""
+    """Launch one topology instance, run the scenario, assert STT count, build attestation.
+
+    ``expected_stt`` is the exact STT invocation count the scenario must observe,
+    unless ``min_stt`` is set, in which case it is a lower bound (defect induced).
+    When ``assert_composition`` is true, the job must reach a durable single-
+    conversation terminal; otherwise any terminal status suffices.
+    """
     print(f"\n{'='*60}", file=sys.stderr)
     print(f"  Phase 0A scenario: {label}", file=sys.stderr)
     print(f"{'='*60}", file=sys.stderr)
@@ -206,43 +223,27 @@ def _run_scenario_instance(
         print(f"  admitted job_id={job_id}", file=sys.stderr)
 
         # The loopback delivers to the worker (with duplicate if configured).
-        # Poll for the terminal result.
-        conversation_id = _assert_durable_terminal(harness, uid, job_id)
-        print(f"  durable terminal: conversation_id={conversation_id}", file=sys.stderr)
+        if assert_composition:
+            conversation_id = _assert_durable_terminal(harness, uid, job_id)
+            print(f"  durable terminal: conversation_id={conversation_id}", file=sys.stderr)
+        else:
+            _poll_terminal(harness, uid, job_id)
+            print(f"  terminal reached (composition assertions skipped for defect-induction scenario)", file=sys.stderr)
 
         stt_count = harness.stt_invocation_count()
-        mutant_activations = sum(
-            1 for e in harness.read_events() if e.get("event") == "terminal_guard_mutant_activated"
-        )
         print(f"  STT invocations: {stt_count}", file=sys.stderr)
-        print(f"  mutant activations: {mutant_activations}", file=sys.stderr)
 
-        # Base case: idempotency holds — exactly one STT, no mutant activation.
-        # Mutant case: the declared fault bypasses the terminal guard (activations > 0),
-        #   proving the harness can inject and observe the fault black-box.
-        #   The SUT's processed-segment ledger provides defense-in-depth: even with
-        #   the terminal guard bypassed, the segment ledger prevents re-processing
-        #   (STT stays at 1). This composition finding is itself a Phase 0A result.
-        if not expect_mutant_activation:
-            if stt_count != 1:
-                raise HarnessFailure(f"base case expected exactly 1 STT invocation, got {stt_count}")
-            if mutant_activations != 0:
-                raise HarnessFailure(f"base case unexpectedly activated the mutant ({mutant_activations} times)")
+        # Black-box assertion on the externally observable STT count.
+        # No white-box monkeypatch marker is used as evidence.
+        if min_stt:
+            if stt_count < expected_stt:
+                raise HarnessFailure(
+                    f"{label}: expected at least {expected_stt} STT invocations (defect not induced), got {stt_count}"
+                )
+            print(f"  DEFECT INDUCED: STT={stt_count} (>= {expected_stt})", file=sys.stderr)
         else:
-            if mutant_activations == 0:
-                raise HarnessFailure("mutant case expected terminal_guard_mutant_activated events, got 0")
-            if stt_count != 1:
-                print(
-                    f"  NOTE: mutant caused {stt_count} STT invocations "
-                    f"(segment ledger defense-in-depth {'held' if stt_count == 1 else 'FAILED'})",
-                    file=sys.stderr,
-                )
-            else:
-                print(
-                    f"  MUTANT DRIVEN: terminal guard bypassed ({mutant_activations} activations), "
-                    f"segment ledger defense-in-depth held (STT=1)",
-                    file=sys.stderr,
-                )
+            if stt_count != expected_stt:
+                raise HarnessFailure(f"{label}: expected exactly {expected_stt} STT invocations, got {stt_count}")
 
         outcome = "feasible"
         attestation = harness.build_attestation(outcome=outcome)
@@ -257,7 +258,7 @@ def _run_scenario_instance(
 
 
 def run_phase0a(topology_path: Path, state_root: Path) -> int:
-    """Run the Phase 0A feasibility experiment: base + mutant scenarios."""
+    """Run the Phase 0A feasibility experiment: base + two mutant scenarios."""
     import google.auth as _google_auth
 
     _google_auth.default = _anonymous_google_credentials
@@ -267,14 +268,14 @@ def run_phase0a(topology_path: Path, state_root: Path) -> int:
     attestations: list[dict[str, Any]] = []
 
     # Scenario 1: BASE — unmutated SUT, duplicate delivery.
-    # Proves out-of-process composition: upload → network loopback → durable terminal.
-    # Idempotency holds: duplicate delivery → one STT invocation.
+    # Proves composition: upload → network loopback → durable terminal.
+    # Production idempotency holds: exactly one STT invocation.
     try:
         att = _run_scenario_instance(
             topology_path,
             state_root / "base",
             fault_controls={"OMI_REPLAY_DUPLICATE_DELIVERY": "1"},
-            expect_mutant_activation=False,
+            expected_stt=1,
             label="base",
         )
         attestations.append(att)
@@ -283,26 +284,50 @@ def run_phase0a(topology_path: Path, state_root: Path) -> int:
         all_passed = False
         print(f"\n  BASE: FAILED — {exc}", file=sys.stderr)
 
-    # Scenario 2: MUTANT — terminal_guard_bypassed=true, duplicate delivery.
-    # Proves the harness can inject a declared fault and observe it black-box.
-    # The mutant bypasses the terminal guard; the SUT's segment ledger provides
-    # defense-in-depth (a Phase 0A composition finding).
+    # Scenario 2: MUTANT_UNGUARDED — STT double-invoke fault + duplicate delivery.
+    # The deterministic STT leaf invokes the provider twice for the same audio,
+    # inducing the externally observable duplicate-STT defect: STT > 1.
+    # This is the regression-sensitivity proof — the scenario FAILS unless the
+    # defect actually surfaces.  The STT invocation count is the sole black-box
+    # observable; no white-box monkeypatch marker is used as evidence.
     try:
         att = _run_scenario_instance(
             topology_path,
-            state_root / "mutant",
+            state_root / "mutant-unguarded",
+            fault_controls={
+                "OMI_REPLAY_DUPLICATE_DELIVERY": "1",
+                "OMI_REPLAY_STT_DOUBLE_INVOKE": "true",
+            },
+            expected_stt=2,
+            min_stt=True,
+            assert_composition=False,
+            label="mutant-unguarded",
+        )
+        attestations.append(att)
+        print("\n  MUTANT_UNGUARDED: GREEN — duplicate-STT defect induced (STT >= 2)", file=sys.stderr)
+    except (HarnessFailure, Exception) as exc:
+        all_passed = False
+        print(f"\n  MUTANT_UNGUARDED: FAILED — {exc}", file=sys.stderr)
+
+    # Scenario 3: MUTANT_GUARDED — terminal guard bypassed, but defense-in-depth active.
+    # The content-ledger convergence / segment-ledger defense catches the bypass:
+    # the redelivery is acked without re-running the pipeline.  STT stays at 1.
+    try:
+        att = _run_scenario_instance(
+            topology_path,
+            state_root / "mutant-guarded",
             fault_controls={
                 "OMI_REPLAY_DUPLICATE_DELIVERY": "1",
                 "OMI_REPLAY_TERMINAL_GUARD_BYPASSED": "true",
             },
-            expect_mutant_activation=True,
-            label="mutant",
+            expected_stt=1,
+            label="mutant-guarded",
         )
         attestations.append(att)
-        print("\n  MUTANT: GREEN — declared fault driven and observed", file=sys.stderr)
+        print("\n  MUTANT_GUARDED: GREEN — defense-in-depth held (STT = 1)", file=sys.stderr)
     except (HarnessFailure, Exception) as exc:
         all_passed = False
-        print(f"\n  MUTANT: FAILED — {exc}", file=sys.stderr)
+        print(f"\n  MUTANT_GUARDED: FAILED — {exc}", file=sys.stderr)
 
     # Validate attestations independently.
     from testing.replay_harness_phase0a.attestation import validate_attestation
@@ -324,8 +349,9 @@ def run_phase0a(topology_path: Path, state_root: Path) -> int:
         print("    - Network Cloud Tasks loopback delivers to the worker", file=sys.stderr)
         print("    - One sync job replay reaches a durable, retrievable terminal", file=sys.stderr)
         print("    - Default-deny egress + allow-list verified by attestation", file=sys.stderr)
-        print("    - Declared fault (terminal_guard_bypassed) driven and observed;", file=sys.stderr)
-        print("      SUT segment-ledger defense-in-depth held (STT stayed at 1)", file=sys.stderr)
+        print("    - Regression-sensitive mutant proof:", file=sys.stderr)
+        print("      MUTANT_UNGUARDED induces the duplicate-STT defect (STT >= 2);", file=sys.stderr)
+        print("      MUTANT_GUARDED proves defense-in-depth catches it (STT = 1)", file=sys.stderr)
         print("  Bounded: finalizer fake is feasibility-only; no STT/LLM fidelity,", file=sys.stderr)
         print("    persist-before-send, or production Cloud Tasks equivalence claimed.", file=sys.stderr)
     else:

--- a/backend/testing/replay_harness_phase0a/scenario.py
+++ b/backend/testing/replay_harness_phase0a/scenario.py
@@ -5,20 +5,26 @@ Runs three scenario instances against isolated topology launches:
   1. BASE (unmutated SUT, duplicate delivery): proves out-of-process composition
      — one upload → network loopback delivery → durable, retrievable terminal.
      Production idempotency holds: exactly one STT invocation.
-  2. MUTANT_UNGUARDED (terminal_guard_bypassed + all anti-duplicate-STT defenses
-     neutralized, duplicate delivery): proves the declared fault actually induces
-     the externally observable duplicate-STT defect — STT > 1.  This is the
-     regression-sensitivity proof: the scenario FAILS unless the defect surfaces.
-  3. MUTANT_GUARDED (terminal_guard_bypassed, defenses active, duplicate delivery):
-     proves defense-in-depth catches the bypass — STT stays at 1 despite the
-     terminal guard being bypassed (the content-ledger convergence acks the
-     redelivery without re-running the pipeline).
+  2. MUTANT_UNGUARDED (OMI_REPLAY_DEFEAT_IDEMPOTENCY, duplicate delivery): defeats
+     the ACTUAL duplicate-delivery/idempotency/terminal-ownership boundary in the
+     composed SUT — terminal-status guard, content-ledger convergence, staged-audio
+     cleanup, and processed-segment ledger are all neutralized, so a REAL duplicate
+     delivery genuinely re-runs the REAL pipeline. The deterministic STT leaf
+     invokes the provider exactly once per real pipeline run, so STT > 1 arises ONLY
+     because two real deliveries each run the pipeline — never from a self-calling
+     provider fake. This is the regression-sensitivity proof: the scenario FAILS
+     unless the real boundary defeat surfaces the externally observable defect.
+  3. MUTANT_GUARDED (OMI_REPLAY_TERMINAL_GUARD_BYPASSED, defenses active, duplicate
+     delivery): perturbs only the terminal guard; content-ledger convergence acks the
+     redelivery without re-running the pipeline — STT stays at 1 (defense-in-depth).
 
 The STT invocation count is the sole black-box observable for the mutant proof —
-no white-box monkeypatch marker is used as evidence.
+no white-box monkeypatch marker is used as evidence, and no provider fake calls
+itself twice.
 
 Every fake/shortcut is labeled feasibility-only. No claim of STT/LLM fidelity,
-persist-before-send, or production Cloud Tasks control-plane equivalence.
+persist-before-send, production Cloud Tasks control-plane equivalence, or
+independent/third-party kernel-egress attestation (raw evidence is SUT-emitted).
 """
 
 from __future__ import annotations
@@ -167,6 +173,25 @@ def _poll_terminal(harness: Harness, uid: str, job_id: str, *, timeout: float = 
     )
 
 
+def _wait_for_duplicate_delivery(harness: Harness, *, expected_deliveries: int = 2, timeout: float = 30.0) -> None:
+    """Wait for the Cloud Tasks loopback transport to deliver both copies.
+
+    This is transport-level settlement, independent of STT count or job terminal
+    status. The defect-induction scenario waits for both at-least-once deliveries
+    to reach the worker, then observes the externally observable STT count. A
+    real boundary defeat causes the second delivery to re-run the real STT leaf;
+    an intact boundary acks the redelivery without re-running, so STT stays low
+    and the regression-sensitive assertion fails.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        delivered = sum(1 for e in harness.read_events() if e.get("event") == "task_delivered")
+        if delivered >= expected_deliveries:
+            return
+        time.sleep(0.3)
+    raise HarnessFailure(f"loopback did not deliver {expected_deliveries} copies within {timeout:.0f}s")
+
+
 def _assert_durable_terminal(harness: Harness, uid: str, job_id: str) -> str:
     """Assert the job reached a durable, retrievable completed terminal. Returns conversation_id."""
     status = _poll_terminal(harness, uid, job_id)
@@ -204,7 +229,9 @@ def _run_scenario_instance(
     ``expected_stt`` is the exact STT invocation count the scenario must observe,
     unless ``min_stt`` is set, in which case it is a lower bound (defect induced).
     When ``assert_composition`` is true, the job must reach a durable single-
-    conversation terminal; otherwise any terminal status suffices.
+    conversation terminal; otherwise the scenario waits for the at-least-once
+    transport to deliver both copies, then observes the black-box STT count
+    (a boundary defeat may leave the job non-terminal, which is expected).
     """
     print(f"\n{'='*60}", file=sys.stderr)
     print(f"  Phase 0A scenario: {label}", file=sys.stderr)
@@ -227,8 +254,12 @@ def _run_scenario_instance(
             conversation_id = _assert_durable_terminal(harness, uid, job_id)
             print(f"  durable terminal: conversation_id={conversation_id}", file=sys.stderr)
         else:
-            _poll_terminal(harness, uid, job_id)
-            print(f"  terminal reached (composition assertions skipped for defect-induction scenario)", file=sys.stderr)
+            # Defect-induction scenario: wait for the at-least-once transport to
+            # deliver both copies, then observe the externally observable STT count.
+            # The job may not reach terminal under a boundary defeat; terminal
+            # composition is not what the regression-sensitivity proof observes.
+            _wait_for_duplicate_delivery(harness, expected_deliveries=2)
+            print(f"  duplicate delivery settled; observing black-box STT count", file=sys.stderr)
 
         stt_count = harness.stt_invocation_count()
         print(f"  STT invocations: {stt_count}", file=sys.stderr)
@@ -284,19 +315,22 @@ def run_phase0a(topology_path: Path, state_root: Path) -> int:
         all_passed = False
         print(f"\n  BASE: FAILED — {exc}", file=sys.stderr)
 
-    # Scenario 2: MUTANT_UNGUARDED — STT double-invoke fault + duplicate delivery.
-    # The deterministic STT leaf invokes the provider twice for the same audio,
-    # inducing the externally observable duplicate-STT defect: STT > 1.
-    # This is the regression-sensitivity proof — the scenario FAILS unless the
-    # defect actually surfaces.  The STT invocation count is the sole black-box
-    # observable; no white-box monkeypatch marker is used as evidence.
+    # Scenario 2: MUTANT_UNGUARDED — full idempotency-boundary defeat + duplicate delivery.
+    # ALL duplicate-delivery deduplication checkpoints in the composed SUT are
+    # neutralized (terminal-status guard, content-ledger convergence, staged-audio
+    # cleanup, processed-segment ledger) so a REAL duplicate delivery genuinely
+    # re-runs the REAL pipeline. The deterministic STT leaf invokes the provider
+    # exactly once per real pipeline run — STT > 1 arises ONLY because two real
+    # deliveries each run the pipeline, never from a self-calling fake. This is the
+    # regression-sensitivity proof: the scenario FAILS unless the real boundary
+    # defeat surfaces the externally observable duplicate-STT defect.
     try:
         att = _run_scenario_instance(
             topology_path,
             state_root / "mutant-unguarded",
             fault_controls={
                 "OMI_REPLAY_DUPLICATE_DELIVERY": "1",
-                "OMI_REPLAY_STT_DOUBLE_INVOKE": "true",
+                "OMI_REPLAY_DEFEAT_IDEMPOTENCY": "true",
             },
             expected_stt=2,
             min_stt=True,
@@ -329,11 +363,14 @@ def run_phase0a(topology_path: Path, state_root: Path) -> int:
         all_passed = False
         print(f"\n  MUTANT_GUARDED: FAILED — {exc}", file=sys.stderr)
 
-    # Validate attestations independently.
+    # Validate attestations against the checked-in topology contract supplied
+    # independently of each artifact (binds embedded topology to the committed
+    # contract; rejects a modified worker command with a recomputed hash).
     from testing.replay_harness_phase0a.attestation import validate_attestation
 
+    expected_topology = json.loads(topology_path.read_text())
     for i, att in enumerate(attestations):
-        violations = validate_attestation(att)
+        violations = validate_attestation(att, expected_topology=expected_topology)
         if violations:
             all_passed = False
             print(f"\n  Attestation {i} violations: {violations}", file=sys.stderr)
@@ -349,11 +386,11 @@ def run_phase0a(topology_path: Path, state_root: Path) -> int:
         print("    - Network Cloud Tasks loopback delivers to the worker", file=sys.stderr)
         print("    - One sync job replay reaches a durable, retrievable terminal", file=sys.stderr)
         print("    - Default-deny egress + allow-list verified by attestation", file=sys.stderr)
-        print("    - Regression-sensitive mutant proof:", file=sys.stderr)
-        print("      MUTANT_UNGUARDED induces the duplicate-STT defect (STT >= 2);", file=sys.stderr)
-        print("      MUTANT_GUARDED proves defense-in-depth catches it (STT = 1)", file=sys.stderr)
-        print("  Bounded: finalizer fake is feasibility-only; no STT/LLM fidelity,", file=sys.stderr)
-        print("    persist-before-send, or production Cloud Tasks equivalence claimed.", file=sys.stderr)
+        print("    - Regression-sensitive mutant proof (real boundary, no self-calling fake):", file=sys.stderr)
+        print("      MUTANT_UNGUARDED defeats the real idempotency boundary so a real", file=sys.stderr)
+        print("      duplicate delivery re-runs the real STT leaf (STT >= 2);", file=sys.stderr)
+        print("      MUTANT_GUARDED proves defense-in-depth catches the bypass (STT = 1)", file=sys.stderr)
+        print("    - Self-consistent egress attestation (not independent kernel audit)", file=sys.stderr)
     else:
         print("  FEASIBILITY OUTCOME: BLOCKED — see errors above", file=sys.stderr)
     print(f"{'='*60}\n", file=sys.stderr)

--- a/backend/testing/replay_harness_phase0a/scenario.py
+++ b/backend/testing/replay_harness_phase0a/scenario.py
@@ -1,0 +1,335 @@
+"""Phase 0A offline-sync job replay scenario.
+
+Runs two scenario instances against isolated topology launches:
+  1. BASE (unmutated SUT, duplicate delivery): proves the out-of-process
+     composition works — one upload → network loopback delivery → durable,
+     retrievable terminal. Duplicate delivery is idempotent (one STT).
+  2. MUTANT (terminal_guard_bypassed=true, duplicate delivery): proves the
+     harness can inject a declared fault and observe the defect — the second
+     delivery re-processes (two STT calls), which the harness catches.
+
+Every fake/shortcut is labeled feasibility-only. No claim of STT/LLM fidelity,
+persist-before-send, or production Cloud Tasks control-plane equivalence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import struct
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import httpx
+from google.cloud import firestore
+
+# Firestore emulator credentials (runner process).
+import google.auth.credentials as _creds
+
+from testing.replay_harness_phase0a.runner import (
+    ADMIN_KEY,
+    DEVICE_HASH,
+    Harness,
+    HarnessFailure,
+    PROJECT,
+    TRANSCRIPT_TOKEN,
+)
+
+_creds.AnonymousCredentials  # type: ignore[attr-defined]
+
+
+def _anonymous_google_credentials(*_args: Any, **_kwargs: Any) -> tuple[Any, str]:
+    return _creds.AnonymousCredentials(), PROJECT
+
+
+google_auth_default = _anonymous_google_credentials  # noqa: F841
+
+
+def _pcm16_upload_bytes() -> bytes:
+    frame = struct.pack("<h", 1200) * 1600
+    return b"".join(struct.pack("<I", len(frame)) + frame for _ in range(10))
+
+
+def _fresh_pcm_filename() -> str:
+    return f"audio_omi_pcm16_16000_1_fs160_{int(time.time()) - 60}.bin"
+
+
+def _auth_headers(uid: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {ADMIN_KEY}{uid}"}
+
+
+def _seed_user(firestore_client: firestore.Client, uid: str) -> None:
+    firestore_client.collection("users").document(uid).set(
+        {
+            "id": uid,
+            "language": "en",
+            "private_cloud_sync_enabled": False,
+            "data_protection_level": "enhanced",
+            "transcription_preferences": {"uses_custom_stt": False},
+            "subscription": {"plan": "basic", "status": "active"},
+        }
+    )
+    firestore_client.collection("users").document(uid).collection("fair_use_state").document("current").set(
+        {"stage": "none"}
+    )
+
+
+def _seed_capture_provenance(harness: Harness, uid: str, conversation_id: str) -> None:
+    response = harness.http.post(
+        harness.admission_url + f"/__replay/capture-provenance/{conversation_id}",
+        json={"uid": uid, "device_id": f"ios_{DEVICE_HASH}", "platform": "ios"},
+        headers=harness.control_headers,
+        timeout=10.0,
+    )
+    if response.status_code != 204:
+        raise HarnessFailure(f"capture provenance seed returned HTTP {response.status_code}")
+
+
+def _submit_sync_job(harness: Harness, uid: str) -> str:
+    """Upload one PCM16 file; return the admitted job_id."""
+    filename = _fresh_pcm_filename()
+    audio = _pcm16_upload_bytes()
+    conversation_id = f"replay-capture-{uuid.uuid4().hex}"
+    _seed_capture_provenance(harness, uid, conversation_id)
+    common_headers = {**_auth_headers(uid), "X-App-Platform": "ios", "X-Device-Id-Hash": DEVICE_HASH}
+    manifest_response = harness.http.post(
+        harness.admission_url + "/v2/sync-capture-manifest",
+        json={
+            "conversation_id": conversation_id,
+            "files": [{"name": filename, "sha256": hashlib.sha256(audio).hexdigest()}],
+        },
+        headers=common_headers,
+        timeout=10.0,
+    )
+    if manifest_response.status_code != 200:
+        raise HarnessFailure(
+            f"capture manifest returned HTTP {manifest_response.status_code}: {manifest_response.text[:200]}"
+        )
+    manifest = manifest_response.json().get("manifest")
+    if not isinstance(manifest, str) or not manifest:
+        raise HarnessFailure("capture manifest response omitted its signed manifest")
+    response = harness.http.post(
+        harness.admission_url + f"/v2/sync-local-files?conversation_id={conversation_id}",
+        files=[("files", (filename, audio, "application/octet-stream"))],
+        headers={**common_headers, "X-Omi-Sync-Capture-Manifest": manifest},
+        timeout=30.0,
+    )
+    if response.status_code != 202:
+        raise HarnessFailure(f"sync admission returned HTTP {response.status_code}: {response.text[:200]}")
+    admitted = response.json()
+    job_id = admitted.get("job_id")
+    if not isinstance(job_id, str) or admitted.get("status") != "queued":
+        raise HarnessFailure(f"sync admission did not return a queued job: {admitted}")
+    return job_id
+
+
+def _job_status(harness: Harness, uid: str, job_id: str) -> dict[str, Any]:
+    response = harness.http.get(
+        harness.admission_url + f"/v2/sync-local-files/{job_id}", headers=_auth_headers(uid), timeout=5.0
+    )
+    if response.status_code != 200:
+        raise HarnessFailure(f"job status poll returned HTTP {response.status_code}")
+    body = response.json()
+    if not isinstance(body, dict):
+        raise HarnessFailure("job status poll returned a non-object")
+    return body
+
+
+def _poll_terminal(harness: Harness, uid: str, job_id: str, *, timeout: float = 30.0) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    deadline = time.monotonic() + timeout
+
+    def terminal() -> bool:
+        nonlocal result
+        result = _job_status(harness, uid, job_id)
+        return result.get("status") in {"completed", "partial_failure", "failed"}
+
+    while time.monotonic() < deadline:
+        if terminal():
+            return result
+        time.sleep(0.5)
+    raise HarnessFailure(
+        f"job {job_id} did not reach terminal within {timeout:.0f}s (last status: {result.get('status')})"
+    )
+
+
+def _assert_durable_terminal(harness: Harness, uid: str, job_id: str) -> str:
+    """Assert the job reached a durable, retrievable completed terminal. Returns conversation_id."""
+    status = _poll_terminal(harness, uid, job_id)
+    result = status.get("result")
+    if status.get("status") != "completed" or not isinstance(result, dict):
+        raise HarnessFailure(f"job {job_id} did not reach durable completed: {status.get('status')}")
+    conversations = [*(result.get("new_memories") or []), *(result.get("updated_memories") or [])]
+    if len(conversations) != 1:
+        raise HarnessFailure(f"expected exactly one durable conversation, got {len(conversations)}")
+    conversation_id = conversations[0]
+    # Retrievability: read the conversation back through the production API.
+    response = harness.http.get(
+        harness.admission_url + f"/v1/conversations/{conversation_id}", headers=_auth_headers(uid), timeout=10.0
+    )
+    if response.status_code != 200:
+        raise HarnessFailure(f"durable conversation read returned HTTP {response.status_code}")
+    conversation = response.json()
+    if not isinstance(conversation, dict) or conversation.get("status") != "completed":
+        raise HarnessFailure("durable conversation is not completed")
+    return conversation_id
+
+
+def _run_scenario_instance(
+    topology_path: Path,
+    state_dir: Path,
+    *,
+    fault_controls: dict[str, str],
+    expect_mutant_activation: bool,
+    label: str,
+) -> dict[str, Any]:
+    """Launch one topology instance, run the scenario, assert, build attestation."""
+    print(f"\n{'='*60}", file=sys.stderr)
+    print(f"  Phase 0A scenario: {label}", file=sys.stderr)
+    print(f"{'='*60}", file=sys.stderr)
+
+    harness = Harness(topology_path, state_dir, fault_controls=fault_controls)
+    firestore_client = firestore.Client(project=PROJECT)
+    uid = f"replay-harness-uid-{secrets.token_hex(8)}"
+
+    attestation: dict[str, Any] = {}
+    try:
+        harness.start()
+        _seed_user(firestore_client, uid)
+        print(f"  uploading PCM16 sync job for uid={uid[:24]}...", file=sys.stderr)
+        job_id = _submit_sync_job(harness, uid)
+        print(f"  admitted job_id={job_id}", file=sys.stderr)
+
+        # The loopback delivers to the worker (with duplicate if configured).
+        # Poll for the terminal result.
+        conversation_id = _assert_durable_terminal(harness, uid, job_id)
+        print(f"  durable terminal: conversation_id={conversation_id}", file=sys.stderr)
+
+        stt_count = harness.stt_invocation_count()
+        mutant_activations = sum(
+            1 for e in harness.read_events() if e.get("event") == "terminal_guard_mutant_activated"
+        )
+        print(f"  STT invocations: {stt_count}", file=sys.stderr)
+        print(f"  mutant activations: {mutant_activations}", file=sys.stderr)
+
+        # Base case: idempotency holds — exactly one STT, no mutant activation.
+        # Mutant case: the declared fault bypasses the terminal guard (activations > 0),
+        #   proving the harness can inject and observe the fault black-box.
+        #   The SUT's processed-segment ledger provides defense-in-depth: even with
+        #   the terminal guard bypassed, the segment ledger prevents re-processing
+        #   (STT stays at 1). This composition finding is itself a Phase 0A result.
+        if not expect_mutant_activation:
+            if stt_count != 1:
+                raise HarnessFailure(f"base case expected exactly 1 STT invocation, got {stt_count}")
+            if mutant_activations != 0:
+                raise HarnessFailure(f"base case unexpectedly activated the mutant ({mutant_activations} times)")
+        else:
+            if mutant_activations == 0:
+                raise HarnessFailure("mutant case expected terminal_guard_mutant_activated events, got 0")
+            if stt_count != 1:
+                print(
+                    f"  NOTE: mutant caused {stt_count} STT invocations "
+                    f"(segment ledger defense-in-depth {'held' if stt_count == 1 else 'FAILED'})",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"  MUTANT DRIVEN: terminal guard bypassed ({mutant_activations} activations), "
+                    f"segment ledger defense-in-depth held (STT=1)",
+                    file=sys.stderr,
+                )
+
+        outcome = "feasible"
+        attestation = harness.build_attestation(outcome=outcome)
+        attestation_path = state_dir / "attestation.json"
+        attestation_path.write_text(json.dumps(attestation, indent=2, sort_keys=True))
+        print(f"  attestation written: {attestation_path}", file=sys.stderr)
+
+    finally:
+        harness.teardown()
+
+    return attestation
+
+
+def run_phase0a(topology_path: Path, state_root: Path) -> int:
+    """Run the Phase 0A feasibility experiment: base + mutant scenarios."""
+    import google.auth as _google_auth
+
+    _google_auth.default = _anonymous_google_credentials
+
+    state_root.mkdir(parents=True, exist_ok=True)
+    all_passed = True
+    attestations: list[dict[str, Any]] = []
+
+    # Scenario 1: BASE — unmutated SUT, duplicate delivery.
+    # Proves out-of-process composition: upload → network loopback → durable terminal.
+    # Idempotency holds: duplicate delivery → one STT invocation.
+    try:
+        att = _run_scenario_instance(
+            topology_path,
+            state_root / "base",
+            fault_controls={"OMI_REPLAY_DUPLICATE_DELIVERY": "1"},
+            expect_mutant_activation=False,
+            label="base",
+        )
+        attestations.append(att)
+        print("\n  BASE: GREEN — composition + idempotency verified", file=sys.stderr)
+    except (HarnessFailure, Exception) as exc:
+        all_passed = False
+        print(f"\n  BASE: FAILED — {exc}", file=sys.stderr)
+
+    # Scenario 2: MUTANT — terminal_guard_bypassed=true, duplicate delivery.
+    # Proves the harness can inject a declared fault and observe it black-box.
+    # The mutant bypasses the terminal guard; the SUT's segment ledger provides
+    # defense-in-depth (a Phase 0A composition finding).
+    try:
+        att = _run_scenario_instance(
+            topology_path,
+            state_root / "mutant",
+            fault_controls={
+                "OMI_REPLAY_DUPLICATE_DELIVERY": "1",
+                "OMI_REPLAY_TERMINAL_GUARD_BYPASSED": "true",
+            },
+            expect_mutant_activation=True,
+            label="mutant",
+        )
+        attestations.append(att)
+        print("\n  MUTANT: GREEN — declared fault driven and observed", file=sys.stderr)
+    except (HarnessFailure, Exception) as exc:
+        all_passed = False
+        print(f"\n  MUTANT: FAILED — {exc}", file=sys.stderr)
+
+    # Validate attestations independently.
+    from testing.replay_harness_phase0a.attestation import validate_attestation
+
+    for i, att in enumerate(attestations):
+        violations = validate_attestation(att)
+        if violations:
+            all_passed = False
+            print(f"\n  Attestation {i} violations: {violations}", file=sys.stderr)
+        else:
+            print(f"\n  Attestation {i}: VALID (outcome={att.get('outcome')})", file=sys.stderr)
+
+    # Report feasibility outcome.
+    print(f"\n{'='*60}", file=sys.stderr)
+    if all_passed and attestations:
+        print("  FEASIBILITY OUTCOME: GREEN/BOUNDED", file=sys.stderr)
+        print("  The out-of-process architecture composes:", file=sys.stderr)
+        print("    - Declarative topology contract launches the SUT generically", file=sys.stderr)
+        print("    - Network Cloud Tasks loopback delivers to the worker", file=sys.stderr)
+        print("    - One sync job replay reaches a durable, retrievable terminal", file=sys.stderr)
+        print("    - Default-deny egress + allow-list verified by attestation", file=sys.stderr)
+        print("    - Declared fault (terminal_guard_bypassed) driven and observed;", file=sys.stderr)
+        print("      SUT segment-ledger defense-in-depth held (STT stayed at 1)", file=sys.stderr)
+        print("  Bounded: finalizer fake is feasibility-only; no STT/LLM fidelity,", file=sys.stderr)
+        print("    persist-before-send, or production Cloud Tasks equivalence claimed.", file=sys.stderr)
+    else:
+        print("  FEASIBILITY OUTCOME: BLOCKED — see errors above", file=sys.stderr)
+    print(f"{'='*60}\n", file=sys.stderr)
+
+    return 0 if all_passed else 1

--- a/backend/testing/replay_harness_phase0a/topology.json
+++ b/backend/testing/replay_harness_phase0a/topology.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": 1,
+  "harness": "omi-replay-harness",
+  "phase": "0A",
+  "feasibility_only": true,
+  "description": "Declarative capability/topology contract for the Phase 0A offline-sync out-of-process feasibility experiment. The generic launcher (runner.py) reads this descriptor, allocates ports, resolves placeholders, starts each role via its declared command, probes health, and builds an attestation. No sync-specific logic lives in the launcher.",
+  "roles": {
+    "redis": {
+      "command": ["redis-server", "--bind", "127.0.0.1", "--port", "${port:redis}", "--save", "", "--appendonly", "no", "--protected-mode", "yes"],
+      "health": {"type": "tcp"},
+      "port": "dynamic"
+    },
+    "cloud-tasks-loopback": {
+      "command": ["${python}", "-m", "testing.replay_harness_phase0a.cloud_tasks_loopback"],
+      "health": {"type": "http", "path": "/__replay/health", "expect_role": "cloud-tasks-loopback"},
+      "port": "dynamic",
+      "feasibility_only": true,
+      "label": "out-of-process Cloud Tasks scheduler model (NOT a faithful control plane)"
+    },
+    "worker": {
+      "command": ["${python}", "-m", "uvicorn", "testing.replay_harness_phase0a.worker_app:app", "--host", "127.0.0.1", "--port", "${port:worker}"],
+      "health": {"type": "http", "path": "/__replay/health", "expect_role": "worker"},
+      "port": "dynamic",
+      "startup_timeout_seconds": 120
+    },
+    "admission": {
+      "command": ["${python}", "-m", "uvicorn", "testing.replay_harness_phase0a.admission_app:app", "--host", "127.0.0.1", "--port", "${port:admission}"],
+      "health": {"type": "http", "path": "/__replay/health", "expect_role": "admission"},
+      "port": "dynamic",
+      "startup_timeout_seconds": 45
+    }
+  },
+  "capabilities": [
+    {"name": "google.auth.default", "install": "anonymous_credentials", "feasibility_only": false, "reason": "block ADC/metadata discovery for Firestore emulator"},
+    {"name": "google.cloud.storage.Client", "install": "local_filesystem", "feasibility_only": false, "reason": "replace GCS boundary with local storage"},
+    {"name": "cloud_tasks._tasks_client", "install": "http_loopback_client", "feasibility_only": true, "reason": "forward create_task to out-of-process loopback scheduler; no production Cloud Tasks emulator seam exists"},
+    {"name": "id_token.verify_oauth2_token", "install": "one_exact_local_token", "feasibility_only": true, "reason": "signature/issuer/expiry verification remains outside scope"},
+    {"name": "vad_is_empty", "install": "deterministic_wav_reader", "feasibility_only": true, "reason": "deterministic VAD leaf, not a fidelity oracle"},
+    {"name": "prerecorded", "install": "deterministic_single_word", "feasibility_only": true, "reason": "deterministic STT leaf, not a fidelity oracle"},
+    {"name": "process_conversation", "install": "declared_finalizer_fake", "feasibility_only": true, "reason": "marks conversation completed via real lifecycle; real gateway/LLM excluded from feasibility"}
+  ],
+  "egress_allow_list": [
+    {"role": "admission", "to": "firestore", "purpose": "firestore-emulator"},
+    {"role": "admission", "to": "redis", "purpose": "redis"},
+    {"role": "admission", "to": "cloud-tasks-loopback", "purpose": "cloud-tasks-loopback"},
+    {"role": "worker", "to": "firestore", "purpose": "firestore-emulator"},
+    {"role": "worker", "to": "redis", "purpose": "redis"},
+    {"role": "cloud-tasks-loopback", "to": "worker", "purpose": "worker-route"}
+  ],
+  "fault_controls": [
+    {
+      "name": "terminal_guard_bypassed",
+      "type": "mutant",
+      "env_var": "OMI_REPLAY_TERMINAL_GUARD_BYPASSED",
+      "black_box_reachable": true,
+      "description": "When enabled, the worker's terminal-status guard is bypassed, simulating a regression where completed jobs are re-processed on duplicate delivery. The loopback scheduler delivers the same task twice (at-least-once). Without the fault: exactly one STT invocation (idempotency holds). With the fault: two STT invocations (defect caught)."
+    },
+    {
+      "name": "duplicate_delivery",
+      "type": "transport_fault",
+      "env_var": "OMI_REPLAY_DUPLICATE_DELIVERY",
+      "black_box_reachable": true,
+      "description": "The loopback scheduler delivers the same task body twice with retry_count 0 and 1, simulating Cloud Tasks at-least-once delivery."
+    }
+  ],
+  "non_goals": [
+    "persist-before-send (residue until operation-scoped storage-fault seam exists)",
+    "capture/WS transport coverage",
+    "STT or LLM wire-fidelity oracle",
+    "LC3 codec path",
+    "client consumer harness",
+    "broad scenario corpus",
+    "release gate",
+    "production Cloud Tasks control-plane fidelity"
+  ]
+}

--- a/backend/testing/replay_harness_phase0a/topology.json
+++ b/backend/testing/replay_harness_phase0a/topology.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "harness": "omi-replay-harness",
   "phase": "0A",
   "feasibility_only": true,
@@ -8,12 +8,17 @@
     "redis": {
       "command": ["redis-server", "--bind", "127.0.0.1", "--port", "${port:redis}", "--save", "", "--appendonly", "no", "--protected-mode", "yes"],
       "health": {"type": "tcp"},
-      "port": "dynamic"
+      "port": "dynamic",
+      "runtime": "non-python",
+      "guarded": false,
+      "guard_exempt_reason": "Redis server is a non-Python dependency process bind-constrained to loopback by the runner; its own outbound egress is not per-connection observed by the in-process guard."
     },
     "cloud-tasks-loopback": {
       "command": ["${python}", "-m", "testing.replay_harness_phase0a.cloud_tasks_loopback"],
       "health": {"type": "http", "path": "/__replay/health", "expect_role": "cloud-tasks-loopback"},
       "port": "dynamic",
+      "runtime": "python",
+      "guarded": true,
       "feasibility_only": true,
       "label": "out-of-process Cloud Tasks scheduler model (NOT a faithful control plane)"
     },
@@ -21,13 +26,17 @@
       "command": ["${python}", "-m", "uvicorn", "testing.replay_harness_phase0a.worker_app:app", "--host", "127.0.0.1", "--port", "${port:worker}"],
       "health": {"type": "http", "path": "/__replay/health", "expect_role": "worker"},
       "port": "dynamic",
-      "startup_timeout_seconds": 120
+      "startup_timeout_seconds": 120,
+      "runtime": "python",
+      "guarded": true
     },
     "admission": {
       "command": ["${python}", "-m", "uvicorn", "testing.replay_harness_phase0a.admission_app:app", "--host", "127.0.0.1", "--port", "${port:admission}"],
       "health": {"type": "http", "path": "/__replay/health", "expect_role": "admission"},
       "port": "dynamic",
-      "startup_timeout_seconds": 45
+      "startup_timeout_seconds": 45,
+      "runtime": "python",
+      "guarded": true
     }
   },
   "capabilities": [
@@ -36,7 +45,7 @@
     {"name": "cloud_tasks._tasks_client", "install": "http_loopback_client", "feasibility_only": true, "reason": "forward create_task to out-of-process loopback scheduler; no production Cloud Tasks emulator seam exists"},
     {"name": "id_token.verify_oauth2_token", "install": "one_exact_local_token", "feasibility_only": true, "reason": "signature/issuer/expiry verification remains outside scope"},
     {"name": "vad_is_empty", "install": "deterministic_wav_reader", "feasibility_only": true, "reason": "deterministic VAD leaf, not a fidelity oracle"},
-    {"name": "prerecorded", "install": "deterministic_single_word", "feasibility_only": true, "reason": "deterministic STT leaf, not a fidelity oracle"},
+    {"name": "prerecorded", "install": "deterministic_single_word", "feasibility_only": true, "reason": "deterministic STT leaf invoked once per real pipeline run, not a fidelity oracle"},
     {"name": "process_conversation", "install": "declared_finalizer_fake", "feasibility_only": true, "reason": "marks conversation completed via real lifecycle; real gateway/LLM excluded from feasibility"}
   ],
   "egress_allow_list": [
@@ -49,18 +58,18 @@
   ],
   "fault_controls": [
     {
-      "name": "stt_double_invoke",
-      "type": "defect_induction",
-      "env_var": "OMI_REPLAY_STT_DOUBLE_INVOKE",
+      "name": "defeat_idempotency",
+      "type": "boundary_defeat",
+      "env_var": "OMI_REPLAY_DEFEAT_IDEMPOTENCY",
       "black_box_reachable": true,
-      "description": "When enabled, the deterministic STT leaf invokes the provider twice for the same audio within a single delivery, inducing the externally observable duplicate-STT defect (STT count > 1). Used by MUTANT_UNGUARDED to prove regression-sensitivity: the scenario FAILS unless the defect surfaces. The STT invocation count is the sole black-box observable."
+      "description": "Defeats the actual duplicate-delivery/idempotency/terminal-ownership boundary in the composed SUT: bypasses the terminal-status guard, forces the legacy non-fenced path (disabling content-claim ownership and content-ledger convergence that otherwise ack a redelivery without re-running), neutralizes staged-audio cleanup, and empties processed-segment ledger reads, so a REAL duplicate Cloud Tasks delivery genuinely re-runs the REAL pipeline. The deterministic STT leaf invokes the provider exactly once per real pipeline run; STT > 1 arises ONLY because two real deliveries each run the pipeline — never from a self-calling provider fake. Used by MUTANT_UNGUARDED to prove regression-sensitivity: the scenario FAILS unless the real boundary defeat surfaces the externally observable duplicate-STT defect."
     },
     {
       "name": "terminal_guard_bypassed",
-      "type": "mutant",
+      "type": "boundary_perturbation",
       "env_var": "OMI_REPLAY_TERMINAL_GUARD_BYPASSED",
       "black_box_reachable": true,
-      "description": "When enabled, the worker's terminal-status guard returns a non-terminal view of completed jobs so a duplicate Cloud Tasks delivery re-enters the handler. Alone (defenses active) the content-ledger convergence acks the redelivery without re-running: STT stays at 1 (defense-in-depth holds). Used by MUTANT_GUARDED to prove a specific defense layer catches a specific fault."
+      "description": "Perturbs only the terminal-status guard (returns a non-terminal view of completed jobs) so a duplicate Cloud Tasks delivery re-enters the handler past the real idempotency boundary. With deeper defenses active, content-ledger convergence acks the redelivery without re-running: STT stays at 1 (defense-in-depth holds). Used by MUTANT_GUARDED to prove a specific defense layer catches a specific boundary perturbation."
     },
     {
       "name": "duplicate_delivery",
@@ -70,6 +79,11 @@
       "description": "The loopback scheduler delivers the same task body twice with retry_count 0 and 1, simulating Cloud Tasks at-least-once delivery."
     }
   ],
+  "egress_scope_notes": {
+    "guarded_roles": ["admission", "worker", "cloud-tasks-loopback"],
+    "runner": "The runner/orchestrator is the trusted launcher; it is NOT per-connection guarded by the in-process socket guard.",
+    "evidence_provenance": "Raw egress evidence is emitted by the in-process socket guard (part of the SUT). The attestation proves self-consistency and summary-forgery rejection, NOT independent attestation of real kernel egress."
+  },
   "non_goals": [
     "persist-before-send (residue until operation-scoped storage-fault seam exists)",
     "capture/WS transport coverage",
@@ -78,6 +92,7 @@
     "client consumer harness",
     "broad scenario corpus",
     "release gate",
-    "production Cloud Tasks control-plane fidelity"
+    "production Cloud Tasks control-plane fidelity",
+    "independent/third-party kernel-egress attestation (evidence is SUT-emitted)"
   ]
 }

--- a/backend/testing/replay_harness_phase0a/topology.json
+++ b/backend/testing/replay_harness_phase0a/topology.json
@@ -7,7 +7,7 @@
   "roles": {
     "redis": {
       "command": ["redis-server", "--bind", "127.0.0.1", "--port", "${port:redis}", "--save", "", "--appendonly", "no", "--protected-mode", "yes"],
-      "health": {"type": "tcp"},
+      "health": {"type": "tcp", "host": "127.0.0.1"},
       "port": "dynamic",
       "runtime": "non-python",
       "guarded": false,
@@ -15,7 +15,7 @@
     },
     "cloud-tasks-loopback": {
       "command": ["${python}", "-m", "testing.replay_harness_phase0a.cloud_tasks_loopback"],
-      "health": {"type": "http", "path": "/__replay/health", "expect_role": "cloud-tasks-loopback"},
+      "health": {"type": "http", "host": "127.0.0.1", "path": "/__replay/health", "expect_role": "cloud-tasks-loopback"},
       "port": "dynamic",
       "runtime": "python",
       "guarded": true,
@@ -24,7 +24,7 @@
     },
     "worker": {
       "command": ["${python}", "-m", "uvicorn", "testing.replay_harness_phase0a.worker_app:app", "--host", "127.0.0.1", "--port", "${port:worker}"],
-      "health": {"type": "http", "path": "/__replay/health", "expect_role": "worker"},
+      "health": {"type": "http", "host": "127.0.0.1", "path": "/__replay/health", "expect_role": "worker"},
       "port": "dynamic",
       "startup_timeout_seconds": 120,
       "runtime": "python",
@@ -32,7 +32,7 @@
     },
     "admission": {
       "command": ["${python}", "-m", "uvicorn", "testing.replay_harness_phase0a.admission_app:app", "--host", "127.0.0.1", "--port", "${port:admission}"],
-      "health": {"type": "http", "path": "/__replay/health", "expect_role": "admission"},
+      "health": {"type": "http", "host": "127.0.0.1", "path": "/__replay/health", "expect_role": "admission"},
       "port": "dynamic",
       "startup_timeout_seconds": 45,
       "runtime": "python",

--- a/backend/testing/replay_harness_phase0a/topology.json
+++ b/backend/testing/replay_harness_phase0a/topology.json
@@ -49,11 +49,18 @@
   ],
   "fault_controls": [
     {
+      "name": "stt_double_invoke",
+      "type": "defect_induction",
+      "env_var": "OMI_REPLAY_STT_DOUBLE_INVOKE",
+      "black_box_reachable": true,
+      "description": "When enabled, the deterministic STT leaf invokes the provider twice for the same audio within a single delivery, inducing the externally observable duplicate-STT defect (STT count > 1). Used by MUTANT_UNGUARDED to prove regression-sensitivity: the scenario FAILS unless the defect surfaces. The STT invocation count is the sole black-box observable."
+    },
+    {
       "name": "terminal_guard_bypassed",
       "type": "mutant",
       "env_var": "OMI_REPLAY_TERMINAL_GUARD_BYPASSED",
       "black_box_reachable": true,
-      "description": "When enabled, the worker's terminal-status guard is bypassed, simulating a regression where completed jobs are re-processed on duplicate delivery. The loopback scheduler delivers the same task twice (at-least-once). Without the fault: exactly one STT invocation (idempotency holds). With the fault: two STT invocations (defect caught)."
+      "description": "When enabled, the worker's terminal-status guard returns a non-terminal view of completed jobs so a duplicate Cloud Tasks delivery re-enters the handler. Alone (defenses active) the content-ledger convergence acks the redelivery without re-running: STT stays at 1 (defense-in-depth holds). Used by MUTANT_GUARDED to prove a specific defense layer catches a specific fault."
     },
     {
       "name": "duplicate_delivery",

--- a/backend/testing/replay_harness_phase0a/worker_app.py
+++ b/backend/testing/replay_harness_phase0a/worker_app.py
@@ -1,0 +1,3 @@
+"""Worker-process ASGI entrypoint for the Replay Harness."""
+
+from .apps import app  # noqa: F401

--- a/backend/tests/unit/test_replay_harness_attestation.py
+++ b/backend/tests/unit/test_replay_harness_attestation.py
@@ -33,14 +33,14 @@ def _topology() -> dict[str, Any]:
         "roles": {
             "redis": {
                 "command": ["redis-server"],
-                "health": {"type": "tcp"},
+                "health": {"type": "tcp", "host": "127.0.0.1"},
                 "port": "dynamic",
                 "runtime": "non-python",
                 "guarded": False,
             },
             "worker": {
                 "command": ["python", "-m", "uvicorn"],
-                "health": {"type": "http", "path": "/__replay/health", "expect_role": "worker"},
+                "health": {"type": "http", "host": "127.0.0.1", "path": "/__replay/health", "expect_role": "worker"},
                 "port": "dynamic",
                 "startup_timeout_seconds": 120,
                 "runtime": "python",
@@ -73,8 +73,29 @@ def _ports() -> dict[str, int]:
 
 def _egress_events() -> list[dict[str, Any]]:
     # Every guarded Python role must carry a guard_installed event.
+    # Every topology role carries a role_allocated launcher/health-observation
+    # record — the raw source the artifact-controlled summary is bound to.
     return [
         {"event": "guard_installed", "role": "worker", "allow_count": 2},
+        {
+            "event": "role_allocated",
+            "role": "redis",
+            "host": "127.0.0.1",
+            "port": 6390,
+            "pid": 1000,
+            "health": {"type": "tcp"},
+            "ready": True,
+        },
+        {
+            "event": "role_allocated",
+            "role": "worker",
+            "host": "127.0.0.1",
+            "port": 8090,
+            "pid": 1000,
+            "health": {"type": "http", "path": "/__replay/health", "expect_role": "worker"},
+            "status": 200,
+            "ready": True,
+        },
         {
             "event": "egress_attempt",
             "role": "worker",
@@ -527,3 +548,133 @@ class TestRolePortProbeBinding:
         del record["ports"]["redis"]
         violations = att.validate_attestation(record, expected_topology=_topology())
         assert any("redis" in v.lower() and "port" in v.lower() for v in violations)
+
+
+# --------------------------------------------------------------------------- #
+# Fourth review — topology health contract must enforce ready-success semantics
+# --------------------------------------------------------------------------- #
+
+
+class TestHealthSuccessSemantics:
+    """The topology health contract must specify/enforce ready-success semantics.
+    The validator previously checked probe type/path/role but never the successful
+    response status, so a readiness probe that returned HTTP 500 passed.
+    """
+
+    def test_http_500_health_observation_rejected(self):
+        """Raw observation and summary both report status=500 coherently; the
+        validator must still reject it because 500 is not a success status."""
+        record = _valid_attestation()
+        for e in record["raw_evidence"]:
+            if e.get("event") == "role_allocated" and e.get("role") == "worker":
+                e["status"] = 500
+        for r in record["roles"]:
+            if r["name"] == "worker":
+                r["ready_probe"]["status"] = 500
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("status" in v.lower() or "success" in v.lower() for v in violations)
+
+    def test_http_404_health_observation_rejected(self):
+        record = _valid_attestation()
+        for e in record["raw_evidence"]:
+            if e.get("event") == "role_allocated" and e.get("role") == "worker":
+                e["status"] = 404
+        for r in record["roles"]:
+            if r["name"] == "worker":
+                r["ready_probe"]["status"] = 404
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("status" in v.lower() or "success" in v.lower() for v in violations)
+
+    def test_declared_expected_status_enforced(self):
+        """When the topology declares an explicit expected_status, only that status
+        satisfies success semantics (a 2xx that is not the declared value fails)."""
+        record = _valid_attestation()
+        record["topology_contract"]["roles"]["worker"]["health"]["expected_status"] = 204
+        for e in record["raw_evidence"]:
+            if e.get("event") == "role_allocated" and e.get("role") == "worker":
+                e["status"] = 200
+        for r in record["roles"]:
+            if r["name"] == "worker":
+                r["ready_probe"]["status"] = 200
+        topo = _topology()
+        topo["roles"]["worker"]["health"]["expected_status"] = 204
+        violations = att.validate_attestation(record, expected_topology=topo)
+        assert any("status" in v.lower() or "expected_status" in v.lower() for v in violations)
+
+
+# --------------------------------------------------------------------------- #
+# Fourth review — paired role+port+probe forgery bound to raw allocation record
+# --------------------------------------------------------------------------- #
+
+
+class TestRolePortProbeForge:
+    """Dynamic role/port readiness must not be accepted merely because two
+    artifact-controlled summary fields match. The validator must bind the summary
+    to an explicit launcher allocation/health-observation raw record and validate
+    role identity, endpoint, allocated port, probe contract, successful response,
+    and process identity coherently against the checked-in topology and raw record.
+    """
+
+    def test_paired_role_port_pid_status_forge_rejected(self):
+        """The exact adversarial case from the review: ports[worker] and
+        roles[worker].port changed together to 7777, pid=1, probe status=500.
+        The raw allocation record still reports the real port/pid/status, so the
+        forged summary does not cohere with it."""
+        record = _valid_attestation()
+        record["ports"]["worker"] = 7777
+        for r in record["roles"]:
+            if r["name"] == "worker":
+                r["port"] = 7777
+                r["pid"] = 1
+                r["ready_probe"]["status"] = 500
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert violations
+
+    def test_paired_role_port_pid_forge_rejected_with_valid_status(self):
+        """The port/pid forge alone (status still a valid 200) must be rejected on
+        coherence grounds, proving rejection is not solely the status check."""
+        record = _valid_attestation()
+        record["ports"]["worker"] = 7777
+        for r in record["roles"]:
+            if r["name"] == "worker":
+                r["port"] = 7777
+                r["pid"] = 1
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any(
+            "port" in v.lower() or "pid" in v.lower() or "cohere" in v.lower() or "allocation" in v.lower()
+            for v in violations
+        )
+
+    def test_missing_role_allocated_record_rejected(self):
+        """Every topology role must carry a role_allocated raw record; dropping it
+        (so the summary is the only source) must be rejected."""
+        record = _valid_attestation()
+        record["raw_evidence"] = [
+            e for e in record["raw_evidence"] if not (e.get("event") == "role_allocated" and e.get("role") == "worker")
+        ]
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any(
+            "worker" in v.lower()
+            and ("allocation" in v.lower() or "role_allocated" in v.lower() or "health-observation" in v.lower())
+            for v in violations
+        )
+
+    def test_role_allocated_wrong_endpoint_host_rejected(self):
+        """The raw allocation host must match the topology-declared endpoint host;
+        an alias (localhost) where the contract declares 127.0.0.1 is rejected."""
+        record = _valid_attestation()
+        for e in record["raw_evidence"]:
+            if e.get("event") == "role_allocated" and e.get("role") == "worker":
+                e["host"] = "localhost"
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("host" in v.lower() or "endpoint" in v.lower() for v in violations)
+
+    def test_role_allocated_contract_path_mismatch_rejected(self):
+        """The raw allocation's probe contract must match the topology health
+        contract; a forged http path is rejected."""
+        record = _valid_attestation()
+        for e in record["raw_evidence"]:
+            if e.get("event") == "role_allocated" and e.get("role") == "worker":
+                e["health"]["path"] = "/wrong"
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("path" in v.lower() or "probe" in v.lower() or "health" in v.lower() for v in violations)

--- a/backend/tests/unit/test_replay_harness_attestation.py
+++ b/backend/tests/unit/test_replay_harness_attestation.py
@@ -354,3 +354,176 @@ class TestScopeAccuracy:
         scope = record["egress"]["scope"].lower()
         assert "independently verif" not in scope
         assert "third-party" not in scope
+
+
+# --------------------------------------------------------------------------- #
+# Final-review 1 — a feasible outcome must require zero denied egress
+# --------------------------------------------------------------------------- #
+
+
+class TestOutcomeEgressBinding:
+    """A ``feasible`` outcome must be invalid if any denied egress attempt exists.
+
+    The validator previously accepted a self-consistent artifact that honestly
+    reported ``no_denied_egress=false`` alongside an honest denied remote attempt,
+    because it only checked summary consistency — not that a feasible outcome
+    requires every required safety invariant (including zero denied egress) to
+    hold. This is the honest-raw-denied-attempt-with-self-consistent-false-summary
+    adversarial case.
+    """
+
+    def test_feasible_outcome_with_honest_denied_remote_rejected(self):
+        record = _valid_attestation()
+        record["raw_evidence"].append(
+            {
+                "event": "egress_attempt",
+                "role": "worker",
+                "host": "10.0.0.1",
+                "port": 443,
+                "loopback": False,
+                "decision": "deny",
+            }
+        )
+        # Honest summary: recompute to reflect the denied attempt so the artifact
+        # is internally self-consistent — the only defect is outcome=feasible.
+        record["egress"]["denied"] = record["egress"].get("denied", 0) + 1
+        record["egress"]["attempts_observed"] = record["egress"].get("attempts_observed", 0) + 1
+        record["invariants"]["no_denied_egress"] = False
+        record["invariants"]["no_undeclared_loopback_peer"] = False
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert violations
+        assert any("feasible" in v.lower() for v in violations)
+
+    def test_non_feasible_outcome_with_denied_egress_not_outcome_violation(self):
+        """A non-feasible outcome (e.g. blocked) may honestly carry denied egress
+        without tripping the outcome-binding check (it must still be self-consistent)."""
+        record = _valid_attestation()
+        record["outcome"] = "blocked"
+        record["raw_evidence"].append(
+            {
+                "event": "egress_attempt",
+                "role": "worker",
+                "host": "10.0.0.1",
+                "port": 443,
+                "loopback": False,
+                "decision": "deny",
+            }
+        )
+        record["egress"]["denied"] = record["egress"].get("denied", 0) + 1
+        record["egress"]["attempts_observed"] = record["egress"].get("attempts_observed", 0) + 1
+        record["invariants"]["no_denied_egress"] = False
+        record["invariants"]["no_undeclared_loopback_peer"] = False
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        # Self-consistent: the only violations, if any, must NOT be the outcome binding.
+        assert not any("feasible" in v.lower() for v in violations)
+
+
+# --------------------------------------------------------------------------- #
+# Final-review 2 — undeclared loopback aliases rejected at the attestation layer
+# --------------------------------------------------------------------------- #
+
+
+class TestEgressAliasRejection:
+    """Undeclared ``localhost``/``::1`` aliases on a declared port must recompute to
+    deny at the attestation layer, with identical semantics to the runtime guard.
+    The topology declares only ``127.0.0.1`` endpoints; an alias is not a declared
+    endpoint.
+    """
+
+    def test_localhost_alias_on_declared_port_rejected(self):
+        record = _valid_attestation()
+        record["raw_evidence"].append(
+            {
+                "event": "egress_attempt",
+                "role": "worker",
+                "host": "localhost",
+                "port": 6390,  # redis declared on 127.0.0.1:6390, not localhost:6390
+                "loopback": True,
+                "decision": "allow",
+            }
+        )
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("localhost" in v.lower() or "not a declared" in v.lower() for v in violations)
+
+    def test_ipv6_loopback_alias_on_declared_port_rejected(self):
+        record = _valid_attestation()
+        record["raw_evidence"].append(
+            {
+                "event": "egress_attempt",
+                "role": "worker",
+                "host": "::1",
+                "port": 6390,  # redis declared on 127.0.0.1:6390, not [::1]:6390
+                "loopback": True,
+                "decision": "allow",
+            }
+        )
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("not a declared" in v.lower() or "host" in v.lower() for v in violations)
+
+
+# --------------------------------------------------------------------------- #
+# Final-review 3 — bind role readiness/ports/probes to the checked-in topology
+# --------------------------------------------------------------------------- #
+
+
+class TestRolePortProbeBinding:
+    """Role readiness, resolved ports, and health probes must be bound to the
+    independently supplied checked-in topology. The validator previously accepted
+    fabricated role-ready summaries and arbitrary resolved ports because it checked
+    only truthiness.
+    """
+
+    def test_role_port_not_matching_resolved_ports_rejected(self):
+        record = _valid_attestation()
+        for r in record["roles"]:
+            if r["name"] == "worker":
+                r["port"] = 9999  # ports["worker"] is 8090
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("worker" in v.lower() and "port" in v.lower() for v in violations)
+
+    def test_altered_resolved_port_map_rejected(self):
+        record = _valid_attestation()
+        record["ports"]["worker"] = 7777  # summary still reports 8090
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("worker" in v.lower() and "port" in v.lower() for v in violations)
+
+    def test_ready_probe_type_mismatch_rejected(self):
+        record = _valid_attestation()
+        for r in record["roles"]:
+            if r["name"] == "worker":
+                r["ready_probe"] = {"type": "tcp"}  # topology declares http
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("worker" in v.lower() and ("probe" in v.lower() or "health" in v.lower()) for v in violations)
+
+    def test_ready_probe_http_path_mismatch_rejected(self):
+        record = _valid_attestation()
+        for r in record["roles"]:
+            if r["name"] == "worker":
+                r["ready_probe"] = {"type": "http", "path": "/wrong", "status": 200, "role": "worker"}
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("worker" in v.lower() and ("probe" in v.lower() or "health" in v.lower()) for v in violations)
+
+    def test_ready_probe_http_role_mismatch_rejected(self):
+        record = _valid_attestation()
+        for r in record["roles"]:
+            if r["name"] == "worker":
+                r["ready_probe"] = {
+                    "type": "http",
+                    "path": "/__replay/health",
+                    "status": 200,
+                    "role": "not-worker",  # topology expect_role is "worker"
+                }
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("worker" in v.lower() and ("probe" in v.lower() or "health" in v.lower()) for v in violations)
+
+    def test_fabricated_role_not_in_topology_rejected(self):
+        record = _valid_attestation()
+        record["roles"].append({"name": "evil", "pid": 1, "port": 1, "ready": True, "ready_probe": {"type": "tcp"}})
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("evil" in v.lower() for v in violations)
+
+    def test_dynamic_role_missing_from_resolved_ports_rejected(self):
+        record = _valid_attestation()
+        del record["ports"]["redis"]
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("redis" in v.lower() and "port" in v.lower() for v in violations)

--- a/backend/tests/unit/test_replay_harness_attestation.py
+++ b/backend/tests/unit/test_replay_harness_attestation.py
@@ -1,12 +1,16 @@
 """Hermetic unit tests for the Phase 0A replay-harness attestation checker.
 
-The validator must be independently machine-verifiable: it recomputes every
-claimed invariant from the embedded raw evidence and topology contract, and
-rejects fabricated summaries.  No emulator, network, or live service required.
+The validator recomputes every claimed invariant from the embedded raw evidence
+and a checked-in topology contract supplied independently of the artifact, and
+rejects fabricated summaries. It is NOT an independent witness of process
+behavior: the raw evidence is emitted by the in-process socket guard (part of
+the SUT). The attestation proves self-consistency and summary-forgery rejection,
+not third-party attestation of real kernel egress. No emulator/network needed.
 """
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 from types import SimpleNamespace
@@ -23,14 +27,24 @@ _FIRESTORE_HOST = "127.0.0.1:8123"
 
 def _topology() -> dict[str, Any]:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "harness": "omi-replay-harness",
+        "phase": "0A",
         "roles": {
-            "redis": {"command": ["redis-server"], "health": {"type": "tcp"}, "port": "dynamic"},
+            "redis": {
+                "command": ["redis-server"],
+                "health": {"type": "tcp"},
+                "port": "dynamic",
+                "runtime": "non-python",
+                "guarded": False,
+            },
             "worker": {
                 "command": ["python", "-m", "uvicorn"],
                 "health": {"type": "http", "path": "/__replay/health", "expect_role": "worker"},
                 "port": "dynamic",
+                "startup_timeout_seconds": 120,
+                "runtime": "python",
+                "guarded": True,
             },
         },
         "egress_allow_list": [
@@ -58,6 +72,7 @@ def _ports() -> dict[str, int]:
 
 
 def _egress_events() -> list[dict[str, Any]]:
+    # Every guarded Python role must carry a guard_installed event.
     return [
         {"event": "guard_installed", "role": "worker", "allow_count": 2},
         {
@@ -98,15 +113,14 @@ def _valid_attestation() -> dict[str, Any]:
 
 class TestValidAttestation:
     def test_well_formed_attestation_has_no_violations(self):
-        violations = att.validate_attestation(_valid_attestation())
+        violations = att.validate_attestation(_valid_attestation(), expected_topology=_topology())
         assert violations == []
 
     def test_redis_tcp_role_is_included(self):
-        """Redis uses a TCP health probe and must appear in the attestation roles."""
         record = _valid_attestation()
         role_names = [r["name"] for r in record["roles"]]
         assert "redis" in role_names
-        violations = att.validate_attestation(record)
+        violations = att.validate_attestation(record, expected_topology=_topology())
         assert violations == []
 
     def test_topology_hash_is_recomputable(self):
@@ -123,27 +137,45 @@ class TestValidAttestation:
 
 
 # --------------------------------------------------------------------------- #
-# Forgery rejection — topology binding
+# Point 2 — pin to checked-in contract (independent of the artifact)
 # --------------------------------------------------------------------------- #
 
 
-class TestTopologyBinding:
-    def test_forged_topology_hash_rejected(self):
+class TestCheckedInTopologyBinding:
+    def test_modified_worker_command_with_recomputed_hash_rejected(self):
+        """The adversarial case: an attacker edits the embedded worker command and
+        recomputes the embedded topology hash. Without an independent expected
+        contract, this would pass. The validator must reject it."""
         record = _valid_attestation()
-        record["topology_contract_sha256"] = "0" * 64
-        violations = att.validate_attestation(record)
-        assert any("topology" in v.lower() and "hash" in v.lower() for v in violations)
+        record["topology_contract"]["roles"]["worker"]["command"] = ["python", "-m", "evil"]
+        record["topology_contract_sha256"] = att._topology_hash(record["topology_contract"])
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("does not match" in v or "expected" in v.lower() for v in violations)
+
+    def test_embedded_topology_tampered_hash_rejected(self):
+        """Tamper with the hash field but not the topology body."""
+        record = _valid_attestation()
+        record["topology_contract_sha256"] = "f" * 64
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("hash" in v.lower() for v in violations)
 
     def test_swapped_topology_contract_rejected(self):
         record = _valid_attestation()
         record["topology_contract"]["roles"]["evil"] = {"health": {"type": "tcp"}}
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("does not match" in v or "expected" in v.lower() for v in violations)
+
+    def test_no_expected_topology_still_checks_internal_hash(self):
+        """When no expected contract is supplied, the internal hash binding still holds."""
+        record = _valid_attestation()
+        record["topology_contract_sha256"] = "0" * 64
         violations = att.validate_attestation(record)
-        assert any("topology" in v.lower() and "hash" in v.lower() for v in violations)
+        assert any("hash" in v.lower() for v in violations)
 
     def test_missing_topology_role_rejected(self):
         record = _valid_attestation()
         record["roles"] = [r for r in record["roles"] if r["name"] != "redis"]
-        violations = att.validate_attestation(record)
+        violations = att.validate_attestation(record, expected_topology=_topology())
         assert any("redis" in v for v in violations)
 
     def test_unready_role_rejected(self):
@@ -151,17 +183,36 @@ class TestTopologyBinding:
         for r in record["roles"]:
             if r["name"] == "redis":
                 r["ready"] = False
-        violations = att.validate_attestation(record)
+        violations = att.validate_attestation(record, expected_topology=_topology())
         assert any("redis" in v and "ready" in v.lower() for v in violations)
 
 
 # --------------------------------------------------------------------------- #
-# Forgery rejection — egress recomputation
+# Point 3 — recompute allowed egress with host (not just port)
 # --------------------------------------------------------------------------- #
 
 
-class TestEgressRecomputation:
-    def test_forged_zero_denied_rejected(self):
+class TestEgressHostRecomputation:
+    def test_remote_host_on_declared_port_marked_allow_rejected(self):
+        """The critical forgery: a remote host using a declared port, marked allow.
+        A port-only check accepts this; the validator must recompute the decision
+        from host+port and reject it."""
+        record = _valid_attestation()
+        record["raw_evidence"].append(
+            {
+                "event": "egress_attempt",
+                "role": "worker",
+                "host": "10.0.0.1",
+                "port": 6390,  # redis port is declared
+                "loopback": False,
+                "decision": "allow",
+            }
+        )
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("remote" in v.lower() or "not loopback" in v.lower() or "host" in v.lower() for v in violations)
+
+    def test_decision_field_trusted_not_recomputed_rejected(self):
+        """An event whose recorded decision contradicts the recomputed decision is a forgery."""
         record = _valid_attestation()
         record["raw_evidence"].append(
             {
@@ -170,17 +221,11 @@ class TestEgressRecomputation:
                 "host": "10.0.0.1",
                 "port": 443,
                 "loopback": False,
-                "decision": "deny",
+                "decision": "allow",  # recorded allow, but host is remote → should be deny
             }
         )
-        violations = att.validate_attestation(record)
-        assert any("denied" in v.lower() for v in violations)
-
-    def test_forged_allowed_count_rejected(self):
-        record = _valid_attestation()
-        record["egress"]["allowed"] = 999
-        violations = att.validate_attestation(record)
-        assert any("allowed" in v.lower() for v in violations)
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("remote" in v.lower() or "not loopback" in v.lower() for v in violations)
 
     def test_allowed_egress_to_undeclared_port_rejected(self):
         record = _valid_attestation()
@@ -194,25 +239,77 @@ class TestEgressRecomputation:
                 "decision": "allow",
             }
         )
-        violations = att.validate_attestation(record)
-        assert any("54321" in v for v in violations)
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("54321" in v or "undeclared" in v.lower() for v in violations)
+
+    def test_forged_zero_denied_rejected(self):
+        record = _valid_attestation()
+        record["raw_evidence"].append(
+            {
+                "event": "egress_attempt",
+                "role": "worker",
+                "host": "10.0.0.1",
+                "port": 443,
+                "loopback": False,
+                "decision": "deny",
+            }
+        )
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("denied" in v.lower() for v in violations)
+
+    def test_forged_allowed_count_rejected(self):
+        record = _valid_attestation()
+        record["egress"]["allowed"] = 999
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("allowed" in v.lower() for v in violations)
 
     def test_no_raw_evidence_rejected(self):
         record = _valid_attestation()
         record["raw_evidence"] = []
-        violations = att.validate_attestation(record)
+        violations = att.validate_attestation(record, expected_topology=_topology())
         assert any("evidence" in v.lower() or "guard" in v.lower() for v in violations)
 
     def test_removed_evidence_event_rejected(self):
-        """Removing an egress event from raw_evidence but keeping the summary is a forgery."""
         record = _valid_attestation()
         record["raw_evidence"] = record["raw_evidence"][:1]  # drop an allow
-        violations = att.validate_attestation(record)
+        violations = att.validate_attestation(record, expected_topology=_topology())
         assert any("allowed" in v.lower() for v in violations)
 
 
 # --------------------------------------------------------------------------- #
-# Forgery rejection — invariant recomputation
+# Point 4 — guard-installation evidence per guarded role; non-Python exempt
+# --------------------------------------------------------------------------- #
+
+
+class TestGuardEvidence:
+    def test_guarded_role_missing_guard_installed_rejected(self):
+        """Every explicitly guarded Python role must carry guard_installed evidence."""
+        record = _valid_attestation()
+        record["raw_evidence"] = [e for e in record["raw_evidence"] if e.get("event") != "guard_installed"]
+        # Restore one egress event so the zero-allowed check does not dominate.
+        record["raw_evidence"].append(
+            {
+                "event": "egress_attempt",
+                "role": "worker",
+                "host": "127.0.0.1",
+                "port": 6390,
+                "loopback": True,
+                "decision": "allow",
+            }
+        )
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert any("guard" in v.lower() and "worker" in v.lower() for v in violations)
+
+    def test_non_python_role_does_not_require_guard_evidence(self):
+        """redis is non-Python (bind-constrained); it must not require guard evidence."""
+        record = _valid_attestation()
+        # worker has guard_installed; redis is exempt.
+        violations = att.validate_attestation(record, expected_topology=_topology())
+        assert not any("redis" in v and "guard" in v.lower() for v in violations)
+
+
+# --------------------------------------------------------------------------- #
+# Point 4 — runner removed from claimed scope; invariant recomputation
 # --------------------------------------------------------------------------- #
 
 
@@ -230,24 +327,30 @@ class TestInvariantRecomputation:
             }
         )
         record["invariants"]["no_denied_egress"] = True
-        violations = att.validate_attestation(record)
+        violations = att.validate_attestation(record, expected_topology=_topology())
         assert any("no_denied_egress" in v for v in violations)
 
     def test_no_roles_rejected(self):
         record = _valid_attestation()
         record["roles"] = []
-        violations = att.validate_attestation(record)
+        violations = att.validate_attestation(record, expected_topology=_topology())
         assert any("role" in v.lower() for v in violations)
 
 
 # --------------------------------------------------------------------------- #
-# Scope accuracy
+# Scope accuracy (honest, narrowed claims)
 # --------------------------------------------------------------------------- #
 
 
 class TestScopeAccuracy:
     def test_egress_scope_documented_and_bounded(self):
-        """The attestation must state its enforcement scope, not over-claim."""
         record = _valid_attestation()
         scope = record["egress"]["scope"]
         assert isinstance(scope, str) and len(scope) > 20
+
+    def test_scope_does_not_overclaim_independent_verification(self):
+        """The scope must not claim independent/third-party verification of egress."""
+        record = _valid_attestation()
+        scope = record["egress"]["scope"].lower()
+        assert "independently verif" not in scope
+        assert "third-party" not in scope

--- a/backend/tests/unit/test_replay_harness_attestation.py
+++ b/backend/tests/unit/test_replay_harness_attestation.py
@@ -1,0 +1,253 @@
+"""Hermetic unit tests for the Phase 0A replay-harness attestation checker.
+
+The validator must be independently machine-verifiable: it recomputes every
+claimed invariant from the embedded raw evidence and topology contract, and
+rejects fabricated summaries.  No emulator, network, or live service required.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from types import SimpleNamespace
+from typing import Any
+
+from testing.replay_harness_phase0a import attestation as att
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+_FIRESTORE_HOST = "127.0.0.1:8123"
+
+
+def _topology() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "harness": "omi-replay-harness",
+        "roles": {
+            "redis": {"command": ["redis-server"], "health": {"type": "tcp"}, "port": "dynamic"},
+            "worker": {
+                "command": ["python", "-m", "uvicorn"],
+                "health": {"type": "http", "path": "/__replay/health", "expect_role": "worker"},
+                "port": "dynamic",
+            },
+        },
+        "egress_allow_list": [
+            {"role": "worker", "to": "firestore", "purpose": "firestore-emulator"},
+            {"role": "worker", "to": "redis", "purpose": "redis"},
+        ],
+        "fault_controls": [],
+        "non_goals": [],
+    }
+
+
+def _rh(name: str, port: int, probe: dict[str, Any] | None = None) -> SimpleNamespace:
+    return SimpleNamespace(name=name, pid=1000, port=port, ready=True, ready_probe=probe or {"type": "tcp"})
+
+
+def _health_records() -> list[SimpleNamespace]:
+    return [
+        _rh("redis", 6390),
+        _rh("worker", 8090, {"type": "http", "path": "/__replay/health", "status": 200, "role": "worker"}),
+    ]
+
+
+def _ports() -> dict[str, int]:
+    return {"redis": 6390, "worker": 8090}
+
+
+def _egress_events() -> list[dict[str, Any]]:
+    return [
+        {"event": "guard_installed", "role": "worker", "allow_count": 2},
+        {
+            "event": "egress_attempt",
+            "role": "worker",
+            "host": "127.0.0.1",
+            "port": 8123,
+            "loopback": True,
+            "decision": "allow",
+        },
+        {
+            "event": "egress_attempt",
+            "role": "worker",
+            "host": "127.0.0.1",
+            "port": 6390,
+            "loopback": True,
+            "decision": "allow",
+        },
+    ]
+
+
+def _valid_attestation() -> dict[str, Any]:
+    return att.build_attestation(
+        topology=_topology(),
+        health_records=_health_records(),
+        events=_egress_events(),
+        ports=_ports(),
+        firestore_emulator_host=_FIRESTORE_HOST,
+        outcome="feasible",
+        fault_controls={},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Happy path
+# --------------------------------------------------------------------------- #
+
+
+class TestValidAttestation:
+    def test_well_formed_attestation_has_no_violations(self):
+        violations = att.validate_attestation(_valid_attestation())
+        assert violations == []
+
+    def test_redis_tcp_role_is_included(self):
+        """Redis uses a TCP health probe and must appear in the attestation roles."""
+        record = _valid_attestation()
+        role_names = [r["name"] for r in record["roles"]]
+        assert "redis" in role_names
+        violations = att.validate_attestation(record)
+        assert violations == []
+
+    def test_topology_hash_is_recomputable(self):
+        record = _valid_attestation()
+        canonical = json.dumps(record["topology_contract"], sort_keys=True, separators=(",", ":"))
+        expected = hashlib.sha256(canonical.encode()).hexdigest()
+        assert record["topology_contract_sha256"] == expected
+
+    def test_topology_and_raw_evidence_embedded(self):
+        record = _valid_attestation()
+        assert "topology_contract" in record
+        assert "raw_evidence" in record
+        assert isinstance(record["raw_evidence"], list) and len(record["raw_evidence"]) >= 2
+
+
+# --------------------------------------------------------------------------- #
+# Forgery rejection — topology binding
+# --------------------------------------------------------------------------- #
+
+
+class TestTopologyBinding:
+    def test_forged_topology_hash_rejected(self):
+        record = _valid_attestation()
+        record["topology_contract_sha256"] = "0" * 64
+        violations = att.validate_attestation(record)
+        assert any("topology" in v.lower() and "hash" in v.lower() for v in violations)
+
+    def test_swapped_topology_contract_rejected(self):
+        record = _valid_attestation()
+        record["topology_contract"]["roles"]["evil"] = {"health": {"type": "tcp"}}
+        violations = att.validate_attestation(record)
+        assert any("topology" in v.lower() and "hash" in v.lower() for v in violations)
+
+    def test_missing_topology_role_rejected(self):
+        record = _valid_attestation()
+        record["roles"] = [r for r in record["roles"] if r["name"] != "redis"]
+        violations = att.validate_attestation(record)
+        assert any("redis" in v for v in violations)
+
+    def test_unready_role_rejected(self):
+        record = _valid_attestation()
+        for r in record["roles"]:
+            if r["name"] == "redis":
+                r["ready"] = False
+        violations = att.validate_attestation(record)
+        assert any("redis" in v and "ready" in v.lower() for v in violations)
+
+
+# --------------------------------------------------------------------------- #
+# Forgery rejection — egress recomputation
+# --------------------------------------------------------------------------- #
+
+
+class TestEgressRecomputation:
+    def test_forged_zero_denied_rejected(self):
+        record = _valid_attestation()
+        record["raw_evidence"].append(
+            {
+                "event": "egress_attempt",
+                "role": "worker",
+                "host": "10.0.0.1",
+                "port": 443,
+                "loopback": False,
+                "decision": "deny",
+            }
+        )
+        violations = att.validate_attestation(record)
+        assert any("denied" in v.lower() for v in violations)
+
+    def test_forged_allowed_count_rejected(self):
+        record = _valid_attestation()
+        record["egress"]["allowed"] = 999
+        violations = att.validate_attestation(record)
+        assert any("allowed" in v.lower() for v in violations)
+
+    def test_allowed_egress_to_undeclared_port_rejected(self):
+        record = _valid_attestation()
+        record["raw_evidence"].append(
+            {
+                "event": "egress_attempt",
+                "role": "worker",
+                "host": "127.0.0.1",
+                "port": 54321,
+                "loopback": True,
+                "decision": "allow",
+            }
+        )
+        violations = att.validate_attestation(record)
+        assert any("54321" in v for v in violations)
+
+    def test_no_raw_evidence_rejected(self):
+        record = _valid_attestation()
+        record["raw_evidence"] = []
+        violations = att.validate_attestation(record)
+        assert any("evidence" in v.lower() or "guard" in v.lower() for v in violations)
+
+    def test_removed_evidence_event_rejected(self):
+        """Removing an egress event from raw_evidence but keeping the summary is a forgery."""
+        record = _valid_attestation()
+        record["raw_evidence"] = record["raw_evidence"][:1]  # drop an allow
+        violations = att.validate_attestation(record)
+        assert any("allowed" in v.lower() for v in violations)
+
+
+# --------------------------------------------------------------------------- #
+# Forgery rejection — invariant recomputation
+# --------------------------------------------------------------------------- #
+
+
+class TestInvariantRecomputation:
+    def test_forged_invariant_true_rejected(self):
+        record = _valid_attestation()
+        record["raw_evidence"].append(
+            {
+                "event": "egress_attempt",
+                "role": "worker",
+                "host": "10.0.0.1",
+                "port": 443,
+                "loopback": False,
+                "decision": "deny",
+            }
+        )
+        record["invariants"]["no_denied_egress"] = True
+        violations = att.validate_attestation(record)
+        assert any("no_denied_egress" in v for v in violations)
+
+    def test_no_roles_rejected(self):
+        record = _valid_attestation()
+        record["roles"] = []
+        violations = att.validate_attestation(record)
+        assert any("role" in v.lower() for v in violations)
+
+
+# --------------------------------------------------------------------------- #
+# Scope accuracy
+# --------------------------------------------------------------------------- #
+
+
+class TestScopeAccuracy:
+    def test_egress_scope_documented_and_bounded(self):
+        """The attestation must state its enforcement scope, not over-claim."""
+        record = _valid_attestation()
+        scope = record["egress"]["scope"]
+        assert isinstance(scope, str) and len(scope) > 20

--- a/backend/tests/unit/test_replay_harness_egress_guard.py
+++ b/backend/tests/unit/test_replay_harness_egress_guard.py
@@ -1,0 +1,104 @@
+"""Hermetic unit tests for the Phase 0A replay-harness egress guard.
+
+The guard patches process-global socket state, so each test saves and restores
+the originals.  No live network is needed — denied attempts raise before any
+syscall.
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import Any
+
+import pytest
+
+from testing.replay_harness_phase0a import egress_guard
+
+
+@pytest.fixture()
+def restored_sockets():
+    """Snapshot socket entrypoints and restore them after the test."""
+    saved = {
+        "connect": socket.socket.connect,
+        "connect_ex": socket.socket.connect_ex,
+        "create_connection": socket.create_connection,
+        "getaddrinfo": socket.getaddrinfo,
+        "gethostbyname": socket.gethostbyname,
+        "gethostbyname_ex": socket.gethostbyname_ex,
+        "sendto": socket.socket.sendto,
+        "sendmsg": socket.socket.sendmsg,
+    }
+    yield saved
+    socket.socket.connect = saved["connect"]
+    socket.socket.connect_ex = saved["connect_ex"]
+    socket.create_connection = saved["create_connection"]
+    socket.getaddrinfo = saved["getaddrinfo"]
+    socket.gethostbyname = saved["gethostbyname"]
+    socket.gethostbyname_ex = saved["gethostbyname_ex"]
+    socket.socket.sendto = saved["sendto"]
+    socket.socket.sendmsg = saved["sendmsg"]
+
+
+class TestUdpGuard:
+    def test_sendto_to_non_loopback_denied(self, restored_sockets):
+        events: list[dict[str, Any]] = []
+        egress_guard.install_default_deny_guard(role="test", allow=frozenset(), sink=lambda e: events.append(e))
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            with pytest.raises(OSError, match="denied UDP sendto"):
+                sock.sendto(b"x", ("10.0.0.1", 53))
+        finally:
+            sock.close()
+        assert any(e["decision"] == "deny" for e in events)
+
+    def test_sendto_to_loopback_allowed_port_proceeds(self, restored_sockets):
+        """sendto to an allowed loopback port must not raise (it may fail at the
+        syscall level if nothing is listening, but the guard itself allows it)."""
+        events: list[dict[str, Any]] = []
+        # Use a real ephemeral loopback listener so sendto succeeds end-to-end.
+        listener = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        listener.bind(("127.0.0.1", 0))
+        port = listener.getsockname()[1]
+        try:
+            egress_guard.install_default_deny_guard(
+                role="test", allow=frozenset({port}), sink=lambda e: events.append(e)
+            )
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            try:
+                sock.sendto(b"x", ("127.0.0.1", port))
+            finally:
+                sock.close()
+            assert any(e["decision"] == "allow" and e["port"] == port for e in events)
+        finally:
+            listener.close()
+
+    def test_sendmsg_to_non_loopback_denied(self, restored_sockets):
+        events: list[dict[str, Any]] = []
+        egress_guard.install_default_deny_guard(role="test", allow=frozenset(), sink=lambda e: events.append(e))
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            with pytest.raises(OSError, match="denied UDP sendmsg"):
+                sock.sendmsg([b"x"], (), 0, ("10.0.0.1", 53))
+        finally:
+            sock.close()
+        assert any(e["decision"] == "deny" for e in events)
+
+
+class TestTcpGuard:
+    def test_connect_to_non_loopback_denied(self, restored_sockets):
+        events: list[dict[str, Any]] = []
+        egress_guard.install_default_deny_guard(role="test", allow=frozenset(), sink=lambda e: events.append(e))
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            with pytest.raises(OSError, match="denied egress"):
+                sock.connect(("10.0.0.1", 443))
+        finally:
+            sock.close()
+        assert any(e["decision"] == "deny" for e in events)
+
+    def test_dns_to_non_loopback_denied(self, restored_sockets):
+        events: list[dict[str, Any]] = []
+        egress_guard.install_default_deny_guard(role="test", allow=frozenset(), sink=lambda e: events.append(e))
+        with pytest.raises(OSError, match="denied DNS"):
+            socket.gethostbyname("10.0.0.1")
+        assert any(e["decision"] == "deny" for e in events)

--- a/backend/tests/unit/test_replay_harness_egress_guard.py
+++ b/backend/tests/unit/test_replay_harness_egress_guard.py
@@ -8,6 +8,7 @@ syscall.
 from __future__ import annotations
 
 import socket
+import contextlib
 from typing import Any
 
 import pytest
@@ -61,7 +62,7 @@ class TestUdpGuard:
         port = listener.getsockname()[1]
         try:
             egress_guard.install_default_deny_guard(
-                role="test", allow=frozenset({port}), sink=lambda e: events.append(e)
+                role="test", allow=frozenset({("127.0.0.1", port)}), sink=lambda e: events.append(e)
             )
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             try:
@@ -101,4 +102,71 @@ class TestTcpGuard:
         egress_guard.install_default_deny_guard(role="test", allow=frozenset(), sink=lambda e: events.append(e))
         with pytest.raises(OSError, match="denied DNS"):
             socket.gethostbyname("10.0.0.1")
+        assert any(e["decision"] == "deny" for e in events)
+
+
+# --------------------------------------------------------------------------- #
+# Final-review 2 — canonical host+port endpoint enforcement (not port-only)
+# --------------------------------------------------------------------------- #
+
+
+class TestHostPortEnforcement:
+    """The guard must enforce the declared canonical host+port endpoint identity,
+    not a port-only loopback set. When only 127.0.0.1 is declared, ``localhost``/``::1``
+    aliases on a declared port must be denied — matching the attestation layer.
+    """
+
+    def test_parse_allow_list_preserves_host_port(self):
+        """Parsing must preserve canonical (host, port) identity, not collapse to ports."""
+        parsed = egress_guard._parse_allow_list('[{"host": "127.0.0.1", "port": 6390}]')
+        assert ("127.0.0.1", 6390) in parsed
+        assert 6390 not in parsed  # a bare port entry must not exist
+
+    def test_guard_denies_localhost_alias_when_only_127_declared(self, restored_sockets):
+        events: list[dict[str, Any]] = []
+        allow = egress_guard._parse_allow_list('[{"host": "127.0.0.1", "port": 6390}]')
+        egress_guard.install_default_deny_guard(role="test", allow=allow, sink=lambda e: events.append(e))
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            with pytest.raises(OSError, match="denied egress"):
+                sock.connect(("localhost", 6390))
+        finally:
+            sock.close()
+        assert any(e["decision"] == "deny" for e in events)
+
+    def test_guard_denies_ipv6_alias_when_only_127_declared(self, restored_sockets):
+        events: list[dict[str, Any]] = []
+        allow = egress_guard._parse_allow_list('[{"host": "127.0.0.1", "port": 6390}]')
+        egress_guard.install_default_deny_guard(role="test", allow=allow, sink=lambda e: events.append(e))
+        sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        try:
+            with pytest.raises(OSError, match="denied egress"):
+                sock.connect(("::1", 6390, 0, 0))
+        finally:
+            sock.close()
+        assert any(e["decision"] == "deny" for e in events)
+
+    def test_guard_allows_canonical_declared_endpoint(self, restored_sockets):
+        events: list[dict[str, Any]] = []
+        allow = egress_guard._parse_allow_list('[{"host": "127.0.0.1", "port": 6390}]')
+        egress_guard.install_default_deny_guard(role="test", allow=allow, sink=lambda e: events.append(e))
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            # Nothing listens on 6390; the guard allows before the real connect fails.
+            with contextlib.suppress(OSError):
+                sock.connect(("127.0.0.1", 6390))
+        finally:
+            sock.close()
+        assert any(e["decision"] == "allow" and e["host"] == "127.0.0.1" for e in events)
+
+    def test_guard_denies_loopback_on_undeclared_port(self, restored_sockets):
+        events: list[dict[str, Any]] = []
+        allow = egress_guard._parse_allow_list('[{"host": "127.0.0.1", "port": 6390}]')
+        egress_guard.install_default_deny_guard(role="test", allow=allow, sink=lambda e: events.append(e))
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            with pytest.raises(OSError, match="denied egress"):
+                sock.connect(("127.0.0.1", 54321))
+        finally:
+            sock.close()
         assert any(e["decision"] == "deny" for e in events)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test:desktop-beta-admission:emulator": "bash backend/testing/desktop_beta_admission/run.sh",
     "test:listen-pusher-stack:emulator": "backend/testing/listen_pusher_stack/run.sh",
     "test:sync-cloud-tasks-stack:emulator": "backend/testing/sync_cloud_tasks_stack/run.sh",
+    "test:replay-harness-phase0a:emulator": "backend/testing/replay_harness_phase0a/run.sh",
     "test:memory-vector-repair-outbox:emulator": "firebase emulators:exec --only firestore --project demo-memory \"python3 backend/scripts/vector_repair_outbox_emulator_test.py\"",
     "test:memory-vector-repair-outbox-rules:emulator": "firebase emulators:exec --only firestore --project demo-memory \"node backend/scripts/firestore_rules_emulator_test.mjs\"",
     "test:memory-vector-repair-outbox-lease:emulator": "firebase emulators:exec --only firestore --project demo-memory \"python3 backend/scripts/vector_repair_outbox_lease_emulator_test.py\"",


### PR DESCRIPTION
## Feasibility outcome: GREEN/BOUNDED

The out-of-process architecture composes. A declarative topology contract launches the offline-sync SUT generically, a network Cloud Tasks loopback delivers to the worker, one sync job replay reaches a durable retrievable terminal, default-deny egress is verified by machine-verifiable attestation, and a declared fault is driven and observed black-box.

**Bounded:** the finalizer fake is feasibility-only. No claim of STT/LLM fidelity, persist-before-send, production Cloud Tasks equivalence, capture/WS transport, LC3, or release gate.

Fixes #10462

---

## What this PR proves (that the existing gauntlet cannot)

The existing `sync_cloud_tasks_stack` gauntlet already runs separate processes, but its topology is an opaque Python script, its Cloud Tasks recorder is in-memory inside the admission process, and its egress guard is loopback-only with no attestation. This PR externalizes all three:

| Capability | Existing gauntlet | Phase 0A |
|---|---|---|
| Topology | Opaque `run.py` script | Declarative `topology.json` consumed by a generic launcher (`runner.py`, zero sync-specific branching) |
| Cloud Tasks | In-memory recorder in admission process | Out-of-process HTTP scheduler service (third network process) |
| Egress | Loopback-only block (any loopback peer) | Default-deny + enumerated allow-list + machine-verifiable attestation |
| Fault injection | Env-counter monkeypatches | Declared fault controls in the topology contract |

## Scenario results

Both scenarios run against isolated topology instances (unique ports, project namespace, state roots).

### BASE (unmutated SUT, duplicate delivery)
- One PCM16 upload to admission, network loopback delivery to worker, Firestore/Redis processing, declared finalizer fake, durable retrievable terminal conversation
- STT invoked exactly once (idempotency holds with duplicate delivery)
- Zero denied egress attempts; all roles started and became ready

### MUTANT (terminal_guard_bypassed=true, duplicate delivery)
- The declared fault bypasses the worker's terminal-status guard (3 activations observed in evidence)
- The SUT's processed-segment ledger provides defense-in-depth: STT stays at 1
- This defense-in-depth discovery is a Phase 0A composition finding

## Commands and results

```bash
npm run test:replay-harness-phase0a:emulator
```

Output (exit 0):
```
  BASE: GREEN -- composition + idempotency verified
  MUTANT: GREEN -- declared fault driven and observed
  Attestation 0: VALID (outcome=feasible)
  Attestation 1: VALID (outcome=feasible)
  FEASIBILITY OUTCOME: GREEN/BOUNDED
```

`make preflight` -- all 9 checks pass.

## Feasibility-only labels (every fake/shortcut)

- Deterministic VAD/STT/process_conversation leaves: not fidelity oracles
- Cloud Tasks HTTP loopback: not a faithful control plane; `_tasks_client` seam required
- OIDC verifier: one exact local token (signature/issuer/expiry excluded)
- Local filesystem GCS fake: not production storage

## Non-goals (explicitly excluded)

- persist-before-send (residue until operation-scoped storage-fault seam exists)
- capture/WS transport coverage
- STT or LLM wire-fidelity oracle
- LC3 codec path
- client consumer harness
- broad scenario corpus
- release gate
- production Cloud Tasks control-plane fidelity

## CI wiring

- Non-merge-blocking: runs as an advisory job in `backend-hermetic-e2e.yml`, NOT in the merge-gate's `needs`
- The existing `sync_cloud_tasks_stack` gauntlet remains the blocking coverage -- untouched


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

