### PR TITLE
fix(users): validate and normalize the primary language on write

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -53,6 +53,7 @@ from database.users import (
     set_user_transcription_preferences,
 )
 from config.stt_provider_policy import supports_live_multilingual_mode
+from utils.user_language import normalize_user_language
 from database.users import *
 from models.conversation import Conversation
 from models.geolocation import Geolocation
@@ -809,9 +810,7 @@ def set_chat_message_analytics(
 def get_user_language(uid: str = Depends(auth.get_current_user_uid)):
     """Get the user's preferred language."""
     language = get_user_language_preference(uid)
-    if not language:
-        return {'language': None}
-    return {'language': language}
+    return {'language': language or None}
 
 
 class SetUserLanguageRequest(BaseModel):
@@ -821,9 +820,9 @@ class SetUserLanguageRequest(BaseModel):
 @router.patch('/v1/users/language', tags=['v1'], response_model=UserLanguageUpdateResponse)
 def set_user_language(data: SetUserLanguageRequest, uid: str = Depends(auth.get_current_user_uid)):
     """Set the user's preferred language (e.g., 'en', 'vi', etc.)."""
-    language = data.language
+    language = normalize_user_language(data.language)
     if not language:
-        raise HTTPException(status_code=400, detail="Language is required")
+        raise HTTPException(status_code=400, detail="A supported language code is required")
     set_user_language_preference(uid, language)
     single_language_mode = not supports_live_multilingual_mode(language)
     set_user_transcription_preferences(uid, single_language_mode=single_language_mode)

--- a/backend/tests/unit/test_user_language_normalization.py
+++ b/backend/tests/unit/test_user_language_normalization.py
@@ -1,0 +1,131 @@
+"""PATCH /v1/users/language must not persist a value no consumer can read."""
+
+import pytest
+
+from utils.user_language import ACCEPTED_BASE_LANGUAGES, normalize_user_language
+
+# Every code the mobile picker can send (app/lib/providers/home_provider.dart).
+CLIENT_SENT_CODES = (
+    'en',
+    'en-US',
+    'en-GB',
+    'en-AU',
+    'en-NZ',
+    'en-IN',
+    'es',
+    'es-419',
+    'zh',
+    'zh-CN',
+    'zh-Hans',
+    'hi',
+    'pt',
+    'pt-BR',
+    'pt-PT',
+    'ru',
+    'ja',
+    'de',
+    'ar',
+    'be',
+    'bn',
+    'bs',
+    'bg',
+    'ca',
+    'zh-TW',
+    'zh-Hant',
+    'zh-HK',
+    'hr',
+    'cs',
+    'da',
+    'da-DK',
+    'nl',
+    'et',
+    'fi',
+    'nl-BE',
+    'fr',
+    'fr-CA',
+    'de-CH',
+    'el',
+    'he',
+    'hu',
+    'id',
+    'it',
+    'kn',
+    'ko',
+    'ko-KR',
+    'lv',
+    'lt',
+    'mk',
+    'ms',
+    'mr',
+    'no',
+    'fa',
+    'pl',
+    'ro',
+    'sr',
+    'sk',
+    'sl',
+    'sv',
+    'sv-SE',
+    'tl',
+    'ta',
+    'te',
+    'th',
+    'th-TH',
+    'tr',
+    'uk',
+    'vi',
+)
+
+
+@pytest.mark.parametrize('code', CLIENT_SENT_CODES)
+def test_a_code_a_client_can_send_is_preserved_exactly(code):
+    assert normalize_user_language(code) == code
+
+
+@pytest.mark.parametrize(
+    'name,expected',
+    [
+        ('japanese', 'ja'),
+        ('Japanese', 'ja'),
+        ('JAPANESE', 'ja'),
+        ('  japanese  ', 'ja'),
+        ('russian', 'ru'),
+        ('portuguese', 'pt'),
+        ('brazilian portuguese', 'pt'),
+        ('mandarin', 'zh'),
+        ('simplified chinese', 'zh'),
+        ('flemish', 'nl'),
+        ('farsi', 'fa'),
+        ('filipino', 'tl'),
+    ],
+)
+def test_a_language_name_resolves_to_its_code(name, expected):
+    """Desktop onboarding sent names; those clients must keep working."""
+    assert normalize_user_language(name) == expected
+
+
+@pytest.mark.parametrize('value', ['', '   ', None, 'not-a-language', 'klingon', 'xx', 'zz-ZZ', 'en_US_extra_junk'])
+def test_an_unresolvable_value_is_rejected(value):
+    assert normalize_user_language(value) is None
+
+
+def test_underscore_separators_are_normalized():
+    assert normalize_user_language('zh_Hans') == 'zh-Hans'
+    assert normalize_user_language('pt_BR') == 'pt-BR'
+
+
+def test_multi_is_accepted_as_the_auto_detect_preference():
+    assert normalize_user_language('multi') == 'multi'
+
+
+def test_accepted_set_is_derived_from_provider_capability():
+    for code in ('multi', 'en', 'ja', 'hi', 'tr', 'mt'):
+        assert code in ACCEPTED_BASE_LANGUAGES
+    assert 'klingon' not in ACCEPTED_BASE_LANGUAGES
+
+
+def test_every_mapped_name_resolves_to_an_accepted_base():
+    from utils.user_language import LANGUAGE_NAME_TO_BASE
+
+    unserviceable = {name: base for name, base in LANGUAGE_NAME_TO_BASE.items() if base not in ACCEPTED_BASE_LANGUAGES}
+    assert unserviceable == {}

--- a/backend/utils/user_language.py
+++ b/backend/utils/user_language.py
@@ -1,0 +1,120 @@
+"""Normalization for the user's stored primary-language preference.
+
+``PATCH /v1/users/language`` accepted any string, so clients that sent a language
+*name* persisted values like ``"japanese"``. No STT capability map can match a name,
+and every consumer reads this field expecting an ISO code.
+"""
+
+from __future__ import annotations
+
+from typing import Final, Optional
+
+from config.stt_provider_policy import (
+    MODULATE_SUPPORTED_LANGUAGES,
+    PARAKEET_MODEL_BY_SURFACE,
+    PARAKEET_SUPPORTED_LANGUAGES_BY_MODEL,
+    STTServingSurface,
+)
+
+# A stored value must be serviceable by some provider, so the accepted set is the
+# union of provider capability rather than a second list that can drift from policy.
+ACCEPTED_BASE_LANGUAGES: Final[frozenset[str]] = MODULATE_SUPPORTED_LANGUAGES | frozenset(
+    PARAKEET_SUPPORTED_LANGUAGES_BY_MODEL[PARAKEET_MODEL_BY_SURFACE[STTServingSurface.PRERECORDED]]
+)
+
+# English names for every accepted code, plus the aliases clients have actually sent.
+LANGUAGE_NAME_TO_BASE: Final[dict[str, str]] = {
+    'afrikaans': 'af',
+    'albanian': 'sq',
+    'arabic': 'ar',
+    'azerbaijani': 'az',
+    'basque': 'eu',
+    'belarusian': 'be',
+    'bengali': 'bn',
+    'bosnian': 'bs',
+    'brazilian portuguese': 'pt',
+    'bulgarian': 'bg',
+    'cantonese': 'zh',
+    'catalan': 'ca',
+    'chinese': 'zh',
+    'chinese simplified': 'zh',
+    'chinese traditional': 'zh',
+    'croatian': 'hr',
+    'czech': 'cs',
+    'danish': 'da',
+    'dutch': 'nl',
+    'english': 'en',
+    'estonian': 'et',
+    'farsi': 'fa',
+    'filipino': 'tl',
+    'finnish': 'fi',
+    'flemish': 'nl',
+    'french': 'fr',
+    'galician': 'gl',
+    'german': 'de',
+    'greek': 'el',
+    'gujarati': 'gu',
+    'hebrew': 'he',
+    'hindi': 'hi',
+    'hungarian': 'hu',
+    'indonesian': 'id',
+    'italian': 'it',
+    'japanese': 'ja',
+    'kannada': 'kn',
+    'kazakh': 'kk',
+    'korean': 'ko',
+    'latvian': 'lv',
+    'lithuanian': 'lt',
+    'macedonian': 'mk',
+    'malay': 'ms',
+    'malayalam': 'ml',
+    'maltese': 'mt',
+    'mandarin': 'zh',
+    'marathi': 'mr',
+    'norwegian': 'no',
+    'persian': 'fa',
+    'polish': 'pl',
+    'portuguese': 'pt',
+    'punjabi': 'pa',
+    'romanian': 'ro',
+    'russian': 'ru',
+    'serbian': 'sr',
+    'simplified chinese': 'zh',
+    'slovak': 'sk',
+    'slovenian': 'sl',
+    'spanish': 'es',
+    'swahili': 'sw',
+    'swedish': 'sv',
+    'tagalog': 'tl',
+    'tamil': 'ta',
+    'telugu': 'te',
+    'thai': 'th',
+    'turkish': 'tr',
+    'ukrainian': 'uk',
+    'urdu': 'ur',
+    'vietnamese': 'vi',
+    'welsh': 'cy',
+}
+
+
+def normalize_user_language(raw: Optional[str]) -> Optional[str]:
+    """Return a storable language preference, or None when it cannot be resolved.
+
+    Region qualifiers survive (``pt-BR`` stays ``pt-BR``) because only the base code
+    drives provider capability. A recognized language name resolves to its base code
+    so older clients keep working instead of persisting an unusable value.
+    """
+    candidate = (raw or '').strip()
+    if not candidate:
+        return None
+
+    base, _, subtag = candidate.replace('_', '-').partition('-')
+    if base.lower() in ACCEPTED_BASE_LANGUAGES and _is_region_subtag(subtag):
+        return f'{base.lower()}-{subtag}' if subtag else base.lower()
+
+    return LANGUAGE_NAME_TO_BASE.get(candidate.lower())
+
+
+def _is_region_subtag(subtag: str) -> bool:
+    """Accept one region/script qualifier (``US``, ``419``, ``Hans``), never a tail of junk."""
+    return not subtag or (subtag.isalnum() and 2 <= len(subtag) <= 4)


### PR DESCRIPTION
Fix 4 of the offline-sync language investigation. #10550 made unroutable languages transcribe anyway; this stops the bad values being written in the first place.

## Problem

`PATCH /v1/users/language` persisted whatever string it was given:

```py
language = data.language
if not language:
    raise HTTPException(status_code=400, detail="Language is required")
set_user_language_preference(uid, language)
```

Desktop onboarding used to send the typed language *name*, so records hold values like `japanese` where the code should be `ja`. A client-side normalizer fixed new desktop writes, but the endpoint still accepts anything from every other client and every older app version in the wild.

The stored value is read as an ISO code by every consumer, and a name can never match an STT capability map.

It also corrupts a derived field. The endpoint computes:

```py
single_language_mode = not supports_live_multilingual_mode(language)
```

`japanese` isn't recognized, so the user is flagged as *not* multi-language-capable and pinned to that unusable value — instead of `ja`, which is recognized and would have left them on auto-detect. The bad write actively pushed users into the worse mode.

## Change

`utils/user_language.py` — `normalize_user_language()`:

- **Codes pass through unchanged**, region qualifiers intact (`pt-BR` stays `pt-BR`) since only the base code drives capability.
- **Names resolve to codes** (`japanese` → `ja`, `mandarin` → `zh`), so older clients keep working instead of persisting an unusable value.
- **Anything unresolvable is rejected** with 400 rather than stored.
- The accepted set is derived from the STT policy's own capability maps (`MODULATE_SUPPORTED_LANGUAGES` ∪ Parakeet's batch model) so it cannot drift from what a provider can actually serve.

