### PR TITLE
ci: raise backend/routers/sync.py line-count baseline for #10550

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -4,14 +4,14 @@
     "backend/routers/chat.py": 1588,
     "backend/routers/developer.py": 2202,
     "backend/routers/mcp_sse.py": 1858,
-    "backend/routers/sync.py": 2058,
+    "backend/routers/sync.py": 2061,
     "backend/routers/users.py": 2046
   },
   "raise_justifications": {
     "backend/routers/chat.py": "Merging the Windows-port chat surface with main combined the stream-error fallback (answered guard) with mains journey/attempt observability in the same SSE generators; +11 lines of combined guard flow, no new route.",
     "backend/routers/developer.py": "From-segments processing now wraps process_conversation in the admission lease guard so the crash-orphan sweep cannot terminalize active work (#10461); +7 lines for the conditional guard with rollback_on_failure=False.",
     "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line.",
-    "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033).",
+    "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033). +3 to honor TranscriptionFailure.retryable at this same boundary (#10550): a failure no retry can resolve must terminalize on first delivery, because sustained 5xx throttles the whole queue's dispatch rate for every other user.",
     "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first."
   },
   "threshold": 1500


### PR DESCRIPTION
#10550 honors `TranscriptionFailure.retryable` at the Cloud Tasks job boundary, which added 3 lines to `backend/routers/sync.py` (2058 → 2061). The product-file line-count ratchet failed on the merge commit `7ab64f8b`, so that SHA cannot pass Release Eligibility and cannot be deployed.

Raises the exact baseline to 2061 with a justification appended to the existing entry, per the ratchet's own remediation message.

The alternative — splitting `routers/sync.py` — is not something to attempt inside a deploy-blocking hotfix path.

`check_product_file_line_count_ratchet.py`: OK. Its own unit tests: 8 passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

