### PR TITLE
fix(ci): exempt generated Swift from the desktop changelog gate

### DIFF
--- a/.github/failure-classes/FC-push-gate-internal-path-scope.json
+++ b/.github/failure-classes/FC-push-gate-internal-path-scope.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "FC-push-gate-internal-path-scope",
+  "violated_contract": "A CI gate that also runs on the post-merge push lane must scope its 'user-facing change' trigger to exclude internal, non-user-facing paths (generated code, tests, release infrastructure); otherwise a legitimate change to those paths reddens main on the push run with no author able to satisfy the gate.",
+  "canonical_prevention": "Keep the gate's exemption set (e.g. EXEMPT_DESKTOP_PATH_PREFIXES) covering every never-user-facing path class, and add a path to it — with a test — rather than relying on a PR-only label that the post-merge push run cannot honor.",
+  "evidence_prs": [10387, 10481],
+  "scope_hints": [".github/scripts/check-desktop-changelog.py", ".github/scripts/"],
+  "status": "open"
+}

--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -32,6 +32,12 @@ EXEMPT_DESKTOP_PATHS = {
 EXEMPT_DESKTOP_PATH_PREFIXES = (
     "desktop/macos/Backend-Rust/",
     "desktop/macos/tests/",
+    # Generated Swift (e.g. Sources/Generated/OmiApi.generated.swift) is
+    # deterministically derived from the backend OpenAPI contract, never a
+    # user-facing app note. Regenerating it after a spec change must not demand
+    # a changelog fragment, and — like tests/ above — the post-merge push run
+    # would otherwise redden main. Same directory the swift-format linter skips.
+    "desktop/macos/Desktop/Sources/Generated/",
 )
 
 

--- a/.github/scripts/test_desktop_changelog.py
+++ b/.github/scripts/test_desktop_changelog.py
@@ -81,11 +81,15 @@ class ChangelogRequirementTests(unittest.TestCase):
             "desktop/macos/tests/some-other-desktop-test.sh",
             # Rust backend prefix.
             "desktop/macos/Backend-Rust/src/main.rs",
+            # Generated Swift is derived from the OpenAPI contract, never a
+            # user-facing app note (EXEMPT_DESKTOP_PATH_PREFIXES).
+            "desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift",
         ):
             with self.subTest(path=path):
                 self.assertFalse(checker.is_desktop_change_requiring_changelog(path))
 
         # Product source still requires a changelog — the exemptions must not leak.
+        # Note the hand-written Sources file is NOT under Sources/Generated/.
         for path in (
             "desktop/macos/Desktop/Sources/AppDelegate.swift",
             "desktop/macos/scripts/some-user-facing-script.sh",


### PR DESCRIPTION
## What

`check-desktop-changelog.py` exempts `Backend-Rust/` and `tests/` from the "desktop change requires a changelog fragment" rule as *never user-facing app notes* — but it does **not** exempt `desktop/macos/Desktop/Sources/Generated/`.

So regenerating `Sources/Generated/OmiApi.generated.swift` after a backend OpenAPI spec change demands a changelog fragment. Worse, exactly as the `tests/` exemption comment already documents (incident #10387): the **post-merge push run** of this gate would redden `main`, because the PR-only `no-changelog-needed` label can't be honored on the push lane.

## Fix

Add `desktop/macos/Desktop/Sources/Generated/` to `EXEMPT_DESKTOP_PATH_PREFIXES`. Generated Swift is deterministically derived from the OpenAPI contract — the same directory the swift-format linter already skips.

A test asserts the generated file is exempt while a hand-written `Sources/AppDelegate.swift` still requires a changelog (the exemption must not leak).

## Why now

The memories baseline toggle (#8728) changed the app-client OpenAPI contract; regenerating `OmiApi.generated.swift` from it is blocked today purely by this gate gap. This is the **second** instance of the push-lane gate over-including internal paths (first: #10387, `tests/`), so it registers `FC-push-gate-internal-path-scope`.

## Verification

```
python3 .github/scripts/test_desktop_changelog.py  →  Ran 4 tests  OK
# self-check: is_desktop_change_requiring_changelog(...)
#   Sources/Generated/OmiApi.generated.swift → False (exempt)
#   Sources/AppDelegate.swift                → True  (still gated)
scripts/failure-class validate ... → ok
```

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

