### PR TITLE
fix(deploy): move pre-recorded ordering in the runtime env manifest + pusher charts

### DIFF
--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -247,7 +247,7 @@ env:
   - name: HOSTED_PARAKEET_API_URL
     value: "http://parakeet.omiapi.com"
   - name: STT_PRERECORDED_MODEL
-    value: "modulate-velma-2,parakeet"
+    value: "parakeet,modulate-velma-2"
   - name: STT_SERVICE_MODELS
     value: "modulate-velma-2,parakeet"
   - name: BASIC_TIER_MINUTES_LIMIT_PER_MONTH

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -256,7 +256,7 @@ env:
   - name: HOSTED_PARAKEET_API_URL
     value: "http://parakeet.omi.me"
   - name: STT_PRERECORDED_MODEL
-    value: "modulate-velma-2,parakeet"
+    value: "parakeet,modulate-velma-2"
   - name: STT_SERVICE_MODELS
     value: "modulate-velma-2,parakeet"
   - name: RAPID_API_KEY

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -32,7 +32,7 @@ environments:
             value: dev
             category: runtime_identity
           STT_PRERECORDED_MODEL:
-            value: modulate-velma-2,parakeet
+            value: parakeet,modulate-velma-2
             category: stt_policy
           GOOGLE_CLIENT_ID:
             config_map:
@@ -225,7 +225,7 @@ environments:
             value: http://parakeet.omiapi.com
             category: service_discovery
           STT_PRERECORDED_MODEL:
-            value: modulate-velma-2,parakeet
+            value: parakeet,modulate-velma-2
             category: stt_policy
           STT_SERVICE_MODELS:
             value: modulate-velma-2,parakeet
@@ -317,7 +317,7 @@ environments:
               env_var: GOOGLE_CLIENT_ID
               category: oauth_metadata
             STT_PRERECORDED_MODEL:
-              value: modulate-velma-2,parakeet
+              value: parakeet,modulate-velma-2
               category: stt_policy
             # Dev Cloud Run must stay within the dev Parakeet topology; never point this at
             # the production-only parakeet.omi.me endpoint.
@@ -454,7 +454,7 @@ environments:
               env_var: GOOGLE_CLIENT_ID
               category: oauth_metadata
             STT_PRERECORDED_MODEL:
-              value: modulate-velma-2,parakeet
+              value: parakeet,modulate-velma-2
               category: stt_policy
             HOSTED_PARAKEET_API_URL:
               value: http://parakeet.omiapi.com
@@ -558,7 +558,7 @@ environments:
               env_var: GOOGLE_CLIENT_ID
               category: oauth_metadata
             STT_PRERECORDED_MODEL:
-              value: modulate-velma-2,parakeet
+              value: parakeet,modulate-velma-2
               category: stt_policy
             HOSTED_PARAKEET_API_URL:
               value: http://parakeet.omiapi.com
@@ -780,7 +780,7 @@ environments:
             value: prod
             category: runtime_identity
           STT_PRERECORDED_MODEL:
-            value: modulate-velma-2,parakeet
+            value: parakeet,modulate-velma-2
             category: stt_policy
           GOOGLE_CLIENT_ID:
             config_map:
@@ -1013,7 +1013,7 @@ environments:
             STRIPE_UNLIMITED_V2_ANNUAL_PRICE_ID:
               value: price_1TuIap1F8wnoWYvwHWq0EvNU
             STT_PRERECORDED_MODEL:
-              value: modulate-velma-2,parakeet
+              value: parakeet,modulate-velma-2
               category: stt_policy
             HOSTED_PARAKEET_API_URL:
               value: http://parakeet.omi.me
@@ -1177,7 +1177,7 @@ environments:
               env_var: GOOGLE_CLIENT_ID
               category: oauth_metadata
             STT_PRERECORDED_MODEL:
-              value: modulate-velma-2,parakeet
+              value: parakeet,modulate-velma-2
               category: stt_policy
             HOSTED_PARAKEET_API_URL:
               value: http://parakeet.omi.me
@@ -1278,7 +1278,7 @@ environments:
               env_var: GOOGLE_CLIENT_ID
               category: oauth_metadata
             STT_PRERECORDED_MODEL:
-              value: modulate-velma-2,parakeet
+              value: parakeet,modulate-velma-2
               category: stt_policy
             HOSTED_PARAKEET_API_URL:
               value: http://parakeet.omi.me


### PR DESCRIPTION
#10564 changed the policy default, both backend-listen charts and the four deploy workflows — but missed `backend/deploy/runtime_env.yaml`, which declares the expected env per service, and the two pusher chart value files. The prod deploy failed its validation gate on every surface:

```
ERROR [prod/gke/backend-listen]:            expected 'parakeet,modulate-velma-2', got 'modulate-velma-2,parakeet'
ERROR [prod/cloud_run/backend]:             …
ERROR [prod/cloud_run/backend-sync]:        …
ERROR [prod/cloud_run/backend-sync-backfill]: …
ERROR [prod/cloud_run/backend-integration]: …
```

All nine `runtime_env.yaml` entries move, plus `prod_omi_pusher_values.yaml` and `dev_omi_pusher_values.yaml`. `STT_SERVICE_MODELS` is untouched — streaming stays Velma-first.

## Verification

Ran the validator that failed, rather than inferring:

```
$ python3 backend/scripts/validate-backend-runtime-env.py --env prod --check-workflows
backend runtime env validation passed for prod
$ python3 backend/scripts/validate-backend-runtime-env.py --env dev --check-workflows
backend runtime env validation passed for dev
```

Swept every `.yaml`/`.yml` for a remaining velma-first pre-recorded value; the only hits are `STT_SERVICE_MODELS` on adjacent lines, which is correct.

CI gate set green.

## Why #10564 missed it

My search for config sources was piped through `head -12` and I treated the truncated output as the complete list. `runtime_env.yaml` and the pusher charts were below the cut. The validator existed precisely to catch this and did — after a failed prod deploy rather than before one.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

