### PR TITLE
Preserve task state during Apple Reminders sync

### DIFF
--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -975,7 +975,7 @@ def batch_sync_update_action_items(uid: str, updates: List[Dict[str, Any]]) -> B
 
     for entry in updates:
         doc_ref = action_items_ref.document(entry['id'])
-        update_data = _prepare_action_item_for_write(entry['data'])
+        update_data = _prepare_action_item_for_write(entry['data'], partial=True)
         update_data['updated_at'] = now
         # Clear sync_requested when item is successfully exported
         if update_data.get('exported') is True:

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -231,7 +231,7 @@ def sync_batch_update(request: SyncBatchRequest, uid: str = Depends(auth.get_cur
                 update_data['completed_at'] = datetime.now(timezone.utc)
             else:
                 update_data['completed_at'] = None
-        if item.due_at is not None:
+        if 'due_at' in item.model_fields_set:
             update_data['due_at'] = item.due_at
         if item.exported is not None:
             update_data['exported'] = item.exported

--- a/backend/tests/unit/test_action_item_canonical_contract.py
+++ b/backend/tests/unit/test_action_item_canonical_contract.py
@@ -137,6 +137,44 @@ def test_database_write_projection_defaults_canonical_fields_without_losing_comp
     assert partial == {'description': 'Edited'}
 
 
+def test_apple_sync_batch_preserves_omitted_canonical_fields(monkeypatch):
+    document_ref = MagicMock()
+    action_items = MagicMock()
+    action_items.document.return_value = document_ref
+    user_ref = MagicMock()
+    user_ref.collection.return_value = action_items
+    users = MagicMock()
+    users.document.return_value = user_ref
+    fake_db = MagicMock()
+    fake_db.collection.return_value = users
+    monkeypatch.setattr(action_items_db, 'db', fake_db)
+
+    result = action_items_db.batch_sync_update_action_items(
+        'user-1',
+        [
+            {
+                'id': 'task-1',
+                'data': {
+                    'exported': True,
+                    'export_platform': 'apple_reminders',
+                    'apple_reminder_id': 'reminder-1',
+                },
+            }
+        ],
+    )
+
+    document_ref.update.assert_called_once()
+    patch = document_ref.update.call_args.args[0]
+    assert isinstance(patch['updated_at'], datetime)
+    assert {key: value for key, value in patch.items() if key != 'updated_at'} == {
+        'exported': True,
+        'export_platform': 'apple_reminders',
+        'apple_reminder_id': 'reminder-1',
+        'sync_requested': False,
+    }, 'an Apple sync patch must not replace omitted canonical task fields with create defaults'
+    assert result.updated_ids == ['task-1']
+
+
 def test_write_mode_reprocessing_soft_retires_removed_tasks_and_preserves_receipt_targets(monkeypatch):
     active = MagicMock(id='task-active')
     removed = MagicMock(id='task-removed')

--- a/backend/tests/unit/test_task_sharing.py
+++ b/backend/tests/unit/test_task_sharing.py
@@ -120,6 +120,7 @@ _stub_module("utils.other.endpoints")
 sys.modules["utils.other.endpoints"].get_current_user_uid = MagicMock()
 
 import database.redis_db as redis_db
+import routers.action_items as action_items_router
 from routers.action_items import (
     share_action_items,
     get_shared_action_items,
@@ -706,3 +707,45 @@ class TestSyncBatchSkipsLocked:
         call_args = mock_db.batch_sync_update_action_items.call_args[0]
         assert len(call_args[1]) == 1
         assert call_args[1][0]['id'] == 't1'
+
+    def test_sync_batch_distinguishes_explicit_due_date_clear_from_omission(self):
+        batch_result = types.SimpleNamespace(
+            updated_ids=["t1"],
+            missing_ids=[],
+            noop_ids=[],
+            updated_count=1,
+        )
+        batch_result.model = lambda: {
+            "updated_count": 1,
+            "updated_ids": ["t1"],
+            "missing_ids": [],
+            "noop_ids": [],
+        }
+
+        with patch.object(action_items_router, 'action_items_db') as mock_db:
+            mock_db.get_action_item.side_effect = [
+                {
+                    "id": "t1",
+                    "description": "Clear the deadline",
+                    "is_locked": False,
+                },
+                {
+                    "id": "t2",
+                    "description": "Leave the deadline unchanged",
+                    "is_locked": False,
+                },
+            ]
+            mock_db.batch_sync_update_action_items.return_value = batch_result
+            request = action_items_router.SyncBatchRequest(
+                items=[
+                    action_items_router.SyncBatchItem.model_validate({'id': 't1', 'due_at': None}),
+                    action_items_router.SyncBatchItem.model_validate({'id': 't2'}),
+                ]
+            )
+
+            action_items_router.sync_batch_update(request, uid='test-uid')
+
+        updates = mock_db.batch_sync_update_action_items.call_args.args[1]
+        assert updates == [
+            {'id': 't1', 'data': {'due_at': None}}
+        ], 'an explicit null due_at must reach storage instead of being treated as an omitted field'


### PR DESCRIPTION
## Problem

The Apple Reminders sync-batch path treats partial task patches as full create payloads and drops explicit due-date clears:

```python
update_data = _prepare_action_item_for_write(entry['data'])

if item.due_at is not None:
    update_data['due_at'] = item.due_at
```

The default write normalizer fills omitted create fields. A metadata-only Apple export therefore writes `status='active'`, `completed=False`, `owner='unknown'`, `source='legacy'`, an empty provenance list, and zero values for sort order and indentation into an existing task.

A title-only or due-only update can also reopen a completed task. When Apple removes a due date, the client sends `due_at: null`, but the router treats that explicit null as if the field was omitted and reports success without clearing storage.

## Reachability / failure scenario

- `AppleRemindersSyncService._performOutboundSync` creates a reminder and sends only `exported`, `export_platform`, and `apple_reminder_id` to `/v1/action-items/sync-batch`.
- Its bidirectional path sends completion-only, description-only, and due-only patches when Apple has the newer value.
- `sync_batch_update` in `routers/action_items.py` builds a partial dictionary for each item.
- `batch_sync_update_action_items` in `database/action_items.py` passes that dictionary through the full-create normalizer before calling Firestore `DocumentReference.update`.
- The injected defaults persistently replace canonical fields that the client never sent.

This is the normal foreground Apple Reminders sync path. It does not require a legacy or malformed task document.

## Fix

`batch_sync_update_action_items` now calls `_prepare_action_item_for_write(..., partial=True)`, matching the ordinary `update_action_item` boundary. Date normalization and completed/status consistency still apply when those fields are present, but omitted canonical fields remain omitted from the Firestore patch.

The router now checks `SyncBatchItem.model_fields_set` for `due_at`. This preserves the difference between an omitted field and an explicit JSON null, so removing a due date in Apple clears the stored due date.

The PR deliberately does not change sync scheduling, Apple bridge behavior, pending-item selection, reminder notifications, or any other task mutation endpoint.

## Tests

- `test_apple_sync_batch_preserves_omitted_canonical_fields` drives the real database helper through a Firestore document update seam and verifies that an outbound export writes only the supplied metadata, `sync_requested=False`, and `updated_at`.
- `test_sync_batch_distinguishes_explicit_due_date_clear_from_omission` uses the real `SyncBatchItem` validation and router handler, patching only the downstream database seam. It verifies that JSON `due_at: null` reaches storage as `{'due_at': None}` while an omitted field stays omitted.

The Firestore fake is faithful for this path because production uses `DocumentReference.update` with the exact mapping passed by the helper. The regression asserts that exact mapping rather than simulating unrelated Firestore behavior.

## Verification

Current upstream base:

```text
3fcce0fd377c3fb1fa83cff535cf3e48ed4a4569
```

Prove-fail:

- Reverted both product files byte-for-byte to `origin/main`.
- Confirmed their product diff against `origin/main` was empty.
- Ran both new regression tests against the reverted product code. Exact failures:

```text
AssertionError: an Apple sync patch must not replace omitted canonical task fields with create defaults
AssertionError: an explicit null due_at must reach storage instead of being treated as an omitted field
Actual: []
Expected: [{'id': 't1', 'data': {'due_at': None}}]
```

- Restored the fix and reran both tests: `2 passed`.

Additional verification:

- Full affected test files: `47 passed`.
- Router test file after adding the symmetric omitted-field assertion: `30 passed`.
- FastAPI HTTP route smoke for `PATCH /v1/action-items/sync-batch`: passed. Request parsing preserved explicit null, omitted `due_at` produced no patch, and the response was HTTP 200.
- `black --line-length 120 --skip-string-normalization --check ...`: 4 files unchanged.
- Pyright on gated `database/action_items.py` at `origin/main`: 0 errors, 13 warnings.
- Pyright on gated `database/action_items.py` on the patched branch: 0 errors, 13 warnings. Delta: 0 errors, 0 warnings. `routers/action_items.py` is explicitly excluded by `pyrightconfig.json`.
- `python scripts/check_module_stub_pollution.py`: 784 test files checked, 0 violations.
- `python scripts/scan_async_blockers.py --dirs routers utils`: 0 selected blocking findings.
- `python scripts/scan_import_time_side_effects.py`: 730 production files checked, 0 violations.
- Product-file line-count ratchet: passed across both changed product files.
- Workflow contract validation: passed.
- `goal_workstream_lifecycle` workflow tests: `40 passed`.
- `bash test.sh`: all 723 selected files ran; 94 files were nonzero on Windows, while both touched test files passed inside the aggregate. A clean refreshed `origin/main` replay in the same environment had already reproduced 87 broad dependency and timing failures. The eight aggregate asymmetries checked separately matched branch and base file-for-file; the remaining full-run nonzero files were not individually replayed.
- `bash scripts/pr-preflight --suggest`: passed; product invariants were `none`, and no `fix:` commit was detected.
- Local preflight with this PR body: passed except for the documented Windows-only `check-manifest-contract` platform assertion.

Product invariants affected: none

Failure-Class: none

## Impact

Every task exported through the foreground Apple Reminders sync can currently lose canonical ownership, source, provenance, ordering, and hierarchy metadata. Title-only and due-only reconciliation can also reopen a completed task because those patches omit completion fields.

Users who remove an Apple reminder deadline can see the stale deadline remain in Omi and be retried on later syncs. The fix limits storage mutations to fields the client actually supplied and preserves explicit clears.
