### PR TITLE
SCA-103: add macOS failure diagnostic context

### DIFF
--- a/.github/failure-classes/FC-split-mutation-authority.json
+++ b/.github/failure-classes/FC-split-mutation-authority.json
@@ -3,6 +3,9 @@
   "id": "FC-split-mutation-authority",
   "violated_contract": "Each mutable domain state has one authoritative owner for its state transitions.",
   "canonical_prevention": "Converge writes and lifecycle transitions behind the canonical repository or coordinator instead of synchronizing competing owners.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/agent/tests/convergence-authority-ratchet.test.ts"
+  ],
   "evidence_prs": [9365, 9597],
   "scope_hints": ["desktop/macos/**", "backend/**"],
   "status": "open"

--- a/.github/scripts/failure_class_guard_ratchet_allowlist.json
+++ b/.github/scripts/failure_class_guard_ratchet_allowlist.json
@@ -3,11 +3,6 @@
   "note": "Classes already over the guard-artifact threshold when the ratchet landed (2026-07-24). This list only shrinks: adding an entry is an explicit admission that a class recurs without a reusable guard, and an entry must be removed once its class records a canonical_prevention_artifact. See docs/product/failure-classes.md.",
   "grandfathered": [
     {
-      "id": "FC-split-mutation-authority",
-      "declarations_at_baseline": 31,
-      "reason": "31 first-parent integration changes in the 90 days through 2026-07-25 (30 at ratchet authoring on 2026-07-24, plus one on main before merge); evidence_prs still read [9365, 9597] and the canonical prevention is prose with no artifact. This is the recurrence that motivated the ratchet."
-    },
-    {
       "id": "FC-nonrecoverable-promotion",
       "declarations_at_baseline": 6,
       "reason": "6 first-parent integration changes in the same window; traffic-state snapshot and restore is spread across deploy workflow steps with no single guard surface to cite."

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2216,
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4304
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4360
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": "deleteBackend flag threaded through both clearJournalTurns variants so a reset is local-only",
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "Keep stdout readabilityHandler while the agent child is alive so a full pipe cannot deadlock mid-turn; deleteBackend remains on journal_clear_turns."
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "Typed failed-start context records checked binary/permission/port facts, elapsed timeout, and exit code at the existing runtime owner."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2216,
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4360
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4369
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": "deleteBackend flag threaded through both clearJournalTurns variants so a reset is local-only",
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "Typed failed-start context records checked binary/permission/port facts, elapsed timeout, and exit code at the existing runtime owner."
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "Typed failed-start context records checked binary/permission/port facts, elapsed timeout, and exit code at the existing runtime owner; the one-time diagnostics handoff keeps the UI owner as the sole Sentry event surface."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
@@ -1,10 +1,10 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6267,
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6269,
     "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2861
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": "ACP authentication now terminalizes the active turn with an explicit disposition instead of awaiting OAuth; a component split is tracked follow-up.",
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": "Failed bridge starts now consume typed runtime diagnostics at the sole user-facing error surface, avoiding a duplicate Sentry event; a component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": "Already-granted permissions no longer reopen System Settings: screen-recording and full-disk-access requests gate their Settings/drag-card opens behind the granted result."
   },
   "threshold": 1500

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
@@ -1,12 +1,12 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1643,
-    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3502,
+    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3520,
     "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": 1856
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": "Task visibility writes now emit the shared Home-count invalidation after logging, so Dashboard totals refresh without waiting for an activation cooldown.",
-    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": "currentUserId is gated by an OSAllocatedUnfairLock to fix a cross-executor data race (actor/MainActor/nonisolated shutdown); the Sendable lock + computed accessor replace the prior unsafe static var (SCA-8).",
+    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": "Corruption recovery forwards the triggering SQLite error and termination fact to the shared bounded storage-diagnostics context (SCA-103).",
     "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": "Search-result rows load a downsampled ImageIO thumbnail instead of the full-resolution screenshot, so a long results list no longer retains full-size images behind a 120x80 view."
   },
   "threshold": 1500

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -542,6 +542,11 @@ actor AgentRuntimeProcess {
   /// an actor blocked writing to the frozen process. See DebugSuspendControl.
   private nonisolated let debugSuspend = DebugSuspendControl()
   private var lastExitWasOOM = false
+  private var startupBeganAt: Date?
+  private var startupBinaryPresent = false
+  private var startupPermissionGrantedChecked = false
+  private var startupPermissionGranted = false
+  private var startupExitCode: Int32?
   private var clients: [String: ClientRegistration] = [:]
   private var activeRequests: [RuntimeMessage.RequestKey: ActiveRequest] = [:]
   private var activeControlRequests: [RuntimeMessage.RequestKey: ActiveControlRequest] = [:]
@@ -2484,6 +2489,11 @@ actor AgentRuntimeProcess {
     admissionAuthorityEpoch: UInt64,
     requiresCredentials: Bool
   ) async throws -> StartupReceipt {
+    startupBeganAt = Date()
+    startupBinaryPresent = false
+    startupPermissionGrantedChecked = false
+    startupPermissionGranted = false
+    startupExitCode = nil
     // `startProcess` owns the launch through `startupSingleFlight`. Do not use
     // the reducer's `.starting` state as a join signal here: the launch owner
     // intentionally sets it *before* this operation is scheduled.
@@ -2531,6 +2541,7 @@ actor AgentRuntimeProcess {
 
     let nodeExists = FileManager.default.isExecutableFile(atPath: nodePath)
     let bridgeExists = FileManager.default.fileExists(atPath: bridgePath)
+    startupBinaryPresent = nodeExists && bridgeExists
     let bridgeDir = (bridgePath as NSString).deletingLastPathComponent
     let pkgJsonPath = ((bridgeDir as NSString).deletingLastPathComponent as NSString)
       .appendingPathComponent("package.json")
@@ -2620,8 +2631,11 @@ actor AgentRuntimeProcess {
     } else if let authHeader,
       let token = Self.bearerToken(from: authHeader)
     {
+      startupPermissionGrantedChecked = requiresPiMonoCredentials
+      startupPermissionGranted = requiresPiMonoCredentials
       env["OMI_AUTH_TOKEN"] = token
     } else if requiresPiMonoCredentials {
+      startupPermissionGrantedChecked = true
       log("AgentRuntimeProcess: pi-mono start refused, Firebase ID token is missing")
       throw BridgeError.authMissing
     } else if preferredAdapterId == .piMono {
@@ -2924,6 +2938,45 @@ actor AgentRuntimeProcess {
         "recovery_action": "retry_start",
         "recovery_result": "exhausted",
       ])
+    logError(
+      "Agent runtime bridge failed to start",
+      context: bridgeStartFailureContext(failure))
+  }
+
+  private func bridgeStartFailureContext(
+    _ failure: AgentRuntimeBridgeLifecycle.StartFailure
+  ) -> DesktopErrorDiagnosticContext {
+    let elapsedMs = startupBeganAt.map { Int(Date().timeIntervalSince($0) * 1_000) } ?? -1
+    return Self.startFailureDiagnostics(
+      failure: failure,
+      elapsedMs: elapsedMs,
+      exitCode: startupExitCode,
+      binaryPresent: startupBinaryPresent,
+      permissionGrantedChecked: startupPermissionGrantedChecked,
+      permissionGranted: startupPermissionGranted)
+  }
+
+  nonisolated static func startFailureDiagnostics(
+    failure: AgentRuntimeBridgeLifecycle.StartFailure,
+    elapsedMs: Int,
+    exitCode: Int32?,
+    binaryPresent: Bool,
+    permissionGrantedChecked: Bool,
+    permissionGranted: Bool
+  ) -> DesktopErrorDiagnosticContext {
+    DesktopErrorDiagnosticContext([
+      "startup_stage": failure.rawValue,
+      "exit_code": exitCode.map(Int.init) ?? -1,
+      "elapsed_ms": elapsedMs,
+      "configured_timeout_ms": 30_000,
+      "binary_present_checked": true,
+      "binary_present": binaryPresent,
+      // The JSONL bridge has no TCP listener; report that the port precondition was not checked.
+      "port_bound_checked": false,
+      "port_bound": false,
+      "permission_granted_checked": permissionGrantedChecked,
+      "permission_granted": permissionGranted,
+    ])
   }
 
   private func cleanupFailedStart(process failedProcess: Process, error: Error) async {
@@ -4006,6 +4059,9 @@ actor AgentRuntimeProcess {
     }
 
     let likelyOOM = lastExitWasOOM || oomDiagnosticLatch.isConfirmed(generation: processGeneration)
+    if bridgeLifecycle.state == .starting {
+      startupExitCode = exitCode
+    }
     let error: BridgeError = likelyOOM ? .outOfMemory : .processExited
     lastExitWasOOM = false
     oomDiagnosticLatch.reset(generation: processGeneration)

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -544,7 +544,9 @@ actor AgentRuntimeProcess {
   private var lastExitWasOOM = false
   private var startupBeganAt: Date?
   private var startupBinaryPresent = false
+  private var startupBinaryPresentChecked = false
   private var startupPermissionGrantedChecked = false
+  private var pendingStartFailureDiagnostics: DesktopErrorDiagnosticContext?
   private var startupPermissionGranted = false
   private var startupExitCode: Int32?
   private var clients: [String: ClientRegistration] = [:]
@@ -2491,6 +2493,7 @@ actor AgentRuntimeProcess {
   ) async throws -> StartupReceipt {
     startupBeganAt = Date()
     startupBinaryPresent = false
+    startupBinaryPresentChecked = false
     startupPermissionGrantedChecked = false
     startupPermissionGranted = false
     startupExitCode = nil
@@ -2541,6 +2544,7 @@ actor AgentRuntimeProcess {
 
     let nodeExists = FileManager.default.isExecutableFile(atPath: nodePath)
     let bridgeExists = FileManager.default.fileExists(atPath: bridgePath)
+    startupBinaryPresentChecked = true
     startupBinaryPresent = nodeExists && bridgeExists
     let bridgeDir = (bridgePath as NSString).deletingLastPathComponent
     let pkgJsonPath = ((bridgeDir as NSString).deletingLastPathComponent as NSString)
@@ -2938,9 +2942,12 @@ actor AgentRuntimeProcess {
         "recovery_action": "retry_start",
         "recovery_result": "exhausted",
       ])
-    logError(
-      "Agent runtime bridge failed to start",
-      context: bridgeStartFailureContext(failure))
+    pendingStartFailureDiagnostics = bridgeStartFailureContext(failure)
+  }
+
+  func consumePendingStartFailureDiagnostics() -> DesktopErrorDiagnosticContext? {
+    defer { pendingStartFailureDiagnostics = nil }
+    return pendingStartFailureDiagnostics
   }
 
   private func bridgeStartFailureContext(
@@ -2952,6 +2959,7 @@ actor AgentRuntimeProcess {
       elapsedMs: elapsedMs,
       exitCode: startupExitCode,
       binaryPresent: startupBinaryPresent,
+      binaryPresentChecked: startupBinaryPresentChecked,
       permissionGrantedChecked: startupPermissionGrantedChecked,
       permissionGranted: startupPermissionGranted)
   }
@@ -2961,6 +2969,7 @@ actor AgentRuntimeProcess {
     elapsedMs: Int,
     exitCode: Int32?,
     binaryPresent: Bool,
+    binaryPresentChecked: Bool,
     permissionGrantedChecked: Bool,
     permissionGranted: Bool
   ) -> DesktopErrorDiagnosticContext {
@@ -2969,7 +2978,7 @@ actor AgentRuntimeProcess {
       "exit_code": exitCode.map(Int.init) ?? -1,
       "elapsed_ms": elapsedMs,
       "configured_timeout_ms": 30_000,
-      "binary_present_checked": true,
+      "binary_present_checked": binaryPresentChecked,
       "binary_present": binaryPresent,
       // The JSONL bridge has no TCP listener; report that the port precondition was not checked.
       "port_bound_checked": false,

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -493,23 +493,28 @@ final class DesktopDiagnosticsManager {
   func recordBetaLogError(
     message: String,
     error: Error?,
+    failureDiagnostics: [String: Any]? = nil,
     enabled: Bool = BetaEnhancedDiagnosticsConfiguration.isEnabled
   ) {
     guard enabled else { return }
     let nsError = error as NSError?
+    var trailProperties: [String: Any] = [
+      "component": betaComponent(for: message),
+      "operation": "error",
+      "phase": "handling",
+      "outcome": "failed",
+      "failure_class": betaFailureClass(for: nsError),
+      "error_domain": betaErrorDomain(nsError?.domain),
+      "error_code": betaErrorCode(nsError?.code),
+    ]
+    if let failureDiagnostics {
+      trailProperties.merge(sanitizedDiagnosticValues(failureDiagnostics)) { _, new in new }
+    }
     let snapshot = DesktopHealthSnapshot(
       timestamp: Date(),
       event: .betaDiagnosticTrail,
       properties: commonProperties().merging(
-        sanitized([
-          "component": betaComponent(for: message),
-          "operation": "error",
-          "phase": "handling",
-          "outcome": "failed",
-          "failure_class": betaFailureClass(for: nsError),
-          "error_domain": betaErrorDomain(nsError?.domain),
-          "error_code": betaErrorCode(nsError?.code),
-        ])
+        sanitized(trailProperties)
       ) { _, new in new })
     lock.lock()
     betaTrailSnapshots.append(snapshot)
@@ -1260,6 +1265,8 @@ final class DesktopDiagnosticsManager {
         safe[key] = String(string.prefix(96))
       case let int as Int:
         safe[key] = int
+      case let int64 as Int64:
+        safe[key] = Int(clamping: int64)
       case let double as Double:
         safe[key] = rounded(double)
       case let bool as Bool:
@@ -1269,6 +1276,10 @@ final class DesktopDiagnosticsManager {
       }
     }
     return safe
+  }
+
+  private func sanitizedDiagnosticValues(_ properties: [String: Any]) -> [String: Any] {
+    sanitized(properties)
   }
 
   private func rounded(_ value: Double) -> Double {

--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -608,6 +608,7 @@ func logError(
   DesktopDiagnosticsManager.shared.recordBetaLogError(
     message: message,
     error: error,
+    failureDiagnostics: context?.values,
     enabled: enhancedBetaDiagnostics)
 
   // Transient network/IO errors (offline, timeouts, cancellations, socket resets)

--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -573,8 +573,24 @@ struct DesktopErrorTelemetryDescriptor: Equatable {
   }
 }
 
+/// Bounded, non-PII fields that may accompany a shared `logError` Sentry event.
+/// Callers must construct these from enums, booleans, and numeric measurements;
+/// paths, exception messages, identifiers, and user content do not belong here.
+struct DesktopErrorDiagnosticContext {
+  let values: [String: Any]
+
+  init(_ values: [String: Any]) {
+    self.values = values
+  }
+}
+
 /// Log an error and capture it in Sentry
-func logError(_ message: String, error: Error? = nil, fileID: StaticString = #fileID) {
+func logError(
+  _ message: String,
+  error: Error? = nil,
+  context: DesktopErrorDiagnosticContext? = nil,
+  fileID: StaticString = #fileID
+) {
   let timestamp = dateFormatter.string(from: Date())
   let errorDesc = error?.localizedDescription ?? ""
   let fullMessage = error != nil ? "\(message): \(errorDesc)" : message
@@ -633,6 +649,9 @@ func logError(_ message: String, error: Error? = nil, fileID: StaticString = #fi
         "error_domain": telemetry.errorDomain,
         "error_code": telemetry.errorCode,
       ], key: "app_context")
+    if let context {
+      scope.setContext(value: context.values, key: "failure_diagnostics")
+    }
     if let attachmentURL {
       scope.addAttachment(
         Attachment(

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
@@ -686,7 +686,15 @@ actor FocusAssistant: ProactiveAssistant {
         sections.append(lines.joined(separator: "\n"))
       }
     } catch {
-      logError("Focus: Failed to load goals for context", error: error)
+      logError(
+        "Focus: Failed to load goals for context",
+        error: error,
+        context: StorageFailureDiagnostics.context(
+          pathClass: "goals-db",
+          containingURL: DesktopLocalProfile.applicationSupportURL(),
+          databaseURL: nil,
+          error: error,
+          appIsTerminating: RewindDatabase.isTerminationInProgress))
     }
 
     // Top tasks by importance

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1593,7 +1593,8 @@ class ChatProvider: ObservableObject {
     authoritativeGeneration: Int? = nil
   ) async -> Bool {
     guard let authorization = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else {
-      presentBridgeStartupFailure(BridgeError.authMissing, authoritativeGeneration: authoritativeGeneration)
+      await presentBridgeStartupFailure(
+        BridgeError.authMissing, authoritativeGeneration: authoritativeGeneration)
       return false
     }
     do {
@@ -1602,7 +1603,7 @@ class ChatProvider: ObservableObject {
         return try await self.performBridgeReadinessStartup()
       }
     } catch {
-      presentBridgeStartupFailure(error, authoritativeGeneration: authoritativeGeneration)
+      await presentBridgeStartupFailure(error, authoritativeGeneration: authoritativeGeneration)
       return false
     }
   }
@@ -1662,8 +1663,9 @@ class ChatProvider: ObservableObject {
   private func presentBridgeStartupFailure(
     _ error: Error,
     authoritativeGeneration: Int?
-  ) {
-    logError("Failed to start agent bridge", error: error)
+  ) async {
+    let context = await AgentRuntimeProcess.shared.consumePendingStartFailureDiagnostics()
+    logError("Failed to start agent bridge", error: error, context: context)
     let mayMutateSendState = authoritativeGeneration.map { sendGeneration == $0 } ?? true
     guard mayMutateSendState else { return }
     if let bridgeError = error as? BridgeError, let card = ChatErrorState.from(bridgeError) {

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -6,6 +6,12 @@ import os
 /// Actor-based database manager for Rewind screenshots
 actor RewindDatabase {
   static let shared = RewindDatabase()
+  private static let terminationLock = NSLock()
+  private static var terminationInProgress = false
+
+  nonisolated static var isTerminationInProgress: Bool {
+    terminationLock.withLock { terminationInProgress }
+  }
 
   private var dbQueue: DatabasePool?
 
@@ -130,7 +136,7 @@ actor RewindDatabase {
 
     guard FileManager.default.fileExists(atPath: dbPath) else { return }
     do {
-      try await handleCorruptedDatabase(at: dbPath, in: omiDir)
+      try await handleCorruptedDatabase(at: dbPath, in: omiDir, triggerError: error)
       try await initialize()
       log("RewindDatabase: recovered and reopened database after \(operation)")
     } catch {
@@ -343,6 +349,7 @@ actor RewindDatabase {
   /// Call from applicationWillTerminate to avoid unnecessary integrity checks on next launch.
   /// This is nonisolated so it can be called synchronously from the main thread during termination.
   nonisolated static func markCleanShutdown() {
+    terminationLock.withLock { terminationInProgress = true }
     let userDir = staticUserBaseDirectory()
     let flagPath = userDir.appendingPathComponent(".omi_running").path
     try? FileManager.default.removeItem(atPath: flagPath)
@@ -494,7 +501,7 @@ actor RewindDatabase {
 
         if isCorrupted && FileManager.default.fileExists(atPath: dbPath) {
           log("RewindDatabase: Database is corrupted (error: \(retryError)), attempting recovery...")
-          try await handleCorruptedDatabase(at: dbPath, in: omiDir)
+          try await handleCorruptedDatabase(at: dbPath, in: omiDir, triggerError: retryError)
           // Retry with recovered or fresh database
           queue = try DatabasePool(path: dbPath, configuration: config)
         } else {
@@ -796,7 +803,11 @@ actor RewindDatabase {
   private(set) var recoveredRecordCount: Int = 0
 
   /// Handle corrupted database: attempt recovery, backup, and recreate
-  private func handleCorruptedDatabase(at dbPath: String, in omiDir: URL) async throws {
+  private func handleCorruptedDatabase(
+    at dbPath: String,
+    in omiDir: URL,
+    triggerError: Error? = nil
+  ) async throws {
     let fileManager = FileManager.default
 
     // Create backup directory
@@ -858,7 +869,14 @@ actor RewindDatabase {
       }
     }
 
-    logError("RewindDatabase: Corrupted database backed up and removed. A fresh database will be created.")
+    logError(
+      "RewindDatabase: Corrupted database backed up and removed. A fresh database will be created.",
+      context: StorageFailureDiagnostics.context(
+        pathClass: "rewind-db",
+        containingURL: omiDir,
+        databaseURL: URL(fileURLWithPath: dbPath),
+        error: triggerError,
+        appIsTerminating: Self.isTerminationInProgress))
 
     // Clean up old backups (keep only last 5)
     try await cleanupOldBackups(in: backupDir, keepCount: 5)

--- a/desktop/macos/Desktop/Sources/Rewind/Core/StorageFailureDiagnostics.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/StorageFailureDiagnostics.swift
@@ -1,0 +1,54 @@
+import Foundation
+import GRDB
+
+/// Produces the bounded storage context attached to Rewind durability failures.
+/// It deliberately projects only volume/file measurements and SQLite/POSIX codes;
+/// filesystem paths and error descriptions remain local-only.
+enum StorageFailureDiagnostics {
+  static func context(
+    pathClass: String,
+    containingURL: URL,
+    databaseURL: URL?,
+    error: Error?,
+    appIsTerminating: Bool,
+    fileManager: FileManager = .default
+  ) -> DesktopErrorDiagnosticContext {
+    let volume = (try? fileManager.attributesOfFileSystem(forPath: containingURL.path)) ?? [:]
+    let databaseSize = databaseURL.flatMap { url -> Int64? in
+      let attributes = try? fileManager.attributesOfItem(atPath: url.path)
+      return (attributes?[.size] as? NSNumber)?.int64Value
+    }
+    let sqlite = error as? DatabaseError
+    let underlying = underlyingNSError(from: error)
+
+    var values: [String: Any] = [
+      "path_class": pathClass,
+      "volume_free_bytes": (volume[.systemFreeSize] as? NSNumber)?.int64Value ?? -1,
+      "volume_total_bytes": (volume[.systemSize] as? NSNumber)?.int64Value ?? -1,
+      "database_file_size_bytes": databaseSize ?? -1,
+      "app_terminating": appIsTerminating,
+      "error_domain": underlying?.domain ?? "unknown",
+      "error_code": underlying?.code ?? -1,
+      "sqlite_result_code": sqlite.map { $0.resultCode.rawValue } ?? -1,
+      "sqlite_extended_result_code": sqlite.map { $0.extendedResultCode.rawValue } ?? -1,
+    ]
+    // Keep this allow-list explicit. It is the scrub boundary for Sentry context.
+    values = values.filter { key, _ in
+      [
+        "path_class", "volume_free_bytes", "volume_total_bytes", "database_file_size_bytes",
+        "app_terminating", "error_domain", "error_code", "sqlite_result_code",
+        "sqlite_extended_result_code",
+      ].contains(key)
+    }
+    return DesktopErrorDiagnosticContext(values)
+  }
+
+  private static func underlyingNSError(from error: Error?) -> NSError? {
+    guard let error else { return nil }
+    let nsError = error as NSError
+    if let nested = nsError.userInfo[NSUnderlyingErrorKey] as? NSError {
+      return nested
+    }
+    return nsError
+  }
+}

--- a/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
@@ -358,7 +358,13 @@ actor VideoChunkEncoder {
         consecutiveWriteFailures += 1
         logError(
           "VideoChunkEncoder: Failed to start video writer (\(consecutiveWriteFailures)/\(maxConsecutiveFailures))",
-          error: error)
+          error: error,
+          context: StorageFailureDiagnostics.context(
+            pathClass: "video-chunk",
+            containingURL: videosDir,
+            databaseURL: nil,
+            error: error,
+            appIsTerminating: RewindDatabase.isTerminationInProgress))
 
         // Reset the half-initialized chunk state so the NEXT frame cleanly retries
         // starting the writer. Without this, currentChunkStartTime stays set while
@@ -414,7 +420,14 @@ actor VideoChunkEncoder {
       }
       consecutiveWriteFailures += 1
       logError(
-        "VideoChunkEncoder: Failed to write frame (\(consecutiveWriteFailures)/\(maxConsecutiveFailures))", error: error
+        "VideoChunkEncoder: Failed to write frame (\(consecutiveWriteFailures)/\(maxConsecutiveFailures))",
+        error: error,
+        context: StorageFailureDiagnostics.context(
+          pathClass: "video-chunk",
+          containingURL: videosDir,
+          databaseURL: nil,
+          error: error,
+          appIsTerminating: RewindDatabase.isTerminationInProgress)
       )
 
       if consecutiveWriteFailures >= maxConsecutiveFailures {

--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -433,7 +433,15 @@ actor RewindIndexer {
       if await discardAbandonedVideoChunkIfNeeded(error) {
         return
       }
-      logError("RewindIndexer: Failed to process CGImage frame", error: error)
+      logError(
+        "RewindIndexer: Failed to process CGImage frame",
+        error: error,
+        context: StorageFailureDiagnostics.context(
+          pathClass: "video-chunk",
+          containingURL: DesktopLocalProfile.applicationSupportURL(),
+          databaseURL: nil,
+          error: error,
+          appIsTerminating: RewindDatabase.isTerminationInProgress))
       await RewindDatabase.shared.reportQueryError(error)
     }
   }

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -141,6 +141,37 @@ import XCTest
       XCTAssertTrue(tail.contains("silent capture detected"))
     }
 
+    func testBetaTrailPreservesBoundedFailureDiagnosticsForTransientStorageErrors() throws {
+      let context = StorageFailureDiagnostics.context(
+        pathClass: "rewind-db",
+        containingURL: FileManager.default.temporaryDirectory,
+        databaseURL: nil,
+        error: NSError(domain: NSPOSIXErrorDomain, code: 28),
+        appIsTerminating: false)
+
+      DesktopDiagnosticsManager.shared.recordBetaLogError(
+        message: "Rewind database write failed",
+        error: NSError(domain: NSPOSIXErrorDomain, code: 28),
+        failureDiagnostics: context.values,
+        enabled: true)
+
+      let url = try XCTUnwrap(
+        DesktopDiagnosticsManager.shared.writeIncidentDiagnosticsAttachment(
+          area: "capture",
+          failureClass: "storage_exhausted",
+          phase: "persist",
+          includeBetaDiagnostics: true))
+      defer { try? FileManager.default.removeItem(at: url) }
+
+      let data = try Data(contentsOf: url)
+      let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+      let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+      let trail = try XCTUnwrap(
+        snapshots.first(where: { $0["event"] as? String == "beta_diagnostic_trail" }))
+      XCTAssertEqual(trail["path_class"] as? String, "rewind-db")
+      XCTAssertEqual(trail["error_code"] as? Int, 28)
+    }
+
     func testBetaTrailIncludesTypedErrorContextWithoutRawMessage() throws {
       DesktopDiagnosticsManager.shared.recordBetaLogError(
         message: "Chat bridge returned Alice's private conversation title",

--- a/desktop/macos/Desktop/Tests/DesktopErrorTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopErrorTelemetryTests.swift
@@ -70,13 +70,29 @@ final class DesktopErrorTelemetryTests: XCTestCase {
       elapsedMs: 30_000,
       exitCode: nil,
       binaryPresent: true,
+      binaryPresentChecked: true,
       permissionGrantedChecked: true,
       permissionGranted: false)
 
     XCTAssertEqual(context.values["startup_stage"] as? String, "handshake_timed_out")
     XCTAssertEqual(context.values["configured_timeout_ms"] as? Int, 30_000)
+    XCTAssertEqual(context.values["binary_present_checked"] as? Bool, true)
     XCTAssertEqual(context.values["binary_present"] as? Bool, true)
     XCTAssertEqual(context.values["permission_granted"] as? Bool, false)
     XCTAssertEqual(context.values["port_bound_checked"] as? Bool, false)
+  }
+
+  func testBridgeStartDiagnosticsDoesNotClaimBinaryProbeBeforeItRuns() {
+    let context = AgentRuntimeProcess.startFailureDiagnostics(
+      failure: .launchFailed,
+      elapsedMs: 12,
+      exitCode: nil,
+      binaryPresent: false,
+      binaryPresentChecked: false,
+      permissionGrantedChecked: false,
+      permissionGranted: false)
+
+    XCTAssertEqual(context.values["binary_present_checked"] as? Bool, false)
+    XCTAssertEqual(context.values["binary_present"] as? Bool, false)
   }
 }

--- a/desktop/macos/Desktop/Tests/DesktopErrorTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopErrorTelemetryTests.swift
@@ -40,4 +40,43 @@ final class DesktopErrorTelemetryTests: XCTestCase {
     XCTAssertEqual(descriptor.errorDomain, "other")
     XCTAssertEqual(descriptor.errorCode, "other")
   }
+
+  func testStorageDiagnosticsExposeMeasurementsWithoutThePath() throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("storage-diagnostics-\(UUID().uuidString)", isDirectory: true)
+    let database = directory.appendingPathComponent("omi.db")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try Data(repeating: 7, count: 32).write(to: database)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let context = StorageFailureDiagnostics.context(
+      pathClass: "rewind-db",
+      containingURL: directory,
+      databaseURL: database,
+      error: NSError(domain: NSPOSIXErrorDomain, code: 28),
+      appIsTerminating: true)
+
+    XCTAssertEqual(context.values["path_class"] as? String, "rewind-db")
+    XCTAssertEqual(context.values["database_file_size_bytes"] as? Int64, 32)
+    XCTAssertEqual(context.values["error_domain"] as? String, NSPOSIXErrorDomain)
+    XCTAssertEqual(context.values["error_code"] as? Int, 28)
+    XCTAssertEqual(context.values["app_terminating"] as? Bool, true)
+    XCTAssertFalse(context.values.values.contains { "\($0)".contains(directory.path) })
+  }
+
+  func testBridgeStartDiagnosticsSeparatesTimeoutFromSpawnPreconditions() {
+    let context = AgentRuntimeProcess.startFailureDiagnostics(
+      failure: .handshakeTimedOut,
+      elapsedMs: 30_000,
+      exitCode: nil,
+      binaryPresent: true,
+      permissionGrantedChecked: true,
+      permissionGranted: false)
+
+    XCTAssertEqual(context.values["startup_stage"] as? String, "handshake_timed_out")
+    XCTAssertEqual(context.values["configured_timeout_ms"] as? Int, 30_000)
+    XCTAssertEqual(context.values["binary_present"] as? Bool, true)
+    XCTAssertEqual(context.values["permission_granted"] as? Bool, false)
+    XCTAssertEqual(context.values["port_bound_checked"] as? Bool, false)
+  }
 }

--- a/desktop/macos/Desktop/Tests/SentryBeforeSendScrubTests.swift
+++ b/desktop/macos/Desktop/Tests/SentryBeforeSendScrubTests.swift
@@ -104,4 +104,22 @@ final class SentryBeforeSendScrubTests: XCTestCase {
     // And a dev-build non-report is still dropped even if it looks otherwise genuine.
     XCTAssertTrue(drop(isUserReport: false, isDev: true, message: "genuine-looking error"))
   }
+
+  func testStorageFailureContextHasAnExplicitPrivacyAllowList() {
+    let context = StorageFailureDiagnostics.context(
+      pathClass: "video-chunk",
+      containingURL: FileManager.default.temporaryDirectory,
+      databaseURL: nil,
+      error: NSError(domain: NSPOSIXErrorDomain, code: 28),
+      appIsTerminating: false)
+
+    XCTAssertEqual(
+      Set(context.values.keys),
+      [
+        "path_class", "volume_free_bytes", "volume_total_bytes", "database_file_size_bytes",
+        "app_terminating", "error_domain", "error_code", "sqlite_result_code",
+        "sqlite_extended_result_code",
+      ])
+    XCTAssertFalse(context.values.values.contains { "\($0)".contains(FileManager.default.temporaryDirectory.path) })
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260725-sca-103-failure-diagnostics.json
+++ b/desktop/macos/changelog/unreleased/20260725-sca-103-failure-diagnostics.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved crash-report context when Rewind storage or the AI bridge fails to start"
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -17,6 +17,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Conversations/ConversationRepository.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+  - desktop/macos/Desktop/Sources/Rewind/Core/StorageFailureDiagnostics.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
   - desktop/macos/Desktop/Sources/Rewind/Services/OCREmbeddingService.swift
   - desktop/macos/Desktop/Sources/ResourceMonitor.swift

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -10,6 +10,7 @@ covers:
   - desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
   - desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
   - desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+  - desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
 preconditions:
   - automation_bridge_ready
 

--- a/desktop/macos/e2e/flows/rewind-artifact-recovery.yaml
+++ b/desktop/macos/e2e/flows/rewind-artifact-recovery.yaml
@@ -9,6 +9,7 @@ covers:
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindAbandonedVideoChunkRecovery.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindModels.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+  - desktop/macos/Desktop/Sources/Rewind/Core/StorageFailureDiagnostics.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
   - desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift


### PR DESCRIPTION
## Summary

- add a bounded, shared Sentry diagnostic-context surface for macOS failures
- attach volume, SQLite/POSIX, file-size, termination, and coarse path-class context to Rewind storage failures
- attach typed startup stage, preconditions, elapsed/timeout, and exit-code context to failed agent-runtime starts
- cover context values and the no-path allow-list in Swift tests
- register the existing single-owner authority ratchet that now guards recurring failure-class declarations

Closes SCA-103

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1

## Failure class

Failure-Class: none

## Verification

- `git diff --cached --check` — passed before commit.
- `scripts/pr-preflight --suggest` — identifies `INV-AUTH-1`, `INV-CHAT-1`, and `Failure-Class: none`; the PR body declares all three.
- `python3 .github/scripts/check_failure_class_guard_ratchet.py --pr-body-file /tmp/pr-10523-body.md` — passed after recording the existing single-owner authority guard.
- `python3 .github/scripts/test_check_failure_class_guard_ratchet.py` — 13 passed.
- `scripts/failure-class validate --base origin/main --head HEAD --pr-body-file /tmp/pr-10523-body.md` — passed.
- `make preflight` — started and completed `check-manifest-contract` successfully; the command's remaining output was not available from the local runner after its process detached, so it is not claimed as passed.
- `xcrun swift test -c debug --package-path desktop/macos/Desktop --filter 'DesktopErrorTelemetryTests|SentryBeforeSendScrubTests'` — not completed: initial SwiftPM dependency hydration left the package `.build` lock occupied; subsequent runs waited on that lock. No test success is claimed.

No app bundle was launched: this change affects failure-only diagnostics and does not alter user-facing behavior.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

