### PR TITLE
fix(listen): unblock the prod deploy + prefer Parakeet for batch transcription

### DIFF
--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -862,7 +862,7 @@ jobs:
           MCP_RESOURCE_URL: ${{ vars.MCP_RESOURCE_URL }}
           RAPID_API_HOST: ${{ vars.RAPID_API_HOST }}
           REDIS_DB_HOST: ${{ vars.REDIS_DB_HOST }}
-          STT_PRERECORDED_MODEL: modulate-velma-2,parakeet
+          STT_PRERECORDED_MODEL: parakeet,modulate-velma-2
           STT_SERVICE_MODELS: modulate-velma-2,parakeet
           SYNC_TASKS_HANDLER_URL: ${{ steps.account-deletion-target.outputs.sync_tasks_handler_url }}
           SYNC_TASKS_INVOKER_SA: ${{ steps.account-deletion-target.outputs.sync_tasks_invoker_sa }}

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -642,7 +642,7 @@ jobs:
           MCP_RESOURCE_URL: ${{ vars.MCP_RESOURCE_URL }}
           RAPID_API_HOST: ${{ vars.RAPID_API_HOST }}
           REDIS_DB_HOST: ${{ vars.REDIS_DB_HOST }}
-          STT_PRERECORDED_MODEL: modulate-velma-2,parakeet
+          STT_PRERECORDED_MODEL: parakeet,modulate-velma-2
           STT_SERVICE_MODELS: modulate-velma-2,parakeet
           TYPESENSE_HOST: ${{ vars.TYPESENSE_HOST }}
           TWILIO_ACCOUNT_SID: ${{ vars.TWILIO_ACCOUNT_SID }}

--- a/.github/workflows/gcp_backend_listen_helm.yml
+++ b/.github/workflows/gcp_backend_listen_helm.yml
@@ -151,6 +151,26 @@ jobs:
           echo "Deploying image tag ${RESOLVED_TAG} (currently ${RUNNING_TAG:-<none>})"
           echo "BACKEND_LISTEN_IMAGE_TAG=$RESOLVED_TAG" >> "$GITHUB_ENV"
 
+      - name: Carry forward config this workflow does not own
+        if: ${{ (github.event.inputs.mode || 'deploy') == 'deploy' }}
+        run: |
+          set -euo pipefail
+          # deploy-backend-config.sh requires these in prod, but only the full backend
+          # deploy derives them (from live Cloud Run state). This workflow refreshes the
+          # same shared ConfigMap, so read the current values back rather than dropping
+          # them or duplicating that derivation.
+          CM=${{ vars.ENV }}-omi-backend-config
+          NS=${{ vars.ENV }}-omi-backend
+          for key in ACCOUNT_DELETION_HANDLER_URL SYNC_TASKS_HANDLER_URL SYNC_TASKS_INVOKER_SA; do
+            value="$(kubectl -n "$NS" get configmap "$CM" -o jsonpath="{.data.$key}" 2>/dev/null || true)"
+            if [[ -z "$value" ]]; then
+              echo "ERROR: $key is absent from configmap $CM; run the full backend deploy first." >&2
+              exit 1
+            fi
+            echo "$key=$value" >> "$GITHUB_ENV"
+            echo "Carried $key"
+          done
+
       - name: Apply non-secret backend runtime config
         if: ${{ (github.event.inputs.mode || 'deploy') == 'deploy' }}
         env:
@@ -168,7 +188,10 @@ jobs:
           MCP_RESOURCE_URL: ${{ vars.MCP_RESOURCE_URL }}
           RAPID_API_HOST: ${{ vars.RAPID_API_HOST }}
           REDIS_DB_HOST: ${{ vars.REDIS_DB_HOST }}
