### PR TITLE
fix(ci): give the preflight HTTP-error mocks a body so the contract suite runs on macOS Python 3.9 (#10565)

### DIFF
--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -32,6 +32,15 @@ class FakeResponse(io.BytesIO):
         self.close()
 
 
+def http_error(code: int, message: str) -> urllib.error.HTTPError:
+    # An HTTPError raised by urllib always carries the response body, and the loader
+    # closes it. On Python 3.9 — the macOS system interpreter `python3` resolves to,
+    # and the one pre-push runs this suite with — HTTPError inherits the tempfile-based
+    # addinfourl, whose close() raises KeyError('file') when it was built without one.
+    # An fp-less mock therefore fails on a path production never takes.
+    return urllib.error.HTTPError("url", code, message, None, io.BytesIO(b""))  # type: ignore[arg-type]
+
+
 class MetadataTests(unittest.TestCase):
     def setUp(self) -> None:
         # `resolve_pr_metadata` short-circuits on OMI_PR_BODY_FILE before it ever
@@ -72,7 +81,7 @@ class MetadataTests(unittest.TestCase):
     def test_api_loader_retries_transient_failures_then_succeeds(self) -> None:
         payload = json.dumps({"number": 9847, "body": "ok", "updated_at": "u", "labels": []}).encode()
         outcomes: list[object] = [
-            urllib.error.HTTPError("url", 502, "bad gateway", None, None),  # type: ignore[arg-type]
+            http_error(502, "bad gateway"),
             TimeoutError("timed out"),
             FakeResponse(payload),
         ]
@@ -93,7 +102,7 @@ class MetadataTests(unittest.TestCase):
 
         def opener(request: object, timeout: int) -> FakeResponse:
             calls["count"] += 1
-            raise urllib.error.HTTPError("url", 404, "not found", None, None)  # type: ignore[arg-type]
+            raise http_error(404, "not found")
 
         with self.assertRaisesRegex(RuntimeError, "HTTP 404") as raised:
             load_from_api("BasedHardware/omi", 9847, "test-token", opener=opener, sleeper=lambda _: None)


### PR DESCRIPTION
## What

`pr-preflight-contract-tests` — the check every PR's check-selection depends on — stops failing on the interpreter `pre-push` actually runs it with. 21/21 pass on macOS system Python 3.9.6 as well as 3.11/3.12.

Fixes #10565.

## Why

`.github/checks-manifest.yaml` registers the suite as `python3 .github/scripts/test_pr_preflight.py`. On a stock Mac that `python3` is 3.9.6, where `urllib.error.HTTPError` still inherits the **tempfile-based** `addinfourl`: `close()` reaches `self._closer` and raises `KeyError('file')` when the error was constructed without a body. In 3.10+ `addinfourl` no longer uses `tempfile`, so the same call is harmless.

Two cases mocked urlopen failures as `HTTPError("url", code, msg, None, None)` — `fp=None`. `pr_metadata.load_from_api` closes the error body (`exc.close()`, `pr_metadata.py:103`), so both tests died inside the loader with `KeyError: 'file'` before reaching a single assertion about retry behavior. A real `urlopen` failure always carries the body, so this was purely an artifact of the mock, not a defect the loader can hit in production.

The interpreter split is why it went unnoticed: CI runners are 3.11+, so the lane stayed green while every developer on stock macOS Python got two red errors at push time (reported against PR #10530). The mocks now carry `io.BytesIO(b"")`, matching real urllib, which makes the suite interpreter-agnostic rather than pinning a lane to one Python.

Test-only change; no production code touched.

## Verification (run in this worktree)

A/B on the same file, both interpreters:

| | 3.9.6 (`/usr/bin/python3`, what pre-push uses) | 3.11.15 (pinned `backend/.venv`) | 3.12 |
|---|---|---|---|
| `HEAD` (before) | **FAILED (errors=2)** — `KeyError: 'file'` | OK 21/21 | — |
| this branch | **OK 21/21** | OK 21/21 | OK 21/21 |

- Before-state reproduced from `git show HEAD:.github/scripts/test_pr_preflight.py`, run as a sibling file so both versions saw the identical `pr_metadata.py` — the failure follows the test file, not the environment.
- The two repaired cases still assert what they are named for: `test_api_loader_retries_transient_failures_then_succeeds` (502 → timeout → success, `sleeps == [2.0, 4.0]`) and `test_api_loader_does_not_retry_permanent_http_errors` (404, single call, `RuntimeError("HTTP 404")` with the `HTTPError` cause) — both now reach those assertions instead of erroring in the loader.
- `scripts/pr-preflight --pr-body-file` (the same `.github/checks-manifest.yaml` CI runs): **11/11 checks passed in 7.14s**, `pr-preflight-contract-tests` among them — under the 3.9.6 `python3` that reddened it before.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

