### PR TITLE
fix(setup): resolve repo root across the whole pre-push chain in linked worktrees

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -24,6 +24,11 @@ checks:
     triggers: ["Makefile", "backend/scripts/sync-python-deps.sh", "scripts/pre-push", "scripts/test-make-setup.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "make setup must provision the minimal, rerunnable backend environment required by selected pre-push checks"
+  - id: pre-push-worktree-fallback
+    command: ["bash", "scripts/test-pre-push-worktree-fallback.sh"]
+    triggers: ["scripts/pre-push", "scripts/pre-push-singleflight", "scripts/pr-preflight", ".github/scripts/preflight_runner.py", ".github/scripts/pr_preflight.py", "scripts/test-pre-push-worktree-fallback.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#10293: the pre-push hook chain must resolve the repo root in linked worktrees where git rev-parse --show-toplevel exits 128, not abort into a --no-verify push"
   - id: check-manifest-contract
     command: ["python3", ".github/scripts/test_run_checks.py"]
     triggers: ["all"]

--- a/.github/scripts/pr_preflight.py
+++ b/.github/scripts/pr_preflight.py
@@ -23,6 +23,18 @@ class Check:
     reason: str
 
 
+def _resolve_repo_root() -> Path:
+    # The pre-push gate cd's to the repo root before invoking this script, and
+    # git runs hooks at the work-tree top, so fall back to the working directory
+    # when `git rev-parse --show-toplevel` cannot resolve a work tree: a linked
+    # worktree whose git context resolves to a git dir exits 128 here ("this
+    # operation must be run in a work tree") and would otherwise abort the gate.
+    try:
+        return Path(run_git(Path.cwd(), "rev-parse", "--show-toplevel"))
+    except subprocess.CalledProcessError:
+        return Path.cwd()
+
+
 def run_git(root: Path, *args: str) -> str:
     result = subprocess.run(
         ["git", *args],
@@ -160,7 +172,7 @@ def main() -> int:
     if bool(args.repository) != bool(args.pr_number):
         print("FAIL: --repository and --pr-number must be supplied together", file=sys.stderr)
         return 2
-    root = (args.root or Path(run_git(Path.cwd(), "rev-parse", "--show-toplevel"))).resolve()
+    root = (args.root or _resolve_repo_root()).resolve()
     started = time.monotonic()
     try:
         merge_base = run_git(root, "merge-base", args.base, args.head)

--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -238,6 +238,27 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def resolve_repo_root() -> Path:
+    # Git runs hooks with the working directory at the top of the invoking work
+    # tree, and the pre-push dispatcher cd's to the repo root before invoking
+    # this runner. Fall back to that working directory when `git rev-parse
+    # --show-toplevel` cannot resolve a work tree: in a linked worktree whose
+    # git context resolves to a git dir rather than a work tree, show-toplevel
+    # exits 128 ("this operation must be run in a work tree") and this runner
+    # would otherwise abort the gate, forcing a --no-verify push.
+    try:
+        toplevel = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError:
+        toplevel = ""
+    return Path(toplevel or Path.cwd()).resolve()
+
+
 def main() -> int:
     args = parse_args()
     command = list(args.command)
@@ -246,7 +267,7 @@ def main() -> int:
     if not command:
         print("FAIL: preflight runner requires a command after --", file=sys.stderr)
         return 2
-    root = Path(subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()).resolve()
+    root = resolve_repo_root()
     # Git supplies ref updates on a pipe. Manual preflight runs inherit a TTY;
     # treating that as empty input avoids waiting forever for an interactive EOF.
     stdin_data = "" if sys.stdin.isatty() else sys.stdin.read()

--- a/scripts/pr-preflight
+++ b/scripts/pr-preflight
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
-ROOT="$(git rev-parse --show-toplevel)"
+# Fall back to the working directory when `git rev-parse --show-toplevel` cannot
+# resolve a work tree: in a linked worktree whose git context resolves to a git
+# dir (show-toplevel exits 128, "this operation must be run in a work tree"),
+# this would otherwise abort. The pre-push gate cd's to the repo root before
+# invoking this script, and hooks run at the work-tree top, so pwd is the root.
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$ROOT"
 exec python3 .github/scripts/pr_preflight.py "$@"

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -2,7 +2,12 @@
 
 set -eo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+# Git runs hooks with the working directory at the top of the invoking work
+# tree, so fall back to it when `git rev-parse --show-toplevel` cannot resolve a
+# work tree. In a linked worktree whose git context resolves to a git dir rather
+# than a work tree, show-toplevel exits 128 ("this operation must be run in a
+# work tree") and this gate would otherwise abort, forcing a --no-verify push.
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 PUSH_REMOTE="${1:-origin}"
 BASE_REMOTE="${PRE_PUSH_BASE_REMOTE:-origin}"

--- a/scripts/pre-push-singleflight
+++ b/scripts/pre-push-singleflight
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
-ROOT="$(git rev-parse --show-toplevel)"
+# Git runs hooks with the working directory at the top of the invoking work
+# tree, so fall back to it when `git rev-parse --show-toplevel` cannot resolve a
+# work tree. In a linked worktree whose git context resolves to a git dir rather
+# than a work tree, show-toplevel exits 128 ("this operation must be run in a
+# work tree") and this script — dispatched from a hook whose ROOT fallback
+# already survived — would otherwise abort here, forcing a --no-verify push.
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$ROOT"
 exec python3 .github/scripts/preflight_runner.py --name pre-push -- scripts/pre-push "$@"

--- a/scripts/test-pre-push-worktree-fallback.sh
+++ b/scripts/test-pre-push-worktree-fallback.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Regression for #10293: `make setup` and the pre-push hook aborted with
+# "fatal: this operation must be run in a work tree" inside linked worktrees.
+#
+# #10401 fixed the Makefile and the installed hook dispatcher, but the scripts
+# the dispatcher hands off to (scripts/pre-push, scripts/pre-push-singleflight,
+# scripts/pr-preflight) and the Python entrypoints they exec
+# (.github/scripts/preflight_runner.py, .github/scripts/pr_preflight.py) still
+# resolved the repo root with an unguarded `git rev-parse --show-toplevel`. When
+# the invoking git context resolves to a git dir rather than a work tree,
+# show-toplevel exits 128 and each of those aborted the gate, forcing a
+# --no-verify push that silently bypasses local checks.
+#
+# A bare GIT_DIR reproduces the exact condition (show-toplevel exits 128) while
+# the working directory is a real work tree, so the fallback to it is correct.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/omi-pre-push-wt.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+BARE="$TMPDIR/bare.git"
+git init -q --bare "$BARE"
+
+# Sanity: confirm the reproduction actually triggers the 128 condition, so a
+# future git that stops failing here turns this into a visible skip rather than a
+# silently vacuous pass.
+if GIT_DIR="$BARE" git -C "$ROOT" rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "SKIP: this git does not surface the show-toplevel work-tree failure; cannot reproduce #10293." >&2
+  exit 0
+fi
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# A stub python3 that reports the working directory it was exec'd in, so the
+# shell resolvers can be exercised against the real script files without running
+# the full gate. It shadows python3 only for the exec-style wrappers below.
+STUB_BIN="$TMPDIR/bin"
+mkdir -p "$STUB_BIN"
+cat >"$STUB_BIN/python3" <<'EOF'
+#!/usr/bin/env bash
+printf 'CWD=%s\n' "$PWD"
+EOF
+chmod +x "$STUB_BIN/python3"
+
+# scripts/pre-push-singleflight and scripts/pr-preflight both resolve the root,
+# cd into it, then exec python3. Under the 128 condition they must reach the
+# stub (printing the real work-tree root) instead of aborting at resolution.
+for script in pre-push-singleflight pr-preflight; do
+  out="$(cd "$ROOT" && GIT_DIR="$BARE" PATH="$STUB_BIN:$PATH" bash "$ROOT/scripts/$script" 2>&1)" \
+    || fail "scripts/$script aborted under the work-tree failure: $out"
+  case "$out" in
+    *"must be run in a work tree"*) fail "scripts/$script still aborts with the work-tree failure: $out" ;;
+    "CWD=$ROOT") : ;;
+    *) fail "scripts/$script resolved the wrong root under the work-tree failure: $out" ;;
+  esac
+done
+
+# scripts/pre-push resolves the root, cd's into it, then fails fast on a missing
+# base ref (this bare repo has no origin/main). The point is that it gets past
+# resolution: the abort must be the base-ref failure, never the work-tree fatal.
+out="$(cd "$ROOT" && GIT_DIR="$BARE" bash "$ROOT/scripts/pre-push" origin file://"$BARE" </dev/null 2>&1)" && true
+case "$out" in
+  *"must be run in a work tree"*) fail "scripts/pre-push still aborts with the work-tree failure: $out" ;;
+  *"cannot find"*) : ;;
+  *) fail "scripts/pre-push did not reach the base-ref check under the work-tree failure: $out" ;;
+esac
+
+# The Python entrypoints resolve the root directly; both must fall back to the
+# working directory instead of raising CalledProcessError under the 128 condition.
+for probe in \
+  "import preflight_runner as m; print(m.resolve_repo_root())" \
+  "import pr_preflight as m; print(m._resolve_repo_root())"; do
+  out="$(cd "$ROOT" && GIT_DIR="$BARE" python3 -c "import sys; sys.path.insert(0, '$ROOT/.github/scripts'); $probe")" \
+    || fail "python resolver aborted under the work-tree failure: $probe"
+  [ "$out" = "$ROOT" ] || fail "python resolver returned wrong root ($out) for: $probe"
+done
+
+echo "pre-push linked-worktree repo-root fallback test passed."


