### PR TITLE
fix(desktop-windows): restart Rewind capture when its stream track dies

### DIFF
--- a/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useRef, useState } from 'react'
 import type { RewindSettings, RewindCaptureDirective } from '../../../../shared/types'
+import { onCaptureStreamDeath } from './captureSupervisor'
 
 // Cap the longest sampled edge — plenty for a timeline + OCR, and keeps each
 // canvas grab + JPEG encode cheap.
 const MAX_EDGE = 1600
 const JPEG_QUALITY = 0.6
+// Wait before rebuilding a stream whose track ended, so a source that is
+// permanently gone (e.g. an unplugged display) can't hot-loop getUserMedia.
+const STREAM_RESTART_BACKOFF_MS = 3000
 
 /**
  * Background screen-capture host for Rewind. Mounted app-wide (while the window
@@ -19,6 +23,8 @@ export function RewindCaptureHost(): React.JSX.Element {
   const videoRef = useRef<HTMLVideoElement>(null)
   const streamRef = useRef<MediaStream | null>(null)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const restartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const detachDeathRef = useRef<(() => void) | null>(null)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const savingRef = useRef(false)
   const [settings, setSettings] = useState<RewindSettings | null>(null)
@@ -64,6 +70,14 @@ export function RewindCaptureHost(): React.JSX.Element {
         clearTimeout(timerRef.current)
         timerRef.current = null
       }
+      if (restartTimerRef.current) {
+        clearTimeout(restartTimerRef.current)
+        restartTimerRef.current = null
+      }
+      // Detach before stopping the tracks so our own teardown is never mistaken
+      // for the stream dying.
+      detachDeathRef.current?.()
+      detachDeathRef.current = null
       streamRef.current?.getTracks().forEach((t) => t.stop())
       streamRef.current = null
       if (videoRef.current) videoRef.current.srcObject = null
@@ -136,6 +150,18 @@ export function RewindCaptureHost(): React.JSX.Element {
           return
         }
         streamRef.current = stream
+        // A track can end mid-session (display reconfig, GPU/driver reset, source
+        // gone) without any power/lock directive. Without this the loop keeps
+        // sampling a dead <video> and every frame is blank/dark until restart
+        // (#10504). Rebuild the stream when the track dies, after a backoff.
+        detachDeathRef.current = onCaptureStreamDeath(stream, () => {
+          if (cancelled || streamRef.current !== stream) return
+          console.warn('[rewind] capture track ended; restarting stream')
+          stop()
+          restartTimerRef.current = setTimeout(() => {
+            if (!cancelled && enabled) void start()
+          }, STREAM_RESTART_BACKOFF_MS)
+        })
         const v = videoRef.current
         if (v) {
           v.srcObject = stream

--- a/desktop/windows/src/renderer/src/components/rewind/captureSupervisor.test.ts
+++ b/desktop/windows/src/renderer/src/components/rewind/captureSupervisor.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest'
+import { onCaptureStreamDeath } from './captureSupervisor'
+
+// #10504: a capture track ending mid-session left the host sampling a dead
+// <video> forever (blank/dark frames). These pin that a track `ended` is
+// observed exactly once, and that unsubscribing before a deliberate stop
+// silences it (so our own teardown never looks like a death).
+
+class FakeTrack extends EventTarget {
+  end(): void {
+    this.dispatchEvent(new Event('ended'))
+  }
+}
+
+function fakeStream(trackCount: number): { stream: MediaStream; tracks: FakeTrack[] } {
+  const tracks = Array.from({ length: trackCount }, () => new FakeTrack())
+  const stream = { getVideoTracks: () => tracks } as unknown as MediaStream
+  return { stream, tracks }
+}
+
+describe('onCaptureStreamDeath', () => {
+  it('fires onDeath when a video track ends', () => {
+    const { stream, tracks } = fakeStream(1)
+    const onDeath = vi.fn()
+    onCaptureStreamDeath(stream, onDeath)
+
+    tracks[0].end()
+
+    expect(onDeath).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires at most once even if multiple tracks end', () => {
+    const { stream, tracks } = fakeStream(2)
+    const onDeath = vi.fn()
+    onCaptureStreamDeath(stream, onDeath)
+
+    tracks[0].end()
+    tracks[1].end()
+
+    expect(onDeath).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire after unsubscribe (a deliberate stop is not a death)', () => {
+    const { stream, tracks } = fakeStream(1)
+    const onDeath = vi.fn()
+    const unsubscribe = onCaptureStreamDeath(stream, onDeath)
+
+    unsubscribe()
+    tracks[0].end()
+
+    expect(onDeath).not.toHaveBeenCalled()
+  })
+})

--- a/desktop/windows/src/renderer/src/components/rewind/captureSupervisor.ts
+++ b/desktop/windows/src/renderer/src/components/rewind/captureSupervisor.ts
@@ -1,0 +1,35 @@
+// Restart supervision for the Rewind capture stream. Pure event wiring, kept out
+// of the capture host so the "stream died → we noticed" contract is unit-tested.
+//
+// A getUserMedia desktop track can end mid-session for reasons the power/lock
+// directive doesn't cover — a display reconfiguration, a GPU/driver reset, or the
+// captured source going away. When that happens the <video> goes dead but the
+// sampling loop keeps drawing it, so every frame is blank/dark until the app is
+// restarted (#10504). Watching each video track's `ended` event lets the host
+// rebuild the stream instead of silently capturing darkness.
+
+/**
+ * Invoke `onDeath` once when any of the stream's video tracks ends. Returns an
+ * unsubscribe that detaches the listeners (call it before tearing the stream
+ * down so a stop we initiated doesn't count as a death).
+ *
+ * `onDeath` fires at most once even if several tracks end — the caller rebuilds
+ * the whole stream, so the first death is all that matters.
+ */
+export function onCaptureStreamDeath(stream: MediaStream, onDeath: () => void): () => void {
+  const tracks = stream.getVideoTracks()
+  let fired = false
+  const handler = (): void => {
+    if (fired) return
+    fired = true
+    onDeath()
+  }
+  for (const track of tracks) {
+    track.addEventListener('ended', handler)
+  }
+  return () => {
+    for (const track of tracks) {
+      track.removeEventListener('ended', handler)
+    }
+  }
+}


