### PR TITLE
fix(desktop/ci): stop flaky timeouts in the Swift test-suite runner

### DIFF
--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -23,6 +23,10 @@ EXEMPT_DESKTOP_PATHS = {
     # Pre-tag readiness gate script: internal release infrastructure (runs on the
     # trusted M1 before tagging), no user-facing app surface.
     "desktop/macos/scripts/pre-tag-readiness.sh",
+    # Swift test runner and its skip registry: internal test infrastructure with
+    # no user-facing app surface (mirrors the tests/ prefix exemption below).
+    "desktop/macos/scripts/swift-test-suites.sh",
+    "desktop/macos/scripts/swift-test-skips.json",
 }
 # Server-side Rust backend changes are internal reliability work, not user-facing app notes.
 # Test and release-infra changes are likewise never user-facing app notes; the

--- a/desktop/macos/scripts/swift-test-skips.json
+++ b/desktop/macos/scripts/swift-test-skips.json
@@ -3,7 +3,8 @@
   "allowed_tests": [
     "ChatDiscoverabilityTests/testAgentControlCapabilitiesMatchCanonicalManifest",
     "ChatDiscoverabilityTests/testDesktopCapabilitiesExistInAgentToolDeclarations",
-    "APIClientRoutingTests/testDeleteConversationRoutesToPython"
+    "APIClientRoutingTests/testDeleteConversationRoutesToPython",
+    "PushToTalkStateMachineTests/testOwnerTransitionTerminatesActiveHubAndDrainsItsPhysicalSession"
   ],
   "skips": [
     {
@@ -20,6 +21,11 @@
       "test": "APIClientRoutingTests/testDeleteConversationRoutesToPython",
       "issue": "https://github.com/BasedHardware/omi/issues/9031",
       "reason": "The client omits ?cascade=true; cascade is backend-gated behind owner sign-off, so flipping it is a data-deletion behavior change."
+    },
+    {
+      "test": "PushToTalkStateMachineTests/testOwnerTransitionTerminatesActiveHubAndDrainsItsPhysicalSession",
+      "issue": "https://github.com/BasedHardware/omi/issues/10492",
+      "reason": "Hangs headless in CI (main regression): the owner-b transition drains the warm hub's physical session and awaits a teardown that never completes without a real transport session. Sibling owner-transition tests pass. Skip until the headless hub-drain hang is fixed."
     }
   ]
 }

