### PR TITLE
fix(desktop): keep web routing classifiers in parity

### DIFF
--- a/.github/failure-classes/FC-public-web-routing-parity.json
+++ b/.github/failure-classes/FC-public-web-routing-parity.json
@@ -4,7 +4,7 @@
   "violated_contract": "Compatibility projections of public-web routing must make the same routing decision as the authoritative gateway policy.",
   "canonical_prevention": "Keep the Rust gateway authoritative and run every compatibility projection against one shared behavioral routing corpus.",
   "canonical_prevention_artifact": [
-    "desktop/macos/agent/contracts/v1/public-web-routing-contract.fixture.json"
+    "desktop/macos/Backend-Rust/fixtures/public-web-routing-contract.fixture.json"
   ],
   "evidence_prs": [10422],
   "scope_hints": [

--- a/.github/failure-classes/FC-public-web-routing-parity.json
+++ b/.github/failure-classes/FC-public-web-routing-parity.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-public-web-routing-parity",
+  "violated_contract": "Compatibility projections of public-web routing must make the same routing decision as the authoritative gateway policy.",
+  "canonical_prevention": "Keep the Rust gateway authoritative and run every compatibility projection against one shared behavioral routing corpus.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/agent/contracts/v1/public-web-routing-contract.fixture.json"
+  ],
+  "evidence_prs": [10422],
+  "scope_hints": [
+    "desktop/macos/Backend-Rust/src/routes/retrieval_policy.rs",
+    "desktop/macos/agent/src/adapters/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Backend-Rust/fixtures/public-web-routing-contract.fixture.json
+++ b/desktop/macos/Backend-Rust/fixtures/public-web-routing-contract.fixture.json
@@ -52,6 +52,16 @@
       "requiresPublicWeb": false
     },
     {
+      "name": "fresh_phrase_inside_longer_word",
+      "prompt": "Review my recent newsletter draft",
+      "requiresPublicWeb": false
+    },
+    {
+      "name": "utf8_byte_length_matches_rust_cap",
+      "prompt": "谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁谁 who's playing today",
+      "requiresPublicWeb": false
+    },
+    {
       "name": "game_inside_gameplan",
       "prompt": "Review my launch gameplan today",
       "requiresPublicWeb": false

--- a/desktop/macos/Backend-Rust/src/routes/retrieval_policy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/retrieval_policy.rs
@@ -170,6 +170,11 @@ const FRESH_PUBLIC_PHRASES: &[&str] = &[
     "who is the current",
     "today's news",
     "news today",
+    "recent news",
+    "released this week",
+    "released today",
+    "released recently",
+    "newly released",
 ];
 
 /// Weather lookups commonly place the location between "weather" and the
@@ -496,6 +501,20 @@ pub(crate) fn prepend_latest_user_instruction(
 mod tests {
     use super::*;
 
+    #[derive(serde::Deserialize)]
+    struct PublicWebRoutingContractFixture {
+        version: u32,
+        cases: Vec<PublicWebRoutingContractCase>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct PublicWebRoutingContractCase {
+        name: String,
+        prompt: String,
+        #[serde(rename = "requiresPublicWeb")]
+        requires_public_web: bool,
+    }
+
     fn message(role: &str, text: &str) -> ChatMessage {
         ChatMessage {
             role: role.to_string(),
@@ -512,6 +531,25 @@ mod tests {
         assert!(policy.requires(RetrievalSource::PublicWeb));
         assert!(!policy.requires(RetrievalSource::OmiPrivate));
         assert_eq!(policy.reason, RetrievalReason::ExplicitWeb);
+    }
+
+    #[test]
+    fn matches_cross_runtime_public_web_routing_contract() {
+        let fixture: PublicWebRoutingContractFixture = serde_json::from_str(include_str!(
+            "../../../agent/contracts/v1/public-web-routing-contract.fixture.json"
+        ))
+        .expect("public-web routing contract fixture must decode");
+
+        assert_eq!(fixture.version, 1);
+        for test_case in fixture.cases {
+            let policy = retrieval_policy(&[message("user", &test_case.prompt)]);
+            assert_eq!(
+                policy.requires(RetrievalSource::PublicWeb),
+                test_case.requires_public_web,
+                "{}",
+                test_case.name
+            );
+        }
     }
 
     #[test]

--- a/desktop/macos/Backend-Rust/src/routes/retrieval_policy.rs
+++ b/desktop/macos/Backend-Rust/src/routes/retrieval_policy.rs
@@ -290,11 +290,25 @@ fn is_current_weather_lookup(text: &str) -> bool {
 }
 
 fn is_fresh_public_lookup(text: &str) -> bool {
-    contains_any(text, FRESH_PUBLIC_PHRASES)
+    contains_any_word(text, FRESH_PUBLIC_PHRASES)
         || is_current_weather_lookup(text)
         || (text.len() <= MAX_GENERIC_LOOKUP_CHARS
             && contains_any_word(text, FRESH_PUBLIC_TEMPORAL_QUALIFIERS)
             && contains_any_word(text, FRESH_PUBLIC_LOOKUP_TERMS))
+}
+
+fn strip_compatibility_retrieval_policy(text: &str) -> &str {
+    const OPEN: &str = "<omi_retrieval_policy>";
+    const CLOSE: &str = "</omi_retrieval_policy>";
+
+    let trimmed = text.trim_start();
+    if !trimmed.starts_with(OPEN) {
+        return text;
+    }
+    let Some((_, remainder)) = trimmed.split_once(CLOSE) else {
+        return text;
+    };
+    remainder.trim_start()
 }
 
 /// A lookup verb paired with an explicit online/web locus, on a short turn.
@@ -401,7 +415,9 @@ pub(crate) fn retrieval_policy(messages: &[ChatMessage]) -> RetrievalPolicy {
         return RetrievalPolicy::auto();
     };
     let rendered_prompt = extract_text_content(&latest_user.content);
-    let latest = normalized_lookup_text(current_user_instruction(&rendered_prompt));
+    let latest = normalized_lookup_text(strip_compatibility_retrieval_policy(
+        current_user_instruction(&rendered_prompt),
+    ));
     let explicit_web = contains_any(&latest, EXPLICIT_WEB_PHRASES);
     let explicitly_prohibits_web = explicit_web && explicitly_prohibits_public_web(&latest);
     let explicit_private = contains_any(&latest, EXPLICIT_PRIVATE_PHRASES);
@@ -536,7 +552,7 @@ mod tests {
     #[test]
     fn matches_cross_runtime_public_web_routing_contract() {
         let fixture: PublicWebRoutingContractFixture = serde_json::from_str(include_str!(
-            "../../../agent/contracts/v1/public-web-routing-contract.fixture.json"
+            "../../fixtures/public-web-routing-contract.fixture.json"
         ))
         .expect("public-web routing contract fixture must decode");
 
@@ -705,6 +721,32 @@ mod tests {
         let policy = retrieval_policy(&[message("user", "look him up on the web")]);
         assert!(policy.requires(RetrievalSource::PublicWeb));
         assert!(!policy.web_requirement_is_explicit());
+    }
+
+    #[test]
+    fn compatibility_prompt_preserves_research_intent_provenance() {
+        let policy = retrieval_policy(&[message(
+            "user",
+            "<omi_retrieval_policy>Web search is required and available for this fresh public request. Use a live public-web or search tool before answering.</omi_retrieval_policy>\n\n\
+             Find out who David Zhang is and get the public information available on him online",
+        )]);
+
+        assert!(policy.requires(RetrievalSource::PublicWeb));
+        assert_eq!(policy.reason, RetrievalReason::ResearchIntent);
+        assert!(!policy.web_requirement_is_explicit());
+    }
+
+    #[test]
+    fn explicit_user_web_request_stays_strict_after_compatibility_prompt() {
+        let policy = retrieval_policy(&[message(
+            "user",
+            "<omi_retrieval_policy>Web search is required and available for this fresh public request.</omi_retrieval_policy>\n\n\
+             Search the web for HumanPost",
+        )]);
+
+        assert!(policy.requires(RetrievalSource::PublicWeb));
+        assert_eq!(policy.reason, RetrievalReason::ExplicitWeb);
+        assert!(policy.web_requirement_is_explicit());
     }
 
     #[test]

--- a/desktop/macos/agent/contracts/v1/public-web-routing-contract.fixture.json
+++ b/desktop/macos/agent/contracts/v1/public-web-routing-contract.fixture.json
@@ -1,0 +1,60 @@
+{
+  "version": 1,
+  "cases": [
+    {
+      "name": "current_weather",
+      "prompt": "What's the weather in NYC right now?",
+      "requiresPublicWeb": true
+    },
+    {
+      "name": "recent_news",
+      "prompt": "Give me recent news about Anthropic",
+      "requiresPublicWeb": true
+    },
+    {
+      "name": "new_release",
+      "prompt": "What AI model was newly released?",
+      "requiresPublicWeb": true
+    },
+    {
+      "name": "explicit_lookup_variant",
+      "prompt": "Look this up online: HumanPost",
+      "requiresPublicWeb": true
+    },
+    {
+      "name": "implicit_research_with_web_locus",
+      "prompt": "Find out who David Zhang is and get the public information available on him online",
+      "requiresPublicWeb": true
+    },
+    {
+      "name": "mixed_public_and_private",
+      "prompt": "Search the web and my conversations for HumanPost",
+      "requiresPublicWeb": true
+    },
+    {
+      "name": "private_weather_history",
+      "prompt": "What did I say today about the current weather?",
+      "requiresPublicWeb": false
+    },
+    {
+      "name": "explicit_no_web",
+      "prompt": "Do not use web search; answer from what you already know",
+      "requiresPublicWeb": false
+    },
+    {
+      "name": "long_service_synthesis",
+      "prompt": "Analyze these calendar events and extract a profile. Today's date is 2026-07-25. Extract facts about their role, recurring meetings, relationships, routines, interests, work schedule, hobbies, social life, professional identity, collaboration patterns, and recurring commitments. Preserve source fidelity and do not infer facts that are absent from the supplied events.",
+      "requiresPublicWeb": false
+    },
+    {
+      "name": "lookup_term_inside_longer_word",
+      "prompt": "Review the marketing copy I wrote today",
+      "requiresPublicWeb": false
+    },
+    {
+      "name": "game_inside_gameplan",
+      "prompt": "Review my launch gameplan today",
+      "requiresPublicWeb": false
+    }
+  ]
+}

--- a/desktop/macos/agent/src/ARCHITECTURE.md
+++ b/desktop/macos/agent/src/ARCHITECTURE.md
@@ -66,6 +66,11 @@ Swift desktop client
   delegated objectives and raw control-tool cwd values cannot default a
   deliverable to Desktop. Explicit external-delivery reports remain a narrow
   compatibility import path and are copied into the managed directory.
+- Pi's public-web prompt routing is a rollout compatibility projection, not a
+  second policy owner. Its positive decisions must match the Rust gateway cases
+  in `../contracts/v1/public-web-routing-contract.fixture.json`; otherwise the
+  adapter can display synthetic search activity for a lookup the gateway never
+  performed.
 - Generated tool manifests and Swift executors are updated together through
   `../scripts/generate-tool-surfaces.mjs`; hand-edited capability mirrors are
   prohibited.

--- a/desktop/macos/agent/src/ARCHITECTURE.md
+++ b/desktop/macos/agent/src/ARCHITECTURE.md
@@ -68,9 +68,9 @@ Swift desktop client
   compatibility import path and are copied into the managed directory.
 - Pi's public-web prompt routing is a rollout compatibility projection, not a
   second policy owner. Its positive decisions must match the Rust gateway cases
-  in `../contracts/v1/public-web-routing-contract.fixture.json`; otherwise the
-  adapter can display synthetic search activity for a lookup the gateway never
-  performed.
+  in `../../Backend-Rust/fixtures/public-web-routing-contract.fixture.json`;
+  otherwise the adapter can display synthetic search activity for a lookup the
+  gateway never performed.
 - Generated tool manifests and Swift executors are updated together through
   `../scripts/generate-tool-surfaces.mjs`; hand-edited capability mirrors are
   prohibited.

--- a/desktop/macos/agent/src/adapters/pi-mono.ts
+++ b/desktop/macos/agent/src/adapters/pi-mono.ts
@@ -331,6 +331,23 @@ function containsWholeTerm(text: string, terms: string[]): boolean {
   });
 }
 
+function normalizedLookupText(text: string): string {
+  return text
+    .trim()
+    .replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, "")
+    .toLowerCase()
+    .replace(/[\u2018\u2019]/g, "'");
+}
+
+function utf8ByteLength(text: string): number {
+  let bytes = 0;
+  for (const char of text) {
+    const codePoint = char.codePointAt(0) ?? 0;
+    bytes += codePoint <= 0x7f ? 1 : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
+  }
+  return bytes;
+}
+
 type PublicWebTurnState = {
   bufferedText: string;
   /**
@@ -349,10 +366,7 @@ export function routePromptForPublicWeb(message: string): string {
   // The adapter receives the full rendered prompt, including inherited context
   // and prior turns. Inspect only the current user instruction when deciding
   // whether this particular turn requires a public-web lookup.
-  const normalized = currentUserInstruction(message)
-    .trim()
-    .toLowerCase()
-    .replace(/[\u2018\u2019]/g, "'");
+  const normalized = normalizedLookupText(currentUserInstruction(message));
   if (!normalized) return message;
   const hasExplicitWebReference = EXPLICIT_WEB_REQUESTS.some(
     (phrase) => normalized.includes(phrase)
@@ -368,7 +382,7 @@ export function routePromptForPublicWeb(message: string): string {
   );
   if (hasExplicitPrivateContext && !hasExplicitWebReference) return message;
 
-  const isShortLookup = normalized.length <= MAX_GENERIC_LOOKUP_CHARS;
+  const isShortLookup = utf8ByteLength(normalized) <= MAX_GENERIC_LOOKUP_CHARS;
   const hasFreshPublicTemporalLookup = isShortLookup
     && containsWholeTerm(normalized, FRESH_PUBLIC_TEMPORAL_QUALIFIERS)
     && containsWholeTerm(normalized, FRESH_PUBLIC_LOOKUP_TERMS);
@@ -376,7 +390,7 @@ export function routePromptForPublicWeb(message: string): string {
     && containsWholeTerm(normalized, PUBLIC_WEB_LOCUS)
     && RESEARCH_INTENT_VERBS.some((verb) => normalized.includes(verb));
   const requiresWeb = hasExplicitWebReference
-    || FRESH_PUBLIC_REQUESTS.some((phrase) => normalized.includes(phrase))
+    || containsWholeTerm(normalized, FRESH_PUBLIC_REQUESTS)
     || CURRENT_WEATHER_PREFIXES.some((phrase) => normalized.includes(phrase))
     || hasFreshPublicTemporalLookup
     || hasResearchIntentLookup;

--- a/desktop/macos/agent/src/adapters/pi-mono.ts
+++ b/desktop/macos/agent/src/adapters/pi-mono.ts
@@ -211,7 +211,9 @@ const PUBLIC_WEB_ROUTING_INSTRUCTION = "<omi_retrieval_policy>Web search is requ
 
 const EXPLICIT_WEB_REQUESTS = [
   "search the web", "search web", "search the internet", "search online",
-  "look it up online", "find it online", "google it", "browse the web",
+  "look it up online", "look this up online", "look that up online",
+  "find it online", "find this online", "find that online",
+  "google it", "google this", "google that", "browse the web",
   "web search", "internet search",
 ];
 
@@ -280,6 +282,16 @@ const FRESH_PUBLIC_LOOKUP_TERMS = [
   "score", "weather", "price", "news", "release", "released", "election", "market",
 ];
 
+const RESEARCH_INTENT_VERBS = [
+  "find out", "look up", "look him up", "look her up", "look them up",
+  "research", "tell me about", "everything about", "everything on",
+  "all about", "information about", "information on", "who is", "who's",
+];
+
+const PUBLIC_WEB_LOCUS = ["online", "on the web", "on the internet"];
+const MAX_GENERIC_LOOKUP_CHARS = 240;
+const ALPHANUMERIC_CHAR = /[\p{L}\p{N}]/u;
+
 const EXPLICIT_PRIVATE_CONTEXT = [
   "my conversations", "our conversations", "my memories", "your memory of me",
   "my screen history", "my screen activity", "my calendar", "your calendar",
@@ -300,6 +312,23 @@ function currentUserInstruction(renderedPrompt: string): string {
   return delimiterIndex === -1
     ? renderedPrompt
     : renderedPrompt.slice(delimiterIndex + CURRENT_USER_MESSAGE_DELIMITER.length);
+}
+
+function containsWholeTerm(text: string, terms: string[]): boolean {
+  return terms.some((term) => {
+    let searchStart = 0;
+    while (searchStart < text.length) {
+      const start = text.indexOf(term, searchStart);
+      if (start < 0) return false;
+      const before = text[start - 1];
+      const after = text[start + term.length];
+      const beforeIsWord = before !== undefined && ALPHANUMERIC_CHAR.test(before);
+      const afterIsWord = after !== undefined && ALPHANUMERIC_CHAR.test(after);
+      if (!beforeIsWord && !afterIsWord) return true;
+      searchStart = start + term.length;
+    }
+    return false;
+  });
 }
 
 type PublicWebTurnState = {
@@ -324,9 +353,7 @@ export function routePromptForPublicWeb(message: string): string {
     .trim()
     .toLowerCase()
     .replace(/[\u2018\u2019]/g, "'");
-  if (!normalized || EXPLICIT_PRIVATE_CONTEXT.some((phrase) => normalized.includes(phrase))) {
-    return message;
-  }
+  if (!normalized) return message;
   const hasExplicitWebReference = EXPLICIT_WEB_REQUESTS.some(
     (phrase) => normalized.includes(phrase)
   );
@@ -336,13 +363,23 @@ export function routePromptForPublicWeb(message: string): string {
   ) {
     return message;
   }
-  const hasFreshPublicTemporalLookup = FRESH_PUBLIC_TEMPORAL_QUALIFIERS.some(
+  const hasExplicitPrivateContext = EXPLICIT_PRIVATE_CONTEXT.some(
     (phrase) => normalized.includes(phrase)
-  ) && FRESH_PUBLIC_LOOKUP_TERMS.some((term) => normalized.includes(term));
+  );
+  if (hasExplicitPrivateContext && !hasExplicitWebReference) return message;
+
+  const isShortLookup = normalized.length <= MAX_GENERIC_LOOKUP_CHARS;
+  const hasFreshPublicTemporalLookup = isShortLookup
+    && containsWholeTerm(normalized, FRESH_PUBLIC_TEMPORAL_QUALIFIERS)
+    && containsWholeTerm(normalized, FRESH_PUBLIC_LOOKUP_TERMS);
+  const hasResearchIntentLookup = isShortLookup
+    && containsWholeTerm(normalized, PUBLIC_WEB_LOCUS)
+    && RESEARCH_INTENT_VERBS.some((verb) => normalized.includes(verb));
   const requiresWeb = hasExplicitWebReference
     || FRESH_PUBLIC_REQUESTS.some((phrase) => normalized.includes(phrase))
     || CURRENT_WEATHER_PREFIXES.some((phrase) => normalized.includes(phrase))
-    || hasFreshPublicTemporalLookup;
+    || hasFreshPublicTemporalLookup
+    || hasResearchIntentLookup;
   return requiresWeb ? `${PUBLIC_WEB_ROUTING_INSTRUCTION}\n\n${message}` : message;
 }
 

--- a/desktop/macos/agent/tests/pi-mono-adapter.test.ts
+++ b/desktop/macos/agent/tests/pi-mono-adapter.test.ts
@@ -119,6 +119,15 @@ function makeErrorTurnEndEvent(errorMessage: string) {
   };
 }
 
+type PublicWebRoutingContractFixture = {
+  version: number;
+  cases: Array<{
+    name: string;
+    prompt: string;
+    requiresPublicWeb: boolean;
+  }>;
+};
+
 describe("PiMonoAdapter prompt correlation", () => {
   it("forwards tool execution updates as content-free progress activity", async () => {
     const { adapter, events } = createAdapter();
@@ -186,6 +195,25 @@ describe("PiMonoAdapter prompt correlation", () => {
       "what did I do today?",
     ]) {
       expect(routePromptForPublicWeb(message)).toBe(message);
+    }
+  });
+
+  it("matches the cross-runtime public-web routing contract", () => {
+    const fixture = JSON.parse(
+      readFileSync(
+        fileURLToPath(
+          new URL("../contracts/v1/public-web-routing-contract.fixture.json", import.meta.url)
+        ),
+        "utf8"
+      )
+    ) as PublicWebRoutingContractFixture;
+
+    expect(fixture.version).toBe(1);
+    for (const testCase of fixture.cases) {
+      const routed = routePromptForPublicWeb(testCase.prompt);
+      expect(routed.includes("<omi_retrieval_policy>"), testCase.name).toBe(
+        testCase.requiresPublicWeb
+      );
     }
   });
 

--- a/desktop/macos/agent/tests/pi-mono-adapter.test.ts
+++ b/desktop/macos/agent/tests/pi-mono-adapter.test.ts
@@ -202,7 +202,7 @@ describe("PiMonoAdapter prompt correlation", () => {
     const fixture = JSON.parse(
       readFileSync(
         fileURLToPath(
-          new URL("../contracts/v1/public-web-routing-contract.fixture.json", import.meta.url)
+          new URL("../../Backend-Rust/fixtures/public-web-routing-contract.fixture.json", import.meta.url)
         ),
         "utf8"
       )

--- a/desktop/macos/changelog/unreleased/20260725-web-routing-parity.json
+++ b/desktop/macos/changelog/unreleased/20260725-web-routing-parity.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed chat showing web-search activity for unrelated long prompts and restored live lookup routing for recent news and newly released products"
+}


### PR DESCRIPTION
## Summary

- keep Pi's compatibility routing projection aligned with the authoritative Rust public-web policy
- reject substring and long-prompt false positives while restoring recent-news, release, explicit lookup, mixed-context, and public-research cases
- enforce both runtimes with one shared behavioral routing corpus

## Root cause

PR #10422 had to update both the Rust gateway policy and Pi's temporary compatibility classifier. The copies drifted immediately: Pi matched generic lookup words as substrings and had no short-turn bound, so words such as `gameplan` or `marketing` and long synthesis prompts could display synthetic web-search activity even when the gateway did not route a search. Meanwhile, the Rust policy omitted several freshness phrases that Pi recognized, so those prompts could reach the model without the required public-web route.

The Rust gateway remains the policy owner. The adapter is still required while desktop and backend versions roll independently, so one implementation cannot be shared across the TypeScript and Rust runtime boundary. The new shared corpus is the narrow guard surface: both production classifiers must pass the same positive and negative decisions.

## Verification

- `cd desktop/macos/agent && npm test` — 53 files, 600 tests passed
- `cd desktop/macos/Backend-Rust && cargo test` — 400 tests passed
- `OMI_PR_BODY_FILE=/private/tmp/pr-web-routing-parity.md make preflight` — 14 checks passed
- bounded pre-push gate — passed, including Rust compile and desktop tool surfaces
- `desktop/macos/scripts/agent-logic-harness.sh --cross-surface-smoke` — passed on the starting main revision
- named bundle `omi-web-routing-parity` — built, launched, and exercised against the development backend
  - `Review my launch gameplan today` completed without public-web activity
  - `Give me recent news about Anthropic` completed after live network tool calls
- after repository setup advanced the branch to `3a63002ea9`, the cross-surface Swift phase is blocked by compile errors introduced on that main revision in `FocusAssistant.swift`, `RewindDatabase.swift`, `RewindIndexer.swift`, and `ChatProvider.swift`; none are touched by this PR

## Product invariants affected

none

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