### PR DESCRIPTION
## What

Make the whole pre-push hook chain resolve the repo root without a work tree in linked worktrees.

`#10401` fixed the Makefile and the installed hook **dispatcher**, but the scripts the dispatcher hands off to — `scripts/pre-push`, `scripts/pre-push-singleflight`, `scripts/pr-preflight` — and the Python entrypoints they exec — `.github/scripts/preflight_runner.py`, `.github/scripts/pr_preflight.py` — still resolved the root with an unguarded `git rev-parse --show-toplevel`.

## Why

In a linked worktree whose git context resolves to a git dir rather than a work tree, `git rev-parse --show-toplevel` exits 128 with `fatal: this operation must be run in a work tree`. The dispatcher survived (`#10401` gave it a `|| pwd` fallback), but it then execs `pre-push-singleflight` → `preflight_runner.py` → `pre-push`, each of which re-ran the unguarded call and aborted — so the gate died and the user was forced into a `--no-verify` push that silently bypasses all local checks. That is exactly the reported symptom (`#10293`):

```
$ git push origin <branch>
fatal: this operation must be run in a work tree
error: failed to push some refs to 'https://github.com/BasedHardware/omi.git'
```

## Fix

Fall back to the invoking work tree — git runs hooks with the working directory at the work-tree top, and the dispatcher/gate `cd` into the resolved root before invoking these scripts — matching the fallback `#10401` established for the dispatcher (`git rev-parse --show-toplevel 2>/dev/null || pwd`; the Python resolvers fall back to `Path.cwd()`).

## What I tested

- **Reproduced the exact failure** end-to-end: ran the real installed dispatcher chain under a bare `GIT_DIR` (which makes `show-toplevel` exit 128, identical to the reporter's condition). Before the fix it aborted at `preflight_runner.py:249` with `fatal: this operation must be run in a work tree`; after the fix the gate proceeds past root resolution.
- **New regression test** `scripts/test-pre-push-worktree-fallback.sh` (wired into `.github/checks-manifest.yaml`, `local`+`ci`): asserts all five call sites resolve the work-tree root instead of aborting under the 128 condition. Verified it **fails** against the pre-fix scripts and **passes** after.
- Happy path unchanged: every resolver returns the correct root with no `GIT_DIR` override; existing `scripts/test-make-setup.sh` and the manifest contract self-test (`test_run_checks.py`, 22 tests) still pass.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

fixes #10293

---
Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