-          STT_PRERECORDED_MODEL: modulate-velma-2,parakeet
+          ACCOUNT_DELETION_HANDLER_URL: ${{ env.ACCOUNT_DELETION_HANDLER_URL }}
+          SYNC_TASKS_HANDLER_URL: ${{ env.SYNC_TASKS_HANDLER_URL }}
+          SYNC_TASKS_INVOKER_SA: ${{ env.SYNC_TASKS_INVOKER_SA }}
+          STT_PRERECORDED_MODEL: parakeet,modulate-velma-2
           STT_SERVICE_MODELS: modulate-velma-2,parakeet
           TYPESENSE_HOST: ${{ vars.TYPESENSE_HOST }}
           TWILIO_ACCOUNT_SID: ${{ vars.TWILIO_ACCOUNT_SID }}

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -197,7 +197,7 @@ jobs:
           MCP_RESOURCE_URL: ${{ vars.MCP_RESOURCE_URL }}
           RAPID_API_HOST: ${{ vars.RAPID_API_HOST }}
           REDIS_DB_HOST: ${{ vars.REDIS_DB_HOST }}
-          STT_PRERECORDED_MODEL: modulate-velma-2,parakeet
+          STT_PRERECORDED_MODEL: parakeet,modulate-velma-2
           STT_SERVICE_MODELS: modulate-velma-2,parakeet
           SYNC_TASKS_HANDLER_URL: ${{ steps.pusher-runtime-targets.outputs.sync_tasks_handler_url }}
           SYNC_TASKS_INVOKER_SA: ${{ steps.pusher-runtime-targets.outputs.sync_tasks_invoker_sa }}

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -204,7 +204,7 @@ env:
   - name: HOSTED_PARAKEET_API_URL
     value: "http://parakeet.omiapi.com"
   - name: STT_PRERECORDED_MODEL
-    value: "modulate-velma-2,parakeet"
+    value: "parakeet,modulate-velma-2"
   - name: STT_SERVICE_MODELS
     value: "modulate-velma-2,parakeet"
   - name: NO_SOCKET_TIMEOUT

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -291,7 +291,7 @@ env:
   - name: HOSTED_PARAKEET_API_URL
     value: "http://parakeet.omi.me"
   - name: STT_PRERECORDED_MODEL
-    value: "modulate-velma-2,parakeet"
+    value: "parakeet,modulate-velma-2"
   - name: STT_SERVICE_MODELS
     value: "modulate-velma-2,parakeet"
   - name: HOSTED_TRANSLATION_API_URL

--- a/backend/config/stt_provider_policy.py
+++ b/backend/config/stt_provider_policy.py
@@ -129,7 +129,10 @@ PROVIDER_SERVING_SURFACES: Final[Mapping[str, frozenset[STTServingSurface]]] = {
 # serving pod instead of maintaining independent listener-local counters.
 DEFAULT_MODELS_BY_SURFACE: Final[Mapping[STTServingSurface, tuple[str, ...]]] = {
     STTServingSurface.STREAMING: ('modulate-velma-2', 'parakeet'),
-    STTServingSurface.PRERECORDED: ('modulate-velma-2', 'parakeet'),
+    # Batch work is queued, so Parakeet's bounded GPU means waiting rather than the
+    # user-visible failure it causes on the streaming surface. Prefer the self-hosted
+    # provider here and keep Velma as the overflow.
+    STTServingSurface.PRERECORDED: ('parakeet', 'modulate-velma-2'),
     STTServingSurface.PTT: ('modulate-velma-2', 'parakeet'),
 }
 

--- a/backend/tests/unit/test_backend_listen_helm_defaults.py
+++ b/backend/tests/unit/test_backend_listen_helm_defaults.py
@@ -27,7 +27,10 @@ ENV_IDENTITY_DEFAULTS = {
     },
 }
 
-SAFE_STT_ROUTE = 'modulate-velma-2,parakeet'
+SAFE_STREAMING_ROUTE = 'modulate-velma-2,parakeet'
+# Batch queues, so the bounded self-hosted GPU is preferred there; the streaming
+# surface must stay Velma-first because a Parakeet admission cap fails users live.
+SAFE_PRERECORDED_ROUTE = 'parakeet,modulate-velma-2'
 
 
 def _load_values(path: Path) -> dict:
@@ -105,11 +108,11 @@ def test_backend_listen_helm_template_requires_image_tag():
 def test_prod_values_make_modulate_the_explicit_live_stt_primary():
     values = _load_values(ENV_IDENTITY_DEFAULTS['prod']['values_file'])
 
