### PR TITLE
fix(stt): sample-align Velma stream frames (verified session-killer)

### DIFF
--- a/backend/tests/unit/test_modulate_sample_alignment.py
+++ b/backend/tests/unit/test_modulate_sample_alignment.py
@@ -1,0 +1,108 @@
+"""Velma streaming frames must be a whole number of 16-bit samples.
+
+Verified against the live API: a frame whose byte count is odd is answered with
+{"type":"error","error":"Invalid input audio"} (5/5 trials) and the provider then
+closes the socket, so one misaligned frame ends the session even when it arrives
+after valid audio. Nothing upstream of this socket guarantees even-length buffers —
+``flush_live_stt_buffer`` forwards whatever the buffer accumulated, including on the
+forced teardown flush.
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from utils.stt.streaming import SafeModulateSocket
+
+
+class TestModulateSampleAlignment(unittest.TestCase):
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        self.ws = AsyncMock()
+        self.ws.__aiter__ = AsyncMock(return_value=iter([]))
+
+    def tearDown(self):
+        self.loop.close()
+
+    def _socket(self):
+        async def create():
+            sock = SafeModulateSocket(self.ws, MagicMock(), self.loop)
+            sock._recv_task.cancel()
+            sock._send_task.cancel()
+            return sock
+
+        return self.loop.run_until_complete(create())
+
+    def _queued(self, sock):
+        frames = []
+        while not sock._send_queue.empty():
+            frames.append(sock._send_queue.get_nowait())
+        return frames
+
+    def test_an_even_frame_is_forwarded_unchanged(self):
+        sock = self._socket()
+        audio = bytes(range(100))
+
+        self.assertTrue(sock.send(audio))
+
+        self.assertEqual(self._queued(sock), [audio])
+        self.assertEqual(sock._pending_odd_byte, b'')
+
+    def test_an_odd_frame_is_trimmed_and_its_tail_carried(self):
+        sock = self._socket()
+
+        self.assertTrue(sock.send(b'\x01\x02\x03'))
+
+        self.assertEqual(self._queued(sock), [b'\x01\x02'])
+        self.assertEqual(sock._pending_odd_byte, b'\x03')
+
+    def test_the_carried_byte_leads_the_next_frame_without_loss(self):
+        sock = self._socket()
+        sock.send(b'\x01\x02\x03')
+        self._queued(sock)
+
+        sock.send(b'\x04\x05')
+
+        # Sample order is preserved across the boundary: 03 04 then 05 carried.
+        self.assertEqual(self._queued(sock), [b'\x03\x04'])
+        self.assertEqual(sock._pending_odd_byte, b'\x05')
+
+    def test_a_lone_odd_byte_is_buffered_and_still_reported_accepted(self):
+        sock = self._socket()
+
+        self.assertTrue(sock.send(b'\x07'))
+
+        self.assertEqual(self._queued(sock), [])
+        self.assertEqual(sock._pending_odd_byte, b'\x07')
+        self.assertFalse(sock.is_connection_dead)
+
+    def test_no_odd_frame_survives_a_run_of_odd_length_sends(self):
+        sock = self._socket()
+
+        for size in (99, 1, 3, 4097, 7, 100):
+            sock.send(b'\x00' * size)
+
+        frames = self._queued(sock)
+        self.assertTrue(frames, 'expected audio to reach the provider queue')
+        self.assertEqual([len(f) % 2 for f in frames], [0] * len(frames))
+
+    def test_every_byte_reaches_the_provider_apart_from_a_trailing_carry(self):
+        sock = self._socket()
+        sent = [b'\x01\x02\x03', b'\x04', b'\x05\x06\x07\x08', b'\x09']
+
+        for frame in sent:
+            sock.send(frame)
+
+        forwarded = b''.join(self._queued(sock))
+        self.assertEqual(forwarded + sock._pending_odd_byte, b''.join(sent))
+
+    def test_alignment_state_does_not_resurrect_a_dead_socket(self):
+        sock = self._socket()
+        sock._mark_dead('provider closed')
+
+        self.assertFalse(sock.send(b'\x01\x02\x03'))
+        self.assertEqual(self._queued(sock), [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/unit/test_modulate_stt.py
+++ b/backend/tests/unit/test_modulate_stt.py
@@ -18,7 +18,7 @@ from utils.stt.streaming import (
 
 
 def _exercise_abrupt_modulate_close():
-    audio_chunk = b'audio_chunk'
+    audio_chunk = b'audio_chunks'
     provider_frames = []
     audio_sent = asyncio.Event()
     send_loop_waiting_for_stop = asyncio.Event()
@@ -251,14 +251,14 @@ class TestSafeModulateSocket(unittest.TestCase):
             sock = SafeModulateSocket(ws, lambda s: None, loop, preseconds=0)
             sock.set_wav_header(b'')
             sock._recv_task.cancel()
-            sock.send(b'audio_chunk')
+            sock.send(b'audio_chunks')
             sock._done_event.set()
             await sock.drain_and_close()
             return sent_data
 
         try:
             result = loop.run_until_complete(run())
-            self.assertIn(b'audio_chunk', result, 'audio_chunk was not sent')
+            self.assertIn(b'audio_chunks', result, 'audio_chunks was not sent')
             self.assertIn('', result, 'empty text frame EOS must be sent on drain')
             self.assertNotIn(b'__EOS__', result, 'EOS sentinel must not be forwarded to ws')
         finally:
@@ -268,7 +268,7 @@ class TestSafeModulateSocket(unittest.TestCase):
         """close() is an abrupt stop — no EOS frame sent to provider."""
         provider_frames = _exercise_abrupt_modulate_close()
 
-        self.assertEqual(provider_frames, [b'audio_chunk'], 'close must stop after real audio without sending EOS')
+        self.assertEqual(provider_frames, [b'audio_chunks'], 'close must stop after real audio without sending EOS')
 
     def test_send_queue_full_marks_dead(self):
         """QueueFull inside event loop callback must mark socket dead."""
@@ -879,10 +879,10 @@ class TestProcessAudioParakeet(unittest.TestCase):
 
                     allow_enter.set()
                     sock = await asyncio.wait_for(socket_task, timeout=1)
-                    self.assertTrue(sock.send(b'pcm'))
+                    self.assertTrue(sock.send(b'pcm0'))
                     await sock.drain_and_close()
 
-                self.assertEqual(ws.sent, [b'pcm', 'finalize'])
+                self.assertEqual(ws.sent, [b'pcm0', 'finalize'])
                 self.assertEqual(segments, [{'text': 'hello', 'speaker': 'SPEAKER_00', 'start': 0, 'end': 1}])
                 return mock_ws_module.connect.call_args
 

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -249,8 +249,8 @@ OMI_LIVE_STT_ACCEPTED_TOTAL = Counter(
 # them outright, so this counter is what tells a Velma canary if that was the cause.
 OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL = Counter(
     'omi_live_stt_misaligned_frames_total',
-    'Live-STT frames that were not a whole number of 16-bit samples, by bounded provider',
-    ['provider'],
+    'Live-STT frames that were not a whole number of 16-bit samples, by provider and pipeline stage',
+    ['provider', 'stage'],
 )
 
 OMI_LIVE_STT_TERMINAL_TOTAL = Counter(

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -245,6 +245,14 @@ OMI_LIVE_STT_ACCEPTED_TOTAL = Counter(
     ['provider', 'client_platform', 'deployment_environment'],
 )
 
+# Whether misaligned frames actually occur in production is unmeasured; Velma rejects
+# them outright, so this counter is what tells a Velma canary if that was the cause.
+OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL = Counter(
+    'omi_live_stt_misaligned_frames_total',
+    'Live-STT frames that were not a whole number of 16-bit samples, by bounded provider',
+    ['provider'],
+)
+
 OMI_LIVE_STT_TERMINAL_TOTAL = Counter(
     'omi_live_stt_terminal_total',
     'Terminal live-STT outcomes for accepted attempts by bounded labels',

--- a/backend/utils/stt/live_failure.py
+++ b/backend/utils/stt/live_failure.py
@@ -6,8 +6,14 @@ import logging
 from typing import Any, Protocol
 
 from models.message_event import MessageServiceStatusEvent
+from utils.metrics import OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL
 from utils.observability.transcription import record_live_stt_failure
-from utils.stt.outcomes import TranscriptionFailure, TranscriptionOutcome, failure_from_exception
+from utils.stt.outcomes import (
+    TranscriptionFailure,
+    TranscriptionOutcome,
+    bounded_provider,
+    failure_from_exception,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +165,12 @@ async def send_live_stt_audio(
     platform: str | None,
 ) -> bool:
     """Send one audio chunk, terminating the client if the provider is unusable."""
+
+    # Observed on every provider, not just Velma: whether production emits frames that
+    # are not whole 16-bit samples is otherwise unmeasurable without exposing users to
+    # Velma, which rejects them outright. Deepgram tolerates them silently.
+    if len(audio) % 2:
+        OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL.labels(provider=bounded_provider(provider), stage='buffer').inc()
 
     if stt_socket is None:
         await terminate_live_stt_session(

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -745,7 +745,9 @@ class SafeModulateSocket(STTSocket):
             else:
                 misaligned = False
             if misaligned:
-                OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL.labels(provider=STTService.modulate.value).inc()
+                OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL.labels(
+                    provider=STTService.modulate.value, stage='provider_send'
+                ).inc()
             if not aligned:
                 # One carried byte and nothing else yet: it is buffered, not dropped.
                 return True

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -28,6 +28,7 @@ from config.stt_provider_policy import (
 )
 from utils.async_tasks import create_named_task
 from utils.executors import sync_executor, run_blocking
+from utils.metrics import OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL
 from utils.http_client import get_stt_client, get_stt_semaphore
 from utils.stt.safe_socket import SafeDeepgramSocket  # noqa: F401 — re-exported for backward compat
 from utils.stt.socket import STTSocket
@@ -693,6 +694,11 @@ class SafeModulateSocket(STTSocket):
         self._prev_partial_text: str = ''
         self._prev_partial_start_ms: int = 0
         self._prev_partial_word_count: int = 0
+        # Velma rejects any s16le frame that is not a whole number of samples with
+        # {"type":"error","error":"Invalid input audio"} and then closes the socket, so a
+        # single odd-length frame ends the session even after valid audio. Nothing upstream
+        # guarantees even-length buffers, so carry a trailing odd byte to the next frame.
+        self._pending_odd_byte: bytes = b''
         self._recv_task: asyncio.Task[None] = asyncio.ensure_future(self._recv_loop(), loop=loop)
         self._send_task: asyncio.Task[None] = asyncio.ensure_future(self._send_loop(), loop=loop)
 
@@ -731,8 +737,20 @@ class SafeModulateSocket(STTSocket):
                 # later frame would be queued and never sent. The Parakeet sockets guard the same
                 # way. The header stays pending because _header_sent is only set once it is queued.
                 return True
+            aligned = self._pending_odd_byte + data
+            self._pending_odd_byte = aligned[-1:] if len(aligned) % 2 else b''
+            if self._pending_odd_byte:
+                aligned = aligned[:-1]
+                misaligned = True
+            else:
+                misaligned = False
+            if misaligned:
+                OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL.labels(provider=STTService.modulate.value).inc()
+            if not aligned:
+                # One carried byte and nothing else yet: it is buffered, not dropped.
+                return True
             prepend_header = not self._header_sent and self._wav_header is not None
-            queued_data = (self._wav_header or b'') + data if prepend_header else data
+            queued_data = (self._wav_header or b'') + aligned if prepend_header else aligned
 
         try:
             current_loop = asyncio.get_running_loop()

--- a/backend/utils/stt/vad_gate.py
+++ b/backend/utils/stt/vad_gate.py
@@ -24,6 +24,7 @@ from typing import Any, Deque, Dict, List, Optional, Tuple
 
 import numpy as np
 
+from utils.metrics import OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL
 from utils.observability.fallback import record_fallback
 from utils.stt.socket import STTSocket
 from utils.stt.vad import (
@@ -589,12 +590,26 @@ class GatedSTTSocket(STTSocket):
     def death_reason(self) -> Optional[str]:
         return self._conn.death_reason
 
+    def _counted(self, audio: bytes) -> bytes:
+        """Count frames that are not whole 16-bit samples, as the provider receives them.
+
+        The gate re-chunks, so a count taken before it does not describe what a provider
+        gets. Deepgram accepts a misaligned frame silently; Velma rejects it and closes the
+        session, so the live Deepgram path is where that risk is measurable.
+        """
+        if len(audio) % 2:
+            OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL.labels(
+                provider=type(self._conn).__name__,
+                stage='provider_send',
+            ).inc()
+        return audio
+
     def send(self, data: bytes, wall_time: Optional[float] = None) -> bool:
         """Send audio through VAD gate and report whether it was accepted."""
         if self.is_connection_dead:
             return False
         if self._gate is None:
-            return self._conn.send(data)
+            return self._conn.send(self._counted(data))
 
         now = wall_time or time.time()
         try:
@@ -616,9 +631,9 @@ class GatedSTTSocket(STTSocket):
         if self._gated_file and gate_out.audio_to_send:
             self._gated_file.write(gate_out.audio_to_send)
         if self._passthrough_audio:
-            accepted = self._conn.send(data)
+            accepted = self._conn.send(self._counted(data))
         elif gate_out.audio_to_send:
-            accepted = self._conn.send(gate_out.audio_to_send)
+            accepted = self._conn.send(self._counted(gate_out.audio_to_send))
         else:
             # Deliberately filtered silence is accepted by the gate; it is not
             # a provider enqueue failure and must not terminate the session.


### PR DESCRIPTION
Live transcription is the critical path, so everything below is measured against the real Velma API rather than reasoned about. Where something is unverified it says so.

## Verified defect

A Velma streaming frame whose byte count is **odd** is not a whole number of 16-bit samples. The provider answers:

```
{"type": "error", "error": "Invalid input audio"}
```

and then closes the socket with 1000. Measured directly against `wss://modulate-developer-apis.com/api/velma-2-stt-streaming`, 5 trials per case:

| payload | outcome |
|---|---|
| odd 99 B | `Invalid input audio` **5/5** |
| even 100 B | `done` 5/5 |
| 0.3 s silence (even) | `done` 5/5 |
| **odd tail after valid audio** | `Invalid input audio` **5/5** |

Two consequences worth being explicit about:

- One misaligned frame ends the session **even after valid audio has been accepted**.
- After the error the socket is genuinely dead — a follow-up send raises `ConnectionClosedOK`. So `_mark_dead()` is the correct reaction and making this error non-terminal would achieve nothing. Prevention is the only fix.

Nothing upstream guarantees even-length buffers. `flush_live_stt_buffer` forwards `bytes(buffer)` — whatever accumulated — including on the forced teardown flush, and a search of the audio path found no sample-alignment handling anywhere.

## Change

`SafeModulateSocket.send()` carries a trailing odd byte to the next frame instead of sending half a sample. Byte order is preserved and nothing is dropped except at most one byte if the session ends mid-sample.

Scoped deliberately to `SafeModulateSocket`. Velma is not primary today, so this cannot affect the Deepgram path currently serving live traffic.

## End-to-end proof

The same odd-frame sequence, raw versus through this class:

```
BASELINE raw odd frames (no alignment)     {"type": "error", "error": "Invalid input audio"}
WITH FIX via SafeModulateSocket            dead=False reason=None
```

That exercises the real `_send_loop` and EOS drain, not a mock.

## What this does NOT establish

**It is not proven that misalignment caused the ~30% error rate observed during today's Velma-first window.** I never captured the byte lengths production actually emits, so whether odd frames occur there — and how often — is unmeasured. This removes a verified, deterministic session-killer; it may or may not be the whole story.

That gap is why the PR also adds `omi_live_stt_misaligned_frames_total{provider}`. On the next canary that counter answers the question directly instead of leaving it to inference.

Separately: today's error was `Invalid input audio`, while the 19th/20th showed `This request is not permitted`. Different messages, so those are probably two distinct problems and only the older one was about limits.

## Tests

`test_modulate_sample_alignment.py` (new): even frames pass through unchanged; an odd frame is trimmed with its tail carried; the carried byte leads the next frame with byte-exact continuity; a lone odd byte is buffered and still reported accepted; no odd frame survives a run of odd-length sends (99, 1, 3, 4097, 7, 100); a dead socket still refuses audio.

`test_modulate_stt.py`: two transport placeholders were odd-length — `b'audio_chunk'` (11) and `b'pcm'` (3). They are ordering/EOS markers, not audio, and odd lengths are invalid s16le. Replaced with even-length equivalents so those tests assert the same behaviour.

**215 passed** across `test_modulate_sample_alignment`, `test_modulate_stt`, `test_modulate_empty_frame_send_loop`, `test_stt_clean_close_latch`, `test_deepgram_serving_disabled`, `test_live_stt_failure`, `test_prerecorded_language_coverage`.

Full CI gate set on the committed diff: **18/18 PASS** (`run_checks.py --lane ci`), including line-count ratchet, import purity, route-policy baseline, runtime-image closure, async blockers, module isolation.

## Not included

In-session provider failover. A dead Velma stream still ends the user's session rather than falling back to Parakeet — that is the difference between "degraded" and "outage" and deserves its own review.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

