### PR TITLE
fix(desktop): anchor screen recording drag guidance

### DIFF
--- a/desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift
+++ b/desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift
@@ -404,33 +404,33 @@ enum CloudConnectorFormAutomation {
     )
   }
 
-  static func systemSettingsWindowAppKitFrame() -> CGRect? {
-    guard
-      let app = NSWorkspace.shared.runningApplications.first(where: {
-        $0.bundleIdentifier == "com.apple.systempreferences"
-      })
+  static func systemSettingsWindowAppKitFrame(pid: pid_t? = nil) -> CGRect? {
+    let settingsPID =
+      pid
+      ?? NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.systempreferences")
+      .first?.processIdentifier
+    guard let settingsPID,
+      let windows = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [[String: Any]]
     else { return nil }
-    let appElement = AXUIElementCreateApplication(app.processIdentifier)
-    var windowElement: AXUIElement?
-    var focused: CFTypeRef?
-    if AXUIElementCopyAttributeValue(appElement, "AXFocusedWindow" as CFString, &focused)
-      == .success,
-      let focused
-    {
-      windowElement = (focused as! AXUIElement)
-    } else {
-      var windowsRef: CFTypeRef?
-      if AXUIElementCopyAttributeValue(appElement, "AXWindows" as CFString, &windowsRef)
-        == .success,
-        let windows = windowsRef as? [AXUIElement], let first = windows.first
-      {
-        windowElement = first
+    return appKitWindowFrame(pid: settingsPID, windows: windows)
+  }
+
+  static func appKitWindowFrame(pid: pid_t, windows: [[String: Any]]) -> CGRect? {
+    windows
+      .compactMap { window -> CGRect? in
+        guard (window[kCGWindowOwnerPID as String] as? Int32) == pid,
+          (window[kCGWindowLayer as String] as? Int) == 0,
+          let bounds = window[kCGWindowBounds as String] as? [String: CGFloat],
+          let x = bounds["X"],
+          let y = bounds["Y"],
+          let width = bounds["Width"],
+          let height = bounds["Height"],
+          min(width, height) > 100
+        else { return nil }
+        return CGRect(x: x, y: y, width: width, height: height)
       }
-    }
-    guard let windowElement else { return nil }
-    let topLeft = frameAttribute(windowElement)
-    guard !topLeft.isNull, !topLeft.isEmpty else { return nil }
-    return SpatialOverlayGeometry.globalAppKitFrame(topLeftFrame: topLeft)
+      .max(by: { $0.width * $0.height < $1.width * $1.height })
+      .map(SpatialOverlayGeometry.globalAppKitFrame(topLeftFrame:))
   }
 
   /// Read-only diagnostic: runs the real Claude detection (no overlay, no clicks) and

--- a/desktop/macos/Desktop/Sources/CloudConnectorGuidanceOverlay.swift
+++ b/desktop/macos/Desktop/Sources/CloudConnectorGuidanceOverlay.swift
@@ -218,7 +218,7 @@ final class CloudConnectorGuidanceOverlay {
   }
 
   /// Screen Recording helper whose app icon can be dropped into System Settings.
-  func presentDragToGrantCard(appIcon: NSImage, appName: String, appURL: URL, near anchor: CGRect?) {
+  func presentDragToGrantCard(appIcon: NSImage, appName: String, appURL: URL, near anchor: CGRect) {
     dismissTask?.cancel()
     settingsWatchTask?.cancel()
     window?.close()
@@ -319,39 +319,29 @@ final class CloudConnectorGuidanceOverlay {
   }
 
   /// Drag-card placement: horizontally centered on the anchor (Settings window)
-  /// and pinned directly beneath it, so the card follows the window and never
-  /// covers the drop target. If there's no room below (Settings sits near the
-  /// screen bottom), flip to just above the window instead. With no anchor yet,
-  /// fall back to the bottom quarter of the screen.
-  static func dragCardFrame(anchor: CGRect?, cardSize: CGSize, visibleFrame: CGRect) -> CGRect {
+  /// and pinned directly beneath it. If Settings fills the screen and leaves no
+  /// room below, keep the card in the screen's bottom quarter where it remains
+  /// close to the permission list instead of jumping to the top.
+  static func dragCardFrame(anchor: CGRect, cardSize: CGSize, visibleFrame: CGRect) -> CGRect {
     let gap: CGFloat = 12
     let padding: CGFloat = 12
-    let x = (anchor ?? visibleFrame).midX - cardSize.width / 2
+    let x = anchor.midX - cardSize.width / 2
     let y: CGFloat
-    if let anchor {
-      // AppKit is bottom-left origin: the window's bottom edge is `minY`, so
-      // "under" the window is a smaller y.
-      let below = anchor.minY - gap - cardSize.height
-      y = below >= visibleFrame.minY + padding ? below : anchor.maxY + gap
-    } else {
-      y = visibleFrame.minY + (visibleFrame.height / 4 - cardSize.height) / 2
-    }
+    // AppKit is bottom-left origin: the window's bottom edge is `minY`, so
+    // "under" the window is a smaller y.
+    let below = anchor.minY - gap - cardSize.height
+    y =
+      below >= visibleFrame.minY + padding
+      ? below
+      : visibleFrame.minY + (visibleFrame.height / 4 - cardSize.height) / 2
     let proposed = CGRect(x: x, y: y, width: cardSize.width, height: cardSize.height)
     return SpatialOverlayGeometry.clamped(proposed, to: visibleFrame, padding: padding)
   }
 
-  /// Whether the drag card's arrow should point DOWN toward the anchor. The card
-  /// normally sits below the Settings window (arrow up), but `dragCardFrame` flips
-  /// it above the window when there's no room below — in which case the drop target
-  /// (the list) is beneath the card and the arrow must point down. Mirrors the exact
-  /// placement decision in `dragCardFrame` so the arrow always points at the list.
-  static func dragCardArrowPointsDown(anchor: CGRect?, cardSize: CGSize, visibleFrame: CGRect) -> Bool {
-    guard let anchor else { return false }  // no anchor → bottom-of-screen fallback, arrow up
-    let gap: CGFloat = 12
-    let padding: CGFloat = 12
-    let below = anchor.minY - gap - cardSize.height
-    let fitsBelow = below >= visibleFrame.minY + padding
-    return !fitsBelow
+  /// The card always stays below the permission target, including its bottom-quarter
+  /// fallback, so its arrow points up.
+  static func dragCardArrowPointsDown(anchor: CGRect, cardSize: CGSize, visibleFrame: CGRect) -> Bool {
+    false
   }
 
   /// A named development bundle can have a much longer display name than the

--- a/desktop/macos/Desktop/Sources/Onboarding/PermissionDragGuidance.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/PermissionDragGuidance.swift
@@ -11,7 +11,7 @@ enum PermissionDragGuidance {
     CloudConnectorGuidanceOverlay.shared.dismiss()
   }
 
-  static func presentDragToGrantHelper() async {
+  static func presentDragToGrantHelper(settingsPID: pid_t? = nil) async {
     if let lastPresentedAt, Date().timeIntervalSince(lastPresentedAt) < 2 { return }
     lastPresentedAt = Date()
 
@@ -29,11 +29,15 @@ enum PermissionDragGuidance {
     // pointing straight up" bug). Mirrors the screen-recording instruction overlay.
     var anchor: CGRect?
     for _ in 0..<12 {  // ~2.4s
-      if let frame = CloudConnectorFormAutomation.systemSettingsWindowAppKitFrame() {
+      if let frame = CloudConnectorFormAutomation.systemSettingsWindowAppKitFrame(pid: settingsPID) {
         anchor = frame
         break
       }
       try? await Task.sleep(nanoseconds: 200_000_000)
+    }
+    guard let anchor else {
+      lastPresentedAt = nil
+      return
     }
 
     // The overlay owns the System Settings lifecycle from here: it re-anchors over

--- a/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
@@ -130,27 +130,20 @@ final class ScreenCaptureService: Sendable {
 
   /// Open System Preferences to Screen Recording settings
   static func openScreenRecordingPreferences() {
-    Task { await PermissionDragGuidance.presentDragToGrantHelper() }
+    guard
+      let url = URL(
+        string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
+    else { return }
 
-    if let url = URL(
-      string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
-    {
-      let opened = NSWorkspace.shared.open(url)
-      if opened {
+    Task { @MainActor in
+      do {
+        let settingsApp = try await NSWorkspace.shared.open(url, configuration: .init())
         log("Opened Screen Recording preferences via URL scheme")
-        // Bring System Settings to front after a brief moment to ensure it's visible
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-          if let settingsApp = NSRunningApplication.runningApplications(
-            withBundleIdentifier: "com.apple.systempreferences"
-          ).first
-            ?? NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.Preferences").first
-          {
-            settingsApp.activate()
-          }
-        }
-      } else {
+        settingsApp.activate()
+        await PermissionDragGuidance.presentDragToGrantHelper(
+          settingsPID: settingsApp.processIdentifier)
+      } catch {
         log("Failed to open Screen Recording preferences via URL scheme — trying fallback")
-        // Fallback: open System Settings directly
         NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:")!)
       }
     }
@@ -247,10 +240,6 @@ final class ScreenCaptureService: Sendable {
       Task {
         _ = await requestScreenCaptureKitPermission()
       }
-    }
-
-    if !CGPreflightScreenCaptureAccess() {
-      Task { await PermissionDragGuidance.presentDragToGrantHelper() }
     }
 
     // Note: callers are responsible for opening System Settings

--- a/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
@@ -156,32 +156,18 @@ final class ScreenRecordingPermissionPolicyTests: XCTestCase {
     XCTAssertEqual(frame.maxY, anchor.minY - 12)
   }
 
-  /// When the Settings window sits too low to fit the card beneath it, the card
-  /// flips to just above the window rather than clamping back over the drop target.
+  /// When Settings leaves no room below it, the card stays in the bottom quarter
+  /// instead of jumping to the top of the screen.
   @MainActor
-  func testDragCardFlipsAboveWhenNoRoomBelow() {
+  func testDragCardUsesBottomQuarterWhenNoRoomBelow() {
     let visible = CGRect(x: 0, y: 0, width: 1600, height: 1000)
     let card = CGSize(width: 180, height: 164)
-    // Low, short window: no 164pt of room below its bottom edge (minY = 20).
-    let anchor = CGRect(x: 900, y: 20, width: 600, height: 200)
+    let anchor = CGRect(x: 900, y: 0, width: 600, height: 1000)
 
     let frame = CloudConnectorGuidanceOverlay.dragCardFrame(
       anchor: anchor, cardSize: card, visibleFrame: visible)
     XCTAssertEqual(frame.midX, anchor.midX)
-    XCTAssertGreaterThanOrEqual(frame.minY, anchor.maxY)
-  }
-
-  /// With no Settings window detected yet, the card falls back to the bottom
-  /// quarter of the screen, centered horizontally.
-  @MainActor
-  func testDragCardFallsBackToBottomQuarterWithoutAnchor() {
-    let visible = CGRect(x: 0, y: 0, width: 1600, height: 1000)
-    let card = CGSize(width: 180, height: 164)
-
-    let centered = CloudConnectorGuidanceOverlay.dragCardFrame(
-      anchor: nil, cardSize: card, visibleFrame: visible)
-    XCTAssertEqual(centered.midX, visible.midX)
-    XCTAssertLessThanOrEqual(centered.maxY, visible.minY + visible.height / 4)
+    XCTAssertEqual(frame.midY, visible.height / 8)
   }
 
   /// Card sits below the window → arrow points up at the list above it.
@@ -196,32 +182,47 @@ final class ScreenRecordingPermissionPolicyTests: XCTestCase {
       "Card below the window must point its arrow UP toward the list")
   }
 
-  /// Card flips above the window (no room below) → arrow must point DOWN at the
-  /// list beneath it, not stay hardcoded up (the reported wrong-arrow bug).
+  /// The bottom-quarter fallback remains below the permission target.
   @MainActor
-  func testDragArrowPointsDownWhenCardFlipsAboveWindow() {
+  func testDragArrowPointsUpInBottomQuarter() {
     let visible = CGRect(x: 0, y: 0, width: 1600, height: 1000)
     let card = CGSize(width: 180, height: 164)
-    let anchor = CGRect(x: 900, y: 20, width: 600, height: 200)
-    XCTAssertTrue(
-      CloudConnectorGuidanceOverlay.dragCardArrowPointsDown(
-        anchor: anchor, cardSize: card, visibleFrame: visible),
-      "Card flipped above the window must point its arrow DOWN toward the list")
-    // And the flip-above placement it mirrors must actually be above the window.
-    let frame = CloudConnectorGuidanceOverlay.dragCardFrame(
-      anchor: anchor, cardSize: card, visibleFrame: visible)
-    XCTAssertGreaterThanOrEqual(frame.minY, anchor.maxY)
-  }
-
-  /// No anchor yet (Settings not open) → default arrow up, matching the
-  /// bottom-of-screen fallback placement.
-  @MainActor
-  func testDragArrowPointsUpWithoutAnchor() {
-    let visible = CGRect(x: 0, y: 0, width: 1600, height: 1000)
-    let card = CGSize(width: 180, height: 164)
+    let anchor = CGRect(x: 900, y: 0, width: 600, height: 1000)
     XCTAssertFalse(
       CloudConnectorGuidanceOverlay.dragCardArrowPointsDown(
-        anchor: nil, cardSize: card, visibleFrame: visible))
+        anchor: anchor, cardSize: card, visibleFrame: visible),
+      "Bottom-quarter card must point its arrow UP toward the list")
+  }
+
+  @MainActor
+  func testSettingsWindowFrameUsesWindowServerMetadataWithoutAccessibility() {
+    let settingsPID: pid_t = 42
+    let windows: [[String: Any]] = [
+      [
+        kCGWindowOwnerPID as String: settingsPID,
+        kCGWindowLayer as String: 0,
+        kCGWindowBounds as String: [
+          "X": CGFloat(200), "Y": CGFloat(100), "Width": CGFloat(700), "Height": CGFloat(600),
+        ],
+      ],
+      [
+        kCGWindowOwnerPID as String: settingsPID,
+        kCGWindowLayer as String: 0,
+        kCGWindowBounds as String: [
+          "X": CGFloat(250), "Y": CGFloat(150), "Width": CGFloat(300), "Height": CGFloat(200),
+        ],
+      ],
+      [
+        kCGWindowOwnerPID as String: pid_t(99),
+        kCGWindowLayer as String: 0,
+        kCGWindowBounds as String: ["X": CGFloat(0), "Y": CGFloat(0), "Width": CGFloat(1200), "Height": CGFloat(900)],
+      ],
+    ]
+
+    let frame = CloudConnectorFormAutomation.appKitWindowFrame(pid: settingsPID, windows: windows)
+    XCTAssertEqual(frame?.minX, 200)
+    XCTAssertEqual(frame?.width, 700)
+    XCTAssertEqual(frame?.height, 600)
   }
 
   @MainActor

--- a/desktop/macos/changelog/unreleased/20260724-screen-recording-drag-card-position.json
+++ b/desktop/macos/changelog/unreleased/20260724-screen-recording-drag-card-position.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the Screen Recording drag helper appearing detached from System Settings during onboarding"
+}


### PR DESCRIPTION
## Summary

- open Screen Recording settings before presenting the drag helper
- locate the System Settings window through WindowServer metadata, which works before Accessibility is granted
- place the helper in the bottom quarter when Settings leaves no room below

## Root cause

The helper was launched independently of the asynchronous System Settings open and relied on Accessibility APIs to locate the window. During onboarding Accessibility is not granted, so the helper could render from a detached fallback before Settings was available.

## Impact

The drag helper now waits for the actual System Settings window and remains near the bottom of the screen when the Settings window fills the available height.

## Verification

- `./scripts/dev-feedback.py --once swift 'ScreenRecordingPermissionPolicyTests'` — 19 tests passed
- `python3 scripts/check_desktop_test_quality.py` — passed
- exercised `/Applications/omi-drag-settings-0724.app` with a fresh onboarding profile; the live helper frame moved from `241,757,240,180` to `241,103,240,180`
- `OMI_PR_BODY_FILE=/tmp/omi-drag-card-pr-body.md make preflight` — 18 checks passed
- bounded pre-push gate — passed, including a full clean Swift build

## Product invariants

- INV-INT-1

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

