### PR TITLE
fix: make conversation automation wait for current detail

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/AuthService.swift": 2812,
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
-    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4256,
+    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4248,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1593,
     "desktop/macos/Desktop/Sources/OmiApp.swift": 1599
   },

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -617,6 +617,16 @@ private func ensureConversationsTabVisibleForAutomation() async throws {
   try await Task.sleep(nanoseconds: 150_000_000)
 }
 
+private func requestAutomationConversationOpen(conversationId: String, showTranscript: Bool) async {
+  await MainActor.run {
+    ConversationDetailAutomationState.shared.requestOpen(
+      conversationId: conversationId,
+      showTranscript: showTranscript
+    )
+    NotificationCenter.default.post(name: .desktopAutomationOpenConversationRequested, object: nil)
+  }
+}
+
 @MainActor
 final class DesktopAutomationActionRegistry {
   static let shared = DesktopAutomationActionRegistry()
@@ -1238,11 +1248,7 @@ final class DesktopAutomationActionRegistry {
       }
       let persisted = try? await TranscriptionStorage.shared.getCachedConversation(id: detail.id)
 
-      NotificationCenter.default.post(
-        name: .desktopAutomationOpenConversationRequested,
-        object: nil,
-        userInfo: ["conversationId": detail.id, "showTranscript": true]
-      )
+      await requestAutomationConversationOpen(conversationId: detail.id, showTranscript: true)
 
       return [
         "list_loaded": appState.conversations.isEmpty ? "false" : "true",
@@ -2565,11 +2571,7 @@ final class DesktopAutomationActionRegistry {
       }
       let showTranscript = boolParam(params["showTranscript"], default: false)
       try await ensureConversationsTabVisibleForAutomation()
-      NotificationCenter.default.post(
-        name: .desktopAutomationOpenConversationRequested,
-        object: nil,
-        userInfo: ["conversationId": conversationId, "showTranscript": showTranscript]
-      )
+      await requestAutomationConversationOpen(conversationId: conversationId, showTranscript: showTranscript)
       let timeoutMs = max(500, intParam(params["timeoutMs"], default: 5_000))
       let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1_000)
       while ConversationDetailAutomationState.shared.openConversationId != conversationId,
@@ -2614,11 +2616,7 @@ final class DesktopAutomationActionRegistry {
       }
       let showTranscript = boolParam(params["showTranscript"], default: false)
       try await ensureConversationsTabVisibleForAutomation()
-      NotificationCenter.default.post(
-        name: .desktopAutomationOpenConversationRequested,
-        object: nil,
-        userInfo: ["conversationId": conversationId, "showTranscript": showTranscript]
-      )
+      await requestAutomationConversationOpen(conversationId: conversationId, showTranscript: showTranscript)
       let timeoutMs = max(500, intParam(params["timeoutMs"], default: 5_000))
       let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1_000)
       while ConversationDetailAutomationState.shared.openConversationId != conversationId,
