### PR TITLE
fix(desktop): correlate realtime close recovery outcomes

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -4,7 +4,7 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2638,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4829,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2584,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift": 1506,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift": 1509,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1536,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1584
   },

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -4,7 +4,8 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2638,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4829,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2584,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1534,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift": 1506,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1536,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1584
   },
   "raise_justifications": {
@@ -12,7 +13,8 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": "The Second Brain onboarding, reach-error, and notch-moment UI keeps the hover menu agent-only and routes idle notch taps through main chat.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": "Second Brain continuous-chat routing shares window geometry with agent-only hover sizing and canonical idle-notch chat ownership.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": "The owning turn manager carries privacy-bounded push-to-talk capture-lifecycle diagnostics wiring alongside strict concurrency, response-critical batch STT, and parallel screen-context capture.",
-    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": "Adds mint_attempt_id correlation on barge-in failover exhaustion so a mint failure joins its terminal exhausted outcome when the alternate provider is already active; telemetry-only, no lifecycle change (#10425).",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift": "Pairs each provider close with its bounded active-turn outcome and immediate recovery decision for release-health analysis; telemetry-only, no lifecycle change (#10425).",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": "Adds bounded realtime mint-failure outcome correlation and close-resolution telemetry so release health distinguishes started recovery from exhaustion; telemetry-only, no lifecycle change (#10425).",
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers without changing runtime behavior."
   },
   "threshold": 1500

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -21,6 +21,7 @@ enum DesktopHealthEventName: String {
   case realtimeProviderExpectedSessionRotation = "realtime_provider_expected_session_rotation"
   case realtimeProviderPolicyClose = "realtime_provider_policy_close"
   case realtimeProviderSessionError = "realtime_provider_session_error"
+  case realtimeProviderCloseResolution = "realtime_provider_close_resolution"
   case userVisibleIssue = "user_visible_issue"
   case betaDiagnosticTrail = "beta_diagnostic_trail"
   case fallbackTriggered = "fallback_triggered"
@@ -29,6 +30,29 @@ enum DesktopHealthEventName: String {
 enum DesktopFallbackOutcome: String {
   case recovered
   case degraded
+  case exhausted
+}
+
+/// The immediate customer-turn/recovery decision made after a realtime transport
+/// closes. This is deliberately separate from the raw close event: the close is
+/// captured before the controller chooses a replacement, failover, or terminal
+/// path, while this closed set records that decision without provider payloads.
+enum RealtimeProviderCloseTurnOutcome: String {
+  case notInterrupted = "not_interrupted"
+  case failed
+  case pendingReplacement = "pending_replacement"
+}
+
+enum RealtimeProviderCloseRecoveryAction: String {
+  case none
+  case sessionRewarm = "session_rewarm"
+  case providerFailover = "provider_failover"
+  case cascade
+}
+
+enum RealtimeProviderCloseRecoveryResult: String {
+  case notNeeded = "not_needed"
+  case started
   case exhausted
 }
 
@@ -70,6 +94,7 @@ final class DesktopDiagnosticsManager {
   /// hub's transport key. A start/stop timer for `voice_tool_latency`; cleared
   /// on turn reset so it can't grow unbounded.
   private var voiceToolStarts: [String: Date] = [:]
+  private var realtimeProviderCloseAttemptID = 0
   private let betaTrailSnapshotLimit = 50
   private var consecutiveNearZeroPTTTurns = 0
   private var lastPTTWatchdogIncidentAt: Date?
@@ -645,6 +670,7 @@ final class DesktopDiagnosticsManager {
       properties: properties)
   }
 
+  @discardableResult
   func recordRealtimeProviderClose(
     provider: String,
     category: String?,
@@ -652,7 +678,11 @@ final class DesktopDiagnosticsManager {
     activeTurn: Bool,
     authMode: CredentialAuthMode?,
     failureClass: CredentialFailureClass?
-  ) {
+  ) -> Int {
+    lock.lock()
+    realtimeProviderCloseAttemptID += 1
+    let closeAttemptID = realtimeProviderCloseAttemptID
+    lock.unlock()
     let normalizedCategory = category ?? failureClass?.logValue ?? "unclassified"
     let event: DesktopHealthEventName
     switch normalizedCategory {
@@ -678,6 +708,7 @@ final class DesktopDiagnosticsManager {
       "category": normalizedCategory,
       "alive_for_seconds": Int(aliveFor),
       "active_turn": activeTurn,
+      "close_attempt_id": closeAttemptID,
       "expected": expectedLifecycle,
       "lifecycle_class": expectedLifecycle ? "expected" : "error",
     ]
@@ -697,6 +728,31 @@ final class DesktopDiagnosticsManager {
     record(
       event,
       properties: properties)
+    return closeAttemptID
+  }
+
+  /// Pair a provider-close event with the controller's immediate lifecycle
+  /// decision. `closeAttemptID` is a process-local monotonic counter, useful
+  /// only to join bounded events from one analytics session; it is not a user,
+  /// device, turn, or provider-session identifier.
+  func recordRealtimeProviderCloseResolution(
+    closeAttemptID: Int,
+    provider: String,
+    activeTurn: Bool,
+    turnOutcome: RealtimeProviderCloseTurnOutcome,
+    recoveryAction: RealtimeProviderCloseRecoveryAction,
+    recoveryResult: RealtimeProviderCloseRecoveryResult
+  ) {
+    record(
+      .realtimeProviderCloseResolution,
+      properties: [
+        "close_attempt_id": closeAttemptID,
+        "provider": safeProvider(provider),
+        "active_turn": activeTurn,
+        "turn_outcome": turnOutcome.rawValue,
+        "recovery_action": recoveryAction.rawValue,
+        "recovery_result": recoveryResult.rawValue,
+      ])
   }
 
   func currentSnapshotsForSentry() -> [[String: Any]] {
@@ -738,6 +794,8 @@ final class DesktopDiagnosticsManager {
       snapshot.event == .userVisibleIssue
       || snapshot.event == .pttAudioCaptureWatchdogTriggered
       || snapshot.event == .pttAudioCaptureLifecycle
+      || snapshot.event == .realtimeProviderSessionError
+      || snapshot.event == .realtimeProviderCloseResolution
       || (includeBetaDiagnostics && snapshot.event == .betaDiagnosticTrail)
     guard includesTypedIncidentContext else {
       return result
@@ -755,7 +813,8 @@ final class DesktopDiagnosticsManager {
     "area", "failure_class", "phase", "build", "build_number", "os_version", "device_model",
     "source", "mode", "hub_active", "turn_audio_seconds", "voiced_audio_seconds", "peak", "rms",
     "is_near_zero", "watchdog_eligible", "consecutive_silent_turns", "tcc_microphone_granted",
-    "input_device_class", "recovery_action", "recovery_result", "threshold",
+    "input_device_class", "close_attempt_id", "turn_outcome", "recovery_action", "recovery_result",
+    "threshold",
     "component", "operation", "outcome", "error_domain", "error_code",
     "osstatus", "keycode", "modifiers",
     // PTT attempt lifecycle correlation (PTTAttemptLifecycleRecorder).
@@ -980,6 +1039,7 @@ final class DesktopDiagnosticsManager {
       lock.lock()
       snapshots.removeAll()
       betaTrailSnapshots.removeAll()
+      realtimeProviderCloseAttemptID = 0
       consecutiveNearZeroPTTTurns = 0
       lastPTTWatchdogIncidentAt = nil
       lastUserVisibleSentryIncidentAt.removeAll()

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -1329,13 +1329,26 @@ extension RealtimeHubController {
       provider: providerTag,
       aliveFor: aliveFor,
       activeTurn: hasActiveTurn)
-    DesktopDiagnosticsManager.shared.recordRealtimeProviderClose(
+    let closeAttemptID = DesktopDiagnosticsManager.shared.recordRealtimeProviderClose(
       provider: providerTag,
       category: closeCategory?.rawValue,
       aliveFor: aliveFor,
       activeTurn: hasActiveTurn,
       authMode: authMode,
       failureClass: credentialFailureClass)
+    func recordCloseResolution(
+      turnOutcome: RealtimeProviderCloseTurnOutcome,
+      recoveryAction: RealtimeProviderCloseRecoveryAction,
+      recoveryResult: RealtimeProviderCloseRecoveryResult
+    ) {
+      DesktopDiagnosticsManager.shared.recordRealtimeProviderCloseResolution(
+        closeAttemptID: closeAttemptID,
+        provider: providerTag,
+        activeTurn: hasActiveTurn,
+        turnOutcome: turnOutcome,
+        recoveryAction: recoveryAction,
+        recoveryResult: recoveryResult)
+    }
     if RealtimeHubCloseClassifier.shouldReportToSentry(closeCategory) {
       // Keep the provider/system payload in the private local log. The Sentry
       // message is constructed only from bounded enums and scalars.
@@ -1353,6 +1366,10 @@ extension RealtimeHubController {
       hasActiveTurn: hasActiveTurn)
     {
       recoverFromExpectedSessionRotation(sessionRotationPlan, activeTurn: activeTurn)
+      recordCloseResolution(
+        turnOutcome: sessionRotationPlan == .terminateActiveTurnAndRewarm ? .failed : .notInterrupted,
+        recoveryAction: .sessionRewarm,
+        recoveryResult: .started)
       return
     }
     if replacementAudioBuffer != nil, let failedProvider = provider {
@@ -1363,12 +1380,23 @@ extension RealtimeHubController {
           from: failedProvider,
           reason: replacementFailoverReason)
       {
+        recordCloseResolution(
+          turnOutcome: .pendingReplacement,
+          recoveryAction: .providerFailover,
+          recoveryResult: .started)
         return
       }
       failBargeInReplacement(provider: failedProvider, reason: message)
       teardownSession()
+      recordCloseResolution(
+        turnOutcome: .failed,
+        recoveryAction: .cascade,
+        recoveryResult: .exhausted)
       return
     }
+    let turnOutcome: RealtimeProviderCloseTurnOutcome =
+      ownsActiveHubTurn && !resolvedScreenProtocol && activeTurn?.providerFinished != true
+      ? .failed : .notInterrupted
     if ownsActiveHubTurn, !resolvedScreenProtocol, activeTurn?.providerFinished != true {
       terminateActiveHubTurn(activeTurn)
     }
@@ -1376,13 +1404,33 @@ extension RealtimeHubController {
     // context. Only switch for stable credential/quota classes; transient fast closes
     // re-warm the same provider and rely on the shared continuity packet.
     if case .providerAuthFailed = credentialFailureClass {
-      if aliveFor < 10, failoverToAlternateProvider(reason: "auth") { return }
+      if aliveFor < 10, failoverToAlternateProvider(reason: "auth") {
+        recordCloseResolution(
+          turnOutcome: turnOutcome,
+          recoveryAction: .providerFailover,
+          recoveryResult: .started)
+        return
+      }
       teardownSession()
+      recordCloseResolution(
+        turnOutcome: turnOutcome,
+        recoveryAction: .cascade,
+        recoveryResult: .exhausted)
       return
     }
     if case .providerQuotaExceeded = credentialFailureClass {
-      if failoverToAlternateProvider(reason: "quota") { return }
+      if failoverToAlternateProvider(reason: "quota") {
+        recordCloseResolution(
+          turnOutcome: turnOutcome,
+          recoveryAction: .providerFailover,
+          recoveryResult: .started)
+        return
+      }
       teardownSession()
+      recordCloseResolution(
+        turnOutcome: turnOutcome,
+        recoveryAction: .cascade,
+        recoveryResult: .exhausted)
       return
     }
     // Re-warm so the NEXT PTT uses the hub, not the STT cascade. Gemini idle-closes
@@ -1398,11 +1446,19 @@ extension RealtimeHubController {
     }
     guard !reconnectPending, hubReconnectStrikes < Self.maxReconnectStrikes else {
       teardownSession()
+      recordCloseResolution(
+        turnOutcome: turnOutcome,
+        recoveryAction: .sessionRewarm,
+        recoveryResult: .exhausted)
       return
     }
     hubReconnectStrikes += 1
     reconnectPending = true
     replaceSessionAfterDrain(reconnectDelayNanoseconds: 1_500_000_000)
+    recordCloseResolution(
+      turnOutcome: turnOutcome,
+      recoveryAction: .sessionRewarm,
+      recoveryResult: .started)
   }
 
   /// OpenAI limits realtime sessions to sixty minutes. Rotation is a normal

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -1329,6 +1329,7 @@ extension RealtimeHubController {
       provider: providerTag,
       aliveFor: aliveFor,
       activeTurn: hasActiveTurn)
+    let shouldCaptureProviderCloseToSentry = RealtimeHubCloseClassifier.shouldReportToSentry(closeCategory)
     let closeAttemptID = DesktopDiagnosticsManager.shared.recordRealtimeProviderClose(
       provider: providerTag,
       category: closeCategory?.rawValue,
@@ -1348,15 +1349,17 @@ extension RealtimeHubController {
         turnOutcome: turnOutcome,
         recoveryAction: recoveryAction,
         recoveryResult: recoveryResult)
+      // `logError` synchronously builds the Sentry attachment. Capture only after
+      // this paired decision exists so the incident carries its bounded recovery
+      // outcome as well as the raw provider-close classification.
+      if shouldCaptureProviderCloseToSentry {
+        logError(reportingPlan.sentryMessage)
+      }
     }
-    if RealtimeHubCloseClassifier.shouldReportToSentry(closeCategory) {
-      // Keep the provider/system payload in the private local log. The Sentry
-      // message is constructed only from bounded enums and scalars.
-      log(reportingPlan.localMessage)
-      logError(reportingPlan.sentryMessage)
-    } else {
-      log(reportingPlan.localMessage)
-    }
+    // Keep the provider/system payload in the private local log. The Sentry
+    // message is constructed only from bounded enums and scalars, after the
+    // recovery decision is available for its synchronous attachment.
+    log(reportingPlan.localMessage)
     log(
       "RealtimeHub: provider close terminal state tool=\(terminalToolName) "
         + "tool_error=\(terminalToolErrorCode) accepted_spawn=\(terminalHadAcceptedSpawn)"

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
@@ -290,15 +290,18 @@ extension RealtimeHubController {
             ownerScope: ownerScope)
         else { return }
         _ = self.releaseMint(generation: mintGeneration, ownerScope: ownerScope)
+        let fallbackStarted =
+          !error.healthError.failureClass.isAccountWide
+          && self.failoverToAlternateProvider(
+            reason: self.failoverReason(for: error.healthError.failureClass),
+            mintAttemptId: String(mintGeneration))
         self.recordRealtimeMintFailure(
           error, provider: providerParam, phase: "warm", context: "realtime_mint",
+          outcome: fallbackStarted ? .degraded : .exhausted,
           mintAttemptId: String(mintGeneration))
         if error.healthError.failureClass.isAccountWide {
           log("RealtimeHub: account credential failure during mint — staying on cascade")
-        } else if !self.failoverToAlternateProvider(
-          reason: self.failoverReason(for: error.healthError.failureClass),
-          mintAttemptId: String(mintGeneration))
-        {
+        } else if !fallbackStarted {
           log("⚠️ RealtimeHub: ephemeral mint failed on both providers — staying on cascade")
         }
         return
@@ -310,18 +313,21 @@ extension RealtimeHubController {
         else { return }
         _ = self.releaseMint(generation: mintGeneration, ownerScope: ownerScope)
         CredentialHealthManager.shared.record(error, context: "realtime_mint")
+        let fallbackStarted =
+          !error.failureClass.isAccountWide
+          && self.failoverToAlternateProvider(
+            reason: self.failoverReason(for: error.failureClass),
+            mintAttemptId: String(mintGeneration))
         DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
           provider: providerParam,
           reason: error.failureClass.logValue,
           phase: "warm",
           httpStatusCode: error.failureClass.httpStatusCode,
+          outcome: fallbackStarted ? .degraded : .exhausted,
           mintAttemptId: String(mintGeneration))
         if error.failureClass.isAccountWide {
           log("RealtimeHub: account credential failure during mint — staying on cascade")
-        } else if !self.failoverToAlternateProvider(
-          reason: self.failoverReason(for: error.failureClass),
-          mintAttemptId: String(mintGeneration))
-        {
+        } else if !fallbackStarted {
           log("⚠️ RealtimeHub: ephemeral mint failed on both providers — staying on cascade")
         }
         return
@@ -335,12 +341,14 @@ extension RealtimeHubController {
         let typed = CredentialHealthError.backendTransient(
           statusCode: nil, message: error.localizedDescription)
         CredentialHealthManager.shared.record(typed, context: "realtime_mint")
+        let fallbackStarted = self.failoverToAlternateProvider(mintAttemptId: String(mintGeneration))
         DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
           provider: providerParam,
           reason: "backend_transient",
           phase: "warm",
+          outcome: fallbackStarted ? .degraded : .exhausted,
           mintAttemptId: String(mintGeneration))
-        if !self.failoverToAlternateProvider(mintAttemptId: String(mintGeneration)) {
+        if !fallbackStarted {
           log("⚠️ RealtimeHub: ephemeral mint failed on both providers — staying on cascade")
         }
         return
@@ -1189,18 +1197,20 @@ extension RealtimeHubController {
           return
         }
         guard self.releaseMint(generation: mintGeneration, ownerScope: ownerScope) else { return }
+        let fallbackStarted =
+          self.shouldFailoverToAlternate(for: error.healthError.failureClass)
+          && self.failoverBargeInReplacement(
+            from: provider,
+            reason: self.failoverReason(for: error.healthError.failureClass),
+            mintAttemptId: String(mintGeneration))
         self.recordRealtimeMintFailure(
           error,
           provider: providerParam,
           phase: "barge_in_replacement",
           context: "realtime_barge_in_mint",
+          outcome: fallbackStarted ? .degraded : .exhausted,
           mintAttemptId: String(mintGeneration))
-        if self.shouldFailoverToAlternate(for: error.healthError.failureClass),
-          self.failoverBargeInReplacement(
-            from: provider,
-            reason: self.failoverReason(for: error.healthError.failureClass),
-            mintAttemptId: String(mintGeneration))
-        {
+        if fallbackStarted {
           return
         }
         self.failBargeInReplacement(provider: provider, reason: error.localizedDescription)
@@ -1218,18 +1228,20 @@ extension RealtimeHubController {
         }
         guard self.releaseMint(generation: mintGeneration, ownerScope: ownerScope) else { return }
         CredentialHealthManager.shared.record(error, context: "realtime_barge_in_mint")
+        let fallbackStarted =
+          self.shouldFailoverToAlternate(for: error.failureClass)
+          && self.failoverBargeInReplacement(
+            from: provider,
+            reason: self.failoverReason(for: error.failureClass),
+            mintAttemptId: String(mintGeneration))
         DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
           provider: providerParam,
           reason: error.failureClass.logValue,
           phase: "barge_in_replacement",
           httpStatusCode: error.failureClass.httpStatusCode,
+          outcome: fallbackStarted ? .degraded : .exhausted,
           mintAttemptId: String(mintGeneration))
-        if self.shouldFailoverToAlternate(for: error.failureClass),
-          self.failoverBargeInReplacement(
-            from: provider,
-            reason: self.failoverReason(for: error.failureClass),
-            mintAttemptId: String(mintGeneration))
-        {
+        if fallbackStarted {
           return
         }
         self.failBargeInReplacement(provider: provider, reason: error.localizedDescription)
@@ -1246,12 +1258,17 @@ extension RealtimeHubController {
           return
         }
         guard self.releaseMint(generation: mintGeneration, ownerScope: ownerScope) else { return }
+        let fallbackStarted = self.failoverBargeInReplacement(
+          from: provider,
+          reason: "other",
+          mintAttemptId: String(mintGeneration))
         DesktopDiagnosticsManager.shared.recordRealtimeTokenMintFailed(
           provider: providerParam,
           reason: "backend_transient",
           phase: "barge_in_replacement",
+          outcome: fallbackStarted ? .degraded : .exhausted,
           mintAttemptId: String(mintGeneration))
-        if self.failoverBargeInReplacement(from: provider, reason: "other", mintAttemptId: String(mintGeneration)) {
+        if fallbackStarted {
           return
         }
         self.failBargeInReplacement(provider: provider, reason: error.localizedDescription)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -814,6 +814,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     provider providerParam: String,
     phase: String,
     context: String,
+    outcome: DesktopFallbackOutcome,
     mintAttemptId: String? = nil
   ) {
     CredentialHealthManager.shared.record(error.healthError, context: context)
@@ -826,6 +827,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       upstreamStatusCode: error.payload?.upstreamStatusCode,
       providerCode: error.payload?.code,
       retryable: error.payload?.retryable,
+      outcome: outcome,
       mintAttemptId: mintAttemptId)
   }
 

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -1292,14 +1292,14 @@ import XCTest
       "Mint failure must clear minting before failover starts the alternate provider")
     XCTAssertTrue(
       hubSource.contains(
-        "if case .providerAuthFailed = credentialFailureClass {\n      if aliveFor < 10, failoverToAlternateProvider(reason: \"auth\") { return }"
+        "if case .providerAuthFailed = credentialFailureClass {\n      if aliveFor < 10, failoverToAlternateProvider(reason: \"auth\") {\n        recordCloseResolution("
       ),
-      "Provider auth failures should try alternate provider before stopping reconnect")
+      "Provider auth failures should record the alternate-provider recovery before stopping reconnect")
     XCTAssertTrue(
       hubSource.contains(
-        "if case .providerQuotaExceeded = credentialFailureClass {\n      if failoverToAlternateProvider(reason: \"quota\") { return }"
+        "if case .providerQuotaExceeded = credentialFailureClass {\n      if failoverToAlternateProvider(reason: \"quota\") {\n        recordCloseResolution("
       ),
-      "Provider quota failures should try alternate provider regardless of socket age")
+      "Provider quota failures should record the alternate-provider recovery regardless of socket age")
     XCTAssertTrue(
       hubSource.contains("let reportingPlan = RealtimeHubFailureReportingPlan.make(")
         && hubSource.contains("logError(reportingPlan.sentryMessage)"),

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -1302,8 +1302,12 @@ import XCTest
       "Provider quota failures should record the alternate-provider recovery regardless of socket age")
     XCTAssertTrue(
       hubSource.contains("let reportingPlan = RealtimeHubFailureReportingPlan.make(")
-        && hubSource.contains("logError(reportingPlan.sentryMessage)"),
-      "Credential close reporting must send only the bounded reporting plan to Sentry")
+        && hubSource.contains(
+          "DesktopDiagnosticsManager.shared.recordRealtimeProviderCloseResolution(\n        closeAttemptID: closeAttemptID,"
+        )
+        && hubSource.contains(
+          "if shouldCaptureProviderCloseToSentry {\n        logError(reportingPlan.sentryMessage)"),
+      "Credential close reporting must record the bounded recovery decision before Sentry captures its attachment")
     XCTAssertTrue(
       hubSource.contains("func shouldFailoverToAlternate(for failureClass: CredentialFailureClass?) -> Bool"),
       "Provider switching must be centralized and limited to stable credential/quota failures")

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -572,6 +572,59 @@ import XCTest
         contains: ["expected": false, "lifecycle_class": "error"])
     }
 
+    func testRealtimeProviderCloseResolutionPairsBoundedDecisionWithCloseAttempt() throws {
+      let closeAttemptID = DesktopDiagnosticsManager.shared.recordRealtimeProviderClose(
+        provider: "gemini",
+        category: RealtimeHubCloseCategory.transportReceive.rawValue,
+        aliveFor: 4,
+        activeTurn: true,
+        authMode: .managed,
+        failureClass: .providerTransient(provider: .gemini))
+
+      try assertLatestHealthSnapshot(
+        event: .realtimeProviderSessionError,
+        contains: [
+          "close_attempt_id": closeAttemptID,
+          "active_turn": true,
+          "lifecycle_class": "error",
+        ])
+
+      DesktopDiagnosticsManager.shared.recordRealtimeProviderCloseResolution(
+        closeAttemptID: closeAttemptID,
+        provider: "gemini",
+        activeTurn: true,
+        turnOutcome: .failed,
+        recoveryAction: .sessionRewarm,
+        recoveryResult: .started)
+
+      try assertLatestHealthSnapshot(
+        event: .realtimeProviderCloseResolution,
+        contains: [
+          "close_attempt_id": closeAttemptID,
+          "active_turn": true,
+          "turn_outcome": "failed",
+          "recovery_action": "session_rewarm",
+          "recovery_result": "started",
+        ])
+
+      let url = try XCTUnwrap(
+        DesktopDiagnosticsManager.shared.writeIncidentDiagnosticsAttachment(
+          area: "realtime_hub",
+          failureClass: "provider_transient",
+          phase: "session",
+          includeBetaDiagnostics: false))
+      defer { try? FileManager.default.removeItem(at: url) }
+
+      let data = try Data(contentsOf: url)
+      let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+      let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+      let resolution = try XCTUnwrap(
+        snapshots.first(where: { $0["event"] as? String == "realtime_provider_close_resolution" }))
+      XCTAssertEqual(resolution["close_attempt_id"] as? Int, closeAttemptID)
+      XCTAssertEqual(resolution["turn_outcome"] as? String, "failed")
+      XCTAssertEqual(resolution["recovery_result"] as? String, "started")
+    }
+
     func testFallbackNamedAreasAreNotCollapsedToOther() throws {
       for area in ["screen_capture", "memory_scope", "desktop_update", "tts_fallback", "task_workflow", "auth_storage"]
       {

--- a/desktop/macos/changelog/unreleased/20260724-realtime-close-resolution.json
+++ b/desktop/macos/changelog/unreleased/20260724-realtime-close-resolution.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved beta realtime diagnostics by recording each provider-close recovery decision and managed token-mint fallback outcome without collecting customer content"
+}

--- a/desktop/macos/docs/release-health-metrics.md
+++ b/desktop/macos/docs/release-health-metrics.md
@@ -1,6 +1,6 @@
 # macOS Release-Health Metric Specification
 
-**Status:** active · **Schema version:** 1 · **Owner:** desktop/macos · **Tracking:** [#10425](https://github.com/BasedHardware/omi/issues/10425)
+**Status:** active · **Schema version:** 2 · **Owner:** desktop/macos · **Tracking:** [#10425](https://github.com/BasedHardware/omi/issues/10425)
 
 This is the **authoritative query contract** for macOS release-health telemetry. It
 defines, per signal, the exact numerator, denominator, time window, minimum cohort,
@@ -77,14 +77,17 @@ the release-evidence layer (`#9523`) will consume.
 - **Phase (warm vs active):** `phase` is a closed set — `warm` (background pre-warm)
   vs `barge_in_replacement` (socket replacement during an active turn); any other
   value is bucketed to `other`. This is the warm-vs-active dimension.
-- **Outcome (recovered/degraded/exhausted):** a mint failure is point-in-time; its
-  terminal fate is the correlated `fallback_triggered`{`area = realtime_hub`} event
-  (`outcome` = `recovered`/`degraded`/`exhausted`). Join on `mint_attempt_id` (present
-  on both when a mint triggered the failover), then `provider` + bounded time window.
-- **Numerator (mint-exhausted, user-impacting):** mint failures joined to a
-  `realtime_hub` fallback with `outcome = exhausted` (fell through to the cascade
-  with no acceptable path). `degraded` (failed over to the alternate provider) is
-  recoverable and is **not** a terminal failure numerator.
+- **Immediate outcome (degraded/exhausted):** the mint-failure event itself records
+  whether the controller started an alternate-provider fallback (`degraded`) or
+  had no remaining managed path (`exhausted`). Its later fallback outcome remains
+  on the correlated `fallback_triggered`{`area = realtime_hub`} event. Join on
+  `mint_attempt_id` (present on both when a mint triggered failover), then provider
+  plus a bounded time window.
+- **Numerator (mint-exhausted, user-impacting):** `outcome = exhausted` on the
+  mint-failure event (no remaining managed path). Use the correlated
+  `realtime_hub` fallback event for the detailed replacement path. `degraded`
+  (alternate-provider fallback started) is recoverable and is **not** a terminal
+  failure numerator.
 - **Window:** PT24H. **Minimum cohort:** 30 mint-attempting users per build.
   **Missing data:** `unknown` if no mint events.
 
@@ -93,10 +96,17 @@ the release-evidence layer (`#9523`) will consume.
 - **Source events:** `realtime_provider_expected_idle_teardown`,
   `realtime_provider_expected_session_rotation` (both `expected = true`),
   `realtime_provider_policy_close`, `realtime_provider_session_error`
-  (both `expected = false`).
-- **Error rate numerator:** `realtime_provider_session_error` +
-  `realtime_provider_policy_close` (`expected = false`). **Denominator:** active
-  realtime sessions (proxy: distinct sessions emitting any `realtime_provider_*`).
+  (both `expected = false`), and `realtime_provider_close_resolution`.
+- **Customer-turn decision:** every provider-close event carries a process-local
+  `close_attempt_id`; its paired `realtime_provider_close_resolution` carries the
+  closed-set `turn_outcome` and the immediate `recovery_action`/`recovery_result`.
+  The id is only valid within the same analytics session and is never a user, device,
+  turn, or provider-session identifier.
+- **Error rate numerator:** active-turn `realtime_provider_session_error` +
+  `realtime_provider_policy_close` (`expected = false`) whose paired resolution has
+  `turn_outcome = failed`. `pending_replacement` is an intermediate recovery state,
+  not a terminal customer-failure numerator. **Denominator:** active realtime
+  sessions (proxy: distinct sessions emitting any `realtime_provider_*`).
 - **Excluded:** the two `expected_*` events (`expected = true`) — normal idle teardown
   and planned 60-min OpenAI session rotation. They remain separately inspectable but
   MUST NOT inflate the realtime error or release-regression rate.
@@ -160,5 +170,6 @@ intermediate event.
 
 Bump `Schema version` and call out the change here when any numerator/denominator
 definition, closed enum, or field name changes. `telemetry_schema_version` on the
-PTT lifecycle snapshot and the `expected`/`outcome`/`mint_attempt_id`/`phase` fields
-are the machine-readable companions to this document.
+PTT lifecycle snapshot and the `expected`/`outcome`/`mint_attempt_id`/`phase`/
+`close_attempt_id`/`turn_outcome` fields are the machine-readable companions to this
+document.


### PR DESCRIPTION
## Summary

- Correlate each realtime provider-close event with a bounded active-turn outcome and its immediate recovery decision.
- Mark managed realtime token-mint failures as `degraded` only when alternate-provider recovery actually starts; otherwise mark them `exhausted`.
- Include the safe correlation fields in incident attachments and document the release-health query changes.

## Failure class

Failure-Class: none

This adds the diagnostic boundary needed to determine whether the release-specific realtime failures are customer-impacting and whether recovery succeeded; the supplied evidence does not establish a single causal runtime defect to repair yet.

## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1

## Verification

- `xcrun swift test --package-path desktop/macos/Desktop --filter DesktopDiagnosticsManagerTests/testRealtimeProviderCloseResolutionPairsBoundedDecisionWithCloseAttempt`
- `./desktop/macos/scripts/agent-logic-harness.sh --swift-only` (517 focused lifecycle/state tests)
- `xcrun swift build -c debug --package-path desktop/macos/Desktop`
- `python3 desktop/macos/scripts/check_desktop_test_quality.py`
- Named ad-hoc dev bundle launched: `/Applications/omi-realtime-ptt-health.app`

## Post-release evidence

Use `close_attempt_id` within an analytics session to join `realtime_provider_session_error` / `realtime_provider_policy_close` to `realtime_provider_close_resolution`. Treat `pending_replacement` as intermediate recovery, not a terminal customer failure. For mint failures, query the direct `outcome` and use the correlated fallback event for recovery-path detail.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

