### PR TITLE
ci: raise sync pipeline line-count baseline for #10544

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -5,12 +5,12 @@
     "backend/utils/memory_ingestion/pipeline.py": 1711,
     "backend/utils/other/storage.py": 1584,
     "backend/utils/retrieval/tools/calendar_tools.py": 1513,
-    "backend/utils/sync/pipeline.py": 2467
+    "backend/utils/sync/pipeline.py": 2493
   },
   "raise_justifications": {
     "backend/utils/apps.py": "get_available_app_model_by_id: the set-preferred-app availability authority as a validated App model, so the summary path honors what the setter admitted instead of re-deciding with the installed slice (#10074).",
     "backend/utils/other/storage.py": "delete_app_logo now requires an exact app-logo bucket prefix (startswith) so a foreign URL embedding the prefix later cannot delete an unrelated object on this deletion path (David review on #9873).",
-    "backend/utils/sync/pipeline.py": "Plan-aware soft-cap evaluation and its default-tier fallback remain in a small helper beside Sync's idempotent fresh-speech metering rather than overgrowing the durable worker coordinator. A lifecycle-fenced deferred reprocess must durably tombstone its conversation before audio side effects; retry hydration must preserve that ownership boundary. Fenced IDs are now discarded from new_memories too, because a conversation created in an earlier segment can be merged into by a later segment."
+    "backend/utils/sync/pipeline.py": "Speech-free segments are now recorded as valid silence beside the existing outcome recorders rather than as retryable failures (#10544), so a recording of pure noise stops finalizing the job failed and re-uploading forever; the helper and its billing guard are colocated with the segment-outcome recording they mirror."
   },
   "threshold": 1500
 }


### PR DESCRIPTION
#10544 (the empty-after-VAD silence fix) grew `backend/utils/sync/pipeline.py` from 2467 to 2493 lines, tripping the frozen-file line-count ratchet and blocking backend deploy eligibility on main.

Raises the exact baseline to 2493 with the justification the check requires. The growth is the silence-not-failure helper and its usage-billing guard, colocated with the segment-outcome recorders they mirror — not unrelated accretion.

Verified: `check_product_file_line_count_ratchet.py` passes, JSON well-formed.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

