### PR TITLE
ci: consolidate impact routing

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -69,10 +69,6 @@ runs:
         fi
 
         FILES=$(scripts/changed-files "$DIFF_BASE"...HEAD)
-        # Translation-only changes cannot break the Android build: the ARBs and
-        # their generated localization classes still go through Dart Analyze and
-        # Flutter Tests, so the expensive Gradle APK build adds no signal.
-        APP_COMPILE_FILES=$(echo "$FILES" | grep -vE '^app/lib/l10n/app_[A-Za-z_]+\.arb$|^app/lib/l10n/app_localizations(_[A-Za-z_]+)?\.dart$' || true)
         echo "$FILES"
         echo "diff_base=$DIFF_BASE" >> "$GITHUB_OUTPUT"
 
@@ -89,13 +85,15 @@ runs:
         has_backend_async_gate=$(echo "$FILES" | grep -qE '^backend/.*\.py$|^backend/agent-proxy/Dockerfile$|^\.github/workflows/(repo-checks|backend-checks)\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
         has_backend_isolation_gate=$(echo "$FILES" | grep -qE '^backend/.*\.py$|^backend/tests/\.(import_time_side_effects_legacy|module_stub_legacy_allowlist)$|^\.github/workflows/(repo-checks|backend-checks)\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
         has_backend_workflow_contracts=$(echo "$FILES" | grep -qE '^\.gitignore$|^backend/testing/workflow_contracts\.json$|^backend/scripts/(check_workflow_contracts|select_backend_unit_tests)\.py$|^scripts/(changed-files|install-git-hooks\.sh|pre-push|pre-push-singleflight)$|^\.github/workflows/(backend-checks|backend-unit-tests|desktop-checks|desktop-swift-ci|repo-checks)\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
-        has_desktop_agent_runtime=$(echo "$FILES" | grep -qE '^desktop/macos/agent/|^desktop/macos/pi-mono-extension/|^desktop/macos/run\.sh$|^desktop/macos/scripts/(audit-desktop-bundle-deps|prepare-agent-runtime|prepare-desktop-bundle-native-deps|test-tool-surfaces|agent-logic-harness)\.sh$|^codemagic\.yaml$|^scripts/pre-push$|^\.github/workflows/(repo-checks|desktop-checks)\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
-        has_app_codegen=$(echo "$FILES" | grep -qE '^app/lib/|^app/pubspec\.yaml$|^app/pubspec\.lock$|^app/build\.yaml$|^app/assets/|^\.github/workflows/(repo-checks|mobile-app-checks)\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
-        has_app_l10n=$(echo "$FILES" | grep -qE '^app/lib/l10n/.*\.arb$|^app/l10n\.yaml$|^\.github/workflows/(repo-checks|mobile-app-checks)\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
-        has_app_compile_smoke=$(echo "$APP_COMPILE_FILES" | grep -qE '^app/(lib/|android/|ios/|pubspec\.yaml$|pubspec\.lock$|build\.yaml$|analysis_options\.yaml$|l10n\.yaml$|flavorizr\.yaml$|setup/prebuilt/|setup/scripts/|config/|assets/)|^\.github/workflows/(repo-checks|mobile-app-checks)\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
-        has_app_dart=$(echo "$FILES" | grep -qE '^app/(lib|test|integration_test)/.*\.dart$|^app/pubspec\.(yaml|lock)$|^app/analysis_options\.yaml$|^app/analysis_baseline\.json$|^app/scripts/analyze_ratchet\.sh$|^app/test\.sh$|^\.github/workflows/mobile-app-checks\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
-        has_desktop_rust=$(echo "$FILES" | grep -qE '^desktop/macos/Backend-Rust/|^\.github/workflows/(repo-checks|desktop-checks)\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
         has_desktop_auth_session_ratchet=$(echo "$FILES" | grep -qE '^desktop/macos/Desktop/Sources/(APIClient|AuthService|AuthSessionCoordinator|DesktopKeychainStore|OmiApp)\.swift$|^desktop/macos/Desktop/Sources/Auth/.*\.swift$|^desktop/macos/scripts/smoke-signed-desktop-artifact\.sh$|^codemagic\.yaml$|^\.github/scripts/check_desktop_auth_session\.py$|^\.github/workflows/(repo-checks|desktop-checks)\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
+
+        IMPACT_FILES=$(mktemp)
+        printf '%s\n' "$FILES" > "$IMPACT_FILES"
+        python3 scripts/pre_push_ci_prediction.py \
+          --changed-files "$IMPACT_FILES" \
+          --base "$DIFF_BASE" \
+          --event "${{ github.event_name }}" \
+          --github-output "$GITHUB_OUTPUT"
 
         {
           echo "has_dart=$has_dart"
@@ -111,12 +109,6 @@ runs:
           echo "has_backend_async_gate=$has_backend_async_gate"
           echo "has_backend_isolation_gate=$has_backend_isolation_gate"
           echo "has_backend_workflow_contracts=$has_backend_workflow_contracts"
-          echo "has_desktop_agent_runtime=$has_desktop_agent_runtime"
-          echo "has_app_codegen=$has_app_codegen"
-          echo "has_app_l10n=$has_app_l10n"
-          echo "has_app_compile_smoke=$has_app_compile_smoke"
-          echo "has_app_dart=$has_app_dart"
-          echo "has_desktop_rust=$has_desktop_rust"
           echo "has_desktop_auth_session_ratchet=$has_desktop_auth_session_ratchet"
         } >> "$GITHUB_OUTPUT"
 
@@ -124,12 +116,6 @@ runs:
           echo "has_format=true" >> "$GITHUB_OUTPUT"
         else
           echo "has_format=false" >> "$GITHUB_OUTPUT"
-        fi
-
-        if [ "$has_app_codegen" = "true" ] || [ "$has_app_l10n" = "true" ]; then
-          echo "has_flutter_generated=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "has_flutter_generated=false" >> "$GITHUB_OUTPUT"
         fi
 
         if [ "$has_backend_runtime_env" = "true" ] || [ "$has_backend_async_gate" = "true" ] || [ "$has_backend_isolation_gate" = "true" ] || [ "$has_backend_workflow_contracts" = "true" ]; then

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -21,7 +21,7 @@ checks:
     reason: "pre-push check selection must use the final PR diff rather than a stale remote feature tip"
   - id: pre-push-ci-prediction-tests
     command: ["python3", ".github/scripts/test_pre_push_ci_prediction.py"]
-    triggers: ["scripts/pre-push", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_pre_push_ci_prediction.py", ".github/checks-manifest.yaml"]
+    triggers: ["scripts/pre-push", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_pre_push_ci_prediction.py", "desktop/macos/scripts/desktop-flow-lint.py", "desktop/macos/scripts/desktop_flow_contract.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#9440: local CI prediction must select only bounded Flutter generator, desktop-flow, and Windows KG-worker checks for the final PR diff"
   - id: setup-pre-push-prerequisites
@@ -276,7 +276,7 @@ checks:
     reason: "conversation lifecycle has one mutation owner"
   - id: desktop-swift-ci-contract
     command: ["python3", ".github/scripts/test_desktop_swift_ci_contract.py"]
-    triggers: [".github/workflows/desktop-swift-ci.yml", ".github/scripts/test_desktop_swift_ci_contract.py"]
+    triggers: [".github/workflows/desktop-swift-ci.yml", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_desktop_swift_ci_contract.py"]
     lanes: ["local", "ci"]
     reason: "#9843 Rung-0: desktop Swift CI must pin its toolchain and cache on Package.resolved"
   - id: desktop-candidate-source-gate
@@ -286,7 +286,7 @@ checks:
     reason: "candidate tags require successful Release Eligibility and both Desktop Swift checks for the exact newest queued releasable desktop SHA"
   - id: desktop-manifest-routes
     command: ["python3", ".github/scripts/test_desktop_manifest_routes.py"]
-    triggers: [".github/workflows/desktop-swift-ci.yml", ".github/checks-manifest.yaml", ".github/scripts/run_checks.py", ".github/scripts/test_desktop_manifest_routes.py"]
+    triggers: [".github/workflows/desktop-swift-ci.yml", ".github/checks-manifest.yaml", ".github/scripts/run_checks.py", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_desktop_manifest_routes.py"]
     lanes: ["local", "ci"]
     reason: "#9843 Ticket 02: macOS-only manifest checks must have an executable CI route"
   - id: desktop-swift-format-wrapper

--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -23,6 +23,10 @@ EXEMPT_DESKTOP_PATHS = {
     # Pre-tag readiness gate script: internal release infrastructure (runs on the
     # trusted M1 before tagging), no user-facing app surface.
     "desktop/macos/scripts/pre-tag-readiness.sh",
+    # CI-only flow-validation script and its shared action-source inventory do
+    # not alter the desktop application a user receives.
+    "desktop/macos/scripts/desktop-flow-lint.py",
+    "desktop/macos/scripts/desktop_flow_contract.py",
 }
 # Server-side Rust backend changes are internal reliability work, not user-facing app notes.
 # Test and release-infra changes are likewise never user-facing app notes; the

--- a/.github/scripts/run_checks.py
+++ b/.github/scripts/run_checks.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import Any
 
-
 VALID_PLATFORMS = {"all", "macos", "linux"}
 
 
@@ -50,6 +49,14 @@ class Exemption:
 class Manifest:
     checks: tuple[Check, ...]
     exempt: tuple[Exemption, ...]
+
+
+@dataclass(frozen=True)
+class CheckSelection:
+    """A manifest check together with the paths that selected it."""
+
+    check: Check
+    matched_paths: tuple[str, ...]
 
 
 def _parse_value(raw: str) -> Any:
@@ -103,8 +110,7 @@ def load_manifest(path: Path) -> Manifest:
         for item in raw.get("checks", [])
     )
     exempt = tuple(
-        Exemption(path=str(item.get("path", "")), reason=str(item.get("reason", "")))
-        for item in raw.get("exempt", [])
+        Exemption(path=str(item.get("path", "")), reason=str(item.get("reason", ""))) for item in raw.get("exempt", [])
     )
     return Manifest(checks=checks, exempt=exempt)
 
@@ -187,8 +193,44 @@ def trigger_matches(pattern: str, path: str) -> bool:
     return False
 
 
-def _platform_matches(check: Check, platform: str) -> bool:
+def _platform_matches(check: Check, platform: str, *, exclusive: bool = False) -> bool:
+    if exclusive:
+        # A macOS-exclusive query intentionally excludes portable checks.  Those
+        # remain owned by the Linux Repo Checks lane even though they could also
+        # execute on a Mac.
+        return set(check.platforms) == {platform}
     return not check.platforms or "all" in check.platforms or platform in check.platforms
+
+
+def matching_paths(check: Check, files: list[str]) -> tuple[str, ...]:
+    """Return changed paths that caused *check* to be selected."""
+    if "all" in check.triggers:
+        return tuple(files) if files else ("all",)
+    return tuple(path for path in files if any(trigger_matches(pattern, path) for pattern in check.triggers))
+
+
+def resolve_check_selections(
+    manifest: Manifest,
+    files: list[str],
+    lane: str,
+    *,
+    include_pr_body_checks: bool = True,
+    platform: str = "all",
+    exclusive_platform: bool = False,
+) -> list[CheckSelection]:
+    """Resolve checks with their manifest-owned path and reason evidence."""
+    selections: list[CheckSelection] = []
+    for check in manifest.checks:
+        if lane not in check.lanes:
+            continue
+        if not include_pr_body_checks and check.requires_pr_body:
+            continue
+        if not _platform_matches(check, platform, exclusive=exclusive_platform):
+            continue
+        paths = matching_paths(check, files)
+        if paths:
+            selections.append(CheckSelection(check=check, matched_paths=paths))
+    return selections
 
 
 def resolve_checks(
@@ -198,23 +240,22 @@ def resolve_checks(
     *,
     include_pr_body_checks: bool = True,
     platform: str = "all",
+    exclusive_platform: bool = False,
 ) -> list[Check]:
     return [
-        check
-        for check in manifest.checks
-        if lane in check.lanes
-        and (include_pr_body_checks or not check.requires_pr_body)
-        and _platform_matches(check, platform)
-        and (
-            "all" in check.triggers
-            or any(trigger_matches(pattern, path) for pattern in check.triggers for path in files)
+        selection.check
+        for selection in resolve_check_selections(
+            manifest,
+            files,
+            lane,
+            include_pr_body_checks=include_pr_body_checks,
+            platform=platform,
+            exclusive_platform=exclusive_platform,
         )
     ]
 
 
-def skipped_platform_checks(
-    manifest: Manifest, files: list[str], lane: str, platform: str
-) -> list[Check]:
+def skipped_platform_checks(manifest: Manifest, files: list[str], lane: str, platform: str) -> list[Check]:
     """Checks that match lane+triggers but are skipped due to platform."""
     return [
         check
@@ -310,6 +351,17 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Platform filter (auto-detected if omitted). macOS-only checks are skipped on other platforms.",
     )
+    parser.add_argument(
+        "--exclusive-platform",
+        action="store_true",
+        help="Select only checks scoped exclusively to --platform (for example macOS-only, not portable, checks).",
+    )
+    parser.add_argument(
+        "--output",
+        choices=("human", "json"),
+        default="human",
+        help="Selection output format. JSON implies --list and includes check IDs, matching paths, and reasons.",
+    )
     return parser.parse_args()
 
 
@@ -332,21 +384,45 @@ def main() -> int:
         print(f"FAIL: could not resolve manifest checks: {exc}", file=sys.stderr)
         return 2
     detected_platform = args.platform or detect_platform()
-    checks = resolve_checks(
+    selections = resolve_check_selections(
         manifest,
         files,
         args.lane,
         include_pr_body_checks=not args.skip_pr_body_checks,
         platform=detected_platform,
+        exclusive_platform=args.exclusive_platform,
     )
+    checks = [selection.check for selection in selections]
+    if args.output == "json":
+        print(
+            json.dumps(
+                {
+                    "lane": args.lane,
+                    "platform": detected_platform,
+                    "exclusive_platform": args.exclusive_platform,
+                    "checks": [
+                        {
+                            "id": selection.check.id,
+                            "matched_paths": list(selection.matched_paths),
+                            "reason": selection.check.reason,
+                        }
+                        for selection in selections
+                    ],
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
     print(
-        f"Check manifest: lane={args.lane} platform={detected_platform} "
+        f"Check manifest: lane={args.lane} platform={detected_platform} exclusive_platform={args.exclusive_platform} "
         f"base={resolved_base[:12]} head={args.head} files={len(files)}"
     )
     for check in checks:
         print(f"  SELECTED {check.id}: {check.reason}")
     for skip in skipped_platform_checks(manifest, files, args.lane, detected_platform):
-        print(f"  SKIPPED {skip.id}: platform-only (requires {', '.join(skip.platforms)}, running on {detected_platform})")
+        print(
+            f"  SKIPPED {skip.id}: platform-only (requires {', '.join(skip.platforms)}, running on {detected_platform})"
+        )
     if args.list:
         return 0
 

--- a/.github/scripts/test_desktop_changelog.py
+++ b/.github/scripts/test_desktop_changelog.py
@@ -74,6 +74,10 @@ class ChangelogRequirementTests(unittest.TestCase):
             "desktop/macos/scripts/qualify-desktop-beta.sh",
             # Sibling qualification-runner helper (EXEMPT_DESKTOP_PATHS).
             "desktop/macos/scripts/qualification-swift-cache.sh",
+            # CI-only flow validation and its shared source inventory do not
+            # alter the desktop application users receive.
+            "desktop/macos/scripts/desktop-flow-lint.py",
+            "desktop/macos/scripts/desktop_flow_contract.py",
             # Test files are never user-facing app changes (EXEMPT_DESKTOP_PATH_PREFIXES).
             # #10374's timeout bump touched this file; without the exemption the
             # post-merge push run of the changelog gate reddened main (#10387).

--- a/.github/scripts/test_desktop_manifest_routes.py
+++ b/.github/scripts/test_desktop_manifest_routes.py
@@ -1,188 +1,110 @@
 #!/usr/bin/env python3
-"""Cross-workflow contract test: macOS-scoped manifest checks must be runnable on macOS CI.
+"""Behavioral routing fixtures for macOS-only deterministic checks.
 
-Ticket 02 of #9843 gave the deterministic check manifest a ``platforms`` field so a
-check can declare ``platforms: ["macos"]`` and execute only under the macOS CI
-workflow (``.github/workflows/desktop-swift-ci.yml``). That workflow gates its
-manifest step behind a changed-file ``grep`` (the "Check changed files" step that
-sets ``should_run``). If a macOS-only check's trigger paths fall outside that gate,
-editing one of those files sets ``should_run=false`` and the manifest step never
-runs -- the check is silently stranded with no CI route at all.
-
-This test pins the contract:
-
-  1. The macOS workflow has a step running ``run_checks.py`` with ``--platform macos``.
-  2. Every macOS-scoped manifest check has at least one trigger path covered by the
-     macOS workflow's changed-file gate, so editing a trigger actually wakes the
-     manifest step on macOS CI.
-  3. Adversarial: a macOS-only check whose trigger escapes the gate is detected as a
-     missing route.
-
-Stdlib-only (no PyYAML dependency) so it runs on any CI runner.
+The desktop workflow asks ``run_checks.py`` for an exclusive macOS selection
+before allocating a hosted runner. These fixtures exercise that resolver
+directly instead of trying to infer routes from workflow regex strings.
 """
 
 from __future__ import annotations
 
 import re
+import sys
 import unittest
 from pathlib import Path
 
-from run_checks import Check, load_manifest, trigger_matches
+from run_checks import Check, Manifest, resolve_check_selections, trigger_matches
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parents[1]
 MANIFEST_PATH = REPO_ROOT / ".github/checks-manifest.yaml"
-WORKFLOW_PATH = REPO_ROOT / ".github/workflows/desktop-swift-ci.yml"
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-# The changed-file gate is a `grep -qE 'PATTERN'` over changed file paths. Capture
-# the single-quoted extended-regex argument (matches -qE, -E, -Eq, ...). The gate
-# uses single quotes, which never contain an escaped single quote, so '[^']+' is safe.
-_GATE_RE = re.compile(r"grep\s+-[A-Za-z]*E[A-Za-z]*\s+'([^']+)'")
-
-
-def _workflow_text() -> str:
-    """Return the raw workflow YAML text (no PyYAML needed)."""
-    return WORKFLOW_PATH.read_text(encoding="utf-8")
-
-
-def _runs_macos_manifest(run_body: str) -> bool:
-    """True if *run_body* invokes run_checks.py scoped to the macos platform."""
-    return "run_checks.py" in run_body and bool(re.search(r"--platform[ =]macos\b", run_body))
-
-
-def _extract_gate(run_body: str) -> str | None:
-    match = _GATE_RE.search(run_body)
-    return match.group(1) if match else None
-
-
-def _macos_route(workflow_text: str) -> tuple[str | None, bool]:
-    """Return ``(changed-file gate regex, has_macos_manifest_step)``.
-
-    The gate is taken from the step sequence surrounding the ``run_checks.py
-    --platform macos`` invocation: that job's changed-file ``grep`` is the only
-    thing standing between a changed trigger and the manifest step executing.
-
-    Works on raw YAML text (no PyYAML) by searching for the ``run_checks.py
-    --platform macos`` marker, then scanning backward for the nearest gate.
-    """
-    has_manifest = _runs_macos_manifest(workflow_text)
-    if not has_manifest:
-        return None, False
-    # The gate appears before the manifest step in the same job. Search the full
-    # text for the last gate before the run_checks.py invocation.
-    manifest_pos = workflow_text.find("run_checks.py")
-    # Find the first gate in the text (there is typically one per job)
-    gate_match = _GATE_RE.search(workflow_text)
-    gate = gate_match.group(1) if gate_match and gate_match.start() < manifest_pos else None
-    # If gate is after manifest step, try to find one before
-    if gate is None:
-        for m in _GATE_RE.finditer(workflow_text):
-            if m.start() < manifest_pos:
-                gate = m.group(1)
-    return gate, True
+from pre_push_ci_prediction import resolve_impact  # noqa: E402
+from run_checks import load_manifest  # noqa: E402
 
 
 def _materialize_trigger(pattern: str) -> list[str]:
-    """Concrete repo-relative paths that would activate *pattern*.
-
-    ``all`` is a marker, not a path, so it yields nothing -- a check whose only
-    trigger is ``all`` routes whenever the manifest step fires. For real globs we
-    synthesize representative paths (recursively, across zero/one intermediate
-    directory) and keep only those the real resolver would actually accept, so we
-    never claim coverage from a path the check would not match.
-    """
+    """Produce concrete paths accepted by a manifest trigger glob."""
     if pattern == "all":
-        return []
-    raw: list[str] = []
+        return ["desktop/macos/Desktop/Sources/Probe.swift"]
     if pattern.endswith("/**"):
         prefix = pattern[:-3].rstrip("/")
-        raw.extend([f"{prefix}/probe", f"{prefix}/nested/probe"])
+        candidates = [f"{prefix}/probe", f"{prefix}/nested/probe"]
     else:
-        bases = {re.sub(r"/\*\*/", "/", pattern), re.sub(r"/\*\*/", "/nested/", pattern)}
-        for base in bases:
-            raw.append(re.sub(r"\*+", "probe", base))
-    return [candidate for candidate in raw if trigger_matches(pattern, candidate)]
+        candidates = [
+            re.sub(r"\*+", "probe", re.sub(r"/\*\*/", "/", pattern)),
+            re.sub(r"\*+", "probe", re.sub(r"/\*\*/", "/nested/", pattern)),
+        ]
+    return [candidate for candidate in candidates if trigger_matches(pattern, candidate)]
 
 
-def _trigger_covered_by_gate(pattern: str, gate_regex: str) -> bool:
-    """True if a path that activates *pattern* also matches the *gate_regex* (grep -E)."""
-    return any(re.search(gate_regex, path) for path in _materialize_trigger(pattern))
-
-
-def _check_has_route(check: Check, gate_regex: str) -> bool:
-    """True if *check* can be woken on macOS CI through the changed-file gate."""
-    if "all" in check.triggers:
-        return True  # matches every change; routes whenever the manifest step fires
-    return any(_trigger_covered_by_gate(trigger, gate_regex) for trigger in check.triggers)
+def resolve_macos_only(paths: list[str], manifest: Manifest) -> list[str]:
+    """The exact exclusive-platform query used by the desktop workflow."""
+    return [
+        selection.check.id
+        for selection in resolve_check_selections(
+            manifest,
+            paths,
+            "ci",
+            include_pr_body_checks=False,
+            platform="macos",
+            exclusive_platform=True,
+        )
+    ]
 
 
 class DesktopManifestRoutesTests(unittest.TestCase):
-    """Guard the macOS manifest-check route in desktop-swift-ci.yml."""
+    """Verify manifest selection behavior for the macOS static phase."""
 
-    def setUp(self) -> None:
-        workflow_text = _workflow_text()
-        self.gate, self.has_manifest_step = _macos_route(workflow_text)
-        self.manifest = load_manifest(MANIFEST_PATH)
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = load_manifest(MANIFEST_PATH)
 
-    def test_macos_manifest_step_exists(self) -> None:
-        """desktop-swift-ci.yml must run run_checks.py with --platform macos."""
-        self.assertTrue(
-            self.has_manifest_step,
-            "desktop-swift-ci.yml must run run_checks.py with --platform macos so "
-            "macOS-scoped checks actually execute on macOS CI.",
-        )
-
-    def test_changed_file_gate_is_present(self) -> None:
-        """The manifest-check job must declare a changed-file gate (grep -E)."""
-        self.assertTrue(
-            self.gate,
-            "desktop-swift-ci.yml must declare a changed-file gate (grep -E) in the "
-            "job that runs the macOS manifest checks.",
-        )
-
-    def test_macos_scoped_checks_have_routes(self) -> None:
-        """Every platforms:[macos] check must reach the macOS workflow's gate."""
-        if not self.gate:
-            self.skipTest("no macOS changed-file gate; guarded by test_changed_file_gate_is_present")
-        macos_checks = [check for check in self.manifest.checks if "macos" in check.platforms]
+    def test_every_macos_only_check_has_a_real_resolver_fixture(self) -> None:
+        macos_checks = [check for check in self.manifest.checks if set(check.platforms) == {"macos"}]
+        self.assertGreater(len(macos_checks), 0)
         for check in macos_checks:
-            with self.subTest(check_id=check.id):
-                self.assertTrue(
-                    _check_has_route(check, self.gate),
-                    f"macOS-scoped check {check.id!r} has no trigger path covered by the "
-                    f"desktop-swift-ci.yml changed-file gate; editing one of its triggers "
-                    f"(triggers={list(check.triggers)}) would not wake the macOS manifest "
-                    f"step, leaving the check with no CI route.",
-                )
+            fixture_paths = [path for trigger in check.triggers for path in _materialize_trigger(trigger)]
+            with self.subTest(check_id=check.id, paths=fixture_paths):
+                self.assertTrue(fixture_paths, "macOS-only checks need at least one materializable trigger")
+                self.assertIn(check.id, resolve_macos_only(fixture_paths, self.manifest))
 
-    def test_adversarial_uncovered_route_is_detected(self) -> None:
-        """A macOS-only check whose trigger escapes the gate must be flagged."""
-        if not self.gate:
-            self.skipTest("no macOS changed-file gate; cannot exercise detection")
-        covered = Check(
-            id="fake-covered-route",
-            command=(),
-            triggers=("desktop/macos/Desktop/Sources/Fake.swift",),
-            lanes=("ci",),
-            reason="",
-            platforms=("macos",),
+    def test_portable_checks_do_not_move_to_the_exclusive_macos_phase(self) -> None:
+        manifest = Manifest(
+            checks=(
+                Check(
+                    id="portable",
+                    command=("true",),
+                    triggers=("desktop/macos/**",),
+                    lanes=("ci",),
+                    reason="portable fixture",
+                ),
+                Check(
+                    id="mac-only",
+                    command=("true",),
+                    triggers=("desktop/macos/**",),
+                    lanes=("ci",),
+                    reason="macOS fixture",
+                    platforms=("macos",),
+                ),
+            ),
+            exempt=(),
         )
-        uncovered = Check(
-            id="fake-uncovered-route",
-            command=(),
-            triggers=("backend/some/macos-only-concern.py",),
-            lanes=("ci",),
-            reason="",
-            platforms=("macos",),
-        )
-        self.assertTrue(
-            _check_has_route(covered, self.gate),
-            "sanity: a trigger under desktop/macos/Desktop/ must be routed by the gate",
-        )
-        self.assertFalse(
-            _check_has_route(uncovered, self.gate),
-            "a macOS-only check whose trigger escapes the gate must be detected as unrouted",
-        )
+        self.assertEqual(resolve_macos_only(["desktop/macos/Desktop/Sources/App.swift"], manifest), ["mac-only"])
+
+    def test_releasable_desktop_path_skips_verifier_only_without_macos_work(self) -> None:
+        # Resource edits retain the stable exact-SHA aggregate but have no
+        # manifest-owned macOS static phase. A verifier skip is therefore an
+        # explicit resolver decision, not an unmaintained workflow regex.
+        paths = ["desktop/macos/Resources/Info.plist"]
+        plan = resolve_impact(paths)
+        self.assertTrue(plan.includes("desktop-ci-only"))
+        self.assertEqual(resolve_macos_only(paths, self.manifest), [])
+
+    def test_swift_source_requires_a_macos_static_phase(self) -> None:
+        paths = ["desktop/macos/Desktop/Sources/Probe.swift"]
+        self.assertTrue(resolve_macos_only(paths, self.manifest))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_desktop_swift_ci_contract.py
+++ b/.github/scripts/test_desktop_swift_ci_contract.py
@@ -12,6 +12,7 @@ compiler the flags run against.
 from __future__ import annotations
 
 import re
+import sys
 import unittest
 from pathlib import Path
 
@@ -19,6 +20,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/desktop-swift-ci.yml"
 RUNNER_PATH = REPO_ROOT / "desktop/macos/scripts/run-swift-ci.sh"
 PRE_PUSH_PATH = REPO_ROOT / "scripts/pre-push"
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from pre_push_ci_prediction import resolve_impact  # noqa: E402
 
 EXPECTED_XCODE_VERSION = "16.4"
 EXPECTED_XCODE_BUILD = "16F6"
@@ -102,8 +106,6 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
 
     def test_release_control_inputs_produce_exact_sha_checks(self):
         """Candidate-building config must run the checks consumed by the release planner."""
-        changes = self.jobs["changes"]
-
         for path in (
             "codemagic.yaml",
             ".github/scripts/plan-desktop-release.py",
@@ -111,7 +113,7 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
             ".github/workflows/desktop-swift-ci.yml",
         ):
             with self.subTest(path=path):
-                self.assertIn(path, changes)
+                self.assertTrue(resolve_impact([path], event="push").includes("desktop-ci-only"))
 
     def test_macos_jobs_have_a_bounded_runner_budget(self):
         """A stuck Swift invocation must not consume hosted macOS capacity forever."""
@@ -130,16 +132,16 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
         self.assertIn("github.event.action != 'closed'", changes)
 
     def test_notification_boundary_runs_targeted_release_regression(self):
-        changes = self.jobs["changes"]
         job = self.jobs["desktop-swift-verify"]
         for path in (
-            "AppState[+]Permissions[.]swift",
-            "Sources/.*Notification.*[.]swift",
-            "OmiApp[.]swift",
-            "Providers/(ChatToolExecutor|DeviceProvider)[.]swift",
-            "Tests/.*Notification.*Tests[.]swift",
+            "desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift",
+            "desktop/macos/Desktop/Sources/NotificationProbe.swift",
+            "desktop/macos/Desktop/Sources/OmiApp.swift",
+            "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift",
+            "desktop/macos/Desktop/Tests/NotificationProbeTests.swift",
         ):
-            self.assertIn(path, changes)
+            with self.subTest(path=path):
+                self.assertTrue(resolve_impact([path]).includes("desktop-swift-notification-release-regression"))
         self.assertIn("runs-on: macos-15", job)
         self.assertIn("--release-notification-regression", job)
         self.assertIn("should_notification_release_regression", job)
@@ -159,38 +161,17 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
 
     def test_full_swift_suite_is_selected_only_for_its_inputs(self):
         """Asset/config candidates retain static evidence without a second Mac job."""
-        changes = self.jobs["changes"]
         verify_job = self.jobs["desktop-swift-verify"]
-
-        self.assertIn("SHOULD_RUN_TESTS=false", changes)
-        self.assertIn("SHOULD_RUN_TESTS=true", changes)
         for path in (
-            "Desktop/(Sources|Tests)/.*[.]swift",
-            "Desktop/Package[.](swift|resolved)",
-            "scripts/(run-swift-ci|swift-test-suites",
-            "desktop/macos/tests/test-.*[.]sh",
-            ".github/workflows/desktop-swift-ci[.]yml",
+            "desktop/macos/Desktop/Sources/Probe.swift",
+            "desktop/macos/Desktop/Package.resolved",
+            "desktop/macos/scripts/run-swift-ci.sh",
+            "desktop/macos/tests/test-probe.sh",
+            ".github/workflows/desktop-swift-ci.yml",
         ):
             with self.subTest(path=path):
-                self.assertIn(path, changes)
+                self.assertTrue(resolve_impact([path]).includes("desktop-swift-tests"))
         self.assertIn("needs.changes.outputs.should_run_tests", verify_job)
-
-    def test_static_macos_lane_is_selected_only_for_macos_contract_inputs(self):
-        """A releasable docs/assets change must not reserve an empty macOS lane."""
-        changes = self.jobs["changes"]
-        verify_job = self.jobs["desktop-swift-verify"]
-
-        self.assertIn("SHOULD_RUN_STATIC=false", changes)
-        self.assertIn("SHOULD_RUN_STATIC=true", changes)
-        for path in (
-            "Desktop/(Sources|Tests)/.*[.]swift",
-            "Desktop/(Package[.]swift|[.]swift-format",
-            "scripts/(swift-format-wrapper|prepare-swiftlint-baseline",
-            ".github/checks-manifest[.]yaml",
-        ):
-            with self.subTest(path=path):
-                self.assertIn(path, changes)
-        self.assertIn("needs.changes.outputs.should_run_static", verify_job)
 
     def test_static_and_test_lanes_share_one_hosted_macos_runner(self):
         """#10507: Swift CI must not reserve two scarce hosted Macs at once."""
@@ -198,6 +179,22 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
 
         self.assertEqual(MACOS_JOBS, ["desktop-swift-verify", "desktop-swift-release-compile"])
         self.assertIn("rather than claiming two", workflow)
+
+    def test_independent_macos_phases_publish_native_step_outcomes(self):
+        """A static failure must not mask the later independent Swift suite."""
+        job = self.jobs["desktop-swift-verify"]
+        for step_id, outcome in (
+            ("macos_manifest_checks", "STATIC_OUTCOME"),
+            ("desktop_launcher_tests", "LAUNCHER_OUTCOME"),
+            ("desktop_swift_tests", "TEST_OUTCOME"),
+            ("desktop_notification_regression", "NOTIFICATION_OUTCOME"),
+        ):
+            with self.subTest(step_id=step_id):
+                self.assertIn(f"id: {step_id}", job)
+                self.assertIn(f"steps.{step_id}.outcome", job)
+                self.assertIn(outcome, job)
+        self.assertIn("always() && !cancelled()", job)
+        self.assertIn("Require independent macOS phase verdicts", job)
 
     def test_ci_uses_one_worker_for_the_shared_swiftpm_build_directory(self):
         """#10507: parallel --skip-build invocations contend on Desktop/.build."""
@@ -310,25 +307,26 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
     def test_release_compile_gates_on_package_resolved(self):
         """Release compile must trigger when Package.resolved changes, even on
         a PR where the manifest source is unchanged."""
-        combined = self.jobs["changes"]
-        # The variable must be wired into the SHOULD_RUN conditional, not just
-        # declared or logged — removing the gate while keeping other references
-        # must fail this test.
         self.assertTrue(
-            re.search(r'"\$PACKAGE_RESOLVED"\s*=\s*"true"', combined),
-            "release-compile job must gate SHOULD_RUN on PACKAGE_RESOLVED=true",
+            resolve_impact(["desktop/macos/Desktop/Package.resolved"], event="pull_request").includes(
+                "desktop-swift-release-compile"
+            ),
+            "release-compile selection must include Package.resolved on pull requests",
         )
 
     def test_every_releasable_desktop_path_produces_exact_sha_checks(self):
         """Planner-eligible packaging/assets must not silently skip Swift evidence."""
-        changes = self.jobs["changes"]
-        self.assertIn("RELEASABLE_DESKTOP=false", changes)
-        self.assertIn("RELEASABLE_DESKTOP=true", changes)
-        self.assertIn("desktop/macos/*", changes)
-        for excluded in ("Backend-Rust/", "changelog/", "CHANGELOG[.]json", "AGENTS[.]md"):
-            self.assertIn(excluded, changes)
-        self.assertIn('"$RELEASABLE_DESKTOP" = "true"', changes)
-        self.assertIn("DESKTOP_SWIFT=$RELEASABLE_DESKTOP", changes)
+        for path in ("desktop/macos/Resources/Info.plist", "desktop/macos/scripts/prepare-bundle.sh"):
+            with self.subTest(path=path):
+                self.assertTrue(resolve_impact([path], event="push").includes("desktop-ci-only"))
+        for path in (
+            "desktop/macos/Backend-Rust/src/main.rs",
+            "desktop/macos/changelog/2026-07-25.json",
+            "desktop/macos/CHANGELOG.json",
+            "desktop/macos/AGENTS.md",
+        ):
+            with self.subTest(path=path):
+                self.assertFalse(resolve_impact([path], event="push").includes("desktop-ci-only"))
 
     def test_manifest_checks_use_the_changed_diff_base_on_pushes(self):
         """Pushes must lint the just-pushed diff, not checkout's origin/main HEAD."""
@@ -375,20 +373,6 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
         job = _job_text(tampered, "desktop-swift-verify")
         key = re.search(r"key:\s*([^\n]+)", job).group(1)
         self.assertNotIn("Package.resolved", key)
-
-    def test_adversarial_remove_package_resolved_gate_detected(self):
-        """Removing the PACKAGE_RESOLVED gate from SHOULD_RUN while keeping
-        other references must fail the positive gate assertion."""
-        wf_text = WORKFLOW_PATH.read_text(encoding="utf-8")
-        tampered = wf_text.replace('|| [ "$PACKAGE_RESOLVED" = "true" ]', "")
-        combined = _job_text(tampered, "changes")
-        # PACKAGE_RESOLVED still appears (declared, detected, echoed) but the
-        # gate condition is gone — the regex must fail to match.
-        self.assertIn("PACKAGE_RESOLVED", combined)  # still referenced
-        self.assertIsNone(
-            re.search(r'"\$PACKAGE_RESOLVED"\s*=\s*"true"', combined),
-            "gate condition must be absent after removal",
-        )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_pre_push_ci_prediction.py
+++ b/.github/scripts/test_pre_push_ci_prediction.py
@@ -10,13 +10,44 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from pre_push_ci_prediction import select_checks  # noqa: E402
+from pre_push_ci_prediction import (  # noqa: E402
+    DESKTOP_FLOW_LINT_INPUTS,
+    github_outputs,
+    resolve_impact,
+    select_checks,
+)
 
 
 class PrePushCiPredictionTests(unittest.TestCase):
-    def select(self, paths: list[str], contents: dict[str, str | None] | None = None) -> list[str]:
+    def select(
+        self,
+        paths: list[str],
+        contents: dict[str, str | None] | None = None,
+        base_contents: dict[str, str | None] | None = None,
+    ) -> list[str]:
         source_contents = contents or {}
-        return select_checks(paths, read_text=lambda path: source_contents.get(path))
+        base_source_contents = base_contents if base_contents is not None else source_contents
+        return select_checks(
+            paths,
+            read_text=lambda path: source_contents.get(path),
+            read_base_text=lambda path: base_source_contents.get(path),
+        )
+
+    def plan(
+        self,
+        paths: list[str],
+        contents: dict[str, str | None] | None = None,
+        base_contents: dict[str, str | None] | None = None,
+        event: str = "local",
+    ):
+        source_contents = contents or {}
+        base_source_contents = base_contents if base_contents is not None else source_contents
+        return resolve_impact(
+            paths,
+            read_text=lambda path: source_contents.get(path),
+            read_base_text=lambda path: base_source_contents.get(path),
+            event=event,
+        )
 
     def test_regular_app_dart_change_does_not_start_build_runner(self) -> None:
         self.assertEqual(
@@ -41,6 +72,22 @@ class PrePushCiPredictionTests(unittest.TestCase):
             ["app-dart-format", "flutter-codegen", "app-ci-only"],
         )
 
+    def test_removing_last_generator_marker_selects_build_runner(self) -> None:
+        path = "app/lib/models/task.dart"
+        self.assertIn(
+            "flutter-codegen",
+            self.select(
+                [path],
+                {path: "class Task {}"},
+                {path: "@JsonSerializable()\nclass Task {}"},
+            ),
+        )
+
+    def test_asset_change_is_an_explicit_codegen_input(self) -> None:
+        plan = self.plan(["app/assets/icons/omi.png"])
+        self.assertTrue(plan.includes("flutter-codegen"))
+        self.assertEqual(github_outputs(plan)["has_app_codegen"], "true")
+
     def test_l10n_and_generated_dart_have_the_right_local_contracts(self) -> None:
         self.assertEqual(
             self.select(["app/lib/l10n/app_en.arb", "app/lib/l10n/app_localizations.dart"]),
@@ -51,6 +98,44 @@ class PrePushCiPredictionTests(unittest.TestCase):
         self.assertEqual(
             self.select(["desktop/macos/e2e/flows/new-flow.yaml"]),
             ["desktop-flow-lint", "desktop-ci-only"],
+        )
+
+    def test_every_desktop_flow_reader_input_selects_flow_lint(self) -> None:
+        for path in DESKTOP_FLOW_LINT_INPUTS:
+            with self.subTest(path=path):
+                self.assertTrue(self.plan([path]).includes("desktop-flow-lint"))
+
+    def test_canonical_swift_driver_selects_the_expensive_test_phase(self) -> None:
+        plan = self.plan(["desktop/macos/scripts/run-swift-ci.sh"])
+        self.assertTrue(plan.includes("desktop-swift-tests"))
+        self.assertEqual(github_outputs(plan)["should_run_tests"], "true")
+
+    def test_unknown_component_paths_select_the_normal_component_lane(self) -> None:
+        app = self.plan(["app/tooling/unknown-input.txt"])
+        desktop = self.plan(["desktop/macos/Resources/unknown-input.txt"])
+        self.assertTrue(app.includes("app-analysis-tests"))
+        self.assertTrue(desktop.includes("desktop-ci-only"))
+
+    def test_selector_change_exercises_broad_resolver_fixtures(self) -> None:
+        plan = self.plan(["scripts/pre_push_ci_prediction.py"])
+        for phase in (
+            "flutter-codegen",
+            "flutter-l10n",
+            "desktop-flow-lint",
+            "desktop-swift-tests",
+            "app-analysis-tests",
+        ):
+            with self.subTest(phase=phase):
+                self.assertTrue(plan.includes(phase))
+
+    def test_release_compile_preserves_pr_and_main_asymmetry(self) -> None:
+        paths = ["desktop/macos/Resources/Info.plist"]
+        self.assertFalse(self.plan(paths, event="pull_request").includes("desktop-swift-release-compile"))
+        self.assertTrue(self.plan(paths, event="push").includes("desktop-swift-release-compile"))
+        self.assertTrue(
+            self.plan(["desktop/macos/Desktop/Package.resolved"], event="pull_request").includes(
+                "desktop-swift-release-compile"
+            )
         )
 
     def test_windows_kgworker_closure_inputs_select_only_the_targeted_test(self) -> None:

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -23,6 +23,7 @@ from run_checks import (
     detect_platform,
     execute_checks,
     load_manifest,
+    resolve_check_selections,
     resolve_checks,
     skipped_platform_checks,
     validate_manifest,
@@ -264,6 +265,58 @@ class PlatformTests(unittest.TestCase):
         for plat in ("macos", "linux"):
             selected = resolve_checks(manifest, ["any/file"], "ci", platform=plat)
             self.assertEqual([c.id for c in selected], ["portable"])
+
+    def test_exclusive_macos_query_excludes_portable_checks(self):
+        manifest = Manifest(
+            checks=(
+                Check(id="portable", command=("true",), triggers=("all",), lanes=("ci",), reason="portable"),
+                Check(
+                    id="mac-only",
+                    command=("true",),
+                    triggers=("all",),
+                    lanes=("ci",),
+                    reason="macOS",
+                    platforms=("macos",),
+                ),
+            ),
+            exempt=(),
+        )
+        self.assertEqual(
+            [check.id for check in resolve_checks(manifest, ["any/file"], "ci", platform="macos")],
+            ["portable", "mac-only"],
+        )
+        self.assertEqual(
+            [
+                check.id
+                for check in resolve_checks(
+                    manifest,
+                    ["any/file"],
+                    "ci",
+                    platform="macos",
+                    exclusive_platform=True,
+                )
+            ],
+            ["mac-only"],
+        )
+
+    def test_machine_readable_selection_carries_path_and_reason(self):
+        manifest = Manifest(
+            checks=(
+                Check(
+                    id="target",
+                    command=("true",),
+                    triggers=("desktop/macos/**",),
+                    lanes=("ci",),
+                    reason="desktop source changed",
+                ),
+            ),
+            exempt=(),
+        )
+        selections = resolve_check_selections(manifest, ["desktop/macos/Desktop/Sources/App.swift"], "ci")
+        self.assertEqual(len(selections), 1)
+        self.assertEqual(selections[0].check.id, "target")
+        self.assertEqual(selections[0].matched_paths, ("desktop/macos/Desktop/Sources/App.swift",))
+        self.assertEqual(selections[0].check.reason, "desktop source changed")
 
     def test_skipped_platform_checks_reports_macos_on_linux(self):
         manifest = Manifest(

--- a/.github/workflows/desktop-backend-contracts.yml
+++ b/.github/workflows/desktop-backend-contracts.yml
@@ -19,9 +19,13 @@ on:
       - "desktop/macos/Backend-Rust/src/services/firestore/**"
       - "desktop/macos/scripts/desktop-core-harness.sh"
       - "desktop/macos/scripts/desktop-flow-lint.py"
+      - "desktop/macos/scripts/desktop_flow_contract.py"
       - "desktop/macos/e2e/**"
       - "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift"
+      - "desktop/macos/Desktop/Sources/DesktopAutomationOpenOmiShortcutQA.swift"
       - "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift"
+      - "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift"
+      - "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift"
       - "desktop/macos/Desktop/Sources/Rewind/Core/RewindArtifactGauntlet.swift"
 
 jobs:

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -47,79 +47,40 @@ jobs:
           echo "$FILES"
           echo "diff_base=$DIFF_BASE" >> "$GITHUB_OUTPUT"
 
-          # Keep the producer aligned with plan-desktop-release.py: every path
-          # eligible for a desktop candidate must produce both exact-SHA Swift
-          # checks. Changelog/control docs and the separately released Rust
-          # backend remain outside the candidate path set.
-          RELEASABLE_DESKTOP=false
-          while IFS= read -r path; do
-            case "$path" in
-              desktop/macos/Backend-Rust/*|desktop/macos/changelog/*|desktop/macos/CHANGELOG[.]json|desktop/macos/AGENTS[.]md)
-                ;;
-              desktop/macos/*|codemagic.yaml|.github/scripts/plan-desktop-release.py|.github/workflows/desktop_auto_release.yml|.github/workflows/desktop-swift-ci.yml)
-                RELEASABLE_DESKTOP=true
-                break
-                ;;
-            esac
-          done <<< "$FILES"
+          IMPACT_FILES=$(mktemp)
+          printf '%s\n' "$FILES" > "$IMPACT_FILES"
+          python3 scripts/pre_push_ci_prediction.py \
+            --changed-files "$IMPACT_FILES" \
+            --base "$DIFF_BASE" \
+            --event "${{ github.event_name }}" \
+            --github-output "$GITHUB_OUTPUT"
 
-          SHOULD_RUN=false
-          if [ "$RELEASABLE_DESKTOP" = "true" ] || echo "$FILES" | grep -qE '^desktop/macos/Desktop/|^desktop/macos/test\.sh$|^desktop/macos/scripts/|^desktop/macos/tests/|^desktop/macos/e2e/flows/|^\.github/workflows/desktop-swift-ci\.yml$|^\.github/checks-manifest\.yaml$|^\.github/scripts/run_checks\.py$|^\.github/scripts/test_desktop_manifest_routes\.py$|^\.github/scripts/test_desktop_swift_ci_contract\.py$'; then
-            SHOULD_RUN=true
-          fi
-          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+          # Static macOS work is owned by the deterministic manifest. Querying
+          # it exclusively prevents portable checks from moving back onto this
+          # scarce runner while preserving their Linux Repo Checks route.
+          python3 .github/scripts/run_checks.py \
+            --lane ci \
+            --platform macos \
+            --exclusive-platform \
+            --base "$DIFF_BASE" \
+            --skip-pr-body-checks \
+            --changed-files "$IMPACT_FILES" \
+            --output json > /tmp/macos-manifest-selection.json
+          SHOULD_RUN_STATIC=$(python3 - <<'PY'
+          import json
+          import sys
+          from pathlib import Path
 
-          # A releasable file still produces the aggregate exact-SHA check, but
-          # only reserve a macOS runner when a lane has actual work to do. The
-          # static lane is limited to macOS-scoped contract inputs; all other
-          # deterministic workflow contracts run in the Linux Repo Checks lane.
-          SHOULD_RUN_STATIC=false
-          if echo "$FILES" | grep -qE '^desktop/macos/Desktop/(Sources|Tests)/.*[.]swift$|^desktop/macos/Desktop/(Package[.]swift|[.]swift-format|[.]swiftlint[.]yml|[.]swiftlint-baseline[.]json)$|^desktop/macos/scripts/(swift-format-wrapper|prepare-swiftlint-baseline|qualify-desktop-beta|prepare-qualification-profile|qualification-swift-cache)[.]sh$|^desktop/macos/tests/test-(feature-sentinel-negative-control|qualify-desktop-beta-contract|qualification-swift-cache)[.]sh$|^\.github/checks-manifest[.]yaml$'; then
-            SHOULD_RUN_STATIC=true
-          fi
+          selection = json.loads(Path("/tmp/macos-manifest-selection.json").read_text())
+          for check in selection["checks"]:
+              print(
+                  f"macOS manifest selection: {check['id']} via {', '.join(check['matched_paths'])}: {check['reason']}",
+                  file=sys.stderr,
+              )
+          print(str(bool(selection["checks"])).lower())
+          PY
+          )
           echo "should_run_static=$SHOULD_RUN_STATIC" >> "$GITHUB_OUTPUT"
-
-          # The expensive isolated XCTest suite is only useful when its Swift
-          # code, test harness, or this workflow changes. This keeps assets,
-          # agent-runtime files, and release-control edits from consuming a
-          # second hosted macOS runner while retaining their exact-SHA gate.
-          SHOULD_RUN_TESTS=false
-          if echo "$FILES" | grep -qE '^desktop/macos/Desktop/(Sources|Tests)/.*[.]swift$|^desktop/macos/Desktop/Package[.](swift|resolved)$|^desktop/macos/test[.]sh$|^desktop/macos/scripts/(run-swift-ci|swift-test-suites|swift-test-skip-ratchet|check_desktop_test_quality|check-main-actor-xctest-hooks)[.]py$|^desktop/macos/scripts/swift-test-suites[.]sh$|^desktop/macos/scripts/swift-test-skips[.]json$|^desktop/macos/tests/test-.*[.]sh$|^\.github/workflows/desktop-swift-ci[.]yml$'; then
-            SHOULD_RUN_TESTS=true
-          fi
-          echo "should_run_tests=$SHOULD_RUN_TESTS" >> "$GITHUB_OUTPUT"
-
-          DESKTOP_SWIFT=$RELEASABLE_DESKTOP
-          if echo "$FILES" | grep -qE '^\.github/workflows/desktop-swift-ci\.yml$'; then
-            DESKTOP_SWIFT=true
-          fi
-          PACKAGE_SWIFT=false
-          if echo "$FILES" | grep -qx 'desktop/macos/Desktop/Package.swift'; then
-            PACKAGE_SWIFT=true
-          fi
-          PACKAGE_RESOLVED=false
-          if echo "$FILES" | grep -qx 'desktop/macos/Desktop/Package.resolved'; then
-            PACKAGE_RESOLVED=true
-          fi
-
-          # Clean release compile: every main push that touches desktop Swift,
-          # plus PRs that change the package manifest or lockfile (highest
-          # release-risk: a dependency graph change can break release builds
-          # even when the manifest source is unchanged).
-          SHOULD_RELEASE_COMPILE=false
-          if [ "$DESKTOP_SWIFT" = "true" ]; then
-            if [ "${{ github.event_name }}" = "push" ] || [ "$PACKAGE_SWIFT" = "true" ] || [ "$PACKAGE_RESOLVED" = "true" ]; then
-              SHOULD_RELEASE_COMPILE=true
-            fi
-          fi
-          echo "should_release_compile=$SHOULD_RELEASE_COMPILE" >> "$GITHUB_OUTPUT"
-
-          SHOULD_NOTIFICATION_RELEASE_REGRESSION=false
-          if echo "$FILES" | grep -qE '^desktop/macos/Desktop/Sources/.*Notification.*[.]swift$|^desktop/macos/Desktop/Sources/AppState/AppState[+]Permissions[.]swift$|^desktop/macos/Desktop/Sources/OmiApp[.]swift$|^desktop/macos/Desktop/Sources/Providers/(ChatToolExecutor|DeviceProvider)[.]swift$|^desktop/macos/Desktop/Tests/.*Notification.*Tests[.]swift$'; then
-            SHOULD_NOTIFICATION_RELEASE_REGRESSION=true
-          fi
-          echo "should_notification_release_regression=$SHOULD_NOTIFICATION_RELEASE_REGRESSION" >> "$GITHUB_OUTPUT"
-          echo "desktop_swift=$DESKTOP_SWIFT package_swift=$PACKAGE_SWIFT package_resolved=$PACKAGE_RESOLVED should_run=$SHOULD_RUN should_run_static=$SHOULD_RUN_STATIC should_run_tests=$SHOULD_RUN_TESTS should_release_compile=$SHOULD_RELEASE_COMPILE should_notification_release_regression=$SHOULD_NOTIFICATION_RELEASE_REGRESSION"
 
   # Hosted macOS capacity is deliberately scarce. Run static contracts and the
   # optional full suite as steps in one selected job, rather than claiming two
@@ -141,7 +102,7 @@ jobs:
         run: desktop/macos/scripts/run-swift-ci.sh --select-toolchain
 
       - name: Restore Swift formatter and linter tools
-        if: needs.changes.outputs.should_run_static == 'true'
+        if: ${{ always() && !cancelled() && needs.changes.outputs.should_run_static == 'true' }}
         id: swift-tools-cache
         uses: actions/cache/restore@v6
         with:
@@ -153,11 +114,12 @@ jobs:
             ${{ runner.os }}-desktop-swift-tools-xcode164-
 
       - name: Install uv for manifest checks
-        if: needs.changes.outputs.should_run_static == 'true'
+        if: ${{ always() && !cancelled() && needs.changes.outputs.should_run_static == 'true' }}
         uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84
 
       - name: Run macOS-scoped manifest checks
-        if: needs.changes.outputs.should_run_static == 'true'
+        if: ${{ always() && !cancelled() && needs.changes.outputs.should_run_static == 'true' }}
+        id: macos_manifest_checks
         run: |
           MANIFEST_ARGS=()
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -169,12 +131,13 @@ jobs:
           python3 .github/scripts/run_checks.py \
             --lane ci \
             --platform macos \
+            --exclusive-platform \
             --base "${{ needs.changes.outputs.diff_base }}" \
             --skip-pr-body-checks \
             "${MANIFEST_ARGS[@]}"
 
       - name: Save Swift formatter and linter tools after checks
-        if: ${{ always() && needs.changes.outputs.should_run_static == 'true' && steps.swift-tools-cache.outputs.cache-hit != 'true' }}
+        if: ${{ always() && !cancelled() && needs.changes.outputs.should_run_static == 'true' && steps.swift-tools-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v6
         with:
           path: |
@@ -183,7 +146,7 @@ jobs:
           key: ${{ runner.os }}-desktop-swift-tools-xcode164-${{ hashFiles('desktop/macos/scripts/swift-format-wrapper.sh', 'desktop/macos/scripts/swiftlint-wrapper.sh') }}
 
       - name: Restore SwiftPM build products
-        if: needs.changes.outputs.should_run_tests == 'true'
+        if: ${{ always() && !cancelled() && needs.changes.outputs.should_run_tests == 'true' }}
         id: swiftpm-cache
         uses: actions/cache/restore@v6
         with:
@@ -195,11 +158,12 @@ jobs:
             ${{ runner.os }}-desktop-swift-build-xcode164-
 
       - name: Install Swift system dependencies
-        if: needs.changes.outputs.should_run_tests == 'true'
+        if: ${{ always() && !cancelled() && needs.changes.outputs.should_run_tests == 'true' }}
         run: brew install actionlint pkg-config webp
 
       - name: Desktop launcher script tests
-        if: needs.changes.outputs.should_run_tests == 'true'
+        if: ${{ always() && !cancelled() && needs.changes.outputs.should_run_tests == 'true' }}
+        id: desktop_launcher_tests
         working-directory: desktop/macos
         run: |
           # Discovery, not a hardcoded list — a new tests/test-*.sh runs here
@@ -213,7 +177,8 @@ jobs:
       # separate job (main push, or PRs that touch Package.swift) so we do not
       # pay for a second configuration that tests never consume.
       - name: Test desktop Swift app
-        if: needs.changes.outputs.should_run_tests == 'true'
+        if: ${{ always() && !cancelled() && needs.changes.outputs.should_run_tests == 'true' }}
+        id: desktop_swift_tests
         working-directory: desktop/macos
         env:
           # Every filtered `swift test --skip-build` process shares Desktop/.build.
@@ -227,7 +192,8 @@ jobs:
       # so the release planner cannot tag notification-boundary changes until
       # the pinned release compiler has exercised the callback handoff.
       - name: Test UserNotifications callback regression in release mode
-        if: ${{ needs.changes.outputs.should_run_tests == 'true' && needs.changes.outputs.should_notification_release_regression == 'true' }}
+        if: ${{ always() && !cancelled() && needs.changes.outputs.should_run_tests == 'true' && needs.changes.outputs.should_notification_release_regression == 'true' }}
+        id: desktop_notification_regression
         working-directory: desktop/macos
         run: ./scripts/run-swift-ci.sh --release-notification-regression
 
@@ -235,13 +201,39 @@ jobs:
       # a failed test command makes the next diagnostic run reuse completed
       # dependency and module work instead of recompiling the same test bundle.
       - name: Save SwiftPM build products after test attempt
-        if: ${{ always() && needs.changes.outputs.should_run_tests == 'true' && steps.swiftpm-cache.outputs.cache-hit != 'true' }}
+        if: ${{ always() && !cancelled() && needs.changes.outputs.should_run_tests == 'true' && steps.swiftpm-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v6
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
             desktop/macos/Desktop/.build
           key: ${{ runner.os }}-desktop-swift-build-xcode164-${{ hashFiles('desktop/macos/Desktop/Package.swift', 'desktop/macos/Desktop/Package.resolved') }}
+
+      - name: Require independent macOS phase verdicts
+        if: ${{ always() && !cancelled() }}
+        env:
+          STATIC_REQUIRED: ${{ needs.changes.outputs.should_run_static }}
+          TESTS_REQUIRED: ${{ needs.changes.outputs.should_run_tests }}
+          NOTIFICATION_REQUIRED: ${{ needs.changes.outputs.should_notification_release_regression }}
+          STATIC_OUTCOME: ${{ steps.macos_manifest_checks.outcome }}
+          LAUNCHER_OUTCOME: ${{ steps.desktop_launcher_tests.outcome }}
+          TEST_OUTCOME: ${{ steps.desktop_swift_tests.outcome }}
+          NOTIFICATION_OUTCOME: ${{ steps.desktop_notification_regression.outcome }}
+        run: |
+          require_success() {
+            local required="$1"
+            local name="$2"
+            local outcome="$3"
+            if [ "$required" = true ] && [ "$outcome" != success ]; then
+              echo "FAIL: $name did not succeed (outcome=$outcome)" >&2
+              return 1
+            fi
+          }
+
+          require_success "$STATIC_REQUIRED" "macOS manifest checks" "$STATIC_OUTCOME"
+          require_success "$TESTS_REQUIRED" "desktop launcher script tests" "$LAUNCHER_OUTCOME"
+          require_success "$TESTS_REQUIRED" "desktop Swift tests" "$TEST_OUTCOME"
+          require_success "$NOTIFICATION_REQUIRED" "notification release regression" "$NOTIFICATION_OUTCOME"
 
   desktop-swift:
     # Keep this name stable: desktop release planning requires this exact

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import re
+import sys
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -14,6 +15,23 @@ def _load_script(name: str):
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)
+    return module
+
+
+def _load_repo_script(name: str):
+    path = BACKEND_DIR.parent / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    previous = sys.modules.get(name)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if previous is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
     return module
 
 
@@ -307,17 +325,30 @@ def test_backend_static_contract_job_uses_the_pinned_backend_environment():
 
 def test_mobile_generated_files_only_run_for_codegen_or_localization_changes():
     repo = BACKEND_DIR.parent
-    detect_changes = (repo / '.github/actions/detect-changes/action.yml').read_text(encoding='utf-8')
     mobile_checks = (repo / '.github/workflows/mobile-app-checks.yml').read_text(encoding='utf-8')
     generated = mobile_checks.split('\n  generated-files:\n', 1)[1].split('\n  analyze:\n', 1)[0]
     android = mobile_checks.split('\n  android-compile-smoke:\n', 1)[1]
     changes = mobile_checks.split('\n  changes:\n', 1)[1].split('\n  generated-files:\n', 1)[0]
+    resolver = _load_repo_script("pre_push_ci_prediction")
 
-    assert 'if [ "$has_app_codegen" = "true" ] || [ "$has_app_l10n" = "true" ]; then' in detect_changes
-    assert (
-        'if [ "$has_dart" = "true" ] || [ "$has_app_codegen" = "true" ] || [ "$has_app_l10n" = "true" ]; then'
-        not in detect_changes
+    regular_dart = "app/lib/utils/date_formats.dart"
+    regular_plan = resolver.resolve_impact(
+        [regular_dart],
+        read_text=lambda path: {regular_dart: "class DateFormats {}"}.get(path),
     )
+    regular_outputs = resolver.github_outputs(regular_plan)
+    assert regular_outputs["has_app_codegen"] == "false"
+    assert regular_outputs["has_app_l10n"] == "false"
+    assert regular_outputs["has_flutter_generated"] == "false"
+
+    asset_plan = resolver.resolve_impact(["app/assets/icons/omi.png"])
+    asset_outputs = resolver.github_outputs(asset_plan)
+    assert asset_outputs["has_app_codegen"] == "true"
+    assert asset_outputs["has_flutter_generated"] == "true"
+
+    assert "if: needs.changes.outputs.has_flutter_generated == 'true'" in generated
+    assert "if: needs.changes.outputs.has_app_codegen == 'true'" in generated
+    assert "if: needs.changes.outputs.has_app_l10n == 'true'" in generated
     assert 'fetch-depth: 1' in generated
     assert 'fetch-depth: 1' in android
     assert 'fetch-depth: 0' in changes

--- a/desktop/macos/scripts/desktop-flow-lint.py
+++ b/desktop/macos/scripts/desktop-flow-lint.py
@@ -8,6 +8,8 @@ import re
 import sys
 from pathlib import Path
 
+from desktop_flow_contract import ACTION_SOURCE_RELATIVE_PATHS
+
 try:
     import yaml
 except ImportError as exc:  # pragma: no cover - surfaced in CI with install hint
@@ -21,14 +23,7 @@ except ImportError as exc:  # pragma: no cover - surfaced in CI with install hin
 SCRIPT_DIR = Path(__file__).resolve().parent
 DESKTOP_DIR = SCRIPT_DIR.parent
 FLOWS_DIR = DESKTOP_DIR / "e2e" / "flows"
-BRIDGE_SOURCE = DESKTOP_DIR / "Desktop/Sources/DesktopAutomationBridge.swift"
-REWIND_GAUNTLET_SOURCE = DESKTOP_DIR / "Desktop/Sources/Rewind/Core/RewindArtifactGauntlet.swift"
-HUB_SOURCE = DESKTOP_DIR / "Desktop/Sources/FloatingControlBar/RealtimeHubController.swift"
-OPEN_OMI_SHORTCUT_QA_SOURCE = DESKTOP_DIR / "Desktop/Sources/DesktopAutomationOpenOmiShortcutQA.swift"
-VIEW_MODEL_ACTION_SOURCES = (
-    DESKTOP_DIR / "Desktop/Sources/MainWindow/Pages/TasksPage.swift",
-    DESKTOP_DIR / "Desktop/Sources/MainWindow/Pages/MemoriesPage.swift",
-)
+ACTION_SOURCES = tuple(DESKTOP_DIR / path for path in ACTION_SOURCE_RELATIVE_PATHS)
 
 TYPED_STEP_KEYS = {
     "bridge.navigate",
@@ -55,13 +50,7 @@ def fail(message: str) -> None:
 def registered_actions() -> set[str]:
     actions: set[str] = set()
     pattern = re.compile(r'name:\s*"([^"]+)"')
-    for path in (
-        BRIDGE_SOURCE,
-        REWIND_GAUNTLET_SOURCE,
-        HUB_SOURCE,
-        OPEN_OMI_SHORTCUT_QA_SOURCE,
-        *VIEW_MODEL_ACTION_SOURCES,
-    ):
+    for path in ACTION_SOURCES:
         if not path.is_file():
             fail(f"missing automation source: {path}")
         actions.update(pattern.findall(path.read_text(encoding="utf-8")))

--- a/desktop/macos/scripts/desktop_flow_contract.py
+++ b/desktop/macos/scripts/desktop_flow_contract.py
@@ -1,0 +1,24 @@
+"""Shared ownership for the files consumed by desktop E2E flow validation."""
+
+from __future__ import annotations
+
+# Paths are relative to desktop/macos. Keep the flow lint reader and CI impact
+# resolver on this single list so an added bridge action cannot skip its flow
+# validation route.
+ACTION_SOURCE_RELATIVE_PATHS = (
+    "Desktop/Sources/DesktopAutomationBridge.swift",
+    "Desktop/Sources/FloatingControlBar/RealtimeHubController.swift",
+    "Desktop/Sources/Rewind/Core/RewindArtifactGauntlet.swift",
+    "Desktop/Sources/DesktopAutomationOpenOmiShortcutQA.swift",
+    "Desktop/Sources/MainWindow/Pages/TasksPage.swift",
+    "Desktop/Sources/MainWindow/Pages/MemoriesPage.swift",
+)
+
+FLOW_LINT_INPUTS = frozenset(
+    {
+        "desktop/macos/scripts/desktop-core-harness.sh",
+        "desktop/macos/scripts/desktop-flow-lint.py",
+        "desktop/macos/scripts/desktop_flow_contract.py",
+        *(f"desktop/macos/{path}" for path in ACTION_SOURCE_RELATIVE_PATHS),
+    }
+)

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -162,7 +162,7 @@ changed_matches() {
   return 1
 }
 
-CI_PREDICTION_SELECTION=$(python3 scripts/pre_push_ci_prediction.py --changed-files "$CHANGED_FILES_LIST")
+CI_PREDICTION_SELECTION=$(python3 scripts/pre_push_ci_prediction.py --changed-files "$CHANGED_FILES_LIST" --base "$BASE_REF")
 if ci_prediction_selected "app-ci-only"; then
   ci_prediction_note_deferred "full Flutter analyzer/tests and platform compiles"
 fi

--- a/scripts/pre_push_ci_prediction.py
+++ b/scripts/pre_push_ci_prediction.py
@@ -1,19 +1,24 @@
 #!/usr/bin/env python3
-"""Select the bounded local checks that predict PR CI from a file diff.
+"""Resolve CI impact from a changed-file list without non-stdlib dependencies.
 
-This intentionally describes only checks that are cheap enough to run before a
-push.  The full app test/compile matrix and release/platform work stay in CI.
+The pre-push hook consumes the bounded local phases while GitHub Actions
+consumes the same plan for component and expensive macOS phases.  The executor
+chooses its own budget; path ownership lives here.
 """
 
 from __future__ import annotations
 
 import argparse
+import importlib.util
+import json
+import subprocess
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-CHECK_ORDER = (
+LOCAL_CHECK_ORDER = (
     "app-dart-format",
     "flutter-l10n",
     "flutter-codegen",
@@ -21,6 +26,17 @@ CHECK_ORDER = (
     "windows-kgworker-native-closure",
     "app-ci-only",
     "desktop-ci-only",
+)
+
+PHASE_ORDER = (
+    *LOCAL_CHECK_ORDER,
+    "app-analysis-tests",
+    "app-compile-smoke",
+    "desktop-agent-runtime",
+    "desktop-rust",
+    "desktop-swift-tests",
+    "desktop-swift-release-compile",
+    "desktop-swift-notification-release-regression",
 )
 
 CODEGEN_CONFIG_INPUTS = {
@@ -43,16 +59,6 @@ CODEGEN_MARKERS = (
     'part "',
 )
 
-DESKTOP_FLOW_LINT_INPUTS = {
-    "desktop/macos/scripts/desktop-core-harness.sh",
-    "desktop/macos/scripts/desktop-flow-lint.py",
-    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift",
-    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift",
-    "desktop/macos/Desktop/Sources/Rewind/Core/RewindArtifactGauntlet.swift",
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift",
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift",
-}
-
 WINDOWS_KGWORKER_NATIVE_CLOSURE_INPUTS = {
     "desktop/windows/scripts/kgworker-native-closure.mjs",
     "desktop/windows/scripts/kgworker-native-closure.test.mjs",
@@ -60,6 +66,62 @@ WINDOWS_KGWORKER_NATIVE_CLOSURE_INPUTS = {
     "desktop/windows/package.json",
     "desktop/windows/pnpm-lock.yaml",
 }
+
+ROUTING_INPUTS = {
+    ".github/checks-manifest.yaml",
+    ".github/scripts/run_checks.py",
+    ".github/scripts/test_run_checks.py",
+    ".github/scripts/test_desktop_manifest_routes.py",
+    ".github/scripts/test_desktop_swift_ci_contract.py",
+    ".github/actions/detect-changes/action.yml",
+    ".github/workflows/desktop-swift-ci.yml",
+    ".github/workflows/mobile-app-checks.yml",
+    "scripts/pre_push_ci_prediction.py",
+    ".github/scripts/test_pre_push_ci_prediction.py",
+}
+
+DESKTOP_SWIFT_TEST_INPUTS = {
+    "desktop/macos/Desktop/Package.swift",
+    "desktop/macos/Desktop/Package.resolved",
+    "desktop/macos/test.sh",
+    "desktop/macos/scripts/run-swift-ci.sh",
+    "desktop/macos/scripts/swift-test-suites.sh",
+    "desktop/macos/scripts/swift-test-skip-ratchet.py",
+    "desktop/macos/scripts/check_desktop_test_quality.py",
+    "desktop/macos/scripts/check-main-actor-xctest-hooks.py",
+}
+
+DESKTOP_NOTIFICATION_REGRESSION_INPUTS = {
+    "desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift",
+    "desktop/macos/Desktop/Sources/OmiApp.swift",
+    "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift",
+    "desktop/macos/Desktop/Sources/Providers/DeviceProvider.swift",
+}
+
+DESKTOP_AGENT_RUNTIME_INPUTS = {
+    "desktop/macos/run.sh",
+    "desktop/macos/scripts/audit-desktop-bundle-deps.sh",
+    "desktop/macos/scripts/prepare-agent-runtime.sh",
+    "desktop/macos/scripts/prepare-desktop-bundle-native-deps.sh",
+    "desktop/macos/scripts/test-tool-surfaces.sh",
+    "desktop/macos/scripts/agent-logic-harness.sh",
+    "codemagic.yaml",
+    "scripts/pre-push",
+}
+
+
+def _load_desktop_flow_lint_inputs() -> frozenset[str]:
+    """Load the lint's own source inventory without importing PyYAML."""
+    path = REPO_ROOT / "desktop/macos/scripts/desktop_flow_contract.py"
+    spec = importlib.util.spec_from_file_location("desktop_flow_contract", path)
+    if spec is None or spec.loader is None:  # pragma: no cover - repository corruption
+        raise RuntimeError(f"cannot load desktop flow contract from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return frozenset(module.FLOW_LINT_INPUTS)
+
+
+DESKTOP_FLOW_LINT_INPUTS = _load_desktop_flow_lint_inputs()
 
 
 def _default_read_text(path: str) -> str | None:
@@ -69,59 +131,248 @@ def _default_read_text(path: str) -> str | None:
         return None
 
 
+def read_text_at_revision(revision: str) -> Callable[[str], str | None]:
+    """Return a stdlib-only reader for paths as they existed at *revision*."""
+
+    def read(path: str) -> str | None:
+        result = subprocess.run(
+            ["git", "show", f"{revision}:{path}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode:
+            return None
+        try:
+            return result.stdout.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+
+    return read
+
+
 def _is_generated_dart(path: str) -> bool:
     return path.endswith((".g.dart", ".gen.dart", ".freezed.dart")) or path.startswith("app/lib/l10n/app_localizations")
 
 
-def _is_codegen_input(path: str, read_text: Callable[[str], str | None]) -> bool:
-    if path in CODEGEN_CONFIG_INPUTS:
+def _contains_codegen_marker(source: str | None) -> bool:
+    return source is not None and any(marker in source for marker in CODEGEN_MARKERS)
+
+
+def _is_codegen_input(
+    path: str,
+    read_text: Callable[[str], str | None],
+    read_base_text: Callable[[str], str | None],
+) -> bool:
+    if path in CODEGEN_CONFIG_INPUTS or path.startswith("app/assets/"):
         return True
     if not path.startswith("app/lib/") or not path.endswith(".dart") or _is_generated_dart(path):
         return False
 
-    # A deleted Dart library might have owned generated output.  Regenerate in
-    # that case rather than guessing from a file that no longer exists.
     source = read_text(path)
-    if source is None:
-        return True
-    return any(marker in source for marker in CODEGEN_MARKERS)
+    base_source = read_base_text(path)
+    # A deleted library or a removed final generator marker has no post-change
+    # annotation to inspect. The base revision is the ownership proof.
+    return (
+        source is None
+        or base_source is None
+        or _contains_codegen_marker(source)
+        or _contains_codegen_marker(base_source)
+    )
 
 
-def select_checks(paths: Iterable[str], read_text: Callable[[str], str | None] = _default_read_text) -> list[str]:
-    """Return selected checks in stable, agent-readable order."""
+def _is_app_l10n_input(path: str) -> bool:
+    return (path.startswith("app/lib/l10n/") and path.endswith(".arb")) or path == "app/l10n.yaml"
 
+
+def _is_app_compile_smoke_input(path: str) -> bool:
+    if path.startswith("app/lib/l10n/app_") and (path.endswith(".arb") or path.endswith(".dart")):
+        return False
+    return path.startswith(
+        (
+            "app/lib/",
+            "app/android/",
+            "app/ios/",
+            "app/setup/prebuilt/",
+            "app/setup/scripts/",
+            "app/config/",
+            "app/assets/",
+        )
+    ) or path in {
+        "app/pubspec.yaml",
+        "app/pubspec.lock",
+        "app/build.yaml",
+        "app/analysis_options.yaml",
+        "app/l10n.yaml",
+        "app/flavorizr.yaml",
+    }
+
+
+def _is_releasable_desktop_path(path: str) -> bool:
+    if path.startswith(("desktop/macos/Backend-Rust/", "desktop/macos/changelog/")):
+        return False
+    if path in {"desktop/macos/CHANGELOG.json", "desktop/macos/AGENTS.md"}:
+        return False
+    return path.startswith("desktop/macos/") or path in {
+        "codemagic.yaml",
+        ".github/scripts/plan-desktop-release.py",
+        ".github/workflows/desktop_auto_release.yml",
+        ".github/workflows/desktop-swift-ci.yml",
+    }
+
+
+def _is_desktop_swift_test_input(path: str) -> bool:
+    return (
+        path in DESKTOP_SWIFT_TEST_INPUTS
+        or (
+            path.startswith(("desktop/macos/Desktop/Sources/", "desktop/macos/Desktop/Tests/"))
+            and path.endswith(".swift")
+        )
+        or (path.startswith("desktop/macos/tests/") and path.endswith(".sh"))
+    )
+
+
+def _is_desktop_notification_input(path: str) -> bool:
+    return (
+        path in DESKTOP_NOTIFICATION_REGRESSION_INPUTS
+        or (path.startswith("desktop/macos/Desktop/Sources/") and path.endswith(".swift") and "Notification" in path)
+        or (path.startswith("desktop/macos/Desktop/Tests/") and path.endswith(".swift") and "Notification" in path)
+    )
+
+
+def _is_desktop_agent_runtime_input(path: str) -> bool:
+    return path in DESKTOP_AGENT_RUNTIME_INPUTS or path.startswith(
+        ("desktop/macos/agent/", "desktop/macos/pi-mono-extension/")
+    )
+
+
+@dataclass(frozen=True)
+class ImpactPlan:
+    """Selected phase IDs in stable display order."""
+
+    phases: frozenset[str]
+
+    def includes(self, phase: str) -> bool:
+        return phase in self.phases
+
+    def ordered(self) -> list[str]:
+        return [phase for phase in PHASE_ORDER if phase in self.phases]
+
+
+def resolve_impact(
+    paths: Iterable[str],
+    *,
+    read_text: Callable[[str], str | None] = _default_read_text,
+    read_base_text: Callable[[str], str | None] | None = None,
+    event: str = "local",
+) -> ImpactPlan:
+    """Resolve component and expensive CI phases for a changed path set."""
+    # Callers that only need the current-tree behavior (for example a focused
+    # unit fixture) can omit the base reader. Diff callers pass one so deleted
+    # inputs and marker removals remain conservative.
+    read_base_text = read_base_text or read_text
     selected: set[str] = set()
-    for raw_path in paths:
-        path = raw_path.strip()
-        if not path:
-            continue
+    normalized_paths = [raw_path.strip() for raw_path in paths if raw_path.strip()]
+    selector_changed = any(
+        path in ROUTING_INPUTS or path.startswith(".github/actions/detect-changes/") for path in normalized_paths
+    )
 
+    for path in normalized_paths:
         if path.startswith("app/"):
-            selected.add("app-ci-only")
+            # Unknown paths within a component remain conservative: they wake
+            # its normal analyzer/test lane rather than silently doing nothing.
+            selected.update({"app-ci-only", "app-analysis-tests"})
+            if _is_app_compile_smoke_input(path):
+                selected.add("app-compile-smoke")
+            if path.endswith(".dart") and not _is_generated_dart(path):
+                selected.add("app-dart-format")
+            if _is_app_l10n_input(path):
+                selected.add("flutter-l10n")
+            if _is_codegen_input(path, read_text, read_base_text):
+                selected.add("flutter-codegen")
+
         if path.startswith("desktop/macos/"):
-            selected.add("desktop-ci-only")
-
-        if path.startswith("app/") and path.endswith(".dart") and not _is_generated_dart(path):
-            selected.add("app-dart-format")
-
-        if path.startswith("app/lib/l10n/") and path.endswith(".arb") or path == "app/l10n.yaml":
-            selected.add("flutter-l10n")
-
-        if _is_codegen_input(path, read_text):
-            selected.add("flutter-codegen")
-
-        if path.startswith("desktop/macos/e2e/") or path in DESKTOP_FLOW_LINT_INPUTS:
-            selected.add("desktop-flow-lint")
+            if _is_releasable_desktop_path(path):
+                selected.add("desktop-ci-only")
+            if _is_desktop_swift_test_input(path):
+                selected.add("desktop-swift-tests")
+            if _is_desktop_notification_input(path):
+                selected.add("desktop-swift-notification-release-regression")
+            if path.startswith("desktop/macos/Backend-Rust/"):
+                selected.add("desktop-rust")
+            if _is_desktop_agent_runtime_input(path):
+                selected.add("desktop-agent-runtime")
+            if path.startswith("desktop/macos/e2e/") or path in DESKTOP_FLOW_LINT_INPUTS:
+                selected.add("desktop-flow-lint")
 
         if path in WINDOWS_KGWORKER_NATIVE_CLOSURE_INPUTS:
             selected.add("windows-kgworker-native-closure")
 
-    return [check for check in CHECK_ORDER if check in selected]
+    if selector_changed:
+        # The selector is the boundary. A change to it runs all of its fixtures
+        # and conservatively wakes each component lane it can influence.
+        selected.update(
+            {
+                "app-ci-only",
+                "app-analysis-tests",
+                "app-compile-smoke",
+                "flutter-l10n",
+                "flutter-codegen",
+                "desktop-ci-only",
+                "desktop-flow-lint",
+                "desktop-swift-tests",
+            }
+        )
+
+    releasable_desktop = any(_is_releasable_desktop_path(path) for path in normalized_paths) or selector_changed
+    package_changed = any(
+        path in {"desktop/macos/Desktop/Package.swift", "desktop/macos/Desktop/Package.resolved"}
+        for path in normalized_paths
+    )
+    if releasable_desktop:
+        selected.add("desktop-ci-only")
+    if releasable_desktop and (event == "push" or package_changed):
+        selected.add("desktop-swift-release-compile")
+
+    return ImpactPlan(frozenset(selected))
+
+
+def select_checks(
+    paths: Iterable[str],
+    read_text: Callable[[str], str | None] = _default_read_text,
+    read_base_text: Callable[[str], str | None] | None = None,
+) -> list[str]:
+    """Return the bounded local subset in stable, agent-readable order."""
+    plan = resolve_impact(paths, read_text=read_text, read_base_text=read_base_text)
+    return [phase for phase in LOCAL_CHECK_ORDER if plan.includes(phase)]
+
+
+def github_outputs(plan: ImpactPlan) -> dict[str, str]:
+    """Map shared phases to the established detect-changes action contract."""
+    return {
+        "has_app_codegen": str(plan.includes("flutter-codegen")).lower(),
+        "has_app_l10n": str(plan.includes("flutter-l10n")).lower(),
+        "has_flutter_generated": str(plan.includes("flutter-codegen") or plan.includes("flutter-l10n")).lower(),
+        "has_app_compile_smoke": str(plan.includes("app-compile-smoke")).lower(),
+        "has_app_dart": str(plan.includes("app-analysis-tests")).lower(),
+        "has_desktop_agent_runtime": str(plan.includes("desktop-agent-runtime")).lower(),
+        "has_desktop_rust": str(plan.includes("desktop-rust")).lower(),
+        "should_run": str(plan.includes("desktop-ci-only")).lower(),
+        "should_run_tests": str(plan.includes("desktop-swift-tests")).lower(),
+        "should_release_compile": str(plan.includes("desktop-swift-release-compile")).lower(),
+        "should_notification_release_regression": str(
+            plan.includes("desktop-swift-notification-release-regression")
+        ).lower(),
+    }
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--changed-files", type=Path, required=True)
+    parser.add_argument("--base", help="Optional Git revision used to detect deleted inputs and marker removals.")
+    parser.add_argument("--event", choices=("local", "pull_request", "push"), default="local")
+    parser.add_argument("--github-output", type=Path, help="Append established detect-changes outputs to this file.")
+    parser.add_argument("--output", choices=("lines", "json"), default="lines")
     args = parser.parse_args()
 
     try:
@@ -129,7 +380,20 @@ def main() -> int:
     except FileNotFoundError:
         parser.error(f"changed-files list not found: {args.changed_files}")
 
-    print("\n".join(select_checks(paths)))
+    plan = resolve_impact(
+        paths,
+        read_base_text=read_text_at_revision(args.base) if args.base else None,
+        event=args.event,
+    )
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as output:
+            for name, value in github_outputs(plan).items():
+                output.write(f"{name}={value}\n")
+
+    if args.output == "json":
+        print(json.dumps({"phases": plan.ordered(), "github_outputs": github_outputs(plan)}, sort_keys=True))
+    else:
+        print("\n".join(plan.ordered()))
     return 0
 
 


### PR DESCRIPTION
## Summary

- Route macOS-only static checks through the manifest resolver's machine-readable exclusive-platform selection.
- Share stdlib-only CI impact planning between pre-push, component change detection, and Desktop Swift phases.
- Preserve independent macOS static and test outcomes, with behavioral fixtures for the former false-green paths.

Closes #10519

## Verification

- `python3 .github/scripts/test_run_checks.py`
- `python3 .github/scripts/test_pre_push_ci_prediction.py`
- `python3 .github/scripts/test_desktop_manifest_routes.py`
- `python3 .github/scripts/test_desktop_swift_ci_contract.py`
- `python3 desktop/macos/scripts/desktop-flow-lint.py`
- Selected `backend/tests/unit/test_workflow_contracts.py` via `backend/test.sh` (22 passed)
- `actionlint -shellcheck '' .github/workflows/desktop-swift-ci.yml .github/workflows/desktop-backend-contracts.yml`
- `make preflight`

## Product invariants

None (CI-only changes).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

