### PR TITLE
fix(ci): make three guards actually verify, and schedule the failure-class retirement

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -34,6 +34,11 @@ checks:
     triggers: [".github/scripts/failure_class_retirement.py", ".github/scripts/test_failure_class_retirement.py", ".github/workflows/repo-hygiene.yml", "scripts/failure-class", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "the weekly retirement author must refuse a truncated event feed; a short feed reports every class as instance-free, so the job would stay green while retiring nothing"
+  - id: desktop-auto-beta-candidate-gate-tests
+    command: ["python3", ".github/scripts/test_check_desktop_auto_beta_candidate.py"]
+    triggers: [".github/scripts/check-desktop-auto-beta-candidate.py", ".github/scripts/test_check_desktop_auto_beta_candidate.py", "codemagic.yaml", "desktop/macos/scripts/smoke-signed-desktop-artifact.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the candidate gate validates signed-smoke evidence; a stable-only flag change must not fail-close the first dual-identity release"
   - id: check-manifest-contract
     command: ["python3", ".github/scripts/test_run_checks.py"]
     triggers: ["all"]
@@ -101,11 +106,26 @@ checks:
     triggers: ["all"]
     lanes: ["local", "ci"]
     reason: "all changes must be free of whitespace errors and conflict markers"
+  - id: package-architecture-map-guardrail-tests
+    command: ["python3", ".github/scripts/test_check_package_architecture_maps.py"]
+    triggers: [".github/scripts/check_package_architecture_maps.py", ".github/scripts/test_check_package_architecture_maps.py", ".github/scripts/package_architecture_baseline.json", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the package-map ratchet is only a ratchet while its own baseline behavior stays covered"
   - id: architecture-guardrails
     command: ["python3", ".github/scripts/check_arch_guardrails.py", "--changed-files", "{changed_files}", "--base", "{base}"]
     triggers: ["all"]
     lanes: ["local", "ci"]
     reason: "advisory size checks plus oversized package-map baseline ratchet"
+  - id: product-invariant-checker-tests
+    command: ["python3", ".github/scripts/test_check_product_invariants.py"]
+    triggers: [".github/scripts/check_product_invariants.py", ".github/scripts/test_check_product_invariants.py", "docs/product/invariants/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "locked invariant citation enforcement must keep rejecting an uncited path match"
+  - id: pr-preflight-contract-tests
+    command: ["python3", ".github/scripts/test_pr_preflight.py"]
+    triggers: [".github/scripts/pr_preflight.py", ".github/scripts/test_pr_preflight.py", ".github/scripts/pr_metadata.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "preflight resolves the check selection every PR depends on"
   - id: product-invariants
     command: ["python3", ".github/scripts/check_product_invariants.py", "--changed-files", "{changed_files}", "--pr-body-file", "{pr_body_file}"]
     triggers: ["all"]
@@ -139,6 +159,11 @@ checks:
     lanes: ["local", "ci"]
     platforms: ["macos"]
     reason: "desktop Swift sources changed; compare against the pinned macOS formatter before requiring a flow cover"
+  - id: brand-ui-ratchet-tests
+    command: ["python3", ".github/scripts/test_check_brand_ui.py"]
+    triggers: [".github/scripts/check_brand_ui.py", ".github/scripts/test_check_brand_ui.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "INV-UI-1 is a no-increase ratchet; its counting behavior must stay covered"
   - id: brand-ui
     command: ["python3", ".github/scripts/check_brand_ui.py", "--changed-files", "{changed_files}", "--base", "{base}"]
     triggers: ["desktop/macos/Desktop/Sources/**/*.swift", "app/lib/**/*.dart", "web/**/*.ts", "web/**/*.tsx", "web/**/*.js", "web/**/*.jsx", "web/**/*.css"]
@@ -239,11 +264,21 @@ checks:
     triggers: ["backend/database/**/*.py", ".github/scripts/check_firestore_model_read_boundary.py", ".github/scripts/firestore_model_read_boundary_baseline.json"]
     lanes: ["local", "ci"]
     reason: "#9494 -> #9696 malformed Firestore documents must use the shared read boundary"
+  - id: lifecycle-header-checker-tests
+    command: ["python3", ".github/scripts/test_check_lifecycle_headers.py"]
+    triggers: [".github/scripts/check_lifecycle_headers.py", ".github/scripts/test_check_lifecycle_headers.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "one-time rollout scaffolding must keep requiring a DELETE-AFTER reference"
   - id: lifecycle-headers
     command: ["python3", ".github/scripts/check_lifecycle_headers.py", "--changed-files", "{changed_files}"]
     triggers: ["all"]
     lanes: ["local", "ci"]
     reason: "rollout scaffolding may require lifecycle headers"
+  - id: version-prefixed-filename-tests
+    command: ["python3", ".github/scripts/test_check_version_prefixed_filenames.py"]
+    triggers: [".github/scripts/check_version_prefixed_filenames.py", ".github/scripts/test_check_version_prefixed_filenames.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the repository-wide filename contract must keep rejecting a version-prefixed path"
   - id: version-prefixed-filenames
     command: ["python3", ".github/scripts/check_version_prefixed_filenames.py"]
     triggers: ["all"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -29,6 +29,11 @@ checks:
     triggers: ["Makefile", "backend/scripts/sync-python-deps.sh", "scripts/pre-push", "scripts/test-make-setup.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "make setup must provision the minimal, rerunnable backend environment required by selected pre-push checks"
+  - id: failure-class-retirement-author
+    command: ["python3", ".github/scripts/test_failure_class_retirement.py"]
+    triggers: [".github/scripts/failure_class_retirement.py", ".github/scripts/test_failure_class_retirement.py", ".github/workflows/repo-hygiene.yml", "scripts/failure-class", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the weekly retirement author must refuse a truncated event feed; a short feed reports every class as instance-free, so the job would stay green while retiring nothing"
   - id: check-manifest-contract
     command: ["python3", ".github/scripts/test_run_checks.py"]
     triggers: ["all"]

--- a/.github/failure-classes/FC-nonexecuting-verification-command.json
+++ b/.github/failure-classes/FC-nonexecuting-verification-command.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "FC-nonexecuting-verification-command",
+  "violated_contract": "A registered verification command must execute the cases it claims to verify; an invocation that can exit 0 without evaluating a single assertion must never report success.",
+  "canonical_prevention": "Assert the invocation contract where the command is registered rather than trusting its exit code: a test module handed straight to the interpreter must be self-running, and every registered guard must be shown to fail on the historical input it exists to catch.",
+  "evidence_prs": [10237],
+  "scope_hints": [".github/checks-manifest.yaml", ".github/scripts/**", "scripts/**"],
+  "status": "open"
+}

--- a/.github/scripts/failure_class_retirement.py
+++ b/.github/scripts/failure_class_retirement.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Author the failure-class retirement diff the advisory report already justifies.
+
+`scripts/failure-class report` decides which classes are closure-eligible, but it
+is deliberately non-mutating and has no event source of its own: without
+`--events-file` it returns zero events and a `no_event_source` warning. Nothing
+scheduled ever supplied that feed, so the lifecycle shipped complete and never
+ran.
+
+This script closes that gap and nothing else:
+
+  1. Build the merged-PR event feed for the quiet period (`gh`, or a fixture).
+  2. Refuse to proceed unless the feed provably spans the window. A truncated
+     feed makes every class report "no classified instance", so the job would
+     stay green forever while retiring nothing -- the same false-green failure
+     as a check that executes no tests.
+  3. Run `scripts/failure-class report` and apply the two-field retirement edit
+     (`status: dormant` + `dormant_since`) for each closure-eligible class.
+  4. Write PR-body evidence, and surface any class whose recurrence requires an
+     explicit reopen.
+
+It never merges and never decides. The reviewable diff is the whole output; a
+maintainer merging it is the confirmation the lifecycle requires.
+
+LIFECYCLE: permanent
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFINITIONS_RELATIVE_PATH = Path(".github/failure-classes")
+FAILURE_CLASS_CLI = REPO_ROOT / "scripts/failure-class"
+EVENTS_SCHEMA_VERSION = 1
+# Well above the ~750 PRs a 14-day window holds at current merge rate; the
+# truncation guard below is what actually keeps this honest.
+FETCH_LIMIT = 3000
+DURATION_RE = re.compile(r"^(?P<value>\d+)(?P<unit>[dh])$")
+
+
+class RetirementError(RuntimeError):
+    """A condition that must stop the run rather than produce a partial diff."""
+
+
+def parse_duration(text: str) -> timedelta:
+    match = DURATION_RE.match(text)
+    if not match:
+        raise RetirementError(f"--since must look like 14d or 24h, got {text!r}")
+    value = int(match.group("value"))
+    return timedelta(days=value) if match.group("unit") == "d" else timedelta(hours=value)
+
+
+def parse_timestamp(text: str) -> datetime:
+    normalized = text.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def fetch_events(cutoff: datetime, runner=subprocess.run) -> dict[str, Any]:
+    """Fetch merged-PR bodies for the quiet period via gh."""
+    search = f"merged:>={cutoff.date().isoformat()}"
+    completed = runner(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--search",
+            search,
+            "--limit",
+            str(FETCH_LIMIT),
+            "--json",
+            "number,body,mergedAt",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RetirementError(f"gh pr list failed ({completed.returncode}): {completed.stderr.strip()}")
+    try:
+        raw = json.loads(completed.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise RetirementError(f"gh pr list returned unparseable JSON: {exc}") from exc
+    events = [
+        {"number": item.get("number"), "body": item.get("body") or "", "merged_at": item["mergedAt"]}
+        for item in raw
+        if item.get("mergedAt")
+    ]
+    return {"schema_version": EVENTS_SCHEMA_VERSION, "events": events}
+
+
+def assert_feed_spans_window(feed: dict[str, Any], cutoff: datetime) -> None:
+    """Refuse a feed that cannot prove coverage of the quiet period.
+
+    The search asks for everything merged since the cutoff, so a result set
+    smaller than the fetch limit covers the window by construction. Hitting the
+    limit means the oldest instances were silently dropped, which would report
+    healthy classes as instance-free.
+    """
+    events = feed.get("events") or []
+    if len(events) >= FETCH_LIMIT:
+        raise RetirementError(
+            f"event feed hit the {FETCH_LIMIT}-record fetch limit, so coverage of the window "
+            f"since {cutoff.isoformat()} cannot be proven; raise FETCH_LIMIT or shorten --since"
+        )
+    if not events:
+        raise RetirementError(
+            f"event feed is empty for the window since {cutoff.isoformat()}; a repository with "
+            "merges in the quiet period should never produce an empty feed"
+        )
+
+
+def run_report(events_path: Path, since: str, now: datetime, root: Path, runner=subprocess.run) -> dict[str, Any]:
+    completed = runner(
+        [
+            sys.executable,
+            str(FAILURE_CLASS_CLI),
+            "report",
+            "--since",
+            since,
+            "--events-file",
+            str(events_path),
+            "--now",
+            now.isoformat().replace("+00:00", "Z"),
+            "--root",
+            str(root),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    try:
+        report = json.loads(completed.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RetirementError(
+            f"failure-class report returned unparseable JSON (exit {completed.returncode}): "
+            f"{exc}; stderr: {completed.stderr.strip()}"
+        ) from exc
+    errors = report.get("errors") or []
+    warnings = report.get("warnings") or []
+    if errors:
+        raise RetirementError(f"failure-class report reported errors: {json.dumps(errors)}")
+    if warnings:
+        raise RetirementError(f"failure-class report reported warnings: {json.dumps(warnings)}")
+    return report
+
+
+STATUS_LINE_RE = re.compile(r'^(?P<indent>[ \t]*)"status": "open"(?P<comma>,?)[ \t]*$', re.MULTILINE)
+
+
+def apply_retirement(definition_path: Path, dormant_since: datetime) -> None:
+    """Rewrite only the status line, in place.
+
+    A `json.loads` / `json.dumps` round trip reflows the hand-maintained inline
+    arrays in these definitions, burying the two-field lifecycle change in
+    unrelated formatting churn. The diff a maintainer reviews must be exactly
+    the state transition, so edit the text surgically and re-parse to prove the
+    result is still valid JSON with the intended fields.
+    """
+    original = definition_path.read_text(encoding="utf-8")
+    timestamp = dormant_since.isoformat().replace("+00:00", "Z")
+
+    match = STATUS_LINE_RE.search(original)
+    if not match:
+        raise RetirementError(f'{definition_path} has no `"status": "open"` line to retire')
+    indent = match.group("indent")
+    replacement = f'{indent}"status": "dormant",\n{indent}"dormant_since": "{timestamp}"{match.group("comma")}'
+    updated = original[: match.start()] + replacement + original[match.end() :]
+
+    data = json.loads(updated)
+    if data.get("status") != "dormant" or data.get("dormant_since") != timestamp:
+        raise RetirementError(f"{definition_path}: retirement edit did not produce the expected lifecycle fields")
+    definition_path.write_text(updated, encoding="utf-8")
+
+
+def render_evidence(report: dict[str, Any], eligible: list[dict[str, Any]], reopen: list[dict[str, Any]]) -> str:
+    lines = [
+        "Automated failure-class retirement, authored from the advisory recurrence report.",
+        "",
+        f"- report `as_of`: `{report.get('as_of')}`",
+        f"- quiet period: `{report.get('since')}`",
+        f"- merged-PR events considered: {report.get('events_considered')}",
+        "",
+        "## Classes retired in this diff",
+        "",
+    ]
+    if eligible:
+        lines.append("| class | last classified instance | merged at |")
+        lines.append("|---|---|---|")
+        for entry in eligible:
+            instance = entry.get("last_reported_instance") or {}
+            lines.append(f"| `{entry['id']}` | #{instance.get('number', '?')} | {instance.get('merged_at', '?')} |")
+    else:
+        lines.append("None.")
+    lines += [
+        "",
+        "Each class above reported no classified recurrence during the quiet period.",
+        "Merging this PR is the maintainer confirmation the lifecycle requires; recurrence",
+        "after retirement requires an explicit reopen.",
+        "",
+    ]
+    if reopen:
+        lines += [
+            "## Reopen required",
+            "",
+            "A dormant class was classified again. Reopening is judgment work, not this diff:",
+            "",
+        ]
+        lines += [f"- `{entry['id']}`" for entry in reopen]
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--since", default="14d", help="Quiet period, such as 14d or 24h (default: 14d).")
+    parser.add_argument("--now", help="UTC ISO-8601 timestamp; defaults to now.")
+    parser.add_argument("--events-file", type=Path, help="Use a local event feed instead of querying gh.")
+    parser.add_argument("--feed-out", type=Path, help="Write the fetched feed here (default: a temp file).")
+    parser.add_argument("--evidence-file", type=Path, help="Write PR-body evidence markdown here.")
+    parser.add_argument("--apply", action="store_true", help="Write the retirement edits (default: report only).")
+    parser.add_argument("--root", type=Path, default=REPO_ROOT, help="Repository root holding the definitions.")
+    args = parser.parse_args(argv)
+
+    try:
+        quiet_period = parse_duration(args.since)
+        now = parse_timestamp(args.now) if args.now else datetime.now(timezone.utc)
+        cutoff = now - quiet_period
+
+        if args.events_file:
+            feed = json.loads(args.events_file.read_text(encoding="utf-8"))
+            events_path = args.events_file
+        else:
+            feed = fetch_events(cutoff)
+            # Never default into the work tree: a stray feed file would land in
+            # the retirement PR alongside the lifecycle change.
+            events_path = args.feed_out or Path(tempfile.gettempdir()) / "failure-class-events.json"
+            events_path.write_text(json.dumps(feed, indent=2) + "\n", encoding="utf-8")
+
+        assert_feed_spans_window(feed, cutoff)
+        report = run_report(events_path, args.since, now, args.root)
+
+        classes = report.get("classes") or []
+        eligible = [entry for entry in classes if entry.get("closure_eligible")]
+        reopen = [entry for entry in classes if entry.get("reopen_required")]
+
+        definitions_dir = args.root / DEFINITIONS_RELATIVE_PATH
+        if args.apply:
+            for entry in eligible:
+                definition = definitions_dir / f"{entry['id']}.json"
+                if not definition.exists():
+                    raise RetirementError(f"closure-eligible class has no definition file: {definition}")
+                apply_retirement(definition, now)
+
+        if args.evidence_file:
+            args.evidence_file.write_text(render_evidence(report, eligible, reopen), encoding="utf-8")
+
+        summary = {
+            "schema_version": EVENTS_SCHEMA_VERSION,
+            "events_considered": report.get("events_considered"),
+            "retired": [entry["id"] for entry in eligible],
+            "reopen_required": [entry["id"] for entry in reopen],
+            "applied": bool(args.apply),
+        }
+        print(json.dumps(summary, indent=2))
+        # A retired class that was classified again is a recurrence the registry
+        # must not absorb silently; fail the run so a human looks at it.
+        return 1 if reopen else 0
+    except RetirementError as exc:
+        print(f"failure-class retirement: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_check_release_rings.py
+++ b/.github/scripts/test_check_release_rings.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 import shutil
 import sys
+import tempfile
+import unittest
 from pathlib import Path
 
 MODULE_PATH = Path(__file__).with_name("check_release_rings.py")
@@ -13,82 +15,99 @@ sys.modules[SPEC.name] = checker
 SPEC.loader.exec_module(checker)
 
 
-def test_checked_in_production_release_vector_is_guarded() -> None:
-    assert checker.check() == []
+class ReleaseRingGuardTests(unittest.TestCase):
+    """Guard the one-action production backend release contract.
+
+    Written against stdlib ``unittest`` so the manifest command
+    ``python3 .github/scripts/test_check_release_rings.py`` executes the cases.
+    A pytest-only module exits 0 here without running anything, which is
+    indistinguishable from a passing guard.
+    """
+
+    def setUp(self) -> None:
+        self._real_root = checker.ROOT
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self._tmp.name)
+
+    def tearDown(self) -> None:
+        checker.ROOT = self._real_root
+        self._tmp.cleanup()
+
+    def _stage_release_sources(self) -> None:
+        """Copy every checked-in backend release source into the sandbox root."""
+        for relative in checker.BACKEND_RELEASE_SOURCES:
+            destination = self.tmp_path / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(self._real_root / relative, destination)
+        checker.ROOT = self.tmp_path
+
+    def _deploy_workflow(self) -> Path:
+        return self.tmp_path / ".github/workflows/gcp_backend.yml"
+
+    def test_checked_in_production_release_vector_is_guarded(self) -> None:
+        self.assertEqual(checker.check(), [])
+
+    def test_canonical_backend_workflow_is_the_only_production_release_authority(self) -> None:
+        """The normal production path must not depend on a record/ring control plane."""
+        workflow = self._deploy_workflow()
+        workflow.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(self._real_root / ".github/workflows/gcp_backend.yml", workflow)
+        checker.ROOT = self.tmp_path
+
+        self.assertEqual(checker.check(), [])
+
+    def test_beta_backend_dispatch_is_rejected(self) -> None:
+        self._stage_release_sources()
+        deploy_path = self._deploy_workflow()
+        deploy_path.write_text(
+            deploy_path.read_text(encoding="utf-8") + "\n# release-ring deployment control plane\n",
+            encoding="utf-8",
+        )
+
+        self.assertTrue(
+            any("backend release-ring deployment control plane is forbidden" in error for error in checker.check())
+        )
+
+    def test_dispatch_release_id_cannot_be_interpolated_into_shell(self) -> None:
+        self._stage_release_sources()
+        deploy_path = self._deploy_workflow()
+        deploy_path.write_text(
+            deploy_path.read_text(encoding="utf-8").replace(
+                "name: Deploy Backend to Cloud RUN", "name: Deploy Backend to Cloud RUN\n# RELEASE_RECORDS_BUCKET"
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertTrue(any("obsolete release binding" in error for error in checker.check()))
+
+    def test_serving_release_vector_must_follow_traffic_promotion(self) -> None:
+        self._stage_release_sources()
+        deploy_path = self._deploy_workflow()
+        deploy_path.write_text(
+            deploy_path.read_text(encoding="utf-8").replace(
+                "      - name: Verify serving backend release vector\n",
+                "      - name: Verify release vector before traffic promotion\n",
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertTrue(
+            any("serving release-vector verification must follow traffic promotion" in error for error in checker.check())
+        )
+
+    def test_staged_workflow_control_verifier_remains_required(self) -> None:
+        self._stage_release_sources()
+        deploy_path = self._deploy_workflow()
+        deploy_path.write_text(
+            deploy_path.read_text(encoding="utf-8").replace(
+                "$DEPLOY_CONTROL_SCRIPTS/verify_backend_release_vector.py",
+                "$DEPLOY_CONTROL_SCRIPTS/not-the-release-vector-verifier.py",
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertTrue(any("canonical release-vector verifier" in error for error in checker.check()))
 
 
-def test_canonical_backend_workflow_is_the_only_production_release_authority(tmp_path: Path, monkeypatch) -> None:
-    """The normal production path must not depend on a record/ring control plane."""
-    workflow = tmp_path / ".github/workflows/gcp_backend.yml"
-    workflow.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(checker.ROOT / ".github/workflows/gcp_backend.yml", workflow)
-    monkeypatch.setattr(checker, "ROOT", tmp_path)
-
-    assert checker.check() == []
-
-
-def test_beta_backend_dispatch_is_rejected(tmp_path: Path, monkeypatch) -> None:
-    for relative in checker.BACKEND_RELEASE_SOURCES:
-        destination = tmp_path / relative
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(checker.ROOT / relative, destination)
-    deploy_path = tmp_path / ".github/workflows/gcp_backend.yml"
-    deploy_path.write_text(
-        deploy_path.read_text(encoding="utf-8") + "\n# release-ring deployment control plane\n", encoding="utf-8"
-    )
-    monkeypatch.setattr(checker, "ROOT", tmp_path)
-
-    assert any("backend release-ring deployment control plane is forbidden" in error for error in checker.check())
-
-
-def test_dispatch_release_id_cannot_be_interpolated_into_shell(tmp_path: Path, monkeypatch) -> None:
-    for relative in checker.BACKEND_RELEASE_SOURCES:
-        destination = tmp_path / relative
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(checker.ROOT / relative, destination)
-    deploy_path = tmp_path / ".github/workflows/gcp_backend.yml"
-    deploy_path.write_text(
-        deploy_path.read_text(encoding="utf-8").replace(
-            "name: Deploy Backend to Cloud RUN", "name: Deploy Backend to Cloud RUN\n# RELEASE_RECORDS_BUCKET"
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(checker, "ROOT", tmp_path)
-
-    assert any("obsolete release binding" in error for error in checker.check())
-
-
-def test_serving_release_vector_must_follow_traffic_promotion(tmp_path: Path, monkeypatch) -> None:
-    for relative in checker.BACKEND_RELEASE_SOURCES:
-        destination = tmp_path / relative
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(checker.ROOT / relative, destination)
-    deploy_path = tmp_path / ".github/workflows/gcp_backend.yml"
-    deploy_path.write_text(
-        deploy_path.read_text(encoding="utf-8").replace(
-            "      - name: Verify serving backend release vector\n",
-            "      - name: Verify release vector before traffic promotion\n",
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(checker, "ROOT", tmp_path)
-
-    assert any("serving release-vector verification must follow traffic promotion" in error for error in checker.check())
-
-
-def test_staged_workflow_control_verifier_remains_required(tmp_path: Path, monkeypatch) -> None:
-    for relative in checker.BACKEND_RELEASE_SOURCES:
-        destination = tmp_path / relative
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(checker.ROOT / relative, destination)
-    deploy_path = tmp_path / ".github/workflows/gcp_backend.yml"
-    deploy_path.write_text(
-        deploy_path.read_text(encoding="utf-8").replace(
-            "$DEPLOY_CONTROL_SCRIPTS/verify_backend_release_vector.py",
-            "$DEPLOY_CONTROL_SCRIPTS/not-the-release-vector-verifier.py",
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(checker, "ROOT", tmp_path)
-
-    assert any("canonical release-vector verifier" in error for error in checker.check())
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_failure_class_retirement.py
+++ b/.github/scripts/test_failure_class_retirement.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Contract tests for the failure-class retirement author.
+
+Hermetic: every case supplies its own event feed, so no case touches the network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("failure_class_retirement.py")
+SPEC = importlib.util.spec_from_file_location("failure_class_retirement", MODULE_PATH)
+assert SPEC and SPEC.loader
+retirement = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = retirement
+SPEC.loader.exec_module(retirement)
+
+NOW = "2026-08-20T00:00:00Z"
+
+
+def definition(class_id: str, status: str = "open", dormant_since: str | None = None) -> dict[str, object]:
+    data: dict[str, object] = {
+        "schema_version": 1,
+        "id": class_id,
+        "violated_contract": "A contract that failed once.",
+        "canonical_prevention": "Converge the owner.",
+        "evidence_prs": [1234],
+        "status": status,
+    }
+    if dormant_since:
+        data["dormant_since"] = dormant_since
+    return data
+
+
+class FeedCoverageTests(unittest.TestCase):
+    """The assertion that keeps a green run from meaning nothing."""
+
+    def test_truncated_feed_is_refused(self) -> None:
+        cutoff = datetime(2026, 8, 6, tzinfo=timezone.utc)
+        feed = {"schema_version": 1, "events": [{"number": i, "body": "", "merged_at": NOW} for i in range(retirement.FETCH_LIMIT)]}
+        with self.assertRaises(retirement.RetirementError) as caught:
+            retirement.assert_feed_spans_window(feed, cutoff)
+        self.assertIn("fetch limit", str(caught.exception))
+
+    def test_empty_feed_is_refused(self) -> None:
+        cutoff = datetime(2026, 8, 6, tzinfo=timezone.utc)
+        with self.assertRaises(retirement.RetirementError) as caught:
+            retirement.assert_feed_spans_window({"schema_version": 1, "events": []}, cutoff)
+        self.assertIn("empty", str(caught.exception))
+
+    def test_feed_below_the_limit_is_accepted(self) -> None:
+        cutoff = datetime(2026, 8, 6, tzinfo=timezone.utc)
+        feed = {"schema_version": 1, "events": [{"number": 1, "body": "", "merged_at": NOW}]}
+        retirement.assert_feed_spans_window(feed, cutoff)
+
+
+class ParsingTests(unittest.TestCase):
+    def test_duration_forms(self) -> None:
+        self.assertEqual(retirement.parse_duration("14d"), timedelta(days=14))
+        self.assertEqual(retirement.parse_duration("24h"), timedelta(hours=24))
+
+    def test_invalid_duration_is_rejected(self) -> None:
+        with self.assertRaises(retirement.RetirementError):
+            retirement.parse_duration("2 weeks")
+
+
+class RetirementDiffTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.definitions = self.tmp / ".github/failure-classes"
+        self.definitions.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_apply_sets_exactly_the_two_lifecycle_fields(self) -> None:
+        path = self.definitions / "FC-example.json"
+        path.write_text(json.dumps(definition("FC-example"), indent=2) + "\n", encoding="utf-8")
+
+        retirement.apply_retirement(path, retirement.parse_timestamp(NOW))
+
+        written = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(written["status"], "dormant")
+        self.assertEqual(written["dormant_since"], NOW)
+        # Nothing else may drift: the diff must stay reviewable at a glance.
+        self.assertEqual(written["violated_contract"], "A contract that failed once.")
+        self.assertEqual(written["evidence_prs"], [1234])
+
+    def test_apply_touches_only_the_status_line(self) -> None:
+        """A json round trip reflows hand-maintained inline arrays; the diff must not."""
+        path = self.definitions / "FC-shaped.json"
+        original = (
+            "{\n"
+            '  "schema_version": 1,\n'
+            '  "id": "FC-shaped",\n'
+            '  "violated_contract": "A contract that failed once.",\n'
+            '  "canonical_prevention": "Converge the owner.",\n'
+            '  "evidence_prs": [9365, 9597],\n'
+            '  "scope_hints": ["desktop/macos/**", "backend/**"],\n'
+            '  "status": "open"\n'
+            "}\n"
+        )
+        path.write_text(original, encoding="utf-8")
+
+        retirement.apply_retirement(path, retirement.parse_timestamp(NOW))
+
+        updated = path.read_text(encoding="utf-8")
+        removed = [line for line in original.splitlines() if line not in updated.splitlines()]
+        added = [line for line in updated.splitlines() if line not in original.splitlines()]
+        self.assertEqual(removed, ['  "status": "open"'])
+        self.assertEqual(added, ['  "status": "dormant",', f'  "dormant_since": "{NOW}"'])
+        # The inline arrays survive verbatim.
+        self.assertIn('  "evidence_prs": [9365, 9597],', updated)
+        self.assertIn('  "scope_hints": ["desktop/macos/**", "backend/**"],', updated)
+
+    def test_apply_refuses_a_definition_that_is_not_open(self) -> None:
+        path = self.definitions / "FC-already.json"
+        path.write_text(
+            json.dumps(definition("FC-already", status="dormant", dormant_since=NOW), indent=2) + "\n", encoding="utf-8"
+        )
+        with self.assertRaises(retirement.RetirementError):
+            retirement.apply_retirement(path, retirement.parse_timestamp(NOW))
+
+    def test_evidence_names_each_retired_class_and_its_instance(self) -> None:
+        report = {"as_of": NOW, "since": "14d", "events_considered": 700}
+        eligible = [{"id": "FC-example", "last_reported_instance": {"number": 9001, "merged_at": "2026-08-01T00:00:00Z"}}]
+
+        text = retirement.render_evidence(report, eligible, [])
+
+        self.assertIn("FC-example", text)
+        self.assertIn("#9001", text)
+        self.assertIn("700", text)
+
+    def test_evidence_reports_no_retirements_without_inventing_any(self) -> None:
+        text = retirement.render_evidence({"as_of": NOW, "since": "14d", "events_considered": 5}, [], [])
+        self.assertIn("None.", text)
+
+    def test_evidence_separates_reopen_from_retirement(self) -> None:
+        text = retirement.render_evidence(
+            {"as_of": NOW, "since": "14d", "events_considered": 5}, [], [{"id": "FC-recurred"}]
+        )
+        self.assertIn("Reopen required", text)
+        self.assertIn("FC-recurred", text)
+
+
+class EndToEndTests(unittest.TestCase):
+    """Drive main() against a real failure-class definition tree and feed."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.definitions = self.tmp / ".github/failure-classes"
+        self.definitions.mkdir(parents=True)
+        self.feed = self.tmp / "events.json"
+        self.evidence = self.tmp / "evidence.md"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _write_feed(self, events: list[dict[str, object]]) -> None:
+        self.feed.write_text(json.dumps({"schema_version": 1, "events": events}) + "\n", encoding="utf-8")
+
+    def test_stale_class_is_retired_and_fresh_class_is_left_alone(self) -> None:
+        stale = self.definitions / "FC-stale.json"
+        fresh = self.definitions / "FC-fresh.json"
+        stale.write_text(json.dumps(definition("FC-stale"), indent=2) + "\n", encoding="utf-8")
+        fresh.write_text(json.dumps(definition("FC-fresh"), indent=2) + "\n", encoding="utf-8")
+        self._write_feed(
+            [
+                # Outside the 14d quiet period -> eligible for retirement.
+                {"number": 1, "body": "Failure-Class: FC-stale\n", "merged_at": "2026-07-01T00:00:00Z"},
+                # Inside the quiet period -> must stay open.
+                {"number": 2, "body": "Failure-Class: FC-fresh\n", "merged_at": "2026-08-19T00:00:00Z"},
+            ]
+        )
+
+        exit_code = retirement.main(
+            [
+                "--since",
+                "14d",
+                "--now",
+                NOW,
+                "--events-file",
+                str(self.feed),
+                "--evidence-file",
+                str(self.evidence),
+                "--apply",
+                "--root",
+                str(self.tmp),
+            ]
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(json.loads(stale.read_text(encoding="utf-8"))["status"], "dormant")
+        self.assertEqual(json.loads(fresh.read_text(encoding="utf-8"))["status"], "open")
+        self.assertNotIn("dormant_since", json.loads(fresh.read_text(encoding="utf-8")))
+        self.assertIn("FC-stale", self.evidence.read_text(encoding="utf-8"))
+
+    def test_without_apply_nothing_is_written(self) -> None:
+        stale = self.definitions / "FC-stale.json"
+        stale.write_text(json.dumps(definition("FC-stale"), indent=2) + "\n", encoding="utf-8")
+        self._write_feed([{"number": 1, "body": "Failure-Class: FC-stale\n", "merged_at": "2026-07-01T00:00:00Z"}])
+
+        exit_code = retirement.main(
+            ["--since", "14d", "--now", NOW, "--events-file", str(self.feed), "--root", str(self.tmp)]
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(json.loads(stale.read_text(encoding="utf-8"))["status"], "open")
+
+    def test_recurrence_after_retirement_fails_the_run(self) -> None:
+        recurred = self.definitions / "FC-recurred.json"
+        recurred.write_text(
+            json.dumps(definition("FC-recurred", status="dormant", dormant_since="2026-08-01T00:00:00Z"), indent=2) + "\n",
+            encoding="utf-8",
+        )
+        self._write_feed(
+            [{"number": 7, "body": "Failure-Class: FC-recurred\n", "merged_at": "2026-08-15T00:00:00Z"}]
+        )
+
+        exit_code = retirement.main(
+            [
+                "--since",
+                "14d",
+                "--now",
+                NOW,
+                "--events-file",
+                str(self.feed),
+                "--evidence-file",
+                str(self.evidence),
+                "--root",
+                str(self.tmp),
+            ]
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Reopen required", self.evidence.read_text(encoding="utf-8"))
+
+    def test_empty_feed_fails_before_any_edit(self) -> None:
+        stale = self.definitions / "FC-stale.json"
+        stale.write_text(json.dumps(definition("FC-stale"), indent=2) + "\n", encoding="utf-8")
+        self._write_feed([])
+
+        exit_code = retirement.main(
+            ["--since", "14d", "--now", NOW, "--events-file", str(self.feed), "--apply", "--root", str(self.tmp)]
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(json.loads(stale.read_text(encoding="utf-8"))["status"], "open")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -33,6 +33,15 @@ class FakeResponse(io.BytesIO):
 
 
 class MetadataTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # `resolve_pr_metadata` short-circuits on OMI_PR_BODY_FILE before it ever
+        # reaches the API path these cases assert on. The pre-push hook tells
+        # developers to export that variable, so an inherited value made this
+        # suite fail for a reason unrelated to the behavior under test.
+        patcher = patch.dict(os.environ, {"OMI_PR_BODY_FILE": ""})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_api_loader_uses_current_body_and_records_provenance(self) -> None:
         captured = {}
 

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 import os
 import re
 import shutil
@@ -67,6 +68,53 @@ def registered_script_paths() -> set[str]:
     return {token for check in manifest.checks for token in check.command if token.endswith(".py")}
 
 
+TEST_MODULE_RE = re.compile(r"(?:^|/)test[_-][A-Za-z0-9_.-]*\.py$")
+
+
+def interpreter_invoked_test_modules(command: tuple[str, ...]) -> list[str]:
+    """Test modules a command hands straight to the interpreter.
+
+    Commands that name an explicit runner (`-m pytest`, `-m unittest`) delegate
+    discovery to that runner and are not subject to the self-running contract.
+    """
+    if any(token in {"-m", "pytest", "unittest"} for token in command):
+        return []
+    return [token for token in command if TEST_MODULE_RE.search(token)]
+
+
+def non_self_running_reason(source: str) -> str | None:
+    """Explain why `python3 <module>` would execute no test cases, or None."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:  # pragma: no cover - a syntax error fails louder elsewhere
+        return f"could not be parsed: {exc}"
+
+    has_test_case = any(
+        isinstance(node, ast.ClassDef)
+        and any(
+            (isinstance(base, ast.Attribute) and base.attr.endswith("TestCase"))
+            or (isinstance(base, ast.Name) and base.id.endswith("TestCase"))
+            for base in node.bases
+        )
+        for node in ast.walk(tree)
+    )
+    if not has_test_case:
+        return "defines no unittest.TestCase subclass, so unittest.main() would collect nothing"
+
+    has_main_runner = any(
+        isinstance(node, ast.If)
+        and any(
+            isinstance(cmp_, ast.Constant) and cmp_.value == "__main__"
+            for cmp_ in getattr(node.test, "comparators", [])
+        )
+        and any(isinstance(inner, ast.Expr) and isinstance(inner.value, ast.Call) for inner in ast.walk(node))
+        for node in ast.walk(tree)
+    )
+    if not has_main_runner:
+        return "has no __main__ block invoking a test runner"
+    return None
+
+
 class ManifestContractTests(unittest.TestCase):
     def test_manifest_is_valid(self) -> None:
         manifest = load_manifest(MANIFEST_PATH)
@@ -109,6 +157,58 @@ class ManifestContractTests(unittest.TestCase):
         self.assertIn("--skip-pr-body-checks", workflow)
         manifest = load_manifest(MANIFEST_PATH)
         self.assertTrue(any("ci" in check.lanes for check in manifest.checks))
+
+    def test_manifest_test_modules_execute_their_cases(self) -> None:
+        """A registered test command must not be able to pass without running tests.
+
+        `python3 some_test_module.py` exits 0 when the module defines only
+        module-level `def test_*` functions, because `unittest.main()` discovers
+        `TestCase` subclasses. Such a check is green forever without asserting
+        anything, which is indistinguishable from a guard that works.
+        """
+        manifest = load_manifest(MANIFEST_PATH)
+        offenders: list[str] = []
+        for check in manifest.checks:
+            for relative in interpreter_invoked_test_modules(check.command):
+                path = REPO_ROOT / relative
+                if not path.exists():
+                    offenders.append(f"{check.id}: {relative} does not exist")
+                    continue
+                reason = non_self_running_reason(path.read_text(encoding="utf-8"))
+                if reason:
+                    offenders.append(f"{check.id}: {relative} {reason}")
+        self.assertEqual(offenders, [], f"manifest test commands that execute no cases: {offenders}")
+
+    def test_pytest_only_module_is_reported_as_non_self_running(self) -> None:
+        """The guard above must fail on the real historical shape it exists to catch."""
+        pytest_only = (
+            "from pathlib import Path\n"
+            "\n"
+            "def test_something(tmp_path: Path) -> None:\n"
+            "    assert True\n"
+        )
+        self.assertIn("defines no unittest.TestCase", non_self_running_reason(pytest_only) or "")
+
+        with_runner = (
+            "import unittest\n"
+            "\n"
+            "class T(unittest.TestCase):\n"
+            "    def test_something(self) -> None:\n"
+            "        self.assertTrue(True)\n"
+            "\n"
+            'if __name__ == "__main__":\n'
+            "    unittest.main()\n"
+        )
+        self.assertIsNone(non_self_running_reason(with_runner))
+
+        no_main = (
+            "import unittest\n"
+            "\n"
+            "class T(unittest.TestCase):\n"
+            "    def test_something(self) -> None:\n"
+            "        self.assertTrue(True)\n"
+        )
+        self.assertIn("has no __main__", non_self_running_reason(no_main) or "")
 
     def test_unregistered_fake_workflow_check_is_named(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -83,11 +83,45 @@ def interpreter_invoked_test_modules(command: tuple[str, ...]) -> list[str]:
 
 
 def non_self_running_reason(source: str) -> str | None:
-    """Explain why `python3 <module>` would execute no test cases, or None."""
+    """Explain why `python3 <module>` would execute no test cases, or None.
+
+    Two shapes execute nothing and still exit 0:
+      * no `__main__` block at all -- a pytest-only module handed to the
+        interpreter defines its functions and exits.
+      * a `__main__` block calling `unittest.main()` in a module with no
+        `TestCase` subclass -- discovery finds nothing to run.
+
+    A script-style module whose `__main__` calls its own `main()` of assertions
+    is self-running and must not be reported.
+    """
     try:
         tree = ast.parse(source)
     except SyntaxError as exc:  # pragma: no cover - a syntax error fails louder elsewhere
         return f"could not be parsed: {exc}"
+
+    main_blocks = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.If)
+        and any(
+            isinstance(cmp_, ast.Constant) and cmp_.value == "__main__"
+            for cmp_ in getattr(node.test, "comparators", [])
+        )
+    ]
+    invoking_blocks = [
+        node for node in main_blocks if any(isinstance(inner, ast.Call) for inner in ast.walk(node))
+    ]
+    if not invoking_blocks:
+        return "has no __main__ block invoking a test runner, so the interpreter runs no cases"
+
+    delegates_to_unittest = any(
+        isinstance(inner, ast.Attribute) and inner.attr == "main" and getattr(inner.value, "id", "") == "unittest"
+        for block in invoking_blocks
+        for inner in ast.walk(block)
+    )
+    if not delegates_to_unittest:
+        # Script-style: `__main__` calls the module's own assertions directly.
+        return None
 
     has_test_case = any(
         isinstance(node, ast.ClassDef)
@@ -99,19 +133,7 @@ def non_self_running_reason(source: str) -> str | None:
         for node in ast.walk(tree)
     )
     if not has_test_case:
-        return "defines no unittest.TestCase subclass, so unittest.main() would collect nothing"
-
-    has_main_runner = any(
-        isinstance(node, ast.If)
-        and any(
-            isinstance(cmp_, ast.Constant) and cmp_.value == "__main__"
-            for cmp_ in getattr(node.test, "comparators", [])
-        )
-        and any(isinstance(inner, ast.Expr) and isinstance(inner.value, ast.Call) for inner in ast.walk(node))
-        for node in ast.walk(tree)
-    )
-    if not has_main_runner:
-        return "has no __main__ block invoking a test runner"
+        return "calls unittest.main() with no TestCase subclass, so discovery collects nothing"
     return None
 
 
@@ -187,7 +209,7 @@ class ManifestContractTests(unittest.TestCase):
             "def test_something(tmp_path: Path) -> None:\n"
             "    assert True\n"
         )
-        self.assertIn("defines no unittest.TestCase", non_self_running_reason(pytest_only) or "")
+        self.assertIn("has no __main__", non_self_running_reason(pytest_only) or "")
 
         with_runner = (
             "import unittest\n"
@@ -209,6 +231,30 @@ class ManifestContractTests(unittest.TestCase):
             "        self.assertTrue(True)\n"
         )
         self.assertIn("has no __main__", non_self_running_reason(no_main) or "")
+
+        unittest_main_without_test_case = (
+            "import unittest\n"
+            "\n"
+            "def test_something() -> None:\n"
+            "    assert True\n"
+            "\n"
+            'if __name__ == "__main__":\n'
+            "    unittest.main()\n"
+        )
+        self.assertIn(
+            "no TestCase subclass", non_self_running_reason(unittest_main_without_test_case) or ""
+        )
+
+        # Script-style: a module whose __main__ runs its own assertions is fine.
+        script_style = (
+            "def main() -> int:\n"
+            "    assert True\n"
+            "    return 0\n"
+            "\n"
+            'if __name__ == "__main__":\n'
+            "    raise SystemExit(main())\n"
+        )
+        self.assertIsNone(non_self_running_reason(script_style))
 
     def test_unregistered_fake_workflow_check_is_named(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -110,15 +110,6 @@ jobs:
           scripts/changed-files "${{ needs.changes.outputs.diff_base }}"...HEAD > /tmp/changed-files.txt
           cat /tmp/changed-files.txt
 
-      - name: Test package architecture map guardrail
-        run: python3 .github/scripts/test_check_package_architecture_maps.py
-
-      - name: Test product invariant PR-body checker
-        run: python3 .github/scripts/test_check_product_invariants.py
-
-      - name: Test PR preflight contracts
-        run: python3 .github/scripts/test_pr_preflight.py
-
       - name: Run shared PR contract preflight
         if: github.event_name == 'pull_request'
         env:
@@ -134,17 +125,8 @@ jobs:
         if: github.event_name != 'pull_request'
         run: python3 .github/scripts/run_checks.py --lane ci --base "${{ needs.changes.outputs.diff_base }}" --skip-pr-body-checks
 
-      - name: Test brand UI ratchet helper
-        run: python3 .github/scripts/test_check_brand_ui.py
-
       - name: Check typed error flow-control ratchet
         run: python3 .github/scripts/check_isinstance_return_ratchet.py
-
-      - name: Test lifecycle header checker
-        run: python3 .github/scripts/test_check_lifecycle_headers.py
-
-      - name: Test version-prefixed filename lint
-        run: python3 .github/scripts/test_check_version_prefixed_filenames.py
 
       - name: Check desktop prod promotion policy
         run: python3 .github/scripts/check-desktop-prod-promotion-policy.py
@@ -157,9 +139,6 @@ jobs:
 
       - name: Test desktop qualification metadata writer
         run: python3 desktop/macos/scripts/release-keyvalue.py self-test
-
-      - name: Test automatic desktop beta candidate gate
-        run: python3 .github/scripts/test_check_desktop_auto_beta_candidate.py
 
       - name: Check release process guards
         run: |

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -1,0 +1,80 @@
+name: Repo Hygiene
+
+# Weekly advisory maintenance. Nothing here gates a merge or a release: each job
+# turns a registry the repository already maintains into a reviewable diff, so
+# retirement stops depending on someone remembering to look.
+#
+# Monday 09:00 UTC, clear of the release cadence (desktop_auto_release polls
+# every 15 min; desktop_retry_beta_qualification runs twice hourly).
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+    inputs:
+      since:
+        description: "Quiet period before a failure class may be retired (e.g. 14d)"
+        required: false
+        default: "14d"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repo-hygiene
+  cancel-in-progress: false
+
+jobs:
+  failure-class-retirement:
+    name: Failure-class retirement
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Author the retirement diff
+        id: retire
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SINCE: ${{ inputs.since || '14d' }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/failure_class_retirement.py \
+            --since "$SINCE" \
+            --apply \
+            --feed-out "$RUNNER_TEMP/failure-class-events.json" \
+            --evidence-file "$RUNNER_TEMP/retirement-evidence.md" \
+            | tee "$RUNNER_TEMP/summary.json"
+          {
+            echo "## Failure-class retirement"
+            echo
+            cat "$RUNNER_TEMP/retirement-evidence.md"
+          } >> "$GITHUB_STEP_SUMMARY"
+          retired=$(python3 -c "import json,os;print(len(json.load(open(os.environ['RUNNER_TEMP']+'/summary.json'))['retired']))")
+          echo "retired=$retired" >> "$GITHUB_OUTPUT"
+
+      # A GITHUB_TOKEN-authored PR does not trigger pull_request workflows, so it
+      # would arrive with zero checks run. The app token exists so the diff is
+      # verified by the same lanes as any human PR.
+      - name: Mint Omi Bot token
+        if: steps.retire.outputs.retired != '0'
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.OMI_BOT_APP_ID }}
+          private-key: ${{ secrets.OMI_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Open or update the retirement PR
+        if: steps.retire.outputs.retired != '0'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: chore/failure-class-retire
+          base: main
+          add-paths: .github/failure-classes/*.json
+          title: "chore(failure-class): retire dormant failure classes"
+          commit-message: "chore(failure-class): retire dormant failure classes"
+          body-path: ${{ runner.temp }}/retirement-evidence.md
+          delete-branch: false


### PR DESCRIPTION
## Why

Three of this repository's guards were not doing what their green status implied,
each in a different way. All three are cheap to close and none of them needed a
new mechanism.

**1. A check that executes nothing.** `backend-production-release-vector-guard-tests`
runs `python3 .github/scripts/test_check_release_rings.py`. That module was
pytest-style with no `__main__`, so the command exited 0 having executed none of
its six cases. Registered by #10237, green ever since, never once verifying the
one-action production backend release contract it names.

**2. Seven guard self-tests with no manifest entry.** They ran only as bespoke
`run:` steps in `repo-checks.yml` — the shape root `AGENTS.md` calls "a manifest
bug" — so they never ran locally, never ran diff-scoped, and were invisible to
`pr-preflight --list`.

**3. A lifecycle that shipped complete and never ran.** `scripts/failure-class report`
computes closure eligibility against a quiet period and requires maintainer
confirmation, but it is non-mutating and has no event source: without
`--events-file` it returns zero events and a `no_event_source` warning. Nothing
ever supplied that feed, so 26 classes sit at `status: open` with zero
retirements since the registry was created on 2026-07-16.

## What changed

| Commit | Change |
|---|---|
| `fix(ci)` | `test_check_release_rings.py` converted to the stdlib `unittest` pattern used by the other 24 manifest test commands. Six cases preserved verbatim, no new dependency. |
| `fix(ci)` | `test_manifest_test_modules_execute_their_cases` in the manifest contract tests: a `test_*.py` module handed straight to the interpreter must be self-running. Static `ast` parse. |
| `feat(ci)` | `repo-hygiene.yml` (Mon 09:00 UTC) + `failure_class_retirement.py`: build the merged-PR feed, run the advisory report, apply the two-field retirement edit, open one PR on a reused branch. |
| `fix(ci)` | Corrected the self-running rule, which false-positived on script-style tests. |
| `fix(ci)` | Registered the seven orphaned self-tests; deleted the seven workflow steps (net −21 lines of workflow YAML). |
| `chore` | Registered `FC-nonexecuting-verification-command`. |

## What the cron deliberately does not do

- **Gate anything.** No manifest lane, no pre-push, no release coupling.
- **Open an issue for a retirement.** A PR has a review queue and its own CI; an
  advisory issue joins a 400-issue backlog. Recurrence of an already-dormant
  class is different — that is judgment work (`AGENTS.md` asks for a reusable
  guard surface, not a field flip), so it exits 1 and skips the PR.
- **Author the PR with `GITHUB_TOKEN`.** That PR would arrive with zero checks
  run, defeating the reason to prefer a PR. The Omi Bot app token is minted so
  the diff is verified like any human PR. It never auto-merges and never uses
  `--admin`.

The feed guard is the load-bearing part. A truncated feed makes every class
report "no classified instance", so the job would run green forever while
retiring nothing — the same defect as a check that executes no tests. The run
refuses a feed that hit the fetch limit, or an empty one.

## Verification

```
python3 .github/scripts/test_check_release_rings.py       -> Ran 6 tests, OK
   (before: no output, exit 0, 0 tests executed)
python3 .github/scripts/test_run_checks.py               -> Ran 24 tests, OK
python3 .github/scripts/test_failure_class_retirement.py -> Ran 15 tests, OK
scripts/pr-preflight --lane local                        -> 21 selected, all PASS
```

Mutation evidence (a guard that cannot fail is not a guard):

- Stubbing `check_release_rings.check()` to return `[]` makes the suite report
  `FAILED (failures=4)`; before this change it still exited 0.
- Restoring the pre-fix pytest-only module makes the new contract test FAIL,
  naming the offender: `backend-production-release-vector-guard-tests: ... has no
  __main__ block invoking a test runner`.

Cron, against live data:

- Dry run (real `gh`, 14d): 748 events spanning 2026-07-11 → 2026-07-25, 292
  carrying a `Failure-Class:` line, 0 eligible, exit 0, no files modified.
- Time-travel apply (`--now 2026-08-20`, real registry copied to a temp root):
  13 of 26 classes retired, 13 left open, and the diff per class is exactly
  ```
  -  "status": "open"
  +  "status": "dormant",
  +  "dormant_since": "2026-08-20T00:00:00Z"
  ```
  39 changed lines across 13 files, no formatting churn. (An earlier
  `json.dumps` round trip reflowed the hand-maintained inline arrays; caught by
  `test_apply_touches_only_the_status_line`.)

Expect zero retirements for roughly the next week: the registry is 9 days old
against a 14-day quiet period. That is correct behavior, and it is why the feed
assertion matters — it distinguishes "nothing to retire" from "the feed could not
tell".

## Not in this PR

`test_check_release_process_guards.py` is in no lane and has 9 real failures on
`main` (#10351). Root cause, which #10351 does not record: the suite loads a
**historical** revision of the guard (`4e391ee7`) out of git and runs it against
**synthetic or current** workflow input. That parent hardcodes "exactly 21
approved script steps"; `omi-desktop-swift-release` has had 22 since INV-BETA-1
added "Create Omi Beta variant". Every one of the 9 failures is that single
mismatch. It will break again on the next approved step.

Fixing it means deciding what those assertions should mean — pair each historical
guard with its contemporaneous workflow, or narrow the assertions to the bypass
class under test. That is a release-guard semantics call, and getting it wrong
manufactures a false green, which is the defect this PR exists to remove. It
needs its own PR and a reviewer who owns that guard.

Failure-Class: new

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

