### PR TITLE
fix(backend): declare route policy for the memory baseline toggle

### DIFF
--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -341,6 +341,29 @@ routes:
         state: active
       owner: backend
   - route_type: http
+    method: PATCH
+    path: /v3/memories/{memory_id}/baseline
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+        placement: dependency
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: memories:modify
+        key_subject: uid
+        enforcement: fail_closed
+        placement: wrapper
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: memories
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
     method: POST
     path: /v1/users/account-deletion-wipes/run
     policy:


### PR DESCRIPTION
Release eligibility fails on every commit, so no backend deploy can be
admitted:

```
new routes missing manifest entries:
  - backend-main:http:PATCH:/v3/memories/{memory_id}/baseline
Manifest checks failed: backend-route-policy-baseline
```

`PATCH /v3/memories/{memory_id}/baseline` was added without a
`route_policy_manifest.yaml` entry. The check grandfathers pre-existing routes
through the legacy baseline, so only this one new route trips it —
`new_missing_manifest_entries: 1`.

This currently blocks deploying the conversation-finalization fix (#10477)
while conversation structuring returns 500 in production.

## Policy

Declared to match the route as written. It authenticates through a Firebase
dependency and sits behind the same fail-closed per-uid rate limit wrapper as
the sibling memory mutations, naming `memories:modify`:

```python
uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "memories:modify"))
```

Nothing about the route changes — this only records the policy it already
enforces. The baseline is not regenerated, since that would grandfather a new
route rather than declare it.

## Verification

`python3 backend/scripts/check_route_policy_baseline.py` — `route policy
missing-route baseline is current`, `new_missing_manifest_entries: 0`.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