-    assert _env_value(values, 'STT_SERVICE_MODELS') == SAFE_STT_ROUTE
-    assert _env_value(values, 'STT_PRERECORDED_MODEL') == SAFE_STT_ROUTE
+    assert _env_value(values, 'STT_SERVICE_MODELS') == SAFE_STREAMING_ROUTE
+    assert _env_value(values, 'STT_PRERECORDED_MODEL') == SAFE_PRERECORDED_ROUTE
 
 
-def test_rendered_prod_deployment_cannot_restore_parakeet_first_routing():
+def test_rendered_prod_deployment_cannot_restore_parakeet_first_streaming():
     helm = shutil.which('helm')
     if helm is None:
         pytest.skip('helm is not installed')
@@ -130,5 +133,8 @@ def test_rendered_prod_deployment_cannot_restore_parakeet_first_routing():
         text=True,
     ).stdout
 
-    assert f'name: STT_SERVICE_MODELS\n              value: "{SAFE_STT_ROUTE}"' in rendered
-    assert 'value: "parakeet,modulate-velma-2"' not in rendered
+    assert f'name: STT_SERVICE_MODELS\n              value: "{SAFE_STREAMING_ROUTE}"' in rendered
+    # Scoped to the streaming key: the same literal is the intended batch route, so a
+    # blanket check would forbid the pre-recorded default as collateral.
+    assert f'name: STT_SERVICE_MODELS\n              value: "{SAFE_PRERECORDED_ROUTE}"' not in rendered
+    assert f'name: STT_PRERECORDED_MODEL\n              value: "{SAFE_PRERECORDED_ROUTE}"' in rendered

--- a/backend/tests/unit/test_modulate_stt.py
+++ b/backend/tests/unit/test_modulate_stt.py
@@ -1366,12 +1366,12 @@ class TestLanguageRoutingExtended(unittest.TestCase):
 
 class TestPrerecordedServiceRouting(unittest.TestCase):
     @patch('utils.stt.pre_recorded.get_prerecorded_models', new=lambda: ('dg-nova-3',))
-    def test_retired_model_routes_to_modulate_default(self):
+    def test_retired_model_routes_to_policy_default(self):
         from utils.stt.pre_recorded import PrerecordedSTTService, get_prerecorded_service
 
         svc, lang, model = get_prerecorded_service('en')
-        self.assertEqual(svc, PrerecordedSTTService.MODULATE)
-        self.assertEqual(model, 'velma-2')
+        self.assertEqual(svc, PrerecordedSTTService.PARAKEET)
+        self.assertEqual(model, 'parakeet')
 
     @patch('utils.stt.pre_recorded.get_prerecorded_models', new=lambda: ('modulate-velma-2',))
     def test_modulate_routes_correctly(self):
@@ -1391,12 +1391,12 @@ class TestPrerecordedServiceRouting(unittest.TestCase):
         self.assertEqual(lang, 'pt')
 
     @patch('utils.stt.pre_recorded.get_prerecorded_models', new=lambda: ('dg-nova-2',))
-    def test_custom_retired_model_routes_to_modulate_default(self):
+    def test_custom_retired_model_routes_to_policy_default(self):
         from utils.stt.pre_recorded import PrerecordedSTTService, get_prerecorded_service
 
         svc, lang, model = get_prerecorded_service('en')
-        self.assertEqual(svc, PrerecordedSTTService.MODULATE)
-        self.assertEqual(model, 'velma-2')
+        self.assertEqual(svc, PrerecordedSTTService.PARAKEET)
+        self.assertEqual(model, 'parakeet')
 
     @patch('utils.stt.pre_recorded.get_prerecorded_models', new=lambda: ('dg-nova-3',))
     def test_multi_language_falls_through_to_parakeet_capability(self):
@@ -1409,18 +1409,18 @@ class TestPrerecordedServiceRouting(unittest.TestCase):
 
 class TestPrerecordedProviderFactory(unittest.TestCase):
     @patch('utils.stt.pre_recorded.get_prerecorded_models', new=lambda: ('dg-nova-3',))
-    def test_factory_returns_modulate_for_retired_model(self):
-        from utils.stt.pre_recorded import ModulatePrerecordedProvider, get_prerecorded_provider
+    def test_factory_returns_policy_default_for_retired_model(self):
+        from utils.stt.pre_recorded import ParakeetPrerecordedProvider, get_prerecorded_provider
 
         provider = get_prerecorded_provider()
