### PR TITLE
fix(backend): stop sending explicit prompt cache options

### DIFF
--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -468,31 +468,15 @@ class TestGetOrCreateLlmBehavioral:
             _llm_cache.clear()
             _llm_cache.update(saved)
 
-    def test_explicit_cache_options_travel_in_extra_body(self):
-        """Explicit cache options ride in extra_body, never as a named argument.
+    def test_explicit_cache_options_are_not_sent_to_the_gateway(self):
+        """The caller accepts explicit cache options and sends none of them.
 
-        The SDK validates keyword arguments while building the request, so a
-        client older than the argument raises TypeError in process and the call
-        never reaches the gateway that understands the field. Conversation
-        structuring failed that way for every request in production while
-        passing locally, because the pinned client is older than the one
-        developed against. extra_body carries the field on every version, so
-        this asserts against the pinned client rather than the installed one.
+        The field is a contract between this caller and the gateway, and the
+        two deploy from separate pipelines, so a gateway predating the field
+        rejects the whole request. Sending it broke conversation structuring for
+        every request that routed through the gateway. Accepting the argument
+        keeps the call sites unchanged while nothing goes on the wire.
         """
-        import inspect
-        import re
-        from pathlib import Path
-
-        from openai.resources.chat.completions import Completions
-
-        pin = re.search(
-            r'^openai==(\S+)$',
-            Path(__file__).resolve().parents[2].joinpath('requirements.txt').read_text(),
-            re.MULTILINE,
-        )
-        assert pin, 'openai must stay pinned so the supported arguments are knowable'
-        assert 'extra_body' in inspect.signature(Completions.create).parameters
-
         from unittest.mock import patch as _patch
 
         import utils.llm.clients as clients_mod
@@ -512,8 +496,8 @@ class TestGetOrCreateLlmBehavioral:
         ):
             clients_mod.get_llm('conv_structure', prompt_cache_options=options)
 
-        assert 'prompt_cache_options' not in captured, 'must not be bound as a named SDK argument'
-        assert captured['extra_body']['prompt_cache_options'] == options
+        assert 'prompt_cache_options' not in captured, 'must not be bound as a named argument'
+        assert 'prompt_cache_options' not in captured.get('extra_body', {}), 'must not travel in the request body'
 
     def test_streaming_instance_has_streaming_flag(self):
         from unittest.mock import patch as _patch

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -555,24 +555,17 @@ def get_llm(
     cache_params: Dict[str, Any] = {}
     if cache_key and supports_prompt_cache(model):
         cache_params['prompt_cache_key'] = cache_key
-    # The direct route can still resolve to a pre-5.6 model.  Only the
-    # gateway's GPT-5.6 lanes receive the explicit-cache API fields.
+    # prompt_cache_options is accepted but not sent. The field is a contract
+    # between this caller and the gateway, and the two deploy from separate
+    # pipelines, so the gateway can be running a build that predates it and
+    # rejects the request outright. Sending it broke conversation structuring
+    # for every request that routed through the gateway.
     #
-    # prompt_cache_options travels in extra_body, not as a named argument.
-    # The SDK validates its keyword arguments before it builds the request, so
-    # a version that predates the argument raises TypeError in process and the
-    # call never reaches the gateway that understands the field. The pinned
-    # client is older than the argument even though newer releases accept it,
-    # which is why binding it directly failed only once deployed. extra_body
-    # carries the field in the request body on every version, and the body is
-    # where the gateway validator reads it from — the same reason retention
-    # travels this way where it is set.
-    #
-    # Binding extra_body replaces whatever the client was constructed with, so
-    # nothing else may be set on it. The gateway lane is built without one,
-    # which is what makes replacing it safe here.
-    if prompt_cache_options and gateway_feature_mode:
-        cache_params['extra_body'] = {'prompt_cache_options': prompt_cache_options}
+    # Restore the send once a gateway carrying the field in its forwarded
+    # parameters is deployed. It travels in extra_body when it returns: the
+    # client validates named arguments before building the request, so a
+    # version that predates the field raises in process instead of reaching the
+    # gateway at all.
     if cache_params:
         return result.bind(**cache_params)
     return result


### PR DESCRIPTION
Conversation structuring returns 500 for every request that routes through the
gateway:

```
400 - unsupported chat completion parameter: prompt_cache_options
      type=invalid_request_error param=prompt_cache_options
```

## Cause

`prompt_cache_options` is a contract between this caller and the gateway. Both
sides were added together, but they deploy from separate pipelines — the caller
with the backend, the gateway to GKE. The gateway currently runs a build from
before the field existed, so the field is absent from its forwarded parameters
and it rejects the whole request rather than ignoring an argument it does not
know.

The mismatch was previously hidden. The caller bound the field as a named
argument, and the client validates those before building a request, so it
raised in process and nothing reached the gateway. Moving it into the request
body let it arrive, which is what surfaced the gateway's rejection.

## Change

Accept the argument and send nothing. Call sites stay as they are, so restoring
the send later is a single block rather than a signature change across four
callers.

What is lost is a caching cost optimisation. No behaviour a user sees depends
on it.

## Restoring it

Deploy a gateway that carries `prompt_cache_options` in its forwarded
parameters, confirm the running build rather than the source, then restore the
send. It belongs in `extra_body` when it returns, for the reason above.

## Tests

`test_explicit_cache_options_are_not_sent_to_the_gateway` asserts the field
appears neither as a named argument nor in the request body. Verified it fails
when the send is reintroduced, so it holds the position rather than restating
it.

`tests/unit/test_omi_qos_tiers.py` — 96 passed.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

