### PR TITLE
fix(desktop): reopen Rewind capture when the display stream dies (#10504)

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-07-rewind-capture-recovery.json
+++ b/desktop/windows/changelog/unreleased/2026-07-rewind-capture-recovery.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Rewind now reopens screen capture when the display stream drops, instead of filling the timeline with blank screenshots."
+  ]
+}

--- a/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.test.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.test.tsx
@@ -120,6 +120,39 @@ describe('RewindCaptureHost — dead capture track', () => {
     expect(saveFrame).toHaveBeenCalled()
   })
 
+  it('keeps a single sampling loop when the track dies mid-save', async () => {
+    // A save is an IPC round-trip, so over hours the track often dies while one is
+    // in flight. That grab must not reschedule itself after the recovery tore the
+    // stream down, or every recovery leaves an extra loop sampling in parallel.
+    let releaseSave: () => void = () => undefined
+    saveFrame.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSave = () => resolve()
+        })
+    )
+    render(<RewindCaptureHost />)
+    await settle()
+
+    await tick(INTERVAL_MS)
+    expect(saveFrame).toHaveBeenCalledTimes(1)
+
+    // Track dies with that save still pending, then the save completes.
+    await act(async () => {
+      tracks[0].die()
+    })
+    await act(async () => {
+      releaseSave()
+    })
+
+    await tick(RESTART_DELAY_MS)
+    expect(getUserMedia).toHaveBeenCalledTimes(2)
+
+    saveFrame.mockClear()
+    await tick(INTERVAL_MS)
+    expect(saveFrame).toHaveBeenCalledTimes(1)
+  })
+
   it('does not reopen the stream after unmount', async () => {
     const view = render(<RewindCaptureHost />)
     await settle()

--- a/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.test.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+//
+// #10504: after hours of capture the Windows timeline filled with blank frames.
+// The host opens ONE persistent desktop stream; when that track dies (display
+// sleep, GPU/driver reset, session change) nothing noticed — the sampler kept
+// drawing a dead <video> and saving frames from it, and capture never recovered.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup, act } from '@testing-library/react'
+import { RewindCaptureHost } from './RewindCaptureHost'
+
+const INTERVAL_MS = 1000
+const RESTART_DELAY_MS = 2000
+
+class FakeTrack extends EventTarget {
+  readyState: 'live' | 'ended' = 'live'
+  stop(): void {
+    this.readyState = 'ended'
+  }
+  /** What the OS does when the capture source goes away (NOT our own stop()). */
+  die(): void {
+    this.readyState = 'ended'
+    this.dispatchEvent(new Event('ended'))
+  }
+}
+
+function fakeStream(track: FakeTrack): MediaStream {
+  return {
+    getTracks: () => [track],
+    getVideoTracks: () => [track]
+  } as unknown as MediaStream
+}
+
+let tracks: FakeTrack[] = []
+let getUserMedia: ReturnType<typeof vi.fn>
+let saveFrame: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  tracks = []
+  saveFrame = vi.fn(async () => undefined)
+  getUserMedia = vi.fn(async () => {
+    const t = new FakeTrack()
+    tracks.push(t)
+    return fakeStream(t)
+  })
+  ;(navigator as unknown as { mediaDevices: unknown }).mediaDevices = { getUserMedia }
+  ;(window as unknown as { omi: unknown }).omi = {
+    rewindGetSettings: async () => ({ captureEnabled: true, intervalMs: INTERVAL_MS }),
+    onRewindSettings: () => () => undefined,
+    rewindGetCaptureDirective: async () => ({ paused: false, intervalMs: INTERVAL_MS }),
+    onRewindCaptureDirective: () => () => undefined,
+    rewindPrimarySourceId: async () => 'screen:0:0',
+    rewindSaveFrame: saveFrame
+  }
+  // jsdom has no media pipeline or 2D canvas: give the host a video that reports
+  // a frame size and a canvas that encodes, so the sampling path can run.
+  HTMLMediaElement.prototype.play = vi.fn(async () => undefined)
+  Object.defineProperty(HTMLVideoElement.prototype, 'videoWidth', {
+    configurable: true,
+    get: () => 1280
+  })
+  Object.defineProperty(HTMLVideoElement.prototype, 'videoHeight', {
+    configurable: true,
+    get: () => 720
+  })
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+    drawImage: vi.fn()
+  } as unknown as CanvasRenderingContext2D)
+  vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation((cb) =>
+    cb({ arrayBuffer: async () => new ArrayBuffer(8) } as Blob)
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  delete (window as unknown as { omi?: unknown }).omi
+})
+
+/** Let the mount's awaited settings/directive/getUserMedia promises settle. */
+async function settle(): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0)
+  })
+}
+
+async function tick(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
+}
+
+describe('RewindCaptureHost — dead capture track', () => {
+  it('stops saving frames and reopens the stream when the capture track dies', async () => {
+    render(<RewindCaptureHost />)
+    await settle()
+    expect(getUserMedia).toHaveBeenCalledTimes(1)
+
+    // Baseline: a live track produces frames.
+    await tick(INTERVAL_MS)
+    expect(saveFrame).toHaveBeenCalledTimes(1)
+
+    // The OS kills the capture source.
+    saveFrame.mockClear()
+    await act(async () => {
+      tracks[0].die()
+    })
+
+    // No blank frames from the dead <video> while the stream is down...
+    await tick(INTERVAL_MS)
+    expect(saveFrame).not.toHaveBeenCalled()
+
+    // ...and capture comes back on its own.
+    await tick(RESTART_DELAY_MS)
+    expect(getUserMedia).toHaveBeenCalledTimes(2)
+    expect(tracks[1].readyState).toBe('live')
+    saveFrame.mockClear()
+    await tick(INTERVAL_MS)
+    expect(saveFrame).toHaveBeenCalled()
+  })
+
+  it('does not reopen the stream after unmount', async () => {
+    const view = render(<RewindCaptureHost />)
+    await settle()
+    expect(getUserMedia).toHaveBeenCalledTimes(1)
+
+    view.unmount()
+    await tick(RESTART_DELAY_MS + INTERVAL_MS)
+    expect(getUserMedia).toHaveBeenCalledTimes(1)
+    expect(saveFrame).not.toHaveBeenCalled()
+  })
+})