-        self.assertIsInstance(provider, ModulatePrerecordedProvider)
+        self.assertIsInstance(provider, ParakeetPrerecordedProvider)
 
     @patch('utils.stt.pre_recorded.get_prerecorded_models', new=lambda: ('dg-nova-2',))
     def test_factory_ignores_custom_retired_model(self):
-        from utils.stt.pre_recorded import ModulatePrerecordedProvider, get_prerecorded_provider
+        from utils.stt.pre_recorded import ParakeetPrerecordedProvider, get_prerecorded_provider
 
         provider = get_prerecorded_provider()
-        self.assertIsInstance(provider, ModulatePrerecordedProvider)
+        self.assertIsInstance(provider, ParakeetPrerecordedProvider)
 
     @patch('utils.stt.pre_recorded.get_prerecorded_models', new=lambda: ('modulate-velma-2',))
     def test_factory_returns_modulate(self):


### PR DESCRIPTION
Two things, both needed before the prod `backend-listen` deploy can succeed with the intended config.

## 1. The prod dispatch failed before touching anything

```
Missing required non-secret deployment variables:
  ACCOUNT_DELETION_HANDLER_URL SYNC_TASKS_HANDLER_URL SYNC_TASKS_INVOKER_SA
```

`deploy-backend-config.sh` requires those three **only when `ENVIRONMENT` is prod**, and only the full backend deploy derives them — at runtime, from live Cloud Run state. This workflow has only ever run against dev, where they are not required, so the gap stayed invisible until the first prod dispatch.

The values already exist in the shared `prod-omi-backend-config` ConfigMap that this workflow rewrites. It now reads them back and passes them through, rather than duplicating that derivation or dropping keys the script then rejects. Fails with a clear pointer if they are absent.

Nothing was mutated by the failed run — it exits before the config write. `backend-listen` is unchanged and healthy.

## 2. Batch transcription prefers Parakeet; live streaming stays Velma-first

Batch work is queued, so Parakeet's bounded GPU means **waiting**. On the streaming surface the same cap is a user-visible failure — that is what caused the 18th outage. Different surfaces, different correct answer.

`STT_PRERECORDED_MODEL` → `parakeet,modulate-velma-2`; `STT_SERVICE_MODELS` stays `modulate-velma-2,parakeet`.

The policy is the source of truth here: deployment values are validated to equal `canonical_model_config(...)`, so editing the workflows alone would have failed the gate. `DEFAULT_MODELS_BY_SURFACE[PRERECORDED]` moves, and the four deployment workflows plus both chart value files follow it.

### The guard this touches

`test_rendered_prod_deployment_cannot_restore_parakeet_first_routing` (added 07-20, "make the deployed Modulate-first route deterministic") asserted the literal `parakeet,modulate-velma-2` appeared **nowhere** in the rendered prod chart.

Its stated purpose is Parakeet live-stream admission, but the blanket string check also forbade that ordering for pre-recorded — collateral, since the two surfaces share the literal. Now scoped to `STT_SERVICE_MODELS`, renamed `..._cannot_restore_parakeet_first_streaming`, with the batch ordering asserted **positively** so neither surface can drift silently. The streaming protection is unchanged.

Four `test_modulate_stt` cases asserted a retired `dg-*` token falls back to *Modulate*. The point of those tests is that a retired token never selects Deepgram; the survivor is whatever the policy default is, now Parakeet for pre-recorded. Renamed to `..._routes_to_policy_default` and updated.

## Worth knowing

The `parakeet,modulate-velma-2` currently on `backend-listen` is **stale pre-07-20 config**, preserved only because that service has not been deployed since. It is not evidence of a current decision — this PR makes it the deliberate one.

Cloud Run `backend-sync` / `backend-sync-backfill` are on `modulate-velma-2,parakeet` today, so offline sync will move to Parakeet-first on their next deploy.

## Verification

197 passed across the STT and helm-defaults suites. Full CI gate set on the committed diff: **29/29 PASS**, including `backend-workflow-contracts`, `gcp-backend-production-boundary`, `deployment-secret-boundary`, `backend-route-policy-baseline`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

