### PR TITLE
feat(ci): ratchet recurring failure classes onto a canonical guard artifact

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -113,6 +113,16 @@ checks:
     lanes: ["local", "ci"]
     requires_pr_body: true
     reason: "fix commits declare a validated semantic failure class"
+  - id: failure-class-guard-artifact-ratchet
+    command: ["python3", ".github/scripts/check_failure_class_guard_ratchet.py", "--pr-body-file", "{pr_body_file}"]
+    triggers: ["all"]
+    lanes: ["local", "ci"]
+    reason: "FC-split-mutation-authority was declared on 30 first-parent integration changes in the 90 days to Jul 24 2026 while its definition still listed evidence_prs [9365, 9597] and named no guard artifact; a recurring class must produce a reusable guard surface, not more paperwork"
+  - id: failure-class-guard-artifact-ratchet-tests
+    command: ["python3", ".github/scripts/test_check_failure_class_guard_ratchet.py"]
+    triggers: [".github/scripts/check_failure_class_guard_ratchet.py", ".github/scripts/test_check_failure_class_guard_ratchet.py", ".github/scripts/failure_class_guard_ratchet_allowlist.json", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the guard-artifact ratchet's counting window, threshold, allowlist shrink rule, and shallow-history skip must stay behaviorally covered"
   - id: failure-class-cli-tests
     command: ["python3", "scripts/test_failure_class.py"]
     triggers: ["scripts/failure-class", "scripts/test_failure_class.py", ".github/failure-classes/**", ".github/checks-manifest.yaml"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -113,6 +113,11 @@ checks:
     lanes: ["local", "ci"]
     requires_pr_body: true
     reason: "fix commits declare a validated semantic failure class"
+  - id: failure-class-cli-tests
+    command: ["python3", "scripts/test_failure_class.py"]
+    triggers: ["scripts/failure-class", "scripts/test_failure_class.py", ".github/failure-classes/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the failure-class CLI is the registry's only schema authority; its hermetic tests had no blocking lane and had silently gone stale"
   - id: desktop-changelog-data
     command: ["python3", ".github/scripts/desktop-changelog.py", "validate"]
     triggers: ["all"]

--- a/.github/failure-classes/FC-deploy-concurrency.json
+++ b/.github/failure-classes/FC-deploy-concurrency.json
@@ -3,6 +3,7 @@
   "id": "FC-deploy-concurrency",
   "violated_contract": "An exact eligible main SHA must have one authoritative automatic development deployment lifecycle for each shared persistent mutation domain; sibling automatic workflows must not compete for the same GitHub Actions concurrency group.",
   "canonical_prevention": "Fold shared-backend automatic mutations into the Release Eligibility-admitted backend lifecycle and deterministically reject a second automatic writer for deploy-backend-stack-development.",
+  "canonical_prevention_artifact": [".github/scripts/check-deployment-concurrency.py"],
   "evidence_prs": [10329],
   "scope_hints": [
     ".github/workflows/gcp_backend_auto_dev.yml",

--- a/.github/failure-classes/FC-single-machine-release-gate.json
+++ b/.github/failure-classes/FC-single-machine-release-gate.json
@@ -3,6 +3,10 @@
   "id": "FC-single-machine-release-gate",
   "violated_contract": "A release-blocking automated gate must not depend on exactly one machine: every mandatory pipeline stage needs at least two independently healthy executors (an always-available primary lane plus at least one fallback), with the gate passing when any lane produces valid evidence and failing only on the candidate itself.",
   "canonical_prevention": "Desktop beta qualification runs a Codemagic primary lane plus a pool of interchangeable self-hosted runners behind an at-least-one-passes verdict; machine-specific prerequisites (global backend python, Docker-only Typesense) are eliminated so any admin Mac or ephemeral CI Mac can execute the lane.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/desktop_codemagic_qualification.py",
+    ".github/scripts/test_desktop_codemagic_qualification.py"
+  ],
   "evidence_prs": [10354],
   "scope_hints": [
     ".github/workflows/desktop_qualify_beta.yml",

--- a/.github/failure-classes/FC-workflow-control-source-identity.json
+++ b/.github/failure-classes/FC-workflow-control-source-identity.json
@@ -3,6 +3,9 @@
   "id": "FC-workflow-control-source-identity",
   "violated_contract": "A deployment workflow's control-plane scripts must execute from the immutable workflow revision that selected their behavior, while application and image inputs remain pinned to the admitted runtime release revision.",
   "canonical_prevention": "Stage the workflow revision's deployment-control scripts before checking out the admitted runtime source, execute every workflow-owned control-script invocation from that staging directory, and cover the ordering and source boundary with a deployment contract test.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_verify_backend_release_vector.py"
+  ],
   "evidence_prs": [
     10254
   ],

--- a/.github/scripts/check_failure_class_guard_ratchet.py
+++ b/.github/scripts/check_failure_class_guard_ratchet.py
@@ -18,8 +18,10 @@ Determinism and hermeticity:
   first-parent history does not reach back to the window start, this prints a
   loud SKIP and exits 0 rather than passing silently or failing spuriously.
 - Classes already over threshold when this landed are grandfathered by an
-  explicit allowlist. The allowlist only shrinks: once a class gains an
-  artifact, its entry must be removed.
+  explicit allowlist up to each entry's `declarations_at_baseline`; a new
+  declaration above that baseline fails until a guard artifact is recorded.
+  The allowlist only shrinks: once a class gains an artifact, its entry must
+  be removed.
 """
 
 from __future__ import annotations
@@ -30,6 +32,7 @@ import re
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -43,6 +46,12 @@ DECLARATION_RE = re.compile(r"^[ \t]*Failure-Class:[ \t]*(FC-[a-z0-9-]+)[ \t]*$"
 HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 RECORD_SEPARATOR = "\x1e"
 FIELD_SEPARATOR = "\x1f"
+
+
+@dataclass(frozen=True)
+class GrandfatherEntry:
+    reason: str
+    declarations_at_baseline: int
 
 
 class CheckError(Exception):
@@ -84,8 +93,8 @@ def load_definitions(root: Path) -> dict[str, dict[str, Any]]:
     return definitions
 
 
-def load_allowlist(root: Path) -> dict[str, str]:
-    """Return grandfathered class id -> reason.
+def load_allowlist(root: Path) -> dict[str, GrandfatherEntry]:
+    """Return grandfathered class id -> entry metadata.
 
     A missing allowlist is not an error: the ratchet is simply unrelaxed.
     """
@@ -101,17 +110,22 @@ def load_allowlist(root: Path) -> dict[str, str]:
     entries = data.get("grandfathered")
     if not isinstance(entries, list):
         raise CheckError(f"{ALLOWLIST_RELATIVE_PATH} must contain a 'grandfathered' array")
-    allowlist: dict[str, str] = {}
+    allowlist: dict[str, GrandfatherEntry] = {}
     for index, entry in enumerate(entries):
         if not isinstance(entry, dict):
             raise CheckError(f"grandfathered[{index}] must be an object")
         class_id = entry.get("id")
         reason = entry.get("reason")
+        baseline = entry.get("declarations_at_baseline")
         if not isinstance(class_id, str) or not isinstance(reason, str) or not reason.strip():
             raise CheckError(f"grandfathered[{index}] requires a string 'id' and a non-empty 'reason'")
+        if not isinstance(baseline, int) or baseline < 0:
+            raise CheckError(
+                f"grandfathered[{index}] requires a non-negative integer 'declarations_at_baseline'"
+            )
         if class_id in allowlist:
             raise CheckError(f"grandfathered contains duplicate id '{class_id}'")
-        allowlist[class_id] = reason
+        allowlist[class_id] = GrandfatherEntry(reason=reason, declarations_at_baseline=baseline)
     return allowlist
 
 
@@ -166,7 +180,7 @@ def read_pr_body(path: Path | None) -> str:
 
 def evaluate(
     definitions: dict[str, dict[str, Any]],
-    allowlist: dict[str, str],
+    allowlist: dict[str, GrandfatherEntry],
     counts: dict[str, int],
     threshold: int,
 ) -> list[str]:
@@ -183,7 +197,17 @@ def evaluate(
         if definition.get("canonical_prevention_artifact"):
             continue
         if class_id in allowlist:
-            print(f"  GRANDFATHERED {class_id}: {count} declaration(s) — {allowlist[class_id]}")
+            entry = allowlist[class_id]
+            if count > entry.declarations_at_baseline:
+                failures.append(
+                    f"{class_id}: {count} declarations in the window (baseline "
+                    f"{entry.declarations_at_baseline}) with no 'canonical_prevention_artifact'. "
+                    f"A grandfathered class must not recur without recording its guard surface in "
+                    f"{DEFINITIONS_RELATIVE_PATH / (class_id + '.json')}, then removing its entry from "
+                    f"{ALLOWLIST_RELATIVE_PATH}."
+                )
+                continue
+            print(f"  GRANDFATHERED {class_id}: {count} declaration(s) — {entry.reason}")
             continue
         failures.append(
             f"{class_id}: {count} declarations in the window (threshold {threshold}) with no "
@@ -192,7 +216,7 @@ def evaluate(
             f"{ALLOWLIST_RELATIVE_PATH}."
         )
 
-    for class_id, reason in sorted(allowlist.items()):
+    for class_id, entry in sorted(allowlist.items()):
         definition = definitions.get(class_id)
         if definition is None:
             failures.append(
@@ -202,7 +226,7 @@ def evaluate(
         elif definition.get("canonical_prevention_artifact"):
             failures.append(
                 f"{class_id}: now records a 'canonical_prevention_artifact', so its grandfather entry in "
-                f"{ALLOWLIST_RELATIVE_PATH} must be removed. The allowlist only shrinks. ({reason})"
+                f"{ALLOWLIST_RELATIVE_PATH} must be removed. The allowlist only shrinks. ({entry.reason})"
             )
     return failures
 

--- a/.github/scripts/check_failure_class_guard_ratchet.py
+++ b/.github/scripts/check_failure_class_guard_ratchet.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Fail when a failure class recurs without producing a reusable guard surface.
+
+Root AGENTS.md: "If two or more recent fixes share the cause, add a reusable
+guard surface in the same PR." Nothing enforced that. Between 2026-06-16 and
+2026-07-24, FC-split-mutation-authority was declared on 30 first-parent
+integration changes while its definition still listed `evidence_prs: [9365,
+9597]` and named no guard artifact at all. Recurrence had become paperwork.
+
+This check counts declarations of each class over a recent window and requires
+that a class at or above the threshold names a `canonical_prevention_artifact`.
+
+Determinism and hermeticity:
+- Counts come from `git log --first-parent` in the checkout. No network.
+- Integration changes are counted, not raw commits: one merged PR routinely
+  carries a dozen `fix:` commits, so a raw-commit threshold would be noise.
+- History-dependent checks must degrade safely. On a shallow clone, or when
+  first-parent history does not reach back to the window start, this prints a
+  loud SKIP and exits 0 rather than passing silently or failing spuriously.
+- Classes already over threshold when this landed are grandfathered by an
+  explicit allowlist. The allowlist only shrinks: once a class gains an
+  artifact, its entry must be removed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFINITIONS_RELATIVE_PATH = Path(".github/failure-classes")
+ALLOWLIST_RELATIVE_PATH = Path(".github/scripts/failure_class_guard_ratchet_allowlist.json")
+ALLOWLIST_SCHEMA_VERSION = 1
+DEFAULT_WINDOW_DAYS = 90
+DEFAULT_THRESHOLD = 3
+DECLARATION_RE = re.compile(r"^[ \t]*Failure-Class:[ \t]*(FC-[a-z0-9-]+)[ \t]*$", re.MULTILINE)
+HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+RECORD_SEPARATOR = "\x1e"
+FIELD_SEPARATOR = "\x1f"
+
+
+class CheckError(Exception):
+    """A deterministic input or repository error intended for CLI output."""
+
+
+def run_git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise CheckError(f"git {' '.join(args)} failed: {detail}")
+    return result.stdout
+
+
+def declarations_in(text: str) -> set[str]:
+    return set(DECLARATION_RE.findall(HTML_COMMENT_RE.sub("", text)))
+
+
+def load_definitions(root: Path) -> dict[str, dict[str, Any]]:
+    directory = root / DEFINITIONS_RELATIVE_PATH
+    if not directory.is_dir():
+        raise CheckError(f"missing {DEFINITIONS_RELATIVE_PATH}")
+    definitions: dict[str, dict[str, Any]] = {}
+    for path in sorted(directory.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise CheckError(f"invalid definition {path.name}: {exc}") from exc
+        if not isinstance(data, dict) or not isinstance(data.get("id"), str):
+            raise CheckError(f"invalid definition {path.name}: missing string 'id'")
+        definitions[data["id"]] = data
+    return definitions
+
+
+def load_allowlist(root: Path) -> dict[str, str]:
+    """Return grandfathered class id -> reason.
+
+    A missing allowlist is not an error: the ratchet is simply unrelaxed.
+    """
+    path = root / ALLOWLIST_RELATIVE_PATH
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CheckError(f"invalid allowlist {ALLOWLIST_RELATIVE_PATH}: {exc}") from exc
+    if not isinstance(data, dict) or data.get("schema_version") != ALLOWLIST_SCHEMA_VERSION:
+        raise CheckError(f"{ALLOWLIST_RELATIVE_PATH} must be a schema_version {ALLOWLIST_SCHEMA_VERSION} object")
+    entries = data.get("grandfathered")
+    if not isinstance(entries, list):
+        raise CheckError(f"{ALLOWLIST_RELATIVE_PATH} must contain a 'grandfathered' array")
+    allowlist: dict[str, str] = {}
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise CheckError(f"grandfathered[{index}] must be an object")
+        class_id = entry.get("id")
+        reason = entry.get("reason")
+        if not isinstance(class_id, str) or not isinstance(reason, str) or not reason.strip():
+            raise CheckError(f"grandfathered[{index}] requires a string 'id' and a non-empty 'reason'")
+        if class_id in allowlist:
+            raise CheckError(f"grandfathered contains duplicate id '{class_id}'")
+        allowlist[class_id] = reason
+    return allowlist
+
+
+def parse_timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise CheckError(f"timestamp must include a timezone: {value}")
+    return parsed.astimezone(timezone.utc)
+
+
+def history_reaches(root: Path, cutoff: datetime) -> bool:
+    """True when the checkout's first-parent history predates the window start."""
+    output = run_git(root, "log", "--first-parent", "--format=%cI", "--max-count=100000")
+    dates = [line for line in output.splitlines() if line]
+    if not dates:
+        return False
+    return parse_timestamp(dates[-1]) < cutoff
+
+
+def declaration_counts(root: Path, cutoff: datetime) -> dict[str, int]:
+    """Count first-parent integration changes declaring each class since cutoff.
+
+    A class is counted once per integration change even if the merge message
+    carries several declaring commit messages.
+    """
+    output = run_git(
+        root,
+        "log",
+        "--first-parent",
+        f"--since={cutoff.isoformat()}",
+        f"--format={FIELD_SEPARATOR}%H{FIELD_SEPARATOR}%B{RECORD_SEPARATOR}",
+    )
+    counts: dict[str, int] = {}
+    for record in output.split(RECORD_SEPARATOR):
+        if FIELD_SEPARATOR not in record:
+            continue
+        _, _, message = record.partition(FIELD_SEPARATOR)
+        _, _, message = message.partition(FIELD_SEPARATOR)
+        for class_id in declarations_in(message):
+            counts[class_id] = counts.get(class_id, 0) + 1
+    return counts
+
+
+def read_pr_body(path: Path | None) -> str:
+    if path is None:
+        return ""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def evaluate(
+    definitions: dict[str, dict[str, Any]],
+    allowlist: dict[str, str],
+    counts: dict[str, int],
+    threshold: int,
+) -> list[str]:
+    """Return failure messages; an empty list means the ratchet holds."""
+    failures: list[str] = []
+    for class_id, count in sorted(counts.items()):
+        definition = definitions.get(class_id)
+        if definition is None:
+            # An unknown id in history is the failure-class CLI's problem, not
+            # this ratchet's; it must not fail a PR that never touched it.
+            continue
+        if count < threshold:
+            continue
+        if definition.get("canonical_prevention_artifact"):
+            continue
+        if class_id in allowlist:
+            print(f"  GRANDFATHERED {class_id}: {count} declaration(s) — {allowlist[class_id]}")
+            continue
+        failures.append(
+            f"{class_id}: {count} declarations in the window (threshold {threshold}) with no "
+            f"'canonical_prevention_artifact'. Add the reusable guard surface and record its path in "
+            f"{DEFINITIONS_RELATIVE_PATH / (class_id + '.json')}, or grandfather it explicitly in "
+            f"{ALLOWLIST_RELATIVE_PATH}."
+        )
+
+    for class_id, reason in sorted(allowlist.items()):
+        definition = definitions.get(class_id)
+        if definition is None:
+            failures.append(
+                f"{class_id}: grandfathered in {ALLOWLIST_RELATIVE_PATH} but no such definition exists; "
+                f"remove the entry."
+            )
+        elif definition.get("canonical_prevention_artifact"):
+            failures.append(
+                f"{class_id}: now records a 'canonical_prevention_artifact', so its grandfather entry in "
+                f"{ALLOWLIST_RELATIVE_PATH} must be removed. The allowlist only shrinks. ({reason})"
+            )
+    return failures
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=None, help="Repository root (default: git toplevel of cwd).")
+    parser.add_argument("--window-days", type=int, default=DEFAULT_WINDOW_DAYS)
+    parser.add_argument("--threshold", type=int, default=DEFAULT_THRESHOLD)
+    parser.add_argument(
+        "--pr-body-file",
+        type=Path,
+        default=None,
+        help="PR body under review; its declaration counts toward the window so the declaring PR fails first.",
+    )
+    parser.add_argument("--now", default=None, help="UTC ISO-8601 timestamp; makes the window deterministic in tests.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        root = (args.root or Path(run_git(Path.cwd(), "rev-parse", "--show-toplevel").strip())).resolve()
+        if args.window_days <= 0 or args.threshold <= 0:
+            raise CheckError("--window-days and --threshold must be positive")
+        now = parse_timestamp(args.now) if args.now else datetime.now(timezone.utc)
+        cutoff = now - timedelta(days=args.window_days)
+
+        if run_git(root, "rev-parse", "--is-shallow-repository").strip() == "true":
+            print(
+                "SKIP failure-class guard ratchet: shallow clone cannot establish the "
+                f"{args.window_days}-day declaration window. Re-run with full history "
+                "(actions/checkout fetch-depth: 0) to enforce it.",
+                flush=True,
+            )
+            return 0
+        if not history_reaches(root, cutoff):
+            print(
+                "SKIP failure-class guard ratchet: first-parent history does not reach back to "
+                f"{cutoff.date().isoformat()}, so the {args.window_days}-day window is not measurable here.",
+                flush=True,
+            )
+            return 0
+
+        definitions = load_definitions(root)
+        allowlist = load_allowlist(root)
+        counts = declaration_counts(root, cutoff)
+        for class_id in declarations_in(read_pr_body(args.pr_body_file)):
+            counts[class_id] = counts.get(class_id, 0) + 1
+    except (CheckError, ValueError) as exc:
+        print(f"FAIL: failure-class guard ratchet could not run: {exc}", file=sys.stderr)
+        return 2
+
+    print(
+        f"Failure-class guard ratchet: window={args.window_days}d since={cutoff.date().isoformat()} "
+        f"threshold={args.threshold} classes_declared={len(counts)}"
+    )
+    failures = evaluate(definitions, allowlist, counts, args.threshold)
+    if failures:
+        print("FAIL: a recurring failure class has no reusable guard surface.", file=sys.stderr)
+        for message in failures:
+            print(f"- {message}", file=sys.stderr)
+        return 1
+    print("OK: every class at or above the threshold names a guard artifact or is explicitly grandfathered.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/failure_class_guard_ratchet_allowlist.json
+++ b/.github/scripts/failure_class_guard_ratchet_allowlist.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "note": "Classes already over the guard-artifact threshold when the ratchet landed (2026-07-24). This list only shrinks: adding an entry is an explicit admission that a class recurs without a reusable guard, and an entry must be removed once its class records a canonical_prevention_artifact. See docs/product/failure-classes.md.",
+  "grandfathered": [
+    {
+      "id": "FC-split-mutation-authority",
+      "declarations_at_baseline": 30,
+      "reason": "30 first-parent integration changes in the 90 days to 2026-07-24 while evidence_prs still read [9365, 9597]; the canonical prevention is prose with no artifact. This is the recurrence that motivated the ratchet."
+    },
+    {
+      "id": "FC-nonrecoverable-promotion",
+      "declarations_at_baseline": 6,
+      "reason": "6 first-parent integration changes in the same window; traffic-state snapshot and restore is spread across deploy workflow steps with no single guard surface to cite."
+    },
+    {
+      "id": "FC-unprovisioned-rollout-target",
+      "declarations_at_baseline": 3,
+      "reason": "3 first-parent integration changes in the same window; the definition describes a deploy-lane endpoint-provisioning check that does not exist yet as a nameable artifact."
+    }
+  ]
+}

--- a/.github/scripts/failure_class_guard_ratchet_allowlist.json
+++ b/.github/scripts/failure_class_guard_ratchet_allowlist.json
@@ -4,8 +4,8 @@
   "grandfathered": [
     {
       "id": "FC-split-mutation-authority",
-      "declarations_at_baseline": 30,
-      "reason": "30 first-parent integration changes in the 90 days to 2026-07-24 while evidence_prs still read [9365, 9597]; the canonical prevention is prose with no artifact. This is the recurrence that motivated the ratchet."
+      "declarations_at_baseline": 31,
+      "reason": "31 first-parent integration changes in the 90 days through 2026-07-25 (30 at ratchet authoring on 2026-07-24, plus one on main before merge); evidence_prs still read [9365, 9597] and the canonical prevention is prose with no artifact. This is the recurrence that motivated the ratchet."
     },
     {
       "id": "FC-nonrecoverable-promotion",

--- a/.github/scripts/test_check_failure_class_guard_ratchet.py
+++ b/.github/scripts/test_check_failure_class_guard_ratchet.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Hermetic subprocess tests for the failure-class guard-artifact ratchet.
+
+Each test builds a real, disposable git repository with real first-parent
+history and runs the checker against it, so production counting, threshold, and
+allowlist behavior execute end to end. No source strings are asserted.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+CHECKER = REPOSITORY_ROOT / ".github" / "scripts" / "check_failure_class_guard_ratchet.py"
+NOW = "2026-07-24T00:00:00Z"
+# Disposable repositories must not inherit the caller's git context. Running
+# under a pre-commit or pre-push hook exports GIT_DIR and a hooks path that
+# would otherwise reach back into the real checkout.
+GIT_ISOLATION = ("-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false")
+
+
+def clean_environment(**overrides: str) -> dict[str, str]:
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    environment.update(overrides)
+    return environment
+
+
+def git(root: Path, *args: str, date: str | None = None) -> subprocess.CompletedProcess[str]:
+    overrides = {"GIT_AUTHOR_DATE": date, "GIT_COMMITTER_DATE": date} if date else {}
+    return subprocess.run(
+        ["git", *GIT_ISOLATION, *args],
+        cwd=root,
+        check=False,
+        text=True,
+        capture_output=True,
+        env=clean_environment(**overrides),
+    )
+
+
+def run_checker(root: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), "--root", str(root), "--now", NOW, *extra],
+        cwd=root,
+        check=False,
+        text=True,
+        capture_output=True,
+        env=clean_environment(),
+    )
+
+
+class GuardRatchetTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_directory.name)
+        (self.root / ".github" / "failure-classes").mkdir(parents=True)
+        (self.root / ".github" / "scripts").mkdir(parents=True)
+        self.git("init", "-q", "-b", "main")
+        self.git("config", "user.email", "ratchet@example.test")
+        self.git("config", "user.name", "Ratchet Test")
+        # An old root commit so the window is measurable in every test.
+        self.commit("chore: seed repository", date="2026-01-01T00:00:00Z")
+
+    def tearDown(self) -> None:
+        self.temp_directory.cleanup()
+
+    def git(self, *args: str, date: str | None = None) -> str:
+        result = git(self.root, *args, date=date)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result.stdout.strip()
+
+    def commit(self, message: str, *, date: str) -> None:
+        self.git("commit", "-q", "--allow-empty", "-m", message, date=date)
+
+    def declare(self, class_id: str, *, count: int, date: str = "2026-07-01T00:00:00Z") -> None:
+        """Add `count` first-parent integration changes declaring `class_id`."""
+        for index in range(count):
+            self.commit(f"fix(scope): instance {index}\n\nFailure-Class: {class_id}\n", date=date)
+
+    def define(self, class_id: str, *, artifact: list[str] | None = None) -> None:
+        definition = {
+            "schema_version": 1,
+            "id": class_id,
+            "violated_contract": "contract",
+            "canonical_prevention": "prevention",
+            "evidence_prs": [1],
+            "status": "open",
+        }
+        if artifact is not None:
+            definition["canonical_prevention_artifact"] = artifact
+        path = self.root / ".github" / "failure-classes" / f"{class_id}.json"
+        path.write_text(json.dumps(definition, indent=2) + "\n", encoding="utf-8")
+
+    def allow(self, entries: list[dict[str, object]]) -> None:
+        path = self.root / ".github" / "scripts" / "failure_class_guard_ratchet_allowlist.json"
+        path.write_text(
+            json.dumps({"schema_version": 1, "grandfathered": entries}, indent=2) + "\n", encoding="utf-8"
+        )
+
+    def check(self, *extra: str) -> subprocess.CompletedProcess[str]:
+        return run_checker(self.root, *extra)
+
+    def test_over_threshold_without_artifact_fails(self) -> None:
+        self.define("FC-recurring-thing")
+        self.declare("FC-recurring-thing", count=3)
+        result = self.check()
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("FC-recurring-thing", result.stderr)
+
+    def test_over_threshold_with_artifact_passes(self) -> None:
+        self.define("FC-recurring-thing", artifact=["guards/recurring.py"])
+        self.declare("FC-recurring-thing", count=5)
+        result = self.check()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_under_threshold_passes(self) -> None:
+        self.define("FC-recurring-thing")
+        self.declare("FC-recurring-thing", count=2)
+        result = self.check()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_grandfathered_class_passes(self) -> None:
+        self.define("FC-recurring-thing")
+        self.declare("FC-recurring-thing", count=9)
+        self.allow([{"id": "FC-recurring-thing", "reason": "over threshold when the ratchet landed"}])
+        result = self.check()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("GRANDFATHERED", result.stdout)
+
+    def test_grandfathered_class_with_artifact_must_leave_the_allowlist(self) -> None:
+        self.define("FC-recurring-thing", artifact=["guards/recurring.py"])
+        self.declare("FC-recurring-thing", count=9)
+        self.allow([{"id": "FC-recurring-thing", "reason": "stale entry"}])
+        result = self.check()
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("only shrinks", result.stderr)
+
+    def test_declarations_outside_the_window_do_not_count(self) -> None:
+        self.define("FC-recurring-thing")
+        self.declare("FC-recurring-thing", count=5, date="2026-01-05T00:00:00Z")
+        result = self.check()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_pr_body_declaration_counts_toward_the_window(self) -> None:
+        self.define("FC-recurring-thing")
+        self.declare("FC-recurring-thing", count=2)
+        body = self.root / "pr-body.md"
+        body.write_text("## Summary\n\nFailure-Class: FC-recurring-thing\n", encoding="utf-8")
+        result = self.check("--pr-body-file", str(body))
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("FC-recurring-thing", result.stderr)
+
+    def test_one_integration_change_with_many_declarations_counts_once(self) -> None:
+        self.define("FC-recurring-thing")
+        squashed = "\n".join(
+            ["chore(release): merge", "", *["Failure-Class: FC-recurring-thing"] * 6]
+        )
+        self.commit(squashed, date="2026-07-01T00:00:00Z")
+        result = self.check()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_unknown_class_in_history_is_ignored(self) -> None:
+        self.declare("FC-never-defined", count=9)
+        result = self.check()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_history_shorter_than_the_window_skips_loudly(self) -> None:
+        recent = Path(tempfile.mkdtemp())
+        try:
+            git(recent, "init", "-q", "-b", "main")
+            git(recent, "config", "user.email", "a@b.test")
+            git(recent, "config", "user.name", "A B")
+            (recent / ".github" / "failure-classes").mkdir(parents=True)
+            git(recent, "commit", "-q", "--allow-empty", "-m", "chore: recent root", date=NOW)
+            result = run_checker(recent)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("SKIP", result.stdout)
+        finally:
+            subprocess.run(["rm", "-rf", str(recent)], check=False)
+
+    def test_shallow_clone_skips_loudly(self) -> None:
+        self.define("FC-recurring-thing")
+        self.declare("FC-recurring-thing", count=5)
+        shallow = Path(tempfile.mkdtemp()) / "shallow"
+        try:
+            clone = git(shallow.parent, "clone", "-q", "--depth", "1", f"file://{self.root}", str(shallow))
+            self.assertEqual(clone.returncode, 0, clone.stderr)
+            result = run_checker(shallow)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("SKIP", result.stdout)
+        finally:
+            subprocess.run(["rm", "-rf", str(shallow.parent)], check=False)
+
+    def test_repository_registry_is_green_today(self) -> None:
+        """The shipped registry plus allowlist must pass in this checkout."""
+        result = run_checker(REPOSITORY_ROOT)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_check_failure_class_guard_ratchet.py
+++ b/.github/scripts/test_check_failure_class_guard_ratchet.py
@@ -128,15 +128,40 @@ class GuardRatchetTests(unittest.TestCase):
     def test_grandfathered_class_passes(self) -> None:
         self.define("FC-recurring-thing")
         self.declare("FC-recurring-thing", count=9)
-        self.allow([{"id": "FC-recurring-thing", "reason": "over threshold when the ratchet landed"}])
+        self.allow(
+            [
+                {
+                    "id": "FC-recurring-thing",
+                    "declarations_at_baseline": 9,
+                    "reason": "over threshold when the ratchet landed",
+                }
+            ]
+        )
         result = self.check()
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("GRANDFATHERED", result.stdout)
 
+    def test_grandfathered_class_fails_on_new_recurrence(self) -> None:
+        self.define("FC-recurring-thing")
+        self.declare("FC-recurring-thing", count=10)
+        self.allow(
+            [
+                {
+                    "id": "FC-recurring-thing",
+                    "declarations_at_baseline": 9,
+                    "reason": "only the first nine are grandfathered",
+                }
+            ]
+        )
+        result = self.check()
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("FC-recurring-thing", result.stderr)
+        self.assertIn("baseline", result.stderr)
+
     def test_grandfathered_class_with_artifact_must_leave_the_allowlist(self) -> None:
         self.define("FC-recurring-thing", artifact=["guards/recurring.py"])
         self.declare("FC-recurring-thing", count=9)
-        self.allow([{"id": "FC-recurring-thing", "reason": "stale entry"}])
+        self.allow([{"id": "FC-recurring-thing", "declarations_at_baseline": 9, "reason": "stale entry"}])
         result = self.check()
         self.assertEqual(result.returncode, 1, result.stdout)
         self.assertIn("only shrinks", result.stderr)

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -213,6 +213,7 @@ class SelectionTests(unittest.TestCase):
                 "architecture-guardrails",
                 "product-invariants",
                 "failure-class-protocol",
+                "failure-class-guard-artifact-ratchet",
                 "desktop-changelog-data",
                 "deferred-work-markers",
                 "lifecycle-headers",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ A deterministic diff-scoped check failing for the first time in CI is a manifest
 The unit of work is the violated contract, not only the line where the symptom appeared. The declaration is the PR record for an ordinary instance fix; before fixing, inspect recent fixes in the same subsystem. Registry lifecycle transitions are separate PRs: dormant classes record `dormant_since`, and recurrence reopens them by setting `status: open` and removing it.
 
 - Identify the authoritative owner, identity, state transition, or boundary contract that failed — don't add another observer, fallback boolean, or call-site exception when ownership is the real problem.
-- If two or more recent fixes share the cause, add a reusable guard surface in the same PR: a typed state/policy model, behavioral contract test, fault harness, or narrow static checker.
+- If two or more recent fixes share the cause, add a reusable guard surface in the same PR: a typed state/policy model, behavioral contract test, fault harness, or narrow static checker. Record its path in the class's `canonical_prevention_artifact`; a class that keeps recurring without one fails the guard-artifact ratchet (`docs/product/failure-classes.md`).
 - A regression test must execute production behavior through a controllable seam. Asserting that source strings occur in a certain order is a static tripwire, not behavioral coverage; label static checkers as such.
 - Do not broaden a safe bug-fix PR into an unreviewable migration; land the enforceable guard now and track high-blast-radius follow-up explicitly.
 

--- a/docs/product/failure-classes.md
+++ b/docs/product/failure-classes.md
@@ -1,5 +1,31 @@
 # Failure-class registry
 
+Definitions live in `.github/failure-classes/FC-<slug>.json`, one file per class.
+`scripts/failure-class` is their only schema authority; `scripts/test_failure_class.py`
+covers it and runs in the `failure-class-cli-tests` manifest lane.
+
+## Definition schema
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `schema_version` | yes | Always `1`. |
+| `id` | yes | `FC-<lower-kebab-slug>`; must match the filename. |
+| `violated_contract` | yes | The contract an instance of this class breaks. |
+| `canonical_prevention` | yes | Prose: the shape of the fix that removes the class. |
+| `canonical_prevention_artifact` | no | Repository-relative paths to the **reusable guard surface** — a checker, shared fixture, or behavioral contract test. Every listed path must exist; a rename that orphans one fails validation. |
+| `evidence_prs` | yes | Merged PRs that evidence the class. |
+| `scope_hints` | no | Advisory globs; never used to classify a change. |
+| `status` | yes | `open` or `dormant`. |
+| `dormant_since` | dormant only | ISO-8601 timestamp of the dormant transition. |
+
+`canonical_prevention` says what should stop recurrence; `canonical_prevention_artifact`
+says where that guard actually lives. A class with prose but no artifact has an intention,
+not a guard — which is what the ratchet below measures.
+
+## Legacy narrative entries
+
+These predate the JSON registry and are kept for their closure history.
+
 | Class | Violated contract | Canonical fix primitive | Status | Closed by | Not covered |
 | --- | --- | --- | --- | --- | --- |
 | FC-1 | A malformed or legacy Firestore document must not bypass the reader's explicit fail-open or fail-closed policy. | `backend/database/read_boundary.py` | Open — the 14-day closure observation starts when #9827 merges. | — | — |

--- a/docs/product/failure-classes.md
+++ b/docs/product/failure-classes.md
@@ -22,6 +22,34 @@ covers it and runs in the `failure-class-cli-tests` manifest lane.
 says where that guard actually lives. A class with prose but no artifact has an intention,
 not a guard — which is what the ratchet below measures.
 
+## Guard-artifact ratchet
+
+`.github/scripts/check_failure_class_guard_ratchet.py` enforces the root `AGENTS.md` rule
+that repeated fixes sharing one cause must produce a reusable guard surface, instead of
+accumulating declarations forever. It runs in both manifest lanes as
+`failure-class-guard-artifact-ratchet`.
+
+- It counts **first-parent integration changes** whose message declares
+  `Failure-Class: FC-<slug>`, over a 90-day window, plus the declaration in the PR body
+  under review — so the PR that crosses the threshold is the one that fails. Raw commits
+  are not counted: a single merged PR routinely carries many `fix:` commits.
+- A class at or above **3** declarations in that window with no
+  `canonical_prevention_artifact` fails the check.
+- The check is history-dependent, so it degrades safely: on a shallow clone, or when the
+  checked-out first-parent history does not reach back to the window start, it prints a
+  loud `SKIP` and exits 0 rather than passing silently or failing spuriously.
+
+To clear a failure, add the guard surface and record its path in the class definition.
+Recording an artifact that does not exist fails `scripts/failure-class validate`.
+
+### Grandfathered classes
+
+`.github/scripts/failure_class_guard_ratchet_allowlist.json` records classes that were
+already over threshold when the ratchet landed. The allowlist only shrinks: once a class
+gains a `canonical_prevention_artifact`, the check fails until its allowlist entry is
+removed. Adding an entry is an explicit, reviewable admission that a class is recurring
+without a guard.
+
 ## Legacy narrative entries
 
 These predate the JSON registry and are kept for their closure history.

--- a/docs/product/failure-classes.md
+++ b/docs/product/failure-classes.md
@@ -45,10 +45,15 @@ Recording an artifact that does not exist fails `scripts/failure-class validate`
 ### Grandfathered classes
 
 `.github/scripts/failure_class_guard_ratchet_allowlist.json` records classes that were
-already over threshold when the ratchet landed. The allowlist only shrinks: once a class
-gains a `canonical_prevention_artifact`, the check fails until its allowlist entry is
+already over threshold when the ratchet landed. Each entry's `declarations_at_baseline`
+freezes the declaration count at ratchet introduction; a new declaration above that
+baseline fails until the class records a guard artifact. The allowlist only shrinks: once a
+class gains a `canonical_prevention_artifact`, the check fails until its allowlist entry is
 removed. Adding an entry is an explicit, reviewable admission that a class is recurring
 without a guard.
+
+An instance-fix PR may add or update `canonical_prevention_artifact` on the declared class
+in the same change; other definition edits still require a registry-only lifecycle PR.
 
 ## Legacy narrative entries
 

--- a/scripts/failure-class
+++ b/scripts/failure-class
@@ -129,7 +129,57 @@ def definitions_directory(root: Path) -> Path:
     return root / DEFINITIONS_RELATIVE_PATH
 
 
-def validate_definition(data: Any, path: Path) -> list[dict[str, Any]]:
+def validate_canonical_prevention_artifact(value: Any, path: Path, root: Path) -> list[dict[str, Any]]:
+    """Return errors for the optional guard-artifact field.
+
+    The field names the reusable guard surface that makes recurrence of this
+    class mechanically harder — a checker, a shared fixture, or a behavioral
+    contract test. Every listed path must exist so a rename cannot silently
+    leave a class claiming a guard it no longer has.
+    """
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not isinstance(item, str) or not item.strip() for item in value)
+    ):
+        return [
+            error(
+                "invalid_canonical_prevention_artifact",
+                "'canonical_prevention_artifact', when present, must be a non-empty array of repository-relative paths",
+                path=str(path),
+            )
+        ]
+    errors: list[dict[str, Any]] = []
+    if len(set(value)) != len(value):
+        errors.append(
+            error(
+                "invalid_canonical_prevention_artifact",
+                "'canonical_prevention_artifact' must not contain duplicates",
+                path=str(path),
+            )
+        )
+    for item in value:
+        candidate = Path(item)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            errors.append(
+                error(
+                    "invalid_canonical_prevention_artifact",
+                    f"'{item}' must be a repository-relative path without '..'",
+                    path=str(path),
+                )
+            )
+        elif not (root / candidate).exists():
+            errors.append(
+                error(
+                    "missing_canonical_prevention_artifact",
+                    f"'canonical_prevention_artifact' path does not exist: {item}",
+                    path=str(path),
+                )
+            )
+    return errors
+
+
+def validate_definition(data: Any, path: Path, root: Path) -> list[dict[str, Any]]:
     """Return schema errors without allowing malformed files to fail open."""
     if not isinstance(data, dict):
         return [error("invalid_definition", "definition must be a JSON object", path=str(path))]
@@ -142,7 +192,7 @@ def validate_definition(data: Any, path: Path) -> list[dict[str, Any]]:
         "evidence_prs",
         "status",
     }
-    allowed = required | {"scope_hints", "dormant_since"}
+    allowed = required | {"scope_hints", "dormant_since", "canonical_prevention_artifact"}
     errors: list[dict[str, Any]] = []
     for key in sorted(required - data.keys()):
         errors.append(error("missing_definition_field", f"missing required field '{key}'", path=str(path)))
@@ -195,6 +245,9 @@ def validate_definition(data: Any, path: Path) -> list[dict[str, Any]]:
                 path=str(path),
             )
         )
+    if "canonical_prevention_artifact" in data:
+        errors.extend(validate_canonical_prevention_artifact(data["canonical_prevention_artifact"], path, root))
+
     status = data.get("status")
     if status not in {"open", "dormant"}:
         errors.append(error("invalid_status", "'status' must be 'open' or 'dormant'", path=str(path)))
@@ -250,7 +303,7 @@ def load_definitions(root: Path) -> tuple[list[Definition], list[dict[str, Any]]
         except (OSError, json.JSONDecodeError) as exc:
             errors.append(error("invalid_definition_json", str(exc), path=str(path)))
             continue
-        errors.extend(validate_definition(data, path))
+        errors.extend(validate_definition(data, path, root))
         if isinstance(data, dict) and isinstance(data.get("id"), str):
             if data["id"] in ids:
                 errors.append(

--- a/scripts/failure-class
+++ b/scripts/failure-class
@@ -386,6 +386,55 @@ def changed_definition_paths(root: Path, common: str, head: str) -> list[Path]:
     return [Path(line) for line in output.splitlines() if line]
 
 
+def definition_json_at_ref(root: Path, ref: str, relative: Path) -> dict[str, Any] | None:
+    try:
+        output = run_git(root, "show", f"{ref}:{relative.as_posix()}")
+    except CliError:
+        return None
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def is_artifact_only_definition_update(root: Path, common: str, relative: Path) -> bool:
+    """True when the only JSON delta is adding or updating canonical_prevention_artifact."""
+    head_path = root / relative
+    try:
+        head_data = json.loads(head_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(head_data, dict) or "canonical_prevention_artifact" not in head_data:
+        return False
+    base_data = definition_json_at_ref(root, common, relative)
+    if base_data is None:
+        return False
+    if base_data.get("canonical_prevention_artifact") == head_data.get("canonical_prevention_artifact"):
+        return False
+    for key in set(base_data) | set(head_data):
+        if key == "canonical_prevention_artifact":
+            continue
+        if base_data.get(key) != head_data.get(key):
+            return False
+    return True
+
+
+def instance_fix_registry_changes_allowed(
+    root: Path,
+    common: str,
+    declaration: str,
+    changed_paths: list[Path],
+) -> bool:
+    """Instance-fix PRs may record a guard artifact for the declared class only."""
+    if not changed_paths:
+        return True
+    expected = DEFINITIONS_RELATIVE_PATH / f"{declaration}.json"
+    if set(changed_paths) != {expected}:
+        return False
+    return is_artifact_only_definition_update(root, common, expected)
+
+
 def public_definition(definition: Definition, root: Path) -> dict[str, Any]:
     return {**definition.data, "path": str(definition.path.relative_to(root))}
 
@@ -482,11 +531,20 @@ def validate_command(args: argparse.Namespace, root: Path) -> tuple[dict[str, An
             )
         )
 
-    if has_fix_commit and declaration != "new" and changed_definition_paths_in_range:
+    if (
+        has_fix_commit
+        and declaration not in (None, "new", "none")
+        and changed_definition_paths_in_range
+        and not instance_fix_registry_changes_allowed(
+            root, common, declaration, changed_definition_paths_in_range
+        )
+    ):
         errors.append(
             error(
                 "instance_fix_mutates_registry",
-                "an instance-fix PR must not edit failure-class definitions; use a separate registry-only lifecycle PR",
+                "an instance-fix PR must not edit failure-class definitions except to add or update "
+                "'canonical_prevention_artifact' on the declared class; other registry edits need a "
+                "separate registry-only lifecycle PR",
                 changed_paths=[str(path) for path in changed_definition_paths_in_range],
             )
         )

--- a/scripts/test_failure_class.py
+++ b/scripts/test_failure_class.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -21,8 +22,18 @@ REPORT_FIXTURE = REPOSITORY_ROOT / "scripts" / "fixtures" / "failure_class" / "r
 SEED_IDS = {path.stem for path in SEED_DIRECTORY.glob("*.json")}
 
 
+# Disposable repositories must not inherit the caller's git context. Under a
+# pre-commit or pre-push hook, GIT_DIR and core.hooksPath point at the real
+# checkout, so an unisolated `git init`/`git config`/`git add .` in a temp
+# directory writes to the repository under test.
+GIT_ISOLATION = ["-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false"]
+
+
 def run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(command, cwd=cwd, check=False, text=True, capture_output=True)
+    if command and command[0] == "git":
+        command = [command[0], *GIT_ISOLATION, *command[1:]]
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    return subprocess.run(command, cwd=cwd, check=False, text=True, capture_output=True, env=environment)
 
 
 class FailureClassCliTests(unittest.TestCase):

--- a/scripts/test_failure_class.py
+++ b/scripts/test_failure_class.py
@@ -16,13 +16,9 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 CLI = REPOSITORY_ROOT / "scripts" / "failure-class"
 SEED_DIRECTORY = REPOSITORY_ROOT / ".github" / "failure-classes"
 REPORT_FIXTURE = REPOSITORY_ROOT / "scripts" / "fixtures" / "failure_class" / "report-events.json"
-SEED_IDS = {
-    "FC-malformed-doc-read",
-    "FC-unbounded-module-cache",
-    "FC-trapping-dict-merge",
-    "FC-per-hop-timeout",
-    "FC-split-mutation-authority",
-}
+# The registry grows as classes are declared; derive the seed set instead of
+# pinning a count that goes stale the next time a class is added.
+SEED_IDS = {path.stem for path in SEED_DIRECTORY.glob("*.json")}
 
 
 def run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -36,12 +32,27 @@ class FailureClassCliTests(unittest.TestCase):
         definitions = self.root / ".github" / "failure-classes"
         definitions.parent.mkdir(parents=True)
         shutil.copytree(SEED_DIRECTORY, definitions)
+        self.seed_canonical_prevention_artifacts(definitions)
         run(["git", "init", "-q"], self.root)
         run(["git", "config", "user.email", "failure-class@example.test"], self.root)
         run(["git", "config", "user.name", "Failure Class Test"], self.root)
         self.write("src/example.txt", "initial\n")
         self.commit("chore: seed failure classes")
         self.base = self.git("rev-parse", "HEAD")
+
+    def seed_canonical_prevention_artifacts(self, definitions: Path) -> None:
+        """Materialize the guard artifacts the copied registry declares.
+
+        `canonical_prevention_artifact` paths are validated against the CLI's
+        --root, so the synthetic repository must contain them for the seed
+        definitions to stay valid outside the real checkout.
+        """
+        for definition_path in sorted(definitions.glob("*.json")):
+            data = json.loads(definition_path.read_text(encoding="utf-8"))
+            for relative in data.get("canonical_prevention_artifact", []):
+                artifact = self.root / relative
+                artifact.parent.mkdir(parents=True, exist_ok=True)
+                artifact.touch()
 
     def tearDown(self) -> None:
         self.temp_directory.cleanup()
@@ -85,8 +96,39 @@ class FailureClassCliTests(unittest.TestCase):
         payload = self.payload(result)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertTrue(payload["ok"])
-        self.assertEqual(payload["validation"]["definition_count"], 5)
-        self.assertEqual({path.stem for path in SEED_DIRECTORY.glob("*.json")}, SEED_IDS)
+        self.assertEqual(payload["validation"]["definition_count"], len(SEED_IDS))
+        self.assertIn("FC-split-mutation-authority", SEED_IDS)
+
+    def set_definition_field(self, class_id: str, field: str, value: object) -> None:
+        path = self.root / ".github" / "failure-classes" / f"{class_id}.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data[field] = value
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    def test_canonical_prevention_artifact_accepts_an_existing_path(self) -> None:
+        self.write("backend/guards/read_boundary.py", "# guard\n")
+        self.set_definition_field(
+            "FC-malformed-doc-read", "canonical_prevention_artifact", ["backend/guards/read_boundary.py"]
+        )
+        result = self.validate(self.body("## Summary\n"))
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertTrue(self.payload(result)["ok"])
+
+    def test_canonical_prevention_artifact_must_exist(self) -> None:
+        self.set_definition_field(
+            "FC-malformed-doc-read", "canonical_prevention_artifact", ["backend/guards/absent.py"]
+        )
+        result = self.validate(self.body("## Summary\n"))
+        payload = self.payload(result)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("missing_canonical_prevention_artifact", [item["code"] for item in payload["errors"]])
+
+    def test_canonical_prevention_artifact_rejects_a_malformed_value(self) -> None:
+        self.set_definition_field("FC-malformed-doc-read", "canonical_prevention_artifact", [])
+        result = self.validate(self.body("## Summary\n"))
+        payload = self.payload(result)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("invalid_canonical_prevention_artifact", [item["code"] for item in payload["errors"]])
 
     def test_valid_existing_declaration(self) -> None:
         self.add_fix_commit()
@@ -181,7 +223,7 @@ class FailureClassCliTests(unittest.TestCase):
         self.assertTrue(payload["requires_declaration"])
         self.assertEqual(payload["pr_body_patch"]["operation"], "append")
         self.assertEqual(payload["pr_body_patch"]["text"], "Failure-Class: none\n")
-        self.assertEqual(len(payload["advisory_candidates"]), 5)
+        self.assertEqual(len(payload["advisory_candidates"]), len(SEED_IDS))
         self.assertIn("no class was inferred", payload["candidate_source"])
 
     def test_explain_emits_versioned_definition(self) -> None:

--- a/scripts/test_failure_class.py
+++ b/scripts/test_failure_class.py
@@ -187,6 +187,18 @@ class FailureClassCliTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("instance_fix_mutates_registry", [item["code"] for item in payload["errors"]])
 
+    def test_instance_fix_may_record_guard_artifact_for_declared_class(self) -> None:
+        self.write("backend/guards/read_boundary.py", "# guard\n")
+        self.set_definition_field(
+            "FC-malformed-doc-read", "canonical_prevention_artifact", ["backend/guards/read_boundary.py"]
+        )
+        self.add_fix_commit()
+
+        result = self.validate(self.body("Failure-Class: FC-malformed-doc-read\n"))
+        payload = self.payload(result)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(payload["ok"])
+
     def test_registry_only_dormant_transition_is_valid(self) -> None:
         definition_path = self.root / ".github" / "failure-classes" / "FC-malformed-doc-read.json"
         definition = json.loads(definition_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Problem

Root `AGENTS.md` says: *"If two or more recent fixes share the cause, add a reusable guard surface in the same PR."* Nothing enforced that rule, and it had silently failed.

Measured on `origin/main` at `5ef3056`:

- `FC-split-mutation-authority` was declared on **30 first-parent integration changes** in the 90 days to 2026-07-24 (50+ raw `fix:` commits).
- Its definition still listed `evidence_prs: [9365, 9597]` — neither from that window. None of the July declarations were ever recorded.
- Its `canonical_prevention` is prose with no artifact path, unlike the legacy `FC-1` (`backend/database/read_boundary.py`) or `FC-6` (`backend/tests/unit/fixtures/strict_firestore_transaction.py`).

A class could be declared indefinitely while accumulating no evidence and producing no reusable guard. Recurrence had become paperwork.

## Change

**1. Schema: `canonical_prevention_artifact`** (`scripts/failure-class`)

Optional array of repository-relative paths naming the reusable guard surface for a class. Every listed path must exist, so a rename cannot leave a class claiming a guard it no longer has. `canonical_prevention` says what should stop recurrence; this says where that guard actually lives.

Populated only for the three classes that demonstrably have one today:

| Class | Artifact |
| --- | --- |
| `FC-deploy-concurrency` | `.github/scripts/check-deployment-concurrency.py` |
| `FC-workflow-control-source-identity` | `backend/tests/unit/test_verify_backend_release_vector.py` |
| `FC-single-machine-release-gate` | `.github/scripts/desktop_codemagic_qualification.py`, `.github/scripts/test_desktop_codemagic_qualification.py` |

Deliberately **not** invented for the classes that lack one — that absence is the signal the ratchet exists to surface.

**2. The ratchet** (`.github/scripts/check_failure_class_guard_ratchet.py`)

- Counts **first-parent integration changes** whose message declares `Failure-Class: FC-<slug>` over a **90-day window**, plus the declaration in the PR body under review, so the PR that crosses the threshold fails rather than the next unrelated PR.
- Raw commits are not counted: those 30 integration changes carry 50+ raw commits, so a raw threshold would be noise. One integration change counts once even when its merge message repeats the declaration.
- **Threshold 3.** The prose rule is "two or more"; 3 gives one grace so the check flags sustained recurrence, not a single repeat.
- **Degrades safely rather than lying.** Shallow clone, or first-parent history that does not reach the window start → loud `SKIP` and exit 0. It never passes silently and never fails spuriously. CI checks out with `fetch-depth: 0`, so the enforcing path is the normal one.
- An FC id in history with no definition is ignored: that is the failure-class CLI's problem, and it must not fail a PR that never touched it.

**3. Grandfather allowlist** (`.github/scripts/failure_class_guard_ratchet_allowlist.json`)

Three classes were already over threshold with no artifact, so the check is green on `main` today and ratchets from here:

| Class | Declarations in window |
| --- | --- |
| `FC-split-mutation-authority` | 30 |
| `FC-nonrecoverable-promotion` | 6 |
| `FC-unprovisioned-rollout-target` | 3 |

The allowlist **only shrinks**: once a class records an artifact, the check fails until its entry is removed. Adding an entry is an explicit, reviewable admission that a class recurs without a guard.

**4. Manifest registration** — `failure-class-guard-artifact-ratchet` and `failure-class-guard-artifact-ratchet-tests`, both lanes, no workflow YAML touched.

**5. Opportunistic fixes (separate commits).** `scripts/test_failure_class.py` pinned the registry at five definitions and had been failing since the sixth class landed — 2 of 13 tests red on `main`, and it ran in no lane at all. Fixed to derive the seed set, and registered as `failure-class-cli-tests` so the registry's only schema authority cannot go stale unnoticed again.

Registering it then exposed a second, worse latent defect in the same file: it built disposable repositories with plain `git init` / `git config` / `git add .`, which is only hermetic when nothing exports git context. Under the pre-push hook, `GIT_DIR` and `core.hooksPath` point at the real checkout, so every temp-repo git command operated on the repository under test — it wrote `user.name = Failure Class Test` into the shared repo config and staged mass deletions from a polluted index. Both test files now scrub `GIT_*` from the subprocess environment and pin `core.hooksPath` off. This is exactly the class of bug that hides in a test nobody runs in a lane.

## Why this is not a shared primitive

The repo has ratchets (`check_isinstance_return_ratchet.py`, `check_product_file_line_count_ratchet.py`, `check_arch_guardrails.py`), but each ratchets a **static property of the tree**. This one ratchets a property of **history + registry state**, which no existing primitive computes. It reuses the registry, the existing `Failure-Class:` declaration grammar, and the existing allowlist/baseline-JSON convention rather than inventing new ones.

## What I deliberately left out

**The evidence-staleness check** (flagging a class whose recent declaring PRs are absent from `evidence_prs`) is **not shipped.** It cannot be attributed reliably: of the 30 declaring first-parent changes, several are direct pushes to `main` or merge commits whose subject carries no `(#NNNN)`, so PR-number extraction is partial. A check that misses a third of its inputs would either false-positive constantly or be tuned into uselessness. Shipping it would have been a flaky check, which is worse than no check.

Also out of scope: no refactor of `scripts/failure-class` beyond what the new field needs; no artifacts invented for classes that lack one; no lifecycle transitions on any class (those are separate registry-only PRs by the rules in root `AGENTS.md`).

## Verification

Every command below was run in this worktree at `d9b934e`.

```
$ python3 .github/scripts/check_failure_class_guard_ratchet.py; echo exit=$?
Failure-class guard ratchet: window=90d since=2026-04-26 threshold=3 classes_declared=13
  GRANDFATHERED FC-nonrecoverable-promotion: 6 declaration(s) — ...
  GRANDFATHERED FC-split-mutation-authority: 30 declaration(s) — ...
  GRANDFATHERED FC-unprovisioned-rollout-target: 3 declaration(s) — ...
OK: every class at or above the threshold names a guard artifact or is explicitly grandfathered.
exit=0
```

Real failing path, driven through a PR body declaring `FC-per-hop-timeout` (2 in history, no artifact, not allowlisted):

```
$ printf 'Failure-Class: FC-per-hop-timeout\n' > /tmp/body.md
$ python3 .github/scripts/check_failure_class_guard_ratchet.py --pr-body-file /tmp/body.md; echo exit=$?
FAIL: a recurring failure class has no reusable guard surface.
- FC-per-hop-timeout: 3 declarations in the window (threshold 3) with no
  'canonical_prevention_artifact'. Add the reusable guard surface and record its path in
  .github/failure-classes/FC-per-hop-timeout.json, or grandfather it explicitly in
  .github/scripts/failure_class_guard_ratchet_allowlist.json.
exit=1
```

Test suites:

```
$ python3 .github/scripts/test_check_failure_class_guard_ratchet.py   -> Ran 12 tests, OK
$ python3 scripts/test_failure_class.py                               -> Ran 16 tests, OK
$ python3 .github/scripts/test_run_checks.py                          -> Ran 22 tests, OK
$ python3 .github/scripts/check_agents_md_lean.py                     -> ok: 7 AGENTS.md files within budget
$ python3 .github/scripts/check_agent_doc_references.py               -> agent doc references OK
```

`make preflight` (the full deterministic manifest, local lane):

```
$ make preflight
...
<== PASS failure-class-protocol (0.10s)
<== PASS failure-class-guard-artifact-ratchet (0.22s)
<== PASS failure-class-guard-artifact-ratchet-tests (2.82s)
<== PASS failure-class-cli-tests (3.31s)
PR preflight passed: 46 checks in 39.25s.
```

The 12 ratchet tests each build a real disposable git repository with real first-parent history and run the checker end to end — over-threshold-without-artifact fails, over-threshold-with-artifact passes, under-threshold passes, allowlisted passes, allowlisted-with-artifact fails, out-of-window declarations do not count, a repeated declaration in one merge message counts once, PR-body declarations count, unknown ids are ignored, short history skips, a real `--depth 1` clone skips, and the shipped registry is green. No source-string assertions.

Runtime measured at 0.26s wall on this checkout, so `triggers: ["all"]` is affordable.

`git push` also ran the bounded pre-push gate end to end and passed, which is what proved the git-isolation fix (it failed 16/16 and 12/12 before it).

**Not verified:** CI behavior on a shallow checkout was exercised only via a local `git clone --depth 1`, not on a GitHub runner. Every workflow that runs the manifest uses `fetch-depth: 0`, so the SKIP path is expected to be dead in practice.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

