### PR TITLE
SCA-107: project durable capture-finalization outcomes

### DIFF
--- a/.github/failure-classes/FC-durable-terminal-projection.json
+++ b/.github/failure-classes/FC-durable-terminal-projection.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "id": "FC-durable-terminal-projection",
+  "violated_contract": "Every accepted capture-finalization job must persist one bounded terminal outcome in its authoritative Firestore transition, and backend-listen must project that durable state without relying on process-local emission.",
+  "canonical_prevention": "Write the terminal outcome in the lease-fenced completion, stale-fence, and dead-letter transactions; aggregate the closed outcome set from Firestore; and verify the transition plus detached listener/Pusher/worker stack.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_conversation_finalization_jobs.py",
+    "backend/tests/unit/test_journey_observability.py",
+    "backend/testing/listen_pusher_stack/run.py"
+  ],
+  "evidence_prs": [10468],
+  "scope_hints": [
+    "backend/database/conversation_finalization_jobs.py",
+    "backend/services/conversation_finalization.py",
+    "backend/utils/metrics.py",
+    "backend/charts/monitoring/**",
+    "backend/testing/listen_pusher_stack/**"
+  ],
+  "status": "open"
+}

--- a/.github/workflows/gcp_backend_pusher_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_pusher_auto_deploy.yml
@@ -7,8 +7,11 @@ on:
       - 'backend/pusher/**'
       - 'backend/charts/pusher/**'
       - 'backend/database/conversation_finalization_jobs.py'
+      - 'backend/routers/pusher.py'
       - 'backend/services/conversation_finalization.py'
+      - 'backend/utils/conversations/lifecycle.py'
       - 'backend/utils/metrics.py'
+      - 'backend/utils/observability/journeys.py'
       - '.github/workflows/gcp_backend_pusher_auto_deploy.yml'
 
 # Share the development pusher lock with manual deployments.

--- a/.github/workflows/gcp_backend_pusher_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_pusher_auto_deploy.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'backend/pusher/**'
       - 'backend/charts/pusher/**'
+      - 'backend/database/conversation_finalization_jobs.py'
+      - 'backend/services/conversation_finalization.py'
+      - 'backend/utils/metrics.py'
+      - '.github/workflows/gcp_backend_pusher_auto_deploy.yml'
 
 # Share the development pusher lock with manual deployments.
 concurrency:

--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -8639,7 +8639,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[30m]))",
+          "expr": "sum(clamp_min(delta((max by (state) (listen_finalization_durable_jobs{state=~\"success|failure\"}))[30m:]), 0))",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -8659,7 +8659,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[30m])), 1)",
+          "expr": "clamp_min(delta((max(listen_finalization_durable_jobs{state=\"failure\"}))[30m:]), 0) / clamp_min(sum(clamp_min(delta((max by (state) (listen_finalization_durable_jobs{state=~\"success|failure\"}))[30m:]), 0)), 1)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -8755,6 +8755,30 @@
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
+    "record": null
+  },
+  {
+    "uid": "omi-capture-finalization-dead-emission",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Capture finalization - durable terminal emission stalled",
+    "condition": "D",
+    "data": [
+      {"refId": "A", "queryType": "", "relativeTimeRange": {"from": 1800, "to": 0}, "datasourceUid": "prometheus", "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "clamp_min(delta((max(listen_finalization_durable_jobs{state=\"accepted\"}))[30m:]), 0)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}},
+      {"refId": "B", "queryType": "", "relativeTimeRange": {"from": 1800, "to": 0}, "datasourceUid": "prometheus", "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(clamp_min(delta((max by (state) (listen_finalization_durable_jobs{state=~\"success|failure|stale\"}))[30m:]), 0))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B"}},
+      {"refId": "C", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "$A >= 5 && $B == 0", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "math"}},
+      {"refId": "D", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["D"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "C", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "D", "type": "reduce"}}
+    ],
+    "updated": "2026-07-25T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {"__dashboardUid__": "omi-resilience-fallbacks", "__panelId__": "9", "summary": "At least five durable capture jobs were accepted in 30m with no durable terminal movement", "threshold": "accepted movement >= 5; success + failure + stale movement = 0", "user_impact": "Capture finalization can be accepted without reaching a customer-visible terminal outcome.", "scope": "The durable Firestore capture-finalization projection on backend-listen.", "verification": "Confirm the replicated gauge with max across listener pods and inspect nonterminal age before intervention.", "safe_next_action": "Use the capture-finalization runbook; do not infer terminal counts from process-local counters or logs."},
+    "labels": {"severity": "warning", "instatus_component": "speech-processing", "alert_identity": "omi-capture-finalization-dead-emission", "component": "speech-processing", "impact": "user-experience"},
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
     "record": null
   },
   {

--- a/backend/charts/monitoring/alerts/resilience.json
+++ b/backend/charts/monitoring/alerts/resilience.json
@@ -421,7 +421,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[30m]))",
+          "expr": "sum(clamp_min(delta((max by (state) (listen_finalization_durable_jobs{state=~\"success|failure\"}))[30m:]), 0))",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -441,7 +441,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[30m])), 1)",
+          "expr": "clamp_min(delta((max(listen_finalization_durable_jobs{state=\"failure\"}))[30m:]), 0) / clamp_min(sum(clamp_min(delta((max by (state) (listen_finalization_durable_jobs{state=~\"success|failure\"}))[30m:]), 0)), 1)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -676,6 +676,99 @@
     "notification_settings": {
       "receiver": "Omi - Services Alerting (Telegram)"
     },
+    "record": null
+  },
+  {
+    "uid": "omi-capture-finalization-dead-emission",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Capture finalization - durable terminal emission stalled",
+    "condition": "D",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {"from": 1800, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "clamp_min(delta((max(listen_finalization_durable_jobs{state=\"accepted\"}))[30m:]), 0)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {"from": 1800, "to": 0},
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum(clamp_min(delta((max by (state) (listen_finalization_durable_jobs{state=~\"success|failure|stale\"}))[30m:]), 0))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {"type": "__expr__", "uid": "__expr__"},
+          "expression": "$A >= 5 && $B == 0",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "math"
+        }
+      },
+      {
+        "refId": "D",
+        "queryType": "",
+        "relativeTimeRange": {"from": 0, "to": 0},
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["D"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}],
+          "datasource": {"type": "__expr__", "uid": "__expr__"},
+          "expression": "C",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "D",
+          "type": "reduce"
+        }
+      }
+    ],
+    "updated": "2026-07-25T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-resilience-fallbacks",
+      "__panelId__": "9",
+      "summary": "At least five durable capture jobs were accepted in 30m with no durable terminal movement",
+      "threshold": "accepted movement >= 5; success + failure + stale movement = 0",
+      "user_impact": "Capture finalization can be accepted without reaching a customer-visible terminal outcome.",
+      "scope": "The durable Firestore capture-finalization projection on backend-listen.",
+      "verification": "Confirm the replicated gauge with max across listener pods and inspect nonterminal age before intervention.",
+      "safe_next_action": "Use the capture-finalization runbook; do not infer terminal counts from process-local counters or logs."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-capture-finalization-dead-emission",
+      "component": "speech-processing",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {"receiver": "Omi - Services Alerting (Telegram)"},
     "record": null
   },
   {

--- a/backend/charts/monitoring/dashboards/omi-services/resilience-fallbacks.json
+++ b/backend/charts/monitoring/dashboards/omi-services/resilience-fallbacks.json
@@ -661,8 +661,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(increase(omi_journey_accepted_total{journey=\"capture_finalization\"}[6h])) - sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\"}[6h]))",
-          "legendFormat": "accepted minus terminal (6h)",
+          "expr": "max by (state) (listen_finalization_durable_jobs)",
+          "legendFormat": "durable {{state}}",
           "range": true,
           "refId": "A"
         },
@@ -672,8 +672,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(omi_capture_finalization_reconciliations_total[15m]))",
-          "legendFormat": "stale reconciliations / second",
+          "expr": "sum(clamp_min(delta((max by (state) (listen_finalization_durable_jobs{state=~\"success|failure|stale\"}))[30m:]), 0))",
+          "legendFormat": "new durable terminals (30m)",
           "range": true,
           "refId": "B"
         },
@@ -700,7 +700,7 @@
           "refId": "D"
         }
       ],
-      "title": "Capture finalization reconciliation and nonterminal work",
+      "title": "Capture finalization durable projection and nonterminal work",
       "type": "timeseries"
     }
   ],

