### PR TITLE
fix(llm-gateway): classify provider request rejections

### DIFF
--- a/.github/scripts/test_desktop_swift_ci_contract.py
+++ b/.github/scripts/test_desktop_swift_ci_contract.py
@@ -290,6 +290,14 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
             "manifest checks must use the pushed-before SHA on main pushes and the PR base on pull requests",
         )
 
+    def test_pr_changelog_metadata_is_owned_by_the_canonical_preflight(self):
+        """#10501 run 30121300487: the macOS lane has no live PR label metadata."""
+        job = self.jobs["desktop-swift-static"]
+
+        self.assertIn('if [ "${{ github.event_name }}" = "pull_request" ]; then', job)
+        self.assertIn("MANIFEST_ARGS+=(--skip-changelog)", job)
+        self.assertIn('"${MANIFEST_ARGS[@]}"', job)
+
     def test_xcode_version_probe_does_not_close_its_pipe_early(self):
         """head(1) aborts Xcode 16.4 under pipefail; sed reads the full output."""
         runner = _runner_text()

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -135,7 +135,19 @@ jobs:
 
       - name: Run macOS-scoped manifest checks
         run: |
-          python3 .github/scripts/run_checks.py --lane ci --platform macos --base "${{ needs.changes.outputs.diff_base }}" --skip-pr-body-checks
+          MANIFEST_ARGS=()
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Repo Checks owns PR metadata enforcement and reruns it for label
+            # changes. This macOS-only lane has no live PR metadata, so it must
+            # not independently reject the supported no-changelog-needed label.
+            MANIFEST_ARGS+=(--skip-changelog)
+          fi
+          python3 .github/scripts/run_checks.py \
+            --lane ci \
+            --platform macos \
+            --base "${{ needs.changes.outputs.diff_base }}" \
+            --skip-pr-body-checks \
+            "${MANIFEST_ARGS[@]}"
 
       - name: Save Swift formatter and linter tools after checks
         if: ${{ always() && steps.swift-tools-cache.outputs.cache-hit != 'true' }}