--- a/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
@@ -5,6 +5,9 @@ import type { RewindSettings, RewindCaptureDirective } from '../../../../shared/
 // canvas grab + JPEG encode cheap.
 const MAX_EDGE = 1600
 const JPEG_QUALITY = 0.6
+// Wait before re-opening a stream whose track died, so a source that is
+// unavailable in bursts (display asleep, GPU reset) can't spin getUserMedia.
+const RESTART_DELAY_MS = 2000
 
 /**
  * Background screen-capture host for Rewind. Mounted app-wide (while the window
@@ -69,13 +72,28 @@ export function RewindCaptureHost(): React.JSX.Element {
       if (videoRef.current) videoRef.current.srcObject = null
     }
 
+    const isLive = (): boolean =>
+      streamRef.current?.getVideoTracks().some((t) => t.readyState === 'live') ?? false
+
+    // A desktop-capture track can die while the app keeps running (display sleep,
+    // GPU/driver reset, resolution or session change). Nothing used to notice: the
+    // sampler kept drawing a dead <video>, so the timeline filled with blank frames
+    // and capture never came back. Re-open the stream instead. Our own teardown
+    // uses track.stop(), which does not fire 'ended', so this can't self-trigger.
+    const onTrackEnded = (): void => {
+      if (cancelled) return
+      console.warn('[rewind] capture track ended — reopening stream')
+      stop()
+      timerRef.current = setTimeout(() => void start(), RESTART_DELAY_MS)
+    }
+
     // Self-pacing: schedule the next grab only after the current one settles, so
     // a slow save can never stack concurrent captures.
     const grabAndSchedule = async (): Promise<void> => {
       if (cancelled) return
       try {
         const v = videoRef.current
-        if (v && v.videoWidth && v.videoHeight && !savingRef.current) {
+        if (v && isLive() && v.videoWidth && v.videoHeight && !savingRef.current) {
           const scale = Math.min(1, MAX_EDGE / Math.max(v.videoWidth, v.videoHeight))
           const w = Math.round(v.videoWidth * scale)
           const h = Math.round(v.videoHeight * scale)
@@ -136,6 +154,7 @@ export function RewindCaptureHost(): React.JSX.Element {
           return
         }
         streamRef.current = stream
+        stream.getVideoTracks().forEach((t) => t.addEventListener('ended', onTrackEnded))
         const v = videoRef.current
         if (v) {
           v.srcObject = stream

--- a/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
@@ -61,8 +61,13 @@ export function RewindCaptureHost(): React.JSX.Element {
     const enabled = !!settings?.captureEnabled && !paused
     const intervalMs = effectiveIntervalMs
     let cancelled = false
+    // Bumped on every teardown so a grab still in flight (a save is an IPC
+    // round-trip) can't reschedule itself onto a stream that is already gone —
+    // otherwise each recovery would leave an extra sampling loop running.
+    let generation = 0
 
     const stop = (): void => {
+      generation++
       if (timerRef.current) {
         clearTimeout(timerRef.current)
         timerRef.current = null
@@ -89,8 +94,8 @@ export function RewindCaptureHost(): React.JSX.Element {
 
     // Self-pacing: schedule the next grab only after the current one settles, so
     // a slow save can never stack concurrent captures.
-    const grabAndSchedule = async (): Promise<void> => {
-      if (cancelled) return
+    const grabAndSchedule = async (gen: number): Promise<void> => {
+      if (cancelled || gen !== generation) return
       try {
         const v = videoRef.current
         if (v && isLive() && v.videoWidth && v.videoHeight && !savingRef.current) {
@@ -107,7 +112,7 @@ export function RewindCaptureHost(): React.JSX.Element {
             const blob = await new Promise<Blob | null>((r) =>
               canvas.toBlob(r, 'image/jpeg', JPEG_QUALITY)
             )
-            if (blob && !cancelled) {
+            if (blob && !cancelled && gen === generation) {
               savingRef.current = true
               try {
                 await window.omi.rewindSaveFrame(new Uint8Array(await blob.arrayBuffer()))
@@ -120,7 +125,9 @@ export function RewindCaptureHost(): React.JSX.Element {
       } catch (e) {
         console.error('[rewind] sample failed:', (e as Error).message)
       } finally {
-        if (!cancelled) timerRef.current = setTimeout(() => void grabAndSchedule(), intervalMs)
+        if (!cancelled && gen === generation) {
+          timerRef.current = setTimeout(() => void grabAndSchedule(gen), intervalMs)
+        }
       }
     }
 
@@ -155,12 +162,13 @@ export function RewindCaptureHost(): React.JSX.Element {
         }
         streamRef.current = stream
         stream.getVideoTracks().forEach((t) => t.addEventListener('ended', onTrackEnded))
+        const gen = generation
         const v = videoRef.current
         if (v) {
           v.srcObject = stream
           await v.play().catch(() => undefined)
         }
-        timerRef.current = setTimeout(() => void grabAndSchedule(), intervalMs)
+        timerRef.current = setTimeout(() => void grabAndSchedule(gen), intervalMs)
       } catch (e) {
         console.error('[rewind] failed to start capture:', (e as Error).message)
       }


### PR DESCRIPTION
## Bug

[#10504](https://github.com/BasedHardware/omi/issues/10504) — on Windows, after Omi Desktop has been running for a few hours the Rewind timeline fills with dark/blank screenshots while the app still reports capture as active.

## Root cause

`RewindCaptureHost` opens **one** persistent `getUserMedia` desktop stream into a hidden `<video>` and samples it on a self-pacing timer. Nothing observed the track's lifecycle. When the OS tears the capture source down mid-session (display sleep, GPU/driver reset, resolution or session change) the track ends, but:

- `grabAndSchedule` kept drawing the now-dead `<video>` (its `videoWidth/videoHeight` stay non-zero) and saving those frames — the blank frames in the timeline, exactly the issue's own hypothesis "the timeline is receiving blank frames while the app still thinks capture is active";
- nothing ever reopened the stream, so capture stayed dead for the rest of the session.

## Fix

Commit 1 — recover from a dead capture track:
- Skip sampling while no video track is `live` — no more blank frames from a dead stream.
- Listen for the track's `ended` event and reopen the stream after a 2s delay. Our own teardown uses `track.stop()`, which per spec does **not** fire `ended`, so this cannot self-trigger or loop on unmount/settings changes.

Commit 2 — keep exactly one sampling loop across a restart:
- A frame save is an IPC round-trip, so the track often dies while a grab is in flight. That grab's `finally` still rescheduled itself after the teardown, orphaning the restart timer's handle and leaving the old loop alive — every mid-save recovery added another parallel sampling loop, doubling capture work each time.
- Each scheduling chain now carries a generation that `stop()` bumps, so a grab from a torn-down stream neither saves its frame nor reschedules itself.

Plus a changelog fragment for the user-visible behavior. Scope: ~30 changed lines in one component plus regression tests.

## Tested

- `pnpm vitest run src/renderer/src/components/rewind/RewindCaptureHost.test.tsx` → **3/3 pass**. The tests drive the real component against a fake desktop stream: baseline frame saved → track dies → no frames while the stream is down → `getUserMedia` called again and saving resumes; a mid-save death yields exactly one frame per interval after recovery; and no reopen after unmount.
- **Teeth checks (both directions).** With the commit-1 component change reverted, 2/3 fail — a frame is still saved from the dead video and the stream never reopens (the reported symptom). With only the commit-2 generation guard reverted, the mid-save case fails with 2 frames per interval after recovery (the duplicated loop).
- Whole rewind suite: `pnpm vitest run src/renderer/src/components/rewind/` → 13/13 pass.
- `pnpm run typecheck` → clean; `pnpm run lint` → 0 errors (pre-existing prettier warnings only, including one on an untouched line of this file that is already present on `main`).
- `make preflight` → 10/10 checks pass on this diff.

Not claimed: this was not reproduced on a real multi-hour Windows session. It fixes a confirmed mechanism for #10504 (blank frames plus no recovery once the capture track dies), not a bisected repro.

🤖 automated by hourly watchdog — tested, then merged in the same run

Failure-Class: none
