### PR TITLE
SCA-93: admit exact gateway production release SHA

### DIFF
--- a/.github/scripts/check-direct-backend-production-admission.py
+++ b/.github/scripts/check-direct-backend-production-admission.py
@@ -19,6 +19,61 @@ HEAD_IDENTITY = "CHECKED_OUT_SHA=$(git rev-parse HEAD)"
 IMAGE_IDENTITY = 'IMAGE_TAG=$(git rev-parse --short=7 "$CHECKED_OUT_SHA")'
 DIAGNOSTIC = "ERROR: checked-out HEAD $CHECKED_OUT_SHA is not an ancestor of fresh origin/main"
 PERSISTED_IMAGE_IDENTITY = 'echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_ENV"'
+GATEWAY_WORKFLOW = Path(".github/workflows/gcp_llm_gateway.yml")
+GATEWAY_RELEASE_SHA_INPUT = (
+    "      release_sha:\n"
+    "        description: 'Production only: exact main SHA with a successful first-attempt Release Eligibility proof'\n"
+    "        required: false\n"
+    "        default: ''"
+)
+
+
+def validate_gateway_release_admission(text: str) -> list[str]:
+    """Require the standalone gateway's production SHA to use the shared proof gate."""
+
+    errors: list[str] = []
+    for fragment, message in (
+        (GATEWAY_RELEASE_SHA_INPUT, "gateway deploy must expose a production-only release_sha input"),
+        (
+            "ref: ${{ github.event.inputs.environment == 'prod' && 'main' || github.event.inputs.branch }}",
+            "gateway development deploy must retain its branch checkout while production starts from main",
+        ),
+        (
+            "sha_pattern='^[0-9a-f]{40}$'",
+            "gateway production admission must reject malformed or missing release_sha",
+        ),
+        (
+            '[[ ! "$DEPLOY_SHA" =~ $sha_pattern || "$DEPLOY_SHA" == "0000000000000000000000000000000000000000" ]]',
+            "gateway production admission must reject malformed or missing release_sha",
+        ),
+        (
+            'git cat-file -e "${DEPLOY_SHA}^{commit}"',
+            "gateway production admission must require the requested SHA commit object",
+        ),
+        (
+            'git merge-base --is-ancestor "$DEPLOY_SHA" "$main_sha"',
+            "gateway production admission must require release_sha to be merged into fresh main",
+        ),
+        (
+            "actions/workflows/release-eligibility.yml/runs?event=push&branch=main&status=completed&head_sha=${DEPLOY_SHA}",
+            "gateway production admission must query Release Eligibility for the exact SHA",
+        ),
+        (
+            ".github/scripts/verify_backend_release_admission.py",
+            "gateway production admission must verify the Release Eligibility proof",
+        ),
+        (
+            'git checkout --detach "$DEPLOY_SHA"',
+            "gateway production admission must check out the admitted SHA",
+        ),
+        (
+            '"$CHECKED_OUT_SHA" != "$DEPLOY_SHA"',
+            "gateway production admission must bind image identity to the admitted checkout",
+        ),
+    ):
+        if fragment not in text:
+            errors.append(message)
+    return errors
 
 
 def validate(root: Path) -> list[str]:
@@ -55,6 +110,8 @@ def validate(root: Path) -> list[str]:
             or persistent_image_writes != [PERSISTED_IMAGE_IDENTITY]
         ):
             errors.append(f"{relative} must establish its immutable image tag exactly once from checked-out HEAD")
+        if relative == GATEWAY_WORKFLOW:
+            errors.extend(validate_gateway_release_admission(text))
     return errors
 
 

--- a/.github/scripts/check-direct-backend-production-admission.py
+++ b/.github/scripts/check-direct-backend-production-admission.py
@@ -80,6 +80,43 @@ def validate_gateway_release_admission(text: str) -> list[str]:
     return errors
 
 
