### PR TITLE
fix(desktop): stop cold-start ACP init from awaiting Claude OAuth in-band

### DIFF
--- a/.github/failure-classes/FC-in-band-auth-await-stall.json
+++ b/.github/failure-classes/FC-in-band-auth-await-stall.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "FC-in-band-auth-await-stall",
+  "violated_contract": "An ACP path that hits a provider auth failure must terminalize the pending turn and leave OAuth out-of-band; it must never `await` the interactive sign-in flow in-band, because that blocks the caller for the whole callback timeout with nothing on the wire to fail fast.",
+  "canonical_prevention": "Signal `auth_required` to the host first, then start (never await) the OAuth flow so the pending send terminalizes as `authentication`; route both the active-turn and cold-start-init paths through the shared beginProviderAuthWithoutBlocking / signalProviderAuthRequired seam rather than awaiting startAuthFlow.",
+  "evidence_prs": [10417, 10407],
+  "scope_hints": ["desktop/macos/agent/src/**"],
+  "status": "open"
+}

--- a/desktop/macos/agent/src/adapters/acp.ts
+++ b/desktop/macos/agent/src/adapters/acp.ts
@@ -154,6 +154,42 @@ export function isAcpProviderAuthFailure(error: unknown): boolean {
 /** @deprecated Renamed to {@link isAcpProviderAuthFailure}; classify-only, no in-band recovery. */
 export const isRecoverableAcpAuthError = isAcpProviderAuthFailure;
 
+/** Seams for {@link beginProviderAuthWithoutBlocking}. */
+export type ProviderAuthKickoffDeps = {
+  /** Tell the host provider auth is required, so a pending turn can terminalize now. */
+  signalAuthRequired: () => void;
+  /**
+   * Run the OAuth flow: local callback server, token exchange, credential
+   * storage, ACP restart. It emits its own `auth_required` carrying the
+   * bridge-issued `authUrl` once one exists.
+   */
+  startAuthFlow: () => Promise<void>;
+  logErr: (message: string) => void;
+};
+
+/**
+ * Begin provider auth without blocking the caller.
+ *
+ * `initialize` used to `await` the OAuth flow, so a cold start with expired
+ * credentials sat inside init for the whole callback timeout with no turn on
+ * the wire to terminalize — the user's first send hung instead of failing fast
+ * (#10407). Signalling first lets that send terminalize as `authentication`
+ * immediately.
+ *
+ * The flow is still *started*, just not awaited: the host's sign-in button needs
+ * the `authUrl` only this flow can mint (Swift `ChatProvider.startClaudeAuth`
+ * refuses to open sign-in without one), so dropping the call outright would
+ * strand the user in an auth-required state with no way out.
+ */
+export function beginProviderAuthWithoutBlocking(deps: ProviderAuthKickoffDeps): void {
+  deps.signalAuthRequired();
+  // Detached on purpose — awaiting is the bug. The rejection is swallowed here so
+  // a failed flow can never surface as an unhandled rejection.
+  void deps.startAuthFlow().catch((error) => {
+    deps.logErr(`ACP background auth flow failed: ${error instanceof Error ? error.message : String(error)}`);
+  });
+}
+
 const MAX_RECENT_STDERR_CHARS = 2_000;
 
 const EXTERNAL_TERMINAL_HTTP_FAILURE = /^\s*HTTP\s+([45]\d{2})\s*:\s*(?:\{|\[)/i;

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -80,7 +80,12 @@ import {
 import { startOAuthFlow, type OAuthFlowHandle } from "./oauth-flow.js";
 import { isProductionAdapterId, type PromptBlock, type RuntimeAdapter } from "./adapters/interface.js";
 import { detectImageMimeType } from "./mime-detect.js";
-import { AcpError, AcpRuntimeAdapter, isAcpProviderAuthFailure } from "./adapters/acp.js";
+import {
+  AcpError,
+  AcpRuntimeAdapter,
+  beginProviderAuthWithoutBlocking,
+  isAcpProviderAuthFailure,
+} from "./adapters/acp.js";
 import { AdapterRegistry } from "./runtime/adapter-registry.js";
 import { nextJournalPumpDelayMs } from "./runtime/journal-pump-backoff.js";
 import { JsonlTransport, type McpServerBuildContext } from "./runtime/jsonl-transport.js";
@@ -1054,10 +1059,16 @@ async function initializeAcp(): Promise<void> {
         }));
       }
       logErr(`ACP requires authentication: ${JSON.stringify(authMethods)}`);
-      await startAuthFlow();
-
-      // Retry initialization after auth (ACP subprocess already restarted)
-      await initializeAcp();
+      // Terminalize-first, same contract the active turn already follows: signal
+      // Swift and return instead of awaiting OAuth in-band. `isInitialized` stays
+      // false, so the pending send reaches the ACP request, hits the same -32000,
+      // and terminalizes as `authentication` via the kernel's recoverable-error
+      // path rather than hanging behind this init (#10407).
+      beginProviderAuthWithoutBlocking({
+        signalAuthRequired: signalProviderAuthRequired,
+        startAuthFlow,
+        logErr,
+      });
       return;
     }
     throw err;

