### PR TITLE
ci(listen): restore prod GKE deploy + add Helm rollback for backend-listen

### DIFF
--- a/.github/workflows/gcp_backend_listen_helm.yml
+++ b/.github/workflows/gcp_backend_listen_helm.yml
@@ -18,6 +18,22 @@ on:
         description: 'Branch to deploy from'
         required: true
         default: 'main'
+      mode:
+        description: 'deploy applies the chart; rollback restores an earlier Helm revision'
+        required: true
+        default: 'deploy'
+        type: choice
+        options:
+          - deploy
+          - rollback
+      image_tag:
+        description: 'Short-SHA image to deploy (blank keeps the running image). Prod requires an ancestor of main.'
+        required: false
+        default: ''
+      helm_revision:
+        description: 'Helm revision to roll back to (blank = previous). See the Helm history step output.'
+        required: false
+        default: ''
 
 # This chart path mutates backend-listen and shared backend-secrets, which are
 # also applied by the full backend deploy for the same environment.
@@ -87,18 +103,56 @@ jobs:
           location: ${{ env.REGION }}
           project_id: ${{ vars.GCP_PROJECT_ID }}
 
-      - name: Resolve deployed backend-listen image tag
+      - name: Show Helm release history
         run: |
-          IMAGE="$(kubectl -n ${{ vars.ENV }}-omi-backend get deploy/${{ vars.ENV }}-omi-backend-listen -o jsonpath='{.spec.template.spec.containers[0].image}')"
-          TAG="${IMAGE##*:}"
-          if [[ -z "$TAG" || "$TAG" == "$IMAGE" || "$TAG" == "latest" ]]; then
-            echo "backend-listen is not currently pinned to an immutable image tag: ${IMAGE:-<missing>}" >&2
-            echo "Run the backend deploy workflow first so chart-only upgrades preserve a short-SHA image tag." >&2
+          echo "Rollback targets for ${{ vars.ENV }}-omi-backend-listen:"
+          helm -n ${{ vars.ENV }}-omi-backend history ${{ vars.ENV }}-omi-backend-listen --max 20 \
+            || echo "No existing release found"
+
+      - name: Resolve backend-listen image tag
+        if: ${{ (github.event.inputs.mode || 'deploy') == 'deploy' }}
+        env:
+          REQUESTED_TAG: ${{ github.event.inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          IMAGE="$(kubectl -n ${{ vars.ENV }}-omi-backend get deploy/${{ vars.ENV }}-omi-backend-listen -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)"
+          RUNNING_TAG="${IMAGE##*:}"
+          if [[ -z "${REQUESTED_TAG}" ]]; then
+            # Chart-only upgrade: keep whatever is serving. This is the auto-push path.
+            if [[ -z "$RUNNING_TAG" || "$RUNNING_TAG" == "$IMAGE" || "$RUNNING_TAG" == "latest" ]]; then
+              echo "ERROR: backend-listen is not pinned to an immutable tag (${IMAGE:-<missing>}) and no image_tag was given." >&2
+              echo "Pass image_tag=<short-sha> to set one explicitly." >&2
+              exit 1
+            fi
+            echo "Keeping the running image tag: $RUNNING_TAG"
+            echo "BACKEND_LISTEN_IMAGE_TAG=$RUNNING_TAG" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          # An explicit tag advances or rewinds the deployed code, so it must be a
+          # reviewed commit. Prod admits only ancestors of main; the same rule the
+          # source checkout is held to above.
+          if ! git cat-file -e "${REQUESTED_TAG}^{commit}" 2>/dev/null; then
+            echo "ERROR: image_tag ${REQUESTED_TAG} is not a commit in this repository." >&2
             exit 1
           fi
-          echo "BACKEND_LISTEN_IMAGE_TAG=$TAG" >> "$GITHUB_ENV"
+          if [[ "${{ github.event.inputs.environment }}" == prod ]]; then
+            if ! git merge-base --is-ancestor "${REQUESTED_TAG}" origin/main; then
+              echo "ERROR: image_tag ${REQUESTED_TAG} is not an ancestor of origin/main." >&2
+              exit 1
+            fi
+          fi
+          RESOLVED_TAG=$(git rev-parse --short=7 "${REQUESTED_TAG}^{commit}")
+          if ! gcloud container images describe "gcr.io/${{ vars.GCP_PROJECT_ID }}/backend:${RESOLVED_TAG}" >/dev/null 2>&1; then
+            echo "ERROR: gcr.io/${{ vars.GCP_PROJECT_ID }}/backend:${RESOLVED_TAG} does not exist." >&2
+            echo "The image is built by the backend deploy workflow; run that for this commit first." >&2
+            exit 1
+          fi
+          echo "Deploying image tag ${RESOLVED_TAG} (currently ${RUNNING_TAG:-<none>})"
+          echo "BACKEND_LISTEN_IMAGE_TAG=$RESOLVED_TAG" >> "$GITHUB_ENV"
 
       - name: Apply non-secret backend runtime config
+        if: ${{ (github.event.inputs.mode || 'deploy') == 'deploy' }}
         env:
           ENVIRONMENT: ${{ vars.ENV }}
           CONVERSATION_SUMMARIZED_APP_IDS: ${{ vars.CONVERSATION_SUMMARIZED_APP_IDS }}
@@ -125,6 +179,7 @@ jobs:
         run: backend/scripts/deploy-backend-config.sh
 
       - name: Helm diff (dry run)
+        if: ${{ (github.event.inputs.mode || 'deploy') == 'deploy' }}
         run: |
           echo "=== Current release values ==="
           helm -n ${{ vars.ENV }}-omi-backend get values ${{ vars.ENV }}-omi-backend-listen || echo "No existing release found"
@@ -145,6 +200,7 @@ jobs:
       # never reaches K8s, and the deployment's secretKeyRef resolves to an
       # empty value — code reads os.getenv(...) as None.
       - name: Upgrade backend-secrets Helm chart
+        if: ${{ (github.event.inputs.mode || 'deploy') == 'deploy' }}
         env:
           ENVIRONMENT: ${{ vars.ENV }}
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
@@ -155,6 +211,7 @@ jobs:
           backend/scripts/deploy-backend-secrets.sh
 
       - name: Upgrade backend-listen Helm chart
+        if: ${{ (github.event.inputs.mode || 'deploy') == 'deploy' }}
         run: |
           helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-listen \
             ./backend/charts/backend-listen \
@@ -163,6 +220,28 @@ jobs:
             --set gcpProjectId=${{ vars.GCP_PROJECT_ID }} \
             --set runtimeGcpProjectId=${{ vars.RUNTIME_GCP_PROJECT_ID }} \
             --set-string "image.tag=${BACKEND_LISTEN_IMAGE_TAG}"
+
+      - name: Roll back backend-listen Helm release
+        if: ${{ github.event.inputs.mode == 'rollback' }}
+        env:
+          TARGET_REVISION: ${{ github.event.inputs.helm_revision }}
+        run: |
+          set -euo pipefail
+          RELEASE=${{ vars.ENV }}-omi-backend-listen
+          NS=${{ vars.ENV }}-omi-backend
+          BEFORE="$(kubectl -n "$NS" get deploy/"$RELEASE" -o jsonpath='{.spec.template.spec.containers[0].image}')"
+          echo "Image before rollback: $BEFORE"
+          # Helm rollback, not kubectl rollout undo: undo reverts the pod template while
+          # leaving Helm's stored release ahead of the cluster, so the next chart upgrade
+          # would silently reapply the bad revision.
+          if [[ -n "$TARGET_REVISION" ]]; then
+            helm -n "$NS" rollback "$RELEASE" "$TARGET_REVISION" --wait --timeout 30m
+          else
+            helm -n "$NS" rollback "$RELEASE" --wait --timeout 30m
+          fi
+          AFTER="$(kubectl -n "$NS" get deploy/"$RELEASE" -o jsonpath='{.spec.template.spec.containers[0].image}')"
+          echo "Image after rollback: $AFTER"
+          helm -n "$NS" history "$RELEASE" --max 10
 
       - name: Verify rollout
         run: |


### PR DESCRIPTION
## The break

`backend-listen` serves `/v4/listen` — all live transcription — and has had **no way to receive new code in prod**.

Two individually reasonable changes closed the loop:

- `1cec708d1e` (06-28, "Pin backend deploys to immutable image tags") made this workflow re-pin **whatever image is already running**, on the assumption that `gcp_backend.yml` sets it. Its own error text says so: *"Run the backend deploy workflow first so chart-only upgrades preserve a short-SHA image tag."*
- `b6a51ab3a0` (07-20, "narrow production deployment boundary") then made `gcp_backend.yml` reject `prod` + `deploy_targets=all`, pointing at *"direct GKE workflows"* as the replacement — but that replacement cannot advance an image.

Net effect: a chart-only deploy still reports success while shipping nothing, so the gap is silent. The image currently running was last moved by hand during the 07-18 incident, and prod live transcription has been frozen on it since.

I checked all five workflows that reference `backend-listen`; none of the others can set a prod listen image.

## What this adds

**`mode=deploy`** with **`image_tag`** — sets the image explicitly. Blank keeps the running image, so the existing auto-push-on-chart-change path behaves exactly as before.

Guards kept, because the point is a working path and not a looser one:
- prod admits only commits that are ancestors of `origin/main`
- the tag must resolve to a real commit in the repo
- the image must already exist in the registry, with a message pointing at the workflow that builds it

**`mode=rollback`** — restores an earlier Helm revision, defaulting to the previous one, and prints `helm history` so revisions are discoverable before and after.

`helm rollback`, not `kubectl rollout undo`: undo reverts the pod template but leaves Helm's stored release ahead of the cluster, so the next chart upgrade would quietly reapply the revision you just rolled away from. Rollback also skips the config and secret steps, which would otherwise re-apply the values being rolled back.

Rollout verification and the pod-status report run in both modes.

## Verification

Step gating, as parsed from the YAML:

| step | condition |
|---|---|
| Show Helm release history | always |
| Resolve backend-listen image tag | mode == deploy |
| Apply non-secret backend runtime config | mode == deploy |
| Helm diff (dry run) | mode == deploy |
| Upgrade backend-secrets Helm chart | mode == deploy |
| Upgrade backend-listen Helm chart | mode == deploy |
| Roll back backend-listen Helm release | mode == rollback |
| Verify rollout | always |

On the auto-push trigger `inputs.mode` is empty, so `(mode || 'deploy') == 'deploy'` keeps the current behaviour and the rollback step stays off.

YAML parses; CI gate set green, including `backend-workflow-contracts`, `deployment-secret-boundary`, `direct-backend-production-admission`.

## Read this before the first prod deploy

This workflow hardcodes, at the config step:

```yaml
STT_PRERECORDED_MODEL: modulate-velma-2,parakeet
STT_SERVICE_MODELS: modulate-velma-2,parakeet
```

and the chart values say the same. The running deployment instead has a hand-applied `dg-nova-3,modulate-velma-2,parakeet` plus a `DEEPGRAM_API_KEY` binding that exists in neither place.

So a prod deploy through this workflow **will move live transcription to Velma-first**, whatever image is chosen. On any image newer than the running one it is worse than that: `dg-nova-3` is inert on current code (it needs `DEEPGRAM_SELF_HOSTED_ENABLED`, which is unset, and there is no self-hosted Deepgram deployment), so Deepgram cannot be selected at all.

That STT-config decision is deliberately **not** in this PR — it is a separate call about which provider serves live transcription. This PR only restores the ability to deploy and roll back.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

