### PR TITLE
fix(sync): keep the retryable short-circuit within the line-count baseline

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -4,14 +4,14 @@
     "backend/routers/chat.py": 1588,
     "backend/routers/developer.py": 2202,
     "backend/routers/mcp_sse.py": 1858,
-    "backend/routers/sync.py": 2061,
+    "backend/routers/sync.py": 2058,
     "backend/routers/users.py": 2046
   },
   "raise_justifications": {
     "backend/routers/chat.py": "Merging the Windows-port chat surface with main combined the stream-error fallback (answered guard) with mains journey/attempt observability in the same SSE generators; +11 lines of combined guard flow, no new route.",
     "backend/routers/developer.py": "From-segments processing now wraps process_conversation in the admission lease guard so the crash-orphan sweep cannot terminalize active work (#10461); +7 lines for the conditional guard with rollback_on_failure=False.",
     "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line.",
-    "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033). +3 to honor TranscriptionFailure.retryable at this same boundary (#10550): a failure no retry can resolve must terminalize on first delivery, because sustained 5xx throttles the whole queue's dispatch rate for every other user.",
+    "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033).",
     "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first."
   },
   "threshold": 1500

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1757,14 +1757,11 @@ async def run_sync_job(request: Request, task_retry_count: int = Depends(verify_
                     return JSONResponse(status_code=200, content={'status': 'done', 'reconciled': True})
             failure = failure_from_exception(e, provider=latest_job.get('stt_provider'))
             sync_model = latest_job.get('stt_model')
-            final_attempt = task_retry_count >= max_attempts - 1
-            # Sustained 5xx throttles the whole queue's dispatch rate, so a failure that
-            # no retry can resolve must not consume the retry budget.
-            if not failure.retryable or final_attempt:
+            if not failure.retryable or task_retry_count >= max_attempts - 1:
                 logger.error(
-                    'event=sync_transcription_job outcome=%s status=%s lane=%s ' 'attempt=%d exception_type=%s',
+                    'event=sync_transcription_job outcome=%s status=failed_final lane=%s '
+                    'attempt=%d exception_type=%s',
                     failure.outcome.value,
-                    'failed_final' if final_attempt else 'failed_not_retryable',
                     sync_lane,
                     task_retry_count + 1,
                     type(e).__name__,


### PR DESCRIPTION
## Why

`main` currently has **no deployable SHA**. Both recent heads failed Release Eligibility on the product-file line-count ratchet:

| SHA | Ratchet failure |
|---|---|
| `7ab64f8b` (#10550) | `backend/routers/sync.py: grew from baseline 2058 to 2061 lines` |
| `6337dcc9` (#10552) | `backend/routers/sync.py: a baseline raise must include the source file in the PR diff` |

#10550 added 3 lines to `routers/sync.py`. #10552 tried to raise the baseline in a baseline-only PR, but the ratchet requires a raise to ship **in the same diff as the source change** — so a follow-up PR can never satisfy it.

## Change

Removes the growth instead of arguing with the guardrail. `routers/sync.py` returns to exactly **2058** lines, and #10552's baseline raise is ratcheted back down.

- Inline the final-attempt comparison rather than binding `final_attempt`.
- Restore the original `status=failed_final` log call; drop the `failed_not_retryable` label. `outcome=` plus `attempt=1` already distinguishes a short circuit from budget exhaustion.

Behavior is unchanged: a failure no retry can resolve still terminalizes on its first delivery instead of consuming the retry budget as 5xx.

## Verification

Ran the checker the way CI does — `--changed-files` takes a path to a newline-delimited list, not a filename. Passing a source path made it read that file's contents as the changed set, report "0 changed product source file(s)", and pass vacuously. That is why neither failure was caught locally.

```
$ printf 'backend/routers/sync.py\n.github/.../backend-routers.json\n' > /tmp/changed.txt
$ python3 .github/scripts/check_product_file_line_count_ratchet.py \
    --changed-files /tmp/changed.txt --base 6337dcc9d8e490689a04f02c6afc397e22db5d30
OK: no line-count increase across 1 changed product source file(s).
```

`wc -l backend/routers/sync.py` → 2058, matching the baseline exactly.

Sync task tests: 78 passed. The 9 failures are identical on `origin/main` (fakeredis Lua limitation). `scan_async_blockers.py`: 0 findings.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