+def validate_gateway_break_glass_hatch(text: str) -> list[str]:
+    """Pin the gateway eligibility-proof break-glass hatch properties.
+
+    Every gated surface must have a break-glass hatch (AGENTS.md). The hatch
+    may skip the eligibility proof, never the ancestry check, and its use must
+    be recorded as a tracking issue. These are static tripwires, not behavioral
+    coverage.
+    """
+
+    errors: list[str] = []
+    for fragment, message in (
+        (
+            "skip_eligibility_proof:\n        description: 'Break-glass: deploy without a Release Eligibility proof (still requires a merged main SHA)'",
+            "gateway deploy must expose a skip_eligibility_proof break-glass input",
+        ),
+        (
+            '!= "deploy-without-proof"',
+            "gateway break-glass must require an explicit confirm string",
+        ),
+        (
+            "requires a non-empty break_glass_reason",
+            "gateway break-glass must require a non-empty reason",
+        ),
+        (
+            'record_break_glass:',
+            "gateway break-glass use must be recorded by a dedicated job",
+        ),
+        (
+            "release-gate-failure",
+            "gateway break-glass tracking issue must carry the release-gate-failure label",
+        ),
+    ):
+        if fragment not in text:
+            errors.append(message)
+    return errors
+
+
 def validate(root: Path) -> list[str]:
     errors: list[str] = []
     for relative in WORKFLOWS:
@@ -116,6 +153,7 @@ def validate(root: Path) -> list[str]:
             errors.append(f"{relative} must establish its immutable image tag exactly once from checked-out HEAD")
         if relative == GATEWAY_WORKFLOW:
             errors.extend(validate_gateway_release_admission(text))
+            errors.extend(validate_gateway_break_glass_hatch(text))
     return errors
 
 

--- a/.github/scripts/check-direct-backend-production-admission.py
+++ b/.github/scripts/check-direct-backend-production-admission.py
@@ -63,6 +63,10 @@ def validate_gateway_release_admission(text: str) -> list[str]:
             "gateway production admission must verify the Release Eligibility proof",
         ),
         (
+            "--require-first-attempt",
+            "gateway production admission must reject Release Eligibility reruns",
+        ),
+        (
             'git checkout --detach "$DEPLOY_SHA"',
             "gateway production admission must check out the admitted SHA",
         ),

--- a/.github/scripts/test_check_backend_deploy_source_admission.py
+++ b/.github/scripts/test_check_backend_deploy_source_admission.py
@@ -64,6 +64,18 @@ class ReleaseAdmissionVerifierTests(unittest.TestCase):
             repository=REPOSITORY,
         )
 
+    def test_backend_default_accepts_successful_rerun(self) -> None:
+        VERIFIER.validate_admission(self.payload(run_attempt=2), sha=SHA, repository=REPOSITORY)
+
+    def test_gateway_first_attempt_mode_rejects_rerun(self) -> None:
+        with self.assertRaisesRegex(VERIFIER.ReleaseAdmissionError, "no successful main"):
+            VERIFIER.validate_admission(
+                self.payload(run_attempt=2),
+                sha=SHA,
+                repository=REPOSITORY,
+                require_first_attempt=True,
+            )
+
     def test_rejects_ambiguous_release_sha(self) -> None:
         for value in ("main", "a" * 7, "A" * 40, "0" * 40):
             with self.subTest(value=value), self.assertRaisesRegex(VERIFIER.ReleaseAdmissionError, "release SHA"):
@@ -76,7 +88,6 @@ class ReleaseAdmissionVerifierTests(unittest.TestCase):
             ("event", {"event": "pull_request"}),
             ("status", {"status": "in_progress"}),
             ("conclusion", {"conclusion": "failure"}),
-            ("rerun", {"run_attempt": 2}),
             ("branch", {"head_branch": "release"}),
             ("sha", {"head_sha": "b" * 40}),
             ("repository", {"head_repository": {"full_name": "fork/omi"}}),

--- a/.github/scripts/test_check_backend_deploy_source_admission.py
+++ b/.github/scripts/test_check_backend_deploy_source_admission.py
@@ -10,7 +10,6 @@ import tempfile
 import unittest
 from pathlib import Path
 
-
 SCRIPT_DIR = Path(__file__).resolve().parent
 ROOT = SCRIPT_DIR.parents[1]
 CHECKER_PATH = SCRIPT_DIR / "check_backend_deploy_source_admission.py"
@@ -42,6 +41,7 @@ def admitted_run(**overrides: object) -> dict[str, object]:
         "event": "push",
         "status": "completed",
         "conclusion": "success",
+        "run_attempt": 1,
         "head_branch": "main",
         "head_sha": SHA,
         "head_repository": {"full_name": REPOSITORY},