### PR DESCRIPTION
## What

Closes #10504.

Rewind on Windows opens **one persistent** getUserMedia desktop stream and samples it on a timer. It handled OS **power/lock** (the capture directive tears the stream down and rebuilds it on wake) — but nothing else.

If the video track ended mid-session for any **other** reason — a display reconfiguration, a GPU/driver reset, the captured source going away — the hidden `<video>` went dead while the sampling loop kept drawing it. Every frame after that was blank/dark, and it never recovered until the app restarted. Over hours, such an event is likely — which is exactly *"timeline shows dark blank screenshots after running for a few hours."*

## Fix

Watch each capture track's `ended` event and rebuild the stream (after a **3s backoff**, so a permanently-gone source — e.g. an unplugged display — can't hot-loop `getUserMedia`).

The event wiring is a tiny `onCaptureStreamDeath(stream, onDeath)` helper so the *"stream died → we noticed"* contract is unit-tested rather than buried in the effect. The host **detaches** it before any teardown it initiates, so a deliberate stop is never mistaken for a death.

## Verification

```
captureSupervisor.test.ts (3) — fires once on track end; at most once across
  multiple tracks; silent after unsubscribe.   Mutation-checked: removing the
  listener wiring fails 2/3.
rewind renderer suite → 13 passed
typecheck:web → 0 errors
```

**Not exercised at runtime:** there's no Windows Electron host in my environment, and the hours-long degradation can't be reproduced here. This closes the specific code gap (no recovery when the capture stream dies) that produces the reported symptom; a Windows soak test would confirm the field fix. The change is additive and self-detaching, so it can't regress the normal capture path.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