--- a/desktop/macos/agent/tests/acp-init-auth-nonblocking.test.ts
+++ b/desktop/macos/agent/tests/acp-init-auth-nonblocking.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { beginProviderAuthWithoutBlocking } from "../src/adapters/acp.js";
+
+/**
+ * Cold-start ACP `initialize` used to `await startAuthFlow()` on -32000, so a
+ * launch with expired credentials sat inside init for the whole OAuth callback
+ * timeout. No turn was on the wire yet, so nothing could terminalize and the
+ * user's first send hung instead of failing fast (#10407).
+ *
+ * These drive the extracted kickoff seam directly: index.ts cannot be imported
+ * under vitest (module scope spawns the ACP subprocess and binds stdin), which
+ * is why its other coverage is source-scraping rather than behaviour.
+ */
+
+function harness(startAuthFlow: () => Promise<void>) {
+  const events: string[] = [];
+  const logs: string[] = [];
+  const deps = {
+    signalAuthRequired: () => events.push("signal"),
+    startAuthFlow: () => {
+      events.push("flow_started");
+      return startAuthFlow();
+    },
+    logErr: (message: string) => logs.push(message),
+  };
+  return { events, logs, deps };
+}
+
+describe("beginProviderAuthWithoutBlocking", () => {
+  it("returns without waiting for the OAuth callback", () => {
+    // Never settles — stands in for a user who never completes sign-in. If the
+    // kickoff awaited it (the bug), control would never reach the assertions.
+    const { events, deps } = harness(() => new Promise<void>(() => {}));
+
+    beginProviderAuthWithoutBlocking(deps);
+
+    expect(events).toEqual(["signal", "flow_started"]);
+  });
+
+  it("signals auth_required before the flow produces anything", async () => {
+    let release: (() => void) | undefined;
+    const { events, deps } = harness(() => new Promise<void>((resolve) => (release = resolve)));
+
+    beginProviderAuthWithoutBlocking(deps);
+    // The host must already be told, so a pending send terminalizes as
+    // `authentication` rather than waiting on the flow below.
+    expect(events[0]).toBe("signal");
+
+    release?.();
+    await Promise.resolve();
+  });
+
+  it("still starts the flow, because sign-in needs its bridge-issued authUrl", () => {
+    // Guards the tempting over-fix: dropping the call entirely leaves Swift's
+    // startClaudeAuth with no URL to open, and the user cannot authenticate.
+    const { events, deps } = harness(async () => {});
+
+    beginProviderAuthWithoutBlocking(deps);
+
+    expect(events).toContain("flow_started");
+  });
+
+  it("logs a failed flow instead of leaking an unhandled rejection", async () => {
+    const { logs, deps } = harness(async () => {
+      throw new Error("callback server refused to bind");
+    });
+
+    beginProviderAuthWithoutBlocking(deps);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain("callback server refused to bind");
+  });
+});

--- a/desktop/macos/changelog/unreleased/20260724-acp-cold-start-auth-fast-fail.json
+++ b/desktop/macos/changelog/unreleased/20260724-acp-cold-start-auth-fast-fail.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the first chat message hanging when Claude sign-in had expired: it now fails fast and prompts you to reconnect instead of waiting on the sign-in window"
+}


### PR DESCRIPTION
## What

Closes #10407.

Cold-start ACP `initializeAcp()` awaited `startAuthFlow()` when the agent returned `-32000` (auth required), then retried init. With expired Claude credentials and no OAuth callback, init sat inside that await for the **entire callback timeout** — and because no turn was on the wire yet, the user's very first send had nothing to terminalize behind it and simply **hung** until the timeout elapsed.

This applies the same terminalize-first contract the active turn already follows (#10417): signal `auth_required` to Swift, then **start — never await —** the OAuth flow and return. `isInitialized` stays `false`, so the pending send reaches the ACP request, hits the same `-32000`, and terminalizes as `authentication` through the kernel's existing recoverable-error path instead of blocking.

The flow is still *started*, not dropped: Swift `ChatProvider.startClaudeAuth` refuses to open sign-in without the bridge-issued `authUrl` that only this flow mints, so dropping the call would strand the user in an auth-required state with no way to sign in. The bug was the `await`, not the call.

## Why a shared seam + failure class

`index.ts` cannot be imported under vitest (module scope spawns the ACP subprocess and binds stdin), so its coverage is source-scraping — a static tripwire, not behavior. The kickoff is extracted to `acp.ts` as `beginProviderAuthWithoutBlocking`, a seam with a real injectable boundary, and tested behaviourally.

This is the **second** instance of one root cause — an ACP path awaiting interactive OAuth in-band so nothing can terminalize. The first (#10417) hardened the active-turn path. Per AGENTS.md ("two or more recent fixes share the cause → add a reusable guard surface"), this declares `Failure-Class: new` and registers **`FC-in-band-auth-await-stall`** (`.github/failure-classes/`) citing both PRs, with `beginProviderAuthWithoutBlocking` as the code-level guard.

## Test

`desktop/macos/agent/tests/acp-init-auth-nonblocking.test.ts` (new, mirrors the issue's falsifiable T1):

- Returns without waiting for the OAuth callback (never-settling flow ⇒ control still reaches the assertions).
- Signals `auth_required` **before** the flow produces anything, so a pending send terminalizes as `authentication`.
- Still starts the flow — guards the tempting over-fix of dropping the call, which would leave Swift with no `authUrl`.
- A failed flow logs instead of leaking an unhandled rejection.

### Verification evidence

```
# agent package (vitest)
acp-init-auth-nonblocking.test.ts .... 4 passed
acp-auth-terminal.test.ts ............ 2 passed
+ acp-tool-activity / protocol-v2 / adapter-selection ... 27 passed total

# mutation check — reintroduce `await startAuthFlow()` before the signal:
acp-init-auth-nonblocking.test.ts .... 3 failed / 1 passed  (as intended)

tsc --noEmit ......................... exit 0
scripts/failure-class validate ....... passes
```

I exercised the extracted seam directly (the real code path init now runs); I did not boot the full macOS app for this change — the behaviour lives entirely in the agent bridge's auth kickoff, covered by the seam above.

## Scope

Agent-bridge TypeScript only — no Swift touched. User-facing changelog fragment included.

Failure-Class: new

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

