### PR TITLE
Keep task auto-sync coordinators out of the database pool

### DIFF
--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -3,7 +3,7 @@ import hashlib
 import logging
 import uuid
 
-from utils.executors import db_executor
+from utils.executors import postprocess_executor, submit_with_context
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import Optional, List
@@ -318,7 +318,7 @@ def create_action_item(request: ActionItemCreateRequest, uid: str = Depends(auth
     def _run_auto_sync():
         asyncio.run(auto_sync_action_item(uid, {"id": action_item_id, **action_item_data}, skip_apple_reminders=True))
 
-    db_executor.submit(_run_auto_sync)
+    submit_with_context(postprocess_executor, _run_auto_sync)
 
     return ActionItemResponse(**action_item)
 

--- a/backend/tests/unit/test_action_item_canonical_contract.py
+++ b/backend/tests/unit/test_action_item_canonical_contract.py
@@ -234,7 +234,7 @@ def test_action_item_router_writes_shared_contract_and_preserves_old_response(mo
     now = datetime(2026, 7, 9, tzinfo=timezone.utc)
     task_links.register_goal_existence_resolver(lambda uid, goal_id: goal_id == 'goal-1')
     monkeypatch.setattr(action_items_router, 'upsert_action_item_vector', lambda *args: None)
-    monkeypatch.setattr(action_items_router.db_executor, 'submit', lambda *args: None)
+    monkeypatch.setattr(action_items_router, 'submit_with_context', lambda *args: None)
     monkeypatch.setattr(action_items_router, 'send_action_item_data_message', lambda **kwargs: None)
     monkeypatch.setattr(
         action_items_router.action_items_db,

--- a/backend/tests/unit/test_action_item_idempotency.py
+++ b/backend/tests/unit/test_action_item_idempotency.py
@@ -278,3 +278,40 @@ def test_content_key_avoids_separator_collision():
     a = action_items_router._content_idempotency_key('org', 'user:task')
     b = action_items_router._content_idempotency_key('org:user', 'task')
     assert a != b
+
+
+def test_create_dispatches_auto_sync_outside_the_database_pool(monkeypatch):
+    postprocess_pool = object()
+    submitted_to = []
+    database_submissions = []
+
+    monkeypatch.setattr(action_items_router, 'postprocess_executor', postprocess_pool, raising=False)
+    monkeypatch.setattr(
+        action_items_router,
+        'submit_with_context',
+        lambda executor, function: submitted_to.append(executor),
+        raising=False,
+    )
+    legacy_db_executor = getattr(action_items_router, 'db_executor', MagicMock())
+    monkeypatch.setattr(legacy_db_executor, 'submit', lambda function: database_submissions.append(function))
+    monkeypatch.setattr(action_items_router, 'db_executor', legacy_db_executor, raising=False)
+    monkeypatch.setattr(action_items_router.task_links, 'validate_task_links', lambda *args, **kwargs: None)
+    monkeypatch.setattr(action_items_db, 'create_action_item', lambda *args, **kwargs: 'task-1')
+    monkeypatch.setattr(
+        action_items_db,
+        'get_action_item',
+        lambda *args, **kwargs: {'id': 'task-1', 'description': 'Plan launch', 'completed': False},
+    )
+    monkeypatch.setattr(action_items_router, 'upsert_action_item_vector', lambda *args, **kwargs: None)
+
+    result = action_items_router.create_action_item(
+        action_items_router.CreateActionItemRequest(description='Plan launch'),
+        uid='user-1',
+    )
+
+    assert result.id == 'task-1'
+    assert submitted_to == [postprocess_pool], (
+        'the task auto-sync coordinator must run on postprocess_executor so its Firestore '
+        'children can acquire db_executor workers'
+    )
+    assert database_submissions == [], 'the task auto-sync coordinator must never occupy a db_executor worker'

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -801,6 +801,49 @@ def test_action_items_skipped_on_discard():
     extract_mock.assert_not_called()
 
 
+def test_conversation_action_item_auto_sync_uses_postprocess_pool(monkeypatch):
+    action_item = MagicMock()
+    action_item.description = 'Send the forecast'
+    action_item.completed = False
+    action_item.created_at = None
+    action_item.updated_at = None
+    action_item.due_at = None
+    action_item.completed_at = None
+
+    conversation = MagicMock()
+    conversation.id = 'conversation-1'
+    conversation.is_locked = False
+    conversation.structured.action_items = [action_item]
+
+    monkeypatch.setattr(process_conversation.conversation_capture, 'process_before_legacy', lambda *args: False)
+    monkeypatch.setattr(process_conversation.conversation_capture, 'canonical_fields', lambda *args: {})
+    monkeypatch.setattr(process_conversation.conversation_capture, 'legacy_document_ids', lambda *args: None)
+    monkeypatch.setattr(process_conversation.conversation_capture, 'reconcile_after_legacy', lambda *args: None)
+    monkeypatch.setattr(process_conversation.action_items_db, 'get_action_items_by_conversation', lambda *args: [])
+    monkeypatch.setattr(
+        process_conversation.action_items_db, 'delete_action_items_for_conversation', lambda *args: None
+    )
+    monkeypatch.setattr(
+        process_conversation.action_items_db,
+        'create_action_items_batch',
+        lambda *args, **kwargs: ['task-1'],
+    )
+    monkeypatch.setattr(process_conversation, 'upsert_action_item_vectors_batch', lambda *args, **kwargs: None)
+    submitted_to = []
+    monkeypatch.setattr(
+        process_conversation,
+        'submit_with_context',
+        lambda executor, function: submitted_to.append(executor),
+    )
+
+    process_conversation._save_action_items('user-1', conversation)
+
+    assert submitted_to == [process_conversation.postprocess_executor], (
+        'conversation task auto-sync must run on postprocess_executor so its Firestore '
+        'children can acquire db_executor workers'
+    )
+
+
 def test_llm_calls_use_omi_qos_tier_system():
     """Verify all LLM functions use get_llm() with correct feature keys and cache_key param."""
     conv_proc_path = Path(__file__).resolve().parent.parent.parent / "utils" / "llm" / "conversation_processing.py"

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -62,7 +62,7 @@ from utils.notifications import send_important_conversation_message
 from models.task import Task, TaskStatus, TaskAction, TaskActionProvider
 from models.notification_message import NotificationMessage
 from utils.apps import get_available_app_model_by_id, get_available_apps, update_persona_prompt
-from utils.executors import db_executor, llm_executor, postprocess_executor, submit_with_context
+from utils.executors import llm_executor, postprocess_executor, submit_with_context
 from utils.llm.conversation_processing import (
     get_transcript_structure,
     get_app_result,
@@ -902,7 +902,7 @@ def _save_action_items(uid: str, conversation: Conversation):
         def _run_auto_sync():
             asyncio.run(auto_sync_action_items_batch(uid, created_items))
 
-        submit_with_context(db_executor, _run_auto_sync)
+        submit_with_context(postprocess_executor, _run_auto_sync)
 
         upsert_action_item_vectors_batch(
             uid,


### PR DESCRIPTION
## Problem

Task auto-sync coordinators are submitted to `db_executor` in both the direct action-item create path and the conversation action-item save path:

```python
db_executor.submit(_run_auto_sync)

submit_with_context(db_executor, _run_auto_sync)
```

Each coordinator then runs `auto_sync_action_item` or `auto_sync_action_items_batch`. The first operation in both functions awaits `run_blocking(db_executor, users_db.get_default_task_integration, uid)`.

`db_executor` has 24 workers. If 24 auto-sync coordinators are queued ahead of their child reads, every worker is occupied by a coordinator waiting for work queued to the same pool. The pool cannot make progress, and unrelated Firestore and Redis work assigned to it is also starved.

## Reachability / failure scenario

- `POST /v1/action-items` persists a task and submits `_run_auto_sync` from `routers/action_items.py`.
- Conversation processing persists extracted action items and submits `_run_auto_sync` from `utils/conversations/process_conversation.py`.
- Both coordinators call `asyncio.run(...)`.
- `auto_sync_action_item` and `auto_sync_action_items_batch` immediately await child reads on `db_executor` in `utils/task_sync.py`.
- A process-wide burst of 24 task-sync coordinators can therefore occupy the complete database pool while all 24 wait for database children queued behind them.

The trigger does not require an external integration to be configured. Determining that no default integration exists already requires the child database read.

## Fix

Both coordinators now run on `postprocess_executor` through `submit_with_context`. Their Firestore and Redis children remain on `db_executor`, so coordinators and children no longer compete for the same finite worker set.

`utils/task_intelligence/candidate_service.py` already submits the same `auto_sync_action_item` coordinator to `postprocess_executor`. This change makes all three production auto-sync entry points use that established boundary.

The task-sync implementation and its child pool assignments are unchanged. This PR also does not change API responses, task integration behavior, retry policy, or provider calls.

## Tests

- `test_create_dispatches_auto_sync_outside_the_database_pool` drives the real create handler and verifies that it submits the coordinator to `postprocess_executor`, never `db_executor`.
- `test_conversation_action_item_auto_sync_uses_postprocess_pool` drives the real conversation action-item persistence helper and verifies the same coordinator boundary.
- The existing canonical action-item handler contract now stubs `submit_with_context` at the new dispatch seam.

## Verification

Current upstream base:

```text
3fcce0fd377c3fb1fa83cff535cf3e48ed4a4569
```

Prove-fail:

- Reverted both product files byte-for-byte to `origin/main`.
- Confirmed `git diff origin/main -- backend/routers/action_items.py backend/utils/conversations/process_conversation.py` printed nothing.
- Ran both new regression tests. They failed with:

```text
AssertionError: the task auto-sync coordinator must run on postprocess_executor so its Firestore children can acquire db_executor workers
AssertionError: conversation task auto-sync must run on postprocess_executor so its Firestore children can acquire db_executor workers
```

- Restored the fix and reran both tests: `2 passed`.

Additional verification:

- All three touched test files plus the six required conversation-lifecycle contract files: `229 passed, 14 warnings`.
- `black --line-length 120 --skip-string-normalization --check ...`: 5 files unchanged.
- `python -m pyright -p pyrightconfig.json routers/action_items.py utils/conversations/process_conversation.py`: 0 errors, 0 warnings, 0 informations.
- `python scripts/check_module_stub_pollution.py`: 784 test files checked, 0 violations.
- `python scripts/scan_async_blockers.py --dirs routers utils`: 0 selected blocking findings and 0 known findings.
- `python scripts/scan_import_time_side_effects.py`: 730 production files checked, 0 violations.
- `python scripts/check_conversation_lifecycle_writes.py`: passed.
- Product-file line-count ratchet: passed across both changed product files.
- `bash test.sh`: all 723 selected files ran; 98 files were nonzero on Windows, while all three touched test files passed inside the aggregate. A clean refreshed `origin/main` replay reproduced 87 of the 98 known broad dependency and timing failures. An isolated replay of the eight aggregate asymmetries matched branch and base file-for-file: five passed and the same three failed only the 0.12-second CPU guard with all assertions passing.
- `bash scripts/pr-preflight --suggest`: passed; product invariants were `none`, and no `fix:` commit was detected.
- Local preflight with this PR body: passed, except for the documented Windows-only `check-manifest-contract` platform assertion.

Product invariants affected: none

Failure-Class: none

## Impact

This affects processes that receive a burst of direct task creates or conversation-derived action items. At the 24-worker saturation point, auto-sync can deadlock the shared database pool instead of completing, which can stall task export and unrelated database-backed requests in that process.

Lower-volume processes do not reach the full deadlock, but the old placement still consumed database capacity while coordinators waited on their own child work. The change restores the executor bulkhead without changing user-visible task semantics.