@@ -76,6 +76,7 @@ class ReleaseAdmissionVerifierTests(unittest.TestCase):
             ("event", {"event": "pull_request"}),
             ("status", {"status": "in_progress"}),
             ("conclusion", {"conclusion": "failure"}),
+            ("rerun", {"run_attempt": 2}),
             ("branch", {"head_branch": "release"}),
             ("sha", {"head_sha": "b" * 40}),
             ("repository", {"head_repository": {"full_name": "fork/omi"}}),
@@ -169,14 +170,26 @@ class WorkflowContractTests(unittest.TestCase):
 
         root = self.fixture_root()
         self.mutate(root, CHECKER.AUTO_WORKFLOW_PATH, 'workflows: ["Release Eligibility"]', 'workflows: ["Build"]')
-        self.assertIn("auto backend deploy must consume completed Release Eligibility runs on main", CHECKER.validate(root))
+        self.assertIn(
+            "auto backend deploy must consume completed Release Eligibility runs on main", CHECKER.validate(root)
+        )
 
     def test_auto_workflow_rejects_wrong_event_conclusion_branch_or_repository(self) -> None:
         cases = (
             ("event", "workflow_run.event == 'push'", "workflow_run.event == 'pull_request'", "push-originated"),
-            ("conclusion", "workflow_run.conclusion == 'success'", "workflow_run.conclusion == 'failure'", "successful Release Eligibility"),
+            (
+                "conclusion",
+                "workflow_run.conclusion == 'success'",
+                "workflow_run.conclusion == 'failure'",
+                "successful Release Eligibility",
+            ),
             ("rerun", "workflow_run.run_attempt == 1", "workflow_run.run_attempt == 2", "first run attempt"),
-            ("branch", "workflow_run.head_branch == 'main'", "workflow_run.head_branch == 'release'", "main Release Eligibility"),
+            (
+                "branch",
+                "workflow_run.head_branch == 'main'",
+                "workflow_run.head_branch == 'release'",
+                "main Release Eligibility",
+            ),
             (
                 "repository",
                 "workflow_run.head_repository.full_name == github.repository",
@@ -190,8 +203,7 @@ class WorkflowContractTests(unittest.TestCase):
                 self.mutate(root, CHECKER.AUTO_WORKFLOW_PATH, old, new)
                 self.assertTrue(
                     any(
-                        expected in error
-                        or "exactly the fail-closed Release Eligibility predicate" in error
+                        expected in error or "exactly the fail-closed Release Eligibility predicate" in error
                         for error in CHECKER.validate(root)
                     )
                 )
@@ -526,11 +538,15 @@ class WorkflowContractTests(unittest.TestCase):
     def test_manual_workflow_rejects_arbitrary_branch_or_missing_proof_query(self) -> None:
         root = self.fixture_root()
         self.mutate(root, CHECKER.MANUAL_WORKFLOW_PATH, "      release_sha:\n", "      branch:\n")
-        self.assertIn("manual backend deploy must keep release_sha optional for traffic-only repair", CHECKER.validate(root))
+        self.assertIn(
+            "manual backend deploy must keep release_sha optional for traffic-only repair", CHECKER.validate(root)
+        )
 
         root = self.fixture_root()
         self.mutate(root, CHECKER.MANUAL_WORKFLOW_PATH, "        required: false", "        required: true")
-        self.assertIn("manual backend deploy must keep release_sha optional for traffic-only repair", CHECKER.validate(root))
+        self.assertIn(
+            "manual backend deploy must keep release_sha optional for traffic-only repair", CHECKER.validate(root)
+        )
 
         root = self.fixture_root()
         self.mutate(
@@ -604,7 +620,12 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("traffic-only repair must use exactly the main-ref recovery condition", CHECKER.validate(root))
 
         root = self.fixture_root()
-        self.mutate(root, CHECKER.MANUAL_WORKFLOW_PATH, "          ref: main", "          ref: ${{ github.event.inputs.release_sha }}")
+        self.mutate(
+            root,
+            CHECKER.MANUAL_WORKFLOW_PATH,
+            "          ref: main",
+            "          ref: ${{ github.event.inputs.release_sha }}",
+        )
         self.assertIn("traffic-only repair must not require a release-source admission", CHECKER.validate(root))
 
 

--- a/.github/scripts/test_check_direct_backend_production_admission.py
+++ b/.github/scripts/test_check_direct_backend_production_admission.py
@@ -117,6 +117,48 @@ class DirectBackendProductionAdmissionTests(unittest.TestCase):
                 target.write_text(text.replace(old, new, 1), encoding="utf-8")
                 self.assertIn(expected, CHECKER.validate(root))
 
+    def test_gateway_rejects_break_glass_hatch_removals(self) -> None:
+        mutations = (
+            (
+                "        description: 'Break-glass: deploy without a Release Eligibility proof (still requires a merged main SHA)'",
+                "        description: 'removed'",
+                "gateway deploy must expose a skip_eligibility_proof break-glass input",
+            ),
+            (
+                '!= "deploy-without-proof"',
+                '!= "nothing"',
+                "gateway break-glass must require an explicit confirm string",
+            ),
+            (
+                "requires a non-empty break_glass_reason",
+                "requires nothing",
+                "gateway break-glass must require a non-empty reason",
+            ),
+            (
+                "  record_break_glass:",
+                "  removed_break_glass:",
+                "gateway break-glass use must be recorded by a dedicated job",
+            ),
+            (
+                "--label release-gate-failure",
+                "--label removed",
+                "gateway break-glass tracking issue must carry the release-gate-failure label",
+            ),
+        )
+        for old, new, expected in mutations:
+            with self.subTest(expected=expected), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                for relative in CHECKER.WORKFLOWS:
+                    source = ROOT / relative
+                    target = root / relative
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(source, target)
+                target = root / CHECKER.GATEWAY_WORKFLOW
+                text = target.read_text(encoding="utf-8")
+                self.assertIn(old, text)
+                target.write_text(text.replace(old, new, 1), encoding="utf-8")
+                self.assertIn(expected, CHECKER.validate(root))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_check_direct_backend_production_admission.py
+++ b/.github/scripts/test_check_direct_backend_production_admission.py
@@ -93,6 +93,11 @@ class DirectBackendProductionAdmissionTests(unittest.TestCase):
                 "gateway production admission must verify the Release Eligibility proof",
             ),
             (
+                "--require-first-attempt",
+                "",
+                "gateway production admission must reject Release Eligibility reruns",
+            ),
+            (
                 'git checkout --detach "$DEPLOY_SHA"',
                 'git checkout --detach main',
                 "gateway production admission must check out the admitted SHA",

--- a/.github/scripts/test_check_direct_backend_production_admission.py
+++ b/.github/scripts/test_check_direct_backend_production_admission.py
@@ -70,6 +70,48 @@ class DirectBackendProductionAdmissionTests(unittest.TestCase):
                     target.write_text(target.read_text(encoding="utf-8") + "\n" + mutation, encoding="utf-8")
                     self.assertTrue(CHECKER.validate(root))
 
+    def test_gateway_rejects_release_sha_admission_bypasses(self) -> None:
+        mutations = (
+            (
+                CHECKER.GATEWAY_RELEASE_SHA_INPUT,
+                "",
+                "gateway deploy must expose a production-only release_sha input",
+            ),
+            (
+                '[[ ! "$DEPLOY_SHA" =~ $sha_pattern || "$DEPLOY_SHA" == "0000000000000000000000000000000000000000" ]]',
+                '[[ -z "$DEPLOY_SHA" ]]',
+                "gateway production admission must reject malformed or missing release_sha",
+            ),
+            (
+                'git merge-base --is-ancestor "$DEPLOY_SHA" "$main_sha"',
+                'git merge-base --is-ancestor HEAD "$main_sha"',
+                "gateway production admission must require release_sha to be merged into fresh main",
+            ),
+            (
+                ".github/scripts/verify_backend_release_admission.py",
+                "true # proof bypass",
+                "gateway production admission must verify the Release Eligibility proof",
+            ),
+            (
+                'git checkout --detach "$DEPLOY_SHA"',
+                'git checkout --detach main',
+                "gateway production admission must check out the admitted SHA",
+            ),
+        )
+        for old, new, expected in mutations:
+            with self.subTest(expected=expected), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                for relative in CHECKER.WORKFLOWS:
+                    source = ROOT / relative
+                    target = root / relative
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(source, target)
+                target = root / CHECKER.GATEWAY_WORKFLOW
+                text = target.read_text(encoding="utf-8")
+                self.assertIn(old, text)
+                target.write_text(text.replace(old, new, 1), encoding="utf-8")
+                self.assertIn(expected, CHECKER.validate(root))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/verify_backend_release_admission.py
+++ b/.github/scripts/verify_backend_release_admission.py
@@ -40,7 +40,7 @@ def _is_release_workflow_path(value: object) -> bool:
     return value in {RELEASE_WORKFLOW_PATH, f"{RELEASE_WORKFLOW_PATH}@{MAIN_BRANCH}"}
 
 
-def is_admitted_run(run: object, *, sha: str, repository: str) -> bool:
+def is_admitted_run(run: object, *, sha: str, repository: str, require_first_attempt: bool = False) -> bool:
     """Return whether one REST workflow-run record proves the requested SHA."""
 
     if not isinstance(run, dict):
@@ -51,14 +51,14 @@ def is_admitted_run(run: object, *, sha: str, repository: str) -> bool:
         and run.get("event") == "push"
         and run.get("status") == "completed"
         and run.get("conclusion") == "success"
-        and run.get("run_attempt") == 1
+        and (not require_first_attempt or run.get("run_attempt") == 1)
         and run.get("head_branch") == MAIN_BRANCH
         and run.get("head_sha") == sha
         and _head_repository_name(run) == repository
     )
 
 
-def validate_admission(payload: object, *, sha: str, repository: str) -> None:
+def validate_admission(payload: object, *, sha: str, repository: str, require_first_attempt: bool = False) -> None:
     """Require an exact successful main proof from the canonical workflow."""
 
     require_full_sha(sha)
@@ -69,7 +69,10 @@ def validate_admission(payload: object, *, sha: str, repository: str) -> None:
     runs = payload.get("workflow_runs")
     if not isinstance(runs, list):
         raise ReleaseAdmissionError("workflow-run response is missing workflow_runs")
-    if not any(is_admitted_run(run, sha=sha, repository=repository) for run in runs):
+    if not any(
+        is_admitted_run(run, sha=sha, repository=repository, require_first_attempt=require_first_attempt)
+        for run in runs
+    ):
         raise ReleaseAdmissionError(
             "release SHA has no successful main Release Eligibility workflow run from this repository"
         )
@@ -80,6 +83,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--sha", required=True)
     parser.add_argument("--repository", required=True)
     parser.add_argument("--workflow-runs", type=Path, required=True)
+    parser.add_argument("--require-first-attempt", action="store_true")
     return parser.parse_args()
 
 
@@ -87,7 +91,12 @@ def main() -> int:
     args = parse_args()
     try:
         payload = json.loads(args.workflow_runs.read_text(encoding="utf-8"))
-        validate_admission(payload, sha=args.sha, repository=args.repository)
+        validate_admission(
+            payload,
+            sha=args.sha,
+            repository=args.repository,
+            require_first_attempt=args.require_first_attempt,
+        )
     except (OSError, json.JSONDecodeError, ReleaseAdmissionError) as exc:
         print(f"backend release admission failed: {exc}", file=sys.stderr)
         return 1

--- a/.github/scripts/verify_backend_release_admission.py
+++ b/.github/scripts/verify_backend_release_admission.py
@@ -10,7 +10,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 MAIN_BRANCH = "main"
 RELEASE_WORKFLOW_NAME = "Release Eligibility"
 RELEASE_WORKFLOW_PATH = ".github/workflows/release-eligibility.yml"
@@ -52,6 +51,7 @@ def is_admitted_run(run: object, *, sha: str, repository: str) -> bool:
         and run.get("event") == "push"
         and run.get("status") == "completed"
         and run.get("conclusion") == "success"
+        and run.get("run_attempt") == 1
         and run.get("head_branch") == MAIN_BRANCH
         and run.get("head_sha") == sha
         and _head_repository_name(run) == repository

--- a/.github/workflows/gcp_llm_gateway.yml
+++ b/.github/workflows/gcp_llm_gateway.yml
@@ -15,6 +15,28 @@ on:
         description: 'Production only: exact main SHA with a successful first-attempt Release Eligibility proof'
         required: false
         default: ''
+      # Break-glass: the eligibility proof requires a *successful*
+      # first-attempt Release Eligibility push-run on this exact SHA. A flaky
+      # or red check therefore poisons that SHA permanently -- rerunning does
+      # not retroactively make the original run succeed, so the only other
+      # recovery is pushing a new commit to main and waiting for a full green
+      # run. That is unacceptable for a hotfix, so this hatch exists.
+      #
+      # It does NOT relax the property that matters: the SHA must still be an
+      # ancestor of main, so unreviewed code can never reach production.
+      skip_eligibility_proof:
+        description: 'Break-glass: deploy without a Release Eligibility proof (still requires a merged main SHA)'
+        required: false
+        default: false
+        type: boolean
+      break_glass_confirm:
+        description: 'Type deploy-without-proof when skip_eligibility_proof is set'
+        required: false
+        default: ''
+      break_glass_reason:
+        description: 'Why the eligibility proof is unavailable (required with skip_eligibility_proof)'
+        required: false
+        default: ''
 
 # LLM Gateway deployment reapplies shared backend-secrets, so it joins the
 # full backend mutation domain for the selected environment.
@@ -35,6 +57,9 @@ jobs:
       id-token: 'write'
 
     runs-on: ubuntu-latest
+    outputs:
+      break_glass: ${{ steps.admitted_source.outputs.break_glass }}
+      admitted_sha: ${{ steps.admitted_source.outputs.admitted_sha }}
     steps:
       - name: Validate Environment Input
         run: |
@@ -54,9 +79,13 @@ jobs:
           fetch-depth: 0
 
       - name: Admit production source and image identity
+        id: admitted_source
         env:
           DEPLOY_SHA: ${{ github.event.inputs.release_sha }}
           DEPLOY_ENVIRONMENT: ${{ github.event.inputs.environment }}
+          SKIP_PROOF: ${{ github.event.inputs.skip_eligibility_proof }}
+          BREAK_GLASS_CONFIRM: ${{ github.event.inputs.break_glass_confirm }}
+          BREAK_GLASS_REASON: ${{ github.event.inputs.break_glass_reason }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -69,19 +98,36 @@ jobs:
             git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
             main_sha="$(git rev-parse --verify 'origin/main^{commit}')"
             git cat-file -e "${DEPLOY_SHA}^{commit}"
+
+            # Always enforced, break-glass or not: only merged main code deploys.
             if ! git merge-base --is-ancestor "$DEPLOY_SHA" "$main_sha"; then
               echo "ERROR: release_sha is not an ancestor of fresh origin/main; only merged code may deploy." >&2
               exit 1
             fi
-            proof_path="${RUNNER_TEMP}/release-eligibility-${DEPLOY_SHA}.json"
-            gh api -H "Accept: application/vnd.github+json" \
-              "repos/${GITHUB_REPOSITORY}/actions/workflows/release-eligibility.yml/runs?event=push&branch=main&status=completed&head_sha=${DEPLOY_SHA}&per_page=100" \
-              > "$proof_path"
-            python3 .github/scripts/verify_backend_release_admission.py \
-              --sha "$DEPLOY_SHA" \
-              --repository "$GITHUB_REPOSITORY" \
-              --workflow-runs "$proof_path" \
-              --require-first-attempt
+
+            if [[ "${SKIP_PROOF:-false}" == "true" ]]; then
+              if [[ "$BREAK_GLASS_CONFIRM" != "deploy-without-proof" ]]; then
+                echo "ERROR: skip_eligibility_proof requires break_glass_confirm=deploy-without-proof." >&2
+                exit 1
+              fi
+              if [[ -z "${BREAK_GLASS_REASON// }" ]]; then
+                echo "ERROR: skip_eligibility_proof requires a non-empty break_glass_reason." >&2
+                exit 1
+              fi
+              echo "::warning::Release Eligibility proof skipped for ${DEPLOY_SHA}: ${BREAK_GLASS_REASON}"
+              printf 'break_glass=true\n' >> "$GITHUB_OUTPUT"
+            else
+              proof_path="${RUNNER_TEMP}/release-eligibility-${DEPLOY_SHA}.json"
+              gh api -H "Accept: application/vnd.github+json" \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/release-eligibility.yml/runs?event=push&branch=main&status=completed&head_sha=${DEPLOY_SHA}&per_page=100" \
+                > "$proof_path"
+              python3 .github/scripts/verify_backend_release_admission.py \
+                --sha "$DEPLOY_SHA" \
+                --repository "$GITHUB_REPOSITORY" \
+                --workflow-runs "$proof_path" \
+                --require-first-attempt
+              printf 'break_glass=false\n' >> "$GITHUB_OUTPUT"
+            fi
             git checkout --detach "$DEPLOY_SHA"
           fi
           CHECKED_OUT_SHA=$(git rev-parse HEAD)
@@ -97,6 +143,9 @@ jobs:
           echo "Admitted deployment source: $CHECKED_OUT_SHA"
           echo "CHECKED_OUT_SHA=$CHECKED_OUT_SHA" >> "$GITHUB_ENV"
           echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_ENV"
+          if [[ "$DEPLOY_ENVIRONMENT" == prod ]]; then
+            printf 'admitted_sha=%s\n' "$DEPLOY_SHA" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Google Auth
         id: auth
@@ -194,3 +243,34 @@ jobs:
 
       - name: Show Output
         run: echo "LLM Gateway deployed to ${{ github.event.inputs.environment }}"
+
+  record_break_glass:
+    needs: deploy
+    if: ${{ needs.deploy.outputs.break_glass == 'true' }}
+    permissions:
+      contents: 'read'
+      issues: 'write'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record that the eligibility proof was bypassed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          DEPLOY_SHA: ${{ needs.deploy.outputs.admitted_sha }}
+          DEPLOY_ENVIRONMENT: ${{ github.event.inputs.environment }}
+          BREAK_GLASS_REASON: ${{ github.event.inputs.break_glass_reason }}
+        run: |
+          set -euo pipefail
+          gh issue create --repo "$REPO" \
+            --title "Release Eligibility bypassed for ${DEPLOY_SHA:0:10} (${DEPLOY_ENVIRONMENT})" \
+            --label release-gate-failure \
+            --body "$(printf '%s\n' \
+              "LLM Gateway deploy ran without a Release Eligibility proof." \
+              "" \
+              "- SHA: \`${DEPLOY_SHA}\` (verified ancestor of main)" \
+              "- Environment: ${DEPLOY_ENVIRONMENT}" \
+              "- Operator: @${GITHUB_ACTOR}" \
+              "- Reason: ${BREAK_GLASS_REASON}" \
+              "- Run: ${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}" \
+              "" \
+              "The gate being unusable is the defect. Fix the gate, then close this.")"

--- a/.github/workflows/gcp_llm_gateway.yml
+++ b/.github/workflows/gcp_llm_gateway.yml
@@ -80,7 +80,8 @@ jobs:
             python3 .github/scripts/verify_backend_release_admission.py \
               --sha "$DEPLOY_SHA" \
               --repository "$GITHUB_REPOSITORY" \
-              --workflow-runs "$proof_path"
+              --workflow-runs "$proof_path" \
+              --require-first-attempt
             git checkout --detach "$DEPLOY_SHA"
           fi
           CHECKED_OUT_SHA=$(git rev-parse HEAD)

--- a/.github/workflows/gcp_llm_gateway.yml
+++ b/.github/workflows/gcp_llm_gateway.yml
@@ -11,6 +11,10 @@ on:
         description: 'Branch to deploy from'
         required: true
         default: 'main'
+      release_sha:
+        description: 'Production only: exact main SHA with a successful first-attempt Release Eligibility proof'
+        required: false
+        default: ''
 
 # LLM Gateway deployment reapplies shared backend-secrets, so it joins the
 # full backend mutation domain for the selected environment.
@@ -26,6 +30,7 @@ jobs:
   deploy:
     environment: ${{ github.event.inputs.environment }}
     permissions:
+      actions: 'read'
       contents: 'read'
       id-token: 'write'
 
@@ -43,19 +48,49 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          # Production starts from fresh main only to validate the requested
+          # immutable SHA; development retains its caller-selected branch.
           ref: ${{ github.event.inputs.environment == 'prod' && 'main' || github.event.inputs.branch }}
           fetch-depth: 0
 
-      - name: Admit checked-out production source and image identity
+      - name: Admit production source and image identity
+        env:
+          DEPLOY_SHA: ${{ github.event.inputs.release_sha }}
+          DEPLOY_ENVIRONMENT: ${{ github.event.inputs.environment }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          CHECKED_OUT_SHA=$(git rev-parse HEAD)
-          if [[ "${{ github.event.inputs.environment }}" == prod ]]; then
-            git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-            if ! git merge-base --is-ancestor "$CHECKED_OUT_SHA" origin/main; then
-              echo "ERROR: checked-out HEAD $CHECKED_OUT_SHA is not an ancestor of fresh origin/main $(git rev-parse origin/main)." >&2
+          sha_pattern='^[0-9a-f]{40}$'
+          if [[ "$DEPLOY_ENVIRONMENT" == prod ]]; then
+            if [[ ! "$DEPLOY_SHA" =~ $sha_pattern || "$DEPLOY_SHA" == "0000000000000000000000000000000000000000" ]]; then
+              echo "ERROR: release_sha must be one non-zero, lowercase, full commit SHA." >&2
               exit 1
             fi
+            git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+            main_sha="$(git rev-parse --verify 'origin/main^{commit}')"
+            git cat-file -e "${DEPLOY_SHA}^{commit}"
+            if ! git merge-base --is-ancestor "$DEPLOY_SHA" "$main_sha"; then
+              echo "ERROR: release_sha is not an ancestor of fresh origin/main; only merged code may deploy." >&2
+              exit 1
+            fi
+            proof_path="${RUNNER_TEMP}/release-eligibility-${DEPLOY_SHA}.json"
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/release-eligibility.yml/runs?event=push&branch=main&status=completed&head_sha=${DEPLOY_SHA}&per_page=100" \
+              > "$proof_path"
+            python3 .github/scripts/verify_backend_release_admission.py \
+              --sha "$DEPLOY_SHA" \
+              --repository "$GITHUB_REPOSITORY" \
+              --workflow-runs "$proof_path"
+            git checkout --detach "$DEPLOY_SHA"
+          fi
+          CHECKED_OUT_SHA=$(git rev-parse HEAD)
+          if [[ "$DEPLOY_ENVIRONMENT" == prod && "$CHECKED_OUT_SHA" != "$DEPLOY_SHA" ]]; then
+            echo "ERROR: checked-out HEAD $CHECKED_OUT_SHA does not match admitted release_sha $DEPLOY_SHA." >&2
+            exit 1
+          fi
+          if [[ "$DEPLOY_ENVIRONMENT" == prod ]] && ! git merge-base --is-ancestor "$CHECKED_OUT_SHA" origin/main; then
+            echo "ERROR: checked-out HEAD $CHECKED_OUT_SHA is not an ancestor of fresh origin/main $(git rev-parse origin/main)." >&2
+            exit 1
           fi
           IMAGE_TAG=$(git rev-parse --short=7 "$CHECKED_OUT_SHA")
           echo "Admitted deployment source: $CHECKED_OUT_SHA"


### PR DESCRIPTION
Closes SCA-93

## Summary

- Add a production-only `release_sha` input to the standalone LLM gateway deploy.
- Admit only a non-zero, lowercase full SHA that is reachable from freshly fetched `origin/main`, has a successful first-attempt `Release Eligibility` push run from this repository, and is checked out before image tagging.
- Keep development branch checkout behavior unchanged and retain the standalone gateway's protected environment, shared deployment lock, rollout, VPC probe, and authenticated smoke path.
- Keep the shared backend admission verifier's existing rerun behavior by making first-attempt validation an explicit gateway-only option.

Gateway and Cloud Run backend deployments deliberately remain separate manual production approvals: this change aligns their trusted source-admission contract without coupling their runtime mutation or approval paths.

Failure-Class: none

## Verification

- `python3 .github/scripts/test_check_backend_deploy_source_admission.py` — 28 passed.
- `python3 .github/scripts/test_check_direct_backend_production_admission.py` — 4 passed.
- `python3 .github/scripts/check_backend_deploy_source_admission.py` — passed.
- `python3 .github/scripts/check-direct-backend-production-admission.py` — passed.
- `actionlint -ignore 'SC2086|SC2016' .github/workflows/gcp_llm_gateway.yml` — passed; the two ignored findings pre-existed in unchanged smoke commands.
- Read-only admission dry-run against current `origin/main` (`c7dda8d6cc81fc8aca8cde69860ba7bc428f2413`) — admitted by the shared verifier.
- `make preflight` — passed all 15 selected checks.
