### PR TITLE
SCA-108: add live STT attempt denominator

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-other.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-other.json
@@ -1,9 +1,11 @@
 {
   "files": {
-    "backend/scripts/validate-backend-runtime-env.py": 1859
+    "backend/scripts/validate-backend-runtime-env.py": 1859,
+    "backend/testing/listen_pusher_stack/run.py": 1503
   },
   "raise_justifications": {
-    "backend/scripts/validate-backend-runtime-env.py": "Serving STT retirement, shared forbidden-env validation, and SCA-29/SCA-33 runtime-versus-workflow source boundaries remain one authoritative deployment contract."
+    "backend/scripts/validate-backend-runtime-env.py": "Serving STT retirement, shared forbidden-env validation, and SCA-29/SCA-33 runtime-versus-workflow source boundaries remain one authoritative deployment contract.",
+    "backend/testing/listen_pusher_stack/run.py": "The detached real listener/Pusher/Firestore harness keeps its process orchestration and privacy-safe end-to-end assertions in one scenario owner."
   },
   "threshold": 1500
 }

--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -9085,7 +9085,7 @@
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
     "ruleGroup": "Resilience",
-    "title": "Live transcription - terminal failure rate elevated",
+  "title": "Live transcription - attempt failure rate elevated",
     "condition": "D",
     "data": [
       {
@@ -9101,7 +9101,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(omi_journey_terminal_total{journey=\"live_transcription\",outcome=~\"success|failure\"}[30m]))",
+        "expr": "sum(increase(omi_live_stt_accepted_total[30m]))",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -9121,7 +9121,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(omi_journey_terminal_total{journey=\"live_transcription\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"live_transcription\",outcome=~\"success|failure\"}[30m])), 1)",
+        "expr": "sum(increase(omi_live_stt_terminal_total{outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_live_stt_accepted_total[30m])), 1)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -9199,8 +9199,8 @@
     "annotations": {
       "__dashboardUid__": "omi-resilience-fallbacks",
       "__panelId__": "7",
-      "summary": "Live-transcription terminal failures exceed 10% with at least 20 terminal real requests in 30m",
-      "threshold": "failure share > 0.10; terminal outcomes >= 20",
+      "summary": "Live-transcription failures exceed 10% with at least 20 accepted real attempts in 30m",
+      "threshold": "failure share > 0.10; accepted attempts >= 20",
       "user_impact": "Users may not receive live transcript text or may experience degraded results.",
       "scope": "The Omi live-transcription production service path.",
       "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",

--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -9198,7 +9198,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "omi-resilience-fallbacks",
-      "__panelId__": "7",
+      "__panelId__": "10",
       "summary": "Live-transcription failures exceed 10% with at least 20 accepted real attempts in 30m",
       "threshold": "failure share > 0.10; accepted attempts >= 20",
       "user_impact": "Users may not receive live transcript text or may experience degraded results.",

--- a/backend/charts/monitoring/alerts/resilience.json
+++ b/backend/charts/monitoring/alerts/resilience.json
@@ -657,7 +657,7 @@
     "keep_firing_for": "0s",
     "annotations": {
       "__dashboardUid__": "omi-resilience-fallbacks",
-      "__panelId__": "7",
+      "__panelId__": "10",
       "summary": "Live-transcription failures exceed 10% with at least 20 accepted real attempts in 30m",
       "threshold": "failure share > 0.10; accepted attempts >= 20",
       "user_impact": "Users may not receive live transcript text or may experience degraded results.",

--- a/backend/charts/monitoring/alerts/resilience.json
+++ b/backend/charts/monitoring/alerts/resilience.json
@@ -544,7 +544,7 @@
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
     "ruleGroup": "Resilience",
-    "title": "Live transcription - terminal failure rate elevated",
+  "title": "Live transcription - attempt failure rate elevated",
     "condition": "D",
     "data": [
       {
@@ -560,7 +560,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(omi_journey_terminal_total{journey=\"live_transcription\",outcome=~\"success|failure\"}[30m]))",
+        "expr": "sum(increase(omi_live_stt_accepted_total[30m]))",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -580,7 +580,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(omi_journey_terminal_total{journey=\"live_transcription\",outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"live_transcription\",outcome=~\"success|failure\"}[30m])), 1)",
+        "expr": "sum(increase(omi_live_stt_terminal_total{outcome=\"failure\"}[30m])) / clamp_min(sum(increase(omi_live_stt_accepted_total[30m])), 1)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -658,8 +658,8 @@
     "annotations": {
       "__dashboardUid__": "omi-resilience-fallbacks",
       "__panelId__": "7",
-      "summary": "Live-transcription terminal failures exceed 10% with at least 20 terminal real requests in 30m",
-      "threshold": "failure share > 0.10; terminal outcomes >= 20",
+      "summary": "Live-transcription failures exceed 10% with at least 20 accepted real attempts in 30m",
+      "threshold": "failure share > 0.10; accepted attempts >= 20",
       "user_impact": "Users may not receive live transcript text or may experience degraded results.",
       "scope": "The Omi live-transcription production service path.",
       "verification": "Verify the condition in the linked Grafana panel and correlate it with production traffic before intervention.",

--- a/backend/charts/monitoring/dashboards/omi-services/resilience-fallbacks.json
+++ b/backend/charts/monitoring/dashboards/omi-services/resilience-fallbacks.json
@@ -550,13 +550,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(sum(increase(omi_live_stt_terminal_total{outcome=\"failure\"}[$__rate_interval])) / clamp_min(sum(increase(omi_live_stt_accepted_total[$__rate_interval])), 1)) and (sum(increase(omi_live_stt_accepted_total[$__rate_interval])) > 0)",
-          "legendFormat": "live STT",
+          "expr": "(sum by (journey) (increase(omi_journey_terminal_total{outcome=\"success\"}[$__rate_interval])) / sum by (journey) (increase(omi_journey_terminal_total{outcome=~\"success|failure\"}[$__rate_interval]))) and on (journey) (sum by (journey) (increase(omi_journey_terminal_total{outcome=~\"success|failure\"}[$__rate_interval])) > 0)",
+          "legendFormat": "{{journey}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Live STT attempt failure rate (failure / accepted)",
+      "title": "Journey terminal success rate (success / success + failure)",
       "type": "timeseries"
     },
     {
@@ -701,6 +701,55 @@
         }
       ],
       "title": "Capture finalization durable projection and nonterminal work",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(sum(increase(omi_live_stt_terminal_total{outcome=\"failure\"}[$__rate_interval])) / clamp_min(sum(increase(omi_live_stt_accepted_total[$__rate_interval])), 1)) and (sum(increase(omi_live_stt_accepted_total[$__rate_interval])) > 0)",
+          "legendFormat": "live STT",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Live STT attempt failure rate (failure / accepted)",
       "type": "timeseries"
     }
   ],

--- a/backend/charts/monitoring/dashboards/omi-services/resilience-fallbacks.json
+++ b/backend/charts/monitoring/dashboards/omi-services/resilience-fallbacks.json
@@ -503,7 +503,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "**Real-traffic journeys:** chat, pusher, live transcription, and capture-finalization measure accepted work through a server-observable terminal boundary. Product-failure alerts require real traffic; cancelled client/transport endings and fenced stale work remain visible without counting as product failures. An absent source is scrape health, not zero traffic. Semantics: `backend/docs/runbooks/real-traffic-journeys.md`.",
+        "content": "**Real-traffic journeys:** chat, pusher, and capture-finalization use their server-observable terminal boundaries. Live STT separately measures accepted listener attempts and their bounded terminal outcomes. Product-failure alerts require real traffic; cancelled client/transport endings and fenced stale work remain visible without counting as product failures. An absent source is scrape health, not zero traffic. Semantics: `backend/docs/runbooks/real-traffic-journeys.md`.",
         "mode": "markdown"
       },
       "pluginVersion": "12.1.0",
@@ -550,13 +550,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(sum by (journey) (increase(omi_journey_terminal_total{outcome=\"success\"}[$__rate_interval])) / sum by (journey) (increase(omi_journey_terminal_total{outcome=~\"success|failure\"}[$__rate_interval]))) and on (journey) (sum by (journey) (increase(omi_journey_terminal_total{outcome=~\"success|failure\"}[$__rate_interval])) > 0)",
-          "legendFormat": "{{journey}}",
+          "expr": "(sum(increase(omi_live_stt_terminal_total{outcome=\"failure\"}[$__rate_interval])) / clamp_min(sum(increase(omi_live_stt_accepted_total[$__rate_interval])), 1)) and (sum(increase(omi_live_stt_accepted_total[$__rate_interval])) > 0)",
+          "legendFormat": "live STT",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Journey terminal success rate (success / success + failure)",
+      "title": "Live STT attempt failure rate (failure / accepted)",
       "type": "timeseries"
     },
     {

--- a/backend/docs/runbooks/real-traffic-journeys.md
+++ b/backend/docs/runbooks/real-traffic-journeys.md
@@ -65,11 +65,12 @@ image, provider-model, or content labels.
 
 ## Dashboard, alerts, and scrape health
 
-The **Resilience / Fallbacks** dashboard includes the separate Live STT
-failure/accepted-attempt rate. It intentionally uses only terminal
-`success` and `failure` outcomes: cancelled client/transport endings and
-stale fenced capture jobs stay visible but do not masquerade as application
-failures.
+The **Resilience / Fallbacks** dashboard retains the generic journey terminal
+success rate for `chat_response`, `pusher_session`, and `capture_finalization`,
+and adds a separate Live STT failure/accepted-attempt rate. The generic rate
+intentionally uses only terminal `success` and `failure` outcomes: cancelled
+client/transport endings and stale fenced capture jobs stay visible but do not
+masquerade as application failures.
 
 The terminal-success-rate panel stays empty (N/A) until a journey has a terminal
 success-or-failure outcome; it never presents idle traffic as a 0% success rate.

--- a/backend/docs/runbooks/real-traffic-journeys.md
+++ b/backend/docs/runbooks/real-traffic-journeys.md
@@ -1,6 +1,6 @@
 # Real-Traffic Journey Outcomes
 
-`omi_journey_*` measures user-originated traffic only. It does not create test
+`omi_journey_*` and `omi_live_stt_*` measure user-originated traffic only. They do not create test
 accounts, synthetic canaries, or generated requests. Dev/beta and production
 are intentionally isolated: each Prometheus instance evaluates only the
 traffic it scrapes, with no cross-environment comparison or labels.
@@ -12,15 +12,23 @@ traffic it scrapes, with no cross-environment comparison or labels.
 | `omi_journey_accepted_total` | `journey` | A production boundary accepted work. |
 | `omi_journey_terminal_total` | `journey`, `outcome` | A one-shot terminal outcome for accepted work. |
 | `omi_journey_latency_seconds` | `journey`, `outcome` | Acceptance-to-terminal latency. |
+| `omi_live_stt_accepted_total` | `provider`, `client_platform`, `deployment_environment` | A listener accepted its first nontrivial live-STT audio frame. |
+| `omi_live_stt_terminal_total` | `provider`, `outcome`, `client_platform`, `deployment_environment`, `phase` | A one-shot terminal outcome for an accepted live-STT attempt. |
+| `omi_live_stt_terminal_failures_total` | `provider`, `outcome`, `client_platform`, `deployment_environment`, `phase` | Provider failure detail correlated with a live-STT terminal. |
 | `omi_capture_finalization_reconciliations_total` | `outcome` | A stale durable capture job was requeued, or its requeue handoff failed. |
 | `listen_finalization_oldest_nonterminal_age_seconds` | none | Age of the oldest queued, leased, or BYOK-blocked capture finalization job. |
 | `listen_finalization_durable_jobs` | `state` | Authoritative Firestore job projection: `accepted`, `success`, `failure`, `stale`, `nonterminal`, `blocked_byok`, or `terminal_unknown`. |
 
-`journey` is exactly `chat_response`, `pusher_session`, `live_transcription`,
-or `capture_finalization`. `outcome` is exactly `success`, `failure`,
+`journey` is exactly `chat_response`, `pusher_session`, or
+`capture_finalization`. Generic journey `outcome` is exactly `success`, `failure`,
 `cancelled`, or `stale`; reconciliation `outcome` is exactly `requeued` or
-`enqueue_failed`. There are no user, conversation, request, error-text,
-provider, or content labels.
+`enqueue_failed`. Live-STT terminal `outcome` is exactly `success`, `failure`,
+or `cancelled`; its terminal `phase` is exactly `transcript_delivery`,
+`initialization`, `connection`, `send`, or `teardown`. `provider` and
+`client_platform` use their existing closed vocabularies, and
+`deployment_environment` is one of `prod`, `dev`, `local`, `offline`, or
+`unknown`. There are no user, conversation, request, error-text, revision,
+image, provider-model, or content labels.
 
 ## Boundary semantics
 
@@ -35,12 +43,15 @@ provider, or content labels.
   server has already identified an application failure. A `1011` or stronger
   application failure is `failure`; other transport/client endings are
   `cancelled`, not product failures.
-- `live_transcription` is accepted when `/v4/listen` receives its first
+- Live STT is accepted when `/v4/listen` receives its first
   nontrivial audio frame. `success` is recorded only after the server has sent
   the first nonempty transcript payload to that WebSocket. This cannot prove
   the client rendered the payload. An upstream/live-session failure or an
   unexpected listen worker failure is `failure`; all other endings before a
-  transcript send are `cancelled`.
+  transcript send are `cancelled`. Provider failures preserve their bounded
+  provider outcome and phase in `omi_live_stt_terminal_failures_total`; the
+  matching accepted attempt has one `failure` terminal in
+  `omi_live_stt_terminal_total`.
 - `capture_finalization` is accepted only once, when the Firestore finalization
   outbox creates a new durable job. Successful completion is `success`, a
   dead-letter is `failure`, and a lifecycle-fenced durable job is `stale`.
@@ -54,8 +65,8 @@ provider, or content labels.
 
 ## Dashboard, alerts, and scrape health
 
-The **Resilience / Fallbacks** dashboard includes all four journey success
-rates and p95 latencies. Success rate intentionally uses only terminal
+The **Resilience / Fallbacks** dashboard includes the separate Live STT
+failure/accepted-attempt rate. It intentionally uses only terminal
 `success` and `failure` outcomes: cancelled client/transport endings and
 stale fenced capture jobs stay visible but do not masquerade as application
 failures.
@@ -63,7 +74,9 @@ failures.
 The terminal-success-rate panel stays empty (N/A) until a journey has a terminal
 success-or-failure outcome; it never presents idle traffic as a 0% success rate.
 
-Product-failure alerts require at least 20 terminal success-or-failure outcomes in 30 minutes,
+The Live STT product-failure alert requires at least 20 accepted listener attempts in 30 minutes,
+then alerts only when bounded live-STT failure terminals exceed 10% of those attempts for 10 minutes.
+The other product-failure alerts require at least 20 terminal success-or-failure outcomes in 30 minutes,
 then alert only when the terminal failure share is above 10% for 10 minutes.
 No traffic produces a zero accepted count and does not page. The separate
 scrape-source alert requires both Prometheus jobs, `backend-listen-metrics` and

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -185,6 +185,8 @@ class ListenSessionRuntime:
 
     def start_live_transcription(self) -> None:
         """Accept the journey once the listen socket has received real audio."""
+        if self.use_custom_stt:
+            return
         if self.state.live_transcription_attempt is None:
             self.state.live_transcription_attempt = LiveSTTAttempt(
                 provider=getattr(self.stt_service, 'value', self.stt_service),

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -45,7 +45,7 @@ from utils.listen_session_bootstrap import finalize_listen_connect_context, load
 from utils.metrics import BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS
 from utils.notifications import send_credit_limit_notification, send_silent_user_notification
 from utils.onboarding import OnboardingHandler
-from utils.observability.journeys import JourneyAttempt, JourneyOutcome
+from utils.observability.transcription import LiveSTTAttempt
 from utils.pusher import PusherCircuitBreakerOpen
 from utils.stt.streaming import get_stt_service_for_language
 from utils.subscription import get_remaining_transcription_seconds, is_trial_paywalled
@@ -186,24 +186,27 @@ class ListenSessionRuntime:
     def start_live_transcription(self) -> None:
         """Accept the journey once the listen socket has received real audio."""
         if self.state.live_transcription_attempt is None:
-            self.state.live_transcription_attempt = JourneyAttempt('live_transcription')
+            self.state.live_transcription_attempt = LiveSTTAttempt(
+                provider=getattr(self.stt_service, 'value', self.stt_service),
+                platform=self.client_device_context.platform,
+            )
 
     def complete_live_transcription(self) -> None:
         """Record the first nonempty transcript successfully delivered to the client."""
         if self.state.live_transcription_attempt is not None:
-            self.state.live_transcription_attempt.finish('success')
+            self.state.live_transcription_attempt.finish('success', phase='transcript_delivery')
 
     def _finish_live_transcription(self) -> None:
         """Terminalize an accepted attempt that never delivered a transcript."""
         attempt = self.state.live_transcription_attempt
         if attempt is None:
             return
-        outcome: JourneyOutcome = (
+        outcome = (
             'failure'
             if self.state.live_transcription_failed or self.state.stt_terminal_failure or self.state.close_code == 1011
             else 'cancelled'
         )
-        attempt.finish(outcome)
+        attempt.finish(outcome, phase='teardown')
 
     async def _admit(self) -> bool:
         if not self.request.uid:

--- a/backend/testing/listen_pusher_stack/README.md
+++ b/backend/testing/listen_pusher_stack/README.md
@@ -64,7 +64,7 @@ never audio or transcript text.
 
 Scenarios:
 
-1. audio → streaming segment → stale live-session lifecycle → persisted content → completed inline job;
+1. audio → one bounded live-STT accepted attempt → streaming segment → one matching successful terminal (including after teardown replay) → stale live-session lifecycle → persisted content → completed inline job;
 2. completed native UUID reconnect replays the terminal binding without a new job;
 3. a stale empty desktop recording is removed by the next-session lifecycle path and creates no job;
 4. a pusher process loses the first 104 before claim, is restarted, and the

--- a/backend/testing/listen_pusher_stack/run.py
+++ b/backend/testing/listen_pusher_stack/run.py
@@ -42,6 +42,7 @@ PYTHON = BACKEND / '.venv' / 'bin' / 'python'
 ADMIN_KEY = 'omi-listen-pusher-stack-admin-'
 PROJECT = 'demo-omi-listen-stack'
 LOCAL_TASK_TOKEN = 'listen-pusher-stack-loopback-task'
+METRICS_SECRET = 'listen-pusher-stack-metrics'
 REST_FINALIZATION_RACE_ENV = (
     'OMI_STACK_FINALIZATION_RACE_UID',
     'OMI_STACK_FINALIZATION_RACE_CONVERSATION_ID',
@@ -195,6 +196,7 @@ class Stack:
                 'FIRESTORE_DATABASE_ID': '(default)',
                 'ENCRYPTION_SECRET': 'omi_listen_pusher_stack_test_secret_32_bytes',
                 'ADMIN_KEY': ADMIN_KEY,
+                'METRICS_SECRET': METRICS_SECRET,
                 'REDIS_DB_HOST': '127.0.0.1',
                 'REDIS_DB_PORT': str(self.redis_port),
                 'HOSTED_PUSHER_API_URL': f'http://127.0.0.1:{self.pusher_port}',
@@ -582,6 +584,16 @@ class Stack:
             raise StackFailure(f'GET /v1/conversations/{conversation_id} returned non-object JSON')
         return body
 
+    async def listener_metrics(self) -> str:
+        async with httpx.AsyncClient(timeout=10.0, trust_env=False) as client:
+            response = await client.get(
+                f'http://127.0.0.1:{self.backend_port}/metrics',
+                headers={'Authorization': f'Bearer {METRICS_SECRET}'},
+            )
+        if response.status_code != 200:
+            raise StackFailure(f'listener metrics endpoint returned {response.status_code}')
+        return response.text
+
 
 def _one_job(stack: Stack, uid: str, conversation_id: str) -> dict[str, Any]:
     jobs = stack.jobs_for(uid, conversation_id)
@@ -622,7 +634,10 @@ async def _connect(stack: Stack, uid: str, session_id: str | None) -> tuple[Any,
     params = urlencode(parameters)
     websocket = await websockets.connect(
         f'ws://127.0.0.1:{stack.backend_port}/v4/listen?{params}',
-        extra_headers={'Authorization': f'Bearer {ADMIN_KEY}{uid}'},
+        extra_headers={
+            'Authorization': f'Bearer {ADMIN_KEY}{uid}',
+            'X-App-Platform': 'desktop',
+        },
         max_size=10 * 1024 * 1024,
     )
     session = await _receive_until(
@@ -649,6 +664,28 @@ async def _record_audio(websocket: Any) -> None:
         lambda payload: isinstance(payload, list) and bool(payload) and payload[0].get('id') == 'stack-segment-1',
         label='streamed transcript',
     )
+
+
+async def _assert_live_stt_attempt_metrics(stack: Stack) -> None:
+    """Exercise the real listener/provider seam without exposing audio or transcript text."""
+
+    metrics = await stack.listener_metrics()
+    accepted = [line for line in metrics.splitlines() if line.startswith('omi_live_stt_accepted_total{')]
+    terminals = [line for line in metrics.splitlines() if line.startswith('omi_live_stt_terminal_total{')]
+    expected_labels = ('client_platform="desktop"', 'deployment_environment="offline"', 'provider="parakeet"')
+    if (
+        len(accepted) != 1
+        or not all(label in accepted[0] for label in expected_labels)
+        or not accepted[0].endswith(' 1.0')
+    ):
+        raise StackFailure(f'expected one bounded accepted live-STT attempt, observed {accepted!r}')
+    expected_terminal_labels = (*expected_labels, 'outcome="success"', 'phase="transcript_delivery"')
+    if (
+        len(terminals) != 1
+        or not all(label in terminals[0] for label in expected_terminal_labels)
+        or not terminals[0].endswith(' 1.0')
+    ):
+        raise StackFailure(f'expected one bounded successful live-STT terminal, observed {terminals!r}')
 
 
 async def _request_rest_finalization(
@@ -743,6 +780,7 @@ async def _normal_and_terminal_reconnect(stack: Stack) -> None:
         timeout=25.0,
     )
     await websocket.close(code=1000)
+    await _assert_live_stt_attempt_metrics(stack)
     job = _wait_for_job(stack, uid, session_id, 'completed')
     conversation = stack.conversation(uid, session_id)
     if not conversation or conversation.get('status') != 'completed' or not conversation.get('has_content'):

--- a/backend/tests/unit/test_journey_observability.py
+++ b/backend/tests/unit/test_journey_observability.py
@@ -31,11 +31,11 @@ def _install_journey_metrics(monkeypatch):
 def test_journey_contract_uses_only_closed_privacy_safe_labels(monkeypatch):
     accepted, terminal, latency, reconciliations = _install_journey_metrics(monkeypatch)
 
-    journeys.record_journey_accepted('live_transcription')
+    journeys.record_journey_accepted('pusher_session')
     journeys.record_journey_terminal('pusher_session', 'cancelled', 1.5)
     journeys.record_capture_finalization_reconciliation('requeued')
 
-    accepted.labels.assert_called_once_with(journey='live_transcription')
+    accepted.labels.assert_called_once_with(journey='pusher_session')
     terminal.labels.assert_called_once_with(journey='pusher_session', outcome='cancelled')
     latency.labels.assert_called_once_with(journey='pusher_session', outcome='cancelled')
     reconciliations.labels.assert_called_once_with(outcome='requeued')
@@ -120,7 +120,8 @@ def test_listener_projects_the_closed_durable_finalization_states(monkeypatch):
 def test_idle_metrics_and_monitoring_contract_distinguish_traffic_from_a_missing_scrape_source():
     exported = metrics.generate_latest().decode()
     assert 'omi_journey_accepted_total{journey="chat_response"}' in exported
-    assert 'omi_journey_accepted_total{journey="live_transcription"}' in exported
+    assert 'omi_live_stt_accepted_total' in exported
+    assert 'omi_live_stt_terminal_total' in exported
     assert 'omi_journey_terminal_total{journey="pusher_session",outcome="success"}' in exported
     assert 'omi_capture_finalization_reconciliations_total{outcome="requeued"}' in exported
     assert 'listen_finalization_stale_processing_reconciliations_total{outcome="completed"}' in exported
@@ -146,6 +147,9 @@ def test_idle_metrics_and_monitoring_contract_distinguish_traffic_from_a_missing
     for rule in product_rules:
         if rule['uid'] == 'omi-journey-capture-fail':
             assert 'listen_finalization_durable_jobs' in rule['data'][0]['model']['expr']
+        elif rule['uid'] == 'omi-journey-live-transcription-fail':
+            assert rule['data'][0]['model']['expr'] == 'sum(increase(omi_live_stt_accepted_total[30m]))'
+            assert 'omi_live_stt_terminal_total{outcome="failure"}' in rule['data'][1]['model']['expr']
         else:
             assert 'outcome=~"success|failure"' in rule['data'][0]['model']['expr']
         assert '$A >= 20 && $B > 0.10' in rule['data'][2]['model']['expression']
@@ -168,13 +172,14 @@ def test_idle_metrics_and_monitoring_contract_distinguish_traffic_from_a_missing
         (monitoring / 'dashboards/omi-services/resilience-fallbacks.json').read_text(encoding='utf-8')
     )
     panel_titles = {panel['title'] for panel in dashboard['panels']}
-    assert 'Journey terminal success rate (success / success + failure)' in panel_titles
+    assert 'Live STT attempt failure rate (failure / accepted)' in panel_titles
     assert 'Journey acceptance-to-terminal latency (p95)' in panel_titles
     assert 'Capture finalization durable projection and nonterminal work' in panel_titles
-    success_panel = next(
-        panel for panel in dashboard['panels'] if panel['title'].startswith('Journey terminal success')
+    live_stt_panel = next(
+        panel for panel in dashboard['panels'] if panel['title'].startswith('Live STT attempt failure')
     )
-    assert 'and on (journey)' in success_panel['targets'][0]['expr']
+    assert 'omi_live_stt_terminal_total{outcome="failure"}' in live_stt_panel['targets'][0]['expr']
+    assert 'omi_live_stt_accepted_total' in live_stt_panel['targets'][0]['expr']
     capture_rule = next(rule for rule in split_alerts if rule['uid'] == 'omi-journey-capture-fail')
     assert 'listen_finalization_durable_jobs' in capture_rule['data'][0]['model']['expr']
     assert 'max by (state)' in capture_rule['data'][0]['model']['expr']

--- a/backend/tests/unit/test_journey_observability.py
+++ b/backend/tests/unit/test_journey_observability.py
@@ -157,7 +157,7 @@ def test_idle_metrics_and_monitoring_contract_distinguish_traffic_from_a_missing
         rule for rule in product_rules if rule['uid'] == 'omi-journey-live-transcription-fail'
     )
     assert live_transcription_rule['noDataState'] == 'OK'
-    assert live_transcription_rule['annotations']['__panelId__'] == '7'
+    assert live_transcription_rule['annotations']['__panelId__'] == '10'
     assert all(
         rule['noDataState'] == 'NoData'
         for rule in product_rules
@@ -172,12 +172,19 @@ def test_idle_metrics_and_monitoring_contract_distinguish_traffic_from_a_missing
         (monitoring / 'dashboards/omi-services/resilience-fallbacks.json').read_text(encoding='utf-8')
     )
     panel_titles = {panel['title'] for panel in dashboard['panels']}
+    assert 'Journey terminal success rate (success / success + failure)' in panel_titles
     assert 'Live STT attempt failure rate (failure / accepted)' in panel_titles
     assert 'Journey acceptance-to-terminal latency (p95)' in panel_titles
     assert 'Capture finalization durable projection and nonterminal work' in panel_titles
     live_stt_panel = next(
         panel for panel in dashboard['panels'] if panel['title'].startswith('Live STT attempt failure')
     )
+    generic_terminal_panel = next(panel for panel in dashboard['panels'] if panel['id'] == 7)
+    assert generic_terminal_panel['title'] == 'Journey terminal success rate (success / success + failure)'
+    assert 'omi_journey_terminal_total{outcome=~"success|failure"}' in generic_terminal_panel['targets'][0]['expr']
+    assert 'and on (journey)' in generic_terminal_panel['targets'][0]['expr']
+    assert live_stt_panel['id'] == 10
+    assert live_stt_panel['gridPos'] == {'h': 8, 'w': 24, 'x': 0, 'y': 40}
     assert 'omi_live_stt_terminal_total{outcome="failure"}' in live_stt_panel['targets'][0]['expr']
     assert 'omi_live_stt_accepted_total' in live_stt_panel['targets'][0]['expr']
     capture_rule = next(rule for rule in split_alerts if rule['uid'] == 'omi-journey-capture-fail')

--- a/backend/tests/unit/test_listen_runtime_regressions.py
+++ b/backend/tests/unit/test_listen_runtime_regressions.py
@@ -228,6 +228,7 @@ class _LiveSTTAttempt:
 
 def _live_transcription_runtime(*, close_code=1001, stt_terminal_failure=False, live_transcription_failed=False):
     runtime = object.__new__(ListenSessionRuntime)
+    runtime.use_custom_stt = False
     runtime.state = SimpleNamespace(
         close_code=close_code,
         stt_terminal_failure=stt_terminal_failure,
@@ -255,6 +256,21 @@ def test_live_transcription_journey_starts_once_and_success_wins_over_teardown(m
     assert _LiveSTTAttempt.instances[0].provider == 'deepgram'
     assert _LiveSTTAttempt.instances[0].platform == 'ios'
     assert _LiveSTTAttempt.instances[0].terminals == [('success', 'transcript_delivery')]
+
+
+def test_custom_stt_does_not_create_a_backend_provider_attempt(monkeypatch):
+    import routers.listen.runtime as runtime_module
+
+    _LiveSTTAttempt.instances = []
+    monkeypatch.setattr(runtime_module, 'LiveSTTAttempt', _LiveSTTAttempt)
+    runtime = _live_transcription_runtime()
+    runtime.use_custom_stt = True
+
+    runtime.start_live_transcription()
+    runtime.complete_live_transcription()
+    runtime._finish_live_transcription()
+
+    assert _LiveSTTAttempt.instances == []
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/test_listen_runtime_regressions.py
+++ b/backend/tests/unit/test_listen_runtime_regressions.py
@@ -209,20 +209,21 @@ def test_runtime_emits_speaker_suggestion_event():
     assert emitted_events[0].person_name == 'Avery'
 
 
-class _JourneyAttempt:
+class _LiveSTTAttempt:
     instances = []
 
-    def __init__(self, journey):
-        self.journey = journey
+    def __init__(self, *, provider, platform):
+        self.provider = provider
+        self.platform = platform
         self.finished = False
-        self.outcomes = []
+        self.terminals = []
         self.__class__.instances.append(self)
 
-    def finish(self, outcome):
+    def finish(self, outcome, *, phase):
         if self.finished:
             return
         self.finished = True
-        self.outcomes.append(outcome)
+        self.terminals.append((outcome, phase))
 
 
 def _live_transcription_runtime(*, close_code=1001, stt_terminal_failure=False, live_transcription_failed=False):
@@ -233,14 +234,16 @@ def _live_transcription_runtime(*, close_code=1001, stt_terminal_failure=False, 
         live_transcription_failed=live_transcription_failed,
         live_transcription_attempt=None,
     )
+    runtime.stt_service = STTService.deepgram
+    runtime.client_device_context = SimpleNamespace(platform='ios')
     return runtime
 
 
 def test_live_transcription_journey_starts_once_and_success_wins_over_teardown(monkeypatch):
     import routers.listen.runtime as runtime_module
 
-    _JourneyAttempt.instances = []
-    monkeypatch.setattr(runtime_module, 'JourneyAttempt', _JourneyAttempt)
+    _LiveSTTAttempt.instances = []
+    monkeypatch.setattr(runtime_module, 'LiveSTTAttempt', _LiveSTTAttempt)
     runtime = _live_transcription_runtime(close_code=1011, stt_terminal_failure=True)
 
     runtime.start_live_transcription()
@@ -248,9 +251,10 @@ def test_live_transcription_journey_starts_once_and_success_wins_over_teardown(m
     runtime.complete_live_transcription()
     runtime._finish_live_transcription()
 
-    assert len(_JourneyAttempt.instances) == 1
-    assert _JourneyAttempt.instances[0].journey == 'live_transcription'
-    assert _JourneyAttempt.instances[0].outcomes == ['success']
+    assert len(_LiveSTTAttempt.instances) == 1
+    assert _LiveSTTAttempt.instances[0].provider == 'deepgram'
+    assert _LiveSTTAttempt.instances[0].platform == 'ios'
+    assert _LiveSTTAttempt.instances[0].terminals == [('success', 'transcript_delivery')]
 
 
 @pytest.mark.parametrize(
@@ -267,8 +271,8 @@ def test_live_transcription_teardown_classifies_unsent_attempts_once(
 ):
     import routers.listen.runtime as runtime_module
 
-    _JourneyAttempt.instances = []
-    monkeypatch.setattr(runtime_module, 'JourneyAttempt', _JourneyAttempt)
+    _LiveSTTAttempt.instances = []
+    monkeypatch.setattr(runtime_module, 'LiveSTTAttempt', _LiveSTTAttempt)
     runtime = _live_transcription_runtime(
         close_code=close_code,
         stt_terminal_failure=stt_terminal_failure,
@@ -279,7 +283,7 @@ def test_live_transcription_teardown_classifies_unsent_attempts_once(
     runtime._finish_live_transcription()
     runtime._finish_live_transcription()
 
-    assert _JourneyAttempt.instances[0].outcomes == [expected]
+    assert _LiveSTTAttempt.instances[0].terminals == [(expected, 'teardown')]
 
 
 @pytest.mark.anyio

--- a/backend/tests/unit/test_live_stt_failure.py
+++ b/backend/tests/unit/test_live_stt_failure.py
@@ -25,6 +25,7 @@ class FakeSession:
     active: bool = True
     close_code: int = 1001
     stt_terminal_failure: bool = False
+    live_transcription_attempt: Any = None
 
 
 class FakeClientSocket:
@@ -143,6 +144,37 @@ async def test_terminal_live_failure_sends_bounded_status_before_safe_close(
     )
     assert len(websocket.actions) == 2
     assert len(recorded) == 1
+
+
+@pytest.mark.asyncio
+async def test_accepted_live_attempt_terminals_once_with_the_same_failure_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    websocket = FakeClientSocket()
+    terminalized: list[tuple[str, str]] = []
+    session = FakeSession(
+        live_transcription_attempt=SimpleNamespace(
+            finish=lambda outcome, *, phase: terminalized.append((outcome, phase))
+        )
+    )
+    monkeypatch.setattr(live_failure, 'record_live_stt_failure', lambda **_labels: None)
+
+    await terminate_live_stt_session(
+        websocket,
+        session,
+        failure=TranscriptionFailure(TranscriptionOutcome.UPSTREAM_ERROR, provider='parakeet'),
+        reason='send_failed',
+        platform='ios',
+    )
+    await terminate_live_stt_session(
+        websocket,
+        session,
+        failure=TranscriptionFailure(TranscriptionOutcome.UPSTREAM_ERROR, provider='parakeet'),
+        reason='connection_lost',
+        platform='ios',
+    )
+
+    assert terminalized == [('failure', 'send')]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_monitoring_alert_rule_contract.py
+++ b/backend/tests/unit/test_monitoring_alert_rule_contract.py
@@ -37,7 +37,7 @@ PARAKEET_STREAM_CAPACITY_RUNBOOK = "backend/docs/runbooks/parakeet-stream-capaci
 PARAKEET_CAPACITY_DASHBOARD = MONITORING / "dashboards/gke/parakeet-asr-monitoring.json"
 LIVE_TRANSCRIPTION_FAILURE_RULE = "omi-journey-live-transcription-fail"
 LIVE_TRANSCRIPTION_FAILURE_EXPR = (
-    'sum(increase(omi_journey_terminal_total{journey="live_transcription",outcome=~"success|failure"}[30m]))'
+    'sum(increase(omi_live_stt_accepted_total[30m]))'
 )
 PARAKEET_READY_POD_NO_SUCCESS_RULE = "omi-parakeet-ready-pod-no-success"
 PARAKEET_READY_POD_NO_SUCCESS_EXPR = (
@@ -235,6 +235,8 @@ def test_live_transcription_alert_is_traffic_gated_and_ignores_idle_no_data():
         rule = rules[LIVE_TRANSCRIPTION_FAILURE_RULE]
         assert rule["noDataState"] == "OK"
         assert rule["data"][0]["model"]["expr"] == LIVE_TRANSCRIPTION_FAILURE_EXPR
+        assert 'omi_live_stt_terminal_total{outcome="failure"}' in rule["data"][1]["model"]["expr"]
+        assert 'omi_live_stt_accepted_total' in rule["data"][1]["model"]["expr"]
         assert rule["data"][2]["model"]["expression"] == "$A >= 20 && $B > 0.10"
         assert rule["annotations"]["__dashboardUid__"] == "omi-resilience-fallbacks"
         assert rule["annotations"]["__panelId__"] == "7"

--- a/backend/tests/unit/test_monitoring_alert_rule_contract.py
+++ b/backend/tests/unit/test_monitoring_alert_rule_contract.py
@@ -239,4 +239,4 @@ def test_live_transcription_alert_is_traffic_gated_and_ignores_idle_no_data():
         assert 'omi_live_stt_accepted_total' in rule["data"][1]["model"]["expr"]
         assert rule["data"][2]["model"]["expression"] == "$A >= 20 && $B > 0.10"
         assert rule["annotations"]["__dashboardUid__"] == "omi-resilience-fallbacks"
-        assert rule["annotations"]["__panelId__"] == "7"
+        assert rule["annotations"]["__panelId__"] == "10"

--- a/backend/tests/unit/test_transcription_outcomes.py
+++ b/backend/tests/unit/test_transcription_outcomes.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 
 from config.prerecorded_stt import PrerecordedSTTConfigurationError
-from utils.observability.transcription import TranscriptionAttempt, record_live_stt_failure
+from utils.observability.transcription import LiveSTTAttempt, TranscriptionAttempt, record_live_stt_failure
 from utils.stt.outcomes import (
     TranscriptionFailure,
     TranscriptionOutcome,
@@ -78,6 +78,37 @@ def test_attempt_records_one_accepted_and_exactly_one_terminal(mock_accepted, mo
     assert mock_completed.labels.call_args.kwargs['outcome'] == 'success'
 
 
+@patch('utils.observability.transcription.OMI_LIVE_STT_TERMINAL_TOTAL')
+@patch('utils.observability.transcription.OMI_LIVE_STT_ACCEPTED_TOTAL')
+def test_live_stt_attempt_records_one_bounded_acceptance_and_terminal(mock_accepted, mock_terminal, monkeypatch):
+    accepted_child = MagicMock()
+    terminal_child = MagicMock()
+    mock_accepted.labels.return_value = accepted_child
+    mock_terminal.labels.return_value = terminal_child
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
+    monkeypatch.setenv('K_REVISION', 'unbounded-revision-value')
+    monkeypatch.setenv('OMI_DEPLOYMENT_VERSION', 'another-unbounded-value')
+
+    attempt = LiveSTTAttempt(provider='deepgram', platform='ios')
+    attempt.finish('failure', phase='send')
+    attempt.finish('cancelled', phase='teardown')
+
+    assert mock_accepted.labels.call_args.kwargs == {
+        'provider': 'deepgram',
+        'client_platform': 'ios',
+        'deployment_environment': 'dev',
+    }
+    assert mock_terminal.labels.call_args.kwargs == {
+        'provider': 'deepgram',
+        'outcome': 'failure',
+        'client_platform': 'ios',
+        'deployment_environment': 'dev',
+        'phase': 'send',
+    }
+    accepted_child.inc.assert_called_once_with()
+    terminal_child.inc.assert_called_once_with()
+
+
 @patch('utils.observability.transcription.OMI_LIVE_STT_TERMINAL_FAILURES_TOTAL')
 def test_live_failure_labels_are_bounded(mock_counter):
     child = MagicMock()
@@ -94,7 +125,7 @@ def test_live_failure_labels_are_bounded(mock_counter):
         'provider': 'unknown',
         'outcome': 'upstream_error',
         'client_platform': 'unknown',
-        'deployment_version': 'unknown',
+        'deployment_environment': 'unknown',
         'phase': 'unknown',
     }
     child.inc.assert_called_once_with()

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -53,7 +53,7 @@ OMI_CAPTURE_FINALIZATION_RECONCILIATIONS_TOTAL = Counter(
 
 # Export zero-valued children from a healthy but idle process. This lets
 # Prometheus/Grafana distinguish no user traffic from an absent scrape target.
-for _journey in ('chat_response', 'pusher_session', 'live_transcription', 'capture_finalization'):
+for _journey in ('chat_response', 'pusher_session', 'capture_finalization'):
     OMI_JOURNEY_ACCEPTED_TOTAL.labels(journey=_journey)
     for _outcome in ('success', 'failure', 'cancelled', 'stale'):
         OMI_JOURNEY_TERMINAL_TOTAL.labels(journey=_journey, outcome=_outcome)
@@ -235,8 +235,20 @@ OMI_SYNC_TRANSCRIPTION_JOBS_TOTAL = Counter(
 
 OMI_LIVE_STT_TERMINAL_FAILURES_TOTAL = Counter(
     'omi_live_stt_terminal_failures_total',
-    'Terminal live-STT failures by bounded provider, outcome, client platform, revision, and phase',
-    ['provider', 'outcome', 'client_platform', 'deployment_version', 'phase'],
+    'Terminal live-STT failures by bounded provider, outcome, client platform, environment, and phase',
+    ['provider', 'outcome', 'client_platform', 'deployment_environment', 'phase'],
+)
+
+OMI_LIVE_STT_ACCEPTED_TOTAL = Counter(
+    'omi_live_stt_accepted_total',
+    'Accepted live-STT attempts by bounded provider, client platform, and deployment environment',
+    ['provider', 'client_platform', 'deployment_environment'],
+)
+
+OMI_LIVE_STT_TERMINAL_TOTAL = Counter(
+    'omi_live_stt_terminal_total',
+    'Terminal live-STT outcomes for accepted attempts by bounded labels',
+    ['provider', 'outcome', 'client_platform', 'deployment_environment', 'phase'],
 )
 
 TASK_WORKSTREAM_ASSOCIATION_TOTAL = Counter(

--- a/backend/utils/observability/journeys.py
+++ b/backend/utils/observability/journeys.py
@@ -13,11 +13,11 @@ from utils.metrics import (
     OMI_JOURNEY_TERMINAL_TOTAL,
 )
 
-JourneyName = Literal['chat_response', 'pusher_session', 'live_transcription', 'capture_finalization']
+JourneyName = Literal['chat_response', 'pusher_session', 'capture_finalization']
 JourneyOutcome = Literal['success', 'failure', 'cancelled', 'stale']
 ReconciliationOutcome = Literal['requeued', 'enqueue_failed']
 
-_JOURNEYS = frozenset({'chat_response', 'pusher_session', 'live_transcription', 'capture_finalization'})
+_JOURNEYS = frozenset({'chat_response', 'pusher_session', 'capture_finalization'})
 _OUTCOMES = frozenset({'success', 'failure', 'cancelled', 'stale'})
 _RECONCILIATION_OUTCOMES = frozenset({'requeued', 'enqueue_failed'})
 

--- a/backend/utils/observability/transcription.py
+++ b/backend/utils/observability/transcription.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import os
 import re
 from time import monotonic
+from typing import Literal
 
 from utils.metrics import (
+    OMI_LIVE_STT_ACCEPTED_TOTAL,
+    OMI_LIVE_STT_TERMINAL_TOTAL,
     OMI_LIVE_STT_TERMINAL_FAILURES_TOTAL,
     OMI_SYNC_TRANSCRIPTION_JOBS_TOTAL,
     OMI_SYNC_TRANSCRIPTION_SEGMENTS_TOTAL,
@@ -14,6 +17,7 @@ from utils.metrics import (
     OMI_TRANSCRIPTION_COMPLETED_TOTAL,
     OMI_TRANSCRIPTION_LATENCY_SECONDS,
 )
+from utils.env_loader import resolve_stage_from_env
 from utils.stt.outcomes import TranscriptionOutcome, bounded_provider
 
 _ROUTES = {'voice_chat_sse', 'voice_rest_multipart', 'voice_rest_pcm', 'sync'}
@@ -22,6 +26,10 @@ _REVISION_PATTERN = re.compile(r'[^a-zA-Z0-9_.-]')
 _SYNC_LANES = {'backfill', 'fresh'}
 _SYNC_MODELS = {'nova-3', 'parakeet', 'velma-2'}
 _LIVE_PHASES = {'connection', 'initialization', 'send'}
+_LIVE_TERMINAL_OUTCOMES = frozenset({'success', 'failure', 'cancelled'})
+_LIVE_TERMINAL_PHASES = frozenset({'connection', 'initialization', 'send', 'teardown', 'transcript_delivery'})
+LiveSTTTerminalOutcome = Literal['success', 'failure', 'cancelled']
+LiveSTTTerminalPhase = Literal['connection', 'initialization', 'send', 'teardown', 'transcript_delivery']
 
 
 def _bounded_route(route: str) -> str:
@@ -37,6 +45,12 @@ def _deployment_version() -> str:
     raw = os.getenv('K_REVISION') or os.getenv('OMI_DEPLOYMENT_VERSION') or 'unknown'
     sanitized = _REVISION_PATTERN.sub('_', raw.strip())[:80]
     return sanitized or 'unknown'
+
+
+def _deployment_environment() -> str:
+    """Return the closed deployment category, never a revision or image identifier."""
+
+    return resolve_stage_from_env() or 'unknown'
 
 
 class TranscriptionAttempt:
@@ -77,6 +91,41 @@ class TranscriptionAttempt:
         }
         OMI_TRANSCRIPTION_COMPLETED_TOTAL.labels(**labels).inc()
         OMI_TRANSCRIPTION_LATENCY_SECONDS.labels(**labels).observe(max(0.0, monotonic() - self.started_at))
+
+
+class LiveSTTAttempt:
+    """One listener-local accepted live-STT attempt and at most one terminal outcome."""
+
+    def __init__(self, *, provider: str | None, platform: str | None) -> None:
+        self.provider = bounded_provider(provider)
+        self.platform = _bounded_platform(platform)
+        self.deployment_environment = _deployment_environment()
+        self._finished = False
+        OMI_LIVE_STT_ACCEPTED_TOTAL.labels(
+            provider=self.provider,
+            client_platform=self.platform,
+            deployment_environment=self.deployment_environment,
+        ).inc()
+
+    @property
+    def finished(self) -> bool:
+        return self._finished
+
+    def finish(self, outcome: LiveSTTTerminalOutcome, *, phase: LiveSTTTerminalPhase) -> None:
+        if self._finished:
+            return
+        if outcome not in _LIVE_TERMINAL_OUTCOMES:
+            raise ValueError(f'unknown live-STT terminal outcome: {outcome}')
+        if phase not in _LIVE_TERMINAL_PHASES:
+            raise ValueError(f'unknown live-STT terminal phase: {phase}')
+        self._finished = True
+        OMI_LIVE_STT_TERMINAL_TOTAL.labels(
+            provider=self.provider,
+            outcome=outcome,
+            client_platform=self.platform,
+            deployment_environment=self.deployment_environment,
+            phase=phase,
+        ).inc()
 
 
 def record_sync_transcription_outcome(
@@ -125,6 +174,6 @@ def record_live_stt_failure(
         provider=bounded_provider(provider),
         outcome=terminal_outcome.value,
         client_platform=_bounded_platform(platform),
-        deployment_version=_deployment_version(),
+        deployment_environment=_deployment_environment(),
         phase=phase if phase in _LIVE_PHASES else 'unknown',
     ).inc()

--- a/backend/utils/stt/live_failure.py
+++ b/backend/utils/stt/live_failure.py
@@ -34,6 +34,7 @@ class LiveSTTSession(Protocol):
     active: bool
     close_code: int
     stt_terminal_failure: bool
+    live_transcription_attempt: Any
 
 
 class LiveSTTClientSocket(Protocol):
@@ -105,6 +106,9 @@ async def terminate_live_stt_session(
             outcome=failure.outcome,
             phase=_FAILURE_PHASE_BY_REASON[bounded_reason],
         )
+        attempt = getattr(session, 'live_transcription_attempt', None)
+        if attempt is not None:
+            attempt.finish('failure', phase=_FAILURE_PHASE_BY_REASON[bounded_reason])
     except Exception as error:
         logger.warning(
             'Unable to record terminal live STT failure error_type=%s',

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -123,6 +123,22 @@ sequenceDiagram
     end
 ```
 
+### Live STT observability
+
+For backend-provider `/v4/listen` sessions, `omi_live_stt_accepted_total`
+increments when the listener receives its first nontrivial audio frame. A
+successful terminal is emitted only after a nonempty transcript has been
+delivered to the client WebSocket. Provider failures finish the same attempt
+through `terminate_live_stt_session`, preserving their bounded failure phase;
+other attempts that end before delivery are classified during teardown as
+`failure` or `cancelled`.
+
+These metrics use only the closed `provider`, client `platform`, deployment
+environment, outcome, and phase labels. They do not include transcript content,
+user IDs, model revisions, or other high-cardinality request data. Custom-STT
+sessions are excluded because the backend does not own their provider socket or
+provider attempt lifecycle.
+
 ### Terminal STT provider failure
 
 Provider initialization failure, a latched dead provider socket, or an audio


### PR DESCRIPTION
## Summary

- Add closed-cardinality, attempt-based Live STT acceptance and terminal metrics for backend-owned `/v4/listen` provider sessions.
- Preserve the existing generic journey success-rate dashboard for chat, Pusher, and capture finalization; add a separate Live STT failure/accepted-attempt panel and link its alert to it.
- Exclude custom-STT sessions from backend-provider metrics and document the Live STT observability owner and terminal boundaries.
- Replace the existing failure metric's free-form revision label with the closed `deployment_environment` vocabulary.

## Verification

RED on base `977cc3536a9ada8b37e6a7b1a309be4814495089`:

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_transcription_outcomes.py -q` failed with `ImportError: cannot import name 'LiveSTTAttempt'`, proving no provider-correlated accepted/terminal owner existed.

GREEN on head `bab7d6162d863a73d16983daf2307b2f59a2e28f`:

- Focused listen/runtime/receiver/transcript/live-failure/metrics/monitoring suite: **53 passed**.
- Monitoring/runtime review subset: **29 passed**.
- `backend/testing/listen_pusher_stack/run.sh --keep`: passed with the real listener, Pusher, Redis, Firestore emulator, controllable Parakeet stub, one accepted attempt, one matching successful terminal, and no duplicate after teardown.
- `cd backend && PYTHON=.venv/bin/python bash test-preflight.sh`: **18 passed, 0 failed** (optional warnings only).
- `make runtime-image-source-closure`: **10 registered images passed**.
- `scripts/failure-class validate`, diff-scoped `scripts/pr-preflight`, `make preflight`, and `git diff --check`: passed.

`make setup` was attempted before the first commit. Its main refresh completed, but hook installation was blocked in this linked worktree by `mkdir: /dev/null: File exists`; the required pinned backend dependency sync was run directly and completed.

## Scope boundary

Instrumentation and monitoring contracts only. No provider selection, retry/fallback, mode-switch/no-audio, client protocol, transcription accuracy, production alert import, deployment, or production change.

Tracks SCA-108.
