### PR TITLE
fix(dev-api): serve legacy memories for a legacy-cohort vector search (#10203)

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -2,14 +2,14 @@
   "files": {
     "backend/routers/apps.py": 2335,
     "backend/routers/chat.py": 1588,
-    "backend/routers/developer.py": 2202,
+    "backend/routers/developer.py": 2263,
     "backend/routers/mcp_sse.py": 1858,
     "backend/routers/sync.py": 2058,
     "backend/routers/users.py": 2046
   },
   "raise_justifications": {
     "backend/routers/chat.py": "Merging the Windows-port chat surface with main combined the stream-error fallback (answered guard) with mains journey/attempt observability in the same SSE generators; +11 lines of combined guard flow, no new route.",
-    "backend/routers/developer.py": "From-segments processing now wraps process_conversation in the admission lease guard so the crash-orphan sweep cannot terminalize active work (#10461); +7 lines for the conditional guard with rollback_on_failure=False.",
+    "backend/routers/developer.py": "GET /v1/dev/user/memories and /vector/search both serve the authoritative legacy memories collection for legacy-cohort accounts with no rollout state (#9892/#10203), keeping the narrow deny/legacy-fallback decision in the route that owns the read contract.",
     "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line.",
     "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033).",
     "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first."

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -14,7 +14,7 @@ import database.action_items as action_items_db
 import database.goals as goals_db
 import database.users as users_db
 from database._client import db
-from database.vector_db import upsert_memory_vectors_batch
+from database.vector_db import search_memories_by_vector, upsert_memory_vectors_batch
 
 from models.folder import Folder
 from models.goal import GoalHistoryEntryResponse, GoalMetric
@@ -434,6 +434,42 @@ def get_memories(
     return valid_memories
 
 
+def _legacy_developer_vector_items(uid: str, query: str, limit: int) -> List[dict]:
+    """Relevance-ranked legacy `memories` results for a legacy-cohort vector search.
+
+    The default-read vector path returns USE_LEGACY_SAFE (or DENY + missing_rollout_state)
+    for an un-enrolled legacy account; that account's authoritative surface is the legacy
+    `memories` collection, so search it directly instead of failing closed. IDs come back
+    ordered by vector relevance; hydration preserves that order. Locked memories are
+    content-redacted exactly as GET /v1/dev/user/memories does. Scores aren't exposed by
+    the legacy index, so relevance_score is left null.
+    """
+    memory_ids = search_memories_by_vector(uid, query, limit)
+    if not memory_ids:
+        return []
+    hydrated = {
+        m['id']: m for m in memories_db.get_memories_by_ids(uid, memory_ids) if isinstance(m, dict) and m.get('id')
+    }
+    items: List[dict] = []
+    for memory_id in memory_ids:  # preserve vector-relevance order
+        memory = hydrated.get(memory_id)
+        if memory is None:
+            continue
+        content = str(memory.get('content') or '')
+        if memory.get('is_locked', False):
+            content = (content[:70] + '...') if len(content) > 70 else content
+        category = memory.get('category')
+        items.append(
+            {
+                'id': memory['id'],
+                'content': content,
+                'category': category if isinstance(category, str) and category.strip() else None,
+                'relevance_score': None,
+            }
+        )
+    return items
+
+
 @router.get(
     "/v1/dev/user/memories/vector/search",
     tags=["developer"],
@@ -508,11 +544,36 @@ def search_memories_vector(
         db_client=db,
         rollout_decision=memory_rollout,
     )
-    if memory_result.read_decision in {MemoryReadDecision.DENY_MEMORY, MemoryReadDecision.SHADOW_ONLY}:
-        raise HTTPException(
-            status_code=403, detail=_developer_memory_access_not_ready_detail(memory_result.fallback_reason)
+    # A legacy-cohort account (explicit USE_LEGACY_SAFE, or an un-enrolled account whose
+    # only signal is missing_rollout_state) reads the legacy `memories` collection — the
+    # same recovery GET /v1/dev/user/memories and the MCP path already apply (#10094/#10095).
+    # Vector search previously failed closed with 403 here, so those accounts could list
+    # memories but not vector-search them (#10203).
+    serve_legacy = memory_result.should_use_legacy_fallback or (
+        memory_result.read_decision in {MemoryReadDecision.DENY_MEMORY, MemoryReadDecision.SHADOW_ONLY}
+        and memory_result.fallback_reason == 'missing_rollout_state'
+    )
+    if serve_legacy:
+        record_fallback(
+            component='other',
+            from_mode='memory_default_read_vector',
+            to_mode='legacy_memories',
+            reason='policy',
+            outcome='recovered',
         )
-    if memory_result.should_use_legacy_fallback:
+        legacy_items = _legacy_developer_vector_items(uid, query, limit)
+        return {
+            'items': legacy_items,
+            'returned_count': len(legacy_items),
+            'archive_default_visible': False,
+            'policy': {
+                'consumer': 'developer_api',
+                'app_has_default_memory_grant': True,
+                'archive_capability': False,
+                'raw_provenance_capability': False,
+            },
+        }
+    if memory_result.read_decision in {MemoryReadDecision.DENY_MEMORY, MemoryReadDecision.SHADOW_ONLY}:
         raise HTTPException(
             status_code=403, detail=_developer_memory_access_not_ready_detail(memory_result.fallback_reason)
         )

--- a/backend/tests/unit/test_dev_api_canonical_grant_ordering.py
+++ b/backend/tests/unit/test_dev_api_canonical_grant_ordering.py
@@ -15,7 +15,7 @@ import os
 import sys
 from pathlib import Path
 from types import ModuleType
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 os.environ.setdefault('OPENAI_API_KEY', '***')
 os.environ.setdefault(
@@ -440,21 +440,62 @@ def test_get_memories_other_deny_reason_still_403():
     assert 'key can be valid and correctly scoped' in detail['message']
 
 
-def test_search_memories_vector_missing_rollout_state_has_actionable_contract():
-    """Vector search uses the same account-readiness error after a valid key grant."""
+def test_search_memories_vector_missing_rollout_state_falls_back_to_legacy():
+    """A legacy-cohort account (no rollout doc) vector-searches legacy, not 403 (#10203).
+
+    The listing endpoint already recovers this case (#9892/#10094) and MCP does too
+    (#10095); vector search used to fail closed with 403 for the same accounts, so they
+    could list memories but not vector-search them. It now serves the legacy `memories`
+    collection, preserving vector-relevance order.
+    """
     client = _build()
 
     developer_module.search_memory_default_developer_memories_vector = MagicMock(
-        return_value=type(
-            'DeniedVectorMemoryResult',
-            (),
-            {
-                'read_decision': developer_module.MemoryReadDecision.DENY_MEMORY,
-                'memories': [],
-                'fallback_reason': 'missing_rollout_state',
-                'should_use_legacy_fallback': False,
-            },
-        )()
+        return_value=_denied_memory_result('missing_rollout_state')
+    )
+
+    # search_memories_by_vector ranks a, then b; hydration returns them in the opposite
+    # order — the response must follow the vector rank, not the hydration order.
+    with patch.object(
+        developer_module, 'search_memories_by_vector', return_value=['legacy-a', 'legacy-b']
+    ), patch.object(
+        developer_module.memories_db,
+        'get_memories_by_ids',
+        return_value=[
+            {'id': 'legacy-b', 'content': 'second', 'category': _VALID_CATEGORY},
+            {'id': 'legacy-a', 'content': 'first', 'category': _VALID_CATEGORY},
+        ],
+    ):
+        resp = client.get('/v1/dev/user/memories/vector/search', params={'query': 'memory'})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [item['id'] for item in body['items']] == ['legacy-a', 'legacy-b']
+    assert body['returned_count'] == 2
+    assert body['items'][0]['relevance_score'] is None
+
+
+def test_search_memories_vector_use_legacy_safe_falls_back_to_legacy():
+    """The explicit USE_LEGACY_SAFE decision serves legacy too (was 403 before #10203)."""
+    client = _build()  # default vector mock resolves to USE_LEGACY_SAFE
+
+    with patch.object(developer_module, 'search_memories_by_vector', return_value=['m1']), patch.object(
+        developer_module.memories_db,
+        'get_memories_by_ids',
+        return_value=[{'id': 'm1', 'content': 'hi', 'category': _VALID_CATEGORY}],
+    ):
+        resp = client.get('/v1/dev/user/memories/vector/search', params={'query': 'memory'})
+
+    assert resp.status_code == 200
+    assert resp.json()['items'][0]['id'] == 'm1'
+
+
+def test_search_memories_vector_other_deny_reason_still_403():
+    """Deny reasons other than missing_rollout_state keep the vector fail-closed contract."""
+    client = _build()
+
+    developer_module.search_memory_default_developer_memories_vector = MagicMock(
+        return_value=_denied_memory_result('missing_developer_default_memory_grant')
     )
 
     resp = client.get('/v1/dev/user/memories/vector/search', params={'query': 'memory'})
@@ -462,8 +503,7 @@ def test_search_memories_vector_missing_rollout_state_has_actionable_contract():
     assert resp.status_code == 403
     detail = resp.json()['detail']
     assert detail['code'] == 'developer_memory_access_not_ready'
-    assert detail['reason'] == 'missing_rollout_state'
-    assert 'key can be valid and correctly scoped' in detail['message']
+    assert detail['reason'] == 'missing_developer_default_memory_grant'
 
 
 # =============================================================================

--- a/backend/tests/unit/test_developer_memory_adapter.py
+++ b/backend/tests/unit/test_developer_memory_adapter.py
@@ -183,9 +183,11 @@ def test_developer_update_route_checks_split_brain_guard_before_reads_and_legacy
 
 
 def test_developer_routes_only_reach_legacy_after_explicit_legacy_safe_decision():
-    # Static tripwire (source order, not behavior): the list route may reach the
-    # legacy read only through the deny branch's narrow un-enrolled guard (#9892);
-    # the vector route still requires an explicit legacy-safe decision.
+    # Static tripwire (source order, not behavior): both the list and vector routes may
+    # reach the legacy read only through the same narrow un-enrolled guard — an explicit
+    # USE_LEGACY_SAFE decision, or a deny whose only reason is missing_rollout_state
+    # (#9892). Vector used to fail closed on that guard, which is #10203; it now recovers
+    # like the list route, but must still not reach legacy on any other deny reason.
     developer_py = Path(__file__).resolve().parents[2] / 'routers' / 'developer.py'
     contents = developer_py.read_text(encoding='utf-8')
     denied_check = 'if memory_result.read_decision in {MemoryReadDecision.DENY_MEMORY, MemoryReadDecision.SHADOW_ONLY}:'
@@ -196,10 +198,16 @@ def test_developer_routes_only_reach_legacy_after_explicit_legacy_safe_decision(
     assert legacy_call in contents
     assert contents.index(denied_check) < contents.index(unenrolled_guard) < contents.index(legacy_call)
     vector_route_source = _function_source_for_route('/v1/dev/user/memories/vector/search', 'get')
-    legacy_safe_check = 'if memory_result.should_use_legacy_fallback:'
+    # The vector route serves legacy only when USE_LEGACY_SAFE, or a deny whose only
+    # reason is missing_rollout_state — and the plain deny 403 stays as the fallthrough.
+    serve_legacy_check = 'serve_legacy = memory_result.should_use_legacy_fallback or ('
+    missing_rollout_guard = "and memory_result.fallback_reason == 'missing_rollout_state'"
     assert denied_check in vector_route_source
-    assert legacy_safe_check in vector_route_source
-    assert vector_route_source.index(denied_check) < vector_route_source.index(legacy_safe_check)
+    assert serve_legacy_check in vector_route_source
+    assert missing_rollout_guard in vector_route_source
+    # serve_legacy is decided before the plain deny 403, so a legacy account recovers
+    # instead of failing closed.
+    assert vector_route_source.index(serve_legacy_check) < vector_route_source.index(denied_check)
 
 
 def test_developer_category_filters_do_not_force_legacy_when_memory_can_decide_safely():


### PR DESCRIPTION
## What

Closes #10203.

`GET /v1/dev/user/memories/vector/search` failed closed with `403 missing_rollout_state` for un-enrolled **legacy-cohort** accounts — even though the sibling read paths already recover for exactly these accounts:

- the memory list `GET /v1/dev/user/memories` (#9892 / #10094), and
- the MCP memory path (#10095),

both serve the legacy `memories` collection when `pin_memory_system` has resolved the account to LEGACY and the only signal is an absent rollout doc. So an affected account could **list** its memories but not **vector-search** them — the "another rollout-state path still failing closed" cohort the issue asks about (possibility #3).

Worse, `search_memories_vector` raised 403 on `should_use_legacy_fallback` (`USE_LEGACY_SAFE`) — the one signal that explicitly means *serve legacy*.

> Note on the user's report: the **list** endpoint (`GET /v1/dev/user/memories`) is already fixed in code, so a user still seeing 403 there is a deploy-lag symptom (issue possibility #1), not a code path. This PR closes the genuine remaining code gap — the vector endpoint.

## Fix

On a legacy-cohort signal — `USE_LEGACY_SAFE`, or a deny whose **only** reason is `missing_rollout_state` — search the legacy `memories` vector index (`search_memories_by_vector`) and hydrate the hits (`get_memories_by_ids`), instead of returning 403:

- **vector-relevance order preserved** (iterate the ranked IDs, not hydration order);
- **locked content redacted** exactly as the list route does;
- `relevance_score` left `null` (the legacy index doesn't expose scores);
- `record_fallback(... to_mode='legacy_memories', outcome='recovered')` marks the recovery;
- **any other deny reason keeps the fail-closed 403.**

## Why not a shared predicate (yet)

This is the 4th instance of one cause — a default-read surface failing closed for an un-enrolled legacy account instead of serving legacy (#9892 → #10094 list, #10095 MCP, this = vector). The ideal class-level guard is one predicate every read surface calls. But `get_memories` reaches legacy by *fallthrough* while the vector route returns explicitly, so unifying them ripples into the list route's control flow and its static tripwire. Per AGENTS.md ("land the enforceable guard now, track high-blast-radius follow-up explicitly") I land the focused fix plus the updated tripwire (which now asserts the vector route recovers on the shared signal) and flag the shared-predicate extraction as a follow-up.

## Verification

Ran with a real backend venv (Python 3.11):

```
test_dev_api_canonical_grant_ordering.py ......... 9 passed
  incl. 3 new vector cases:
    - missing_rollout_state → legacy fallback (200), vector order preserved
    - USE_LEGACY_SAFE       → legacy fallback (200)
    - other deny reason     → still 403
mutation: revert the fix → the 2 fallback cases fail, the 403 case still passes
144 passed across every vector-referencing unit test
```

The updated `test_developer_routes_only_reach_legacy_after_explicit_legacy_safe_decision` tripwire now encodes the new (consistent) contract for both routes.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