Shape is validated, not just the prefix — an early version accepted `en_US_extra_junk` because its base was `en`. One region/script subtag of 2–4 alphanumerics is allowed (`US`, `419`, `Hans`); a tail of junk is not. My own test caught that.

`routers/users.py` — one line changed to normalize before persisting, plus a folded early-return in the GET handler.

## Line-count ratchet

`routers/users.py` was at **2047** on `main` while its baseline records **2046** — pre-existing drift, so *any* PR touching that file currently fails the ratchet. Folding the GET early-return puts the file at exactly **2046**, matching the baseline. No baseline change needed, and the landmine is cleared for the next person.

## Verification

Ran the full CI check set locally this time, rather than one checker at a time:

```
$ python3 .github/scripts/run_checks.py --lane ci --base daae675ab9 --head HEAD \
    --skip-pr-body-checks --skip-changelog
```

**18/18 PASS** — including `product-file-line-count-ratchet`, `backend-import-purity`, `backend-route-policy-baseline`, `backend-runtime-image-source-closure`, `backend-async-blockers`, `firestore-query-coverage`, `backend-module-isolation`.

Note the selection is diff-based, so the checks only resolve after committing; running it on a dirty tree silently selects a much smaller set.

Tests: 109 passed (`test_user_language_normalization.py` + `tests/routers/test_users.py`). Coverage includes all 68 codes the mobile picker can send round-tripping unchanged, name resolution, rejection of unresolvable input, and an assertion that every mapped name lands on a base the policy can serve.

## Not included

Backfilling the language names already in Firestore — that's fix 5, and it needs a count first.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

