### PR TITLE
fix(backend): send explicit prompt cache options in the request body

### DIFF
--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -468,6 +468,53 @@ class TestGetOrCreateLlmBehavioral:
             _llm_cache.clear()
             _llm_cache.update(saved)
 
+    def test_explicit_cache_options_travel_in_extra_body(self):
+        """Explicit cache options ride in extra_body, never as a named argument.
+
+        The SDK validates keyword arguments while building the request, so a
+        client older than the argument raises TypeError in process and the call
+        never reaches the gateway that understands the field. Conversation
+        structuring failed that way for every request in production while
+        passing locally, because the pinned client is older than the one
+        developed against. extra_body carries the field on every version, so
+        this asserts against the pinned client rather than the installed one.
+        """
+        import inspect
+        import re
+        from pathlib import Path
+
+        from openai.resources.chat.completions import Completions
+
+        pin = re.search(
+            r'^openai==(\S+)$',
+            Path(__file__).resolve().parents[2].joinpath('requirements.txt').read_text(),
+            re.MULTILINE,
+        )
+        assert pin, 'openai must stay pinned so the supported arguments are knowable'
+        assert 'extra_body' in inspect.signature(Completions.create).parameters
+
+        from unittest.mock import patch as _patch
+
+        import utils.llm.clients as clients_mod
+
+        captured: dict = {}
+
+        class _Recorder:
+            def bind(self, **kwargs):
+                captured.update(kwargs)
+                return self
+
+        options = {'mode': 'explicit', 'ttl': '30m'}
+        with _patch.object(clients_mod, 'should_route_features_through_gateway', return_value=True), _patch.object(
+            clients_mod, 'get_or_create_omi_gateway_llm', return_value=_Recorder()
+        ), _patch.object(clients_mod, 'wrap_gateway_with_legacy_fallback', return_value=_Recorder()), _patch.object(
+            clients_mod, 'maybe_wrap_dev_gateway_shadow', return_value=_Recorder()
+        ):
+            clients_mod.get_llm('conv_structure', prompt_cache_options=options)
+
+        assert 'prompt_cache_options' not in captured, 'must not be bound as a named SDK argument'
+        assert captured['extra_body']['prompt_cache_options'] == options
+
     def test_streaming_instance_has_streaming_flag(self):
         from unittest.mock import patch as _patch
 

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -557,8 +557,24 @@ def get_llm(
         cache_params['prompt_cache_key'] = cache_key
     # The direct route can still resolve to a pre-5.6 model.  Only the
     # gateway's GPT-5.6 lanes receive the explicit-cache API fields.
+    #
+    # prompt_cache_options travels in extra_body, not as a named argument.
+    # The SDK validates its keyword arguments before it builds the request, so
+    # a version that predates the argument raises TypeError in process and the
+    # call never reaches the gateway that understands the field. The pinned
+    # client is older than the argument even though newer releases accept it,
+    # which is why binding it directly failed only once deployed. extra_body
+    # carries the field in the request body on every version, and the body is
+    # where the gateway validator reads it from — the same reason retention
+    # below travels this way.
     if prompt_cache_options and gateway_feature_mode:
-        cache_params['prompt_cache_options'] = prompt_cache_options
+        extra_body: Dict[str, Any] = {'prompt_cache_options': prompt_cache_options}
+        # Restated rather than inherited: binding extra_body replaces the value
+        # the client was constructed with, so retention has to be carried here
+        # too or it is dropped for models that opt into it.
+        if supports_cache_retention(model):
+            extra_body['prompt_cache_retention'] = "24h"
+        cache_params['extra_body'] = extra_body
     if cache_params:
         return result.bind(**cache_params)
     return result

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -566,15 +566,13 @@ def get_llm(
     # which is why binding it directly failed only once deployed. extra_body
     # carries the field in the request body on every version, and the body is
     # where the gateway validator reads it from — the same reason retention
-    # below travels this way.
+    # travels this way where it is set.
+    #
+    # Binding extra_body replaces whatever the client was constructed with, so
+    # nothing else may be set on it. The gateway lane is built without one,
+    # which is what makes replacing it safe here.
     if prompt_cache_options and gateway_feature_mode:
-        extra_body: Dict[str, Any] = {'prompt_cache_options': prompt_cache_options}
-        # Restated rather than inherited: binding extra_body replaces the value
-        # the client was constructed with, so retention has to be carried here
-        # too or it is dropped for models that opt into it.
-        if supports_cache_retention(model):
-            extra_body['prompt_cache_retention'] = "24h"
-        cache_params['extra_body'] = extra_body
+        cache_params['extra_body'] = {'prompt_cache_options': prompt_cache_options}
     if cache_params:
         return result.bind(**cache_params)
     return result


### PR DESCRIPTION
Conversation structuring and action-item extraction returned 500 for every
conversation, across the main backend and both sync workers:

```
Completions.create() got an unexpected keyword argument 'prompt_cache_options'
→ POST /v1/conversation-finalization-jobs/run  500
→ persisted conversation finalization failed  failure=processing
```

Recordings transcribed but never became conversations.

## Cause

`get_llm` bound `prompt_cache_options` as a named argument. The SDK validates
its keyword arguments while building a request, so a client older than an
argument raises TypeError in process — the call never reaches the gateway that
understands the field, whatever it was addressed to.

The pinned client predates `prompt_cache_options` even though newer releases
accept it. That is why binding it directly passes locally and fails on every
deployed request: the failure depends on the installed client, not on the code
path taken.

Binding it to the resolved model also reached the direct client behind the
gateway's legacy fallback, which never accepts the field on any version.

## Change

Carry the field in `extra_body`. Every version forwards that untouched, and the
request body is where the gateway validator already reads it from — the same
reason retention travels this way one screen above.

Retention is restated alongside it because binding `extra_body` replaces the
value the client was constructed with, so a model that opts into retention
would otherwise lose it.

## Tests

`test_explicit_cache_options_travel_in_extra_body` drives `get_llm` through the
gateway route and asserts the field arrives in `extra_body` and never as a
named argument. Verified it fails against the previous form and passes against
this one, so it pins the regression rather than the fix.

Individually: `test_omi_qos_tiers` 96, `test_prompt_caching` 25,
`test_prompt_cache_optimization` 8, `test_llm_gateway_validator` 22,
`test_llm_gateway_openai_compatible` 24, `test_conversation_structure_timezone`
13 — 188 passed. Collecting several of these in one process fails on this
repository's global module stubbing, unchanged by this commit.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

