### PR TITLE
fix(desktop-windows): release chat auto-follow on any scroll-up, not just the wheel

### DIFF
--- a/.github/failure-classes/FC-single-input-device-release.json
+++ b/.github/failure-classes/FC-single-input-device-release.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "FC-single-input-device-release",
+  "violated_contract": "A viewport that auto-follows live content must release that follow on the reader's navigation intent from every input path the platform can deliver (wheel, scrollbar, keyboard, touch), not from one device's event type.",
+  "canonical_prevention": "Decide follow/release from the resulting scroll POSITION and its direction, which every input path produces identically, rather than from a device-specific event; keep that decision in one shared surface so no copy of it can drift.",
+  "evidence_prs": [
+    10515,
+    10562
+  ],
+  "scope_hints": [
+    "desktop/windows/src/renderer/**"
+  ],
+  "status": "open"
+}

--- a/desktop/windows/src/renderer/src/components/bar/AgentPillView.tsx
+++ b/desktop/windows/src/renderer/src/components/bar/AgentPillView.tsx
@@ -5,8 +5,9 @@
 // assistant text), NOT the shared Omi thread (INV-CHAT-1). This is the fix — a
 // click on a spawned-agent pill lands here, on that run's own conversation, never
 // the shared chat.
-import { useEffect, useLayoutEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { ChatMessages } from '../chat/ChatMessages'
+import { useLiveEdgeFollow } from '../../hooks/useLiveEdgeFollow'
 import { displayLabel, displayTintToken, isFinished, type AgentPill } from './agentPills'
 import { pillChipClasses } from './agentPillTranscript'
 import type { ChatMsg } from '../../hooks/useChat'
@@ -44,7 +45,6 @@ export function AgentPillView(props: AgentPillViewProps): React.JSX.Element {
   const finished = isFinished(pill.displayStatus)
   const scrollRef = useRef<HTMLDivElement>(null)
   const messagesRef = useRef<HTMLDivElement>(null)
-  const followRef = useRef(true)
 
   // Focus the surface so Esc/back keys land here on open.
   useEffect(() => {
@@ -52,32 +52,9 @@ export function AgentPillView(props: AgentPillViewProps): React.JSX.Element {
   }, [])
 
   // Keep the list pinned to the live edge while the assistant text streams, but
-  // disengage when the reader scrolls up (re-engage at the bottom). Mirrors the
-  // Omi conversation's follow logic in BarChatSurface.
-  useLayoutEffect(() => {
-    const el = scrollRef.current
-    const content = messagesRef.current
-    if (!el || !content) return
-    const pin = (): void => {
-      if (followRef.current) el.scrollTop = el.scrollHeight
-    }
-    pin()
-    const ro = new ResizeObserver(pin)
-    ro.observe(content)
-    const onWheel = (e: WheelEvent): void => {
-      if (e.deltaY < 0 && el.scrollHeight > el.clientHeight + 8) followRef.current = false
-    }
-    const onScroll = (): void => {
-      if (el.scrollHeight - el.scrollTop - el.clientHeight <= 8) followRef.current = true
-    }
-    el.addEventListener('wheel', onWheel, { passive: true })
-    el.addEventListener('scroll', onScroll, { passive: true })
-    return () => {
-      ro.disconnect()
-      el.removeEventListener('wheel', onWheel)
-      el.removeEventListener('scroll', onScroll)
-    }
-  }, [])
+  // disengage when the reader scrolls up (re-engage at the bottom). Same follow
+  // logic as the Omi conversation in BarChatSurface.
+  useLiveEdgeFollow(scrollRef, messagesRef)
 
   return (
     <div key={`agent-${pill.id}`} className="flex flex-col">

--- a/desktop/windows/src/renderer/src/components/bar/BarChatSurface.tsx
+++ b/desktop/windows/src/renderer/src/components/bar/BarChatSurface.tsx
@@ -7,6 +7,7 @@
 // window.omiBar.sendChat). This component owns NO chat engine.
 import { memo, useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 import { ChatMessages } from '../chat/ChatMessages'
+import { useLiveEdgeFollow } from '../../hooks/useLiveEdgeFollow'
 import { displayLabel, displayTintToken, isFinished, type AgentPill } from './agentPills'
 import { pillChipClasses } from './agentPillTranscript'
 import type { BarChatState } from '../../../../shared/types'
@@ -278,7 +279,6 @@ export function BarChatSurface(props: BarChatSurfaceProps): React.JSX.Element {
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const messagesRef = useRef<HTMLDivElement>(null)
-  const followRef = useRef(true)
   // Monotonic submit id — a refused send may only restore its text if it is still
   // the last thing the user asked (see submit()).
   const submitSeq = useRef(0)
@@ -313,33 +313,13 @@ export function BarChatSurface(props: BarChatSurfaceProps): React.JSX.Element {
   }, [props.draft, view])
 
   // Keep the list pinned to the live edge while streaming, but disengage when the
-  // reader scrolls up (re-engage on returning to the bottom).
+  // reader scrolls up (re-engage on returning to the bottom). Re-runs on
+  // `hasHistory` because the scroller only mounts once the thread has messages.
   const hasHistory = chat.messages.length > 0
-  useEffect(() => {
-    if (view !== 'conversation') return
-    const el = scrollRef.current
-    const content = messagesRef.current
-    if (!el || !content) return
-    const pin = (): void => {
-      if (followRef.current) el.scrollTop = el.scrollHeight
-    }
-    pin()
-    const ro = new ResizeObserver(pin)
-    ro.observe(content)
-    const onWheel = (e: WheelEvent): void => {
-      if (e.deltaY < 0 && el.scrollHeight > el.clientHeight + 8) followRef.current = false
-    }
-    const onScroll = (): void => {
-      if (el.scrollHeight - el.scrollTop - el.clientHeight <= 8) followRef.current = true
-    }
-    el.addEventListener('wheel', onWheel, { passive: true })
-    el.addEventListener('scroll', onScroll, { passive: true })
-    return () => {
-      ro.disconnect()
-      el.removeEventListener('wheel', onWheel)
-      el.removeEventListener('scroll', onScroll)
-    }
-  }, [hasHistory, view])
+  const { resumeFollow } = useLiveEdgeFollow(scrollRef, messagesRef, {
+    enabled: view === 'conversation',
+    resetKey: hasHistory
+  })
 
   // The single send path. Whether it navigates is DERIVED from the view: a hub
   // send (view 'list') opens the conversation — the ONLY moment the surface
@@ -353,7 +333,7 @@ export function BarChatSurface(props: BarChatSurfaceProps): React.JSX.Element {
     const text = p.draft.trim()
     if (!text) return
     p.setDraft('')
-    followRef.current = true
+    resumeFollow()
     // Flip to the conversation BEFORE awaiting the send so the reply streams into
     // the response state (always the shared Omi thread). A send refused by the
     // usage limit still lands here and surfaces its notice + restored text inline,
@@ -375,7 +355,7 @@ export function BarChatSurface(props: BarChatSurfaceProps): React.JSX.Element {
       if (!notice || seq !== submitSeq.current) return
       p.setDraft((current) => (current.trim() ? current : text))
     })
-  }, [])
+  }, [resumeFollow])
 
   // Textarea key handling, one stable handler per surface flavor. Both let PTT
   // claim Space first (hold-to-talk while focused) and send on Enter. The hub

--- a/desktop/windows/src/renderer/src/components/home/hub/HubChatPanel.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HubChatPanel.test.tsx
@@ -70,6 +70,33 @@ describe('HubChatPanel live-edge follow', () => {
     expect(el.scrollTop).toBe(200)
   })
 
+  // #10505: the reader dragged the scrollbar thumb / hit PageUp instead of using
+  // the wheel, and the next streamed chunk yanked them straight back down — the
+  // wheel-only release never fired, so the panel thought it was still following.
+  it('does NOT yank the reader back after a scroll up with no wheel (scrollbar drag, PageUp)', () => {
+    const el = renderPanel()
+    act(() => roCallback?.()) // following the stream at the live edge
+    // The reader drags up; the browser reports it as a plain scroll event.
+    el.scrollTop = 200
+    fireEvent.scroll(el)
+    act(() => roCallback?.())
+    expect(el.scrollTop).toBe(200)
+  })
+
+  it('keeps following when a shrinking thread clamps the viewport to the bottom', () => {
+    const el = renderPanel()
+    // Start pinned at the live edge, then the thread shrinks (switched/cleared
+    // chat): the browser clamps scrollTop DOWN, which must not read as the reader
+    // scrolling away — the viewport is still at the bottom.
+    act(() => roCallback?.())
+    Object.defineProperty(el, 'scrollHeight', { value: 400, configurable: true })
+    el.scrollTop = 100 // 400 - 100 - 300 = 0 -> still at the edge
+    fireEvent.scroll(el)
+    Object.defineProperty(el, 'scrollHeight', { value: 1000, configurable: true })
+    act(() => roCallback?.())
+    expect(el.scrollTop).toBe(1000)
+  })
+
   it('re-engages following once the reader returns to the live edge', () => {
     const el = renderPanel()
     fireEvent.wheel(el, { deltaY: -40 })

--- a/desktop/windows/src/renderer/src/components/home/hub/HubChatPanel.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HubChatPanel.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 import { ChatMessages } from '../../chat/ChatMessages'
+import { useLiveEdgeFollow } from '../../../hooks/useLiveEdgeFollow'
 import type { ChatMsg } from '../../../hooks/useChat'
 
 // The chat stage. It renders the app's ONE chat engine (useAppState().chat) through
@@ -21,37 +22,10 @@ export function HubChatPanel(props: {
   const { messages, sending, header, children } = props
   const scrollRef = useRef<HTMLDivElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
-  const followRef = useRef(true)
 
-  // Pin the live edge. RevealMarkdown grows the streaming reply's text WITHOUT a
-  // history change, so watching `messages` alone would lag the reveal by a chunk —
-  // observe the content box and re-pin on every size change (mirrors BarChatSurface).
-  // Only pin while following: disengage when the reader scrolls up so a streaming
-  // reply can't yank them back to the bottom, re-engage on returning to the edge.
-  useEffect(() => {
-    const content = contentRef.current
-    const el = scrollRef.current
-    if (!content || !el) return
-    const pin = (): void => {
-      if (followRef.current) el.scrollTop = el.scrollHeight
-    }
-    pin()
-    const ro = new ResizeObserver(pin)
-    ro.observe(content)
-    const onWheel = (e: WheelEvent): void => {
-      if (e.deltaY < 0 && el.scrollHeight > el.clientHeight + 8) followRef.current = false
-    }
-    const onScroll = (): void => {
-      if (el.scrollHeight - el.scrollTop - el.clientHeight <= 8) followRef.current = true
-    }
-    el.addEventListener('wheel', onWheel, { passive: true })
-    el.addEventListener('scroll', onScroll, { passive: true })
-    return () => {
-      ro.disconnect()
-      el.removeEventListener('wheel', onWheel)
-      el.removeEventListener('scroll', onScroll)
-    }
-  }, [])
+  // Pin the live edge while the reply streams, releasing as soon as the reader
+  // scrolls up to read earlier messages (shared with the bar surfaces).
+  useLiveEdgeFollow(scrollRef, contentRef)
 
   return (
     <div

--- a/desktop/windows/src/renderer/src/hooks/useLiveEdgeFollow.ts
+++ b/desktop/windows/src/renderer/src/hooks/useLiveEdgeFollow.ts
@@ -1,0 +1,94 @@
+import { useCallback, useLayoutEffect, useRef, type RefObject } from 'react'
+
+// Within this many px of the bottom counts as "at the live edge".
+const EDGE_PX = 8
+
+/**
+ * Pin a chat scroller to the live edge while the assistant streams, and let go the
+ * moment the reader scrolls away from it.
+ *
+ * RevealMarkdown grows the streaming reply's text WITHOUT a history change, so
+ * watching the message array alone lags the reveal by a chunk — this observes the
+ * content box and re-pins on every size change.
+ *
+ * Releasing follow is the part that has to be right. Watching `wheel` alone (what
+ * the three chat surfaces each did before) only catches the mouse wheel and the
+ * trackpad: dragging the scrollbar thumb, PageUp/Home/arrow keys and touch drags
+ * left `following` engaged, so the next streamed chunk yanked the reader straight
+ * back to the bottom and they could not read earlier messages during generation
+ * (#10505). So the release decision is made from the scroll POSITION instead:
+ * any upward movement is reader intent, whatever moved the viewport.
+ *
+ * Direction — rather than LegacyHome's is-this-scroll-programmatic flag — is what
+ * makes that safe under streaming. A pin only ever moves the viewport DOWN (to the
+ * max), and growing content does not move `scrollTop` at all, so neither can be
+ * mistaken for the reader scrolling up. A flag cleared on the next frame cannot
+ * make that distinction while the reply grows every frame: it would be set almost
+ * continuously and would swallow the very scrollbar drag this fixes.
+ *
+ * The `wheel` handler is kept for the one case position can't see yet: an upward
+ * wheel while already AT the bottom releases before the browser applies the delta,
+ * so the reader never sees a frame of yank.
+ */
+export function useLiveEdgeFollow(
+  scrollRef: RefObject<HTMLElement | null>,
+  contentRef: RefObject<HTMLElement | null>,
+  opts: { enabled?: boolean; resetKey?: unknown } = {}
+): { resumeFollow: () => void } {
+  const { enabled = true, resetKey } = opts
+  const followRef = useRef(true)
+  // Last position we know about, so a scroll event can be read as up or down.
+  const lastTopRef = useRef(0)
+
+  // Re-engage following on demand — the reader's own send is an explicit ask to
+  // be taken back to the live edge, wherever they had scrolled to.
+  const resumeFollow = useCallback((): void => {
+    followRef.current = true
+    const el = scrollRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+    lastTopRef.current = el.scrollTop
+  }, [scrollRef])
+
+  useLayoutEffect(() => {
+    if (!enabled) return
+    const el = scrollRef.current
+    const content = contentRef.current
+    if (!el || !content) return
+
+    lastTopRef.current = el.scrollTop
+    const pin = (): void => {
+      if (!followRef.current) return
+      el.scrollTop = el.scrollHeight
+      lastTopRef.current = el.scrollTop
+    }
+    pin()
+
+    const ro = new ResizeObserver(pin)
+    ro.observe(content)
+
+    const onWheel = (e: WheelEvent): void => {
+      if (e.deltaY < 0 && el.scrollHeight > el.clientHeight + EDGE_PX) followRef.current = false
+    }
+    const onScroll = (): void => {
+      const top = el.scrollTop
+      // >1px, so sub-pixel jitter on fractional-scale displays isn't a scroll up.
+      const movedUp = top < lastTopRef.current - 1
+      lastTopRef.current = top
+      // At the edge always follows — including when the viewport lands there
+      // because the thread SHRANK (a cleared or switched thread clamps scrollTop
+      // down, which looks like an upward scroll but leaves us at the bottom).
+      if (el.scrollHeight - top - el.clientHeight <= EDGE_PX) followRef.current = true
+      else if (movedUp) followRef.current = false
+    }
+    el.addEventListener('wheel', onWheel, { passive: true })
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      ro.disconnect()
+      el.removeEventListener('wheel', onWheel)
+      el.removeEventListener('scroll', onScroll)
+    }
+  }, [scrollRef, contentRef, enabled, resetKey])
+
+  return { resumeFollow }
+}


### PR DESCRIPTION
## What

Scrolling up to re-read earlier messages while the assistant is writing no longer snaps the desktop chat back to the bottom — for every way of scrolling, not just the wheel.

## Why

#10505 is still open. #10515 fixed the wheel case yesterday, and that is what shipped:

```ts
const onWheel = (e: WheelEvent): void => {
  if (e.deltaY < 0 && ...) followRef.current = false   // the ONLY release path
}
const onScroll = (): void => {
  if (atBottom) followRef.current = true               // only ever re-engages
}
```

A scrollbar-thumb drag, PageUp/Home/arrow keys or a touch drag moves the viewport with **no wheel event**, so `following` stays engaged and the next `ResizeObserver` pin re-pins the reader to the bottom. Those pins fire on every streamed chunk (`RevealMarkdown` grows the reply's text without a history change), so the reader is yanked back within a frame or two — the reported symptom, unchanged for anyone who doesn't scroll with a wheel.

Reproduced on current `main` in a real browser (numbers below): a scroll up to `top:120` mid-stream was back at the live edge 300 ms later.

Three surfaces each carried their own copy of this logic — `HubChatPanel` (Hub chat stage), `BarChatSurface` (bar conversation) and `AgentPillView` (agent pill transcript) — so the same defect existed three times.

## What changed

The three copies become one `useLiveEdgeFollow` hook that makes the release decision from the scroll **position**: any upward movement releases follow, whatever moved the viewport.

Direction — rather than LegacyHome's is-this-scroll-programmatic flag — is what keeps that safe while streaming. A pin only ever moves the viewport *down* (to the max), and growing content doesn't move `scrollTop` at all, so neither can be mistaken for the reader scrolling up. A flag cleared on the next frame can't make that distinction when the reply grows every frame: it would be set almost continuously and would swallow the very scrollbar drag this fixes. Landing back at the edge re-engages, including when a shrinking thread clamps the viewport there. The `wheel` handler stays for the one case position can't see yet — an upward wheel while already at the bottom releases before the browser applies the delta, so there's no frame of yank.

Net −88/+140 lines; three duplicate implementations down to one.

## Tested

**Real browser, real streaming.** A throwaway Vite harness (not committed) mounted the real `HubChatPanel` with a reply streaming in every 150 ms and drove it with Playwright — real layout, real scroll events, real `ResizeObserver`:

| step | `main` today (#10515) | this branch |
|---|---|---|
| streaming, untouched | pinned to the edge (`dist 0`) | pinned to the edge (`dist 0`) |
| **scroll up to `top:120`, no wheel** (scrollbar drag / PageUp) | **yanked to `658` in 300 ms, then `931`** | **held at `120`** while the thread grew to `909` |
| returned to the bottom | follows again | follows again |
| wheel up | releases | releases |

The screenshot taken at that held position shows the panel sitting on "Earlier question/answer 2-5" while the live reply keeps growing below — the reader can read back through the thread mid-generation.

**Unit.** `pnpm vitest run src/renderer/src/components/home/hub/HubChatPanel.test.tsx` → 5/5 pass. The new scrollbar-drag regression test fails against the pre-fix component (`expected 200, received 1000` — yanked to the live edge) and passes with the fix.

**Suite / static.** `pnpm vitest run src/renderer/src/components/bar src/renderer/src/components/home src/renderer/src/hooks` → 381 passed, with the same 12 pre-existing failures this sandbox shows on a clean tree (379 passed / 12 failed before the change; all in untouched files — `useHubStats`, `useChat`, `useMemories.coldStart`, `ConnectionsPanel` — failing on `localStorage`/module resolution because native postinstall was skipped here). `pnpm typecheck:web`, `pnpm eslint` on the touched files and `prettier --check` are clean.

**Not** exercised in the packaged Electron app — this machine can't run the Windows desktop build. The harness drives the same renderer component and the same hook in Chromium.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: new

Adds `FC-single-input-device-release`: a viewport that auto-follows live content must release on the reader's navigation intent from every input path the platform can deliver (wheel, scrollbar, keyboard, touch), not from one device's event type.

fixes #10505

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

