### PR TITLE
fix(desktop): refocus chat input on open

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -1320,11 +1320,11 @@ struct DashboardPage: View {
     guard !useLegacyHomeDesign else { return }
     openHomeChat()
   }
-
   private func openHomeChat(focusInput: Bool = true) {
-    guard homeMode != .chat else { return }
-    OmiMotion.withGated(Self.homeStageAnimation) {
-      homeMode = .chat
+    if homeMode != .chat {
+      OmiMotion.withGated(Self.homeStageAnimation) {
+        homeMode = .chat
+      }
     }
     if focusInput {
       focusHomeAskFieldAfterStageTransition()

--- a/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
@@ -85,12 +85,22 @@ final class DashboardCaptureStateTests: XCTestCase {
 
   func testHomeAskBarRefocusesAfterOpeningChatStage() throws {
     let source = try dashboardSource()
+    let openChat = try methodBody(named: "openHomeChat", in: source)
 
     XCTAssertTrue(source.contains("private func openHomeChat(focusInput: Bool = true)"))
     XCTAssertTrue(source.contains("focusHomeAskFieldAfterStageTransition()"))
     XCTAssertTrue(source.contains("await Task.yield()"))
     XCTAssertTrue(source.contains("homeAskFieldFocused = true"))
     XCTAssertTrue(source.contains("openHomeChat(focusInput: false)"))
+    // omi-test-quality: source-inspection -- static contract: the SwiftUI focus
+    // state and navigation method are private view wiring, so the hotkey's
+    // already-visible-chat path cannot be driven from the test host.
+    XCTAssertTrue(
+      openChat.contains("if homeMode != .chat {"),
+      "Opening an already-visible chat must still continue to the input-focus request")
+    XCTAssertFalse(
+      openChat.contains("guard homeMode != .chat else { return }"),
+      "An early return drops the hotkey's input focus when chat is already visible")
   }
 
   func testSecondaryHomePagesReturnHomeOnEscape() throws {

--- a/desktop/macos/changelog/unreleased/20260724-chat-input-autofocus.json
+++ b/desktop/macos/changelog/unreleased/20260724-chat-input-autofocus.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved chat so its input is ready whenever you open it"
+}


### PR DESCRIPTION
## Summary

- Focus the Home chat input whenever the chat-open path runs, including when chat is already visible.
- Keep non-interactive chat transitions unfocused and add the required macOS changelog entry.

## Verification

- `xcrun swift test --package-path Desktop --filter DashboardCaptureStateTests`
- `python3 scripts/check_desktop_test_quality.py`
- `./scripts/agent-logic-harness.sh --cross-surface-smoke`
- `xcrun swift build -c debug --package-path Desktop`
- `make preflight`

Built and launched the isolated `omi-chat-autofocus` bundle with the local automation bridge. Its local profile is signed out, so the authenticated UI flow could not be completed.

## Failure class

Failure-Class: none

No existing failure class covers this isolated UI focus-routing defect, and it does not warrant a new cross-cutting class.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

