### PR TITLE
fix(backend): treat empty-after-VAD sync segments as silence, not a retryable failure

### DIFF
--- a/backend/tests/unit/test_sync_silent_failure.py
+++ b/backend/tests/unit/test_sync_silent_failure.py
@@ -767,8 +767,13 @@ class TestProcessSegmentReal:
     def _import_process_segment(self):
         return self._process_segment
 
-    def test_empty_words_after_vad_are_retryable_failure(self):
-        """Speech-eligible input with no provider words must remain retryable."""
+    def test_empty_words_after_vad_are_silence_not_failure(self):
+        """Speech-eligible input with no provider words is silence, not a failure.
+
+        VAD over-reports on noise, so a provider returning nothing is the
+        authority on whether there was speech. The segment produces nothing and
+        records no error, so its job does not fail and the client stops
+        re-uploading it as a failed recording."""
         process_segment = self._import_process_segment()
 
         response = {'updated_memories': set(), 'new_memories': set()}
@@ -787,12 +792,12 @@ class TestProcessSegmentReal:
             )
 
         assert result is False
-        assert errors == ['stt_empty_unexpected']
+        assert errors == []
         assert len(response['new_memories']) == 0
         assert len(response['updated_memories']) == 0
 
-    def test_empty_postprocessed_after_vad_is_retryable_failure(self):
-        """Provider words filtered to no segments must not be reported as success."""
+    def test_empty_postprocessed_after_vad_is_silence_not_failure(self):
+        """Provider words filtered to no segments is silence, not a failure."""
         process_segment = self._import_process_segment()
 
         response = {'updated_memories': set(), 'new_memories': set()}
@@ -813,7 +818,7 @@ class TestProcessSegmentReal:
             )
 
         assert result is False
-        assert errors == ['stt_empty_unexpected']
+        assert errors == []
         assert len(response['new_memories']) == 0
         assert len(response['updated_memories']) == 0
 
@@ -978,15 +983,19 @@ class TestProcessSegmentReal:
         assert len(errors) == 0
         assert 'conv-existing' in response['updated_memories']
 
-    def test_speech_eligible_empty_segments_are_all_failed(self):
-        """VAD-positive segments with empty STT results must not complete successfully."""
+    def test_speech_eligible_empty_segments_complete_as_silence(self):
+        """VAD-positive segments that all transcribe empty complete, not fail.
+
+        A recording that is entirely noise records no segment errors, so its job
+        finalizes completed rather than failed and is not offered back to the
+        client for a retry that would repeat identically."""
         process_segment = self._import_process_segment()
 
         response = {'updated_memories': set(), 'new_memories': set()}
         errors = []
         lock = threading.Lock()
 
