### PR TITLE
Disable update checks during background download

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+Controls.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+Controls.swift
@@ -549,10 +549,12 @@ extension SettingsContentView {
               updaterViewModel.checkForUpdates()
             }
             .buttonStyle(OmiButtonStyle(.primary, size: .compact))
-            .disabled(!updaterViewModel.canCheckForUpdates)
+            .disabled(!updaterViewModel.canManuallyCheckForUpdates)
             .help(
-              updaterViewModel.canCheckForUpdates
-                ? "Check for app updates" : "Already checking for updates…")
+              updaterViewModel.canManuallyCheckForUpdates
+                ? "Check for app updates"
+                : updaterViewModel.updateSessionInProgress
+                  ? "An update is already downloading…" : "Already checking for updates…")
           }
 
           if let lastCheck = updaterViewModel.lastUpdateCheckDate {

--- a/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
+++ b/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
@@ -699,6 +699,14 @@ final class UpdaterViewModel: ObservableObject {
     didSet { UpdaterViewModel._isUpdateInProgress = updateSessionInProgress }
   }
 
+  /// Whether a user can start a new manual update check from Settings.
+  var canManuallyCheckForUpdates: Bool {
+    Self.allowsManualCheck(
+      canCheckForUpdates: canCheckForUpdates,
+      updateSessionInProgress: updateSessionInProgress
+    )
+  }
+
   /// Nonisolated snapshot for cross-actor reads
   private nonisolated(unsafe) static var _isUpdateInProgress: Bool = false
 
@@ -798,6 +806,13 @@ final class UpdaterViewModel: ObservableObject {
   /// Quick check if Sparkle is mid-update (safe to call from anywhere)
   nonisolated static var isUpdateInProgress: Bool {
     _isUpdateInProgress
+  }
+
+  nonisolated static func allowsManualCheck(
+    canCheckForUpdates: Bool,
+    updateSessionInProgress: Bool
+  ) -> Bool {
+    canCheckForUpdates && !updateSessionInProgress
   }
 
   /// Manually check for updates

--- a/desktop/macos/Desktop/Tests/UpdaterViewModelTests.swift
+++ b/desktop/macos/Desktop/Tests/UpdaterViewModelTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class UpdaterViewModelTests: XCTestCase {
+  func testManualCheckIsUnavailableWhileBackgroundUpdateSessionIsInProgress() {
+    XCTAssertFalse(
+      UpdaterViewModel.allowsManualCheck(
+        canCheckForUpdates: true,
+        updateSessionInProgress: true
+      )
+    )
+  }
+
+  func testManualCheckRequiresSparkleToAllowChecking() {
+    XCTAssertFalse(
+      UpdaterViewModel.allowsManualCheck(
+        canCheckForUpdates: false,
+        updateSessionInProgress: false
+      )
+    )
+  }
+
+  func testManualCheckIsAvailableWhenNoSessionIsInProgress() {
+    XCTAssertTrue(
+      UpdaterViewModel.allowsManualCheck(
+        canCheckForUpdates: true,
+        updateSessionInProgress: false
+      )
+    )
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260724-update-check-download.json
+++ b/desktop/macos/changelog/unreleased/20260724-update-check-download.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Settings so Check Now is unavailable while an app update downloads in the background"
+}


### PR DESCRIPTION
## Summary

- Disable the Settings “Check Now” control while Sparkle has an active update session.
- Explain the disabled state in the button help text and cover manual-check availability with focused regression tests.

## Verification

- `cd desktop/macos && ./scripts/dev-feedback.py --once swift 'UpdaterViewModelTests'`
- `cd desktop/macos && ./scripts/agent-logic-harness.sh --cross-surface-smoke`
- `make preflight`
- Built and launched the isolated `omi-check-now-download` named bundle; its local bridge navigated the live app to Settings → About.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