--- a/desktop/macos/scripts/swift-test-suites.sh
+++ b/desktop/macos/scripts/swift-test-suites.sh
@@ -58,13 +58,32 @@ run_suite() {
   "${command[@]}" >"$log_path" 2>&1 &
   local command_pid=$!
   (
-    sleep "$SUITE_TIMEOUT_SECONDS"
-    if kill -0 "$command_pid" 2>/dev/null; then
+    # Parallel workers share one SwiftPM `.build` lock, so `swift test` can block
+    # on "Another instance of SwiftPM is already running ... waiting" before it
+    # executes anything. That queue time must not count against the per-suite run
+    # budget, or a merely-queued suite gets killed as if it hung. Spend the run
+    # budget only while the suite is NOT parked on the build lock (its log's last
+    # line is that wait message); a separate, generous cap still fails a suite
+    # that can never acquire the lock (e.g. a wedged holder).
+    local lock_wait_cap="${OMI_SWIFT_TEST_LOCK_WAIT_CAP_SECONDS:-1200}"
+    local remaining="$SUITE_TIMEOUT_SECONDS"
+    local lock_waited=0
+    while kill -0 "$command_pid" 2>/dev/null; do
+      sleep 1
+      if tail -n 1 "$log_path" 2>/dev/null | grep -q "Another instance of SwiftPM is already running"; then
+        lock_waited=$((lock_waited + 1))
+        [ "$lock_waited" -lt "$lock_wait_cap" ] && continue
+      else
+        lock_waited=0
+        remaining=$((remaining - 1))
+        [ "$remaining" -gt 0 ] && continue
+      fi
       touch "$timeout_path"
       terminate_process_tree "$command_pid" TERM
       sleep 5
       terminate_process_tree "$command_pid" KILL
-    fi
+      exit 0
+    done
   ) &
   local watchdog_pid=$!
   wait "$command_pid"

--- a/desktop/macos/tests/test-swift-test-suites.sh
+++ b/desktop/macos/tests/test-swift-test-suites.sh
@@ -104,6 +104,14 @@ if [ -n "${FAKE_XCRUN_HANG_SUITE:-}" ] && [ "$FAKE_XCRUN_HANG_SUITE" = "$suite" 
   wait "$child_pid"
 fi
 
+if [ -n "${FAKE_XCRUN_LOCKWAIT_SUITE:-}" ] && [ "$FAKE_XCRUN_LOCKWAIT_SUITE" = "$suite" ]; then
+  # Park on the shared SwiftPM build lock (its wait message is the last log line)
+  # for longer than the run budget, then proceed — the runner must not charge
+  # this queue time against the per-suite timeout.
+  echo "Another instance of SwiftPM is already running using '.build', waiting until that process has finished execution..."
+  sleep "${FAKE_XCRUN_LOCKWAIT_SECONDS:-5}"
+fi
+
 echo "$suite passed"
 SH
 chmod +x "$TMPDIR/bin/xcrun"
@@ -165,6 +173,18 @@ fi
 hanging_child_pid="$(cat "$FAKE_XCRUN_HANG_CHILD_PID_PATH")"
 if kill -0 "$hanging_child_pid" 2>/dev/null; then
   fail "runner left the timed-out suite's descendant process alive"
+fi
+
+# A suite parked on the shared SwiftPM build lock must not spend its run budget:
+# with a 2s budget it still passes after a 5s lock wait. (AlphaTests still fails
+# with exit 42, so the runner exits non-zero overall — assert on BetaTests only.)
+unset FAKE_XCRUN_HANG_SUITE
+export OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS=2
+export FAKE_XCRUN_LOCKWAIT_SUITE=BetaTests
+export FAKE_XCRUN_LOCKWAIT_SECONDS=5
+"$RUNNER" >"$TMPDIR/lockwait-runner.out" 2>"$TMPDIR/lockwait-runner.err" || true
+if grep -q -- "--- FAILED: BetaTests ---" "$TMPDIR/lockwait-runner.out"; then
+  fail "runner charged SwiftPM build-lock wait against the per-suite run budget"
 fi
 
 echo "swift-test-suites tests passed"


### PR DESCRIPTION
## What this does

Makes the `Desktop Swift Test Suites` CI job reliable. It has been failing on
random, unrelated test suites — which has blocked desktop PRs for a long time.

## The problem

The runner executes test suites in parallel, but they share one build directory
and `swift test` locks it. So a suite often has to wait in line for the lock
before it can start. The per-suite 120s timeout started counting while a suite
was still *waiting for the lock* — so suites that were merely queued got killed
as if they had hung. Which suites lost the race was luck of the draw, so the
failures looked random.

Separately, one voice test genuinely hangs in CI's headless (no-display)
environment.

## The fix

1. **Don't count lock-wait against the timeout.** The per-suite clock now starts
   only once a suite is actually running. A separate, generous cap still fails a
   suite that can never get the lock, and genuine hangs are caught exactly as
   before.
2. **Skip the one genuinely-hanging voice test** (`PushToTalk` owner-transition
   session drain), tracked in #10492.
3. **Exempt the test-runner scripts from the changelog gate** — they're internal
   tooling, not a user-facing change.

## Tests

Added a case to the runner's own fixture test: a suite that waits on the build
lock must still pass. Confirmed it fails against the old runner and passes with
this fix; all existing fixture checks still pass.

Failure-Class: none
