### PR TITLE
fix(stt): pre-recorded selection floor + stop non-retryable sync jobs throttling the queue

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1757,11 +1757,17 @@ async def run_sync_job(request: Request, task_retry_count: int = Depends(verify_
                     return JSONResponse(status_code=200, content={'status': 'done', 'reconciled': True})
             failure = failure_from_exception(e, provider=latest_job.get('stt_provider'))
             sync_model = latest_job.get('stt_model')
-            if task_retry_count >= max_attempts - 1:
+            final_attempt = task_retry_count >= max_attempts - 1
+            # Segment-level outcomes already honor ``retryable``; the job boundary did
+            # not, so a permanently-unprocessable job consumed every attempt as a 500.
+            # Sustained 5xx makes Cloud Tasks throttle the whole queue's dispatch rate,
+            # which is how one such job slowed every other user's sync. Finalize a
+            # non-retryable failure on its first delivery instead.
+            if not failure.retryable or final_attempt:
                 logger.error(
-                    'event=sync_transcription_job outcome=%s status=failed_final lane=%s '
-                    'attempt=%d exception_type=%s',
+                    'event=sync_transcription_job outcome=%s status=%s lane=%s ' 'attempt=%d exception_type=%s',
                     failure.outcome.value,
+                    'failed_final' if final_attempt else 'failed_not_retryable',
                     sync_lane,
                     task_retry_count + 1,
                     type(e).__name__,

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1758,11 +1758,8 @@ async def run_sync_job(request: Request, task_retry_count: int = Depends(verify_
             failure = failure_from_exception(e, provider=latest_job.get('stt_provider'))
             sync_model = latest_job.get('stt_model')
             final_attempt = task_retry_count >= max_attempts - 1
-            # Segment-level outcomes already honor ``retryable``; the job boundary did
-            # not, so a permanently-unprocessable job consumed every attempt as a 500.
-            # Sustained 5xx makes Cloud Tasks throttle the whole queue's dispatch rate,
-            # which is how one such job slowed every other user's sync. Finalize a
-            # non-retryable failure on its first delivery instead.
+            # Sustained 5xx throttles the whole queue's dispatch rate, so a failure that
+            # no retry can resolve must not consume the retry budget.
             if not failure.retryable or final_attempt:
                 logger.error(
                     'event=sync_transcription_job outcome=%s status=%s lane=%s ' 'attempt=%d exception_type=%s',

--- a/backend/tests/unit/test_modulate_stt.py
+++ b/backend/tests/unit/test_modulate_stt.py
@@ -1431,13 +1431,7 @@ class TestPrerecordedProviderFactory(unittest.TestCase):
 
     @patch('utils.stt.pre_recorded.get_prerecorded_models', new=lambda: ('modulate-velma-2', 'dg-nova-3'))
     def test_uncovered_language_reaches_velma_instead_of_failing_closed(self):
-        """Failing closed on an uncovered language stranded real users' audio.
-
-        Hindi is in neither the literal Velma set nor Parakeet's batch model, so this
-        raised — and the raise surfaced as a retryable error that Cloud Tasks retried
-        until sustained 5xx throttled the sync queue. Velma's batch API detects the
-        language itself, so it can serve anything the capability maps omit.
-        """
+        """Hindi is in neither the literal Velma set nor Parakeet's batch model."""
         from utils.stt.pre_recorded import (
             ModulatePrerecordedProvider,
             PrerecordedSTTService,

--- a/backend/tests/unit/test_modulate_stt.py
+++ b/backend/tests/unit/test_modulate_stt.py
@@ -1430,13 +1430,26 @@ class TestPrerecordedProviderFactory(unittest.TestCase):
         self.assertIsInstance(provider, ModulatePrerecordedProvider)
 
     @patch('utils.stt.pre_recorded.get_prerecorded_models', new=lambda: ('modulate-velma-2', 'dg-nova-3'))
-    def test_unsupported_language_fails_closed_without_deepgram_fallback(self):
-        from utils.stt.pre_recorded import get_prerecorded_provider, get_prerecorded_service
+    def test_uncovered_language_reaches_velma_instead_of_failing_closed(self):
+        """Failing closed on an uncovered language stranded real users' audio.
 
-        with self.assertRaises(RuntimeError):
-            get_prerecorded_service('hi')
-        with self.assertRaises(RuntimeError):
-            get_prerecorded_provider('hi')
+        Hindi is in neither the literal Velma set nor Parakeet's batch model, so this
+        raised — and the raise surfaced as a retryable error that Cloud Tasks retried
+        until sustained 5xx throttled the sync queue. Velma's batch API detects the
+        language itself, so it can serve anything the capability maps omit.
+        """
+        from utils.stt.pre_recorded import (
+            ModulatePrerecordedProvider,
+            PrerecordedSTTService,
+            get_prerecorded_provider,
+            get_prerecorded_service,
+        )
+
+        svc, lang, model = get_prerecorded_service('hi')
+        self.assertEqual(svc, PrerecordedSTTService.MODULATE)
+        self.assertEqual(lang, 'multi')
+        self.assertEqual(model, 'velma-2')
+        self.assertIsInstance(get_prerecorded_provider('hi'), ModulatePrerecordedProvider)
 
     def test_providers_implement_abc(self):
         from utils.stt.pre_recorded import (

--- a/backend/tests/unit/test_prerecorded_language_coverage.py
+++ b/backend/tests/unit/test_prerecorded_language_coverage.py
@@ -1,10 +1,4 @@
-"""Pre-recorded STT selection must cover every language a client can store.
-
-Selection raised when no capability map claimed the language. The literal Velma set
-covers 10 languages and Parakeet's batch model 26, while the clients offer 49 — so
-22 of them reached no provider. The raise surfaced as a retryable ``upstream_error``,
-which Cloud Tasks retried until sustained 5xx throttled the whole sync queue.
-"""
+"""Pre-recorded STT selection must cover every language a client can store."""
 
 import pytest
 
@@ -64,9 +58,8 @@ CLIENT_OFFERED_LANGUAGES = (
     'zh',
 )
 
-# Languages a capability map already claimed. These must keep their exact provider:
-# widening Velma's gate instead of adding a floor would pull them — and 'multi', the
-# default for most users — off self-hosted Parakeet onto metered Velma.
+# Must keep their exact provider: widening Velma's gate would pull these — including
+# 'multi', the default for most users — off self-hosted Parakeet onto metered Velma.
 ALREADY_ROUTED = {
     'multi': PrerecordedSTTService.PARAKEET,
     'ru': PrerecordedSTTService.PARAKEET,
@@ -80,7 +73,7 @@ ALREADY_ROUTED = {
     'zh': PrerecordedSTTService.MODULATE,
 }
 
-# In neither capability map. These raised before the floor existed.
+# In neither capability map.
 PREVIOUSLY_UNROUTABLE = (
     'ar',
     'be',
@@ -130,9 +123,6 @@ def test_a_language_a_capability_map_claims_keeps_its_provider(language, expecte
 
 @pytest.mark.parametrize('language', PREVIOUSLY_UNROUTABLE)
 def test_an_uncovered_language_reaches_velma_by_detection(language):
-    """Velma's batch API detects the language itself — we never send a code — so it
-    can serve what the capability maps omit. Ask for detection rather than assert a
-    language no map recognizes."""
     service, resolved_language, model = get_prerecorded_service(language)
 
     assert service == PrerecordedSTTService.MODULATE
@@ -142,10 +132,7 @@ def test_an_uncovered_language_reaches_velma_by_detection(language):
 
 @pytest.mark.parametrize('stored_language', ['japanese', 'russian', 'português', 'not-a-language'])
 def test_a_stored_language_name_falls_back_to_provider_detection(stored_language):
-    """Desktop onboarding saved language *names* before they were normalized to codes.
-
-    Those values are still in Firestore, and a name can never match a capability map.
-    """
+    """Desktop onboarding saved language names before they were normalized to codes."""
     service, resolved_language, model = get_prerecorded_service(stored_language)
 
     assert service == PrerecordedSTTService.MODULATE
@@ -159,7 +146,6 @@ def test_region_qualified_codes_resolve_on_their_base_language():
 
 
 def test_parakeet_only_deployment_still_reaches_velma_for_a_language_it_cannot_serve(monkeypatch):
-    """Parakeet's batch model has no Hindi. Falling through beats raising."""
     monkeypatch.setenv('STT_PRERECORDED_MODEL', 'parakeet')
 
     assert get_prerecorded_service('ru') == (PrerecordedSTTService.PARAKEET, 'ru', 'parakeet')
@@ -170,7 +156,6 @@ def test_parakeet_only_deployment_still_reaches_velma_for_a_language_it_cannot_s
 
 
 def test_no_enabled_provider_raises_a_non_retryable_config_failure(monkeypatch):
-    """The only remaining raise must not re-enter an at-least-once retry loop."""
     monkeypatch.setattr('utils.stt.pre_recorded.provider_is_enabled', lambda *_args, **_kwargs: False)
     monkeypatch.setattr('utils.stt.pre_recorded.default_models_for_surface', lambda *_args, **_kwargs: ())
 

--- a/backend/tests/unit/test_prerecorded_language_coverage.py
+++ b/backend/tests/unit/test_prerecorded_language_coverage.py
@@ -1,0 +1,191 @@
+"""Pre-recorded STT selection must cover every language a client can store.
+
+Selection raised when no capability map claimed the language. The literal Velma set
+covers 10 languages and Parakeet's batch model 26, while the clients offer 49 — so
+22 of them reached no provider. The raise surfaced as a retryable ``upstream_error``,
+which Cloud Tasks retried until sustained 5xx throttled the whole sync queue.
+"""
+
+import pytest
+
+from config.prerecorded_stt import TranscriptionOutcome
+from utils.stt.outcomes import TranscriptionFailure, failure_from_exception
+from utils.stt.pre_recorded import PrerecordedSTTService, get_prerecorded_service
+
+# Every base language the mobile picker offers (app/lib/providers/home_provider.dart).
+CLIENT_OFFERED_LANGUAGES = (
+    'ar',
+    'be',
+    'bg',
+    'bn',
+    'bs',
+    'ca',
+    'cs',
+    'da',
+    'de',
+    'el',
+    'en',
+    'es',
+    'et',
+    'fa',
+    'fi',
+    'fr',
+    'he',
+    'hi',
+    'hr',
+    'hu',
+    'id',
+    'it',
+    'ja',
+    'kn',
+    'ko',
+    'lt',
+    'lv',
+    'mk',
+    'mr',
+    'ms',
+    'nl',
+    'no',
+    'pl',
+    'pt',
+    'ro',
+    'ru',
+    'sk',
+    'sl',
+    'sr',
+    'sv',
+    'ta',
+    'te',
+    'th',
+    'tl',
+    'tr',
+    'uk',
+    'vi',
+    'zh',
+)
+
+# Languages a capability map already claimed. These must keep their exact provider:
+# widening Velma's gate instead of adding a floor would pull them — and 'multi', the
+# default for most users — off self-hosted Parakeet onto metered Velma.
+ALREADY_ROUTED = {
+    'multi': PrerecordedSTTService.PARAKEET,
+    'ru': PrerecordedSTTService.PARAKEET,
+    'pl': PrerecordedSTTService.PARAKEET,
+    'uk': PrerecordedSTTService.PARAKEET,
+    'cs': PrerecordedSTTService.PARAKEET,
+    'sv': PrerecordedSTTService.PARAKEET,
+    'en': PrerecordedSTTService.MODULATE,
+    'ja': PrerecordedSTTService.MODULATE,
+    'ko': PrerecordedSTTService.MODULATE,
+    'zh': PrerecordedSTTService.MODULATE,
+}
+
+# In neither capability map. These raised before the floor existed.
+PREVIOUSLY_UNROUTABLE = (
+    'ar',
+    'be',
+    'bn',
+    'bs',
+    'ca',
+    'fa',
+    'he',
+    'hi',
+    'id',
+    'kn',
+    'mk',
+    'mr',
+    'ms',
+    'no',
+    'sr',
+    'ta',
+    'te',
+    'th',
+    'tl',
+    'tr',
+    'ur',
+    'vi',
+)
+
+
+@pytest.fixture(autouse=True)
+def _prod_model_preference(monkeypatch):
+    monkeypatch.setenv('STT_PRERECORDED_MODEL', 'modulate-velma-2,parakeet')
+
+
+@pytest.mark.parametrize('language', CLIENT_OFFERED_LANGUAGES)
+def test_every_client_offered_language_resolves_to_a_provider(language):
+    service, _resolved_language, model = get_prerecorded_service(language)
+
+    assert service in {PrerecordedSTTService.MODULATE, PrerecordedSTTService.PARAKEET}
+    assert model in {'velma-2', 'parakeet'}
+
+
+@pytest.mark.parametrize('language,expected_service', sorted(ALREADY_ROUTED.items()))
+def test_a_language_a_capability_map_claims_keeps_its_provider(language, expected_service):
+    service, resolved_language, _model = get_prerecorded_service(language)
+
+    assert service == expected_service
+    assert resolved_language == language
+
+
+@pytest.mark.parametrize('language', PREVIOUSLY_UNROUTABLE)
+def test_an_uncovered_language_reaches_velma_by_detection(language):
+    """Velma's batch API detects the language itself — we never send a code — so it
+    can serve what the capability maps omit. Ask for detection rather than assert a
+    language no map recognizes."""
+    service, resolved_language, model = get_prerecorded_service(language)
+
+    assert service == PrerecordedSTTService.MODULATE
+    assert resolved_language == 'multi'
+    assert model == 'velma-2'
+
+
+@pytest.mark.parametrize('stored_language', ['japanese', 'russian', 'português', 'not-a-language'])
+def test_a_stored_language_name_falls_back_to_provider_detection(stored_language):
+    """Desktop onboarding saved language *names* before they were normalized to codes.
+
+    Those values are still in Firestore, and a name can never match a capability map.
+    """
+    service, resolved_language, model = get_prerecorded_service(stored_language)
+
+    assert service == PrerecordedSTTService.MODULATE
+    assert resolved_language == 'multi'
+    assert model == 'velma-2'
+
+
+def test_region_qualified_codes_resolve_on_their_base_language():
+    assert get_prerecorded_service('pt-BR') == (PrerecordedSTTService.MODULATE, 'pt', 'velma-2')
+    assert get_prerecorded_service('zh_Hans') == (PrerecordedSTTService.MODULATE, 'zh', 'velma-2')
+
+
+def test_parakeet_only_deployment_still_reaches_velma_for_a_language_it_cannot_serve(monkeypatch):
+    """Parakeet's batch model has no Hindi. Falling through beats raising."""
+    monkeypatch.setenv('STT_PRERECORDED_MODEL', 'parakeet')
+
+    assert get_prerecorded_service('ru') == (PrerecordedSTTService.PARAKEET, 'ru', 'parakeet')
+
+    service, resolved_language, _model = get_prerecorded_service('hi')
+    assert service == PrerecordedSTTService.MODULATE
+    assert resolved_language == 'multi'
+
+
+def test_no_enabled_provider_raises_a_non_retryable_config_failure(monkeypatch):
+    """The only remaining raise must not re-enter an at-least-once retry loop."""
+    monkeypatch.setattr('utils.stt.pre_recorded.provider_is_enabled', lambda *_args, **_kwargs: False)
+    monkeypatch.setattr('utils.stt.pre_recorded.default_models_for_surface', lambda *_args, **_kwargs: ())
+
+    with pytest.raises(TranscriptionFailure) as raised:
+        get_prerecorded_service('en')
+
+    assert raised.value.outcome == TranscriptionOutcome.CONFIG_ERROR
+    assert raised.value.retryable is False
+
+
+def test_a_selection_failure_stays_non_retryable_through_the_public_mapping():
+    failure = failure_from_exception(
+        TranscriptionFailure(TranscriptionOutcome.CONFIG_ERROR, retryable=False),
+        provider='unknown',
+    )
+
+    assert failure.outcome == TranscriptionOutcome.CONFIG_ERROR
+    assert failure.retryable is False

--- a/backend/tests/unit/test_sync_cloud_tasks.py
+++ b/backend/tests/unit/test_sync_cloud_tasks.py
@@ -2065,6 +2065,86 @@ async def test_sync_task_final_attempt_publishes_one_bounded_terminal_failure():
 
 
 @pytest.mark.asyncio
+async def test_sync_task_non_retryable_failure_terminates_on_its_first_delivery():
+    """A permanent failure must not spend the retry budget returning 5xx.
+
+    Cloud Tasks throttles a queue's whole dispatch rate under sustained 5xx, so
+    retrying a job that can never succeed slows every other user's sync. Finalize
+    on the first delivery instead of after ``max_attempts`` 500s.
+    """
+
+    module, saved_modules, _, _, _, _ = _load_sync_router_for_fast_path()
+    from utils.stt.outcomes import TranscriptionFailure
+
+    request = _configure_task_handler(
+        module,
+        pipeline_error=TranscriptionFailure(
+            module.TranscriptionOutcome.CONFIG_ERROR,
+            retryable=False,
+        ),
+        latest_job={
+            'job_id': 'job-1',
+            'status': 'processing',
+            'stt_provider': 'unknown',
+            'stt_model': 'unknown',
+        },
+    )
+
+    try:
+        response = await module.run_sync_job(request, task_retry_count=0)
+
+        assert response.status_code == 200
+        assert json.loads(response.body) == {'status': 'failed_final'}
+        module._finalize_sync_job_failure.assert_awaited_once()
+        assert (
+            module._finalize_sync_job_failure.await_args.kwargs['outcome'] == module.TranscriptionOutcome.CONFIG_ERROR
+        )
+        # No queued reset and no retained staging: there is nothing to retry.
+        module.fenced_mark_job_queued_for_retry.assert_not_called()
+        module._delete_staged_blobs_async.assert_awaited_once_with(['staged/audio.opus'])
+    finally:
+        sys.modules.pop('routers.sync', None)
+        sys.modules.pop('utils.sync.pipeline', None)
+        for mod_name, orig in saved_modules.items():
+            if orig is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = orig
+
+
+@pytest.mark.asyncio
+async def test_sync_task_retryable_failure_still_retries_before_exhaustion():
+    """The non-retryable short circuit must not collapse genuine transient retries."""
+
+    module, saved_modules, _, _, _, _ = _load_sync_router_for_fast_path()
+    request = _configure_task_handler(
+        module,
+        pipeline_error=TimeoutError('transient upstream detail'),
+        latest_job={
+            'job_id': 'job-1',
+            'status': 'processing',
+            'stt_provider': 'parakeet',
+            'stt_model': 'parakeet',
+        },
+    )
+
+    try:
+        response = await module.run_sync_job(request, task_retry_count=0)
+
+        assert response.status_code == 500
+        assert json.loads(response.body) == {'status': 'retry'}
+        module._finalize_sync_job_failure.assert_not_awaited()
+    finally:
+        sys.modules.pop('routers.sync', None)
+        sys.modules.pop('utils.sync.pipeline', None)
+        for mod_name, orig in saved_modules.items():
+            if orig is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = orig
+
+
+@pytest.mark.asyncio
 async def test_sync_post_enqueue_cleanup_does_not_unstage(monkeypatch):
     """Successful enqueue + failed local cleanup must keep staged blobs for the handler."""
     import shutil

--- a/backend/tests/unit/test_sync_cloud_tasks.py
+++ b/backend/tests/unit/test_sync_cloud_tasks.py
@@ -2066,12 +2066,7 @@ async def test_sync_task_final_attempt_publishes_one_bounded_terminal_failure():
 
 @pytest.mark.asyncio
 async def test_sync_task_non_retryable_failure_terminates_on_its_first_delivery():
-    """A permanent failure must not spend the retry budget returning 5xx.
-
-    Cloud Tasks throttles a queue's whole dispatch rate under sustained 5xx, so
-    retrying a job that can never succeed slows every other user's sync. Finalize
-    on the first delivery instead of after ``max_attempts`` 500s.
-    """
+    """A permanent failure must not spend the retry budget returning 5xx."""
 
     module, saved_modules, _, _, _, _ = _load_sync_router_for_fast_path()
     from utils.stt.outcomes import TranscriptionFailure
@@ -2099,7 +2094,6 @@ async def test_sync_task_non_retryable_failure_terminates_on_its_first_delivery(
         assert (
             module._finalize_sync_job_failure.await_args.kwargs['outcome'] == module.TranscriptionOutcome.CONFIG_ERROR
         )
-        # No queued reset and no retained staging: there is nothing to retry.
         module.fenced_mark_job_queued_for_retry.assert_not_called()
         module._delete_staged_blobs_async.assert_awaited_once_with(['staged/audio.opus'])
     finally:

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -16,6 +16,7 @@ from pydub import AudioSegment  # pydub is untyped
 from config.prerecorded_stt import (
     PrerecordedSTTConfigurationError as _PrerecordedSTTConfigurationError,
     PrerecordedSTTService,
+    TranscriptionOutcome,
     get_prerecorded_models,
     require_provider_environment,
 )
@@ -31,6 +32,7 @@ from config.stt_provider_policy import (
 from models.transcript_segment import TranscriptSegment
 from utils.byok import get_byok_key
 from utils.other.endpoints import timeit
+from utils.stt.outcomes import TranscriptionFailure
 from utils.stt.speaker_embedding import SPEAKER_MATCH_THRESHOLD, compare_embeddings, extract_embedding_from_bytes
 
 _DG_TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=30.0, pool=10.0)
@@ -81,6 +83,10 @@ def get_prerecorded_service(language: Optional[str] = 'en') -> Tuple[str, Option
     First model allowed by the central serving policy that supports the language
     wins. Disabled-provider tokens are ignored, then policy-owned defaults provide
     the serving fallback.
+
+    Capability matching stays exactly as configured so no working language changes
+    provider. Selection then has a Velma floor instead of raising, because the
+    narrow literal set below covers 10 languages while the clients offer 49.
     """
     base_lang = normalized_stt_language(language) or 'en'
 
@@ -106,7 +112,18 @@ def get_prerecorded_service(language: Optional[str] = 'en') -> Tuple[str, Option
     if selected is not None:
         return selected
 
-    raise RuntimeError(f'No configured pre-recorded STT provider supports language {language!r}')
+    # Floor. Velma's batch API detects the language itself — we never send a code —
+    # so it can serve anything the capability maps have not enumerated, including a
+    # stored value that is not an ISO code at all. Ask for auto-detection rather
+    # than asserting an unrecognized language, and let the provider report what it
+    # heard. Reaching a provider always beats failing the job on a stale list.
+    if provider_is_enabled(MODULATE_PROVIDER, STTServingSurface.PRERECORDED):
+        return PrerecordedSTTService.MODULATE, 'multi', 'velma-2'
+
+    # Only reachable when policy has disabled every pre-recorded provider, which no
+    # retry can resolve. Raise the typed non-retryable failure so callers finalize
+    # once instead of returning 5xx into an at-least-once retry loop.
+    raise TranscriptionFailure(TranscriptionOutcome.CONFIG_ERROR, retryable=False)
 
 
 # Lazily initialized because constructing the SDK client at import makes every

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -82,11 +82,8 @@ def get_prerecorded_service(language: Optional[str] = 'en') -> Tuple[str, Option
     Iterates comma-separated models (same pattern as STT_SERVICE_MODELS for streaming).
     First model allowed by the central serving policy that supports the language
     wins. Disabled-provider tokens are ignored, then policy-owned defaults provide
-    the serving fallback.
-
-    Capability matching stays exactly as configured so no working language changes
-    provider. Selection then has a Velma floor instead of raising, because the
-    narrow literal set below covers 10 languages while the clients offer 49.
+    the serving fallback. A language no capability map claims falls through to Velma
+    rather than failing selection.
     """
     base_lang = normalized_stt_language(language) or 'en'
 
@@ -112,17 +109,12 @@ def get_prerecorded_service(language: Optional[str] = 'en') -> Tuple[str, Option
     if selected is not None:
         return selected
 
-    # Floor. Velma's batch API detects the language itself — we never send a code —
-    # so it can serve anything the capability maps have not enumerated, including a
-    # stored value that is not an ISO code at all. Ask for auto-detection rather
-    # than asserting an unrecognized language, and let the provider report what it
-    # heard. Reaching a provider always beats failing the job on a stale list.
+    # Velma's batch API detects the language itself — we never send a code — so it can
+    # serve languages the capability maps omit, and values that are not codes at all.
     if provider_is_enabled(MODULATE_PROVIDER, STTServingSurface.PRERECORDED):
         return PrerecordedSTTService.MODULATE, 'multi', 'velma-2'
 
-    # Only reachable when policy has disabled every pre-recorded provider, which no
-    # retry can resolve. Raise the typed non-retryable failure so callers finalize
-    # once instead of returning 5xx into an at-least-once retry loop.
+    # Only reachable with every pre-recorded provider disabled, which no retry resolves.
     raise TranscriptionFailure(TranscriptionOutcome.CONFIG_ERROR, retryable=False)
 
 


### PR DESCRIPTION
## Problem

Offline-sync jobs were failing with `outcome=upstream_error provider=unknown model=unknown exception_type=RuntimeError`, retrying five times each, and throttling the shared sync queue. In the last hour before this change ~18% of `POST /v2/sync-jobs/run` returned 500.

Two independent defects combined.

### 1. Pre-recorded STT selection could fail closed

`get_prerecorded_service()` matches the requested language against two capability maps:

- a literal set inside the function — 10 languages: `en es fr de it pt nl ja ko zh`
- Parakeet's batch model — 26 languages plus `multi`

If neither claimed the language it raised. The mobile picker offers **49** base languages, so **22 of them resolved to no provider at all**: `ar be bn bs ca fa he hi id kn mk mr ms no sr ta te th tl tr ur vi`. Any user pinned to one of those (`single_language_mode`) could not process offline audio.

The same call also fails for a stored value that is not an ISO code. Desktop onboarding used to save the typed language *name* (`"japanese"` rather than `"ja"`); a client-side normalizer fixed new writes, but existing records still hold names and no capability map can ever match one.

The raise landed on the assignment itself, which is why `sync_provider` was still `unknown` in the logs.

Before the pre-recorded Deepgram path was retired, the function ended with an unconditional `return PrerecordedSTTService.DEEPGRAM, language, 'nova-3'`, so selection could not fail. Removing Deepgram removed that floor and replaced it with `raise`, while leaving the narrow literal set in place.

### 2. The job boundary ignored `retryable`

`TranscriptionFailure` carries a `retryable` flag, and segment-level outcomes honor it. The task handler did not: any exception consumed the full Cloud Tasks retry budget as HTTP 500.

Cloud Tasks throttles a queue's entire dispatch rate under sustained 5xx — not just the failing task. So a job that can never succeed degraded throughput for every other user's sync.

## Change

**`utils/stt/pre_recorded.py`** — add a Velma floor before the raise. Velma's batch API detects the language itself (we never send a code — the request body is the audio plus `speaker_diarization`), so it can serve anything the capability maps omit. Uncovered languages and non-ISO stored values now route to Velma in auto-detect mode and the provider reports what it heard.

The remaining raise is only reachable when policy has disabled every pre-recorded provider. It now raises the typed non-retryable `CONFIG_ERROR` instead of a bare `RuntimeError`, so it cannot be misread as transient.

**`routers/sync.py`** — finalize a non-retryable failure on its first delivery instead of after `max_attempts` 500s. Retryable failures keep their existing backoff and attempt accounting.

## Deliberately not included

Replacing the literal set with the policy's `modulate_supports_language()` — the obvious-looking fix — would also make Velma claim `multi`, the default for most users, plus ~18 European languages currently served by Parakeet. That moves the bulk of pre-recorded traffic off self-hosted Parakeet onto metered Velma. It is a cost and capacity decision, not a bug fix, and `test_multi_language_falls_through_to_parakeet_capability` shows the current routing is intentional.

The floor fixes all 22 languages with **zero routing change** for any language that already worked. `test_a_language_a_capability_map_claims_keeps_its_provider` pins that, so widening the gate later is an explicit, visible decision.

Also out of scope, tracked separately: validating language on write at `PATCH /v1/users/language` (it currently accepts any string), and backfilling the stored language names.

## Tests

- `test_prerecorded_language_coverage.py` (new) — all 49 client languages resolve; the 22 previously-unroutable ones reach Velma by detection; stored names do too; region-qualified codes resolve on their base; already-claimed languages keep their exact provider; no enabled provider yields a non-retryable `CONFIG_ERROR`.
- `test_sync_cloud_tasks.py` — a non-retryable failure finalizes on delivery one without a queued reset or retained staging; a transient failure still returns 500 for a retry.
- `test_modulate_stt.py` — the fail-closed expectation is replaced by reaching Velma.

Affected suites: **609 passed**. 10 failures are identical on `origin/main` (fakeredis Lua limitation in `TestFencedJobMutations`/`TestLegacyJobMutations` plus one ordering-dependent desktop test) and are unrelated to this change.

`scripts/scan_async_blockers.py`: 0 findings.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

