### PR TITLE
test(desktop): bound isolated Swift suites

### DIFF
--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -407,7 +407,7 @@ final class OnboardingFlowTests: XCTestCase {
     let secondBrainSource = try desktopSourceFile("Onboarding/SecondBrain/SBOnboardingView.swift")
     for title in ["Set up Omi →", "Continue"] {
       XCTAssertTrue(
-        secondBrainSource.contains("SBInkButton(title: \"\\(title)\", isDefaultAction: true)"),
+        secondBrainSource.contains("SBInkButton(title: \"\(title)\", isDefaultAction: true)"),
         "the second-brain \(title) action must accept Return")
     }
     XCTAssertEqual(

--- a/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/PushToTalkStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/PushToTalkStateMachineTests.swift
@@ -348,6 +348,7 @@ final class PushToTalkStateMachineTests: XCTestCase {
         allowAutomationOverride: false,
         plannedNextOwner: { _, _ in ownerID },
         retargetLocalStorage: { _, _ in },
+        prepareLocalStorageTransition: { _, _ in },
         ownerDidChange: {}
       ) { defaults in
         defaults.set(ownerID, forKey: .authUserId)

--- a/desktop/macos/changelog/unreleased/20260724-desktop-swift-ci-reliability.json
+++ b/desktop/macos/changelog/unreleased/20260724-desktop-swift-ci-reliability.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved desktop test reliability by isolating owner-transition fixtures and bounding stalled suites"
+}

--- a/desktop/macos/scripts/swift-test-suites.sh
+++ b/desktop/macos/scripts/swift-test-suites.sh
@@ -15,6 +15,7 @@ PACKAGE_PATH="${OMI_SWIFT_TEST_PACKAGE_PATH:-Desktop}"
 # diagnosis (`OMI_SWIFT_TEST_SUITE_WORKERS=1`).
 WORKERS="${OMI_SWIFT_TEST_SUITE_WORKERS:-${SWIFT_TEST_SUITE_WORKERS:-4}}"
 PREBUILD="${OMI_SWIFT_TEST_PREBUILD:-1}"
+SUITE_TIMEOUT_SECONDS="${OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS:-120}"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -26,6 +27,7 @@ run_suite() {
   local suite="$2"
   local log_path="$log_dir/$suite.log"
   local status_path="$log_dir/$suite.status"
+  local timeout_path="$log_dir/$suite.timeout"
   local -a skip_args=()
 
   while IFS= read -r skip_arg; do
@@ -40,8 +42,26 @@ run_suite() {
     command+=("${skip_args[@]}")
   fi
   set +e
-  "${command[@]}" >"$log_path" 2>&1
+  "${command[@]}" >"$log_path" 2>&1 &
+  local command_pid=$!
+  (
+    sleep "$SUITE_TIMEOUT_SECONDS"
+    if kill -0 "$command_pid" 2>/dev/null; then
+      touch "$timeout_path"
+      kill -TERM "$command_pid" 2>/dev/null || true
+      sleep 5
+      kill -KILL "$command_pid" 2>/dev/null || true
+    fi
+  ) &
+  local watchdog_pid=$!
+  wait "$command_pid"
   local status=$?
+  kill "$watchdog_pid" 2>/dev/null || true
+  wait "$watchdog_pid" 2>/dev/null || true
+  if [ -f "$timeout_path" ]; then
+    echo "suite timed out after ${SUITE_TIMEOUT_SECONDS}s" >>"$log_path"
+    status=124
+  fi
   set -e
   echo "$status" >"$status_path"
   exit "$status"
@@ -57,6 +77,11 @@ if [ "$WORKERS" -lt 1 ]; then
 fi
 if [ "$PREBUILD" != "0" ] && [ "$PREBUILD" != "1" ]; then
   fail "OMI_SWIFT_TEST_PREBUILD must be 0 or 1, got '$PREBUILD'"
+fi
+[[ "$SUITE_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] \
+  || fail "OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS must be a positive integer, got '$SUITE_TIMEOUT_SECONDS'"
+if [ "$SUITE_TIMEOUT_SECONDS" -lt 1 ]; then
+  fail "OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS must be at least 1"
 fi
 
 # Static guardrails are part of the authoritative Swift component suite, not a

--- a/desktop/macos/scripts/swift-test-suites.sh
+++ b/desktop/macos/scripts/swift-test-suites.sh
@@ -22,6 +22,19 @@ fail() {
   exit 1
 }
 
+terminate_process_tree() {
+  local pid="$1"
+  local signal="$2"
+  local children child
+  children="$(pgrep -P "$pid" 2>/dev/null || true)"
+  for child in $children; do
+    terminate_process_tree "$child" "$signal"
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "-$signal" "$pid" 2>/dev/null || true
+  fi
+}
+
 run_suite() {
   local log_dir="$1"
   local suite="$2"
@@ -48,9 +61,9 @@ run_suite() {
     sleep "$SUITE_TIMEOUT_SECONDS"
     if kill -0 "$command_pid" 2>/dev/null; then
       touch "$timeout_path"
-      kill -TERM "$command_pid" 2>/dev/null || true
+      terminate_process_tree "$command_pid" TERM
       sleep 5
-      kill -KILL "$command_pid" 2>/dev/null || true
+      terminate_process_tree "$command_pid" KILL
     fi
   ) &
   local watchdog_pid=$!

--- a/desktop/macos/tests/test-swift-test-suites.sh
+++ b/desktop/macos/tests/test-swift-test-suites.sh
@@ -97,8 +97,11 @@ if [ "$suite" = "AlphaTests" ]; then
   exit 42
 fi
 
-if [ "${FAKE_XCRUN_HANG_SUITE:-}" = "$suite" ]; then
-  sleep 5
+if [ -n "${FAKE_XCRUN_HANG_SUITE:-}" ] && [ "$FAKE_XCRUN_HANG_SUITE" = "$suite" ]; then
+  sleep 30 &
+  child_pid=$!
+  echo "$child_pid" >"$FAKE_XCRUN_HANG_CHILD_PID_PATH"
+  wait "$child_pid"
 fi
 
 echo "$suite passed"
@@ -146,6 +149,7 @@ fi
 
 export OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS=1
 export FAKE_XCRUN_HANG_SUITE=BetaTests
+export FAKE_XCRUN_HANG_CHILD_PID_PATH="$TMPDIR/hanging-child.pid"
 if "$RUNNER" >"$TMPDIR/timeout-runner.out" 2>"$TMPDIR/timeout-runner.err"; then
   fail "timeout fixture unexpectedly succeeded"
 fi
@@ -154,6 +158,13 @@ if ! grep -q -- "--- FAILED: BetaTests ---" "$TMPDIR/timeout-runner.out"; then
 fi
 if ! grep -q "suite timed out after 1s" "$TMPDIR/timeout-runner.out"; then
   fail "runner did not report the per-suite timeout"
+fi
+if [ ! -s "$FAKE_XCRUN_HANG_CHILD_PID_PATH" ]; then
+  fail "timeout fixture did not record its descendant process"
+fi
+hanging_child_pid="$(cat "$FAKE_XCRUN_HANG_CHILD_PID_PATH")"
+if kill -0 "$hanging_child_pid" 2>/dev/null; then
+  fail "runner left the timed-out suite's descendant process alive"
 fi
 
 echo "swift-test-suites tests passed"

--- a/desktop/macos/tests/test-swift-test-suites.sh
+++ b/desktop/macos/tests/test-swift-test-suites.sh
@@ -97,6 +97,10 @@ if [ "$suite" = "AlphaTests" ]; then
   exit 42
 fi
 
+if [ "${FAKE_XCRUN_HANG_SUITE:-}" = "$suite" ]; then
+  sleep 5
+fi
+
 echo "$suite passed"
 SH
 chmod +x "$TMPDIR/bin/xcrun"
@@ -138,6 +142,18 @@ if "$RUNNER" >"$TMPDIR/default-runner.out" 2>"$TMPDIR/default-runner.err"; then
 fi
 if ! grep -q "Ran 6 Swift suites in isolation with 4 worker(s)." "$TMPDIR/default-runner.out"; then
   fail "runner did not default local suite execution to four workers"
+fi
+
+export OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS=1
+export FAKE_XCRUN_HANG_SUITE=BetaTests
+if "$RUNNER" >"$TMPDIR/timeout-runner.out" 2>"$TMPDIR/timeout-runner.err"; then
+  fail "timeout fixture unexpectedly succeeded"
+fi
+if ! grep -q -- "--- FAILED: BetaTests ---" "$TMPDIR/timeout-runner.out"; then
+  fail "runner did not identify the timed-out suite"
+fi
+if ! grep -q "suite timed out after 1s" "$TMPDIR/timeout-runner.out"; then
+  fail "runner did not report the per-suite timeout"
 fi
 
 echo "swift-test-suites tests passed"


### PR DESCRIPTION
## What changed and why

The post-merge desktop Swift job for #10448 stalled inside the aggregate suite command with no suite name, consuming the full one-hour timeout. This PR:

- bounds every isolated XCTest suite to 120 seconds and reports the suite name
- terminates the timed-out suite's whole process tree so a surviving SwiftPM child cannot hold the shared build lock
- keeps synthetic Push-to-Talk owner-transition tests off the production Rewind storage reset path
- fixes the onboarding default-action assertion so it interpolates the button title it intends to inspect

## Verification

- `bash desktop/macos/tests/test-swift-test-suites.sh` — passed; the fixture proves a timed-out suite is named and its descendant process is gone
- `PushToTalkStateMachineTests` — 50/50 complete suite runs passed
- `OnboardingFlowTests/testOnboardingProceedActionsUseDefaultActionKeyboardShortcut` — 50/50 runs passed
- `shellcheck desktop/macos/scripts/swift-test-suites.sh desktop/macos/tests/test-swift-test-suites.sh` — passed
- `make preflight` — passed

## Product invariants

None; this changes only desktop test execution and test fixtures.

## Changelog

`desktop/macos/changelog/unreleased/20260724-desktop-swift-ci-reliability.json`
