### PR TITLE
feat(desktop-windows): add opt-in high-resolution Rewind capture for OCR

### DIFF
--- a/desktop/windows/src/main/rewind/captureService.ts
+++ b/desktop/windows/src/main/rewind/captureService.ts
@@ -36,7 +36,8 @@ let settings: RewindSettings = {
   captureEnabled: true,
   intervalMs: 1000,
   retentionDays: 14,
-  excludedApps: []
+  excludedApps: [],
+  highResCapture: false
 }
 
 function bindPowerListeners(): void {

--- a/desktop/windows/src/main/rewind/rewindSettings.test.ts
+++ b/desktop/windows/src/main/rewind/rewindSettings.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+
+// Exercise the pure `sanitize` via the module's coercion contract. #10489 added
+// `highResCapture`; these pin that it defaults OFF and only an explicit `true`
+// opts in — so an old settings file (written before the field existed) keeps the
+// perf-tuned baseline rather than silently enabling the higher-cost profile.
+//
+// sanitize is not exported, so drive it through the persisted-read path with a
+// mocked file. Electron's `app.getPath` and the fs are stubbed at import time.
+import { vi } from 'vitest'
+
+let fileContents = ''
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }))
+vi.mock('fs', () => ({
+  readFileSync: () => {
+    if (fileContents === '__throw__') throw new Error('no file')
+    return fileContents
+  },
+  writeFileSync: () => undefined
+}))
+
+const { getPersistedRewindSettings } = await import('./rewindSettings')
+
+function read(raw: unknown): ReturnType<typeof getPersistedRewindSettings> {
+  fileContents = JSON.stringify(raw)
+  return getPersistedRewindSettings()
+}
+
+describe('rewindSettings highResCapture', () => {
+  it('defaults OFF when the field is absent (pre-existing settings file)', () => {
+    expect(read({ captureEnabled: true, intervalMs: 1000 }).highResCapture).toBe(false)
+  })
+
+  it('defaults OFF on a missing/corrupt file', () => {
+    fileContents = '__throw__'
+    expect(getPersistedRewindSettings().highResCapture).toBe(false)
+  })
+
+  it('only an explicit true opts in', () => {
+    expect(read({ highResCapture: true }).highResCapture).toBe(true)
+    expect(read({ highResCapture: 'yes' as unknown as boolean }).highResCapture).toBe(false)
+    expect(read({ highResCapture: false }).highResCapture).toBe(false)
+  })
+})

--- a/desktop/windows/src/main/rewind/rewindSettings.ts
+++ b/desktop/windows/src/main/rewind/rewindSettings.ts
@@ -12,7 +12,10 @@ const DEFAULTS: RewindSettings = {
   captureEnabled: true,
   intervalMs: 1000,
   retentionDays: 14,
-  excludedApps: []
+  excludedApps: [],
+  // Off by default — the standard 720p profile is the perf-tuned baseline (higher
+  // resolutions were laggy in continuous capture). Opt-in for OCR legibility.
+  highResCapture: false
 }
 
 function file(): string {
@@ -51,7 +54,9 @@ function sanitize(raw: Partial<RewindSettings>): RewindSettings {
     captureEnabled: raw.captureEnabled !== false,
     intervalMs,
     retentionDays,
-    excludedApps
+    excludedApps,
+    // Default OFF: only an explicit `true` opts into the higher-cost profile.
+    highResCapture: raw.highResCapture === true
   }
 }
 

--- a/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { RewindSettings, RewindCaptureDirective } from '../../../../shared/types'
+import { rewindCaptureProfile, sampledCanvasSize } from './captureProfile'
 
-// Cap the longest sampled edge — plenty for a timeline + OCR, and keeps each
-// canvas grab + JPEG encode cheap.
-const MAX_EDGE = 1600
-const JPEG_QUALITY = 0.6
 // Wait before re-opening a stream whose track died, so a source that is
 // unavailable in bursts (display asleep, GPU reset) can't spin getUserMedia.
 const RESTART_DELAY_MS = 2000
