### PR TITLE
fix(desktop): make "Restart to update" actually install the update (#10509)

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-07-restart-to-update.json
+++ b/desktop/windows/changelog/unreleased/2026-07-restart-to-update.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "\"Restart to update\" now installs the update and reopens Omi on the new version, and it only appears once the update has actually downloaded."
+  ]
+}

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -149,7 +149,7 @@ import {
   destroyTray,
   isTrayCreated
 } from './tray'
-import { initAutoUpdater, getPendingUpdate, checkForUpdatesNow } from './updater'
+import { initAutoUpdater, getPendingUpdate, checkForUpdatesNow, installUpdateNow } from './updater'
 import {
   registerRecordShortcut,
   setRecordAcceleratorForced,
@@ -1360,6 +1360,9 @@ app.whenReady().then(async () => {
   // Query the staged update on demand (the update:ready event fires once,
   // usually while Settings isn't mounted — see updater.getPendingUpdate).
   ipcMain.handle('update:get-pending', () => getPendingUpdate())
+  // Install the staged update and relaunch (About → "Restart to update"). False
+  // means nothing was staged, so the UI must not pretend it restarted into it.
+  ipcMain.handle('update:install-now', () => installUpdateNow())
   // App identity for Settings → About.
   ipcMain.handle('app:get-version', () => ({ name: app.getName(), version: app.getVersion() }))
   // Manual update check (About). Inert in unpackaged dev (returns `unsupported`).

--- a/desktop/windows/src/main/updater.test.ts
+++ b/desktop/windows/src/main/updater.test.ts
@@ -19,7 +19,8 @@ const autoUpdater = vi.hoisted(() => ({
   autoInstallOnAppQuit: false,
   forceDevUpdateConfig: false,
   on: vi.fn(),
-  checkForUpdates: vi.fn().mockResolvedValue({ updateInfo: { version: '9.9.9' } })
+  checkForUpdates: vi.fn().mockResolvedValue({ updateInfo: { version: '9.9.9' } }),
+  quitAndInstall: vi.fn()
 }))
 vi.mock('electron-updater', () => ({ autoUpdater }))
 vi.mock('electron', () => ({
@@ -37,7 +38,7 @@ vi.mock('electron', () => ({
 }))
 vi.mock('./tray', () => ({ setTrayUpdateReady: vi.fn() }))
 
-import { initAutoUpdater } from './updater'
+import { initAutoUpdater, installUpdateNow, getPendingUpdate } from './updater'
 import { setAppSettings } from './appSettings'
 
 afterAll(() => rmSync(dir, { recursive: true, force: true }))
@@ -72,5 +73,30 @@ describe('updater beta channel wiring', () => {
     expect(autoUpdater.checkForUpdates).not.toHaveBeenCalled()
 
     vi.useRealTimers()
+  })
+})
+
+// #10509: "Restart to update" used to just quit the app and trust
+// autoInstallOnAppQuit, which installs without ever relaunching — and does
+// nothing at all when no update is staged, so users reopened on the old version.
+describe('installUpdateNow', () => {
+  it('does nothing when no update is staged', () => {
+    expect(getPendingUpdate()).toBeNull()
+    expect(installUpdateNow()).toBe(false)
+    expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled()
+  })
+
+  it('installs and relaunches once an update is downloaded', () => {
+    const downloaded = autoUpdater.on.mock.calls.find(
+      (c) => c[0] === 'update-downloaded'
+    )?.[1] as (info: { version: string }) => void
+    expect(downloaded).toBeTypeOf('function')
+    downloaded({ version: '2.0.0' })
+
+    expect(getPendingUpdate()).toEqual({ version: '2.0.0' })
+    expect(installUpdateNow()).toBe(true)
+    // isSilent + isForceRunAfter: install without a wizard, come back up on the
+    // new version instead of leaving the user with a closed app.
+    expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, true)
   })
 })

--- a/desktop/windows/src/main/updater.ts
+++ b/desktop/windows/src/main/updater.ts
@@ -9,6 +9,7 @@
 import { app, type BrowserWindow } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { setTrayUpdateReady } from './tray'
+import { markQuitting } from './lifecycle'
 import { getAppSettings, onAppSettingsChanged } from './appSettings'
 import { betaOptInToAllowPrerelease, resolveBetaChannelChange } from './updaterChannel'
 import type { UpdateCheckResult } from '../shared/types'
@@ -45,6 +46,23 @@ export async function checkForUpdatesNow(): Promise<UpdateCheckResult> {
     console.warn('[updater] manual check failed (non-fatal):', message)
     return { status: 'error', message }
   }
+}
+
+/**
+ * Install the staged update now (Settings → About "Restart to update"). Plain
+ * app.quit() relies on autoInstallOnAppQuit, which runs the NSIS installer
+ * *without* relaunching — the app just disappears and the user has to reopen it.
+ * quitAndInstall(silent, forceRunAfter) installs and comes back up on the new
+ * version, which is what the button promises.
+ *
+ * Returns false when nothing is actually staged (nothing to install), so the UI
+ * can say so instead of quitting the app for no reason.
+ */
+export function installUpdateNow(): boolean {
+  if (!started || !pendingUpdate) return false
+  markQuitting()
+  autoUpdater.quitAndInstall(true, true)
+  return true
 }
 
 export function initAutoUpdater(getMainWindow: () => BrowserWindow | null): void {

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -674,6 +674,7 @@ const omi: OmiBridgeApi = {
   getBetaUpdatesOptIn: () => ipcRenderer.invoke('update:get-beta-optin'),
   setBetaUpdatesOptIn: (enabled: boolean) => ipcRenderer.invoke('update:set-beta-optin', enabled),
   getPendingUpdate: () => ipcRenderer.invoke('update:get-pending'),
+  installUpdateNow: () => ipcRenderer.invoke('update:install-now'),
   suspendShortcutCapture: () => ipcRenderer.send('shortcuts:suspend-capture'),
   resumeShortcutCapture: () => ipcRenderer.send('shortcuts:resume-capture'),
   // --- Track 6 (UI surfaces) additions ---

--- a/desktop/windows/src/renderer/src/components/settings/tabs/AboutTab.test.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/AboutTab.test.tsx
@@ -12,6 +12,7 @@ const getBetaUpdatesOptIn = vi.fn()
 const setBetaUpdatesOptIn = vi.fn()
 const whatsNewOpenNotes = vi.fn()
 const quitApp = vi.fn()
+const installUpdateNow = vi.fn()
 
 const renderTab = (): void => {
   render(
@@ -30,6 +31,7 @@ beforeEach(() => {
   setBetaUpdatesOptIn.mockReset().mockResolvedValue(true)
   whatsNewOpenNotes.mockReset()
   quitApp.mockReset()
+  installUpdateNow.mockReset().mockResolvedValue(true)
   ;(globalThis as unknown as { window: { omi: unknown } }).window.omi = {
     getAppVersion,
     getPendingUpdate,
@@ -38,7 +40,8 @@ beforeEach(() => {
     getBetaUpdatesOptIn,
     setBetaUpdatesOptIn,
     whatsNewOpenNotes,
-    quitApp
+    quitApp,
+    installUpdateNow
   }
 })
 afterEach(cleanup)
@@ -88,6 +91,32 @@ describe('AboutTab', () => {
     renderTab()
     await waitFor(() => expect(screen.getByText(/Version 2\.0\.0 is ready/)).toBeTruthy())
     fireEvent.click(screen.getByText('Restart to update'))
-    expect(quitApp).toHaveBeenCalled()
+    // Installs + relaunches. A plain quit would just close the app with the
+    // update never applied (#10509).
+    await waitFor(() => expect(installUpdateNow).toHaveBeenCalled())
+    expect(quitApp).not.toHaveBeenCalled()
+  })
+
+  // #10509: a merely *available* update is not a downloaded one. Promoting the
+  // check result to "Update ready" gave users a restart button that quit the app
+  // with nothing staged, so it reopened on the same version.
+  it('does not claim an update is ready just because one is available', async () => {
+    checkForUpdates.mockResolvedValue({ status: 'update-available', version: '2.0.0' })
+    renderTab()
+    fireEvent.click(screen.getByText('Check for updates'))
+    await waitFor(() => expect(screen.getByText(/downloading in the background/)).toBeTruthy())
+    expect(screen.queryByText('Restart to update')).toBeNull()
+    expect(screen.queryByText(/is ready\. Restart Omi to apply it\./)).toBeNull()
+  })
+
+  it('keeps the app open when the staged update vanished', async () => {
+    getPendingUpdate.mockResolvedValue({ version: '2.0.0' })
+    installUpdateNow.mockResolvedValue(false)
+    renderTab()
+    await waitFor(() => expect(screen.getByText(/Version 2\.0\.0 is ready/)).toBeTruthy())
+    fireEvent.click(screen.getByText('Restart to update'))
+    await waitFor(() => expect(screen.getByText(/no longer staged/)).toBeTruthy())
+    expect(quitApp).not.toHaveBeenCalled()
+    expect(screen.queryByText('Restart to update')).toBeNull()
   })
 })

--- a/desktop/windows/src/renderer/src/components/settings/tabs/AboutTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/AboutTab.tsx
@@ -46,7 +46,7 @@ function checkResultMessage(r: UpdateCheckResult): string {
     case 'up-to-date':
       return `You're on the latest version (${r.version ?? 'current'}).`
     case 'update-available':
-      return `Update available${r.version ? ` (version ${r.version})` : ''} — it will install the next time you restart Omi.`
+      return `Update available${r.version ? ` (version ${r.version})` : ''} — downloading in the background. Omi will offer to restart once it's ready.`
     case 'error':
       return `Couldn't check for updates${r.message ? `: ${r.message}` : '.'}`
     default:
@@ -82,13 +82,27 @@ export function AboutTab(): React.JSX.Element {
     setCheckMsg(null)
     try {
       const res = await window.omi?.checkForUpdates?.()
-      if (res) {
-        setCheckMsg(checkResultMessage(res))
-        if (res.status === 'update-available' && res.version) setPending(res.version)
-      }
+      // Only report the result here. `update-available` means a newer version
+      // exists in the feed, NOT that it is downloaded — promoting it to the
+      // "Update ready / Restart to update" affordance made the button quit the
+      // app with nothing staged, so it reopened on the same version (#10509).
+      // The staged state comes from main alone (getPendingUpdate/onUpdateReady).
+      if (res) setCheckMsg(checkResultMessage(res))
     } finally {
       setChecking(false)
     }
+  }
+
+  // Install the staged update and relaunch on the new version. Quitting alone
+  // relies on install-on-quit, which never brings the app back up. If main says
+  // nothing is staged, keep the app open and say so rather than quitting.
+  const restartToUpdate = async (): Promise<void> => {
+    const installing = await window.omi?.installUpdateNow?.().catch(() => false)
+    if (installing) return
+    setPending(null)
+    setCheckMsg(
+      'That update is no longer staged. Omi will offer to restart once it downloads again.'
+    )
   }
 
   // Opt in/out of pre-release (beta) builds. The pref is persisted in main and the
@@ -194,7 +208,7 @@ export function AboutTab(): React.JSX.Element {
           control={
             <button
               type="button"
-              onClick={() => window.omi?.quitApp?.()}
+              onClick={() => void restartToUpdate()}
               className="rounded-md bg-white px-3 py-1.5 text-xs font-medium text-black transition-opacity hover:opacity-90"
             >
               Restart to update

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -127,12 +127,7 @@ export type ChatMessage = {
  * See lib/sync/outbox.ts for the transition rules and dedupe strategy.
  */
 export type ConversationSyncState =
-  | 'local_only'
-  | 'pending'
-  | 'posting'
-  | 'done'
-  | 'failed'
-  | 'unconfirmed'
+  'local_only' | 'pending' | 'posting' | 'done' | 'failed' | 'unconfirmed'
 
 /** One transcript segment in the `/v1/conversations/from-segments` request shape
  * (snake_case matches the wire verbatim). `start`/`end` are WALL-CLOCK
@@ -1213,6 +1208,9 @@ export type OmiBridgeApi = {
   /** The update staged for install-on-quit, if any (query on Settings mount —
    *  the one-shot update:ready event usually fires while Settings is unmounted). */
   getPendingUpdate: () => Promise<{ version: string } | null>
+  /** Install the staged update and relaunch on the new version. Resolves false
+   *  when nothing is staged (nothing downloaded yet) — the app stays open. */
+  installUpdateNow: () => Promise<boolean>
   /** App display name + version (from Electron's app metadata). Shown in About. */
   getAppVersion: () => Promise<{ name: string; version: string }>
   /** Manually trigger an update check (Settings → About "Check for updates").
@@ -1703,13 +1701,7 @@ export type MemoryExportResult = {
 }
 
 export type IndexedFileType =
-  | 'document'
-  | 'code'
-  | 'image'
-  | 'media'
-  | 'archive'
-  | 'application'
-  | 'other'
+  'document' | 'code' | 'image' | 'media' | 'archive' | 'application' | 'other'
 
 export type IndexedFileRecord = {
   path: string
@@ -1803,14 +1795,7 @@ export type RebuildResult = {
 // the macOS-parity local graph synthesized from indexed_files + memories and
 // consumed by the chat pre-step. Never conflate the two mechanisms.
 export type LocalKGNodeType =
-  | 'project'
-  | 'app'
-  | 'technology'
-  | 'person'
-  | 'org'
-  | 'interest'
-  | 'file_group'
-  | 'card' // background-synthesized natural-language overview served to the chat floor
+  'project' | 'app' | 'technology' | 'person' | 'org' | 'interest' | 'file_group' | 'card' // background-synthesized natural-language overview served to the chat floor
 
 export type LocalKGNode = {
   id: string // `${slug(label)}:${nodeType}` — stable across re-synthesis


### PR DESCRIPTION
## Bug (#10509)

On Omi Desktop for Windows, Settings → About shows **"Update ready — Version X is ready. Restart Omi to apply it."** with a `Restart to update` button. Clicking it closes the app, and reopening lands on the *same* version — the update was never applied.

## Root cause

Two defects on the same path:

1. **The renderer invented the "staged" state.** `AboutTab.checkForUpdates` promoted a check result of `update-available` to `setPending(version)`. `update-available` only means a newer version exists in the feed — it is **not** downloaded. Enabling "Receive beta updates" kicks that check immediately (`toggleBeta` → `checkForUpdates`), which is exactly the reporter's repro: toggle beta → "Update ready" appears at once, before anything has downloaded.
2. **The button never installed anything.** It called `quitApp()` and relied on `autoUpdater.autoInstallOnAppQuit`. With nothing staged that installs nothing; even when something *is* staged, install-on-quit never relaunches, so the app just disappears.

The staged-update state has one authoritative owner — main (`updater.ts`, set from `update-downloaded`) — and the renderer was a second writer for it.

## Fix

- `AboutTab`: the check only reports its result (wording corrected to "downloading in the background"). The ready affordance comes from main alone (`getPendingUpdate` / `update:ready`).
- New `update:install-now` IPC → `installUpdateNow()` in `updater.ts`: `autoUpdater.quitAndInstall(true, true)` — silent install, relaunch on the new version. Returns `false` when nothing is staged, and the UI then keeps the app open and says so instead of quitting for nothing.
- `markQuitting()` before install so close-to-tray handlers don't fight the quit. `quitAndInstall` goes through `app.quit()`, so `before-quit`/`will-quit` teardown (clean-exit marker, tray, helpers) still runs; if the installer file is missing, electron-updater emits `error` (already handled non-fatally) and the app stays open — no path here is worse than today's behavior.

## Tested

- `vitest run src/main/updater.test.ts src/renderer/.../AboutTab.test.tsx` → **11/11 pass**.
- New regression test **fails on the old code**: restoring `setPending` on `update-available` makes "does not claim an update is ready just because one is available" fail (`expected <button …> to be null`).
- New main-process tests: `installUpdateNow()` is a no-op with nothing staged, and calls `quitAndInstall(true, true)` after `update-downloaded`.
- `npm run typecheck` (node + web) clean; `eslint` clean on touched files; prettier applied.
- Pre-existing, unrelated failures in `settings/tabs/{Advanced,Agents,Shortcuts,Transcription}` reproduce identically on a clean `origin/main` checkout (19 failed both before and after).
- Windows-only app: the packaged installer path could not be exercised from macOS. `quitAndInstall(isSilent, isForceRunAfter)` is electron-updater's canonical install-and-relaunch call (verified against the vendored `electron-updater@6.8.9` `BaseUpdater` source: it spawns the installer and then `app.quit()`s gracefully).

Product-Invariants: none
Failure-Class: FC-split-mutation-authority

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