-        # VAD already selected these three segments as speech-eligible.
+        # VAD selected these three as speech-eligible; every one transcribes empty.
         with patch('utils.sync.pipeline.prerecorded', return_value=([], 'en')), patch(
             'utils.sync.pipeline.delete_syncing_temporal_file'
         ), patch('utils.sync.pipeline.get_syncing_file_temporal_signed_url', return_value='https://fake'), patch(
@@ -999,18 +1008,10 @@ class TestProcessSegmentReal:
 
         total_segments = 3
         failed_segments = len(errors)
-        successful_segments = total_segments - failed_segments
 
-        assert errors == ['stt_empty_unexpected'] * 3
-        assert successful_segments == 0
-
-        if total_segments > 0 and successful_segments == 0:
-            status = 500
-        elif failed_segments > 0:
-            status = 207
-        else:
-            status = 200
-        assert status == 500
+        # No errors → _sync_job_finalization_updates yields 'completed'.
+        assert errors == []
+        assert failed_segments == 0
 
     def test_runtime_error_from_dg_becomes_segment_error(self):
         """When deepgram_prerecorded raises RuntimeError (retry exhaustion),

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -2215,8 +2215,11 @@ class TestAsyncCoordinatorBehavioral:
             self._cleanup(stubs['saved_modules'])
 
     @pytest.mark.asyncio
-    async def test_provider_empty_after_vad_releases_content_for_retry(self):
-        """VAD-positive empty STT must fail and leave the content ledger retryable."""
+    async def test_provider_empty_after_vad_completes_as_silence(self):
+        """A provider that returns no words for VAD-admitted audio is reporting
+        silence, not failing. The job completes, the content ledger is marked
+        done rather than left retryable, and no usage is billed — the client
+        stops re-uploading the same noise as a failed recording."""
         module, stubs = self._load_sync_module()
         try:
             stubs['pipeline'].decode_files_to_wav = MagicMock(return_value=['/tmp/w.wav'])
@@ -2234,11 +2237,11 @@ class TestAsyncCoordinatorBehavioral:
             stubs['pipeline'].get_prerecorded_service = MagicMock(return_value=('deepgram', 'multi', 'nova-3'))
             stubs['pipeline'].prerecorded = MagicMock(return_value=([], 'en'))
             terminal_events = []
-            stubs['pipeline'].release_sync_content_claim_after_job_retired.side_effect = (
-                lambda *_args: terminal_events.append('claim_released')
+            stubs['pipeline'].mark_sync_content_completed.side_effect = lambda *_a, **_k: (
+                terminal_events.append('content_completed') or True
             )
             stubs['sync_jobs'].finalize_sync_job.side_effect = lambda *_args: (
-                terminal_events.append('job_finalized') or {'status': 'partial_failure'}
+                terminal_events.append('job_finalized') or {'status': 'completed'}
             )
 
             await module._run_full_pipeline_background_async(
@@ -2252,16 +2255,16 @@ class TestAsyncCoordinatorBehavioral:
             )
 
             result = stubs['sync_jobs'].finalize_sync_job.call_args[0][1]
-            assert result['failed_segments'] == 1
-            assert result['errors'] == ['stt_empty_unexpected']
-            assert result['outcome'] == 'empty_unexpected'
-            stubs['pipeline'].mark_sync_content_completed.assert_not_called()
-            stubs['pipeline'].release_sync_content_claim_after_job_retired.assert_called_once_with(
-                'uid', 'content-empty', 'j-empty'
-            )
+            assert result['failed_segments'] == 0
+            assert result['errors'] == []
+            assert result['outcome'] == 'success'
+            # Marked complete, not released for a retry that would repeat identically.
+            stubs['pipeline'].mark_sync_content_completed.assert_called_once()
+            stubs['pipeline'].release_sync_content_claim_after_job_retired.assert_not_called()
             stubs['pipeline'].release_sync_content_claim.assert_not_called()
-            assert terminal_events[:2] == ['job_finalized', 'claim_released']
-            stubs['sync_jobs'].add_processed_segment.assert_not_called()
+            # No transcript was produced, so nothing is billed.
+            stubs['pipeline'].record_usage.assert_not_called()
+            assert 'content_completed' in terminal_events
         finally:
             self._cleanup(stubs['saved_modules'])
 

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -104,7 +104,6 @@ from utils.stt.outcomes import (
     TranscriptionFailure,
     TranscriptionOutcome,
     bounded_provider,
-    empty_unexpected_failure,
     failure_from_exception,
 )
 from utils.stt.speaker_embedding import (
@@ -122,6 +121,10 @@ from utils.metrics import OMI_SYNC_BACKFILL_DAILY_USED_MS, OMI_SYNC_LANE_SPEECH_
 logger = logging.getLogger(__name__)
 
 MAX_VAD_SEGMENT_SECONDS = int(os.getenv('SYNC_MAX_VAD_SEGMENT_SECONDS', '300'))
+
+# Segment outcomes that are valid terminal results, not errors: a transcript, or
+# audio that carried no transcribable speech. Everything else is a real failure.
+_NON_ERROR_SEGMENT_OUTCOMES = frozenset({TranscriptionOutcome.SUCCESS, TranscriptionOutcome.EXPECTED_SILENCE})
 _SYNC_STT_MODELS = {'nova-3', 'velma-2', 'parakeet'}
 _PARTIAL_RESULT_FENCED_CONVERSATION_IDS = 'fenced_conversation_ids'
 _RESPONSE_FENCED_CONVERSATION_IDS = '_fenced_conversation_ids'
@@ -206,7 +209,7 @@ def _record_sync_segment_outcome(
             # completing. A later retry may duplicate this metric, but not the
             # customer-visible transcription result.
             logger.warning('event=sync_transcription_metric outcome=dedupe_failed kind=segment')
-    log = logger.info if outcome == TranscriptionOutcome.SUCCESS else logger.error
+    log = logger.info if outcome in _NON_ERROR_SEGMENT_OUTCOMES else logger.error
     log(
         'event=sync_transcription_segment outcome=%s provider=%s model=%s lane=%s retryable=%s',
         outcome.value,
@@ -250,6 +253,36 @@ def _record_sync_segment_failure(
         )
     with lock:
         errors.append(failure.error_code)
+
+
+def _record_empty_segment_as_silence(
+    *,
+    provider: str,
+    model: str,
+    lane: str,
+    deferred_outcome: dict | None,
+) -> None:
+    """Record a speech-free segment as a valid empty result, not a failure.
+
+    Records the outcome exactly as the success path does but appends nothing to
+    the job's error list, so a job whose every segment is speech-free finalizes
+    completed rather than failed and the client stops re-uploading it.
+    """
+    _set_deferred_segment_outcome(
+        deferred_outcome,
+        outcome=TranscriptionOutcome.EXPECTED_SILENCE,
+        provider=provider,
+        model=model,
+        retryable=False,
+    )
+    if deferred_outcome is None:
+        _record_sync_segment_outcome(
+            TranscriptionOutcome.EXPECTED_SILENCE,
+            provider=provider,
+            model=model,
+            lane=lane,
+            retryable=False,
+        )
 
 
 def _set_deferred_segment_outcome(
@@ -1040,43 +1073,30 @@ def process_segment(
         )
         language = user_language if (single_language_mode and user_language) else detected_language
         if not words:
-            # Every process_segment input has already passed VAD and is therefore
-            # speech-eligible. A provider returning no words here is not the same
-            # as the valid zero-segment result produced by the VAD phase.
-            failure = empty_unexpected_failure(provider)
-            _set_deferred_segment_outcome(
-                deferred_outcome,
-                outcome=failure.outcome,
-                provider=failure.provider,
-                model=model,
-                retryable=failure.retryable,
-            )
-            _record_sync_segment_failure(
-                failure,
+            # A provider that returns without error and produces no words is
+            # reporting that the audio holds no transcribable speech. VAD
+            # admitting the segment is not evidence to the contrary — it
+            # over-reports on noise — so this is the same valid empty result as
+            # VAD finding nothing, not a failure to retry. Counting it as a
+            # failed segment finalized the whole job failed, and the client
+            # re-uploaded the same noise on every pass until it gave up and
+            # showed the recording as permanently failed.
+            _record_empty_segment_as_silence(
+                provider=provider,
                 model=model,
                 lane=sync_lane,
-                lock=lock,
-                errors=errors,
-                record_metric=deferred_outcome is None,
+                deferred_outcome=deferred_outcome,
             )
             return False
         transcript_segments: List[TranscriptSegment] = postprocess_words(words, 0)
         if not transcript_segments:
-            failure = empty_unexpected_failure(provider)
-            _set_deferred_segment_outcome(
-                deferred_outcome,
-                outcome=failure.outcome,
-                provider=failure.provider,
-                model=model,
-                retryable=failure.retryable,
-            )
-            _record_sync_segment_failure(
-                failure,
+            # Words survived the provider but nothing survived post-processing:
+            # again no transcribable speech, valid and empty rather than failed.
+            _record_empty_segment_as_silence(
+                provider=provider,
                 model=model,
                 lane=sync_lane,
-                lock=lock,
-                errors=errors,
-                record_metric=deferred_outcome is None,
+                deferred_outcome=deferred_outcome,
             )
             return False
 
@@ -2019,6 +2039,11 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
                 _RESPONSE_FENCED_CONVERSATION_IDS: fenced_conversation_ids,
             }
             segment_errors = []
+            # Segments that yielded a transcript, distinct from ones that failed
+            # and ones that held no speech. Only transcribed audio is billed, so
+            # a job of nothing but silence records no usage even though it is not
+            # a failure.
+            content_segment_count = [0]
             segment_lock = threading.Lock()
 
             # Segments that fully landed in a prior Cloud Tasks attempt are skipped
@@ -2079,6 +2104,7 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
                     # Therefore any skipped segment on a retry has its visible
                     # conversation IDs available for response hydration.
                     with segment_lock:
+                        content_segment_count[0] += 1
                         partial = {
                             'new_memories': sorted(response['new_memories']),
                             'updated_memories': sorted(response['updated_memories']),
@@ -2241,7 +2267,7 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
                 result['total_segments'] = total_segments
                 result['errors'] = segment_errors[:10]
 
-            if successful_segments > 0:
+            if content_segment_count[0] > 0:
                 try:
                     usage_seconds = int(total_speech_seconds)
                     should_record_usage = bool(content_id) or await run_blocking(


### PR DESCRIPTION
A user's recordings sat in the app as "26 recordings need attention — Failed,
tap Retry," repeating across days, and retrying never cleared them. They
confirmed the audio was noise.

## What was happening

The sync pipeline runs VAD, then transcribes each segment VAD marked as speech.
When a provider returned without error but produced no words, the pipeline
treated that as a failed segment:

```python
if not words:
    # ...VAD passed, so a provider returning nothing "is not the same
    # as the valid zero-segment result produced by the VAD phase."
    failure = empty_unexpected_failure(provider)   # retryable
```

A recording of pure noise made every segment "fail," so the whole job finalized
`failed`, the content ledger was released for retry, and the client re-uploaded
the same audio on the next pass — forever, until it gave up and showed the
recording as permanently failed. Retrying could never succeed, because the audio
had nothing to transcribe.

The premise — "VAD passed, so there was speech" — is wrong. VAD over-reports on
noise. Two independent providers return empty on the same audio at similar rates
(measured: ~77% of one, ~54% of the other), and the user confirmed the
recordings are noise. So an empty result from a provider that did not error is
the authority that there was nothing to transcribe, not a fault to retry.

Platform-wide this was finalizing ~568 sync jobs an hour as failed, all of them
this outcome, and it means the STT fleet spends most of its work transcribing
noise.

## Change

A speech-free segment now records the same valid empty result that VAD-empty
already produces, and appends nothing to the job's error list. So:

- A job whose every segment is speech-free finalizes `completed`, not `failed`.
- Its content ledger is marked done, not released for a retry that repeats
  identically. The client sees a terminal result and stops re-uploading.
- Usage is billed only for segments that produced a transcript, so a job of
  nothing but silence records none, rather than metering noise it declined to
  transcribe.

Only genuine provider failures — timeouts and upstream errors — stay retryable.
Decode failures stay failures too; this is scoped to a provider that succeeded
and returned nothing.

Existing stuck recordings self-heal on the user's next sync: the re-upload now
returns `completed` and clears from "needs attention."

## Tests

`test_provider_empty_after_vad_completes_as_silence` asserts the job finalizes
with no failed segments, marks the content ledger complete rather than releasing
it, and bills no usage. `test_sync_silent_failure` covers `process_segment`
directly: an empty provider result and empty post-processed result each return
without appending an error, and an all-empty three-segment job has zero failed
segments. Verified all three fail against the previous behaviour.

Decode-failure and provider-exception paths are unchanged and still asserted
failing.

`test_sync_v2` 168, `test_sync_silent_failure` 38, `test_transcription_outcomes`
6, `test_sync_record_usage` 19, `test_sync_transcription_prefs` 64,
`test_sync_pcm_decode` 23, `test_sync_opus_decode` 35 — all passed.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

