### PR TITLE
fix(desktop-windows): sync the Tasks keyboard ref during the commit, not after it

### DIFF
--- a/desktop/windows/src/renderer/src/components/settings/tabs/NotificationsTab.test.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/NotificationsTab.test.tsx
@@ -24,11 +24,15 @@ import type { AssistantSettingsView } from '../../../../../shared/types'
 // (the MutationObserver still resolves the instant the DOM updates, so passing
 // tests aren't slowed) and restore it after the file so it can't bleed into
 // suites sharing the worker.
+// The test timeout is captured when `it()` registers, i.e. during collection of this
+// module, so it must be raised here at module scope — inside beforeAll it is a no-op
+// and each test keeps the 5000ms default, which fires before the asyncUtilTimeout
+// below can report the DOM it was waiting on.
+vi.setConfig({ testTimeout: 15000 })
 let prevAsyncUtilTimeout = 1000
 beforeAll(() => {
   prevAsyncUtilTimeout = getConfig().asyncUtilTimeout
   configure({ asyncUtilTimeout: 5000 })
-  vi.setConfig({ testTimeout: 15000 })
 })
 afterAll(() => {
   configure({ asyncUtilTimeout: prevAsyncUtilTimeout })

--- a/desktop/windows/src/renderer/src/pages/Memories.editDelete.test.tsx
+++ b/desktop/windows/src/renderer/src/pages/Memories.editDelete.test.tsx
@@ -22,11 +22,15 @@ import type { Memory } from '../hooks/useMemories'
 // tests. Give the async utils headroom (the MutationObserver still resolves the
 // instant the DOM updates, so passing tests aren't slowed); restored after the
 // file so it can't bleed into suites sharing the worker.
+// The test timeout is captured when `it()` registers, i.e. during collection of this
+// module, so it must be raised here at module scope — inside beforeAll it is a no-op
+// and each test keeps the 5000ms default, which fires before the asyncUtilTimeout
+// below can report the DOM it was waiting on.
+vi.setConfig({ testTimeout: 15000 })
 let prevAsyncUtilTimeout = 1000
 beforeAll(() => {
   prevAsyncUtilTimeout = getConfig().asyncUtilTimeout
   configure({ asyncUtilTimeout: 5000 })
-  vi.setConfig({ testTimeout: 15000 })
 })
 afterAll(() => {
   configure({ asyncUtilTimeout: prevAsyncUtilTimeout })

--- a/desktop/windows/src/renderer/src/pages/Tasks.test.tsx
+++ b/desktop/windows/src/renderer/src/pages/Tasks.test.tsx
@@ -24,11 +24,15 @@ import type { ActionItemRecord } from '../../../shared/types'
 // async utils generous headroom; the MutationObserver still resolves them the
 // instant the DOM changes, so passing tests are never slowed. Restored after the
 // file so the raised ceiling can't bleed into other suites sharing the worker.
+// vitest captures each test's timeout when `it()` registers it, i.e. while this
+// module is collected — before any hook runs — so the raise has to happen here at
+// module scope. From inside beforeAll it is a no-op and every test keeps the 5000ms
+// default, which then fires *before* the 5000ms asyncUtilTimeout below can report.
+vi.setConfig({ testTimeout: 15000 })
 let prevAsyncUtilTimeout = 1000
 beforeAll(() => {
   prevAsyncUtilTimeout = getConfig().asyncUtilTimeout
   configure({ asyncUtilTimeout: 5000 })
-  vi.setConfig({ testTimeout: 15000 })
 })
 afterAll(() => {
   configure({ asyncUtilTimeout: prevAsyncUtilTimeout })
@@ -341,6 +345,29 @@ describe('Tasks — keyboard navigation (mac parity, flat list)', () => {
   const selectedText = (): string | null =>
     document.querySelector('[data-selected="true"]')?.textContent ?? null
 
+  // Regression: the document keydown handler reads the list through a ref. While that
+  // ref was synced in a passive effect (a task scheduled *after* the commit), a key
+  // pressed in the window between the rows appearing and that effect running was
+  // handled against the previous, empty navOrder and silently did nothing. The
+  // MutationObserver callback below is a microtask on the commit that paints the
+  // rows, so it lands squarely inside that window — deterministically, not by luck.
+  it('a key pressed the instant the rows paint still drives the list', async () => {
+    incomplete = twoRows()
+    await renderTasks()
+
+    await new Promise<void>((resolve) => {
+      const obs = new MutationObserver(() => {
+        if (!screen.queryByText('first')) return
+        obs.disconnect()
+        fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+        resolve()
+      })
+      obs.observe(document.body, { childList: true, subtree: true })
+    })
+
+    await waitFor(() => expect(selectedText()).toContain('first'))
+  })
+
   it('Down selects the first row, Down again moves to the second; Up moves back', async () => {
     incomplete = twoRows()
     await renderTasks()
@@ -520,23 +547,19 @@ describe('Tasks — keyboard navigation (mac parity, flat list)', () => {
     expect(evt.defaultPrevented).toBe(false)
   })
 
-  it(
-    'Esc with a selection deselects and preventDefault (consumes it)',
-    async () => {
-      incomplete = twoRows()
-      await renderTasks()
-      await waitFor(() => expect(screen.queryByText('first')).not.toBeNull())
+  it('Esc with a selection deselects and preventDefault (consumes it)', async () => {
+    incomplete = twoRows()
+    await renderTasks()
+    await waitFor(() => expect(screen.queryByText('first')).not.toBeNull())
 
-      fireEvent.keyDown(document.body, { key: 'ArrowDown' })
-      await waitFor(() => expect(selectedText()).toContain('first'))
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+    await waitFor(() => expect(selectedText()).toContain('first'))
 
-      const evt = createEvent.keyDown(document.body, { key: 'Escape' })
-      fireEvent(document.body, evt)
-      expect(evt.defaultPrevented).toBe(true)
-      await waitFor(() => expect(selectedText()).toBeNull())
-    },
-    15_000
-  )
+    const evt = createEvent.keyDown(document.body, { key: 'Escape' })
+    fireEvent(document.body, evt)
+    expect(evt.defaultPrevented).toBe(true)
+    await waitFor(() => expect(selectedText()).toBeNull())
+  })
 
   it('Ctrl+D on the last row moves selection to the previous row', async () => {
     incomplete = twoRows()

--- a/desktop/windows/src/renderer/src/pages/Tasks.tsx
+++ b/desktop/windows/src/renderer/src/pages/Tasks.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { ListChecks, Check, RefreshCw, Plus, Trash2, Calendar, X, Loader2 } from 'lucide-react'
 import { omiApi } from '../lib/apiClient'
@@ -377,7 +377,11 @@ export function Tasks(): React.JSX.Element {
   }
 
   // Latest values the document keydown handler reads. Kept in a ref so the listener
-  // registers once (no add/remove churn) yet never sees a stale closure.
+  // registers once (no add/remove churn) yet never sees a stale closure. The sync
+  // runs in a *layout* effect: a passive effect is scheduled after the commit, so a
+  // key pressed in the window between "the reloaded rows are on screen" and "the
+  // passive effect ran" would be handled against the previous navOrder — an
+  // arrow/Ctrl+D that silently does nothing right after the list refreshes.
   const kbd = useRef({
     navOrder,
     selectedId: keyboardSelectedTaskId,
@@ -388,7 +392,7 @@ export function Tasks(): React.JSX.Element {
     deleteItem,
     startEdit
   })
-  useEffect(() => {
+  useLayoutEffect(() => {
     kbd.current = {
       navOrder,
       selectedId: keyboardSelectedTaskId,


### PR DESCRIPTION
## What

An arrow key or Ctrl+D pressed in the moment a refreshed task list paints no longer does nothing — and `Desktop Windows CI` stops going red on the Tasks keyboard-nav suite.

## Why

`Tasks.tsx` keeps the values its document-level keydown handler reads in a ref, and synced that ref in a **passive** effect — a task React schedules *after* the commit that puts the rows on screen. A key pressed in that window is handled against the previous `navOrder` (empty right after a load), so the handler bails and the keystroke is dropped silently. A layout effect publishes the ref inside the commit, so the handler can never see a list older than the DOM.

That same window is what reddens main: the keyboard-nav tests fire `ArrowDown` as soon as the rows appear, sometimes land inside it, and then wait for a selection that never comes — the `Test timed out in 5000ms` failure on main ([run 30163470503](https://github.com/BasedHardware/omi/actions/runs/30163470503), `Tasks.test.tsx > Ctrl+D deletes the selected row and moves selection to the neighbour`).

The regression test reproduces the window **deterministically** rather than by luck: it dispatches `ArrowDown` from a `MutationObserver` callback — a microtask on the commit that paints the rows, which always precedes React's passive-effect task.

**Second defect, same flake.** The three suites that raise their own ceilings called `vi.setConfig({ testTimeout: 15000 })` inside `beforeAll`. vitest captures a test's timeout when `it()` registers it — during collection, before any hook runs — so the raise was a no-op and every test kept the 5000ms default, exactly equal to the `asyncUtilTimeout` those same files set. A slow wait therefore died on vitest's bare timeout instead of testing-library's DOM dump, which is why CI reported a timeout with no clue in it. The call moves to module scope, where it applies; the one-off `15_000` argument added for the Esc test in `3fef34b50a` is redundant now and goes away.

## Verification (`desktop/windows`, node 22.23.1 — the version CI uses)

- `npx vitest run src/renderer/src/pages/Tasks.test.tsx -t "instant the rows paint"` — passes with the fix; **fails** (5.2s, the selection never arrives) with only `Tasks.tsx` reverted. The test catches the bug it is named for.
- The timeout no-op, proven by A/B: a 6s test appended to this suite times out at 5000ms on the `HEAD` copy of the file and passes on the fixed copy.
- 40× `npx vitest run .../Tasks.test.tsx` with 8 cores kept busy: **0 failures**. The same loop on `HEAD`: 1 failure in 20, mode `Test timed out in 5000ms` — the CI symptom reproduced locally.
- Full renderer suite (`npx vitest run`): 523 files, 5037 tests, 0 failures.
- `pnpm typecheck` clean; `eslint` on the four changed files clean.
- **Not exercised in the running app:** `pnpm dev` boots the dev instance, but it stops at the sign-in screen and this non-interactive session cannot complete the Google OAuth. The keypress was verified through the real component and its real document-level listener, not through a signed-in window.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

