### PR TITLE
feat(desktop): polish Memory and conversation surfaces

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -91,6 +91,9 @@ struct ChatMessagesView<WelcomeContent: View>: View {
   /// Horizontal inset of the message column. Home passes 0 so bubbles align
   /// exactly with the ask bar's edges; other surfaces keep the default gutter.
   var horizontalContentPadding: CGFloat = OmiSpacing.xxl
+  /// Vertical transcript inset. Home uses a tighter value because its page
+  /// shell already provides the breathing room beneath the floating top bar.
+  var verticalContentPadding: CGFloat = OmiSpacing.xl
   /// Extra trailing inset only. Home passes a small value so the macOS overlay
   /// scrollbar doesn't clip right-aligned user pills when horizontalContentPadding
   /// is 0; the left edge stays aligned with the ask bar. Default 0.
@@ -175,7 +178,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
       }
       .padding(.horizontal, horizontalContentPadding)
       .padding(.trailing, trailingContentPadding)
-      .padding(.vertical, OmiSpacing.xl)
+      .padding(.vertical, verticalContentPadding)
       // Do not enable text selection on the whole stack. SelectionOverlay on every
       // chrome Text (agent card headers, tool summaries, timestamps) can peg the
       // main thread in GraphHost layout. Message bodies opt in via OmiMarkdown.

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/OmiSearchField.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/OmiSearchField.swift
@@ -56,6 +56,10 @@ final class DebouncedSearchCoordinator: ObservableObject {
   static func normalized(_ query: String) -> String {
     query.trimmingCharacters(in: .whitespacesAndNewlines)
   }
+
+  static func isActive(_ query: String) -> Bool {
+    !normalized(query).isEmpty
+  }
 }
 
 /// Shared search chrome for desktop list pages.

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/OmiSearchField.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/OmiSearchField.swift
@@ -1,0 +1,108 @@
+import OmiTheme
+import SwiftUI
+
+/// One search interaction for the desktop's list surfaces.
+///
+/// Queries commit after a short pause while clearing commits immediately. The
+/// coordinator keeps that timing and cancellation behavior identical across
+/// Memories and Conversations without coupling either page to the other's data.
+@MainActor
+final class DebouncedSearchCoordinator: ObservableObject {
+  typealias Sleeper = @Sendable (UInt64) async throws -> Void
+
+  static let standardDelayNanoseconds: UInt64 = 250_000_000
+
+  private let delayNanoseconds: UInt64
+  private let sleeper: Sleeper
+  private var pendingTask: Task<Void, Never>?
+
+  init(
+    delayNanoseconds: UInt64 = DebouncedSearchCoordinator.standardDelayNanoseconds,
+    sleeper: @escaping Sleeper = { try await Task.sleep(nanoseconds: $0) }
+  ) {
+    self.delayNanoseconds = delayNanoseconds
+    self.sleeper = sleeper
+  }
+
+  deinit {
+    pendingTask?.cancel()
+  }
+
+  func submit(
+    _ rawQuery: String,
+    perform: @escaping @MainActor (String) async -> Void
+  ) {
+    pendingTask?.cancel()
+
+    let query = Self.normalized(rawQuery)
+    guard !query.isEmpty else {
+      pendingTask = Task { await perform("") }
+      return
+    }
+
+    let delayNanoseconds = delayNanoseconds
+    let sleeper = sleeper
+    pendingTask = Task {
+      do {
+        try await sleeper(delayNanoseconds)
+      } catch {
+        return
+      }
+      guard !Task.isCancelled else { return }
+      await perform(query)
+    }
+  }
+
+  static func normalized(_ query: String) -> String {
+    query.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}
+
+/// Shared search chrome for desktop list pages.
+struct OmiSearchField: View {
+  let placeholder: String
+  @Binding var text: String
+  var isLoading = false
+
+  var body: some View {
+    HStack(spacing: OmiSpacing.sm) {
+      Group {
+        if isLoading {
+          ProgressView()
+            .controlSize(.small)
+        } else {
+          Image(systemName: "magnifyingglass")
+            .scaledFont(size: OmiType.body, weight: .medium)
+        }
+      }
+      .frame(width: 16, height: 16)
+      .foregroundStyle(OmiColors.textTertiary)
+
+      TextField(placeholder, text: $text)
+        .textFieldStyle(.plain)
+        .scaledFont(size: OmiType.body)
+        .foregroundStyle(OmiColors.textPrimary)
+
+      if !text.isEmpty {
+        Button {
+          text = ""
+        } label: {
+          Image(systemName: "xmark.circle.fill")
+            .scaledFont(size: OmiType.body)
+            .foregroundStyle(OmiColors.textTertiary)
+        }
+        .buttonStyle(.plain)
+        .help("Clear search")
+        .accessibilityLabel("Clear search")
+      }
+    }
+    .padding(.horizontal, OmiSpacing.md)
+    .frame(minHeight: 44)
+    .omiControlSurface(
+      fill: OmiColors.backgroundSecondary,
+      radius: 16,
+      stroke: OmiColors.border.opacity(0.18)
+    )
+    .accessibilityElement(children: .contain)
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -52,6 +52,8 @@ struct DesktopHomeView: View {
   @AppStorage("onboardingFurthestStep") private var onboardingFurthestStep = 0
   @AppStorage("onboardingJustCompleted") private var onboardingJustCompleted = false
   @AppStorage("useLegacyHomeDesign") private var useLegacyHomeDesign = false
+  @AppStorage(MemoryHubDestination.storageKey) private var memoryDestinationRawValue =
+    MemoryHubDestination.memories.rawValue
   /// Reference instant for the top bar's "new since you were last here" counts —
   /// updated to now whenever Omi resigns front (see the didResignActive handler).
   @AppStorage("topBarNewSince") private var topBarNewSinceRaw: Double = 0
@@ -59,7 +61,6 @@ struct DesktopHomeView: View {
   // Settings sidebar state
   @State private var selectedSettingsSection: SettingsContentView.SettingsSection = .general
   @State private var highlightedSettingId: String? = nil
-  @State private var memoryHubSegment = 0
   @State private var showTryAskingPopup = false
   @State private var previousIndexBeforeSettings: Int = 0
   @State private var logoPulse = false
@@ -1062,7 +1063,6 @@ struct DesktopHomeView: View {
             viewModelContainer: viewModelContainer,
             selectedSettingsSection: $selectedSettingsSection,
             highlightedSettingId: $highlightedSettingId,
-            memoryHubSegment: $memoryHubSegment,
             selectedTabIndex: $selectedIndex
           )
         }
@@ -1147,14 +1147,17 @@ struct DesktopHomeView: View {
       if let rawValue = notification.userInfo?["rawValue"] as? Int,
         let item = SidebarNavItem(rawValue: rawValue)
       {
+        if let destination = MemoryHubDestination.destination(for: item) {
+          memoryDestinationRawValue = destination.rawValue
+        }
         selectedIndex = item.rawValue
       }
     }
     .onReceive(NotificationCenter.default.publisher(for: .desktopAutomationOpenConversationRequested)) { _ in
-      // Conversations now live behind the Memory hub's second segment. Route at
+      // Conversations now live behind the Memory menu. Route at
       // the owning shell before the detail page mounts; its retained request is
       // then consumed by ConversationsPage on appearance.
-      memoryHubSegment = 1
+      memoryDestinationRawValue = MemoryHubDestination.conversations.rawValue
       selectedIndex = SidebarNavItem.conversations.rawValue
     }
     .onChange(of: selectedIndex) { oldValue, newValue in
@@ -1283,7 +1286,6 @@ private struct PageContentView: View {
   let viewModelContainer: ViewModelContainer
   @Binding var selectedSettingsSection: SettingsContentView.SettingsSection
   @Binding var highlightedSettingId: String?
-  @Binding var memoryHubSegment: Int
   @Binding var selectedTabIndex: Int
 
   /// The list/detail pages (Conversations, Memories, Tasks, Apps) render their
@@ -1321,8 +1323,7 @@ private struct PageContentView: View {
       case 1:
         MemoryHubPage(
           appState: appState,
-          viewModelContainer: viewModelContainer,
-          segment: $memoryHubSegment
+          viewModelContainer: viewModelContainer
         )
       case 2:
         ChatPage(

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1229,32 +1229,6 @@ private struct HubSegmentedControl: View {
   }
 }
 
-enum MemoryHubDestination: Int, CaseIterable, Identifiable {
-  static let storageKey = "memoryHubDestination"
-
-  case memories
-  case conversations
-  case brainMap
-
-  var id: Int { rawValue }
-
-  var title: String {
-    switch self {
-    case .memories: return "Memories"
-    case .conversations: return "Conversations"
-    case .brainMap: return "Brain Map"
-    }
-  }
-
-  var icon: String {
-    switch self {
-    case .memories: return "brain.head.profile"
-    case .conversations: return "text.bubble"
-    case .brainMap: return "point.3.connected.trianglepath.dotted"
-    }
-  }
-}
-
 private struct MemoryHubPage: View {
   let appState: AppState
   let viewModelContainer: ViewModelContainer

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -969,7 +969,7 @@ struct DesktopHomeView: View {
     viewModelContainer.tasksStore.isActive =
       index == SidebarNavItem.dashboard.rawValue || index == SidebarNavItem.tasks.rawValue
     viewModelContainer.memoriesViewModel.isActive =
-      index == SidebarNavItem.memories.rawValue
+      index == SidebarNavItem.conversations.rawValue || index == SidebarNavItem.memories.rawValue
   }
 
   private var mainContent: some View {
@@ -1229,61 +1229,57 @@ private struct HubSegmentedControl: View {
   }
 }
 
-/// "Memory" tab — Conversations + Memories folded into one surface.
-private struct MemoryHubPage: View {
-  let appState: AppState
-  let viewModelContainer: ViewModelContainer
-  @Binding var segment: Int
+enum MemoryHubDestination: Int, CaseIterable, Identifiable {
+  static let storageKey = "memoryHubDestination"
 
-  /// Memories and conversations stay easy to scan in a calm, readable column;
-  /// the spatial Brain Map needs the full content surface so users can pan and
-  /// zoom without hitting an artificial canvas boundary.
-  private static let listContentWidth: CGFloat = 900
+  case memories
+  case conversations
+  case brainMap
 
-  var body: some View {
-    Group {
-      if segment == 2 {
-        ZStack(alignment: .top) {
-          // Keep the graph's camera framing intact while removing the list-page
-          // width cap. The map only occupies more of the visual field when the
-          // user deliberately pans or zooms into it.
-          MemoryGraphPage(viewModel: viewModelContainer.memoryGraphViewModel)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+  var id: Int { rawValue }
 
-          hubSegmentedControl
-        }
-      } else {
-        VStack(spacing: 0) {
-          hubSegmentedControl
-
-          if segment == 0 {
-            constrainedListContent(
-              MemoriesPage(
-                viewModel: viewModelContainer.memoriesViewModel,
-                graphViewModel: viewModelContainer.memoryGraphViewModel))
-          } else {
-            constrainedListContent(ConversationsPageHost(appState: appState))
-          }
-        }
-      }
+  var title: String {
+    switch self {
+    case .memories: return "Memories"
+    case .conversations: return "Conversations"
+    case .brainMap: return "Brain Map"
     }
   }
 
-  private var hubSegmentedControl: some View {
-    // The "Memory" rail item lands here, so Memories is the default segment;
-    // Conversations (with its live transcript) is second, and the Brain Map
-    // graph is its own tab.
-    HubSegmentedControl(segments: ["Memories", "Conversations", "Brain Map"], selection: $segment)
-      .frame(maxWidth: Self.listContentWidth)
-      .padding(.top, 22)
-      .padding(.horizontal, 28)
-      .padding(.bottom, 4)
+  var icon: String {
+    switch self {
+    case .memories: return "brain.head.profile"
+    case .conversations: return "text.bubble"
+    case .brainMap: return "point.3.connected.trianglepath.dotted"
+    }
+  }
+}
+
+private struct MemoryHubPage: View {
+  let appState: AppState
+  let viewModelContainer: ViewModelContainer
+  @AppStorage(MemoryHubDestination.storageKey) private var destinationRawValue =
+    MemoryHubDestination.memories.rawValue
+
+  private var destination: MemoryHubDestination {
+    MemoryHubDestination(rawValue: destinationRawValue) ?? .memories
   }
 
-  private func constrainedListContent<V: View>(_ content: V) -> some View {
-    content
-      .frame(maxWidth: Self.listContentWidth, maxHeight: .infinity)
+  var body: some View {
+    switch destination {
+    case .memories:
+      MemoriesPage(
+        viewModel: viewModelContainer.memoriesViewModel,
+        graphViewModel: viewModelContainer.memoryGraphViewModel
+      )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
+    case .conversations:
+      ConversationsPageHost(appState: appState)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    case .brainMap:
+      MemoryGraphPage(viewModel: viewModelContainer.memoryGraphViewModel)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -14,6 +14,8 @@ struct DesktopTopBar: View {
   /// last resigned front (see DesktopHomeView).
   let sinceDate: Date
   let onRewind: () -> Void
+  @AppStorage(MemoryHubDestination.storageKey) private var memoryDestinationRawValue =
+    MemoryHubDestination.memories.rawValue
 
   private struct NavItem: Identifiable {
     let index: Int
@@ -78,38 +80,67 @@ struct DesktopTopBar: View {
     // items are muted text; the selected item gets a subtle highlight only.
     HStack(spacing: OmiSpacing.xs) {
       ForEach(navItems) { item in
-        Button {
-          OmiMotion.withGated(.easeOut(duration: 0.08)) { selectedIndex = item.index }
-        } label: {
-          HStack(spacing: 6) {
-            Image(systemName: item.icon)
-              .scaledFont(size: OmiType.caption, weight: .semibold)
-            Text(item.title)
-              .scaledFont(size: OmiType.caption, weight: .semibold)
-            // New-item badge lives on the button it belongs to (Memory =
-            // memories + conversations, Tasks = tasks) since Omi was last front.
-            if newCount(for: item) > 0 {
-              Text("+\(newCount(for: item))")
-                .scaledFont(size: OmiType.micro, weight: .bold)
-                .foregroundColor(OmiColors.textPrimary)
-                .padding(.horizontal, 5)
-                .padding(.vertical, 1)
-                .background(Capsule(style: .continuous).fill(OmiColors.textPrimary.opacity(0.16)))
+        if item.index == SidebarNavItem.conversations.rawValue {
+          Menu {
+            ForEach(MemoryHubDestination.allCases) { destination in
+              Button {
+                memoryDestinationRawValue = destination.rawValue
+                OmiMotion.withGated(.easeOut(duration: 0.08)) {
+                  selectedIndex = SidebarNavItem.conversations.rawValue
+                }
+              } label: {
+                Label(destination.title, systemImage: destination.icon)
+              }
             }
+          } label: {
+            navLabel(for: item, showsDisclosure: true)
           }
-          .foregroundColor(selectedIndex == item.index ? OmiColors.textPrimary : OmiColors.textTertiary)
-          .padding(.horizontal, OmiSpacing.md)
-          .padding(.vertical, 6)
-          .background(
-            Capsule(style: .continuous)
-              .fill(selectedIndex == item.index ? OmiColors.textPrimary.opacity(0.08) : Color.clear)
-          )
-          .contentShape(Capsule())
+          .menuStyle(.borderlessButton)
+          .fixedSize()
+          .help("Choose a Memory view")
+        } else {
+          Button {
+            OmiMotion.withGated(.easeOut(duration: 0.08)) { selectedIndex = item.index }
+          } label: {
+            navLabel(for: item)
+          }
+          .buttonStyle(.plain)
+          .help(item.title)
         }
-        .buttonStyle(.plain)
-        .help(item.title)
       }
     }
+  }
+
+  private func navLabel(for item: NavItem, showsDisclosure: Bool = false) -> some View {
+    HStack(spacing: 6) {
+      Image(systemName: item.icon)
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+      Text(item.title)
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+      if showsDisclosure {
+        Image(systemName: "chevron.down")
+          .scaledFont(size: 8, weight: .bold)
+          .foregroundStyle(OmiColors.textQuaternary)
+      }
+      // New-item badge lives on the button it belongs to (Memory =
+      // memories + conversations, Tasks = tasks) since Omi was last front.
+      if newCount(for: item) > 0 {
+        Text("+\(newCount(for: item))")
+          .scaledFont(size: OmiType.micro, weight: .bold)
+          .foregroundColor(OmiColors.textPrimary)
+          .padding(.horizontal, 5)
+          .padding(.vertical, 1)
+          .background(Capsule(style: .continuous).fill(OmiColors.textPrimary.opacity(0.16)))
+      }
+    }
+    .foregroundColor(selectedIndex == item.index ? OmiColors.textPrimary : OmiColors.textTertiary)
+    .padding(.horizontal, OmiSpacing.md)
+    .padding(.vertical, 6)
+    .background(
+      Capsule(style: .continuous)
+        .fill(selectedIndex == item.index ? OmiColors.textPrimary.opacity(0.08) : Color.clear)
+    )
+    .contentShape(Capsule())
   }
 
   /// New-item count to badge on a nav button (since Omi was last in front).

--- a/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
@@ -23,4 +23,17 @@ enum MemoryHubDestination: Int, CaseIterable, Identifiable {
     case .brainMap: return "point.3.connected.trianglepath.dotted"
     }
   }
+
+  /// Resolves navigation into the Memory rail item. Existing callers such as
+  /// Cmd+2 and desktop automation only know about the rail item, so they must
+  /// land on Conversations instead of whichever Memory destination was last
+  /// persisted.
+  static func destination(
+    for sidebarItem: SidebarNavItem,
+    requestedRawValue: Int? = nil
+  ) -> MemoryHubDestination? {
+    guard sidebarItem == .conversations else { return nil }
+    guard let requestedRawValue else { return .conversations }
+    return MemoryHubDestination(rawValue: requestedRawValue) ?? .conversations
+  }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
@@ -1,0 +1,26 @@
+/// Destinations available from the Memory navigation menu.
+enum MemoryHubDestination: Int, CaseIterable, Identifiable {
+  static let storageKey = "memoryHubDestination"
+
+  case memories
+  case conversations
+  case brainMap
+
+  var id: Int { rawValue }
+
+  var title: String {
+    switch self {
+    case .memories: return "Memories"
+    case .conversations: return "Conversations"
+    case .brainMap: return "Brain Map"
+    }
+  }
+
+  var icon: String {
+    switch self {
+    case .memories: return "brain.head.profile"
+    case .conversations: return "text.bubble"
+    case .brainMap: return "point.3.connected.trianglepath.dotted"
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -1,28 +1,5 @@
-import Combine
 import OmiTheme
 import SwiftUI
-
-// MARK: - Search Debouncer
-
-/// Debounces search queries to avoid excessive API calls
-class SearchDebouncer: ObservableObject {
-  /// The input query (set immediately when user types)
-  @Published var inputQuery: String = ""
-  /// The debounced query (updated 250ms after user stops typing)
-  @Published var debouncedQuery: String = ""
-  private var cancellables = Set<AnyCancellable>()
-
-  init() {
-    // Observe input and debounce to output
-    $inputQuery
-      .debounce(for: .milliseconds(250), scheduler: DispatchQueue.main)
-      .removeDuplicates()
-      .sink { [weak self] value in
-        self?.debouncedQuery = value
-      }
-      .store(in: &cancellables)
-  }
-}
 
 // MARK: - Conversations Page
 
@@ -50,7 +27,7 @@ struct ConversationsPage: View {
   @State private var searchResults: [ServerConversation] = []
   @State private var isSearching: Bool = false
   @State private var searchError: String? = nil
-  @StateObject private var searchDebouncer = SearchDebouncer()
+  @StateObject private var searchCoordinator = DebouncedSearchCoordinator()
 
   // Date picker state
   @State private var showDatePicker: Bool = false
@@ -230,9 +207,14 @@ struct ConversationsPage: View {
       // Fixed page header — title + actions stay pinned; everything below it
       // (live transcript, search, filters, list) scrolls together as one.
       HStack {
-        Text("Conversations")
-          .scaledFont(size: OmiType.heading, weight: .semibold)
-          .foregroundColor(OmiColors.textPrimary)
+        VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+          Text("Conversations")
+            .scaledFont(size: OmiType.heading, weight: .semibold)
+            .foregroundColor(OmiColors.textPrimary)
+          Text("Recordings, notes, and transcripts from your day")
+            .scaledFont(size: OmiType.caption)
+            .foregroundStyle(OmiColors.textTertiary)
+        }
 
         Spacer()
 
@@ -409,44 +391,16 @@ struct ConversationsPage: View {
     VStack(spacing: 0) {
       // Section header with search bar and filters
       HStack(spacing: OmiSpacing.sm) {
-        // Search bar
-        HStack(spacing: OmiSpacing.sm) {
-          Image(systemName: "magnifyingglass")
-            .scaledFont(size: OmiType.body)
-            .foregroundColor(OmiColors.textTertiary)
-
-          TextField("Search conversations...", text: $searchQuery)
-            .textFieldStyle(.plain)
-            .scaledFont(size: OmiType.body)
-            .foregroundColor(OmiColors.textPrimary)
-            .onChange(of: searchQuery) { _, newValue in
-              // Feed input to debouncer
-              searchDebouncer.inputQuery = newValue
-            }
-            .onChange(of: searchDebouncer.debouncedQuery) { _, newValue in
-              // Debounced value changed - perform search
-              performSearch(query: newValue)
-            }
-
-          if !searchQuery.isEmpty {
-            Button(action: {
-              searchQuery = ""
-              searchDebouncer.inputQuery = ""
-              searchResults = []
-              searchError = nil
-            }) {
-              Image(systemName: "xmark.circle.fill")
-                .scaledFont(size: OmiType.body)
-                .foregroundColor(OmiColors.textTertiary)
-            }
-            .buttonStyle(.plain)
+        OmiSearchField(
+          placeholder: "Search conversations",
+          text: $searchQuery,
+          isLoading: isSearching
+        )
+        .onChange(of: searchQuery) { _, newValue in
+          searchCoordinator.submit(newValue) { query in
+            performSearch(query: query)
           }
         }
-        .padding(.horizontal, OmiSpacing.sm)
-        .padding(.vertical, OmiSpacing.md)
-        .frame(minHeight: 46)
-        .omiControlSurface(
-          fill: OmiColors.backgroundSecondary, radius: 18, stroke: OmiColors.border.opacity(0.18))
 
         // Filter buttons
         filterButtonsRow

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -422,7 +422,7 @@ struct ConversationsPage: View {
       // embedded (no inner ScrollView); the page's outer ScrollView (see
       // `scrollingBody`) owns scrolling so the whole page scrolls together.
       // Floating load-more / merge bars live in `floatingActionBars`.
-      if !searchQuery.isEmpty {
+      if DebouncedSearchCoordinator.isActive(searchQuery) {
         // Search results view
         searchResultsView
       } else {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -747,7 +747,6 @@ struct DashboardPage: View {
   /// suggested questions under the bar while the hub is showing.
   private func homeStage(stageWidth: CGFloat, stageHeight: CGFloat) -> some View {
     let askBarWidth = homeAskBarWidth(for: stageWidth)
-
     return Group {
       if homeMode == .hub {
         homeHubStage(stageWidth: stageWidth, askBarWidth: askBarWidth)
@@ -756,12 +755,7 @@ struct DashboardPage: View {
         homePanelStage(stageWidth: stageWidth, askBarWidth: askBarWidth)
       }
     }
-    .padding(
-      .top,
-      homeMode == .hub
-        ? Self.homeStageTopPadding
-        : (homeMode == .chat ? 0 : OmiSpacing.lg)
-    )
+    .padding(.top, homeMode.topPadding(hub: Self.homeStageTopPadding))
     .padding(.bottom, Self.homeStageBottomPadding)
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -756,7 +756,12 @@ struct DashboardPage: View {
         homePanelStage(stageWidth: stageWidth, askBarWidth: askBarWidth)
       }
     }
-    .padding(.top, homeMode == .hub ? Self.homeStageTopPadding : OmiSpacing.lg)
+    .padding(
+      .top,
+      homeMode == .hub
+        ? Self.homeStageTopPadding
+        : (homeMode == .chat ? 0 : OmiSpacing.lg)
+    )
     .padding(.bottom, Self.homeStageBottomPadding)
   }
 
@@ -1120,6 +1125,7 @@ struct DashboardPage: View {
           FloatingControlBarManager.shared.openAgentChatFromTimeline(ref: ref, completion: completion)
         },
         horizontalContentPadding: 0,
+        verticalContentPadding: OmiSpacing.sm,
         trailingContentPadding: OmiSpacing.md,
         welcomeContent: { dashboardChatWelcome }
       )
@@ -1128,7 +1134,7 @@ struct DashboardPage: View {
         LinearGradient(
           stops: [
             .init(color: .clear, location: 0.0),
-            .init(color: .black, location: 0.05),
+            .init(color: .black, location: 0.025),
             .init(color: .black, location: 0.97),
             .init(color: .clear, location: 1.0),
           ],
@@ -1136,7 +1142,7 @@ struct DashboardPage: View {
           endPoint: .bottom
         )
       )
-      .padding(.vertical, OmiSpacing.xs)
+      .padding(.bottom, OmiSpacing.xs)
 
     }
     // Chat is the Home surface itself — no card chrome, it sits directly on

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/HomeStagePresentation.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/HomeStagePresentation.swift
@@ -1,3 +1,4 @@
+import OmiTheme
 import SwiftUI
 
 enum HomeStageMode: Equatable {
@@ -12,6 +13,14 @@ enum HomeStageMode: Equatable {
   /// click or Esc *open* the chat.
   static func collapseCatcherActive(mode: HomeStageMode, resting: HomeStageMode) -> Bool {
     mode != resting && mode != .hub
+  }
+
+  func topPadding(hub: CGFloat) -> CGFloat {
+    switch self {
+    case .hub: return hub
+    case .chat: return 0
+    case .connect: return OmiSpacing.lg
+    }
   }
 
   var automationLabel: String {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -113,12 +113,15 @@ class MemoriesViewModel: ObservableObject {
       if oldValue != searchText {
         bumpScopeGeneration()
         displayLimit = pageSize
-        Task { await performSearch() }
+        searchCoordinator.submit(searchText) { [weak self] _ in
+          await self?.performSearch()
+        }
       }
     }
   }
   @Published private(set) var isSearching = false
   @Published private(set) var searchResults: [ServerMemory] = []
+  private let searchCoordinator = DebouncedSearchCoordinator()
   @Published var selectedLayerFilter: MemoryLayerFilter = .defaultAccess {
     didSet {
       guard oldValue != selectedLayerFilter else { return }
@@ -1758,171 +1761,169 @@ struct MemoriesPage: View {
   // MARK: - Header
 
   private var header: some View {
-    HStack(spacing: OmiSpacing.md) {
-      // Search field
-      HStack(spacing: OmiSpacing.sm) {
-        if viewModel.isSearching || viewModel.isLoadingFiltered {
-          ProgressView()
-            .scaleEffect(0.7)
-            .frame(width: 14, height: 14)
-        } else {
-          Image(systemName: "magnifyingglass")
-            .foregroundColor(OmiColors.textTertiary)
+    VStack(alignment: .leading, spacing: OmiSpacing.md) {
+      HStack(alignment: .firstTextBaseline) {
+        VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+          Text("Memories")
+            .scaledFont(size: OmiType.heading, weight: .semibold)
+            .foregroundStyle(OmiColors.textPrimary)
+          Text("What Omi has learned and saved for you")
+            .scaledFont(size: OmiType.caption)
+            .foregroundStyle(OmiColors.textTertiary)
         }
-
-        TextField("Search memories...", text: $viewModel.searchText)
-          .textFieldStyle(.plain)
-          .foregroundColor(OmiColors.textPrimary)
-
-        if !viewModel.searchText.isEmpty {
-          Button {
-            viewModel.searchText = ""
-          } label: {
-            Image(systemName: "xmark.circle.fill")
-              .foregroundColor(OmiColors.textTertiary)
-          }
-          .buttonStyle(.plain)
-        }
+        Spacer()
       }
-      .padding(.horizontal, OmiSpacing.md)
-      .padding(.vertical, OmiSpacing.md)
-      .frame(minHeight: 46)
-      .omiControlSurface(fill: OmiColors.backgroundTertiary, radius: 18)
 
-      if viewModel.canonicalLifecycleExposed {
+      HStack(spacing: OmiSpacing.sm) {
+        OmiSearchField(
+          placeholder: "Search memories",
+          text: $viewModel.searchText,
+          isLoading: viewModel.isSearching || viewModel.isLoadingFiltered
+        )
+
+        if viewModel.canonicalLifecycleExposed {
         // Layer filter dropdown. Default is product default access: Short-term + Long-term.
-        Menu {
-          ForEach(MemoryLayerFilter.allCases) { filter in
-            Button {
-              viewModel.selectedLayerFilter = filter
-            } label: {
-              HStack {
-                Text(filter.displayName)
-                if viewModel.selectedLayerFilter == filter {
-                  Image(systemName: "checkmark")
+          Menu {
+            ForEach(MemoryLayerFilter.allCases) { filter in
+              Button {
+                viewModel.selectedLayerFilter = filter
+              } label: {
+                HStack {
+                  Text(filter.displayName)
+                  if viewModel.selectedLayerFilter == filter {
+                    Image(systemName: "checkmark")
+                  }
                 }
               }
+              .help(filter.description)
             }
-            .help(filter.description)
+          } label: {
+            HStack(spacing: OmiSpacing.xs) {
+              Image(
+                systemName: viewModel.selectedLayerFilter == .archive
+                  ? "archivebox" : "clock.badge.checkmark"
+              )
+              .scaledFont(size: OmiType.caption)
+              Text(viewModel.selectedLayerFilter.displayName)
+                .scaledFont(
+                  size: OmiType.body,
+                  weight: viewModel.selectedLayerFilter == .defaultAccess ? .regular : .medium)
+              Image(systemName: "chevron.down")
+                .scaledFont(size: OmiType.micro)
+            }
+            .foregroundColor(
+              viewModel.selectedLayerFilter == .defaultAccess
+                ? OmiColors.textSecondary : OmiColors.textPrimary
+            )
+            .padding(.horizontal, OmiSpacing.md)
+            .frame(minHeight: 44)
+            .omiControlSurface(
+              fill: viewModel.selectedLayerFilter == .defaultAccess
+                ? OmiColors.backgroundSecondary : OmiColors.backgroundRaised,
+              radius: 16,
+              stroke: OmiColors.border.opacity(
+                viewModel.selectedLayerFilter == .defaultAccess ? 0.18 : 0.6)
+            )
           }
+          .menuStyle(.button)
+          .buttonStyle(.plain)
+          .help("Default shows Short-term + Long-term. Archive is explicit.")
+        }
+
+        Button {
+          viewModel.filterThisDeviceOnly.toggle()
         } label: {
           HStack(spacing: OmiSpacing.xs) {
-            Image(systemName: viewModel.selectedLayerFilter == .archive ? "archivebox" : "clock.badge.checkmark")
+            Image(systemName: "desktopcomputer")
               .scaledFont(size: OmiType.caption)
-            Text(viewModel.selectedLayerFilter.displayName)
+            Text("This device")
               .scaledFont(
-                size: OmiType.body, weight: viewModel.selectedLayerFilter == .defaultAccess ? .regular : .medium)
+                size: OmiType.body, weight: viewModel.filterThisDeviceOnly ? .medium : .regular)
+          }
+          .foregroundColor(
+            viewModel.filterThisDeviceOnly ? OmiColors.textPrimary : OmiColors.textSecondary
+          )
+          .padding(.horizontal, OmiSpacing.md)
+          .frame(minHeight: 44)
+          .omiControlSurface(
+            fill: viewModel.filterThisDeviceOnly
+              ? OmiColors.backgroundRaised : OmiColors.backgroundSecondary,
+            radius: 16,
+            stroke: OmiColors.border.opacity(viewModel.filterThisDeviceOnly ? 0.6 : 0.18)
+          )
+        }
+        .buttonStyle(.plain)
+        .help("Show memories captured on this Mac")
+
+        // Category filter dropdown
+        Button {
+          pendingSelectedTags = viewModel.selectedTags
+          categorySearchText = ""
+          showCategoryFilter = true
+        } label: {
+          HStack(spacing: OmiSpacing.xs) {
+            Image(systemName: "line.3.horizontal.decrease")
+              .scaledFont(size: OmiType.caption)
+            Text(categoryFilterLabel)
+              .scaledFont(
+                size: OmiType.body, weight: viewModel.selectedTags.isEmpty ? .regular : .medium)
             Image(systemName: "chevron.down")
               .scaledFont(size: OmiType.micro)
           }
           .foregroundColor(
-            viewModel.selectedLayerFilter == .defaultAccess ? OmiColors.textSecondary : OmiColors.textPrimary
+            viewModel.selectedTags.isEmpty ? OmiColors.textSecondary : OmiColors.textPrimary
           )
           .padding(.horizontal, OmiSpacing.md)
-          .padding(.vertical, OmiSpacing.md)
-          .frame(minHeight: 46)
+          .frame(minHeight: 44)
           .omiControlSurface(
-            fill: viewModel.selectedLayerFilter == .defaultAccess
-              ? OmiColors.backgroundTertiary : OmiColors.backgroundRaised,
-            radius: 18,
-            stroke: viewModel.selectedLayerFilter == .defaultAccess ? nil : OmiColors.border.opacity(0.6)
+            fill: viewModel.selectedTags.isEmpty
+              ? OmiColors.backgroundSecondary : OmiColors.backgroundRaised,
+            radius: 16,
+            stroke: OmiColors.border.opacity(viewModel.selectedTags.isEmpty ? 0.18 : 0.6)
           )
         }
-        .menuStyle(.button)
         .buttonStyle(.plain)
-        .help("Default shows Short-term + Long-term. Archive is explicit.")
-      }
-
-      Button {
-        viewModel.filterThisDeviceOnly.toggle()
-      } label: {
-        HStack(spacing: OmiSpacing.xs) {
-          Image(systemName: "desktopcomputer")
-            .scaledFont(size: OmiType.caption)
-          Text("This device")
-            .scaledFont(size: OmiType.body, weight: viewModel.filterThisDeviceOnly ? .medium : .regular)
+        .popover(isPresented: $showCategoryFilter, arrowEdge: .bottom) {
+          categoryFilterPopover
         }
-        .foregroundColor(
-          viewModel.filterThisDeviceOnly ? OmiColors.textPrimary : OmiColors.textSecondary
-        )
-        .padding(.horizontal, OmiSpacing.md)
-        .padding(.vertical, OmiSpacing.md)
-        .frame(minHeight: 46)
-        .omiControlSurface(
-          fill: viewModel.filterThisDeviceOnly
-            ? OmiColors.backgroundRaised : OmiColors.backgroundTertiary,
-          radius: 18,
-          stroke: viewModel.filterThisDeviceOnly ? OmiColors.border.opacity(0.6) : nil
-        )
-      }
-      .buttonStyle(.plain)
-      .help("Show memories captured on this Mac")
 
-      // Category filter dropdown
-      Button {
-        pendingSelectedTags = viewModel.selectedTags
-        categorySearchText = ""
-        showCategoryFilter = true
-      } label: {
-        HStack(spacing: OmiSpacing.xs) {
-          Image(systemName: "line.3.horizontal.decrease")
-            .scaledFont(size: OmiType.caption)
-          Text(categoryFilterLabel)
-            .scaledFont(size: OmiType.body, weight: viewModel.selectedTags.isEmpty ? .regular : .medium)
-          Image(systemName: "chevron.down")
-            .scaledFont(size: OmiType.micro)
+        // Add Memory button (icon only)
+        Button {
+          viewModel.showingAddMemory = true
+        } label: {
+          Image(systemName: "plus")
+            .scaledFont(size: OmiType.body)
+            .foregroundColor(.black)
+            .frame(width: 44, height: 44)
+            .background(OmiColors.textPrimary)
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         }
-        .foregroundColor(
-          viewModel.selectedTags.isEmpty ? OmiColors.textSecondary : OmiColors.textPrimary
-        )
-        .padding(.horizontal, OmiSpacing.md)
-        .padding(.vertical, OmiSpacing.md)
-        .frame(minHeight: 46)
-        .omiControlSurface(
-          fill: viewModel.selectedTags.isEmpty
-            ? OmiColors.backgroundTertiary : OmiColors.backgroundRaised,
-          radius: 18,
-          stroke: viewModel.selectedTags.isEmpty ? nil : OmiColors.border.opacity(0.6)
-        )
-      }
-      .buttonStyle(.plain)
-      .popover(isPresented: $showCategoryFilter, arrowEdge: .bottom) {
-        categoryFilterPopover
-      }
+        .buttonStyle(.plain)
+        .help("Add Memory")
 
-      // Add Memory button (icon only)
-      Button {
-        viewModel.showingAddMemory = true
-      } label: {
-        Image(systemName: "plus")
-          .scaledFont(size: OmiType.body)
-          .foregroundColor(.black)
-          .frame(width: 42, height: 42)
-          .background(OmiColors.textPrimary)
-          .clipShape(RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous))
-      }
-      .buttonStyle(.plain)
-      .help("Add Memory")
-
-      // Management menu
-      Button {
-        showManagementMenu = true
-      } label: {
-        Image(systemName: "chevron.down")
-          .scaledFont(size: OmiType.caption, weight: .medium)
-          .foregroundColor(.black)
-          .frame(width: 42, height: 42)
-          .background(OmiColors.textPrimary)
-          .clipShape(RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous))
-      }
-      .buttonStyle(.plain)
-      .popover(isPresented: $showManagementMenu, arrowEdge: .bottom) {
-        managementMenuPopover
+        // Management menu
+        Button {
+          showManagementMenu = true
+        } label: {
+          Image(systemName: "ellipsis")
+            .scaledFont(size: OmiType.caption, weight: .semibold)
+            .foregroundColor(OmiColors.textSecondary)
+            .frame(width: 44, height: 44)
+            .omiControlSurface(
+              fill: OmiColors.backgroundSecondary,
+              radius: 14,
+              stroke: OmiColors.border.opacity(0.18)
+            )
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showManagementMenu, arrowEdge: .bottom) {
+          managementMenuPopover
+        }
       }
     }
     .padding(.horizontal, OmiSpacing.xxl)
-    .padding(.top, OmiSpacing.xxl)
-    .padding(.bottom, OmiSpacing.xl)
+    .padding(.top, OmiSpacing.lg)
+    .padding(.bottom, OmiSpacing.md)
     .alert("Delete Default Memories?", isPresented: $viewModel.showingDeleteAllConfirmation) {
       Button("Cancel", role: .cancel) {}
       Button("Delete Default Memories", role: .destructive) {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1759,7 +1759,6 @@ struct MemoriesPage: View {
   }
 
   // MARK: - Header
-
   private var header: some View {
     VStack(alignment: .leading, spacing: OmiSpacing.md) {
       HStack(alignment: .firstTextBaseline) {
@@ -1782,7 +1781,7 @@ struct MemoriesPage: View {
         )
 
         if viewModel.canonicalLifecycleExposed {
-        // Layer filter dropdown. Default is product default access: Short-term + Long-term.
+          // Layer filter dropdown. Default is product default access: Short-term + Long-term.
           Menu {
             ForEach(MemoryLayerFilter.allCases) { filter in
               Button {

--- a/desktop/macos/Desktop/Sources/ViewExporter.swift
+++ b/desktop/macos/Desktop/Sources/ViewExporter.swift
@@ -59,7 +59,7 @@ enum ViewExporter {
               viewModel: DashboardViewModel(),
               appState: AppState(),
               appProvider: AppProvider(),
-              chatProvider: ChatProvider(),
+              chatProvider: previewChatProvider(),
               memoriesViewModel: MemoriesViewModel(),
               selectedIndex: .constant(0)))
         },
@@ -287,6 +287,16 @@ enum ViewExporter {
         }
       ),
       (
+        "full-conversations", 1,
+        {
+          AnyView(
+            ConversationsPage(
+              appState: previewConversationsAppState(),
+              selectedConversation: .constant(nil)
+            ))
+        }
+      ),
+      (
         "full-ai-chat", 2,
         { AnyView(ChatPage(appProvider: AppProvider(), chatProvider: previewChatProvider())) }
       ),
@@ -324,31 +334,110 @@ enum ViewExporter {
     let entry = pages[index]
     let pageContent = entry.2()
 
-    // Compose: mock sidebar + rounded content area (mirrors DesktopHomeView layout)
+    let topBarAppState = AppState()
+    let topBarMemories = previewMemoriesViewModel()
+    let topBarTasks = TasksStore.shared
+
+    // Compose with the production top bar and rounded shell.
     let fullView = AnyView(
-      HStack(spacing: 0) {
-        ZStack {
-          RoundedRectangle(cornerRadius: OmiChrome.controlRadius)
-            .fill(
-              Color(nsColor: NSColor(red: 0.09, green: 0.09, blue: 0.09, alpha: 1)).opacity(0.4)
-            )
-            .overlay(
-              RoundedRectangle(cornerRadius: OmiChrome.controlRadius)
-                .stroke(
-                  Color(nsColor: NSColor(red: 0.15, green: 0.15, blue: 0.15, alpha: 1)).opacity(
-                    0.3), lineWidth: 1)
-            )
+      ZStack {
+        RoundedRectangle(cornerRadius: OmiChrome.windowRadius, style: .continuous)
+          .fill(Color(red: 0.050, green: 0.052, blue: 0.059))
+          .overlay(
+            RoundedRectangle(cornerRadius: OmiChrome.windowRadius, style: .continuous)
+              .stroke(OmiColors.border.opacity(0.22), lineWidth: 1)
+          )
+
+        VStack(spacing: 0) {
+          DesktopTopBar(
+            selectedIndex: .constant(entry.1),
+            appState: topBarAppState,
+            memoriesViewModel: topBarMemories,
+            tasksStore: topBarTasks,
+            sinceDate: Date(),
+            onRewind: {}
+          )
           pageContent
-            .clipShape(RoundedRectangle(cornerRadius: OmiChrome.controlRadius))
         }
-        .padding(OmiSpacing.md)
+        .clipShape(RoundedRectangle(cornerRadius: OmiChrome.windowRadius, style: .continuous))
       }
+      .padding(OmiSpacing.md)
     )
 
-    return (entry.0, fullView, CGSize(width: 1200, height: 800))
+    return (entry.0, fullView, CGSize(width: 1600, height: 1000))
   }
 
-  static var fullPageCount: Int { 10 }
+  static var fullPageCount: Int { 11 }
+
+  private static func previewConversationsAppState() -> AppState {
+    let appState = AppState()
+    let now = Date()
+    let previews = [
+      (
+        "Product design review",
+        "We reviewed the desktop Memory experience and agreed to remove the nested navigation, widen the content, and make search behavior consistent.",
+        "✨"
+      ),
+      (
+        "Launch readiness check",
+        "The team covered beta health, release notes, and the final desktop smoke test before the next rollout.",
+        "🚀"
+      ),
+      (
+        "Weekly planning",
+        "Priorities this week are onboarding polish, a cleaner conversation reader, and fewer competing controls in the header.",
+        "🗓"
+      ),
+      (
+        "Customer feedback",
+        "Customers want transcripts to be easier to scan and Memory to feel like one coherent place instead of three separate tools.",
+        "💬"
+      ),
+      (
+        "Engineering sync",
+        "The search services now share the same debounce and cancellation policy while preserving each page's data source.",
+        "🛠"
+      ),
+      (
+        "Design system cleanup",
+        "We aligned search fields, filter pills, radii, and loading states around the existing Omi neutral palette.",
+        "◐"
+      ),
+    ]
+
+    appState.conversations = previews.enumerated().map { index, preview in
+      let createdAt = now.addingTimeInterval(Double(-index * 3_600))
+      return ServerConversation(
+        id: "conversation_preview_\(index)",
+        createdAt: createdAt,
+        startedAt: createdAt,
+        finishedAt: createdAt.addingTimeInterval(2_700),
+        structured: Structured(
+          title: preview.0,
+          overview: preview.1,
+          emoji: preview.2,
+          category: "other",
+          actionItems: [],
+          events: []
+        ),
+        transcriptSegments: [],
+        transcriptSegmentsIncluded: true,
+        geolocation: nil,
+        photos: [],
+        appsResults: [],
+        source: .desktop,
+        language: "en",
+        status: .completed,
+        discarded: false,
+        deleted: false,
+        isLocked: false,
+        starred: index == 0,
+        folderId: nil,
+        inputDeviceName: "MacBook Pro Microphone"
+      )
+    }
+    return appState
+  }
 
   private static func previewChatProvider() -> ChatProvider {
     let provider = ChatProvider()

--- a/desktop/macos/Desktop/Tests/DebouncedSearchCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/DebouncedSearchCoordinatorTests.swift
@@ -7,6 +7,8 @@ final class DebouncedSearchCoordinatorTests: XCTestCase {
   func testQueryNormalizationMatchesAcrossSearchSurfaces() {
     XCTAssertEqual(DebouncedSearchCoordinator.normalized("  project atlas \n"), "project atlas")
     XCTAssertEqual(DebouncedSearchCoordinator.normalized(" \n\t "), "")
+    XCTAssertTrue(DebouncedSearchCoordinator.isActive(" project atlas "))
+    XCTAssertFalse(DebouncedSearchCoordinator.isActive(" \n\t "))
     XCTAssertEqual(DebouncedSearchCoordinator.standardDelayNanoseconds, 250_000_000)
   }
 

--- a/desktop/macos/Desktop/Tests/DebouncedSearchCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/DebouncedSearchCoordinatorTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class DebouncedSearchCoordinatorTests: XCTestCase {
+  @MainActor
+  func testQueryNormalizationMatchesAcrossSearchSurfaces() {
+    XCTAssertEqual(DebouncedSearchCoordinator.normalized("  project atlas \n"), "project atlas")
+    XCTAssertEqual(DebouncedSearchCoordinator.normalized(" \n\t "), "")
+    XCTAssertEqual(DebouncedSearchCoordinator.standardDelayNanoseconds, 250_000_000)
+  }
+
+  @MainActor
+  func testNonEmptyQueryCommitsThroughInjectedDebounceSleeper() async {
+    let committed = expectation(description: "query committed")
+    let coordinator = DebouncedSearchCoordinator(
+      sleeper: { _ in }
+    )
+
+    coordinator.submit("  release notes  ") { query in
+      XCTAssertEqual(query, "release notes")
+      committed.fulfill()
+    }
+
+    await fulfillment(of: [committed], timeout: 1)
+  }
+
+  @MainActor
+  func testClearingSearchCommitsImmediately() async {
+    let committed = expectation(description: "clear committed")
+    let coordinator = DebouncedSearchCoordinator(
+      sleeper: { _ in
+        XCTFail("Clearing search must not wait for the debounce sleeper")
+      }
+    )
+
+    coordinator.submit("   ") { query in
+      XCTAssertEqual(query, "")
+      committed.fulfill()
+    }
+
+    await fulfillment(of: [committed], timeout: 1)
+  }
+}

--- a/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
@@ -34,6 +34,18 @@ final class MemoryGraphRevisitTests: XCTestCase {
     XCTAssertEqual(MemoryHubDestination.conversations.title, "Conversations")
     XCTAssertEqual(MemoryHubDestination.brainMap.title, "Brain Map")
     XCTAssertEqual(MemoryHubDestination(rawValue: 1), .conversations)
+    XCTAssertEqual(
+      MemoryHubDestination.destination(for: .conversations),
+      .conversations
+    )
+    XCTAssertEqual(
+      MemoryHubDestination.destination(
+        for: .conversations,
+        requestedRawValue: MemoryHubDestination.brainMap.rawValue
+      ),
+      .brainMap
+    )
+    XCTAssertNil(MemoryHubDestination.destination(for: .tasks))
   }
 
   @MainActor

--- a/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
@@ -16,13 +16,24 @@ final class MemoryGraphRevisitTests: XCTestCase {
     // The Brain Map moved from an inline Memories card to its own hub tab, still
     // driven by the persistent, container-owned view model.
     XCTAssertTrue(home.contains("MemoryGraphPage(viewModel: viewModelContainer.memoryGraphViewModel)"))
-    // Static wiring tripwire: list content keeps its capped column while the
-    // Brain Map owns the full content surface and paints with the page's shared
-    // background token instead of a distinct gray canvas.
+    // Static wiring tripwire: the Memory menu routes each destination into the
+    // same full-width surface while the graph keeps the shared background.
     XCTAssertFalse(home.contains("constrainedListPage(MemoryHubPage"))
-    XCTAssertTrue(home.contains("if segment == 2"))
+    XCTAssertFalse(home.contains("listContentWidth"))
+    XCTAssertTrue(home.contains("switch destination"))
     XCTAssertTrue(home.contains("MemoryGraphPage(viewModel: viewModelContainer.memoryGraphViewModel)"))
     XCTAssertTrue(graph.contains("scnView.backgroundColor = NSColor(OmiColors.backgroundPrimary)"))
+  }
+
+  func testMemoryHubDestinationMenuHasStableRoutes() {
+    XCTAssertEqual(
+      MemoryHubDestination.allCases,
+      [.memories, .conversations, .brainMap]
+    )
+    XCTAssertEqual(MemoryHubDestination.memories.title, "Memories")
+    XCTAssertEqual(MemoryHubDestination.conversations.title, "Conversations")
+    XCTAssertEqual(MemoryHubDestination.brainMap.title, "Brain Map")
+    XCTAssertEqual(MemoryHubDestination(rawValue: 1), .conversations)
   }
 
   @MainActor

--- a/desktop/macos/Desktop/Tests/MemoryLayerFilterTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryLayerFilterTests.swift
@@ -166,14 +166,14 @@ final class MemoryLayerFilterTests: XCTestCase {
 
   func testLayerFilterControlsRenderOnlyAfterCanonicalLifecycleExposure() throws {
     let source = try memoriesPageSource()
+    let headerStart = try XCTUnwrap(source.range(of: "private var header: some View"))
+    let headerSource = source[headerStart.lowerBound...]
+    let lifecycleGate = try XCTUnwrap(
+      headerSource.range(of: "if viewModel.canonicalLifecycleExposed {")?.lowerBound)
+    let layerOptions = try XCTUnwrap(
+      headerSource.range(of: "ForEach(MemoryLayerFilter.allCases)")?.lowerBound)
 
-    XCTAssertTrue(source.contains("if viewModel.canonicalLifecycleExposed {\n        // Layer filter dropdown"))
-    XCTAssertTrue(source.contains("ForEach(MemoryLayerFilter.allCases)"))
-    XCTAssertLessThan(
-      try XCTUnwrap(
-        source.range(of: "if viewModel.canonicalLifecycleExposed {\n        // Layer filter dropdown")?.lowerBound),
-      try XCTUnwrap(source.range(of: "ForEach(MemoryLayerFilter.allCases)")?.lowerBound)
-    )
+    XCTAssertLessThan(lifecycleGate, layerOptions)
   }
 
   private func memoriesPageSource() throws -> String {

--- a/desktop/macos/changelog/unreleased/20260725-memory-navigation-polish.json
+++ b/desktop/macos/changelog/unreleased/20260725-memory-navigation-polish.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved Memory with full-width conversations, a single navigation menu, consistent search, and tighter chat spacing"
+}

--- a/desktop/macos/e2e/flows/home-stage.yaml
+++ b/desktop/macos/e2e/flows/home-stage.yaml
@@ -4,6 +4,7 @@ tier: 2
 description: Redesigned Home stage transitions (hub/chat/connect) via automation bridge
 app: non-prod
 covers:
+  - desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/HomeStagePresentation.swift
   - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift

--- a/desktop/macos/e2e/flows/memories.yaml
+++ b/desktop/macos/e2e/flows/memories.yaml
@@ -1,9 +1,11 @@
 version: 2
 name: memories
 tier: manual
-description: Memory tab — navigate sub-tabs (Memories, Conversations, Brain Map), search, filter (v0.12.119+ redesign)
+description: Memory menu — navigate full-width Memories, Conversations, and Brain Map destinations
 app: com.omi.computer-macos
 covers:
+  - desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Components/OmiSearchField.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
 preconditions:
@@ -11,8 +13,8 @@ preconditions:
 
 steps:
   - id: S1
-    name: Navigate to Memory tab
-    do: "Click the Memory button in the top nav bar (agent-swift find text 'Memory' click). Verify Memory page loads with 3 sub-tabs: Memories, Conversations, Brain Map."
+    name: Open the Memory destination menu
+    do: "Click the Memory button in the top nav bar (agent-swift find text 'Memory' click). Verify its menu exposes Memories, Conversations, and Brain Map."
     expect:
       text_visible:
         - Memories
@@ -20,14 +22,14 @@ steps:
         - Brain Map
 
   - id: S2
-    name: Verify Memories sub-tab
-    do: "Verify the Memories sub-tab is active. Check for search bar ('Search memories...'), filter buttons ('This device', 'All'), Add button, and a list of memory items with timestamps."
+    name: Select and verify Memories
+    do: "Choose Memories from the Memory menu. Verify the full-width page shows the shared search field ('Search memories'), filter buttons ('This device', 'All'), Add button, and memory rows with timestamps."
     expect:
       interactive_count: { min: 4 }
 
   - id: S3
-    name: Switch to Conversations sub-tab
-    do: "Click the Conversations sub-tab button. Verify Conversations page loads with Live section (red dot, 'Listening...'), search bar, category filter tabs (All, Starred, Work, Personal, Social), and a list of conversations grouped by date."
+    name: Select Conversations
+    do: "Open the Memory menu and choose Conversations. Verify the full-width Conversations page loads with the shared search field, filters, and a list grouped by date."
     expect:
       text_visible:
         - Conversations
@@ -39,15 +41,15 @@ steps:
       interactive_count: { min: 3 }
 
   - id: S5
-    name: Switch to Brain Map sub-tab
-    do: "Click the Brain Map sub-tab button. Verify Brain Map renders with an interactive node graph visualization showing connected entities."
+    name: Select Brain Map
+    do: "Open the Memory menu and choose Brain Map. Verify Brain Map renders with an interactive node graph visualization showing connected entities."
     expect:
       text_visible:
         - Brain Map
 
   - id: S6
-    name: Return to Memories sub-tab
-    do: "Click the Memories sub-tab button to return. Verify the memory list is visible with search and filter controls."
+    name: Return to Memories
+    do: "Open the Memory menu and choose Memories. Verify the memory list is visible with the shared search and filter controls."
     expect:
       text_visible:
         - Memories


### PR DESCRIPTION
## Summary

- make Memories, Conversations, and Brain Map full-width destinations under one persistent Memory navigation menu
- unify Memories and Conversations on one search field and cancellation-aware 250 ms debounce policy
- preserve Cmd+2 and automation routes to Conversations, including whitespace-only search reset behavior
- tighten the Home chat transcript inset and top fade while preserving the shared chat surface
- update the built-in SwiftUI exporter with realistic full-page Memory and Conversations states

## Product invariants

- INV-CHAT-1 — the Home spacing adjustment continues to use the shared `ChatMessagesView` and transcript fade rather than introducing a separate chat implementation

## Verification

- `xcrun swift test --package-path desktop/macos/Desktop --filter 'DebouncedSearchCoordinatorTests|MemoryGraphRevisitTests|DesktopChatDriftGuardTests'` — 16 tests passed
- `xcrun swift test --package-path desktop/macos/Desktop --filter 'DebouncedSearchCoordinatorTests|MemoryGraphRevisitTests|MemoryLayerFilterTests|DesktopAutomationSecondaryActionTests'` — 55 tests passed
- `xcrun swift build -c debug --package-path desktop/macos/Desktop` — passed
- `backend/.venv/bin/python desktop/macos/scripts/desktop-flow-lint.py` — passed (59 flows, 135 registered actions)
- `make preflight` — passed
- `scripts/pr-preflight --pr-body-file /tmp/omi-memory-ui-pr-body.md` — passed

The push uses the documented `PRE_PUSH_SKIP_DESKTOP_FLOW_LINT=1` hatch because the hook hardcodes a system Python without PyYAML. The identical linter passed with the setup-managed backend virtualenv above.

## Failure class (fixes)

Failure-Class: none

## Manual verification

- rendered the production SwiftUI Memory and Conversations surfaces at 1600 × 1000 with the built-in exporter
- visually compared the full-width results against the supplied before screenshots
- launched a named ad-hoc development bundle without touching Omi or Omi Beta; authenticated live-data exercise was unavailable because the local bundle had no seeded auth session

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