--- a/app/lib/backend/schema/gen/memories_wire.g.dart
+++ b/app/lib/backend/schema/gen/memories_wire.g.dart
@@ -82,6 +82,7 @@ class GeneratedMemoryDB {
   final String? headline;
   final String id;
   final DateTime? invalidAt;
+  final bool isBaseline;
   final bool isLocked;
   final bool kgExtracted;
   final String? layer;
@@ -122,6 +123,7 @@ class GeneratedMemoryDB {
     this.headline,
     required this.id,
     this.invalidAt,
+    this.isBaseline = false,
     this.isLocked = false,
     this.kgExtracted = false,
     required this.layer,
@@ -164,6 +166,7 @@ class GeneratedMemoryDB {
       headline: _readFieldValue<String>(_readField(json, const ["headline"]), "headline", _readString, requiredField: false, nullable: true),
       id: _required(_readFieldValue<String>(_readField(json, const ["id"]), "id", _readString, requiredField: true, nullable: false), "id"),
       invalidAt: _readFieldValue<DateTime>(_readField(json, const ["invalid_at"]), "invalid_at", _readDateTime, requiredField: false, nullable: true),
+      isBaseline: _required(_readFieldValue<bool>(_readField(json, const ["is_baseline"]), "is_baseline", _readBool, requiredField: false, nullable: false, defaultValue: false), "is_baseline"),
       isLocked: _required(_readFieldValue<bool>(_readField(json, const ["is_locked"]), "is_locked", _readBool, requiredField: false, nullable: false, defaultValue: false), "is_locked"),
       kgExtracted: _required(_readFieldValue<bool>(_readField(json, const ["kg_extracted"]), "kg_extracted", _readBool, requiredField: false, nullable: false, defaultValue: false), "kg_extracted"),
       layer: _readFieldValue<String>(_readField(json, const ["layer"]), "layer", _readString, requiredField: true, nullable: true),
@@ -207,6 +210,7 @@ class GeneratedMemoryDB {
       'headline': headline,
       'id': id,
       'invalid_at': invalidAt?.toUtc().toIso8601String(),
+      'is_baseline': isBaseline,
       'is_locked': isLocked,
       'kg_extracted': kgExtracted,
       'layer': layer,

--- a/backend/llm_gateway/config/README.md
+++ b/backend/llm_gateway/config/README.md
@@ -35,10 +35,15 @@ versus after the first non-empty chunk are separate bounded phases. Provider com
 client received the terminal chunk.
 
 `llm_gateway_requests_total` and `llm_gateway_request_latency_seconds` include bounded `api_surface`, `streaming`,
-`phase`, and `credential_source` labels. `llm_gateway_stream_ttfb_seconds` measures time to the first non-empty
-chunk. Request IDs are opaque UUIDs emitted only in response headers and structured logs, never as Prometheus
-labels. Pre-route contract failures use `llm_gateway_request_rejections_total{api_surface,error_class}`; service
-authentication failures use `llm_gateway_auth_rejections_total{reason}`.
+`phase`, `credential_source`, and `provider_rejection` labels. The provider-rejection label is parsed from only an
+allowlisted set of upstream error codes and parameter roots; unknown values collapse to `other_4xx`, and provider
+messages, request values, and raw bodies never become labels or terminal-log fields. Provider 4xx responses that
+describe unsupported parameters remain `capability_mismatch`; invalid requests such as
+`context_length_exceeded` use the separate, non-fallback `provider_invalid_request` failure class.
+`llm_gateway_stream_ttfb_seconds` measures time to the first non-empty chunk. Request IDs are opaque UUIDs emitted
+only in response headers and structured logs, never as Prometheus labels. Pre-route contract failures use
+`llm_gateway_request_rejections_total{api_surface,error_class}`; service authentication failures use
+`llm_gateway_auth_rejections_total{reason}`.
 
 ## Usage accounting ledger
 

--- a/backend/llm_gateway/config/lanes.yaml
+++ b/backend/llm_gateway/config/lanes.yaml
@@ -21,6 +21,7 @@ lanes:
         - byok_unsupported_provider
         - missing_byok_key
         - capability_mismatch
+        - provider_invalid_request
         - invalid_config
     active_route: route.public_shared_conversation_chat.2026_07_19.001
     last_known_good: route.public_shared_conversation_chat.2026_07_19.001
@@ -49,6 +50,7 @@ lanes:
         - byok_unsupported_provider
         - missing_byok_key
         - capability_mismatch
+        - provider_invalid_request
         - invalid_config
     active_route: route.chat_structured.2026_06_27.001
     last_known_good: route.chat_structured.2026_06_20.001

--- a/backend/llm_gateway/config/route_artifacts.yaml
+++ b/backend/llm_gateway/config/route_artifacts.yaml
@@ -1,6 +1,6 @@
 route_artifacts:
   - route_artifact_id: route.public_shared_conversation_chat.2026_07_19.001
-    artifact_digest: sha256:2b001db329d1ade5f0ce65a11271e4fbe29b2acf815cb32e5a2a13302b793b31
+    artifact_digest: sha256:f9900baf225db6fc1386b668d008d9fe9de391f1ea8c1b1b3de15e6486800df4
     lane_id: omi:auto:public-shared-conversation-chat
     surface: openai.chat_completions
     primary:
@@ -40,6 +40,7 @@ route_artifacts:
         - byok_unsupported_provider
         - missing_byok_key
         - capability_mismatch
+        - provider_invalid_request
         - invalid_config
     fallback_policy:
       fallback_on: []
@@ -50,10 +51,11 @@ route_artifacts:
         - byok_unsupported_provider
         - missing_byok_key
         - capability_mismatch
+        - provider_invalid_request
         - invalid_config
 
   - route_artifact_id: route.chat_structured.2026_06_27.001
-    artifact_digest: sha256:d9ab75d4eb53c029028c7a2ebccee8d273d043d6d7553a8e8c9f9897d28bfb6a
+    artifact_digest: sha256:707331066d53439c5abd3a3614c5a5f3972880713e53b68fe470b0bf2a930104
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     primary:
@@ -95,6 +97,7 @@ route_artifacts:
         - byok_unsupported_provider
         - missing_byok_key
         - capability_mismatch
+        - provider_invalid_request
         - invalid_config
     fallback_policy:
       fallback_on:
@@ -108,10 +111,11 @@ route_artifacts:
         - byok_unsupported_provider
         - missing_byok_key
         - capability_mismatch
+        - provider_invalid_request
         - invalid_config
 
   - route_artifact_id: route.chat_structured.2026_06_20.001
-    artifact_digest: sha256:70f61658ab9f0283514d86ce3438bdcd89ed3f15dd8d42533648384840894e67
+    artifact_digest: sha256:7a8c23fbb2bae7e005b69844c84191f4852e97f56cb99dd3bca75360c430a273
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     # The gateway LKG mirrors the active model so shadow serving and fallback use
@@ -153,6 +157,7 @@ route_artifacts:
         - byok_unsupported_provider
         - missing_byok_key
         - capability_mismatch
+        - provider_invalid_request
         - invalid_config
     fallback_policy:
       fallback_on:
@@ -166,4 +171,5 @@ route_artifacts:
         - byok_unsupported_provider
         - missing_byok_key
         - capability_mismatch
+        - provider_invalid_request
         - invalid_config

--- a/backend/llm_gateway/gateway/config_loader.py
+++ b/backend/llm_gateway/gateway/config_loader.py
@@ -261,6 +261,7 @@ def _generated_feature_route_items(
                         'byok_unsupported_provider',
                         'missing_byok_key',
                         'capability_mismatch',
+                        'provider_invalid_request',
                         'invalid_config',
                     ],
                 },
@@ -322,6 +323,7 @@ def _credential_policy() -> dict[str, Any]:
             'byok_unsupported_provider',
             'missing_byok_key',
             'capability_mismatch',
+            'provider_invalid_request',
             'invalid_config',
         ],
     }

--- a/backend/llm_gateway/gateway/errors.py
+++ b/backend/llm_gateway/gateway/errors.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import Enum
 
-from llm_gateway.gateway.schemas import FailureClass
+from llm_gateway.gateway.schemas import FailureClass, ProviderRejection
 
 
 class GatewayErrorCode(str, Enum):
@@ -12,6 +12,7 @@ class GatewayErrorCode(str, Enum):
     CAPABILITY_NOT_SUPPORTED = 'capability_not_supported'
     INVALID_ROUTE_CONFIG = 'invalid_route_config'
     CREDENTIAL_FAILURE = 'credential_failure'
+    PROVIDER_REQUEST_REJECTED = 'provider_request_rejected'
     PROVIDER_FAILURE = 'provider_failure'
 
 
@@ -29,6 +30,21 @@ class GatewayError(Exception):
         self.code = code
         self.failure_class = failure_class
         self.param = param
+        self.provider = 'none'
+        self.model = 'none'
+        self.provider_rejection = ProviderRejection.NONE
+
+    def with_provider_context(
+        self,
+        *,
+        provider: str,
+        model: str,
+        provider_rejection: ProviderRejection = ProviderRejection.NONE,
+    ) -> 'GatewayError':
+        self.provider = provider
+        self.model = model
+        self.provider_rejection = provider_rejection
+        return self
 
     def to_error_dict(self) -> dict[str, str | None]:
         return {
@@ -90,5 +106,15 @@ class GatewayProviderFailureError(GatewayError):
             message,
             code=GatewayErrorCode.PROVIDER_FAILURE,
             failure_class=failure_class,
+            param=param,
+        )
+
+
+class GatewayProviderRequestRejectedError(GatewayError):
+    def __init__(self, message: str, *, param: str | None = 'provider') -> None:
+        super().__init__(
+            message,
+            code=GatewayErrorCode.PROVIDER_REQUEST_REJECTED,
+            failure_class=FailureClass.PROVIDER_INVALID_REQUEST,
             param=param,
         )

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -17,6 +17,7 @@ from llm_gateway.gateway.errors import (
     GatewayError,
     GatewayInvalidRouteConfigError,
     GatewayProviderFailureError,
+    GatewayProviderRequestRejectedError,
 )
 from llm_gateway.gateway.providers import (
     ChatCompletionProvider,
@@ -299,7 +300,7 @@ async def _attempt_provider(
                 )
             return response, None
         except ProviderFailure as exc:
-            error = _map_provider_failure(exc, credential_context)
+            error = _map_provider_failure(exc, credential_context, provider_ref)
             if attempt_trace is not None:
                 attempt_trace.record(
                     provider=provider_ref.provider,
@@ -486,22 +487,36 @@ def _unsupported_provider_error(
     return GatewayInvalidRouteConfigError(f'provider is not supported for this route: {provider_ref.provider}')
 
 
-def _map_provider_failure(exc: ProviderFailure, credential_context: CredentialContext) -> GatewayError:
+def _map_provider_failure(
+    exc: ProviderFailure,
+    credential_context: CredentialContext,
+    provider_ref: ProviderRef,
+) -> GatewayError:
     failure_class = exc.failure_class
     if failure_class == FailureClass.INVALID_CONFIG:
-        return GatewayInvalidRouteConfigError(_safe_failure_message(failure_class, exc.safe_message), param='provider')
-    if failure_class == FailureClass.CAPABILITY_MISMATCH:
-        return GatewayCapabilityMismatchError(_safe_failure_message(failure_class, exc.safe_message), param='provider')
-    if credential_context.mode == CredentialMode.BYOK or is_byok_failure_class(failure_class):
-        return GatewayCredentialFailureError(
+        error: GatewayError = GatewayInvalidRouteConfigError(
+            _safe_failure_message(failure_class, exc.safe_message), param='provider'
+        )
+    elif failure_class == FailureClass.CAPABILITY_MISMATCH:
+        error = GatewayCapabilityMismatchError(_safe_failure_message(failure_class, exc.safe_message), param='provider')
+    elif failure_class == FailureClass.PROVIDER_INVALID_REQUEST:
+        error = GatewayProviderRequestRejectedError(_safe_failure_message(failure_class, exc.safe_message))
+    elif credential_context.mode == CredentialMode.BYOK or is_byok_failure_class(failure_class):
+        error = GatewayCredentialFailureError(
             _safe_failure_message(failure_class, exc.safe_message),
             failure_class=failure_class,
             param='provider',
         )
-    return GatewayProviderFailureError(
-        _safe_failure_message(failure_class, exc.safe_message),
-        failure_class=failure_class,
-        param='provider',
+    else:
+        error = GatewayProviderFailureError(
+            _safe_failure_message(failure_class, exc.safe_message),
+            failure_class=failure_class,
+            param='provider',
+        )
+    return error.with_provider_context(
+        provider=provider_ref.provider,
+        model=provider_ref.model,
+        provider_rejection=exc.provider_rejection,
     )
 
 

--- a/backend/llm_gateway/gateway/metrics.py
+++ b/backend/llm_gateway/gateway/metrics.py
@@ -10,7 +10,7 @@ from prometheus_client import Counter, Histogram
 from llm_gateway.gateway.accounting import AccountingEvent
 from llm_gateway.gateway.errors import GatewayError
 from llm_gateway.gateway.output_budget import OutputBudgetDecision, output_budget_bucket
-from llm_gateway.gateway.schemas import FailureClass
+from llm_gateway.gateway.schemas import FailureClass, ProviderRejection
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +32,7 @@ _REQUEST_LABELS = [
     'fallback_reason',
     'outcome',
     'error_class',
+    'provider_rejection',
     'budget_source',
     'output_budget',
     'completion_size',
@@ -151,14 +152,15 @@ def observe_error(
         started_at,
         lane_id=lane_id,
         route_artifact_id=route_artifact_id,
-        provider='none',
-        model='none',
+        provider=error.provider,
+        model=error.model,
         credential_source=credential_source,
         used_lkg=False,
         fallback_used=False,
         fallback_reason=error.failure_class,
         outcome='error',
         error_class=error.code.value,
+        provider_rejection=error.provider_rejection,
         request_id=request_id,
         api_surface=api_surface,
         streaming=streaming,
@@ -183,6 +185,7 @@ def observe_route_result(
     api_surface: str,
     streaming: bool,
     phase: str,
+    provider_rejection: ProviderRejection | str = ProviderRejection.NONE,
     ttfb_seconds: float | None = None,
     budget_source: str = 'none',
     output_budget: str = 'none',
@@ -203,6 +206,7 @@ def observe_route_result(
         'fallback_reason': _enum_label(fallback_reason, default='none'),
         'outcome': _bounded(outcome),
         'error_class': _bounded(error_class),
+        'provider_rejection': _provider_rejection_label(provider_rejection),
         'budget_source': _budget_source_label(budget_source),
         'output_budget': _output_budget_label(output_budget),
         'completion_size': _completion_size_label(completion_size),
@@ -220,6 +224,7 @@ def observe_route_result(
     terminal_log(
         'llm_gateway_terminal request_id=%s surface=%s streaming=%s phase=%s lane=%s route=%s provider=%s '
         'model=%s credential_source=%s outcome=%s error_class=%s failure_class=%s fallback_used=%s '
+        'provider_rejection=%s '
         'budget_source=%s output_budget=%s completion_size=%s finish_reason=%s ttfb_seconds=%s',
         request_id,
         _bounded(api_surface),
@@ -234,6 +239,7 @@ def observe_route_result(
         labels['error_class'],
         labels['fallback_reason'],
         labels['fallback_used'],
+        labels['provider_rejection'],
         labels['budget_source'],
         labels['output_budget'],
         labels['completion_size'],
@@ -298,6 +304,14 @@ def _enum_label(value: object, *, default: str = 'unknown') -> str:
     if raw_value is None:
         return default
     return _bounded(str(raw_value))
+
+
+def _provider_rejection_label(value: object) -> str:
+    raw_value = getattr(value, 'value', value)
+    try:
+        return ProviderRejection(str(raw_value)).value
+    except ValueError:
+        return ProviderRejection.OTHER_4XX.value
 
 
 def _bounded(value: str) -> str:

--- a/backend/llm_gateway/gateway/providers.py
+++ b/backend/llm_gateway/gateway/providers.py
@@ -24,7 +24,7 @@ from llm_gateway.gateway.accounting import (
     vertex_usage_from_response,
 )
 from llm_gateway.gateway.credentials import CredentialContext
-from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef
+from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef, ProviderRejection
 from llm_gateway.gateway.sse import SSEEventDecoder
 from utils.executors import critical_executor, run_blocking
 from utils.log_sanitizer import sanitize
@@ -59,6 +59,7 @@ class ChatCompletionProvider(Protocol):
 class ProviderFailure(Exception):
     failure_class: FailureClass
     safe_message: str = GENERIC_PROVIDER_FAILURE_MESSAGE
+    provider_rejection: ProviderRejection = ProviderRejection.NONE
 
     def __str__(self) -> str:
         return self.safe_message
@@ -874,7 +875,66 @@ def _raise_for_status(
             FailureClass.PROVIDER_5XX_OMI_PAID, safe_message=_provider_error_message(status_code, body)
         )
     if status_code >= 400:
-        raise ProviderFailure(FailureClass.CAPABILITY_MISMATCH, safe_message=_provider_error_message(status_code, body))
+        provider_rejection = _provider_rejection(body)
+        failure_class = (
+            FailureClass.CAPABILITY_MISMATCH
+            if provider_rejection.value.startswith('unsupported_')
+            else FailureClass.PROVIDER_INVALID_REQUEST
+        )
+        raise ProviderFailure(
+            failure_class,
+            safe_message=_provider_error_message(status_code, body),
+            provider_rejection=provider_rejection,
+        )
+
+
+_PROVIDER_REJECTION_PARAMS = {
+    'model': 'model',
+    'messages': 'messages',
+    'response_format': 'response_format',
+    'reasoning_effort': 'reasoning_effort',
+    'temperature': 'temperature',
+    'max_tokens': 'output_limit',
+    'max_completion_tokens': 'output_limit',
+    'prompt_cache_key': 'prompt_cache',
+    'prompt_cache_options': 'prompt_cache',
+    'tools': 'tools',
+    'tool_choice': 'tools',
+    'stream': 'stream',
+    'stream_options': 'stream',
+}
+
+
+def _provider_rejection(body: bytes) -> ProviderRejection:
+    """Extract only allowlisted provider error semantics from a bounded body preview."""
+    try:
+        parsed = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return ProviderRejection.OTHER_4XX
+    if not isinstance(parsed, Mapping):
+        return ProviderRejection.OTHER_4XX
+    error = parsed.get('error')
+    if not isinstance(error, Mapping):
+        return ProviderRejection.OTHER_4XX
+
+    code = error.get('code')
+    if code == 'context_length_exceeded':
+        return ProviderRejection.CONTEXT_LENGTH_EXCEEDED
+    if code == 'model_not_found':
+        return ProviderRejection.MODEL_NOT_FOUND
+
+    prefix = 'unsupported' if code == 'unsupported_parameter' else None
+    if code in {'invalid_parameter', 'invalid_value', 'invalid_type'}:
+        prefix = 'invalid'
+    if prefix is not None:
+        raw_param = error.get('param')
+        root_param = raw_param.split('[', 1)[0].split('.', 1)[0] if isinstance(raw_param, str) else ''
+        bounded_param = _PROVIDER_REJECTION_PARAMS.get(root_param, 'other')
+        return ProviderRejection(f'{prefix}_{bounded_param}')
+
+    if error.get('type') == 'invalid_request_error':
+        return ProviderRejection.INVALID_REQUEST
+    return ProviderRejection.OTHER_4XX
 
 
 def _provider_error_message(status_code: int, body: bytes) -> str:

--- a/backend/llm_gateway/gateway/resolver.py
+++ b/backend/llm_gateway/gateway/resolver.py
@@ -19,6 +19,7 @@ AUTO_LANE_PREFIX = 'omi:auto:'
 NEVER_LKG_FAILURE_CLASSES = frozenset(
     {
         FailureClass.CAPABILITY_MISMATCH,
+        FailureClass.PROVIDER_INVALID_REQUEST,
         FailureClass.INVALID_CONFIG,
         FailureClass.BYOK_AUTH,
         FailureClass.BYOK_QUOTA,

--- a/backend/llm_gateway/gateway/schemas.py
+++ b/backend/llm_gateway/gateway/schemas.py
@@ -43,6 +43,7 @@ class FailureClass(str, Enum):
     TIMEOUT_BEFORE_OUTPUT = 'timeout_before_output'
     PROVIDER_429_OMI_PAID = 'provider_429_omi_paid'
     PROVIDER_5XX_OMI_PAID = 'provider_5xx_omi_paid'
+    PROVIDER_INVALID_REQUEST = 'provider_invalid_request'
     BYOK_AUTH = 'byok_auth'
     BYOK_QUOTA = 'byok_quota'
     BYOK_RATE_LIMIT = 'byok_rate_limit'
@@ -50,6 +51,36 @@ class FailureClass(str, Enum):
     MISSING_BYOK_KEY = 'missing_byok_key'
     CAPABILITY_MISMATCH = 'capability_mismatch'
     INVALID_CONFIG = 'invalid_config'
+
+
+class ProviderRejection(str, Enum):
+    """Privacy-safe classification of an upstream provider's rejected request."""
+
+    NONE = 'none'
+    CONTEXT_LENGTH_EXCEEDED = 'context_length_exceeded'
+    MODEL_NOT_FOUND = 'model_not_found'
+    INVALID_REQUEST = 'invalid_request'
+    INVALID_MODEL = 'invalid_model'
+    INVALID_MESSAGES = 'invalid_messages'
+    INVALID_RESPONSE_FORMAT = 'invalid_response_format'
+    INVALID_REASONING_EFFORT = 'invalid_reasoning_effort'
+    INVALID_TEMPERATURE = 'invalid_temperature'
+    INVALID_OUTPUT_LIMIT = 'invalid_output_limit'
+    INVALID_PROMPT_CACHE = 'invalid_prompt_cache'
+    INVALID_TOOLS = 'invalid_tools'
+    INVALID_STREAM = 'invalid_stream'
+    INVALID_OTHER = 'invalid_other'
+    UNSUPPORTED_MODEL = 'unsupported_model'
+    UNSUPPORTED_MESSAGES = 'unsupported_messages'
+    UNSUPPORTED_RESPONSE_FORMAT = 'unsupported_response_format'
+    UNSUPPORTED_REASONING_EFFORT = 'unsupported_reasoning_effort'
+    UNSUPPORTED_TEMPERATURE = 'unsupported_temperature'
+    UNSUPPORTED_OUTPUT_LIMIT = 'unsupported_output_limit'
+    UNSUPPORTED_PROMPT_CACHE = 'unsupported_prompt_cache'
+    UNSUPPORTED_TOOLS = 'unsupported_tools'
+    UNSUPPORTED_STREAM = 'unsupported_stream'
+    UNSUPPORTED_OTHER = 'unsupported_other'
+    OTHER_4XX = 'other_4xx'
 
 
 class BenchmarkSource(str, Enum):

--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -269,6 +269,7 @@ def _error_type_for_code(code: GatewayErrorCode) -> str:
         GatewayErrorCode.INVALID_ROUTE_CONFIG,
         GatewayErrorCode.UNSUPPORTED_MODEL,
         GatewayErrorCode.CAPABILITY_NOT_SUPPORTED,
+        GatewayErrorCode.PROVIDER_REQUEST_REJECTED,
     }:
         return 'invalid_request_error'
     return 'api_error'
@@ -281,6 +282,7 @@ def _status_code_for_error(exc: GatewayError) -> int:
         GatewayErrorCode.INVALID_REQUEST,
         GatewayErrorCode.UNSUPPORTED_MODEL,
         GatewayErrorCode.CAPABILITY_NOT_SUPPORTED,
+        GatewayErrorCode.PROVIDER_REQUEST_REJECTED,
     }:
         return 400
     if exc.code == GatewayErrorCode.CREDENTIAL_FAILURE:
@@ -478,7 +480,7 @@ async def _prepared_streaming_iterator(
                 cache_requested=cache_requested_for_openai_request(provider_request),
             )
         except ProviderFailure as exc:
-            last_error = _map_provider_failure(exc, credentials)
+            last_error = _map_provider_failure(exc, credentials, provider_ref)
             attempt_trace.record(
                 provider=provider_ref.provider,
                 configured_model=provider_ref.model,

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -10,6 +10,7 @@ from llm_gateway.gateway.errors import (
     GatewayCredentialFailureError,
     GatewayInvalidRouteConfigError,
     GatewayProviderFailureError,
+    GatewayProviderRequestRejectedError,
 )
 from llm_gateway.gateway.accounting import AttemptTrace
 from llm_gateway.gateway.executor import ProviderRegistry, execute_chat_completion, selected_serving_route_artifact_id
@@ -171,6 +172,7 @@ async def test_executor_attempt_trace_retains_each_retry_and_fallback() -> None:
     [
         (FailureClass.INVALID_CONFIG, GatewayInvalidRouteConfigError),
         (FailureClass.CAPABILITY_MISMATCH, GatewayCapabilityMismatchError),
+        (FailureClass.PROVIDER_INVALID_REQUEST, GatewayProviderRequestRejectedError),
         (FailureClass.BYOK_AUTH, GatewayCredentialFailureError),
         (FailureClass.BYOK_QUOTA, GatewayCredentialFailureError),
         (FailureClass.BYOK_RATE_LIMIT, GatewayCredentialFailureError),
@@ -237,6 +239,7 @@ async def test_executor_uses_active_route_fallback_for_policy_allowed_failures(f
     [
         (FailureClass.INVALID_CONFIG, GatewayInvalidRouteConfigError),
         (FailureClass.CAPABILITY_MISMATCH, GatewayCapabilityMismatchError),
+        (FailureClass.PROVIDER_INVALID_REQUEST, GatewayProviderRequestRejectedError),
         (FailureClass.BYOK_AUTH, GatewayCredentialFailureError),
         (FailureClass.BYOK_QUOTA, GatewayCredentialFailureError),
         (FailureClass.BYOK_RATE_LIMIT, GatewayCredentialFailureError),

--- a/backend/tests/unit/test_llm_gateway_metrics.py
+++ b/backend/tests/unit/test_llm_gateway_metrics.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 
 from llm_gateway.gateway import metrics
+from llm_gateway.gateway.errors import GatewayProviderRequestRejectedError
+from llm_gateway.gateway.schemas import ProviderRejection
 
 
 class _MetricChild:
@@ -66,6 +68,7 @@ def test_stream_terminal_metric_exposes_bounded_surface_phase_and_byok_source(mo
     assert labels['output_budget'] == 'le_128'
     assert labels['completion_size'] == 'le_256'
     assert labels['finish_reason'] == 'length'
+    assert labels['provider_rejection'] == 'none'
     assert 'request_id' not in labels
     assert latency.observations[0][0] == labels
     assert ttfb.observations == [
@@ -122,9 +125,50 @@ def test_terminal_errors_are_warning_logs_with_only_bounded_failure_fields(monke
         'surface=openai_chat_completions streaming=false phase=before_output '
         'lane=omi:auto:conv-structure route=route.conv_structure.model_config.001 '
         'provider=none model=none credential_source=service_forwarded_byok outcome=error '
-        'error_class=credential_failure failure_class=byok_auth fallback_used=false budget_source=none '
-        'output_budget=none completion_size=unknown finish_reason=unknown ttfb_seconds=none'
+        'error_class=credential_failure failure_class=byok_auth fallback_used=false provider_rejection=none '
+        'budget_source=none output_budget=none completion_size=unknown finish_reason=unknown ttfb_seconds=none'
     ]
+
+
+def test_provider_rejection_terminal_identifies_route_target_and_bounds_rejection(monkeypatch, caplog):
+    requests = _Metric()
+    latency = _Metric()
+    monkeypatch.setattr(metrics, 'REQUESTS_TOTAL', requests)
+    monkeypatch.setattr(metrics, 'REQUEST_LATENCY_SECONDS', latency)
+    error = GatewayProviderRequestRejectedError('provider request failed').with_provider_context(
+        provider='openai',
+        model='gpt-5.4-nano',
+        provider_rejection=ProviderRejection.CONTEXT_LENGTH_EXCEEDED,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=metrics.logger.name):
+        metrics.observe_error(
+            metrics.time_request(),
+            lane_id='omi:auto:knowledge-graph',
+            route_artifact_id='route.knowledge_graph.model_config.001',
+            error=error,
+            credential_source='omi_managed',
+            request_id='936c2c10-c509-41f1-95cf-2162710d5ac8',
+        )
+
+    labels = requests.increments[0]
+    assert labels['provider'] == 'openai'
+    assert labels['model'] == 'gpt-5.4-nano'
+    assert labels['error_class'] == 'provider_request_rejected'
+    assert labels['fallback_reason'] == 'provider_invalid_request'
+    assert labels['provider_rejection'] == 'context_length_exceeded'
+
+    error.provider_rejection = 'private-customer-value'  # type: ignore[assignment]
+    metrics.observe_error(
+        metrics.time_request(),
+        lane_id='omi:auto:knowledge-graph',
+        route_artifact_id='route.knowledge_graph.model_config.001',
+        error=error,
+        credential_source='omi_managed',
+        request_id='936c2c10-c509-41f1-95cf-2162710d5ac8',
+    )
+    assert requests.increments[1]['provider_rejection'] == 'other_4xx'
+    assert 'private-customer-value' not in caplog.text
 
 
 def test_pre_route_rejection_metric_has_only_bounded_contract_labels(monkeypatch, caplog):

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -14,7 +14,7 @@ from llm_gateway.gateway.credentials import build_omi_managed_credential_context
 from llm_gateway.gateway.executor import ProviderRegistry, provider_request_for
 from llm_gateway.gateway.providers import FakeChatCompletionProvider, ProviderFailure
 from llm_gateway.gateway.resolver import resolve_chat_completion_route
-from llm_gateway.gateway.schemas import FailureClass, ProviderRef
+from llm_gateway.gateway.schemas import FailureClass, ProviderRef, ProviderRejection
 from llm_gateway.main import app
 from llm_gateway.routers import dependencies, openai_compatible
 from models.structured_extraction import ActionItemsExtraction, ConversationStructureExtraction
@@ -89,6 +89,51 @@ def test_chat_completions_success_uses_lane_model_and_hides_route_metadata(monke
     assert provider.calls[0].request['temperature'] == 0
     assert provider.calls[0].request['max_completion_tokens'] == 64
     assert 'metadata' not in provider.calls[0].request
+
+
+@pytest.mark.parametrize(
+    ('failure_class', 'provider_rejection', 'expected_code'),
+    [
+        (
+            FailureClass.CAPABILITY_MISMATCH,
+            ProviderRejection.UNSUPPORTED_REASONING_EFFORT,
+            'capability_not_supported',
+        ),
+        (
+            FailureClass.PROVIDER_INVALID_REQUEST,
+            ProviderRejection.CONTEXT_LENGTH_EXCEEDED,
+            'provider_request_rejected',
+        ),
+    ],
+)
+def test_provider_rejection_preserves_exact_terminal_class_and_bounded_member(
+    monkeypatch,
+    failure_class,
+    provider_rejection,
+    expected_code,
+):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+    recorded: list[dict] = []
+    provider = FakeChatCompletionProvider([ProviderFailure(failure_class, provider_rejection=provider_rejection)])
+    monkeypatch.setattr(openai_compatible, 'observe_error', lambda *_args, **kwargs: recorded.append(kwargs))
+    app.dependency_overrides[dependencies.get_provider_registry] = lambda: ProviderRegistry({'openai': provider})
+    try:
+        response = TestClient(app).post(
+            '/v1/chat/completions',
+            json=valid_request(),
+            headers=auth_headers(),
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 400
+    assert response.json()['error']['code'] == expected_code
+    assert len(recorded) == 1
+    error = recorded[0]['error']
+    assert error.failure_class == failure_class
+    assert error.provider == 'openai'
+    assert error.model == 'gpt-5.4-nano'
+    assert error.provider_rejection == provider_rejection
 
 
 def test_chat_completions_persists_cache_aware_attempt_with_authenticated_attribution(monkeypatch):

--- a/backend/tests/unit/test_llm_gateway_openai_provider.py
+++ b/backend/tests/unit/test_llm_gateway_openai_provider.py
@@ -12,7 +12,7 @@ from llm_gateway.gateway.providers import (
     ProviderFailure,
 )
 from llm_gateway.gateway import providers as providers_mod
-from llm_gateway.gateway.schemas import FailureClass, ProviderRef
+from llm_gateway.gateway.schemas import FailureClass, ProviderRef, ProviderRejection
 
 
 @pytest.mark.asyncio
@@ -192,7 +192,7 @@ async def test_openai_compatible_provider_maps_transport_error(monkeypatch):
 @pytest.mark.parametrize(
     ('status_code', 'failure_class'),
     [
-        (400, FailureClass.CAPABILITY_MISMATCH),
+        (400, FailureClass.PROVIDER_INVALID_REQUEST),
         (401, FailureClass.INVALID_CONFIG),
         (403, FailureClass.INVALID_CONFIG),
         (408, FailureClass.TIMEOUT_BEFORE_OUTPUT),
@@ -219,6 +219,68 @@ async def test_openai_compatible_provider_maps_status_without_leaking_body(monke
 
     assert exc_info.value.failure_class == failure_class
     assert raw_body not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('error', 'failure_class', 'provider_rejection'),
+    [
+        (
+            {
+                'code': 'unsupported_parameter',
+                'param': 'reasoning_effort',
+                'message': 'private provider detail',
+            },
+            FailureClass.CAPABILITY_MISMATCH,
+            ProviderRejection.UNSUPPORTED_REASONING_EFFORT,
+        ),
+        (
+            {
+                'code': 'context_length_exceeded',
+                'param': 'messages',
+                'message': 'private provider detail',
+            },
+            FailureClass.PROVIDER_INVALID_REQUEST,
+            ProviderRejection.CONTEXT_LENGTH_EXCEEDED,
+        ),
+        (
+            {
+                'code': 'invalid_value',
+                'param': 'customer-secret-field',
+                'message': 'private provider detail',
+            },
+            FailureClass.PROVIDER_INVALID_REQUEST,
+            ProviderRejection.INVALID_OTHER,
+        ),
+    ],
+)
+async def test_openai_provider_classifies_bounded_rejection_without_leaking_body(
+    monkeypatch,
+    error,
+    failure_class,
+    provider_rejection,
+):
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+    provider = OpenAICompatibleChatCompletionProvider(
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(400, json={'error': {**error, 'sensitive': 'must-not-leak'}})
+            )
+        ),
+    )
+
+    with pytest.raises(ProviderFailure) as exc_info:
+        await provider.create_chat_completion(
+            {'model': 'gpt-5.4-nano', 'messages': [{'role': 'user', 'content': 'secret'}], 'stream': False},
+            provider_ref=ProviderRef(provider='openai', model='gpt-5.4-nano'),
+            credentials=build_omi_managed_credential_context(ServiceCaller(name='backend')),
+            timeout_ms=8000,
+        )
+
+    assert exc_info.value.failure_class == failure_class
+    assert exc_info.value.provider_rejection == provider_rejection
+    assert 'private provider detail' not in str(exc_info.value)
+    assert 'customer-secret-field' not in exc_info.value.provider_rejection.value
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_llm_gateway_resolver.py
+++ b/backend/tests/unit/test_llm_gateway_resolver.py
@@ -107,6 +107,7 @@ def test_lkg_is_selected_only_for_active_route_policy_allowed_failure():
         FailureClass.BYOK_UNSUPPORTED_PROVIDER,
         FailureClass.MISSING_BYOK_KEY,
         FailureClass.CAPABILITY_MISMATCH,
+        FailureClass.PROVIDER_INVALID_REQUEST,
         FailureClass.INVALID_CONFIG,
     ],
 )

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager+OwnerBoundaryTestSupport.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager+OwnerBoundaryTestSupport.swift
@@ -1,0 +1,10 @@
+#if DEBUG
+  @MainActor
+  extension PushToTalkManager {
+    /// Installs the production effect handler without starting capture or
+    /// muting system audio in hermetic owner-boundary tests.
+    func installOwnerBoundaryEffectHandlerFixture() {
+      configureVoiceTurnCoordinator(barState: FloatingControlBarState())
+    }
+  }
+#endif

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -330,7 +330,7 @@ class PushToTalkManager: ObservableObject {
     log("PushToTalkManager: setup complete, micPermission=\(hasMicPermission)")
   }
 
-  private func configureVoiceTurnCoordinator(barState: FloatingControlBarState) {
+  func configureVoiceTurnCoordinator(barState: FloatingControlBarState) {
     voiceTurnCoordinator.configure(barState: barState)
     voiceTurnCoordinator.setEffectHandler { [weak self] effect in
       self?.handleVoiceTurnEffect(effect)

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -2688,6 +2688,7 @@ public enum OmiAPI {
     public let headline: String?
     public let id: String
     public let invalidAt: String?
+    public let isBaseline: Bool?
     public let isLocked: Bool?
     public let kgExtracted: Bool?
     public let layer: String?
@@ -2728,6 +2729,7 @@ public enum OmiAPI {
       case headline
       case id
       case invalidAt = "invalid_at"
+      case isBaseline = "is_baseline"
       case isLocked = "is_locked"
       case kgExtracted = "kg_extracted"
       case layer
@@ -2770,6 +2772,7 @@ public enum OmiAPI {
       headline = try c.decodeIfPresent(String.self, forKey: .headline)
       id = try c.decode(String.self, forKey: .id)
       invalidAt = try c.decodeIfPresent(String.self, forKey: .invalidAt)
+      isBaseline = try c.decodeIfPresent(Bool.self, forKey: .isBaseline)
       isLocked = try c.decodeIfPresent(Bool.self, forKey: .isLocked)
       kgExtracted = try c.decodeIfPresent(Bool.self, forKey: .kgExtracted)
       layer = try c.decodeIfPresent(String.self, forKey: .layer)
@@ -2795,7 +2798,7 @@ public enum OmiAPI {
       visibility = try c.decodeIfPresent(String.self, forKey: .visibility)
     }
 
-    public init(appId: String?, arguments: [String: OmiAnyCodable]?, captureConfidence: Double?, captureDeviceIds: [String]?, category: MemoryCategory?, content: String, conversationId: String?, createdAt: String, dataProtectionLevel: String?, durability: String?, edited: Bool?, evidence: [Evidence]?, headline: String?, id: String, invalidAt: String?, isLocked: Bool?, kgExtracted: Bool?, layer: String?, manuallyAdded: Bool?, memoryId: String?, memoryTier: MemoryLayer?, objectEntityIds: [String]?, predicate: String?, primaryCaptureDevice: String?, qualifiers: [String: OmiAnyCodable]?, reviewed: Bool?, scoring: String?, subjectAttribution: SubjectAttribution?, subjectEntityId: String?, supersededBy: String?, tags: [String]?, uid: String, uncertaintyReasons: [String]?, updatedAt: String, userReview: Bool?, validAt: String?, veracity: Double?, visibility: String?) {
+    public init(appId: String?, arguments: [String: OmiAnyCodable]?, captureConfidence: Double?, captureDeviceIds: [String]?, category: MemoryCategory?, content: String, conversationId: String?, createdAt: String, dataProtectionLevel: String?, durability: String?, edited: Bool?, evidence: [Evidence]?, headline: String?, id: String, invalidAt: String?, isBaseline: Bool?, isLocked: Bool?, kgExtracted: Bool?, layer: String?, manuallyAdded: Bool?, memoryId: String?, memoryTier: MemoryLayer?, objectEntityIds: [String]?, predicate: String?, primaryCaptureDevice: String?, qualifiers: [String: OmiAnyCodable]?, reviewed: Bool?, scoring: String?, subjectAttribution: SubjectAttribution?, subjectEntityId: String?, supersededBy: String?, tags: [String]?, uid: String, uncertaintyReasons: [String]?, updatedAt: String, userReview: Bool?, validAt: String?, veracity: Double?, visibility: String?) {
       self.appId = appId
       self.arguments = arguments
       self.captureConfidence = captureConfidence
@@ -2811,6 +2814,7 @@ public enum OmiAPI {
       self.headline = headline
       self.id = id
       self.invalidAt = invalidAt
+      self.isBaseline = isBaseline
       self.isLocked = isLocked
       self.kgExtracted = kgExtracted
       self.layer = layer
@@ -14167,6 +14171,33 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
+  public static func updateMemoryBaselineV3MemoriesMemoryIdBaselinePatch(client: OmiApiClient, memoryId: String, value: Bool, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> OmiAnyCodable {
+    let _path = "/v3/memories/\(memoryId)/baseline"
+    guard var components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    var queryItems: [URLQueryItem] = []
+    queryItems.append(URLQueryItem(name: "value", value: String(value)))
+    if !queryItems.isEmpty { components.queryItems = queryItems }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "PATCH"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
   public static func reviewMemoryV3MemoriesMemoryIdReviewPost(client: OmiApiClient, memoryId: String, value: Bool, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> OmiAnyCodable {
     let _path = "/v3/memories/\(memoryId)/review"
     guard var components = URLComponents(string: client.baseURL + _path) else {
@@ -14357,5 +14388,5 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  // Total: 382 Swift client methods generated.
+  // Total: 385 Swift client methods generated.
 }

--- a/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/PushToTalkStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/PushToTalkStateMachineTests.swift
@@ -150,10 +150,7 @@ final class PushToTalkStateMachineTests: XCTestCase {
       manager.cleanup()
       await transitionOwner(defaults: defaults, to: "owner-a")
 
-      // Install the production physical-effect handler without touching a real
-      // microphone, then admit an exact non-hub capture through the reducer.
-      _ = manager.beginPushToTalkForAutomation()
-      manager.cleanup()
+      manager.installOwnerBoundaryEffectHandlerFixture()
       let turnID = VoiceTurnCoordinator.shared.begin(intent: .hold, ownerID: "owner-a")
       VoiceTurnCoordinator.shared.publish(
         .selectRoute(turnID: turnID, route: .deepgramLive))
@@ -214,8 +211,7 @@ final class PushToTalkStateMachineTests: XCTestCase {
       manager.cleanup()
       await transitionOwner(defaults: defaults, to: "owner-a")
 
-      _ = manager.beginPushToTalkForAutomation()
-      manager.cleanup()
+      manager.installOwnerBoundaryEffectHandlerFixture()
       hub.installOwnerBoundaryFixture(ownerID: "owner-a")
       let turnID = VoiceTurnCoordinator.shared.begin(intent: .hold, ownerID: "owner-a")
       VoiceTurnCoordinator.shared.publish(
@@ -244,8 +240,7 @@ final class PushToTalkStateMachineTests: XCTestCase {
       manager.cleanup()
       await transitionOwner(defaults: defaults, to: "owner-a")
 
-      _ = manager.beginPushToTalkForAutomation()
-      manager.cleanup()
+      manager.installOwnerBoundaryEffectHandlerFixture()
       hub.installOwnerBoundaryFixture(ownerID: "owner-a")
       let turnID = VoiceTurnCoordinator.shared.begin(intent: .hold, ownerID: "owner-a")
       VoiceTurnCoordinator.shared.publish(
@@ -300,10 +295,7 @@ final class PushToTalkStateMachineTests: XCTestCase {
       manager.cleanup()
       await transitionOwner(defaults: defaults, to: "owner-a")
 
-      // Install the production terminal-effect handler without starting a real
-      // microphone capture, then model a begin whose receipt was lost to Swift.
-      _ = manager.beginPushToTalkForAutomation()
-      manager.cleanup()
+      manager.installOwnerBoundaryEffectHandlerFixture()
       let turnID = VoiceTurnCoordinator.shared.begin(intent: .hold, ownerID: "owner-a")
       hub.installOwnerBoundaryUnresolvedExternalRunFixture(
         ownerID: "owner-a",

--- a/desktop/macos/e2e/flows/ptt-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/ptt-lifecycle.yaml
@@ -11,6 +11,7 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/LegacyVoiceJournalImporter.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/PTTAttemptLifecycleRecorder.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager+OwnerBoundaryTestSupport.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager+InputDeviceRouting.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RawWebSocket.swift

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -2196,6 +2196,7 @@ export interface MemoryDB {
   headline?: string | null;
   id: string;
   invalid_at?: string | null;
+  is_baseline?: boolean;
   is_locked?: boolean;
   kg_extracted?: boolean;
   layer: string | null;
@@ -8016,6 +8017,17 @@ export interface OmiApiPaths {
     };
     delete: {
       operationId: "delete_memory_v3_memories__memory_id__delete";
+      responses: {
+        "200": MemoryMutationResponse;
+        "401": void;
+        "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v3/memories/{memory_id}/baseline": {
+    patch: {
+      operationId: "update_memory_baseline_v3_memories__memory_id__baseline_patch";
       responses: {
         "200": MemoryMutationResponse;
         "401": void;
@@ -15507,6 +15519,28 @@ export async function delete_memory_v3_memories__memory_id__delete(path: { memor
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function update_memory_baseline_v3_memories__memory_id__baseline_patch(path: { memory_id: string }, query: { value: boolean }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<MemoryMutationResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v3/memories/${path.memory_id}/baseline`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "PATCH",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function review_memory_v3_memories__memory_id__review_post(path: { memory_id: string }, query: { value: boolean }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<MemoryMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v3/memories/${path.memory_id}/review`;
@@ -15654,4 +15688,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 382 client methods generated.
+// Total: 385 client methods generated.

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -13495,6 +13495,11 @@
             ],
             "title": "Invalid At"
           },
+          "is_baseline": {
+            "default": false,
+            "title": "Is Baseline",
+            "type": "boolean"
+          },
           "is_locked": {
             "default": false,
             "title": "Is Locked",
@@ -55645,6 +55650,105 @@
           }
         ],
         "summary": "Edit Memory",
+        "tags": [
+          "memories"
+        ]
+      }
+    },
+    "/v3/memories/{memory_id}/baseline": {
+      "patch": {
+        "description": "Toggle the baseline flag for a memory.\n\nBaseline memories are always injected first into the AI context window.\nNot supported for canonical-path users: MemoryItem has no is_baseline field,\nso writing to the legacy store would silently have no effect for canonical readers.\nCanonical users receive 503 explicitly rather than a silent wrong-store write.",
+        "operationId": "update_memory_baseline_v3_memories__memory_id__baseline_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "memory_id",
+            "required": true,
+            "schema": {
+              "title": "Memory Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "value",
+            "required": true,
+            "schema": {
+              "title": "Value",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryMutationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Update Memory Baseline",
         "tags": [
           "memories"
         ]

--- a/docs/api-reference/integration-public-openapi.json
+++ b/docs/api-reference/integration-public-openapi.json
@@ -1086,6 +1086,11 @@
             ],
             "title": "Invalid At"
           },
+          "is_baseline": {
+            "default": false,
+            "title": "Is Baseline",
+            "type": "boolean"
+          },
           "is_locked": {
             "default": false,
             "title": "Is Locked",

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -2196,6 +2196,7 @@ export interface MemoryDB {
   headline?: string | null;
   id: string;
   invalid_at?: string | null;
+  is_baseline?: boolean;
   is_locked?: boolean;
   kg_extracted?: boolean;
   layer: string | null;
@@ -8016,6 +8017,17 @@ export interface OmiApiPaths {
     };
     delete: {
       operationId: "delete_memory_v3_memories__memory_id__delete";
+      responses: {
+        "200": MemoryMutationResponse;
+        "401": void;
+        "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v3/memories/{memory_id}/baseline": {
+    patch: {
+      operationId: "update_memory_baseline_v3_memories__memory_id__baseline_patch";
       responses: {
         "200": MemoryMutationResponse;
         "401": void;
@@ -15507,6 +15519,28 @@ export async function delete_memory_v3_memories__memory_id__delete(path: { memor
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function update_memory_baseline_v3_memories__memory_id__baseline_patch(path: { memory_id: string }, query: { value: boolean }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<MemoryMutationResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v3/memories/${path.memory_id}/baseline`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "PATCH",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function review_memory_v3_memories__memory_id__review_post(path: { memory_id: string }, query: { value: boolean }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<MemoryMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v3/memories/${path.memory_id}/review`;
@@ -15654,4 +15688,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 382 client methods generated.
+// Total: 385 client methods generated.

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -2196,6 +2196,7 @@ export interface MemoryDB {
   headline?: string | null;
   id: string;
   invalid_at?: string | null;
+  is_baseline?: boolean;
   is_locked?: boolean;
   kg_extracted?: boolean;
   layer: string | null;
@@ -8016,6 +8017,17 @@ export interface OmiApiPaths {
     };
     delete: {
       operationId: "delete_memory_v3_memories__memory_id__delete";
+      responses: {
+        "200": MemoryMutationResponse;
+        "401": void;
+        "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v3/memories/{memory_id}/baseline": {
+    patch: {
+      operationId: "update_memory_baseline_v3_memories__memory_id__baseline_patch";
       responses: {
         "200": MemoryMutationResponse;
         "401": void;
@@ -15507,6 +15519,28 @@ export async function delete_memory_v3_memories__memory_id__delete(path: { memor
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function update_memory_baseline_v3_memories__memory_id__baseline_patch(path: { memory_id: string }, query: { value: boolean }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<MemoryMutationResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v3/memories/${path.memory_id}/baseline`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "PATCH",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function review_memory_v3_memories__memory_id__review_post(path: { memory_id: string }, query: { value: boolean }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<MemoryMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v3/memories/${path.memory_id}/review`;
@@ -15654,4 +15688,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 382 client methods generated.
+// Total: 385 client methods generated.

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -2196,6 +2196,7 @@ export interface MemoryDB {
   headline?: string | null;
   id: string;
   invalid_at?: string | null;
+  is_baseline?: boolean;
   is_locked?: boolean;
   kg_extracted?: boolean;
   layer: string | null;
@@ -8016,6 +8017,17 @@ export interface OmiApiPaths {
     };
     delete: {
       operationId: "delete_memory_v3_memories__memory_id__delete";
+      responses: {
+        "200": MemoryMutationResponse;
+        "401": void;
+        "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v3/memories/{memory_id}/baseline": {
+    patch: {
+      operationId: "update_memory_baseline_v3_memories__memory_id__baseline_patch";
       responses: {
         "200": MemoryMutationResponse;
         "401": void;
@@ -15507,6 +15519,28 @@ export async function delete_memory_v3_memories__memory_id__delete(path: { memor
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function update_memory_baseline_v3_memories__memory_id__baseline_patch(path: { memory_id: string }, query: { value: boolean }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<MemoryMutationResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v3/memories/${path.memory_id}/baseline`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "PATCH",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function review_memory_v3_memories__memory_id__review_post(path: { memory_id: string }, query: { value: boolean }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<MemoryMutationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v3/memories/${path.memory_id}/review`;
@@ -15654,4 +15688,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 382 client methods generated.
+// Total: 385 client methods generated.


### PR DESCRIPTION
## Summary

- Stop classifying every upstream provider 4xx as `capability_mismatch`.
- Preserve the attempted provider/model in terminal outcomes and add one bounded `provider_rejection` label derived only from allowlisted upstream error codes and parameter roots.
- Keep true unsupported-parameter responses as non-fallback capability mismatches, while classifying invalid requests such as `context_length_exceeded` as the separate non-fallback `provider_invalid_request` class.
- Update static and generated route contracts so both terminal classes are explicitly never-fallback.
- Refresh the app-client and integration-public OpenAPI snapshots, plus their dependent generated Dart, TypeScript, and Swift clients, that the contract gate revealed were already stale for the baseline-memory schema and endpoint.
- Keep label-aware desktop changelog enforcement in the canonical PR preflight; the macOS static lane now skips that metadata-only check instead of rejecting a valid `no-changelog-needed` label.
- Keep owner-boundary Swift fixtures hermetic by installing their production effect handler without starting screen capture, audio capture, or system muting.

## Root cause and scope

The production terminal events occurred after route resolution and before output. The gateway's OpenAI-compatible provider adapter mapped every non-auth, non-rate-limit provider 4xx to `capability_mismatch`; the executor then discarded the attempted provider/model when it built terminal telemetry. As a result, the historical records prove an upstream 4xx but cannot prove which request member the provider rejected.

This PR repairs that owning boundary. It parses only a bounded semantic enum from the already bounded provider error preview. Unknown codes and parameter names collapse to `other_4xx` / `invalid_other`; provider messages, raw bodies, prompts, IDs, credentials, and request values never become response, metric, or terminal-log fields.

The leading unproven explanation for the affected `knowledge-graph` and `memories` lanes is context size: the gateway override uses GPT-5.4 nano (400K context), while the legacy GPT-4.1 mini route has a 1M context and both callers can assemble large per-user history. Successful requests alongside intermittent rejections are consistent with that boundary. This PR intentionally does not change those routes until deployed telemetry reports `provider_rejection=context_length_exceeded`; an unsupported member will instead be reported as a bounded `unsupported_*` value.

The separate BYOK rate-limit events remain unchanged and retain their existing fail-closed behavior.

Two independent macOS CI defects were also exposed while verifying the generated Swift client. First, the static lane reran a changelog check without the PR label metadata owned by canonical preflight. Second, owner-boundary tests started the real automation capture path merely to install a voice-turn effect handler; on the runner, that path muted the output device and stalled during cleanup, while three other SwiftPM processes timed out waiting for the shared build lock. The workflow fix restores the metadata owner, and a DEBUG-only fixture seam now installs the production effect handler without touching OS capture or audio state.

## Regression and privacy evidence

- The provider adapter test distinguishes `unsupported_parameter/reasoning_effort` from `context_length_exceeded` and proves arbitrary parameter names and provider messages do not survive classification.
- The HTTP route test sends both terminal classes through real gateway resolution/execution and asserts the exact public error code plus provider/model/rejection context.
- The metrics test proves an arbitrary rejection value collapses to `other_4xx` and is absent from terminal logs.

## Verification

- `backend/.venv/bin/pytest -q backend/tests/unit/test_llm_gateway_*.py backend/tests/unit/test_gateway_resilience.py backend/tests/unit/test_gateway_observability.py` — 309 passed.
- `cd backend && .venv/bin/pytest tests/unit/test_llm_gateway_validator.py -q` — 22 passed.
- `cd backend && .venv/bin/pytest tests/unit/test_llm_gateway_service.py tests/unit/test_gateway_resilience.py tests/unit/test_gateway_observability.py -q` — 12 passed.
- Local running gateway + local mock OpenAI HTTP endpoint: a synthetic `context_length_exceeded` 400 returned `provider_request_rejected` / `provider_invalid_request`; the terminal record contained `provider=openai model=gpt-5.4-nano provider_rejection=context_length_exceeded` and did not contain the synthetic private provider message.
- `OMI_PR_BODY_FILE=/tmp/omi-llm-gateway-provider-rejections-pr.md make preflight` — 19 checks passed.
- `cd backend && scripts/openapi_runner.sh scripts/export_openapi.py --surface app-client --check ../docs/api-reference/app-client-openapi.json` — passed.
- `cd backend && scripts/openapi_runner.sh scripts/export_openapi.py --surface integration-public --check ../docs/api-reference/integration-public-openapi.json` — passed.
- `cd backend && .venv/bin/python scripts/generate_dart_models.py --group memories` — generated output is clean and deterministic.
- `backend/.venv/bin/python backend/scripts/generate_ts_openapi_types.py --check` — passed for all four generated TypeScript clients.
- `cd backend && .venv/bin/python scripts/generate_swift_openapi_types.py --check` — passed.
- `cd desktop/macos && xcrun swift build -c debug --package-path Desktop` — passed.
- `python3 .github/scripts/test_desktop_swift_ci_contract.py` — 22 passed.
- `actionlint .github/workflows/desktop-swift-ci.yml` — passed.
- `xcrun swift test --package-path Desktop --skip-build --filter 'PushToTalkStateMachineTests/'` — 9 passed; repeated 50/50.
- `python3 desktop/macos/scripts/desktop-flow-lint.py` — 58 flows and 135 registered actions passed.
- `make preflight` — 30 checks passed.
- The pre-push typecheck completed with 0 errors and its selected 22 backend test files passed.

## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1

Failure-Class: none