--- a/backend/database/conversation_finalization_jobs.py
+++ b/backend/database/conversation_finalization_jobs.py
@@ -456,6 +456,7 @@ def _mark_finalization_completed_txn(
         {
             'status': 'completed',
             'completed_at': now,
+            'terminal_outcome': 'success',
             'updated_at': now,
             'lease_expires_at': now,
             'reconcile_after_at': firestore.DELETE_FIELD,
@@ -526,6 +527,7 @@ def _fenced_finalization_update(now: datetime) -> dict[str, Any]:
         'reconcile_after_at': firestore.DELETE_FIELD,
         'last_failure_code': None,
         'finalization_outcome': 'fenced',
+        'terminal_outcome': 'stale',
         'fanout_status': 'fenced',
         'fanout_fenced_at': now,
     }
@@ -736,6 +738,7 @@ def _mark_finalization_dead_letter_txn(
             'status': 'dead_letter',
             'updated_at': now,
             'terminal_at': now,
+            'terminal_outcome': 'failure',
             'lease_expires_at': now,
             'reconcile_after_at': firestore.DELETE_FIELD,
             'task_retry_count': retry_count,
@@ -1149,14 +1152,24 @@ def reacquire_deferred_processing(uid: str, conversation_id: str, *, firestore_c
 
 
 def get_finalization_job_summary(*, firestore_client: Any = None) -> dict[str, float | int]:
-    """Privacy-safe aggregate counts plus a bounded overdue-age sample."""
+    """Privacy-safe durable lifecycle projection plus a bounded overdue-age sample."""
     client = _client(firestore_client)
     now = _now()
     collection = client.collection(FINALIZATION_JOBS_COLLECTION)
+
+    def count(query: Any) -> int:
+        aggregate = query.count().get()
+        return int(aggregate[0][0].value) if aggregate and aggregate[0] else 0
+
     counts: dict[str, int] = {}
     for status in (*NONTERMINAL_JOB_STATUSES, *TERMINAL_JOB_STATUSES):
-        aggregate = collection.where('status', '==', status).count().get()
-        counts[status] = int(aggregate[0][0].value) if aggregate and aggregate[0] else 0
+        counts[status] = count(collection.where('status', '==', status))
+
+    terminal_outcomes = {
+        outcome: count(collection.where('terminal_outcome', '==', outcome))
+        for outcome in ('success', 'failure', 'stale')
+    }
+    terminal_unknown = max(0, counts['completed'] + counts['dead_letter'] - sum(terminal_outcomes.values()))
 
     oldest_age_seconds = 0.0
     # The bounded due page prevents historical terminal rows from making the
@@ -1166,10 +1179,16 @@ def get_finalization_job_summary(*, firestore_client: Any = None) -> dict[str, f
         if isinstance(created_at, datetime):
             oldest_age_seconds = max(oldest_age_seconds, max(0.0, (now - created_at).total_seconds()))
     return {
+        'accepted': count(collection),
+        'success': terminal_outcomes['success'],
+        'failure': terminal_outcomes['failure'],
+        'stale': terminal_outcomes['stale'],
+        'nonterminal': counts['queued'] + counts['leased'],
         'queued': counts['queued'],
         'leased': counts['leased'],
         'blocked_byok': counts['blocked_byok'],
         'completed': counts['completed'],
         'dead_letter': counts['dead_letter'],
+        'terminal_unknown': terminal_unknown,
         'oldest_nonterminal_age_seconds': oldest_age_seconds,
     }

--- a/backend/database/conversation_finalization_jobs.py
+++ b/backend/database/conversation_finalization_jobs.py
@@ -8,6 +8,7 @@ No transcript, credential, request header, or raw exception is stored here.
 from __future__ import annotations
 
 import os
+from hashlib import sha256
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Literal, Mapping, TypedDict
 
@@ -19,6 +20,13 @@ from database.firestore_transaction_retry import run_with_transaction_contention
 
 CONVERSATIONS_COLLECTION = 'conversations'
 FINALIZATION_JOBS_COLLECTION = 'conversation_finalization_jobs'
+# This projection starts at the first release that writes terminal outcomes.
+# It intentionally does not backfill historical jobs: terminal writes for rows
+# without this generation remain durable on the job itself but cannot move the
+# new denominator.  Reading this fixed shard set is safe on every replica.
+FINALIZATION_PROJECTION_COLLECTION = 'conversation_finalization_projection_shards'
+FINALIZATION_PROJECTION_GENERATION = 'terminal-outcomes-v1'
+FINALIZATION_PROJECTION_SHARD_COUNT = 16
 
 FinalizationJobStatus = Literal['queued', 'leased', 'completed', 'dead_letter', 'blocked_byok']
 TERMINAL_JOB_STATUSES = frozenset({'completed', 'dead_letter'})
@@ -136,6 +144,49 @@ def _job_ref(client: Any, job_id: str) -> Any:
     return client.collection(FINALIZATION_JOBS_COLLECTION).document(job_id)
 
 
+def _projection_shard(job_id: str) -> int:
+    """Choose a stable aggregate shard without exposing job identity in metrics."""
+    return int.from_bytes(sha256(job_id.encode('utf-8')).digest()[:4], 'big') % FINALIZATION_PROJECTION_SHARD_COUNT
+
+
+def _projection_shard_id(generation: str, shard: int) -> str:
+    return f'{generation}-{shard:02d}'
+
+
+def _projection_ref_for_job(projection_collection: Any, job: Mapping[str, Any]) -> Any | None:
+    generation = job.get('projection_generation')
+    shard = job.get('projection_shard')
+    if not isinstance(generation, str) or not isinstance(shard, int):
+        return None
+    if generation != FINALIZATION_PROJECTION_GENERATION or not 0 <= shard < FINALIZATION_PROJECTION_SHARD_COUNT:
+        return None
+    return projection_collection.document(_projection_shard_id(generation, shard))
+
+
+def _record_projection_delta(
+    transaction: Any, projection_collection: Any | None, job: Mapping[str, Any], **deltas: int
+) -> None:
+    """Atomically add state deltas for an admitted projection generation.
+
+    A terminal replay returns before this helper, and Firestore retries rerun
+    the transaction against a fresh snapshot. Therefore each committed state
+    transition contributes exactly once without a per-job metrics side record.
+    """
+    if projection_collection is None:
+        return
+    shard_ref = _projection_ref_for_job(projection_collection, job)
+    if shard_ref is None:
+        return
+    fields: dict[str, Any] = {
+        'generation': FINALIZATION_PROJECTION_GENERATION,
+        'shard': int(job['projection_shard']),
+    }
+    fields.update({name: firestore.Increment(delta) for name, delta in deltas.items() if delta})
+    if len(fields) == 2:
+        return
+    transaction.set(shard_ref, fields, merge=True)
+
+
 def _job_id(uid: str, conversation_id: str, revision: int) -> str:
     return document_id_from_seed(f'listen-finalization:{uid}:{conversation_id}:{revision}')
 
@@ -185,6 +236,7 @@ def _create_or_get_finalization_intent_txn(
     finalization_admission: Callable[[Mapping[str, Any]], FinalizationAdmission],
     now: datetime,
     *,
+    projection_collection: Any | None = None,
     force_process: bool = False,
     extra_updates: Mapping[str, Any] | None = None,
 ) -> FinalizationIntent:
@@ -251,6 +303,8 @@ def _create_or_get_finalization_intent_txn(
         'dispatch_generation': 1,
         'attempt_count': 0,
         'task_retry_count': 0,
+        'projection_generation': FINALIZATION_PROJECTION_GENERATION,
+        'projection_shard': _projection_shard(job_id),
         'created_at': now,
         'updated_at': now,
         'dispatch_requested_at': now,
@@ -258,6 +312,13 @@ def _create_or_get_finalization_intent_txn(
     if not requires_byok:
         job['reconcile_after_at'] = now + get_finalization_reconcile_stale_after()
     transaction.set(job_ref, job)
+    _record_projection_delta(
+        transaction,
+        projection_collection,
+        job,
+        accepted=1,
+        **({'blocked_byok': 1} if requires_byok else {'queued': 1}),
+    )
     conversation_updates = dict(extra_updates or {})
     # Lifecycle fields are authoritative to this outbox transaction. Callers
     # may atomically persist request metadata (for example calendar context),
@@ -287,6 +348,7 @@ def create_or_get_finalization_intent(
     client = _client(firestore_client)
     conversation_ref = _conversation_ref(client, uid, conversation_id)
     jobs_collection = client.collection(FINALIZATION_JOBS_COLLECTION)
+    projection_collection = client.collection(FINALIZATION_PROJECTION_COLLECTION)
 
     def create_intent_in_transaction(transaction: Any) -> FinalizationIntent:
         # The Firestore SDK's transactional wrapper retains retry state. Build
@@ -302,6 +364,7 @@ def create_or_get_finalization_intent(
             requires_byok,
             finalization_admission,
             _now(),
+            projection_collection=projection_collection,
             force_process=force_process,
             extra_updates=extra_updates,
         )
@@ -313,7 +376,9 @@ def create_or_get_finalization_intent(
     )
 
 
-def _resume_blocked_byok_job_txn(transaction: Any, job_ref: Any, now: datetime) -> FinalizationIntent:
+def _resume_blocked_byok_job_txn(
+    transaction: Any, job_ref: Any, now: datetime, projection_collection: Any | None = None
+) -> FinalizationIntent:
     snapshot = job_ref.get(transaction=transaction)
     if not getattr(snapshot, 'exists', False):
         return {
@@ -337,6 +402,7 @@ def _resume_blocked_byok_job_txn(transaction: Any, job_ref: Any, now: datetime) 
                 'reconcile_after_at': firestore.DELETE_FIELD,
             },
         )
+        _record_projection_delta(transaction, projection_collection, job, blocked_byok=-1, queued=1)
         job['status'] = 'queued'
     return _intent_from_job(snapshot.id, job)
 
@@ -345,7 +411,12 @@ def resume_blocked_byok_job_for_live_session(job_id: str, *, firestore_client: A
     client = _client(firestore_client)
     transaction = client.transaction()
     transactional = firestore.transactional(_resume_blocked_byok_job_txn)
-    return transactional(transaction, _job_ref(client, job_id), _now())
+    return transactional(
+        transaction,
+        _job_ref(client, job_id),
+        _now(),
+        client.collection(FINALIZATION_PROJECTION_COLLECTION),
+    )
 
 
 def _claim_finalization_job_txn(
@@ -357,6 +428,7 @@ def _claim_finalization_job_txn(
     now: datetime,
     expected_uid: str | None = None,
     expected_conversation_id: str | None = None,
+    projection_collection: Any | None = None,
 ) -> FinalizationClaim:
     snapshot = job_ref.get(transaction=transaction)
     if not getattr(snapshot, 'exists', False):
@@ -404,6 +476,8 @@ def _claim_finalization_job_txn(
             'attempt_count': attempt_count,
         },
     )
+    if status == 'queued':
+        _record_projection_delta(transaction, projection_collection, job, queued=-1, leased=1)
     created_at = job.get('created_at')
     return _claim_result(
         'claimed',
@@ -435,11 +509,17 @@ def claim_finalization_job(
         _now(),
         expected_uid,
         expected_conversation_id,
+        client.collection(FINALIZATION_PROJECTION_COLLECTION),
     )
 
 
 def _mark_finalization_completed_txn(
-    transaction: Any, job_ref: Any, dispatch_generation: int, lease_epoch: int, now: datetime
+    transaction: Any,
+    job_ref: Any,
+    dispatch_generation: int,
+    lease_epoch: int,
+    now: datetime,
+    projection_collection: Any | None = None,
 ) -> bool:
     snapshot = job_ref.get(transaction=transaction)
     if not getattr(snapshot, 'exists', False):
@@ -463,6 +543,7 @@ def _mark_finalization_completed_txn(
             'last_failure_code': None,
         },
     )
+    _record_projection_delta(transaction, projection_collection, job, leased=-1, completed=1, success=1)
     return True
 
 
@@ -472,11 +553,23 @@ def mark_finalization_completed(
     client = _client(firestore_client)
     transaction = client.transaction()
     transactional = firestore.transactional(_mark_finalization_completed_txn)
-    return transactional(transaction, _job_ref(client, job_id), dispatch_generation, lease_epoch, _now())
+    return transactional(
+        transaction,
+        _job_ref(client, job_id),
+        dispatch_generation,
+        lease_epoch,
+        _now(),
+        client.collection(FINALIZATION_PROJECTION_COLLECTION),
+    )
 
 
 def _mark_finalization_fenced_txn(
-    transaction: Any, job_ref: Any, dispatch_generation: int, lease_epoch: int, now: datetime
+    transaction: Any,
+    job_ref: Any,
+    dispatch_generation: int,
+    lease_epoch: int,
+    now: datetime,
+    projection_collection: Any | None = None,
 ) -> bool:
     """Terminally complete a current lease that was fenced before fanout.
 
@@ -496,6 +589,7 @@ def _mark_finalization_fenced_txn(
     if job.get('fanout_status') not in (None, 'pending'):
         return False
     transaction.update(job_ref, _fenced_finalization_update(now))
+    _record_projection_delta(transaction, projection_collection, job, leased=-1, completed=1, stale=1)
     return True
 
 
@@ -505,7 +599,14 @@ def mark_finalization_fenced(
     client = _client(firestore_client)
     transaction = client.transaction()
     transactional = firestore.transactional(_mark_finalization_fenced_txn)
-    return transactional(transaction, _job_ref(client, job_id), dispatch_generation, lease_epoch, _now())
+    return transactional(
+        transaction,
+        _job_ref(client, job_id),
+        dispatch_generation,
+        lease_epoch,
+        _now(),
+        client.collection(FINALIZATION_PROJECTION_COLLECTION),
+    )
 
 
 def _fanout_key(job: dict[str, Any]) -> str:
@@ -556,6 +657,7 @@ def _claim_finalization_fanout_txn(
     lease_epoch: int,
     now: datetime,
     conversation_ref_for_job: Callable[[str, str], Any],
+    projection_collection: Any | None = None,
 ) -> FinalizationFanoutClaim:
     """Claim fanout only if this job still owns the completed conversation.
 
@@ -578,6 +680,7 @@ def _claim_finalization_fanout_txn(
     conversation_id = job.get('conversation_id')
     if not isinstance(uid, str) or not uid or not isinstance(conversation_id, str) or not conversation_id:
         transaction.update(job_ref, _fenced_finalization_update(now))
+        _record_projection_delta(transaction, projection_collection, job, leased=-1, completed=1, stale=1)
         return _fanout_claim('fenced', fanout_key)
 
     conversation_ref = conversation_ref_for_job(uid, conversation_id)
@@ -585,6 +688,7 @@ def _claim_finalization_fanout_txn(
     conversation = conversation_snapshot.to_dict() if getattr(conversation_snapshot, 'exists', False) else None
     if not isinstance(conversation, Mapping) or not _conversation_admits_fanout(conversation, job, job_ref.id):
         transaction.update(job_ref, _fenced_finalization_update(now))
+        _record_projection_delta(transaction, projection_collection, job, leased=-1, completed=1, stale=1)
         return _fanout_claim('fenced', fanout_key)
 
     transaction.update(
@@ -617,6 +721,7 @@ def claim_finalization_fanout(
         lease_epoch,
         _now(),
         lambda uid, conversation_id: _conversation_ref(client, uid, conversation_id),
+        client.collection(FINALIZATION_PROJECTION_COLLECTION),
     )
 
 
@@ -660,7 +765,13 @@ def mark_finalization_fanout_completed(
 
 
 def _mark_finalization_retryable_txn(
-    transaction: Any, job_ref: Any, dispatch_generation: int, lease_epoch: int, failure_code: str, now: datetime
+    transaction: Any,
+    job_ref: Any,
+    dispatch_generation: int,
+    lease_epoch: int,
+    failure_code: str,
+    now: datetime,
+    projection_collection: Any | None = None,
 ) -> bool:
     snapshot = job_ref.get(transaction=transaction)
     if not getattr(snapshot, 'exists', False):
@@ -682,6 +793,7 @@ def _mark_finalization_retryable_txn(
             'last_failure_code': failure_code,
         },
     )
+    _record_projection_delta(transaction, projection_collection, job, leased=-1, queued=1)
     return True
 
 
@@ -696,7 +808,15 @@ def mark_finalization_retryable(
     client = _client(firestore_client)
     transaction = client.transaction()
     transactional = firestore.transactional(_mark_finalization_retryable_txn)
-    return transactional(transaction, _job_ref(client, job_id), dispatch_generation, lease_epoch, failure_code, _now())
+    return transactional(
+        transaction,
+        _job_ref(client, job_id),
+        dispatch_generation,
+        lease_epoch,
+        failure_code,
+        _now(),
+        client.collection(FINALIZATION_PROJECTION_COLLECTION),
+    )
 
 
 def _mark_finalization_dead_letter_txn(
@@ -707,6 +827,7 @@ def _mark_finalization_dead_letter_txn(
     retry_count: int,
     now: datetime,
     conversation_ref_for_job: Callable[[str, str], Any] | None = None,
+    projection_collection: Any | None = None,
 ) -> bool:
     snapshot = job_ref.get(transaction=transaction)
     if not getattr(snapshot, 'exists', False):
@@ -745,6 +866,7 @@ def _mark_finalization_dead_letter_txn(
             'last_failure_code': 'final_attempt_failed',
         },
     )
+    _record_projection_delta(transaction, projection_collection, job, leased=-1, dead_letter=1, failure=1)
     if (
         conversation_ref is not None
         and isinstance(conversation, Mapping)
@@ -778,6 +900,7 @@ def mark_finalization_dead_letter(
         retry_count,
         _now(),
         lambda uid, conversation_id: _conversation_ref(client, uid, conversation_id),
+        client.collection(FINALIZATION_PROJECTION_COLLECTION),
     )
 
 
@@ -789,7 +912,11 @@ def get_finalization_job(job_id: str, *, firestore_client: Any = None) -> dict[s
 
 
 def _claim_finalization_replay_txn(
-    transaction: Any, job_ref: Any, stale_after: timedelta, now: datetime
+    transaction: Any,
+    job_ref: Any,
+    stale_after: timedelta,
+    now: datetime,
+    projection_collection: Any | None = None,
 ) -> FinalizationIntent:
     snapshot = job_ref.get(transaction=transaction)
     if not getattr(snapshot, 'exists', False):
@@ -828,6 +955,8 @@ def _claim_finalization_replay_txn(
             'reconcile_after_at': now + stale_after,
         },
     )
+    if status == 'leased':
+        _record_projection_delta(transaction, projection_collection, job, leased=-1, queued=1)
     job['status'] = 'queued'
     job['dispatch_generation'] = generation
     return _intent_from_job(snapshot.id, job)
@@ -839,7 +968,13 @@ def claim_finalization_replay(
     client = _client(firestore_client)
     transaction = client.transaction()
     transactional = firestore.transactional(_claim_finalization_replay_txn)
-    return transactional(transaction, _job_ref(client, job_id), stale_after, _now())
+    return transactional(
+        transaction,
+        _job_ref(client, job_id),
+        stale_after,
+        _now(),
+        client.collection(FINALIZATION_PROJECTION_COLLECTION),
+    )
 
 
 def get_finalization_replay_candidates(*, limit: int = 100, firestore_client: Any = None) -> list[dict[str, Any]]:
@@ -1152,43 +1287,66 @@ def reacquire_deferred_processing(uid: str, conversation_id: str, *, firestore_c
 
 
 def get_finalization_job_summary(*, firestore_client: Any = None) -> dict[str, float | int]:
-    """Privacy-safe durable lifecycle projection plus a bounded overdue-age sample."""
+    """Read one generation's fixed shard fan-in plus a bounded overdue-age sample.
+
+    This deliberately never aggregates ``conversation_finalization_jobs``. A
+    backend-listen replica performs exactly ``FINALIZATION_PROJECTION_SHARD_COUNT``
+    projection-document reads, regardless of terminal history size. Pre-release
+    jobs carry no generation and remain absent from this new denominator; their
+    terminal field is still preserved on the authoritative job document.
+    """
     client = _client(firestore_client)
     now = _now()
-    collection = client.collection(FINALIZATION_JOBS_COLLECTION)
-
-    def count(query: Any) -> int:
-        aggregate = query.count().get()
-        return int(aggregate[0][0].value) if aggregate and aggregate[0] else 0
-
-    counts: dict[str, int] = {}
-    for status in (*NONTERMINAL_JOB_STATUSES, *TERMINAL_JOB_STATUSES):
-        counts[status] = count(collection.where('status', '==', status))
-
-    terminal_outcomes = {
-        outcome: count(collection.where('terminal_outcome', '==', outcome))
-        for outcome in ('success', 'failure', 'stale')
+    jobs_collection = client.collection(FINALIZATION_JOBS_COLLECTION)
+    projection_collection = client.collection(FINALIZATION_PROJECTION_COLLECTION)
+    totals = {
+        name: 0
+        for name in (
+            'accepted',
+            'queued',
+            'leased',
+            'blocked_byok',
+            'completed',
+            'dead_letter',
+            'success',
+            'failure',
+            'stale',
+        )
     }
-    terminal_unknown = max(0, counts['completed'] + counts['dead_letter'] - sum(terminal_outcomes.values()))
+    for shard in range(FINALIZATION_PROJECTION_SHARD_COUNT):
+        snapshot = projection_collection.document(_projection_shard_id(FINALIZATION_PROJECTION_GENERATION, shard)).get()
+        if not getattr(snapshot, 'exists', False):
+            continue
+        data = snapshot.to_dict() or {}
+        # A malformed or stale document cannot contaminate this generation's
+        # denominator. The writer is the sole producer of matching documents.
+        if data.get('generation') != FINALIZATION_PROJECTION_GENERATION or data.get('shard') != shard:
+            continue
+        for name in totals:
+            value = data.get(name, 0)
+            if isinstance(value, (int, float)):
+                totals[name] += int(value)
 
     oldest_age_seconds = 0.0
     # The bounded due page prevents historical terminal rows from making the
     # periodic metric collection an ever-growing Firestore scan.
-    for snapshot in collection.where('reconcile_after_at', '<=', now).limit(100).stream():
+    for snapshot in jobs_collection.where('reconcile_after_at', '<=', now).limit(100).stream():
         created_at = (snapshot.to_dict() or {}).get('created_at')
         if isinstance(created_at, datetime):
             oldest_age_seconds = max(oldest_age_seconds, max(0.0, (now - created_at).total_seconds()))
     return {
-        'accepted': count(collection),
-        'success': terminal_outcomes['success'],
-        'failure': terminal_outcomes['failure'],
-        'stale': terminal_outcomes['stale'],
-        'nonterminal': counts['queued'] + counts['leased'],
-        'queued': counts['queued'],
-        'leased': counts['leased'],
-        'blocked_byok': counts['blocked_byok'],
-        'completed': counts['completed'],
-        'dead_letter': counts['dead_letter'],
-        'terminal_unknown': terminal_unknown,
+        'accepted': totals['accepted'],
+        'success': totals['success'],
+        'failure': totals['failure'],
+        'stale': totals['stale'],
+        'nonterminal': totals['queued'] + totals['leased'],
+        'queued': totals['queued'],
+        'leased': totals['leased'],
+        'blocked_byok': totals['blocked_byok'],
+        'completed': totals['completed'],
+        'dead_letter': totals['dead_letter'],
+        # Every admitted generation terminal transition writes an outcome.
+        # Historical terminals are intentionally out of this bounded generation.
+        'terminal_unknown': 0,
         'oldest_nonterminal_age_seconds': oldest_age_seconds,
     }

--- a/backend/docs/runbooks/real-traffic-journeys.md
+++ b/backend/docs/runbooks/real-traffic-journeys.md
@@ -14,6 +14,7 @@ traffic it scrapes, with no cross-environment comparison or labels.
 | `omi_journey_latency_seconds` | `journey`, `outcome` | Acceptance-to-terminal latency. |
 | `omi_capture_finalization_reconciliations_total` | `outcome` | A stale durable capture job was requeued, or its requeue handoff failed. |
 | `listen_finalization_oldest_nonterminal_age_seconds` | none | Age of the oldest queued, leased, or BYOK-blocked capture finalization job. |
+| `listen_finalization_durable_jobs` | `state` | Authoritative Firestore job projection: `accepted`, `success`, `failure`, `stale`, `nonterminal`, `blocked_byok`, or `terminal_unknown`. |
 
 `journey` is exactly `chat_response`, `pusher_session`, `live_transcription`,
 or `capture_finalization`. `outcome` is exactly `success`, `failure`,
@@ -43,9 +44,13 @@ provider, or content labels.
 - `capture_finalization` is accepted only once, when the Firestore finalization
   outbox creates a new durable job. Successful completion is `success`, a
   dead-letter is `failure`, and a lifecycle-fenced durable job is `stale`.
-  Existing job re-dispatches do not increment acceptance. A nonterminal job is
-  reconciled after its bounded stale delay; use the reconciliation counter and
-  oldest-nonterminal-age gauge to interpret accepted minus terminal work.
+  Existing job re-dispatches do not increment acceptance. Historical terminal
+  rows without the bounded field are `terminal_unknown`; `blocked_byok` stays
+  intentionally nonterminal. This Firestore projection is the capture
+  denominator: PromQL takes `max` across listener pods, then uses
+  `clamp_min(delta(...), 0)` for movement. It never sums replicated global
+  gauges. A dead-emission condition is bounded new `accepted` movement with
+  zero new `success`/`failure`/`stale` movement.
 
 ## Dashboard, alerts, and scrape health
 

--- a/backend/docs/runbooks/resilience-dashboards.md
+++ b/backend/docs/runbooks/resilience-dashboards.md
@@ -19,7 +19,7 @@ Cross-platform view of backend Prometheus fallbacks, desktop PostHog heals, and 
 | Fallback rate by component & outcome | `sum by (component, outcome) (rate(omi_fallback_total[5m]))` | Dashboard only (`recovered` is expected) |
 | Sync enqueue uncertainty share | `sum(rate(omi_sync_dispatch_attempts_total{mode="enqueue_uncertain"}[10m])) / clamp_min(sum(rate(omi_sync_dispatch_attempts_total[10m])), 1e-9)` | Dashboard only until Cloud Run scrape — see [sync-dispatch-fallback.md](./sync-dispatch-fallback.md) |
 | Pusher degraded sessions & ratio | `pusher_sessions_degraded`, `pusher_active_ws_connections`, ratio | **PAGE** — see [pusher-degraded.md](./pusher-degraded.md) |
-| Real-traffic journey outcomes | `omi_journey_*`, `omi_capture_finalization_reconciliations_total`, `listen_finalization_oldest_nonterminal_age_seconds` | Traffic-gated product alerts plus separate scrape-source health — see [real-traffic-journeys.md](./real-traffic-journeys.md) |
+| Real-traffic journey outcomes | `omi_journey_*`, `omi_capture_finalization_reconciliations_total`, `listen_finalization_durable_jobs`, `listen_finalization_oldest_nonterminal_age_seconds` | Traffic-gated product alerts plus separate scrape-source health — see [real-traffic-journeys.md](./real-traffic-journeys.md) |
 | LLM gateway fallback rate | `sum(rate(llm_gateway_requests_total{fallback_used="true"}[30m])) / clamp_min(sum(rate(llm_gateway_requests_total[30m])), 1e-9)` | **Ticket** — see [llm-gateway-fallback.md](./llm-gateway-fallback.md) |
 
 The dashboard text panel repeats paging policy: page only on exhausted outcomes, sync enqueue uncertainty, and pusher degraded ratio. Successful `outcome=recovered` heals are dashboard-only.

--- a/backend/services/conversation_finalization.py
+++ b/backend/services/conversation_finalization.py
@@ -19,6 +19,7 @@ from utils.cloud_tasks import (
 )
 from utils.metrics import (
     LISTEN_FINALIZATION_DEAD_LETTER_TOTAL,
+    LISTEN_FINALIZATION_DURABLE_JOBS,
     LISTEN_FINALIZATION_JOB_STATUS,
     LISTEN_FINALIZATION_OLDEST_NONTERMINAL_AGE_SECONDS,
     LISTEN_FINALIZATION_RETRIES_TOTAL,
@@ -227,5 +228,7 @@ def _publish_job_metrics(*, firestore_client: Any = None) -> None:
         logger.exception('listen finalization metrics query failed')
         return
     LISTEN_FINALIZATION_OLDEST_NONTERMINAL_AGE_SECONDS.set(float(summary['oldest_nonterminal_age_seconds']))
+    for state in ('accepted', 'success', 'failure', 'stale', 'nonterminal', 'blocked_byok', 'terminal_unknown'):
+        LISTEN_FINALIZATION_DURABLE_JOBS.labels(state=state).set(float(summary[state]))
     for status in ('queued', 'leased', 'blocked_byok', 'dead_letter'):
         LISTEN_FINALIZATION_JOB_STATUS.labels(status=status).set(float(summary[status]))

--- a/backend/testing/listen_pusher_stack/README.md
+++ b/backend/testing/listen_pusher_stack/README.md
@@ -82,8 +82,8 @@ Scenarios:
    recovery path from #9960 enqueues one opaque Cloud Tasks task, then a real
    worker retry preserves `processing` until it completes the same job;
 8. a worker exhausting its two-attempt test budget atomically dead-letters the
-   job and marks the still-current conversation `failed`/`discarded`, while a
-   later duplicate delivery is fenced;
+   job with `terminal_outcome=failure` and marks the still-current conversation
+   `failed`/`discarded`, while a later duplicate delivery is fenced;
 9. an integration failure after processing retries only durable fanout, never
    re-runs completed conversation processing.
 

--- a/backend/testing/listen_pusher_stack/run.py
+++ b/backend/testing/listen_pusher_stack/run.py
@@ -1084,7 +1084,11 @@ async def _shutdown_window_retries_through_cloud_tasks(stack: Stack) -> None:
         raise StackFailure(f'retry Cloud Tasks delivery did not complete: {(status_code, body)}')
     completed_job = _one_job(stack, uid, conversation_id)
     completed_conversation = stack.conversation(uid, conversation_id)
-    if completed_job.get('status') != 'completed' or completed_job.get('attempt_count') != 2:
+    if (
+        completed_job.get('status') != 'completed'
+        or completed_job.get('terminal_outcome') != 'success'
+        or completed_job.get('attempt_count') != 2
+    ):
         raise StackFailure('successful retry did not complete the exact durable job')
     if completed_job.get('fanout_status') != 'completed':
         raise StackFailure('successful retry did not complete durable fanout')
@@ -1119,6 +1123,7 @@ async def _terminal_cloud_tasks_failure_dead_letters(stack: Stack) -> None:
     conversation = stack.conversation(uid, conversation_id)
     if (
         dead_letter.get('status') != 'dead_letter'
+        or dead_letter.get('terminal_outcome') != 'failure'
         or dead_letter.get('attempt_count') != 2
         or dead_letter.get('task_retry_count') != 2
     ):

--- a/backend/tests/unit/test_conversation_finalization_jobs.py
+++ b/backend/tests/unit/test_conversation_finalization_jobs.py
@@ -464,6 +464,7 @@ def test_finalization_completion_requires_durable_fanout_completion():
 
     completed = _Transaction()
     assert jobs._mark_finalization_completed_txn(completed, ref, 1, 4, now) is True
+    assert completed.updates[0][1]['terminal_outcome'] == 'success'
 
 
 def test_fanout_claim_terminally_fences_a_discard_that_wins_before_its_transaction():
@@ -550,6 +551,7 @@ def test_fenced_finalization_is_a_terminal_no_fanout_outcome():
     update = transaction.updates[0][1]
     assert update['status'] == 'completed'
     assert update['finalization_outcome'] == 'fenced'
+    assert update['terminal_outcome'] == 'stale'
     assert update['fanout_status'] == 'fenced'
 
 
@@ -661,6 +663,7 @@ def test_final_attempt_sets_visible_dead_letter_instead_of_completed():
     assert jobs._mark_finalization_dead_letter_txn(transaction, ref, 3, 1, 5, _now()) is True
     update = transaction.updates[0][1]
     assert update['status'] == 'dead_letter'
+    assert update['terminal_outcome'] == 'failure'
     assert update['task_retry_count'] == 5
     assert 'completed_at' not in update
 
@@ -707,6 +710,7 @@ def test_final_attempt_atomically_closes_its_bound_processing_conversation():
                 'status': 'dead_letter',
                 'updated_at': _now(),
                 'terminal_at': _now(),
+                'terminal_outcome': 'failure',
                 'lease_expires_at': _now(),
                 'reconcile_after_at': jobs.firestore.DELETE_FIELD,
                 'task_retry_count': 5,
@@ -722,6 +726,63 @@ def test_final_attempt_atomically_closes_its_bound_processing_conversation():
             },
         ),
     ]
+
+
+def test_durable_summary_distinguishes_terminal_outcomes_and_legacy_terminal_rows(monkeypatch):
+    class Query:
+        def __init__(self, counts, key):
+            self.counts = counts
+            self.key = key
+
+        def where(self, field, _operator, value):
+            return Query(self.counts, (field, value))
+
+        def count(self):
+            return self
+
+        def get(self):
+            return [[SimpleNamespace(value=self.counts.get(self.key, 0))]]
+
+        def limit(self, _limit):
+            return self
+
+        def stream(self):
+            return iter(())
+
+    class Client:
+        def collection(self, name):
+            assert name == jobs.FINALIZATION_JOBS_COLLECTION
+            return Query(
+                {
+                    None: 11,
+                    ('status', 'queued'): 2,
+                    ('status', 'leased'): 1,
+                    ('status', 'blocked_byok'): 3,
+                    ('status', 'completed'): 4,
+                    ('status', 'dead_letter'): 1,
+                    ('terminal_outcome', 'success'): 2,
+                    ('terminal_outcome', 'stale'): 1,
+                    ('terminal_outcome', 'failure'): 1,
+                },
+                None,
+            )
+
+    summary = jobs.get_finalization_job_summary(firestore_client=Client())
+
+    assert summary == {
+        'accepted': 11,
+        'success': 2,
+        'failure': 1,
+        'stale': 1,
+        'nonterminal': 3,
+        'queued': 2,
+        'leased': 1,
+        'blocked_byok': 3,
+        'completed': 4,
+        'dead_letter': 1,
+        'terminal_unknown': 1,
+        'oldest_nonterminal_age_seconds': 0.0,
+    }
 
 
 class _BoundedReplayCollection:

--- a/backend/tests/unit/test_conversation_finalization_jobs.py
+++ b/backend/tests/unit/test_conversation_finalization_jobs.py
@@ -58,7 +58,7 @@ class _Transaction:
     def update(self, ref, data):
         self.updates.append((ref, data))
 
-    def set(self, ref, data):
+    def set(self, ref, data, **_kwargs):
         self.sets.append((ref, data))
 
 
@@ -169,6 +169,7 @@ def test_create_or_get_intent_retries_read_contention_with_a_fresh_transaction(m
 
     conversation_ref = _conversation()
     jobs_collection = _Collection({})
+    projection_collection = _Collection({})
     transactions: list[_Transaction] = []
 
     class _Client:
@@ -178,8 +179,10 @@ def test_create_or_get_intent_retries_read_contention_with_a_fresh_transaction(m
             return transaction
 
         def collection(self, name: str):
-            assert name == jobs.FINALIZATION_JOBS_COLLECTION
-            return jobs_collection
+            if name == jobs.FINALIZATION_JOBS_COLLECTION:
+                return jobs_collection
+            assert name == jobs.FINALIZATION_PROJECTION_COLLECTION
+            return projection_collection
 
     transactional_calls = 0
 
@@ -217,8 +220,15 @@ def test_create_or_get_intent_retries_read_contention_with_a_fresh_transaction(m
     assert transactional_calls == 2
     assert len(transactions) == 2
     assert transactions[0] is not transactions[1]
+    assert transactions[0].sets == []
     assert intent['status'] == 'queued'
-    assert len(transactions[1].sets) == 1
+    # The retry's committed transaction creates exactly one job and one shard
+    # delta; the aborted attempt never contributes a second accepted count.
+    assert len(transactions[1].sets) == 2
+    assert transactions[1].sets[1][0].id == jobs._projection_shard_id(
+        jobs.FINALIZATION_PROJECTION_GENERATION,
+        transactions[1].sets[0][1]['projection_shard'],
+    )
 
 
 def test_photo_only_conversation_with_durable_content_marker_is_admitted():
@@ -465,6 +475,68 @@ def test_finalization_completion_requires_durable_fanout_completion():
     completed = _Transaction()
     assert jobs._mark_finalization_completed_txn(completed, ref, 1, 4, now) is True
     assert completed.updates[0][1]['terminal_outcome'] == 'success'
+
+
+def test_admitted_terminal_replay_updates_its_shard_once():
+    now = _now()
+    ref = _Ref(
+        'job-1',
+        {
+            'status': 'leased',
+            'dispatch_generation': 1,
+            'lease_epoch': 4,
+            'fanout_status': 'completed',
+            'projection_generation': jobs.FINALIZATION_PROJECTION_GENERATION,
+            'projection_shard': jobs._projection_shard('job-1'),
+        },
+    )
+    projection = _Collection({})
+
+    first = _Transaction()
+    assert jobs._mark_finalization_completed_txn(first, ref, 1, 4, now, projection) is True
+    assert len(first.sets) == 1
+    assert first.sets[0][0].id == jobs._projection_shard_id(
+        jobs.FINALIZATION_PROJECTION_GENERATION, jobs._projection_shard('job-1')
+    )
+
+    # A Firestore retry observes the committed terminal snapshot and performs
+    # no second aggregate write, even though the API remains idempotently true.
+    ref.data = ref.data | first.updates[0][1]
+    replay = _Transaction()
+    assert jobs._mark_finalization_completed_txn(replay, ref, 1, 4, now, projection) is True
+    assert replay.updates == []
+    assert replay.sets == []
+
+
+def test_pre_projection_terminal_keeps_its_outcome_without_moving_the_new_denominator():
+    ref = _Ref(
+        'legacy-job',
+        {'status': 'leased', 'dispatch_generation': 1, 'lease_epoch': 1, 'fanout_status': 'completed'},
+    )
+    transaction = _Transaction()
+
+    assert jobs._mark_finalization_completed_txn(transaction, ref, 1, 1, _now(), _Collection({})) is True
+    assert transaction.updates[0][1]['terminal_outcome'] == 'success'
+    assert transaction.sets == []
+
+
+def test_byok_resume_moves_only_its_admitted_projection_state():
+    ref = _Ref(
+        'job-1',
+        {
+            'status': 'blocked_byok',
+            'requires_byok': True,
+            'projection_generation': jobs.FINALIZATION_PROJECTION_GENERATION,
+            'projection_shard': 3,
+        },
+    )
+    transaction = _Transaction()
+
+    intent = jobs._resume_blocked_byok_job_txn(transaction, ref, _now(), _Collection({}))
+
+    assert intent['status'] == 'queued'
+    assert transaction.updates[0][1]['status'] == 'queued'
+    assert transaction.sets[0][0].id == jobs._projection_shard_id(jobs.FINALIZATION_PROJECTION_GENERATION, 3)
 
 
 def test_fanout_claim_terminally_fences_a_discard_that_wins_before_its_transaction():
@@ -728,59 +800,82 @@ def test_final_attempt_atomically_closes_its_bound_processing_conversation():
     ]
 
 
-def test_durable_summary_distinguishes_terminal_outcomes_and_legacy_terminal_rows(monkeypatch):
-    class Query:
-        def __init__(self, counts, key):
-            self.counts = counts
-            self.key = key
+def test_durable_summary_reads_a_fixed_projection_shard_set_without_job_aggregations():
+    class Snapshot:
+        def __init__(self, data):
+            self.exists = data is not None
+            self._data = data
 
-        def where(self, field, _operator, value):
-            return Query(self.counts, (field, value))
+        def to_dict(self):
+            return self._data
 
-        def count(self):
+    class Projection:
+        def __init__(self):
+            self.read_ids: list[str] = []
+
+        def document(self, doc_id):
+            projection = self
+
+            class Ref:
+                def get(self):
+                    projection.read_ids.append(doc_id)
+                    shard = int(doc_id.rsplit('-', 1)[1])
+                    if shard != 0:
+                        return Snapshot(None)
+                    return Snapshot(
+                        {
+                            'generation': jobs.FINALIZATION_PROJECTION_GENERATION,
+                            'shard': 0,
+                            'accepted': 8,
+                            'queued': 2,
+                            'leased': 1,
+                            'blocked_byok': 2,
+                            'completed': 2,
+                            'dead_letter': 1,
+                            'success': 1,
+                            'stale': 1,
+                            'failure': 1,
+                        }
+                    )
+
+            return Ref()
+
+    class JobQuery:
+        def where(self, field, operator, _value):
+            assert (field, operator) == ('reconcile_after_at', '<=')
             return self
 
-        def get(self):
-            return [[SimpleNamespace(value=self.counts.get(self.key, 0))]]
-
-        def limit(self, _limit):
+        def limit(self, value):
+            assert value == 100
             return self
 
         def stream(self):
             return iter(())
 
+    projection = Projection()
+
     class Client:
         def collection(self, name):
+            if name == jobs.FINALIZATION_PROJECTION_COLLECTION:
+                return projection
             assert name == jobs.FINALIZATION_JOBS_COLLECTION
-            return Query(
-                {
-                    None: 11,
-                    ('status', 'queued'): 2,
-                    ('status', 'leased'): 1,
-                    ('status', 'blocked_byok'): 3,
-                    ('status', 'completed'): 4,
-                    ('status', 'dead_letter'): 1,
-                    ('terminal_outcome', 'success'): 2,
-                    ('terminal_outcome', 'stale'): 1,
-                    ('terminal_outcome', 'failure'): 1,
-                },
-                None,
-            )
+            return JobQuery()
 
     summary = jobs.get_finalization_job_summary(firestore_client=Client())
 
+    assert len(projection.read_ids) == jobs.FINALIZATION_PROJECTION_SHARD_COUNT
     assert summary == {
-        'accepted': 11,
-        'success': 2,
+        'accepted': 8,
+        'success': 1,
         'failure': 1,
         'stale': 1,
         'nonterminal': 3,
         'queued': 2,
         'leased': 1,
-        'blocked_byok': 3,
-        'completed': 4,
+        'blocked_byok': 2,
+        'completed': 2,
         'dead_letter': 1,
-        'terminal_unknown': 1,
+        'terminal_unknown': 0,
         'oldest_nonterminal_age_seconds': 0.0,
     }
 

--- a/backend/tests/unit/test_journey_observability.py
+++ b/backend/tests/unit/test_journey_observability.py
@@ -76,6 +76,47 @@ def test_terminal_finalization_failure_records_once_after_dead_letter(monkeypatc
     terminal.assert_called_once_with('failure', accepted_at)
 
 
+def test_listener_projects_the_closed_durable_finalization_states(monkeypatch):
+    durable = MagicMock()
+    durable.labels.return_value = MagicMock()
+    backlog = MagicMock()
+    backlog.labels.return_value = MagicMock()
+    monkeypatch.setattr(
+        conversation_finalization.jobs_db,
+        'get_finalization_job_summary',
+        MagicMock(
+            return_value={
+                'accepted': 9,
+                'success': 3,
+                'failure': 1,
+                'stale': 2,
+                'nonterminal': 1,
+                'blocked_byok': 1,
+                'terminal_unknown': 1,
+                'queued': 1,
+                'leased': 0,
+                'dead_letter': 1,
+                'oldest_nonterminal_age_seconds': 12.5,
+            }
+        ),
+    )
+    monkeypatch.setattr(conversation_finalization, 'LISTEN_FINALIZATION_DURABLE_JOBS', durable)
+    monkeypatch.setattr(conversation_finalization, 'LISTEN_FINALIZATION_JOB_STATUS', backlog)
+    monkeypatch.setattr(conversation_finalization, 'LISTEN_FINALIZATION_OLDEST_NONTERMINAL_AGE_SECONDS', MagicMock())
+
+    conversation_finalization._publish_job_metrics()
+
+    assert {call.kwargs['state'] for call in durable.labels.call_args_list} == {
+        'accepted',
+        'success',
+        'failure',
+        'stale',
+        'nonterminal',
+        'blocked_byok',
+        'terminal_unknown',
+    }
+
+
 def test_idle_metrics_and_monitoring_contract_distinguish_traffic_from_a_missing_scrape_source():
     exported = metrics.generate_latest().decode()
     assert 'omi_journey_accepted_total{journey="chat_response"}' in exported
@@ -94,15 +135,19 @@ def test_idle_metrics_and_monitoring_contract_distinguish_traffic_from_a_missing
         'omi-journey-pusher-fail',
         'omi-journey-live-transcription-fail',
         'omi-journey-capture-fail',
+        'omi-capture-finalization-dead-emission',
         'omi-journey-scrape-missing',
     }
     assert expected_ids <= {rule['uid'] for rule in split_alerts}
     assert expected_ids <= {rule['uid'] for rule in combined_alerts}
 
-    product_rule_ids = expected_ids - {'omi-journey-scrape-missing'}
+    product_rule_ids = expected_ids - {'omi-journey-scrape-missing', 'omi-capture-finalization-dead-emission'}
     product_rules = [rule for rule in split_alerts if rule['uid'] in product_rule_ids]
     for rule in product_rules:
-        assert 'outcome=~"success|failure"' in rule['data'][0]['model']['expr']
+        if rule['uid'] == 'omi-journey-capture-fail':
+            assert 'listen_finalization_durable_jobs' in rule['data'][0]['model']['expr']
+        else:
+            assert 'outcome=~"success|failure"' in rule['data'][0]['model']['expr']
         assert '$A >= 20 && $B > 0.10' in rule['data'][2]['model']['expression']
     live_transcription_rule = next(
         rule for rule in product_rules if rule['uid'] == 'omi-journey-live-transcription-fail'
@@ -125,8 +170,18 @@ def test_idle_metrics_and_monitoring_contract_distinguish_traffic_from_a_missing
     panel_titles = {panel['title'] for panel in dashboard['panels']}
     assert 'Journey terminal success rate (success / success + failure)' in panel_titles
     assert 'Journey acceptance-to-terminal latency (p95)' in panel_titles
-    assert 'Capture finalization reconciliation and nonterminal work' in panel_titles
+    assert 'Capture finalization durable projection and nonterminal work' in panel_titles
     success_panel = next(
         panel for panel in dashboard['panels'] if panel['title'].startswith('Journey terminal success')
     )
     assert 'and on (journey)' in success_panel['targets'][0]['expr']
+    capture_rule = next(rule for rule in split_alerts if rule['uid'] == 'omi-journey-capture-fail')
+    assert 'listen_finalization_durable_jobs' in capture_rule['data'][0]['model']['expr']
+    assert 'max by (state)' in capture_rule['data'][0]['model']['expr']
+    assert 'clamp_min(delta' in capture_rule['data'][1]['model']['expr']
+    projection_panel = next(panel for panel in dashboard['panels'] if panel['id'] == 9)
+    assert projection_panel['targets'][0]['expr'] == 'max by (state) (listen_finalization_durable_jobs)'
+    dead_emission_rule = next(rule for rule in split_alerts if rule['uid'] == 'omi-capture-finalization-dead-emission')
+    assert 'max(listen_finalization_durable_jobs{state="accepted"})' in dead_emission_rule['data'][0]['model']['expr']
+    assert 'max by (state)' in dead_emission_rule['data'][1]['model']['expr']
+    assert dead_emission_rule['data'][2]['model']['expression'] == '$A >= 5 && $B == 0'

--- a/backend/tests/unit/test_pusher_auto_deploy_paths.py
+++ b/backend/tests/unit/test_pusher_auto_deploy_paths.py
@@ -1,0 +1,25 @@
+"""Contract for development Pusher image freshness on shared runtime imports."""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+WORKFLOW = REPO / '.github/workflows/gcp_backend_pusher_auto_deploy.yml'
+
+
+def test_pusher_auto_deploy_tracks_its_shared_lifecycle_and_observability_imports():
+    lines = WORKFLOW.read_text(encoding='utf-8').splitlines()
+    paths_start = lines.index('    paths:') + 1
+    paths = set()
+    for line in lines[paths_start:]:
+        if not line.startswith('      - '):
+            break
+        paths.add(line.split("'", 2)[1])
+
+    assert paths == {
+        'backend/pusher/**',
+        'backend/charts/pusher/**',
+        'backend/database/conversation_finalization_jobs.py',
+        'backend/services/conversation_finalization.py',
+        'backend/utils/metrics.py',
+        '.github/workflows/gcp_backend_pusher_auto_deploy.yml',
+    }

--- a/backend/tests/unit/test_pusher_auto_deploy_paths.py
+++ b/backend/tests/unit/test_pusher_auto_deploy_paths.py
@@ -19,7 +19,10 @@ def test_pusher_auto_deploy_tracks_its_shared_lifecycle_and_observability_import
         'backend/pusher/**',
         'backend/charts/pusher/**',
         'backend/database/conversation_finalization_jobs.py',
+        'backend/routers/pusher.py',
         'backend/services/conversation_finalization.py',
+        'backend/utils/conversations/lifecycle.py',
         'backend/utils/metrics.py',
+        'backend/utils/observability/journeys.py',
         '.github/workflows/gcp_backend_pusher_auto_deploy.yml',
     }

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -72,6 +72,12 @@ LISTEN_FINALIZATION_JOB_STATUS = Gauge(
     ['status'],
 )
 
+LISTEN_FINALIZATION_DURABLE_JOBS = Gauge(
+    'listen_finalization_durable_jobs',
+    'Authoritative Firestore finalization jobs by closed durable lifecycle state',
+    ['state'],
+)
+
 LISTEN_FINALIZATION_RETRIES_TOTAL = Counter(
     'listen_finalization_retries_total',
     'Durable listen finalization jobs replayed by the reconciler',


### PR DESCRIPTION
## Summary

- persist bounded `success`, `stale`, and `failure` outcomes in the authoritative Firestore finalization transitions
- project privacy-safe durable job state through the existing scraped backend-listen reconciler as `listen_finalization_durable_jobs{state=...}`
- use replica-safe `max` plus gauge deltas for capture completeness and dead-emission monitoring
- make shared finalization/metrics changes trigger the development Pusher auto-deploy workflow
- extend the existing listen/Pusher/Cloud Tasks emulator stack and monitoring/workflow contracts

SCA-107

## Causal boundary

The durable `conversation_finalization_jobs` document is the authority: job creation is acceptance; `mark_finalization_completed`, `mark_finalization_fenced`, and `mark_finalization_dead_letter` own terminal truth. `blocked_byok` remains explicitly nonterminal; this PR does not invent cancellation or change customer-visible BYOK behavior.

Structured Cloud Logging was rejected as the primary denominator because a crash after the Firestore commit can lose the log and retry can duplicate it. The existing scraped backend-listen summary is the lowest-blast-radius durable projection and needs no new runtime credential, sidecar, or Cloud Run scrape.

## Failure class

Failure-Class: new

Violated contract: every accepted capture-finalization job must contribute at most one authoritative terminal outcome to a bounded, replica-safe projection. Canonical guard: generation-scoped deterministic Firestore shards updated atomically with job transitions, plus fixed-read, retry/replay, monitoring, and detached-stack contracts. Supporting evidence: the pre-existing unbounded terminal-history scan was caught in review; PR #10468 supplies the related crash-safe finalization transition seam.

## Verification

- focused database/service/journey/monitoring/workflow tests: 164 passed
- `backend/test-preflight.sh`: passed with the pinned Python
- `listen_pusher_stack` Firestore/Redis/loopback-Cloud-Tasks gauntlet: scenarios completed
- `make runtime-image-source-closure`: passed
- `git diff --check`: passed
- failure-class validation: passed

Not fully run:

- `make runtime-image-smoke SERVICE=pusher`: blocked by HTTP 403 fetching the private GCR base image
- `make preflight`: blocked by the unrelated existing `FC-split-mutation-authority` guard-ratchet failure

## Real path and rollout boundary

The named non-production proof is the existing `listen_pusher_stack` Cloud Tasks scenario with detached listener, Pusher, finalization worker, Firestore emulator, Redis, and loopback task delivery. After independent review, merge and dev-only deployment/monitoring are authorized by SCA-101. This PR does not authorize or perform production deployment, traffic/config/IAM/secret changes, Firestore backfill, or customer-data access.

Rollback: revert this focused merge and restore the prior dev Pusher image/revision. Production promotion remains a separate human decision.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

