### PR TITLE
fix(desktop): stop chat force-scrolling to bottom while streaming (#10505)

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-07-chat-scroll-follow.json
+++ b/desktop/windows/changelog/unreleased/2026-07-chat-scroll-follow.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "The chat no longer forces you back to the bottom while the assistant is thinking or writing — scroll up to read earlier messages and it stays put, then follows again once you return to the latest message."
+  ]
+}

--- a/desktop/windows/src/renderer/src/components/home/hub/HubChatPanel.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HubChatPanel.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, act } from '@testing-library/react'
+import { HubChatPanel } from './HubChatPanel'
+import type { ChatMsg } from '../../../hooks/useChat'
+
+// The panel pins the live edge with a ResizeObserver (absent in jsdom). Capture
+// the callback so the test can fire it to simulate the streaming reply growing.
+let roCallback: (() => void) | null = null
+/* eslint-disable @typescript-eslint/no-empty-function -- no-op ResizeObserver stub */
+class ResizeObserverStub {
+  constructor(cb: () => void) {
+    roCallback = cb
+  }
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+/* eslint-enable @typescript-eslint/no-empty-function */
+;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub
+
+// Markdown rendering is tested elsewhere; stub the list so this test focuses on
+// the scroll-follow behavior.
+vi.mock('../../chat/ChatMessages', () => ({
+  ChatMessages: ({ messages }: { messages: unknown[] }) => (
+    <div data-testid="messages">{messages.length}</div>
+  )
+}))
+
+const messages: ChatMsg[] = [
+  { id: 'u1', role: 'user', content: 'hello' },
+  { id: 'a1', role: 'assistant', content: 'streaming answer...' }
+]
+
+function renderPanel(): HTMLDivElement {
+  const { container } = render(
+    <HubChatPanel messages={messages} sending={true}>
+      <div>ask bar</div>
+    </HubChatPanel>
+  )
+  const el = container.querySelector('.overflow-y-auto') as HTMLDivElement
+  // jsdom has no layout, so fake the scroll geometry: a 1000px document in a
+  // 300px viewport.
+  Object.defineProperty(el, 'scrollHeight', { value: 1000, configurable: true })
+  Object.defineProperty(el, 'clientHeight', { value: 300, configurable: true })
+  return el
+}
+
+afterEach(() => {
+  cleanup()
+  roCallback = null
+})
+
+describe('HubChatPanel live-edge follow', () => {
+  it('pins to the bottom while following as the reply grows', () => {
+    const el = renderPanel()
+    el.scrollTop = 0
+    act(() => roCallback?.())
+    expect(el.scrollTop).toBe(1000)
+  })
+
+  it('does NOT yank the reader back to the bottom after they scroll up mid-stream', () => {
+    const el = renderPanel()
+    // Reader scrolls up to read earlier messages during generation.
+    fireEvent.wheel(el, { deltaY: -40 })
+    el.scrollTop = 200
+    // Streaming appends more text -> ResizeObserver fires again.
+    act(() => roCallback?.())
+    // The view must stay where the reader left it, not jump to the live edge.
+    expect(el.scrollTop).toBe(200)
+  })
+
+  it('re-engages following once the reader returns to the live edge', () => {
+    const el = renderPanel()
+    fireEvent.wheel(el, { deltaY: -40 })
+    el.scrollTop = 200
+    act(() => roCallback?.())
+    expect(el.scrollTop).toBe(200)
+    // Reader scrolls back down to within the bottom threshold.
+    el.scrollTop = 700 // 1000 - 700 - 300 = 0 <= 8 -> at bottom
+    fireEvent.scroll(el)
+    el.scrollTop = 400
+    act(() => roCallback?.())
+    expect(el.scrollTop).toBe(1000)
+  })
+})

--- a/desktop/windows/src/renderer/src/components/home/hub/HubChatPanel.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HubChatPanel.tsx
@@ -21,21 +21,36 @@ export function HubChatPanel(props: {
   const { messages, sending, header, children } = props
   const scrollRef = useRef<HTMLDivElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
+  const followRef = useRef(true)
 
   // Pin the live edge. RevealMarkdown grows the streaming reply's text WITHOUT a
   // history change, so watching `messages` alone would lag the reveal by a chunk —
   // observe the content box and re-pin on every size change (mirrors BarChatSurface).
+  // Only pin while following: disengage when the reader scrolls up so a streaming
+  // reply can't yank them back to the bottom, re-engage on returning to the edge.
   useEffect(() => {
     const content = contentRef.current
-    if (!content) return
+    const el = scrollRef.current
+    if (!content || !el) return
     const pin = (): void => {
-      const el = scrollRef.current
-      if (el) el.scrollTop = el.scrollHeight
+      if (followRef.current) el.scrollTop = el.scrollHeight
     }
     pin()
     const ro = new ResizeObserver(pin)
     ro.observe(content)
-    return () => ro.disconnect()
+    const onWheel = (e: WheelEvent): void => {
+      if (e.deltaY < 0 && el.scrollHeight > el.clientHeight + 8) followRef.current = false
+    }
+    const onScroll = (): void => {
+      if (el.scrollHeight - el.scrollTop - el.clientHeight <= 8) followRef.current = true
+    }
+    el.addEventListener('wheel', onWheel, { passive: true })
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      ro.disconnect()
+      el.removeEventListener('wheel', onWheel)
+      el.removeEventListener('scroll', onScroll)
+    }
   }, [])
 
   return (


### PR DESCRIPTION
## Bug (#10505)

On Omi Desktop, the chat forcibly scrolls to the bottom while the assistant is thinking or writing. If the reader scrolls up to read earlier messages during generation, the view is repeatedly forced back to the bottom, making longer conversations hard to follow.

## Root cause

`HubChatPanel` (the Windows Hub chat stage) pins the live edge with a `ResizeObserver` whose callback set `scrollTop = scrollHeight` **unconditionally** on every content-size change. Because `RevealMarkdown` grows the streaming reply's text on each chunk, every growth re-pinned to the bottom regardless of where the reader had scrolled.

The effect's own comment claimed to "mirror BarChatSurface", but it dropped the follow guard that `BarChatSurface` has.

## Fix

Port the `followRef` guard from `BarChatSurface`:
- pin only while following,
- disengage on wheel-up (when the list is actually scrollable),
- re-engage once the reader returns within 8px of the bottom.

~18 lines in one component; no behavior change when the reader is already at the live edge.

## What I tested

- Added `HubChatPanel.test.tsx` (3 tests) driving the real pin path through a captured `ResizeObserver`: pins while following, **stays put after a mid-stream scroll-up**, re-engages at the live edge.
- Teeth check: reverted to the old unconditional pin — the two follow-disengage assertions fail (`scrollTop` forced to 1000 instead of staying at 200, i.e. the exact reported symptom). Restored fix → all pass.
- `vitest run` on the new test: 3/3 pass.
- `tsc` (web project) and `eslint` on the changed files: clean.
- Note: the Windows Electron app cannot be run on this macOS runner, so the fix is verified through the behavioral regression test that exercises the identical follow/pin code path, not the live packaged app.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

