### PR TITLE
fix(desktop): refresh Windows Rewind screenshot count live (#10503)

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-07-rewind-count-live.json
+++ b/desktop/windows/changelog/unreleased/2026-07-rewind-count-live.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "The screenshot count now updates live while recording, instead of freezing after the app has been open a while."
+  ]
+}

--- a/desktop/windows/src/main/ipc/rewind.ts
+++ b/desktop/windows/src/main/ipc/rewind.ts
@@ -147,7 +147,18 @@ export function registerRewindHandlers(): void {
   ipcMain.handle('rewind:primarySourceId', async () => getPrimarySourceId())
   // Receive a sampled JPEG frame from the renderer capture host and store it
   // (after foreground-window metadata + idle/lock/dup gating).
-  ipcMain.handle('rewind:saveFrame', async (_e, data: Uint8Array) =>
-    ingestRewindFrame(Buffer.from(data))
-  )
+  ipcMain.handle('rewind:saveFrame', async (_e, data: Uint8Array) => {
+    const result = await ingestRewindFrame(Buffer.from(data))
+    // A stored frame bumps the all-time frame count. Tell open windows so the
+    // Hub's "Screenshots" stat re-reads live instead of freezing at whatever it
+    // was when the Hub mounted (it fetches the count once and has no other
+    // refresh trigger). Only fire when a frame was actually stored — deduped /
+    // idle / locked frames don't change the count.
+    if (result.captured) {
+      for (const w of BrowserWindow.getAllWindows()) {
+        if (!w.isDestroyed()) w.webContents.send('rewind:captured')
+      }
+    }
+    return result
+  })
 }

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -344,6 +344,11 @@ const omi: OmiBridgeApi = {
     ipcRenderer.invoke('rewind:framesSampled', from, to),
   rewindDayBounds: () => ipcRenderer.invoke('rewind:dayBounds'),
   rewindFrameCount: () => ipcRenderer.invoke('rewind:frameCount'),
+  onRewindCaptured: (cb: () => void) => {
+    const listener = (): void => cb()
+    ipcRenderer.on('rewind:captured', listener)
+    return () => ipcRenderer.removeListener('rewind:captured', listener)
+  },
   rewindSearch: (query: string) => ipcRenderer.invoke('rewind:search', query),
   // --- Track 4 (Rewind semantic search) --- Phase 2 of a search: the same results
   // with semantic hits merged in, pushed if/when the embedding round-trip lands.

--- a/desktop/windows/src/renderer/src/components/home/hub/useHubStats.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/useHubStats.test.tsx
@@ -13,7 +13,11 @@ const h = vi.hoisted(() => ({
   currentUser: { uid: 'A' } as { uid: string } | null,
   cb: null as ((u: { uid: string } | null) => void) | null,
   tasks: [] as { id: string }[],
-  frames: 0
+  frames: 0,
+  // Captured onRewindCaptured subscriber + a COUNT(*) call counter, for the
+  // live-refresh / throttle assertions below.
+  rewindCapturedCb: null as (() => void) | null,
+  frameCountCalls: 0
 }))
 
 vi.mock('../../../lib/firebase', () => ({
@@ -51,9 +55,20 @@ beforeEach(() => {
   h.cb = null
   h.tasks = []
   h.frames = 0
+  h.rewindCapturedCb = null
+  h.frameCountCalls = 0
   ;(window as unknown as { omi: unknown }).omi = {
-    rewindFrameCount: () => Promise.resolve(h.frames),
-    onTasksChanged: () => () => {}
+    rewindFrameCount: () => {
+      h.frameCountCalls++
+      return Promise.resolve(h.frames)
+    },
+    onTasksChanged: () => () => {},
+    onRewindCaptured: (cb: () => void) => {
+      h.rewindCapturedCb = cb
+      return () => {
+        h.rewindCapturedCb = null
+      }
+    }
   }
 })
 
@@ -114,5 +129,37 @@ describe('useHubStats — in-place account switch (no remount)', () => {
     // and A's 2 must not be stamped under B.
     expect(result.current.conversations).toBeNull()
     expect(getCachedHubStats('B').conversations).toBeNull()
+  })
+})
+
+describe('useHubStats — live screenshot count', () => {
+  it('re-reads the count when a frame is captured (does not freeze at its mount value)', async () => {
+    // The reported bug: the Hub fetched the count once on mount and never again,
+    // so a session left open all day showed a frozen number while capture ran.
+    h.frames = 5
+    const { result } = renderHook(() => useHubStats())
+    await waitFor(() => expect(result.current.screenshots).toBe(5))
+
+    // A new frame is stored while the Hub stays mounted.
+    h.frames = 6
+    act(() => h.rewindCapturedCb?.())
+    await waitFor(() => expect(result.current.screenshots).toBe(6))
+  })
+
+  it('throttles a burst of captures instead of one COUNT(*) per frame', async () => {
+    h.frames = 5
+    const { result } = renderHook(() => useHubStats())
+    await waitFor(() => expect(result.current.screenshots).toBe(5))
+    const callsAfterMount = h.frameCountCalls
+
+    // A rapid burst of stored frames within one throttle window: only the leading
+    // edge re-reads synchronously; the rest collapse into a single pending trailing
+    // read, so this is not one COUNT(*) per captured frame.
+    act(() => {
+      h.rewindCapturedCb?.()
+      h.rewindCapturedCb?.()
+      h.rewindCapturedCb?.()
+    })
+    expect(h.frameCountCalls).toBe(callsAfterMount + 1)
   })
 })

--- a/desktop/windows/src/renderer/src/components/home/hub/useHubStats.ts
+++ b/desktop/windows/src/renderer/src/components/home/hub/useHubStats.ts
@@ -29,6 +29,12 @@ import { getCachedHubStats, overlay, persistHubStats } from './hubStatsCache'
 // says so ("100+"); a short page IS the whole set and is rendered exactly.
 const CLOUD_PAGE_SIZE = 100
 
+// Frames are stored up to ~once a second during active capture. Re-running the
+// screenshot COUNT(*) on every one would be wasteful, so coalesce bursts to at
+// most one re-read per this window (with a trailing read so the final count is
+// never missed).
+const REWIND_COUNT_REFRESH_MS = 5000
+
 export function useHubStats(): HubStatCounts {
   // The account the cache is scoped to. Read synchronously so the FIRST render
   // already resolves the right blob (no em-dash flash), and track auth changes so
@@ -72,14 +78,40 @@ export function useHubStats(): HubStatCounts {
   const [screenshots, setScreenshots] = useState<number | null>(null)
   useEffect(() => {
     let live = true
-    void window.omi
-      ?.rewindFrameCount?.()
-      .then((n) => {
-        if (live) setScreenshots(n)
-      })
-      .catch(() => {})
+    const read = (): void => {
+      void window.omi
+        ?.rewindFrameCount?.()
+        .then((n) => {
+          if (live) setScreenshots(n)
+        })
+        .catch(() => {})
+    }
+    read()
+    // Re-read when a frame is stored so a Hub left open all day keeps a live
+    // count instead of freezing at its mount value (the reported bug). Throttled:
+    // re-read at most once per window, with a trailing read so the last frame's
+    // count still lands.
+    let lastReadAt = 0
+    let trailing: ReturnType<typeof setTimeout> | null = null
+    const onCaptured = (): void => {
+      const now = Date.now()
+      const since = now - lastReadAt
+      if (since >= REWIND_COUNT_REFRESH_MS) {
+        lastReadAt = now
+        read()
+      } else if (trailing === null) {
+        trailing = setTimeout(() => {
+          trailing = null
+          lastReadAt = Date.now()
+          read()
+        }, REWIND_COUNT_REFRESH_MS - since)
+      }
+    }
+    const unsub = window.omi?.onRewindCaptured?.(onCaptured)
     return () => {
       live = false
+      if (trailing !== null) clearTimeout(trailing)
+      unsub?.()
     }
     // Keyed on uid for the same reason as the tasks read above.
   }, [uid])

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -986,6 +986,10 @@ export type OmiBridgeApi = {
   rewindDayBounds: () => Promise<{ min: number; max: number } | null>
   /** Total captured frames, all time — a COUNT(*), not a row fetch. */
   rewindFrameCount: () => Promise<number>
+  /** Fires (no payload) each time a frame is actually stored, so a live view of
+   *  the frame count (the Hub's "Screenshots" stat) can re-read `rewindFrameCount`
+   *  instead of freezing at its mount-time value. */
+  onRewindCaptured: (cb: () => void) => () => void
   /** Phase 1 of a Rewind search: KEYWORD (FTS5/BM25) results, immediately. Never
    *  waits on the network — semantic hits follow on `onRewindSearchResults`. */
   rewindSearch: (query: string) => Promise<RewindSearchGroup[]>


### PR DESCRIPTION
## Bug (#10503)

On Omi Desktop for Windows the Rewind **screenshot count** freezes — reported stuck at `211` while recording ran all day — making it look like capture had stalled.

## Root cause

The Hub's "Screenshots" stat (`useHubStats`) fetched `rewindFrameCount()` **once on mount**, in an effect keyed only on `uid`, with no other refresh trigger. So a Hub left open all day never re-read the count. The sibling `tasks` stat does not have this problem: it re-reads on the `onTasksChanged` push.

## Fix

Mirror the existing `tasks:changed` / `conversations:changed` pattern:

- **main** (`ipc/rewind.ts`): broadcast `rewind:captured` when a frame is actually stored (`captured: true` only — deduped/idle/locked frames don't change the count).
- **preload**: expose `onRewindCaptured(cb)`.
- **renderer** (`useHubStats.ts`): re-read the count on that event, throttled (leading + trailing, 5s) so a ~1/s capture burst doesn't run one `COUNT(*)` per frame.

Existing `rewind:saveFrame` callers still receive the same `IngestResult`.

## Tested

- Added regression tests in `useHubStats.test.tsx`: the count re-reads when a frame is captured (would fail before this fix), and a burst is throttled to a single leading read.
- `vitest run` over the affected area: **92/92 passing** (`components/home/hub` + `ipc/rewind*`).
- `typecheck:node` + `typecheck:web` clean; `eslint` clean on touched files.
- Windows-only app (couldn't run the packaged app on macOS); the hook logic is exercised end-to-end via `renderHook`.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