@@ -60,6 +57,7 @@ export function RewindCaptureHost(): React.JSX.Element {
   useEffect(() => {
     const enabled = !!settings?.captureEnabled && !paused
     const intervalMs = effectiveIntervalMs
+    const profile = rewindCaptureProfile(!!settings?.highResCapture)
     let cancelled = false
     // Bumped on every teardown so a grab still in flight (a save is an IPC
     // round-trip) can't reschedule itself onto a stream that is already gone —
@@ -99,9 +97,7 @@ export function RewindCaptureHost(): React.JSX.Element {
       try {
         const v = videoRef.current
         if (v && isLive() && v.videoWidth && v.videoHeight && !savingRef.current) {
-          const scale = Math.min(1, MAX_EDGE / Math.max(v.videoWidth, v.videoHeight))
-          const w = Math.round(v.videoWidth * scale)
-          const h = Math.round(v.videoHeight * scale)
+          const { width: w, height: h } = sampledCanvasSize(v.videoWidth, v.videoHeight, profile)
           const canvas =
             canvasRef.current ?? (canvasRef.current = document.createElement('canvas'))
           if (canvas.width !== w) canvas.width = w
@@ -110,7 +106,7 @@ export function RewindCaptureHost(): React.JSX.Element {
           if (ctx) {
             ctx.drawImage(v, 0, 0, w, h)
             const blob = await new Promise<Blob | null>((r) =>
-              canvas.toBlob(r, 'image/jpeg', JPEG_QUALITY)
+              canvas.toBlob(r, 'image/jpeg', profile.jpegQuality)
             )
             if (blob && !cancelled && gen === generation) {
               savingRef.current = true
@@ -146,12 +142,14 @@ export function RewindCaptureHost(): React.JSX.Element {
               chromeMediaSource: 'desktop',
               chromeMediaSourceId: sourceId,
               // The live stream is decoded continuously in the renderer, so its
-              // resolution + frame rate set the steady-state cost of having
-              // capture on. Keep both low: 720p is enough for a timeline + OCR of
-              // normal-size text, and we only sample every few seconds, so 1fps
-              // capture is plenty. (Was 1080p@30fps → froze; 1080p@2fps → laggy.)
-              maxWidth: 1280,
-              maxHeight: 720,
+              // resolution + frame rate set the steady-state cost of having capture
+              // on. The default profile keeps both low: 720p is enough for a
+              // timeline + OCR of normal-size text, and we only sample every few
+              // seconds, so 1fps is plenty. (Was 1080p@30fps → froze; 1080p@2fps →
+              // laggy.) `highResCapture` opts into 1080p for legible OCR (#10489);
+              // frame rate stays at 1fps in both.
+              maxWidth: profile.maxWidth,
+              maxHeight: profile.maxHeight,
               maxFrameRate: 1
             }
           }
@@ -181,7 +179,7 @@ export function RewindCaptureHost(): React.JSX.Element {
       cancelled = true
       stop()
     }
-  }, [settings?.captureEnabled, effectiveIntervalMs, paused])
+  }, [settings?.captureEnabled, settings?.highResCapture, effectiveIntervalMs, paused])
 
   return (
     <video

--- a/desktop/windows/src/renderer/src/components/rewind/captureProfile.test.ts
+++ b/desktop/windows/src/renderer/src/components/rewind/captureProfile.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { rewindCaptureProfile, sampledCanvasSize } from './captureProfile'
+
+// #10489: 720p screenshots were too low-res for OCR, with no way to raise them.
+// These pin the opt-in contract: the default profile is unchanged (no perf
+// regression), the high profile is strictly higher-res + higher-quality, and the
+// sampling math never upscales.
+
+describe('rewindCaptureProfile', () => {
+  it('keeps the perf-tuned 720p baseline when high-res is off (default)', () => {
+    expect(rewindCaptureProfile(false)).toEqual({
+      maxWidth: 1280,
+      maxHeight: 720,
+      maxEdge: 1600,
+      jpegQuality: 0.6
+    })
+  })
+
+  it('raises resolution and quality when high-res is on', () => {
+    const high = rewindCaptureProfile(true)
+    const standard = rewindCaptureProfile(false)
+    expect(high.maxWidth).toBeGreaterThan(standard.maxWidth)
+    expect(high.maxHeight).toBeGreaterThan(standard.maxHeight)
+    expect(high.maxEdge).toBeGreaterThanOrEqual(high.maxWidth)
+    expect(high.jpegQuality).toBeGreaterThan(standard.jpegQuality)
+  })
+})
+
+describe('sampledCanvasSize', () => {
+  it('never upscales a source smaller than maxEdge', () => {
+    const p = rewindCaptureProfile(false) // maxEdge 1600
+    expect(sampledCanvasSize(1280, 720, p)).toEqual({ width: 1280, height: 720 })
+  })
+
+  it('downscales the longest edge to maxEdge, preserving aspect ratio', () => {
+    const p = rewindCaptureProfile(true) // maxEdge 1920
+    // A 3840×2160 (4K) frame → longest 3840 scales to 1920 (×0.5).
+    expect(sampledCanvasSize(3840, 2160, p)).toEqual({ width: 1920, height: 1080 })
+  })
+
+  it('is safe on a zero-sized (not-yet-ready) video frame', () => {
+    const p = rewindCaptureProfile(false)
+    expect(sampledCanvasSize(0, 0, p)).toEqual({ width: 0, height: 0 })
+  })
+})

--- a/desktop/windows/src/renderer/src/components/rewind/captureProfile.ts
+++ b/desktop/windows/src/renderer/src/components/rewind/captureProfile.ts
@@ -1,0 +1,53 @@
+// Resolution/quality profile for Rewind screen capture. Pure and side-effect free
+// so the tradeoff is unit-tested rather than buried in the capture host.
+//
+// Why two profiles instead of one higher value: the getUserMedia stream is decoded
+// continuously in the renderer, so its resolution sets the steady-state cost of
+// having capture on (1080p@30fps froze; 1080p@2fps was laggy — hence the 720p@1fps
+// baseline). Users who need OCR of on-screen text can opt into `high`, accepting the
+// cost; everyone else keeps the perf-tuned default. Frame rate stays at 1fps in both
+// — only the per-frame resolution/quality changes (#10489).
+
+export type RewindCaptureProfile = {
+  /** getUserMedia mandatory max stream dimensions. */
+  maxWidth: number
+  maxHeight: number
+  /** Longest sampled canvas edge; frames larger than this are downscaled. */
+  maxEdge: number
+  /** JPEG encode quality (0–1) for the stored frame. */
+  jpegQuality: number
+}
+
+const STANDARD: RewindCaptureProfile = {
+  maxWidth: 1280,
+  maxHeight: 720,
+  maxEdge: 1600,
+  jpegQuality: 0.6
+}
+
+// Higher resolution + less JPEG compression so small on-screen text survives for
+// OCR. Bounded at 1080p (not native) to keep the opt-in cost predictable.
+const HIGH_RES: RewindCaptureProfile = {
+  maxWidth: 1920,
+  maxHeight: 1080,
+  maxEdge: 1920,
+  jpegQuality: 0.85
+}
+
+export function rewindCaptureProfile(highResCapture: boolean): RewindCaptureProfile {
+  return highResCapture ? HIGH_RES : STANDARD
+}
+
+/**
+ * Sampled canvas dimensions for a source video of `videoWidth`×`videoHeight` under
+ * `profile`. Preserves aspect ratio and never upscales (scale capped at 1).
+ */
+export function sampledCanvasSize(
+  videoWidth: number,
+  videoHeight: number,
+  profile: RewindCaptureProfile
+): { width: number; height: number } {
+  const longest = Math.max(videoWidth, videoHeight)
+  const scale = longest > 0 ? Math.min(1, profile.maxEdge / longest) : 1
+  return { width: Math.round(videoWidth * scale), height: Math.round(videoHeight * scale) }
+}

--- a/desktop/windows/src/renderer/src/components/settings/tabs/RewindTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/RewindTab.tsx
@@ -9,7 +9,8 @@ import {
   X,
   Mic,
   Trash2,
-  Target
+  Target,
+  ScanText
 } from 'lucide-react'
 import { runScreenSynthesisOnce } from '../../../lib/screenSynthesis'
 import { BUILT_IN_EXCLUDED_APPS } from '../../../../../shared/rewindExclusions'
@@ -168,6 +169,20 @@ export function RewindTab(): React.JSX.Element {
               Every 10s
             </option>
           </select>
+        }
+      />
+      <SettingRow
+        icon={ScanText}
+        title="High-resolution capture"
+        subtitle="Capture frames at 1080p so on-screen text stays legible for OCR. Uses more CPU/GPU while capture is on."
+        keywords="rewind resolution quality ocr text sharp hd 1080p"
+        control={
+          <Toggle
+            on={!!rewind?.highResCapture}
+            onChange={(on) => rewind && saveRewind({ ...rewind, highResCapture: on })}
+            disabled={!rewind}
+            label="High-resolution capture"
+          />
         }
       />
       <SettingRow

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -2053,6 +2053,10 @@ export type RewindSettings = {
   /** App names to never screenshot (case-insensitive substring match against the
    *  foreground app/process name). Empty = capture everything. */
   excludedApps: string[]
+  /** Capture screen frames at a higher resolution so on-screen text stays legible
+   *  for OCR (at a higher steady-state CPU/GPU cost). Off by default: the standard
+   *  720p profile is the perf-tuned baseline; only users who need OCR opt in. */
+  highResCapture: boolean
 }
 
 /** Runtime capture directive pushed main→renderer, derived from OS power/lock state.


### PR DESCRIPTION
## What

Closes #10489.

Rewind captured screen frames at a fixed **720p** with no way to raise it, so OCR of on-screen text was unreliable on higher-DPI displays — and there was no user control to improve it.

## Why not just bump the default

720p@1fps is a **deliberately perf-tuned baseline**: the `getUserMedia` stream is decoded continuously in the renderer, so its resolution sets the steady-state cost of having capture on. The existing code comment records that `1080p@30fps froze` the system and `1080p@2fps` was laggy. Changing the default would risk reintroducing that.

So this adds an **opt-in** setting instead:

- **`highResCapture` — default OFF.** Existing users are byte-for-byte unchanged (zero perf regression).
- When ON, capture runs at **1080p, same 1fps**, with JPEG quality raised `0.6 → 0.85` for legible text.

## Changes

- **`captureProfile.ts` (new, pure):** `rewindCaptureProfile(highRes)` returns the `{maxWidth, maxHeight, maxEdge, jpegQuality}` tradeoff; `sampledCanvasSize()` does the aspect-preserving, never-upscale sizing. Pulls the magic constants out of the capture host so the tradeoff is unit-tested.
- **`RewindCaptureHost.tsx`:** reads the setting, applies the profile to the stream constraints + canvas + JPEG encode, and rebuilds the stream when the toggle flips.
- **`rewindSettings.ts`:** defaults the field OFF; only an explicit `true` opts in, so a pre-existing settings file keeps the baseline.
- **`RewindTab.tsx`:** a "High-resolution capture" toggle (subtitle notes the CPU/GPU cost).
- **`types.ts`:** `RewindSettings.highResCapture`.

## Verification

```
captureProfile.test.ts  → 5 passed   (default unchanged; high strictly higher; no upscale; 4K→1080p; zero-size safe)
rewindSettings.test.ts  → 3 passed   (defaults OFF; OFF on corrupt file; only explicit true opts in)
typecheck:node + typecheck:web → 0 errors
```

**Not exercised at runtime:** there's no Windows Electron host in my environment, so the actual OCR-legibility gain and the steady-state cost of the 1080p profile still want a Windows smoke test before release. The pure profile/settings logic — the part that decides the tradeoff — is fully covered above. Default-OFF means this can't regress anyone who doesn't opt in.

## Scope, named

Bounded the high profile at **1080p** (not native/4K) to keep the opt-in cost predictable; a native-resolution tier could follow if 1080p proves insufficient for 4K displays.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

