### PR TITLE
fix(desktop): select Calendar host-scoped auth cookie

### DIFF
--- a/desktop/macos/Desktop/Sources/BrowserGoogleSession.swift
+++ b/desktop/macos/Desktop/Sources/BrowserGoogleSession.swift
@@ -11,6 +11,7 @@ struct BrowserGoogleSession: Equatable {
   static let chromiumCookiePythonSupport = """
     import sys, json, os, sqlite3, hashlib, time
     from http.cookiejar import MozillaCookieJar, Cookie
+    from urllib.request import Request
 
     try:
         from Crypto.Cipher import AES
@@ -113,6 +114,24 @@ struct BrowserGoogleSession: Equatable {
             )
             jar.set_cookie(cookie)
         return jar
+
+    def cookie_value_for_request(jar, url, names):
+        # A Chromium profile can keep same-named Google cookies with different
+        # host scopes. Derive the value from the exact Cookie header this jar
+        # would send to `url`; querying the decrypted SQLite rows directly is
+        # unordered and can select a cookie Google will not receive.
+        request = Request(url)
+        jar.add_cookie_header(request)
+        cookie_header = request.get_header('Cookie') or ''
+        values = {}
+        for item in cookie_header.split(';'):
+            name, separator, value = item.strip().partition('=')
+            if separator and name not in values:
+                values[name] = value
+        for name in names:
+            if name in values:
+                return values[name]
+        return None
 
     def write_json_result(prefix, payload):
         import tempfile

--- a/desktop/macos/Desktop/Sources/CalendarReaderService.swift
+++ b/desktop/macos/Desktop/Sources/CalendarReaderService.swift
@@ -553,27 +553,11 @@ actor CalendarReaderService {
           except Exception:
               return None
 
-      def fetch_calendar_events(jar, cookies_list, days_back, days_forward, max_results):
+      def fetch_calendar_events(jar, days_back, days_forward, max_results):
           # Returns (events, error, http_status). http_status lets the caller
           # distinguish an expired session (401/403) from a transient network
           # failure so the user gets the right recovery step (philosophy §3).
-          # Find SAPISID cookie
-          sapisid = None
-          for c in cookies_list:
-              if c['name'] == 'SAPISID':
-                  sapisid = c['value']
-                  break
-          if not sapisid:
-              # Try __Secure-3PAPISID
-              for c in cookies_list:
-                  if c['name'] == '__Secure-3PAPISID':
-                      sapisid = c['value']
-                      break
-          if not sapisid:
-              return None, "No SAPISID cookie found", None
-
           origin = "https://calendar.google.com"
-          auth_header = get_sapisidhash(sapisid, origin)
 
           now = datetime.now(timezone.utc)
           time_min = (now - timedelta(days=days_back)).strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -595,6 +579,16 @@ actor CalendarReaderService {
                   url += f"&pageToken={urllib.parse.quote(page_token)}"
 
               req = urllib.request.Request(url)
+              # The SAPISIDHASH must use the same host-scoped cookie Chrome
+              # would send to clients6.google.com. Selecting the first
+              # same-named cookie from SQLite can hash a cookie from a
+              # different Google host and make a live browser session look
+              # expired.
+              sapisid = cookie_value_for_request(
+                  jar, url, ('SAPISID', '__Secure-3PAPISID'))
+              if not sapisid:
+                  return None, "No SAPISID cookie applicable to Calendar found", None
+              auth_header = get_sapisidhash(sapisid, origin)
               req.add_header('Authorization', auth_header)
               req.add_header('Origin', origin)
               req.add_header('Referer', 'https://calendar.google.com/')
@@ -675,7 +669,7 @@ actor CalendarReaderService {
               continue
 
           jar = make_cookie_jar(cookies)
-          events, fetch_err, http_status = fetch_calendar_events(jar, cookies, days_back, days_forward, max_results)
+          events, fetch_err, http_status = fetch_calendar_events(jar, days_back, days_forward, max_results)
           if fetch_err or events is None:
               attempts.append({'browser': browser['name'], 'stage': 'fetch',
                                'reason': (fetch_err or 'unknown fetch error'),

--- a/desktop/macos/Desktop/Tests/BrowserGoogleSessionTests.swift
+++ b/desktop/macos/Desktop/Tests/BrowserGoogleSessionTests.swift
@@ -113,4 +113,41 @@ final class BrowserGoogleSessionTests: XCTestCase {
       String(data: result.stderr, encoding: .utf8) ?? "Python cookie check failed"
     )
   }
+
+  func testRequestCookieValueUsesOnlyCookiesApplicableToTheTargetHost() throws {
+    let script =
+      BrowserGoogleSession.chromiumCookiePythonSupport + """
+
+        cookies = [
+            {
+                'domain': 'accounts.google.com',
+                'name': 'SAPISID',
+                'value': 'wrong-host-cookie',
+                'path': '/',
+                'secure': True,
+            },
+            {
+                'domain': '.google.com',
+                'name': 'SAPISID',
+                'value': 'calendar-cookie',
+                'path': '/',
+                'secure': True,
+            },
+        ]
+        jar = make_cookie_jar(cookies)
+        value = cookie_value_for_request(
+            jar,
+            'https://clients6.google.com/calendar/v3/calendars/primary/events',
+            ('SAPISID', '__Secure-3PAPISID'),
+        )
+        assert value == 'calendar-cookie', value
+        """
+
+    let result = try BrowserPythonRunner.run(script: script, arguments: [])
+    XCTAssertEqual(
+      result.terminationStatus,
+      0,
+      String(data: result.stderr, encoding: .utf8) ?? "Python cookie selection check failed"
+    )
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260724-calendar-host-scoped-cookie.json
+++ b/desktop/macos/changelog/unreleased/20260724-calendar-host-scoped-cookie.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Google Calendar imports incorrectly treating a valid browser session as expired when profiles contain host-scoped Google cookies"
+}


### PR DESCRIPTION
## Summary

- Correct Calendar's SAPISIDHASH input to use the host-scoped Google cookie that the request will actually send to `clients6.google.com`.
- Add a regression test for profiles that contain same-named cookies from multiple Google host scopes.
- Preserve Gmail behavior; the supplied evidence shows Gmail successfully imported 135 emails and completed synthesis.

## Root cause

Calendar read the first `SAPISID` from an unordered Chromium cookie query, then used it to sign the Calendar request. A profile can contain same-named Google cookies for different hosts. When the selected cookie was not applicable to the Calendar API host, Google rejected the signature and the app reported `session_expired`, despite a browser session that Gmail could use.

## Product invariants

- INV-INT-1

## Failure class

Failure-Class: none

This is a one-off third-party browser-cookie compatibility defect. No registered failure class applies, and this scoped regression test is the appropriate guard surface.

## Verification

- Passed: direct execution of the embedded production Python helper with an `accounts.google.com` decoy `SAPISID` and a `.google.com` Calendar cookie; it selected only the host-applicable cookie.
- Passed: `desktop/macos/scripts/swift-format-wrapper.sh lint Desktop/Sources/BrowserGoogleSession.swift Desktop/Sources/CalendarReaderService.swift Desktop/Tests/BrowserGoogleSessionTests.swift`
- Passed: `python3 desktop/macos/scripts/check_desktop_test_quality.py`
- Attempted: `xcrun swift test --package-path Desktop --filter BrowserGoogleSessionTests/` from `desktop/macos`; blocked before compilation because SwiftPM could not fetch `google-ads-on-device-conversion-ios-sdk` and could not map cached ONNX Runtime/Sparkle binary artifacts.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