@@ -4009,16 +4007,10 @@ final class DesktopAutomationBridge: @unchecked Sendable {
   private func dispatchOpenConversation(_ payload: DesktopAutomationOpenConversationRequest) async throws {
     await activateMainWindowIfNeeded(payload.activateApp ?? true)
     try await ensureConversationsTabVisibleForAutomation()
-    await MainActor.run {
-      NotificationCenter.default.post(
-        name: .desktopAutomationOpenConversationRequested,
-        object: nil,
-        userInfo: [
-          "conversationId": payload.conversationId,
-          "showTranscript": payload.showTranscript ?? false,
-        ]
-      )
-    }
+    await requestAutomationConversationOpen(
+      conversationId: payload.conversationId,
+      showTranscript: payload.showTranscript ?? false
+    )
   }
 
   private func activateMainWindowIfNeeded(_ activateApp: Bool) async {

--- a/desktop/macos/Desktop/Sources/MainWindow/ConversationDetailAutomationState.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ConversationDetailAutomationState.swift
@@ -1,18 +1,48 @@
+import Combine
 import Foundation
 
 /// Tracks conversation detail UI state for hermetic automation bridge snapshots.
 @MainActor
-final class ConversationDetailAutomationState {
+final class ConversationDetailAutomationState: ObservableObject {
+  struct OpenRequest: Equatable {
+    let conversationId: String
+    let showTranscript: Bool
+  }
+
   static let shared = ConversationDetailAutomationState()
 
-  private(set) var openConversationId: String?
-  private(set) var transcriptDrawerOpen = false
+  @Published private(set) var openConversationId: String?
+  @Published private(set) var transcriptDrawerOpen = false
+  @Published private(set) var pendingOpenRequest: OpenRequest?
+  private var pendingTranscriptConversationId: String?
 
-  private init() {}
+  init() {}
 
-  func setOpen(conversationId: String, transcriptDrawerOpen: Bool) {
+  /// Retain and publish an automation request until the Conversations view consumes it.
+  /// The state publisher remains observable across a tab transition, unlike a one-shot
+  /// notification which can arrive before SwiftUI mounts its receiver.
+  func requestOpen(conversationId: String, showTranscript: Bool) {
+    pendingOpenRequest = OpenRequest(conversationId: conversationId, showTranscript: showTranscript)
+    pendingTranscriptConversationId = showTranscript ? conversationId : nil
+  }
+
+  func takePendingOpenRequest() -> OpenRequest? {
+    defer { pendingOpenRequest = nil }
+    return pendingOpenRequest
+  }
+
+  /// Synchronizes the automation snapshot when a detail view appears or is reused
+  /// for a different conversation by SwiftUI. Returns the drawer state to render.
+  @discardableResult
+  func syncPresentedDetail(conversationId: String, transcriptDrawerOpen: Bool) -> Bool {
+    let shouldShowTranscript =
+      transcriptDrawerOpen || pendingTranscriptConversationId == conversationId
     openConversationId = conversationId
-    self.transcriptDrawerOpen = transcriptDrawerOpen
+    self.transcriptDrawerOpen = shouldShowTranscript
+    if pendingTranscriptConversationId == conversationId {
+      pendingTranscriptConversationId = nil
+    }
+    return shouldShowTranscript
   }
 
   func setTranscriptDrawerOpen(_ open: Bool, conversationId: String) {
@@ -24,5 +54,8 @@ final class ConversationDetailAutomationState {
     guard openConversationId == conversationId else { return }
     openConversationId = nil
     transcriptDrawerOpen = false
+    if pendingTranscriptConversationId == conversationId {
+      pendingTranscriptConversationId = nil
+    }
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -59,6 +59,7 @@ struct DesktopHomeView: View {
   // Settings sidebar state
   @State private var selectedSettingsSection: SettingsContentView.SettingsSection = .general
   @State private var highlightedSettingId: String? = nil
+  @State private var memoryHubSegment = 0
   @State private var showTryAskingPopup = false
   @State private var previousIndexBeforeSettings: Int = 0
   @State private var logoPulse = false
@@ -1061,6 +1062,7 @@ struct DesktopHomeView: View {
             viewModelContainer: viewModelContainer,
             selectedSettingsSection: $selectedSettingsSection,
             highlightedSettingId: $highlightedSettingId,
+            memoryHubSegment: $memoryHubSegment,
             selectedTabIndex: $selectedIndex
           )
         }
@@ -1148,6 +1150,13 @@ struct DesktopHomeView: View {
         selectedIndex = item.rawValue
       }
     }
+    .onReceive(NotificationCenter.default.publisher(for: .desktopAutomationOpenConversationRequested)) { _ in
+      // Conversations now live behind the Memory hub's second segment. Route at
+      // the owning shell before the detail page mounts; its retained request is
+      // then consumed by ConversationsPage on appearance.
+      memoryHubSegment = 1
+      selectedIndex = SidebarNavItem.conversations.rawValue
+    }
     .onChange(of: selectedIndex) { oldValue, newValue in
       // Track the previous index when navigating to settings
       if newValue == SidebarNavItem.settings.rawValue
@@ -1224,7 +1233,7 @@ private struct HubSegmentedControl: View {
 private struct MemoryHubPage: View {
   let appState: AppState
   let viewModelContainer: ViewModelContainer
-  @State private var segment = 0
+  @Binding var segment: Int
 
   /// Memories and conversations stay easy to scan in a calm, readable column;
   /// the spatial Brain Map needs the full content surface so users can pan and
@@ -1304,6 +1313,7 @@ private struct PageContentView: View {
   let viewModelContainer: ViewModelContainer
   @Binding var selectedSettingsSection: SettingsContentView.SettingsSection
   @Binding var highlightedSettingId: String?
+  @Binding var memoryHubSegment: Int
   @Binding var selectedTabIndex: Int
 
   /// The list/detail pages (Conversations, Memories, Tasks, Apps) render their
@@ -1339,7 +1349,11 @@ private struct PageContentView: View {
           taskChatCoordinator: viewModelContainer.taskChatCoordinator,
           selectedIndex: $selectedTabIndex)
       case 1:
-        MemoryHubPage(appState: appState, viewModelContainer: viewModelContainer)
+        MemoryHubPage(
+          appState: appState,
+          viewModelContainer: viewModelContainer,
+          segment: $memoryHubSegment
+        )
       case 2:
         ChatPage(
           appProvider: viewModelContainer.appProvider,

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -184,13 +184,19 @@ struct ConversationDetailView: View {
     .opacity(hasAppeared ? 1 : 0)
     .offset(y: hasAppeared ? 0 : 20)
     .onAppear {
-      ConversationDetailAutomationState.shared.setOpen(
+      showTranscriptDrawer = ConversationDetailAutomationState.shared.syncPresentedDetail(
         conversationId: conversation.id,
         transcriptDrawerOpen: showTranscriptDrawer
       )
       OmiMotion.withGated(.easeOut(duration: 0.5)) {
         hasAppeared = true
       }
+    }
+    .onChange(of: conversation.id) { _, conversationId in
+      showTranscriptDrawer = ConversationDetailAutomationState.shared.syncPresentedDetail(
+        conversationId: conversationId,
+        transcriptDrawerOpen: showTranscriptDrawer
+      )
     }
     .onDisappear {
       ConversationDetailAutomationState.shared.clear(conversationId: conversation.id)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -29,6 +29,7 @@ class SearchDebouncer: ObservableObject {
 struct ConversationsPage: View {
   @ObservedObject var appState: AppState
   @Binding var selectedConversation: ServerConversation?
+  @ObservedObject private var automation = ConversationDetailAutomationState.shared
 
   /// When true, renders without internal ScrollViews (for embedding in an outer ScrollView)
   var embedded: Bool = false
@@ -137,10 +138,14 @@ struct ConversationsPage: View {
           await appState.loadFolders()
         }
       }
+      consumePendingAutomationOpenConversation()
+    }
+    .onReceive(automation.$pendingOpenRequest.compactMap { $0 }) { _ in
+      consumePendingAutomationOpenConversation()
     }
     .onReceive(NotificationCenter.default.publisher(for: .desktopAutomationOpenConversationRequested)) {
-      notification in
-      handleAutomationOpenConversation(notification)
+      _ in
+      consumePendingAutomationOpenConversation()
     }
     .onReceive(
       NotificationCenter.default.publisher(for: .desktopAutomationSetConversationsSearchRequested)
@@ -186,20 +191,15 @@ struct ConversationsPage: View {
     }
   }
 
-  private func handleAutomationOpenConversation(_ notification: Notification) {
-    guard let conversationId = notification.userInfo?["conversationId"] as? String else { return }
-    let showTranscript = notification.userInfo?["showTranscript"] as? Bool ?? false
+  private func consumePendingAutomationOpenConversation() {
+    guard let request = ConversationDetailAutomationState.shared.takePendingOpenRequest() else { return }
+    handleAutomationOpenConversation(conversationId: request.conversationId)
+  }
+
+  private func handleAutomationOpenConversation(conversationId: String) {
 
     func present(_ conversation: ServerConversation) {
       selectedConversation = conversation
-      guard showTranscript else { return }
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-        NotificationCenter.default.post(
-          name: .desktopAutomationShowConversationTranscriptRequested,
-          object: nil,
-          userInfo: ["conversationId": conversation.id]
-        )
-      }
     }
 
     if let conversation = appState.conversations.first(where: { $0.id == conversationId }) {

--- a/desktop/macos/Desktop/Tests/ConversationDetailAutomationStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationDetailAutomationStateTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class ConversationDetailAutomationStateTests: XCTestCase {
+  func testPendingOpenSurvivesUntilTheConversationsPageConsumesIt() {
+    let state = ConversationDetailAutomationState()
+
+    state.requestOpen(conversationId: "conversation-1", showTranscript: true)
+
+    XCTAssertEqual(
+      state.takePendingOpenRequest(),
+      .init(conversationId: "conversation-1", showTranscript: true)
+    )
+    XCTAssertNil(state.takePendingOpenRequest())
+  }
+
+  func testAppearingDetailConsumesTranscriptIntentWithoutDelay() {
+    let state = ConversationDetailAutomationState()
+
+    state.requestOpen(conversationId: "conversation-1", showTranscript: true)
+    _ = state.takePendingOpenRequest()
+
+    XCTAssertTrue(state.syncPresentedDetail(conversationId: "conversation-1", transcriptDrawerOpen: false))
+    XCTAssertEqual(state.openConversationId, "conversation-1")
+    XCTAssertTrue(state.transcriptDrawerOpen)
+  }
+
+  func testLaterRequestWithoutTranscriptReplacesEarlierDrawerIntent() {
+    let state = ConversationDetailAutomationState()
+
+    state.requestOpen(conversationId: "conversation-1", showTranscript: true)
+    state.requestOpen(conversationId: "conversation-2", showTranscript: false)
+    _ = state.takePendingOpenRequest()
+
+    XCTAssertFalse(state.syncPresentedDetail(conversationId: "conversation-2", transcriptDrawerOpen: false))
+    XCTAssertFalse(state.transcriptDrawerOpen)
+  }
+
+  func testNormalDetailOpenDoesNotShowTranscriptDrawer() {
+    let state = ConversationDetailAutomationState()
+
+    XCTAssertFalse(state.syncPresentedDetail(conversationId: "conversation-1", transcriptDrawerOpen: false))
+    XCTAssertFalse(state.transcriptDrawerOpen)
+  }
+
+  func testSyncPresentedDetailReplacesAutomationOpenStateWhenSwiftUIReusesTheDetailView() {
+    let state = ConversationDetailAutomationState()
+
+    _ = state.syncPresentedDetail(conversationId: "conversation-1", transcriptDrawerOpen: true)
+    let drawerOpen = state.syncPresentedDetail(conversationId: "conversation-2", transcriptDrawerOpen: false)
+
+    XCTAssertEqual(state.openConversationId, "conversation-2")
+    XCTAssertFalse(drawerOpen)
+    XCTAssertFalse(state.transcriptDrawerOpen)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260724-conversation-automation-reliability.json
+++ b/desktop/macos/changelog/unreleased/20260724-conversation-automation-reliability.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved conversation navigation reliability when switching between memory and conversation views"
+}

--- a/desktop/macos/e2e/flows/conversation-detail.yaml
+++ b/desktop/macos/e2e/flows/conversation-detail.yaml
@@ -6,6 +6,7 @@ app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+  - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
   - desktop/macos/Desktop/Sources/MainWindow/ConversationDetailAutomationState.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/LiveTranscriptView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/TranscriptDetailView.swift
@@ -39,16 +40,14 @@ steps:
       name: open_latest_conversation
       params:
         showTranscript: "true"
-        settleMs: "500"
     expect:
       ok: true
+      result.detail.detail_open: "true"
 
   - id: S4
     name: Conversation detail snapshot
     bridge.action:
       name: conversation_detail_snapshot
-      params:
-        settleMs: "500"
     expect:
       result.detail.detail_open: "true"
       result.detail.transcript_drawer_open: "true"

--- a/desktop/macos/e2e/flows/conversation-sharing.yaml
+++ b/desktop/macos/e2e/flows/conversation-sharing.yaml
@@ -37,16 +37,14 @@ steps:
       name: open_latest_conversation
       params:
         showTranscript: "false"
-        settleMs: "500"
     expect:
       ok: true
+      result.detail.detail_open: "true"
 
   - id: S4
     name: Detail open snapshot
     bridge.action:
       name: conversation_detail_snapshot
-      params:
-        settleMs: "300"
     expect:
       result.detail.detail_open: "true"
 


### PR DESCRIPTION
## Summary
- Retain conversation-open automation requests across Memory hub routing and consume them through the mounted conversation surface.
- Synchronize automation detail state when SwiftUI reuses an existing detail view for a newer conversation.
- Make detail and sharing flows assert the action completion contract directly, without settle delays.

## Root cause
A one-shot notification could arrive before the Conversations surface mounted, and a reused `ConversationDetailView` did not run `onAppear` for the new conversation. The bridge therefore timed out while its observable detail state still referenced the previous conversation.

## Verification
- `xcrun swift build -c debug --package-path Desktop`
- `xcrun swift test --package-path Desktop --filter 'ConversationDetailAutomationStateTests|DesktopAutomationSecondaryActionTests'`
- `./scripts/swift-format-wrapper.sh lint -r "$(./scripts/swift-format-wrapper.sh scope)"`
- `./scripts/swiftlint-wrapper.sh lint`
- `python3 scripts/check_desktop_test_quality.py`
- `python3 scripts/desktop-flow-lint.py`
- `PATH="$PWD/../../backend/.venv/bin:$PATH" PROVIDER_MODE=offline ./scripts/desktop-core-harness.sh --self-check`
- Named non-production, local offline emulator (`alice`), bridge port `47831`:
  - `conversation-detail.yaml` — PASS
  - `conversation-sharing.yaml` — PASS
  - `speaker-naming.yaml` — PASS

## Failure-Class
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

