### PR TITLE
fix(android): make BLE reconnect and CV1/Limitless backlog recovery transactional

### DIFF
--- a/app/android/app/src/main/kotlin/com/friend/ios/batch/BaseBatchAudioWriter.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/batch/BaseBatchAudioWriter.kt
@@ -143,6 +143,25 @@ abstract class BaseBatchAudioWriter(
         }
     }
 
+    protected fun checkpointLocked(): Pair<Long, Long> = currentBytes to currentFrames
+
+    protected fun currentFilePathLocked(): String? = currentFile?.absolutePath
+
+    protected fun rollbackLocked(checkpoint: Pair<Long, Long>): Boolean {
+        val out = raf ?: return false
+        return try {
+            out.setLength(checkpoint.first)
+            out.seek(checkpoint.first)
+            currentBytes = checkpoint.first
+            currentFrames = checkpoint.second
+            out.fd.sync()
+            true
+        } catch (e: Exception) {
+            Log.w(tag, "rollback failed: ${e.message}")
+            false
+        }
+    }
+
     protected fun maybeFsyncLocked(nowMs: Long) {
         if (nowMs - lastFsyncMs >= FSYNC_INTERVAL_MS) {
             fsyncLocked()

--- a/app/android/app/src/main/kotlin/com/friend/ios/batch/LimitlessBatchAudioWriter.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/batch/LimitlessBatchAudioWriter.kt
@@ -1,9 +1,12 @@
 package com.friend.ios.batch
 
 import com.friend.ios.ble.OmiBleManager
+import com.friend.ios.limitless.LimitlessPageDeduplicator
 
 import android.content.Context
 import java.io.File
+import java.io.RandomAccessFile
+import java.util.Locale
 import kotlin.math.abs
 
 /**
@@ -23,9 +26,10 @@ import kotlin.math.abs
  *    recordings scanner matching, and the `limitless` substring makes the backend tag
  *    the resulting conversation `source=limitless`.
  *
- * ACK safety: the drain engine must call [sync] (fsync barrier) and get `true` back
- * BEFORE ACKing pages to the pendant — an ACK deletes the pendant's copy, so bytes
- * must be durable on phone storage first. [append] itself only fsyncs periodically.
+ * ACK safety: each page append fsyncs its audio and synchronously persists a
+ * per-device/session page watermark. A redrain after an ambiguous ACK therefore
+ * recognizes the durable page instead of appending it twice. The drain engine also
+ * calls [sync] before sending the cumulative pendant-deletion ACK.
  */
 class LimitlessBatchAudioWriter(context: Context) : BaseBatchAudioWriter(context, TAG, "audio_${DEVICE_MARKER}_") {
     companion object {
@@ -35,6 +39,8 @@ class LimitlessBatchAudioWriter(context: Context) : BaseBatchAudioWriter(context
         private const val MAX_AUDIO_SECONDS = 900L // 15 min of audio per file
         private const val FRAMES_PER_SECOND = 50L // opus_fs320 = 20 ms frames
         private const val MIN_VALID_TS_MS = 1_577_836_800_000L // 2020-01-01: pendant clock sanity gate
+        private const val PENDING_PATH_KEY = "limitlessPendingAppend.path"
+        private const val PENDING_OFFSET_KEY = "limitlessPendingAppend.offset"
     }
 
     private var lastPageTimestampMs: Long = 0
@@ -42,13 +48,33 @@ class LimitlessBatchAudioWriter(context: Context) : BaseBatchAudioWriter(context
     /**
      * Append the opus frames extracted from one flash page. [pageTimestampMs] is the
      * pendant-clock capture time of that page. Returns true once the frames are
-     * written (durability requires a subsequent [sync] before ACK).
+     * written and its durable identity is committed.
      */
-    fun append(frames: List<ByteArray>, pageTimestampMs: Long): Boolean {
+    fun append(
+        deviceId: String,
+        pageIndex: Int,
+        session: Int,
+        frames: List<ByteArray>,
+        pageTimestampMs: Long,
+    ): Boolean {
         if (frames.isEmpty()) return true
         val now = System.currentTimeMillis()
 
         synchronized(lock) {
+            if (!recoverPendingAppendLocked()) return false
+            val watermarkKey = pageWatermarkKey(deviceId, session)
+            val deduplicator = LimitlessPageDeduplicator(
+                readWatermark = { prefs().getInt(it, Int.MIN_VALUE) },
+                writeWatermark = { key, value ->
+                    prefs().edit()
+                        .putInt(key, value)
+                        .remove(PENDING_PATH_KEY)
+                        .remove(PENDING_OFFSET_KEY)
+                        .commit()
+                },
+            )
+            if (deduplicator.isDurable(watermarkKey, pageIndex)) return true
+
             // Pendant clock sanity: pages recorded before the first msg6 time-sync carry
             // a bogus epoch. Inside an open session inherit the last valid timestamp so a
             // bogus page can't fake a session gap; otherwise fall back to drain wall-clock.
@@ -76,12 +102,53 @@ class LimitlessBatchAudioWriter(context: Context) : BaseBatchAudioWriter(context
                 if (!openLocked(dir, name, startSec, now)) return false // storage full or open failed
             }
 
-            if (!writeFramesLocked(frames)) return false
+            val checkpoint = checkpointLocked()
+            val path = currentFilePathLocked() ?: return false
+            if (!prefs().edit()
+                    .putString(PENDING_PATH_KEY, path)
+                    .putLong(PENDING_OFFSET_KEY, checkpoint.first)
+                    .commit()
+            ) {
+                return false
+            }
+            val appended = deduplicator.appendOnce(
+                watermarkKey,
+                pageIndex,
+                appendDurably = { writeFramesLocked(frames) && fsyncLocked() },
+                rollback = { rollbackLocked(checkpoint) },
+            )
+            if (!appended) {
+                clearPendingAppend()
+                return false
+            }
             lastPageTimestampMs = ts
-            maybeFsyncLocked(now)
             return true
         }
     }
+
+    private fun pageWatermarkKey(deviceId: String, session: Int): String =
+        "limitlessPageWatermark.${deviceId.uppercase(Locale.US)}.session$session"
+
+    private fun recoverPendingAppendLocked(): Boolean {
+        val path = prefs().getString(PENDING_PATH_KEY, null) ?: return true
+        val offset = prefs().getLong(PENDING_OFFSET_KEY, -1L)
+        if (offset < 0L) return clearPendingAppend()
+        return try {
+            val file = File(path)
+            if (file.exists()) {
+                RandomAccessFile(file, "rw").use {
+                    it.setLength(offset)
+                    it.fd.sync()
+                }
+            }
+            clearPendingAppend()
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun clearPendingAppend(): Boolean =
+        prefs().edit().remove(PENDING_PATH_KEY).remove(PENDING_OFFSET_KEY).commit()
 
     /** Fsync barrier: returns true when everything appended so far is durable on disk.
      *  The drain engine must get `true` here before ACKing the covered pages. */

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/BleHostApiImpl.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/BleHostApiImpl.kt
@@ -133,11 +133,11 @@ class BleHostApiImpl(private val getActivity: () -> Activity?) : BleHostApi {
     // ── Diagnostics ──
 
     override fun startRssiStreaming(uuid: String) {
-        bleManager.isRssiStreamingEnabled = true
+        bleManager.startRssiStreaming(uuid)
     }
 
     override fun stopRssiStreaming(uuid: String) {
-        bleManager.isRssiStreamingEnabled = false
+        bleManager.stopRssiStreaming(uuid)
     }
 
     override fun getBatteryHistory(uuid: String, callback: (Result<List<BleBatteryPoint>>) -> Unit) {

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/BleReconnectBackoff.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/BleReconnectBackoff.kt
@@ -1,0 +1,59 @@
+package com.friend.ios.ble
+
+import kotlin.math.roundToLong
+
+internal object BleReconnectBackoff {
+    private const val INITIAL_DELAY_MS = 500L
+    private const val MAX_DELAY_MS = 30_000L
+    private const val JITTER_FRACTION = 0.20
+
+    /**
+     * Exponential reconnect delay with bounded jitter.
+     *
+     * [jitterUnit] is injected so production can spread radio work while tests
+     * remain deterministic: 0 maps to -20%, 0.5 to no jitter, and 1 to +20%.
+     */
+    fun delayMillis(attempt: Int, jitterUnit: Double): Long {
+        val boundedAttempt = attempt.coerceIn(0, 30)
+        val multiplier = 1L shl boundedAttempt
+        val base = (INITIAL_DELAY_MS * multiplier).coerceAtMost(MAX_DELAY_MS)
+        val boundedJitter = jitterUnit.coerceIn(0.0, 1.0)
+        val factor = 1.0 - JITTER_FRACTION + (2.0 * JITTER_FRACTION * boundedJitter)
+        return (base * factor).roundToLong().coerceAtMost(MAX_DELAY_MS)
+    }
+}
+
+internal data class BleReconnectAttempt(
+    val number: Int,
+    val delayMillis: Long,
+)
+
+/**
+ * Reconnect lifecycle ownership. Reaching L2CAP is not success: discovery,
+ * MTU, and subscriptions may still fail. Only a stable session (or an
+ * explicit user/OS reconnect signal) resets the failure history.
+ */
+internal class BleReconnectState {
+    private var failedAttempts = 0
+
+    fun recordFailure(jitterUnit: Double): BleReconnectAttempt {
+        val attempt = failedAttempts
+        failedAttempts = (attempt + 1).coerceAtMost(30)
+        return BleReconnectAttempt(
+            number = attempt + 1,
+            delayMillis = BleReconnectBackoff.delayMillis(attempt, jitterUnit),
+        )
+    }
+
+    fun markTransportConnected() {
+        // Intentionally retained: setup may still fail after physical connect.
+    }
+
+    fun markStable() {
+        failedAttempts = 0
+    }
+
+    fun resetForExplicitRequest() {
+        failedAttempts = 0
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/GattOperationQueue.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/GattOperationQueue.kt
@@ -1,0 +1,235 @@
+package com.friend.ios.ble
+
+import java.util.ArrayDeque
+
+/**
+ * Identity of one asynchronous Android GATT operation.
+ *
+ * Android permits only one outstanding GATT operation per client. Matching the
+ * callback to this identity prevents a late callback from releasing an
+ * unrelated command.
+ */
+internal data class GattOperationKey(
+    val address: String,
+    val kind: GattOperationKind,
+    val target: String = "",
+) {
+    fun normalized(): GattOperationKey = copy(
+        address = address.uppercase(),
+        target = target.lowercase(),
+    )
+}
+
+internal enum class GattOperationKind {
+    DISCOVER_SERVICES,
+    REQUEST_MTU,
+    READ_CHARACTERISTIC,
+    WRITE_CHARACTERISTIC,
+    WRITE_WITHOUT_RESPONSE,
+    WRITE_DESCRIPTOR,
+    READ_RSSI,
+}
+
+internal enum class GattOperationFailure {
+    REJECTED,
+    TIMED_OUT,
+    CANCELLED,
+    EXCEPTION,
+}
+
+internal enum class GattWriteMode {
+    WITH_RESPONSE,
+    WITHOUT_RESPONSE,
+}
+
+internal fun preferredGattWriteMode(
+    supportsWrite: Boolean,
+    supportsWriteWithoutResponse: Boolean,
+): GattWriteMode? =
+    when {
+        supportsWrite -> GattWriteMode.WITH_RESPONSE
+        supportsWriteWithoutResponse -> GattWriteMode.WITHOUT_RESPONSE
+        else -> null
+    }
+
+/**
+ * Small, platform-independent state machine for Android's one-operation GATT
+ * contract. Production supplies Handler-backed dispatch/scheduling; JVM tests
+ * use deterministic fakes.
+ */
+internal class GattOperationQueue(
+    private val dispatch: (() -> Unit) -> Unit,
+    private val schedule: (delayMillis: Long, task: () -> Unit) -> (() -> Unit),
+    private val timeoutMillis: Long,
+) {
+    private data class Entry(
+        val key: GattOperationKey,
+        val start: () -> Boolean,
+        val onFailure: (GattOperationFailure) -> Unit,
+        var cancelTimeout: (() -> Unit)? = null,
+    )
+
+    private val queued = ArrayDeque<Entry>()
+    private var current: Entry? = null
+    private var callbackDepth = 0
+
+    fun enqueue(
+        key: GattOperationKey,
+        start: () -> Boolean,
+        onFailure: (GattOperationFailure) -> Unit = {},
+    ) {
+        synchronized(this) {
+            queued.addLast(Entry(key.normalized(), start, onFailure))
+        }
+        processNext()
+    }
+
+    fun contains(key: GattOperationKey): Boolean {
+        val normalized = key.normalized()
+        return synchronized(this) {
+            current?.key == normalized || queued.any { it.key == normalized }
+        }
+    }
+
+    fun isActive(key: GattOperationKey): Boolean {
+        val normalized = key.normalized()
+        return synchronized(this) {
+            current?.key == normalized
+        }
+    }
+
+    /**
+     * Completes only the currently active matching operation. [onSuccess] runs
+     * before the next command can start, so per-operation callback state can be
+     * safely removed without a same-characteristic successor overwriting it.
+     */
+    fun complete(key: GattOperationKey, onSuccess: () -> Unit = {}): Boolean {
+        val normalized = key.normalized()
+        val entry = synchronized(this) {
+            current?.takeIf { it.key == normalized }?.also {
+                current = null
+                callbackDepth++
+            }
+        } ?: return false
+
+        entry.cancelTimeout?.invoke()
+        try {
+            onSuccess()
+        } finally {
+            synchronized(this) {
+                callbackDepth--
+            }
+            processNext()
+        }
+        return true
+    }
+
+    fun cancelAddress(address: String) {
+        val normalizedAddress = address.uppercase()
+        val cancelled = mutableListOf<Entry>()
+
+        synchronized(this) {
+            current?.takeIf { it.key.address == normalizedAddress }?.let {
+                current = null
+                cancelled.add(it)
+            }
+
+            val iterator = queued.iterator()
+            while (iterator.hasNext()) {
+                val entry = iterator.next()
+                if (entry.key.address == normalizedAddress) {
+                    iterator.remove()
+                    cancelled.add(entry)
+                }
+            }
+            if (cancelled.isNotEmpty()) callbackDepth++
+        }
+
+        try {
+            for (entry in cancelled) {
+                entry.cancelTimeout?.invoke()
+                try {
+                    entry.onFailure(GattOperationFailure.CANCELLED)
+                } catch (_: Exception) {
+                    // One caller must not prevent the remaining operations
+                    // from learning that their peripheral disconnected.
+                }
+            }
+        } finally {
+            if (cancelled.isNotEmpty()) {
+                synchronized(this) {
+                    callbackDepth--
+                }
+            }
+            processNext()
+        }
+    }
+
+    internal fun pendingCount(): Int = synchronized(this) {
+        queued.size + if (current == null) 0 else 1
+    }
+
+    private fun processNext() {
+        val entry = synchronized(this) {
+            if (current != null || callbackDepth > 0 || queued.isEmpty()) return
+            queued.removeFirst().also { current = it }
+        }
+
+        dispatch {
+            if (!isCurrent(entry)) return@dispatch
+
+            val cancelTimeout = schedule(timeoutMillis) {
+                fail(entry, GattOperationFailure.TIMED_OUT)
+            }
+            val accepted = synchronized(this) {
+                if (current === entry) {
+                    entry.cancelTimeout = cancelTimeout
+                    true
+                } else {
+                    false
+                }
+            }
+            if (!accepted) {
+                cancelTimeout()
+                return@dispatch
+            }
+
+            val started = try {
+                entry.start()
+            } catch (_: Exception) {
+                fail(entry, GattOperationFailure.EXCEPTION)
+                return@dispatch
+            }
+            if (!started) {
+                fail(entry, GattOperationFailure.REJECTED)
+            }
+        }
+    }
+
+    private fun isCurrent(entry: Entry): Boolean = synchronized(this) {
+        current === entry
+    }
+
+    private fun fail(entry: Entry, reason: GattOperationFailure) {
+        val removed = synchronized(this) {
+            if (current !== entry) {
+                false
+            } else {
+                current = null
+                callbackDepth++
+                true
+            }
+        }
+        if (!removed) return
+
+        entry.cancelTimeout?.invoke()
+        try {
+            entry.onFailure(reason)
+        } finally {
+            synchronized(this) {
+                callbackDepth--
+            }
+            processNext()
+        }
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/NotificationTransitionState.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/NotificationTransitionState.kt
@@ -1,0 +1,44 @@
+package com.friend.ios.ble
+
+/**
+ * Coalesces notification requests for one CCCD.
+ *
+ * Android callbacks do not expose a request ID or the value written. Keeping
+ * only one transition in flight and remembering the latest desired state
+ * avoids redundant same-state writes when native/background and Flutter
+ * subscribers attach to the same characteristic.
+ */
+internal class NotificationTransitionState {
+    private var confirmed: Boolean? = null
+    private var desired: Boolean? = null
+    private var inFlight: Boolean? = null
+
+    @Synchronized
+    fun request(enabled: Boolean): Boolean? {
+        desired = enabled
+        if (inFlight != null || confirmed == enabled) return null
+        inFlight = enabled
+        return enabled
+    }
+
+    @Synchronized
+    fun currentInFlight(): Boolean? = inFlight
+
+    /**
+     * Returns the next coalesced transition, already marked in-flight.
+     * Failures are left to session recovery rather than retried on a GATT that
+     * may no longer be usable.
+     */
+    @Synchronized
+    fun complete(attempted: Boolean, success: Boolean): Boolean? {
+        if (inFlight != attempted) return null
+        inFlight = null
+        if (!success) return null
+        confirmed = attempted
+
+        val next = desired
+        if (next == null || next == confirmed) return null
+        inFlight = next
+        return next
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
@@ -44,7 +44,6 @@ class OmiBleForegroundService : Service() {
         private const val MTU_REQUEST_DELAY_MS = 100L
         private const val MTU_SIZE = 512
         private const val STABILITY_TIMER_MS = 60_000L
-        private const val RECONNECT_DELAY_MS = 3_000L
         private const val COMPANION_RATE_LIMIT_MS = 15_000L
         private const val PREFS_NAME = "ble_config"
         private const val PREFS_KEY = "managed_device"
@@ -143,10 +142,10 @@ class OmiBleForegroundService : Service() {
 
     // ── Per-device state ──
 
-    data class ManagedDevice(
+    private data class ManagedDevice(
         val address: String,
         var requiresBond: Boolean,
-        var retryCount: Int = 0,
+        val reconnectState: BleReconnectState = BleReconnectState(),
         var connectionStartTime: Long? = null,
         var currentGattHash: Int? = null,
         var hasEverConnected: Boolean = false,
@@ -186,8 +185,8 @@ class OmiBleForegroundService : Service() {
                 incrementReconnectionCount(addr)
                 backfillTimeToReconnect(addr, managed)
             }
-            managed.retryCount = 0
             managed.hasEverConnected = true
+            managed.reconnectState.markTransportConnected()
             managed.currentAttemptEstablished = true
             managed.pendingReconnect?.let { handler.removeCallbacks(it) }
             managed.pendingReconnect = null
@@ -195,7 +194,7 @@ class OmiBleForegroundService : Service() {
             managed.currentGattHash = gatt.hashCode()
 
             startStabilityTimer(addr)
-            bleManager.startRssiKeepAlive(addr)
+            bleManager.resumeRssiDiagnostics(addr)
             updateNotification("Connected to Omi")
         }
 
@@ -219,10 +218,7 @@ class OmiBleForegroundService : Service() {
                 bleManager.requestBond(addr) { result ->
                     val bonded = result.getOrDefault(false)
                     Log.i(TAG, "Bond result for $addr: $bonded")
-                    if (bonded) {
-                        managed.retryCount = 0
-                        managed.requiresBond = false
-                    }
+                    if (bonded) managed.requiresBond = false
                     requestMtuThenNotifyReady(addr, services)
                 }
             } else {
@@ -230,41 +226,18 @@ class OmiBleForegroundService : Service() {
             }
         }
 
-        override fun onMtuChanged(address: String, mtu: Int, status: Int) {
-            // Handled inline via the MTU flow in requestMtuThenNotifyReady
-        }
     }
 
     // ── Post-discovery pipeline ──
 
     private fun requestMtuThenNotifyReady(address: String, services: List<BleService>) {
         val addr = address.uppercase()
-        val gatt = bleManager.connectedGatts[addr] ?: return
-
-        val originalListener = bleManager.connectionListener
-        bleManager.connectionListener = object : OmiBleManager.BleConnectionListener by connectionListener {
-            override fun onMtuChanged(address: String, mtu: Int, status: Int) {
-                bleManager.connectionListener = originalListener
-                Log.i(TAG, "MTU done for $addr (mtu=$mtu, status=$status)")
-                fireDeviceReady(addr, services)
-            }
-        }
+        if (!bleManager.connectedGatts.containsKey(addr)) return
 
         handler.postDelayed({
-            bleManager.enqueueCommand {
-                try {
-                    if (!gatt.requestMtu(MTU_SIZE)) {
-                        Log.e(TAG, "requestMtu failed for $addr")
-                        bleManager.completeCommand()
-                        bleManager.connectionListener = originalListener
-                        fireDeviceReady(addr, services)
-                    }
-                } catch (e: Exception) {
-                    Log.e(TAG, "requestMtu exception for $addr: ${e.message}")
-                    bleManager.completeCommand()
-                    bleManager.connectionListener = originalListener
-                    fireDeviceReady(addr, services)
-                }
+            bleManager.requestMtu(addr, MTU_SIZE) { mtu, status ->
+                Log.i(TAG, "MTU done for $addr (mtu=$mtu, status=$status)")
+                fireDeviceReady(addr, services)
             }
         }, MTU_REQUEST_DELAY_MS)
     }
@@ -317,12 +290,7 @@ class OmiBleForegroundService : Service() {
         }
 
         Log.i(TAG, "notifyReadyForConnectedGatt: rediscovering services for already-connected $addr")
-        bleManager.enqueueCommand {
-            if (!gatt.discoverServices()) {
-                Log.e(TAG, "notifyReadyForConnectedGatt: discoverServices returned false for $addr")
-                bleManager.completeCommand()
-            }
-        }
+        bleManager.discoverServices(addr)
         return true
     }
 
@@ -346,7 +314,7 @@ class OmiBleForegroundService : Service() {
         val existing = managedDevices[addr]
         if (existing != null && bleManager.isPeripheralConnected(addr)) {
             if (requiresBond && !existing.requiresBond) existing.requiresBond = true
-            existing.retryCount = 0
+            existing.reconnectState.resetForExplicitRequest()
             existing.currentGattHash = bleManager.connectedGatts[addr]?.hashCode()
             existing.hasEverConnected = true
             existing.currentAttemptEstablished = true
@@ -434,7 +402,7 @@ class OmiBleForegroundService : Service() {
 
         managed.pendingReconnect?.let { handler.removeCallbacks(it) }
         managed.pendingReconnect = null
-        managed.retryCount = 0
+        managed.reconnectState.resetForExplicitRequest()
         connectToDevice(addr, source)
     }
 
@@ -458,7 +426,7 @@ class OmiBleForegroundService : Service() {
                 // Cancel any pending retry so it doesn't race with the fresh attempt
                 managed.pendingReconnect?.let { handler.removeCallbacks(it) }
                 managed.pendingReconnect = null
-                managed.retryCount = 0
+                managed.reconnectState.resetForExplicitRequest()
                 // Close the stuck GATT so connectToDevice opens a fresh one
                 if (bleManager.connectedGatts.containsKey(addr)) {
                     bleManager.closeGatt(addr)
@@ -489,7 +457,7 @@ class OmiBleForegroundService : Service() {
 
             val duration = managed.connectionStartTime?.let { System.currentTimeMillis() - it } ?: 0
             if (duration >= STABILITY_TIMER_MS) {
-                managed.retryCount = 0
+                managed.reconnectState.markStable()
             }
 
             bleManager.disconnectGatt(addr)
@@ -540,15 +508,15 @@ class OmiBleForegroundService : Service() {
 
         if (isDestroying || status == -1 || !isBluetoothEnabled) return
 
-        managed.retryCount++
-        Log.i(TAG, "Retry #${managed.retryCount} for $addr in ${RECONNECT_DELAY_MS}ms (status=$status)")
+        val retry = managed.reconnectState.recordFailure(Math.random())
+        Log.i(TAG, "Retry #${retry.number} for $addr in ${retry.delayMillis}ms (status=$status)")
 
         val runnable = Runnable {
             managed.pendingReconnect = null
-            connectToDevice(addr, "retry_${managed.retryCount}")
+            connectToDevice(addr, "retry_${retry.number}")
         }
         managed.pendingReconnect = runnable
-        handler.postDelayed(runnable, RECONNECT_DELAY_MS)
+        handler.postDelayed(runnable, retry.delayMillis)
     }
 
     // ── Stability timer ──
@@ -559,7 +527,7 @@ class OmiBleForegroundService : Service() {
 
         managed.stabilityTimerRunnable?.let { handler.removeCallbacks(it) }
         val runnable = Runnable {
-            managed.retryCount = 0
+            managed.reconnectState.markStable()
         }
         managed.stabilityTimerRunnable = runnable
         handler.postDelayed(runnable, STABILITY_TIMER_MS)
@@ -579,7 +547,6 @@ class OmiBleForegroundService : Service() {
             when (bondState) {
                 BluetoothDevice.BOND_BONDED -> {
                     Log.i(TAG, "Bond completed for $address")
-                    managed.retryCount = 0
                 }
                 BluetoothDevice.BOND_NONE -> {
                     Log.w(TAG, "Bond removed/failed for $address")
@@ -604,7 +571,7 @@ class OmiBleForegroundService : Service() {
                         managed.pendingReconnect = null
                         managed.stabilityTimerRunnable?.let { handler.removeCallbacks(it) }
                         managed.stabilityTimerRunnable = null
-                        bleManager.stopRssiKeepAlive()
+                        bleManager.pauseRssiDiagnostics(addr)
                         bleManager.closeGatt(addr)
                         managed.currentGattHash = null
                         bleManager.mainHandler.post {
@@ -767,6 +734,7 @@ class OmiBleForegroundService : Service() {
         34 -> "link_key_mismatch"
         62 -> "connection_failed_instant_passed"
         -1 -> "app_closed"
+        -2 -> "gatt_operation_timeout"
         else -> "gatt_error_$status"
     }
 

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleManager.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleManager.kt
@@ -23,7 +23,6 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentLinkedQueue
 
 /**
  * Pure GATT wrapper — scanning, characteristic ops, and command queue.
@@ -38,6 +37,8 @@ class OmiBleManager private constructor(private val application: Application) {
         private const val TAG = "OmiBle"
         private const val RSSI_HISTORY_LIMIT = 10
         private const val BOND_TIMEOUT_MS = 15000L // 15s — bond request timeout
+        private const val GATT_OPERATION_TIMEOUT_MS = 30_000L
+        private const val GATT_OPERATION_TIMEOUT_STATUS = -2
         private const val PREFS_BATTERY = "battery_history"
         private const val MAX_BATTERY_HISTORY = 2000
         private const val BATTERY_RETENTION_MS = 7L * 24 * 3600 * 1000
@@ -83,7 +84,6 @@ class OmiBleManager private constructor(private val application: Application) {
         fun onGattConnected(address: String, gatt: BluetoothGatt)
         fun onGattDisconnected(address: String, gattHash: Int, status: Int)
         fun onGattServicesDiscovered(address: String, services: List<BleService>)
-        fun onMtuChanged(address: String, mtu: Int, status: Int)
     }
 
     @Volatile
@@ -106,21 +106,38 @@ class OmiBleManager private constructor(private val application: Application) {
     val connectedGatts = ConcurrentHashMap<String, BluetoothGatt>()
     private val readCompletions = ConcurrentHashMap<String, (Result<ByteArray>) -> Unit>()
     private val writeCompletions = ConcurrentHashMap<String, (Result<Unit>) -> Unit>()
+    private val mtuCompletions = ConcurrentHashMap<String, (Int, Int) -> Unit>()
 
     private val servicesDiscoveredFor = ConcurrentHashMap.newKeySet<String>()
+
+    private data class NotificationStateKey(
+        val address: String,
+        val gattIdentity: Int,
+        val serviceUuid: String,
+        val characteristicUuid: String,
+        val descriptorUuid: String,
+    )
+
+    private val notificationTransitions = ConcurrentHashMap<NotificationStateKey, NotificationTransitionState>()
 
     private var isScanning = false
     private var scanCallback: ScanCallback? = null
     private var scanTimeoutRunnable: Runnable? = null
 
-    private val gattQueue: ConcurrentLinkedQueue<Runnable> = ConcurrentLinkedQueue()
-    @Volatile
-    private var isProcessingCommand = false
+    private val gattOperations = GattOperationQueue(
+        dispatch = { command -> mainHandler.post(command) },
+        schedule = { delayMillis, task ->
+            val runnable = Runnable(task)
+            mainHandler.postDelayed(runnable, delayMillis)
+            val cancel: () -> Unit = { mainHandler.removeCallbacks(runnable) }
+            cancel
+        },
+        timeoutMillis = GATT_OPERATION_TIMEOUT_MS,
+    )
 
-    private var rssiKeepAliveRunnable: Runnable? = null
-    private val rssiKeepAliveInterval = 3000L // ms
-    @Volatile
-    var isRssiStreamingEnabled = false
+    private val rssiDiagnosticsPolicy = RssiDiagnosticsPolicy()
+    private var rssiDiagnosticsRunnable: Runnable? = null
+    private val rssiDiagnosticsInterval = 3000L // ms
 
     /// Most recent RSSI per device (uppercase MAC). Used by the foreground service
     /// to annotate disconnect events so we can tell range-driven drops from healthy-signal drops.
@@ -285,9 +302,9 @@ class OmiBleManager private constructor(private val application: Application) {
 
     fun closeGatt(address: String) {
         val addr = address.uppercase()
+        val gatt = connectedGatts.remove(addr)
         cleanupPeripheral(addr)
-        connectedGatts[addr]?.close()
-        connectedGatts.remove(addr)
+        gatt?.close()
     }
 
     fun isPeripheralConnected(address: String): Boolean {
@@ -349,15 +366,24 @@ class OmiBleManager private constructor(private val application: Application) {
         }
 
         val key = "$addr:$serviceUuid:$characteristicUuid".lowercase()
-        readCompletions[key] = completion
-
-        enqueueCommand {
-            if (!gatt.readCharacteristic(characteristic)) {
-                Log.e(TAG, "readCharacteristic returned false for $key")
-                readCompletions.remove(key)?.invoke(Result.failure(Exception("Read request rejected")))
-                completeCommand()
+        val operationKey = characteristicOperationKey(
+            addr,
+            GattOperationKind.READ_CHARACTERISTIC,
+            serviceUuid,
+            characteristicUuid,
+        )
+        enqueueGattOperation(
+            key = operationKey,
+            start = {
+                readCompletions[key] = completion
+                gatt.readCharacteristic(characteristic)
+            },
+            onFailure = { reason ->
+                (readCompletions.remove(key) ?: completion).invoke(
+                    Result.failure(Exception("GATT read failed before callback: $reason")),
+                )
             }
-        }
+        )
     }
 
     fun writeCharacteristic(
@@ -375,42 +401,55 @@ class OmiBleManager private constructor(private val application: Application) {
             return
         }
 
-        val writeType = if (characteristic.properties and BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE != 0) {
-            BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
-        } else {
-            BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+        val writeType = preferredWriteType(characteristic)
+        if (writeType == null) {
+            completion(Result.failure(Exception("Characteristic is not writable")))
+            return
         }
 
         val key = "$addr:$serviceUuid:$characteristicUuid".lowercase()
-        if (writeType == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT) {
-            writeCompletions[key] = completion
-        }
-
-        enqueueCommand {
-            @Suppress("deprecation")
-            val success = if (Build.VERSION.SDK_INT >= 33) {
-                val result = gatt.writeCharacteristic(characteristic, data, writeType)
-                if (result != BluetoothStatusCodes.SUCCESS) {
-                    Log.e(TAG, "writeCharacteristic returned $result for $key")
-                }
-                result == BluetoothStatusCodes.SUCCESS
+        val operationKey = characteristicOperationKey(
+            addr,
+            if (writeType == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT) {
+                GattOperationKind.WRITE_CHARACTERISTIC
             } else {
-                characteristic.value = data
-                characteristic.writeType = writeType
-                gatt.writeCharacteristic(characteristic)
-            }
-            if (!success) {
-                Log.e(TAG, "writeCharacteristic failed for $key")
-                writeCompletions.remove(key)?.invoke(Result.failure(Exception("Write request rejected")))
-                completeCommand()
-            } else if (writeType == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
-                completeCommand()
-            }
-        }
+                GattOperationKind.WRITE_WITHOUT_RESPONSE
+            },
+            serviceUuid,
+            characteristicUuid,
+        )
+        enqueueGattOperation(
+            key = operationKey,
+            start = {
+                if (writeType == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT) {
+                    writeCompletions[key] = completion
+                }
 
-        if (writeType == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
-            completion(Result.success(Unit))
-        }
+                @Suppress("deprecation")
+                val success = if (Build.VERSION.SDK_INT >= 33) {
+                    val result = gatt.writeCharacteristic(characteristic, data, writeType)
+                    if (result != BluetoothStatusCodes.SUCCESS) {
+                        Log.e(TAG, "writeCharacteristic returned $result for $key")
+                    }
+                    result == BluetoothStatusCodes.SUCCESS
+                } else {
+                    characteristic.value = data
+                    characteristic.writeType = writeType
+                    gatt.writeCharacteristic(characteristic)
+                }
+
+                if (success && writeType == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
+                    gattOperations.complete(operationKey) {
+                        completion(Result.success(Unit))
+                    }
+                }
+                success
+            },
+            onFailure = { reason ->
+                writeCompletions.remove(key)
+                completion(Result.failure(Exception("GATT write failed before callback: $reason")))
+            },
+        )
     }
 
     fun subscribeCharacteristic(address: String, serviceUuid: String, characteristicUuid: String) {
@@ -419,14 +458,13 @@ class OmiBleManager private constructor(private val application: Application) {
         val characteristic = findCharacteristic(gatt, serviceUuid, characteristicUuid) ?: return
 
         val descriptor = characteristic.getDescriptor(CCCD_UUID)
-        enqueueCommand {
-            gatt.setCharacteristicNotification(characteristic, true)
-            if (descriptor != null) {
-                writeDescriptorCompat(gatt, descriptor, BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE)
-            } else {
-                completeCommand()
-            }
-        }
+        enqueueNotificationChange(
+            addr,
+            gatt,
+            characteristic,
+            descriptor,
+            enabled = true,
+        )
     }
 
     fun unsubscribeCharacteristic(address: String, serviceUuid: String, characteristicUuid: String) {
@@ -435,33 +473,61 @@ class OmiBleManager private constructor(private val application: Application) {
         val characteristic = findCharacteristic(gatt, serviceUuid, characteristicUuid) ?: return
 
         val descriptor = characteristic.getDescriptor(CCCD_UUID)
-        enqueueCommand {
-            gatt.setCharacteristicNotification(characteristic, false)
-            if (descriptor != null) {
-                writeDescriptorCompat(gatt, descriptor, BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE)
-            } else {
-                completeCommand()
-            }
+        enqueueNotificationChange(
+            addr,
+            gatt,
+            characteristic,
+            descriptor,
+            enabled = false,
+        )
+    }
+
+    // ── RSSI diagnostics ──
+
+    fun startRssiStreaming(address: String) {
+        val addr = address.uppercase()
+        rssiDiagnosticsPolicy.subscribe(addr)
+        resumeRssiDiagnostics(addr)
+    }
+
+    fun stopRssiStreaming(address: String) {
+        if (rssiDiagnosticsPolicy.unsubscribe(address)) {
+            pauseRssiDiagnostics()
         }
     }
 
-    // ── RSSI keep-alive ──
-
-    fun startRssiKeepAlive(address: String) {
-        stopRssiKeepAlive()
+    fun resumeRssiDiagnostics(address: String) {
+        val addr = address.uppercase()
+        if (!rssiDiagnosticsPolicy.shouldPoll(addr, connectedGatts.containsKey(addr))) return
+        pauseRssiDiagnostics()
         val runnable = object : Runnable {
             override fun run() {
-                connectedGatts[address]?.readRemoteRssi()
-                mainHandler.postDelayed(this, rssiKeepAliveInterval)
+                val gatt = connectedGatts[addr]
+                if (gatt != null && rssiDiagnosticsPolicy.shouldPoll(addr, isConnected = true)) {
+                    val operationKey = GattOperationKey(addr, GattOperationKind.READ_RSSI)
+                    if (!gattOperations.contains(operationKey)) {
+                        enqueueGattOperation(
+                            key = operationKey,
+                            start = { gatt.readRemoteRssi() },
+                            onFailure = { reason ->
+                                Log.w(TAG, "RSSI read was not completed for $addr: $reason")
+                            },
+                        )
+                    }
+                }
+                if (rssiDiagnosticsPolicy.shouldPoll(addr, connectedGatts.containsKey(addr))) {
+                    mainHandler.postDelayed(this, rssiDiagnosticsInterval)
+                }
             }
         }
-        rssiKeepAliveRunnable = runnable
-        mainHandler.postDelayed(runnable, rssiKeepAliveInterval)
+        rssiDiagnosticsRunnable = runnable
+        mainHandler.postDelayed(runnable, rssiDiagnosticsInterval)
     }
 
-    fun stopRssiKeepAlive() {
-        rssiKeepAliveRunnable?.let { mainHandler.removeCallbacks(it) }
-        rssiKeepAliveRunnable = null
+    fun pauseRssiDiagnostics(address: String? = null) {
+        if (address != null && !rssiDiagnosticsPolicy.isSubscribed(address)) return
+        rssiDiagnosticsRunnable?.let { mainHandler.removeCallbacks(it) }
+        rssiDiagnosticsRunnable = null
     }
 
     // ── State & utility ──
@@ -477,32 +543,144 @@ class OmiBleManager private constructor(private val application: Application) {
         }
     }
 
-    // ── Command queue ──
+    // ── Serialized GATT operations ──
 
-    @Synchronized
-    fun enqueueCommand(command: Runnable) {
-        gattQueue.add(command)
-        processNextCommand()
+    private fun enqueueGattOperation(
+        key: GattOperationKey,
+        start: () -> Boolean,
+        onFailure: (GattOperationFailure) -> Unit = {},
+    ) {
+        gattOperations.enqueue(
+            key = key,
+            start = start,
+            onFailure = { reason ->
+                onFailure(reason)
+                if (reason == GattOperationFailure.TIMED_OUT && shouldRecoverAfterGattTimeout(key.kind)) {
+                    recoverTimedOutGatt(key)
+                }
+            },
+        )
     }
 
-    @Synchronized
-    private fun processNextCommand() {
-        if (isProcessingCommand) return
-        val cmd = gattQueue.peek() ?: return
-        isProcessingCommand = true
-        try {
-            mainHandler.post(cmd)
-        } catch (e: Exception) {
-            Log.e(TAG, "Error posting command: ${e.message}")
-            completeCommand()
-        }
+    private fun characteristicOperationKey(
+        address: String,
+        kind: GattOperationKind,
+        serviceUuid: String,
+        characteristicUuid: String,
+    ) = GattOperationKey(
+        address = address,
+        kind = kind,
+        target = "${serviceUuid.lowercase()}:${characteristicUuid.lowercase()}",
+    )
+
+    private fun notificationStateKey(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        descriptor: BluetoothGattDescriptor?,
+    ) = NotificationStateKey(
+        address = gatt.device.address.uppercase(),
+        gattIdentity = System.identityHashCode(gatt),
+        serviceUuid = characteristic.service.uuid.toString().lowercase(),
+        characteristicUuid = characteristic.uuid.toString().lowercase(),
+        descriptorUuid = descriptor?.uuid?.toString()?.lowercase().orEmpty(),
+    )
+
+    private fun notificationOperationKey(key: NotificationStateKey, enabled: Boolean) =
+        GattOperationKey(
+            address = key.address,
+            kind = GattOperationKind.WRITE_DESCRIPTOR,
+            target =
+                "${key.gattIdentity}:${key.serviceUuid}:${key.characteristicUuid}:${key.descriptorUuid}:${if (enabled) "enable" else "disable"}",
+        )
+
+    private fun enqueueNotificationChange(
+        address: String,
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        descriptor: BluetoothGattDescriptor?,
+        enabled: Boolean,
+    ) {
+        val stateKey = notificationStateKey(gatt, characteristic, descriptor)
+        val state = notificationTransitions.computeIfAbsent(stateKey) { NotificationTransitionState() }
+        val transition = state.request(enabled) ?: return
+        startNotificationTransition(address, gatt, characteristic, descriptor, stateKey, transition)
     }
 
-    @Synchronized
-    fun completeCommand() {
-        gattQueue.poll()
-        isProcessingCommand = false
-        processNextCommand()
+    private fun startNotificationTransition(
+        address: String,
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        descriptor: BluetoothGattDescriptor?,
+        stateKey: NotificationStateKey,
+        enabled: Boolean,
+    ) {
+        val operationKey = notificationOperationKey(stateKey, enabled)
+        enqueueGattOperation(
+            key = operationKey,
+            start = {
+                if (!gatt.setCharacteristicNotification(characteristic, enabled)) {
+                    return@enqueueGattOperation false
+                }
+                if (descriptor == null) {
+                    gattOperations.complete(operationKey) {
+                        finishNotificationTransition(
+                            address,
+                            gatt,
+                            characteristic,
+                            descriptor,
+                            stateKey,
+                            enabled,
+                            success = true,
+                        )
+                    }
+                    true
+                } else {
+                    writeDescriptorCompat(
+                        gatt,
+                        descriptor,
+                        if (enabled) {
+                            BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                        } else {
+                            BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
+                        },
+                    )
+                }
+            },
+            onFailure = { reason ->
+                finishNotificationTransition(
+                    address,
+                    gatt,
+                    characteristic,
+                    descriptor,
+                    stateKey,
+                    enabled,
+                    success = false,
+                )
+                Log.e(
+                    TAG,
+                    "Notification ${if (enabled) "enable" else "disable"} failed for ${characteristic.uuid}: $reason",
+                )
+                if (
+                    reason == GattOperationFailure.REJECTED ||
+                    reason == GattOperationFailure.EXCEPTION
+                ) {
+                    recoverRejectedGatt(operationKey, reason)
+                }
+            },
+        )
+    }
+
+    private fun finishNotificationTransition(
+        address: String,
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        descriptor: BluetoothGattDescriptor?,
+        stateKey: NotificationStateKey,
+        attempted: Boolean,
+        success: Boolean,
+    ) {
+        val next = notificationTransitions[stateKey]?.complete(attempted, success) ?: return
+        startNotificationTransition(address, gatt, characteristic, descriptor, stateKey, next)
     }
 
     private fun findCharacteristic(gatt: BluetoothGatt?, serviceUuid: String, characteristicUuid: String): BluetoothGattCharacteristic? {
@@ -510,40 +688,135 @@ class OmiBleManager private constructor(private val application: Application) {
         return service.getCharacteristic(UUID.fromString(characteristicUuid))
     }
 
+    /**
+     * A write-with-response property wins when a characteristic advertises
+     * both modes. Its callback gives the queue an actual delivery boundary;
+     * write-without-response is reserved for characteristics with no safer
+     * option.
+     */
+    private fun preferredWriteType(characteristic: BluetoothGattCharacteristic): Int? =
+        when (
+            preferredGattWriteMode(
+                supportsWrite =
+                    characteristic.properties and BluetoothGattCharacteristic.PROPERTY_WRITE != 0,
+                supportsWriteWithoutResponse =
+                    characteristic.properties and BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE != 0,
+            )
+        ) {
+            GattWriteMode.WITH_RESPONSE ->
+                BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+            GattWriteMode.WITHOUT_RESPONSE ->
+                BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
+            null -> null
+        }
+
     @Suppress("deprecation")
-    private fun writeDescriptorCompat(gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, value: ByteArray) {
-        val success = if (Build.VERSION.SDK_INT >= 33) {
+    private fun writeDescriptorCompat(
+        gatt: BluetoothGatt,
+        descriptor: BluetoothGattDescriptor,
+        value: ByteArray,
+    ): Boolean =
+        if (Build.VERSION.SDK_INT >= 33) {
             gatt.writeDescriptor(descriptor, value) == BluetoothStatusCodes.SUCCESS
         } else {
             descriptor.value = value
             gatt.writeDescriptor(descriptor)
         }
-        if (!success) {
-            Log.e(TAG, "writeDescriptor failed for ${descriptor.uuid}")
-            completeCommand()
+
+    fun discoverServices(address: String) {
+        val addr = address.uppercase()
+        val gatt = connectedGatts[addr] ?: return
+        val operationKey = GattOperationKey(addr, GattOperationKind.DISCOVER_SERVICES)
+        enqueueGattOperation(
+            key = operationKey,
+            start = { gatt.discoverServices() },
+            onFailure = { reason ->
+                Log.e(TAG, "Service discovery did not start/finish for $addr: $reason")
+                if (
+                    reason == GattOperationFailure.REJECTED ||
+                    reason == GattOperationFailure.EXCEPTION
+                ) {
+                    recoverRejectedGatt(operationKey, reason)
+                }
+            },
+        )
+    }
+
+    /**
+     * Requests MTU without replacing the process-wide connection listener.
+     * Immediate rejection falls back to the default ATT MTU; a missing callback
+     * is treated as an unresponsive GATT and recovered by reconnecting.
+     */
+    fun requestMtu(address: String, mtu: Int, completion: (mtu: Int, status: Int) -> Unit) {
+        val addr = address.uppercase()
+        val gatt = connectedGatts[addr]
+        if (gatt == null) {
+            completion(23, BluetoothGatt.GATT_FAILURE)
+            return
         }
+        val operationKey = GattOperationKey(addr, GattOperationKind.REQUEST_MTU)
+        enqueueGattOperation(
+            key = operationKey,
+            start = {
+                mtuCompletions[addr] = completion
+                gatt.requestMtu(mtu)
+            },
+            onFailure = { reason ->
+                mtuCompletions.remove(addr)
+                if (reason == GattOperationFailure.REJECTED || reason == GattOperationFailure.EXCEPTION) {
+                    completion(23, BluetoothGatt.GATT_FAILURE)
+                }
+            },
+        )
     }
 
     fun cleanupPeripheral(address: String) {
         val addr = address.uppercase()
         servicesDiscoveredFor.remove(addr)
-        stopRssiKeepAlive()
+        pauseRssiDiagnostics(addr)
         bondingAddress = null
         bondTimeoutRunnable?.let { mainHandler.removeCallbacks(it) }
         bondTimeoutRunnable = null
         bondCompletionCallback?.invoke(false)
         bondCompletionCallback = null
 
-        for (key in readCompletions.keys().toList().filter { it.startsWith(addr.lowercase()) }) {
-            readCompletions.remove(key)?.invoke(Result.failure(Exception("Peripheral disconnected")))
-        }
-        for (key in writeCompletions.keys().toList().filter { it.startsWith(addr.lowercase()) }) {
-            writeCompletions.remove(key)?.invoke(Result.failure(Exception("Peripheral disconnected")))
-        }
-
-        gattQueue.clear()
-        isProcessingCommand = false
+        gattOperations.cancelAddress(addr)
+        notificationTransitions.keys
+            .filter { it.address == addr }
+            .forEach { notificationTransitions.remove(it) }
+        mtuCompletions.remove(addr)
     }
+
+    private fun recoverRejectedGatt(key: GattOperationKey, reason: GattOperationFailure) {
+        // Rejection of discovery/CCCD setup leaves a connected-but-unusable
+        // session. Reconnect instead of advertising a false ready state.
+        Log.e(TAG, "Recovering unusable GATT after ${key.kind} $reason for ${key.address}")
+        recoverGatt(key.address, BluetoothGatt.GATT_FAILURE)
+    }
+
+    private fun recoverTimedOutGatt(key: GattOperationKey) {
+        Log.e(TAG, "GATT operation timed out: ${key.kind} for ${key.address}")
+        recoverGatt(key.address, GATT_OPERATION_TIMEOUT_STATUS)
+    }
+
+    private fun recoverGatt(address: String, status: Int) {
+        val addr = address.uppercase()
+        val gatt = connectedGatts.remove(addr) ?: return
+        val gattHash = gatt.hashCode()
+        cleanupPeripheral(addr)
+        try {
+            gatt.disconnect()
+        } catch (_: Exception) {
+        }
+        try {
+            gatt.close()
+        } catch (_: Exception) {
+        }
+        connectionListener?.onGattDisconnected(addr, gattHash, status)
+    }
+
+    private fun isActiveGatt(gatt: BluetoothGatt): Boolean =
+        connectedGatts[gatt.device.address.uppercase()] === gatt
 
     // ── Battery history ──
 
@@ -601,25 +874,33 @@ class OmiBleManager private constructor(private val application: Application) {
             val address = gatt.device.address.uppercase()
             Log.i(TAG, "onConnectionStateChange: address=$address, status=$status, newState=$newState")
 
+            if (!isActiveGatt(gatt)) {
+                Log.w(TAG, "Ignoring callback from retired GATT for $address (${gatt.hashCode()})")
+                if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                    try {
+                        gatt.close()
+                    } catch (_: Exception) {
+                    }
+                }
+                return
+            }
+
             when (newState) {
                 BluetoothProfile.STATE_CONNECTED -> {
                     Log.i(TAG, "Connected to $address, discovering services")
-                    connectedGatts[address] = gatt
-
-                    // Discover services
-                    enqueueCommand {
-                        if (!gatt.discoverServices()) {
-                            Log.e(TAG, "discoverServices returned false for $address")
-                            completeCommand()
-                        }
-                    }
+                    discoverServices(address)
 
                     // Notify the connection owner
                     connectionListener?.onGattConnected(address, gatt)
                 }
                 BluetoothProfile.STATE_DISCONNECTED -> {
                     Log.i(TAG, "Disconnected from $address (status=$status, gattHash=${gatt.hashCode()})")
+                    connectedGatts.remove(address, gatt)
                     cleanupPeripheral(address)
+                    try {
+                        gatt.close()
+                    } catch (_: Exception) {
+                    }
 
                     // Notify the connection owner with GATT hash for stale callback rejection
                     connectionListener?.onGattDisconnected(address, gatt.hashCode(), status)
@@ -629,23 +910,31 @@ class OmiBleManager private constructor(private val application: Application) {
 
         override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
             val address = gatt.device.address.uppercase()
+            if (!isActiveGatt(gatt)) return
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 Log.e(TAG, "MTU request failed for $address (status=$status)")
             } else {
                 Log.i(TAG, "MTU changed to $mtu for $address")
             }
-            completeCommand()
-
-            // Notify connection owner so it can fire onDeviceReady
-            connectionListener?.onMtuChanged(address, mtu, status)
+            val operationKey = GattOperationKey(address, GattOperationKind.REQUEST_MTU)
+            if (!gattOperations.complete(operationKey) {
+                    mtuCompletions.remove(address)?.invoke(mtu, status)
+                }
+            ) {
+                Log.w(TAG, "Ignoring MTU callback with no matching request for $address")
+            }
         }
 
         override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
             val address = gatt.device.address.uppercase()
+            if (!isActiveGatt(gatt)) return
+            val operationKey = GattOperationKey(address, GattOperationKind.DISCOVER_SERVICES)
 
-            if (servicesDiscoveredFor.contains(address)) {
+            // CoreBluetooth stacks can emit duplicate callbacks, but an
+            // explicit rediscovery for an already-connected GATT is valid
+            // (the foreground service uses it when Flutter reattaches).
+            if (servicesDiscoveredFor.contains(address) && !gattOperations.isActive(operationKey)) {
                 Log.i(TAG, "Ignoring duplicate onServicesDiscovered for $address")
-                completeCommand()
                 return
             }
 
@@ -653,12 +942,22 @@ class OmiBleManager private constructor(private val application: Application) {
 
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 Log.e(TAG, "Service discovery failed for $address (status=$status)")
-                completeCommand()
+                if (!gattOperations.complete(operationKey) {
+                        recoverRejectedGatt(operationKey, GattOperationFailure.REJECTED)
+                    }
+                ) {
+                    Log.w(TAG, "Ignoring failed service callback with no matching discovery for $address")
+                }
                 return
             }
 
             val services = gatt.services ?: run {
-                completeCommand()
+                if (!gattOperations.complete(operationKey) {
+                        recoverRejectedGatt(operationKey, GattOperationFailure.REJECTED)
+                    }
+                ) {
+                    Log.w(TAG, "Ignoring empty service callback with no matching discovery for $address")
+                }
                 return
             }
             val bleServices = services.map { svc ->
@@ -668,18 +967,22 @@ class OmiBleManager private constructor(private val application: Application) {
                 )
             }
 
-            servicesDiscoveredFor.add(address)
-
-            if (!gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)) {
-                Log.w(TAG, "Failed to request high connection priority")
+            if (!gattOperations.complete(operationKey) {
+                    servicesDiscoveredFor.add(address)
+                    if (!gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)) {
+                        Log.w(TAG, "Failed to request high connection priority")
+                    }
+                }
+            ) {
+                Log.w(TAG, "Ignoring service callback with no matching discovery for $address")
+                return
             }
-
-            completeCommand()
 
             connectionListener?.onGattServicesDiscovered(address, bleServices)
         }
 
         override fun onCharacteristicChanged(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, value: ByteArray) {
+            if (!isActiveGatt(gatt)) return
             val address = gatt.device.address.uppercase()
             val serviceUuid = characteristic.service.uuid.toString().lowercase()
             val charUuid = characteristic.uuid.toString().lowercase()
@@ -704,18 +1007,28 @@ class OmiBleManager private constructor(private val application: Application) {
 
         override fun onCharacteristicRead(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, value: ByteArray, status: Int) {
             val address = gatt.device.address.uppercase()
+            if (!isActiveGatt(gatt)) return
             val serviceUuid = characteristic.service.uuid.toString().lowercase()
             val charUuid = characteristic.uuid.toString().lowercase()
             val key = "$address:$serviceUuid:$charUuid".lowercase()
+            val operationKey = characteristicOperationKey(
+                address,
+                GattOperationKind.READ_CHARACTERISTIC,
+                serviceUuid,
+                charUuid,
+            )
 
-            val completion = readCompletions.remove(key)
-            if (status == BluetoothGatt.GATT_SUCCESS) {
-                completion?.invoke(Result.success(value))
-            } else {
-                completion?.invoke(Result.failure(Exception("Read failed with status $status")))
+            if (!gattOperations.complete(operationKey) {
+                    val completion = readCompletions.remove(key)
+                    if (status == BluetoothGatt.GATT_SUCCESS) {
+                        completion?.invoke(Result.success(value))
+                    } else {
+                        completion?.invoke(Result.failure(Exception("Read failed with status $status")))
+                    }
+                }
+            ) {
+                Log.w(TAG, "Ignoring characteristic read callback with no matching operation: $key")
             }
-
-            completeCommand()
         }
 
         // Deprecated overload called on Android < 13 (API < 33)
@@ -726,40 +1039,102 @@ class OmiBleManager private constructor(private val application: Application) {
 
         override fun onCharacteristicWrite(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int) {
             val address = gatt.device.address.uppercase()
+            if (!isActiveGatt(gatt)) return
             val serviceUuid = characteristic.service.uuid.toString().lowercase()
             val charUuid = characteristic.uuid.toString().lowercase()
             val key = "$address:$serviceUuid:$charUuid".lowercase()
-
-            val completion = writeCompletions.remove(key)
-            if (status == BluetoothGatt.GATT_SUCCESS) {
-                completion?.invoke(Result.success(Unit))
-            } else {
-                completion?.invoke(Result.failure(Exception("Write failed with status $status")))
+            if (preferredWriteType(characteristic) == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
+                // Some Android stacks emit this optional callback after the
+                // accepted WNR operation was completed synchronously. Never
+                // let it release a later operation for the same target.
+                Log.d(TAG, "Ignoring optional write-without-response callback: $key")
+                return
             }
+            val operationKey = characteristicOperationKey(
+                address,
+                GattOperationKind.WRITE_CHARACTERISTIC,
+                serviceUuid,
+                charUuid,
+            )
 
-            completeCommand()
+            if (!gattOperations.complete(operationKey) {
+                    val completion = writeCompletions.remove(key)
+                    if (status == BluetoothGatt.GATT_SUCCESS) {
+                        completion?.invoke(Result.success(Unit))
+                    } else {
+                        completion?.invoke(Result.failure(Exception("Write failed with status $status")))
+                    }
+                }
+            ) {
+                Log.d(TAG, "Ignoring characteristic write callback with no matching operation: $key")
+            }
         }
 
         override fun onDescriptorWrite(gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int) {
+            if (!isActiveGatt(gatt)) return
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 Log.e(TAG, "Descriptor write failed (status=$status) for ${descriptor.characteristic.uuid}")
             }
-            completeCommand()
+            val stateKey = notificationStateKey(gatt, descriptor.characteristic, descriptor)
+            val enabled = notificationTransitions[stateKey]?.currentInFlight()
+            if (enabled == null) {
+                Log.w(TAG, "Ignoring descriptor callback with no notification transition for ${descriptor.uuid}")
+                return
+            }
+            val operationKey = notificationOperationKey(stateKey, enabled)
+            if (status == BluetoothGatt.GATT_SUCCESS) {
+                if (!gattOperations.complete(operationKey) {
+                        finishNotificationTransition(
+                            gatt.device.address,
+                            gatt,
+                            descriptor.characteristic,
+                            descriptor,
+                            stateKey,
+                            enabled,
+                            success = true,
+                        )
+                    }
+                ) {
+                    Log.w(TAG, "Ignoring descriptor callback with no matching operation for ${descriptor.uuid}")
+                }
+            } else {
+                if (!gattOperations.complete(operationKey) {
+                        finishNotificationTransition(
+                            gatt.device.address,
+                            gatt,
+                            descriptor.characteristic,
+                            descriptor,
+                            stateKey,
+                            enabled,
+                            success = false,
+                        )
+                        recoverRejectedGatt(operationKey, GattOperationFailure.REJECTED)
+                    }
+                ) {
+                    Log.w(TAG, "Ignoring failed descriptor callback with no matching operation for ${descriptor.uuid}")
+                }
+            }
         }
 
         override fun onReadRemoteRssi(gatt: BluetoothGatt, rssi: Int, status: Int) {
+            if (!isActiveGatt(gatt)) return
+            val address = gatt.device.address.uppercase()
+            val operationKey = GattOperationKey(address, GattOperationKind.READ_RSSI)
+            if (!gattOperations.complete(operationKey)) {
+                Log.d(TAG, "Ignoring RSSI callback with no matching operation for $address")
+                return
+            }
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 Log.w(TAG, "RSSI read failed: status=$status for ${gatt.device.address}")
                 return
             }
-            val address = gatt.device.address.uppercase()
             lastRssi[address] = rssi
             val deque = rssiHistory.getOrPut(address) { java.util.ArrayDeque() }
             synchronized(deque) {
                 deque.addLast(Pair(System.currentTimeMillis(), rssi))
                 while (deque.size > RSSI_HISTORY_LIMIT) deque.removeFirst()
             }
-            if (isRssiStreamingEnabled) {
+            if (rssiDiagnosticsPolicy.isSubscribed(address)) {
                 mainHandler.post {
                     flutterApi?.onRssiUpdate(address, rssi.toLong()) {}
                 }

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/RssiDiagnosticsPolicy.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/RssiDiagnosticsPolicy.kt
@@ -1,0 +1,32 @@
+package com.friend.ios.ble
+
+/**
+ * Keeps RSSI polling scoped to the one diagnostics view that requested it.
+ *
+ * A disconnect pauses polling without losing the subscription, so a reconnect
+ * can resume diagnostics without turning RSSI reads into connection keep-alives.
+ */
+internal class RssiDiagnosticsPolicy {
+    @Volatile
+    private var subscribedAddress: String? = null
+
+    fun subscribe(address: String) {
+        subscribedAddress = address.uppercase()
+    }
+
+    fun unsubscribe(address: String): Boolean {
+        val normalized = address.uppercase()
+        if (subscribedAddress != normalized) return false
+        subscribedAddress = null
+        return true
+    }
+
+    fun shouldPoll(address: String, isConnected: Boolean): Boolean =
+        isConnected && subscribedAddress == address.uppercase()
+
+    fun isSubscribed(address: String): Boolean =
+        subscribedAddress == address.uppercase()
+}
+
+internal fun shouldRecoverAfterGattTimeout(kind: GattOperationKind): Boolean =
+    kind != GattOperationKind.READ_RSSI

--- a/app/android/app/src/main/kotlin/com/friend/ios/limitless/ContiguousFlashPageLedger.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/limitless/ContiguousFlashPageLedger.kt
@@ -1,0 +1,66 @@
+package com.friend.ios.limitless
+
+/**
+ * Orders a Limitless flash drain and exposes only its contiguous, appended
+ * prefix as ACK-eligible.
+ *
+ * The pendant's ACK is cumulative: ACKing page N deletes every page through N.
+ * A later page must therefore never move the watermark across a missing page.
+ */
+internal class ContiguousFlashPageLedger(
+    oldestPageIndex: Int,
+    val newestPageIndex: Int,
+    private val appendPage: (LimitlessProtocol.FlashPage) -> Boolean,
+) {
+    enum class OfferResult {
+        NO_PROGRESS,
+        PROGRESSED,
+        APPEND_FAILED,
+        BUFFER_LIMIT_REACHED,
+    }
+
+    companion object {
+        private const val MAX_PENDING_PAGES = 64
+    }
+
+    private val pendingPages = mutableMapOf<Int, LimitlessProtocol.FlashPage>()
+    private var nextPageIndex = oldestPageIndex
+
+    var lastAppendedPageIndex: Int = oldestPageIndex - 1
+        private set
+
+    var pagesSinceAck: Int = 0
+        private set
+
+    val isComplete: Boolean
+        get() = nextPageIndex > newestPageIndex
+
+    internal val pendingPageCount: Int
+        get() = pendingPages.size
+
+    fun offer(page: LimitlessProtocol.FlashPage): OfferResult {
+        val index = page.index ?: return OfferResult.NO_PROGRESS
+        if (index < nextPageIndex || index > newestPageIndex) return OfferResult.NO_PROGRESS
+
+        pendingPages.putIfAbsent(index, page)
+        if (pendingPages.size > MAX_PENDING_PAGES) return OfferResult.BUFFER_LIMIT_REACHED
+
+        var progressed = false
+        while (true) {
+            val nextPage = pendingPages[nextPageIndex] ?: break
+            if (!appendPage(nextPage)) return OfferResult.APPEND_FAILED
+
+            pendingPages.remove(nextPageIndex)
+            lastAppendedPageIndex = nextPageIndex
+            nextPageIndex++
+            pagesSinceAck++
+            progressed = true
+        }
+
+        return if (progressed) OfferResult.PROGRESSED else OfferResult.NO_PROGRESS
+    }
+
+    fun markAcked() {
+        pagesSinceAck = 0
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/limitless/ContiguousFlashPageLedger.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/limitless/ContiguousFlashPageLedger.kt
@@ -60,7 +60,7 @@ internal class ContiguousFlashPageLedger(
         return if (progressed) OfferResult.PROGRESSED else OfferResult.NO_PROGRESS
     }
 
-    fun markAcked() {
-        pagesSinceAck = 0
+    fun markAcked(throughPageIndex: Int) {
+        pagesSinceAck = (lastAppendedPageIndex - throughPageIndex).coerceAtLeast(0)
     }
 }

--- a/app/android/app/src/main/kotlin/com/friend/ios/limitless/LimitlessAckCommitGate.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/limitless/LimitlessAckCommitGate.kt
@@ -1,0 +1,43 @@
+package com.friend.ios.limitless
+
+/**
+ * Owns the cumulative pendant-deletion watermark while a BLE ACK is in flight.
+ * A requested page becomes acknowledged only after the transport callback succeeds.
+ */
+internal class LimitlessAckCommitGate(initialPageIndex: Int) {
+    enum class RequestResult { NOOP, STARTED, PENDING, BLOCKED }
+
+    var lastAckedPageIndex: Int = initialPageIndex
+        private set
+    var inFlight: Boolean = false
+        private set
+    var blocked: Boolean = false
+        private set
+
+    fun request(
+        pageIndex: Int,
+        durableBarrier: () -> Boolean,
+        transmit: (Int, (Boolean) -> Unit) -> Unit,
+        settled: (Boolean, Int) -> Unit,
+    ): RequestResult {
+        if (blocked) return RequestResult.BLOCKED
+        if (inFlight) return RequestResult.PENDING
+        if (pageIndex <= lastAckedPageIndex) return RequestResult.NOOP
+        if (!durableBarrier()) {
+            blocked = true
+            return RequestResult.BLOCKED
+        }
+
+        inFlight = true
+        transmit(pageIndex) { success ->
+            inFlight = false
+            if (success) {
+                lastAckedPageIndex = pageIndex
+            } else {
+                blocked = true
+            }
+            settled(success, pageIndex)
+        }
+        return RequestResult.STARTED
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/limitless/LimitlessFlashDrainEngine.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/limitless/LimitlessFlashDrainEngine.kt
@@ -57,10 +57,9 @@ class LimitlessFlashDrainEngine(
     private var requestId = 0L
     private val fragmentBuffer = mutableMapOf<Int, MutableMap<Int, ByteArray>>()
     private var endPage = 0
-    private var maxSeenPageIndex = -1
-    private var lastAppendedPageIndex = -1
+    private var pageLedger: ContiguousFlashPageLedger? = null
     private var lastAckedPageIndex = -1
-    private var pagesSinceAck = 0
+    private var ackBarrierFailed = false
     private var lastPageAtMs = 0L
     private var cycleTask: ScheduledFuture<*>? = null
     private var statusTimeoutTask: ScheduledFuture<*>? = null
@@ -175,10 +174,11 @@ class LimitlessFlashDrainEngine(
         val address = deviceAddress ?: run { phase = Phase.IDLE; return }
         fragmentBuffer.clear()
         endPage = state.newestFlashPage
-        maxSeenPageIndex = -1
-        lastAppendedPageIndex = -1
-        lastAckedPageIndex = -1
-        pagesSinceAck = 0
+        pageLedger = ContiguousFlashPageLedger(state.oldestFlashPage, state.newestFlashPage) { page ->
+            page.opusFrames.isEmpty() || writer.append(page.opusFrames, page.timestampMs)
+        }
+        lastAckedPageIndex = state.oldestFlashPage - 1
+        ackBarrierFailed = false
         lastPageAtMs = System.currentTimeMillis()
         phase = Phase.DRAINING
         setBoolPref("pendantDraining", true)
@@ -195,45 +195,50 @@ class LimitlessFlashDrainEngine(
 
     private fun processFlashPage(page: LimitlessProtocol.FlashPage) {
         lastPageAtMs = System.currentTimeMillis()
-        val index = page.index ?: return
+        val ledger = pageLedger ?: return
 
-        if (page.opusFrames.isNotEmpty()) {
-            if (!writer.append(page.opusFrames, page.timestampMs)) {
+        when (ledger.offer(page)) {
+            ContiguousFlashPageLedger.OfferResult.APPEND_FAILED -> {
                 Log.w(TAG, "append failed (storage guard?) — pausing drain without ACKing unwritten pages")
                 finishDrain("append_failed")
                 return
             }
+            ContiguousFlashPageLedger.OfferResult.BUFFER_LIMIT_REACHED -> {
+                Log.w(TAG, "too many pages buffered behind a gap — pausing drain for a clean retry")
+                finishDrain("page_gap")
+                return
+            }
+            ContiguousFlashPageLedger.OfferResult.NO_PROGRESS,
+            ContiguousFlashPageLedger.OfferResult.PROGRESSED -> Unit
         }
-        lastAppendedPageIndex = maxOf(lastAppendedPageIndex, index)
-        maxSeenPageIndex = maxOf(maxSeenPageIndex, index)
-        pagesSinceAck++
 
-        if (pagesSinceAck >= ACK_EVERY_PAGES) {
+        if (ledger.pagesSinceAck >= ACK_EVERY_PAGES) {
             if (!ackWritten()) {
                 finishDrain("fsync_failed")
                 return
             }
         }
-        if (maxSeenPageIndex >= endPage) {
+        if (ledger.isComplete) {
             finishDrain("caught_up")
         }
     }
 
-    /** fsync barrier, then ACK everything appended so far. Never ACKs unwritten pages.
-     *  On a failed barrier the watermark rolls back to the last ACK — a later ACK is
-     *  up-to-index and would otherwise cover the unconfirmed pages — and the caller
-     *  must end the drain so those pages redeliver next cycle. */
+    /** fsync barrier, then ACK the contiguous prefix appended so far.
+     *  A failed barrier blocks every later ACK in this drain cycle. */
     private fun ackWritten(): Boolean {
         val address = deviceAddress ?: return true
+        if (ackBarrierFailed) return false
+        val ledger = pageLedger ?: return true
+        val lastAppendedPageIndex = ledger.lastAppendedPageIndex
         if (lastAppendedPageIndex <= lastAckedPageIndex) return true
         if (!writer.sync()) {
-            Log.w(TAG, "fsync failed — dropping ACK watermark, pages redrain next cycle")
-            lastAppendedPageIndex = lastAckedPageIndex
+            Log.w(TAG, "fsync failed — blocking ACKs so pages redrain next cycle")
+            ackBarrierFailed = true
             return false
         }
         write(address, LimitlessProtocol.encodeAcknowledgeProcessedData(messageIndex++, ++requestId, lastAppendedPageIndex))
         lastAckedPageIndex = lastAppendedPageIndex
-        pagesSinceAck = 0
+        ledger.markAcked()
         return true
     }
 
@@ -251,7 +256,12 @@ class LimitlessFlashDrainEngine(
         }
         phase = Phase.IDLE
         setBoolPref("pendantDraining", false)
-        Log.i(TAG, "drain finished ($reason): appended<=$lastAppendedPageIndex acked<=$lastAckedPageIndex end=$endPage")
+        Log.i(
+            TAG,
+            "drain finished ($reason): appended<=${pageLedger?.lastAppendedPageIndex ?: -1} " +
+                "acked<=$lastAckedPageIndex end=$endPage",
+        )
+        pageLedger = null
     }
 
     private fun resetDrainState(reason: String) {
@@ -260,6 +270,8 @@ class LimitlessFlashDrainEngine(
         statusTimeoutTask = null
         stallCheckTask = null
         fragmentBuffer.clear()
+        pageLedger = null
+        ackBarrierFailed = false
         if (phase == Phase.DRAINING) {
             Log.i(TAG, "drain aborted ($reason): acked<=$lastAckedPageIndex")
             setBoolPref("pendantDraining", false)

--- a/app/android/app/src/main/kotlin/com/friend/ios/limitless/LimitlessFlashDrainEngine.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/limitless/LimitlessFlashDrainEngine.kt
@@ -58,8 +58,8 @@ class LimitlessFlashDrainEngine(
     private val fragmentBuffer = mutableMapOf<Int, MutableMap<Int, ByteArray>>()
     private var endPage = 0
     private var pageLedger: ContiguousFlashPageLedger? = null
-    private var lastAckedPageIndex = -1
-    private var ackBarrierFailed = false
+    private var ackGate = LimitlessAckCommitGate(-1)
+    private var pendingFinishReason: String? = null
     private var lastPageAtMs = 0L
     private var cycleTask: ScheduledFuture<*>? = null
     private var statusTimeoutTask: ScheduledFuture<*>? = null
@@ -175,10 +175,21 @@ class LimitlessFlashDrainEngine(
         fragmentBuffer.clear()
         endPage = state.newestFlashPage
         pageLedger = ContiguousFlashPageLedger(state.oldestFlashPage, state.newestFlashPage) { page ->
-            page.opusFrames.isEmpty() || writer.append(page.opusFrames, page.timestampMs)
+            val pageIndex = page.index
+            when {
+                page.opusFrames.isEmpty() -> true
+                pageIndex == null -> false
+                else -> writer.append(
+                    address,
+                    requireNotNull(pageIndex),
+                    page.session ?: state.currentStorageSession,
+                    page.opusFrames,
+                    page.timestampMs,
+                )
+            }
         }
-        lastAckedPageIndex = state.oldestFlashPage - 1
-        ackBarrierFailed = false
+        ackGate = LimitlessAckCommitGate(state.oldestFlashPage - 1)
+        pendingFinishReason = null
         lastPageAtMs = System.currentTimeMillis()
         phase = Phase.DRAINING
         setBoolPref("pendantDraining", true)
@@ -223,30 +234,48 @@ class LimitlessFlashDrainEngine(
         }
     }
 
-    /** fsync barrier, then ACK the contiguous prefix appended so far.
-     *  A failed barrier blocks every later ACK in this drain cycle. */
+    /** Fsync barrier, then start an ACK for the contiguous prefix appended so far.
+     *  The destructive watermark advances only from the successful BLE callback. */
     private fun ackWritten(): Boolean {
         val address = deviceAddress ?: return true
-        if (ackBarrierFailed) return false
         val ledger = pageLedger ?: return true
         val lastAppendedPageIndex = ledger.lastAppendedPageIndex
-        if (lastAppendedPageIndex <= lastAckedPageIndex) return true
-        if (!writer.sync()) {
-            Log.w(TAG, "fsync failed — blocking ACKs so pages redrain next cycle")
-            ackBarrierFailed = true
-            return false
+        val result = ackGate.request(
+            lastAppendedPageIndex,
+            durableBarrier = writer::sync,
+            transmit = { pageIndex, callback ->
+                write(
+                    address,
+                    LimitlessProtocol.encodeAcknowledgeProcessedData(messageIndex++, ++requestId, pageIndex),
+                ) { callback(it.isSuccess) }
+            },
+        ) { success, pageIndex ->
+            if (success) pageLedger?.markAcked(pageIndex)
+            else Log.w(TAG, "ACK write failed — pages remain on pendant for retry")
+            pendingFinishReason?.let { reason ->
+                pendingFinishReason = null
+                completeDrain(reason)
+            }
         }
-        write(address, LimitlessProtocol.encodeAcknowledgeProcessedData(messageIndex++, ++requestId, lastAppendedPageIndex))
-        lastAckedPageIndex = lastAppendedPageIndex
-        ledger.markAcked()
-        return true
+        if (result == LimitlessAckCommitGate.RequestResult.BLOCKED) {
+            Log.w(TAG, "fsync failed — blocking ACKs so pages redrain next cycle")
+        }
+        return result != LimitlessAckCommitGate.RequestResult.BLOCKED
     }
 
     private fun finishDrain(reason: String) {
         if (phase != Phase.DRAINING) return
         stallCheckTask?.cancel(false)
         stallCheckTask = null
-        ackWritten()
+        pendingFinishReason = reason
+        if (!ackWritten() || !ackGate.inFlight) {
+            pendingFinishReason = null
+            completeDrain(reason)
+        }
+    }
+
+    private fun completeDrain(reason: String) {
+        if (phase != Phase.DRAINING) return
         val address = deviceAddress
         // Return the pendant to record-to-flash — unless batch mode was turned off
         // mid-drain, in which case the Dart connector owns the mode ({0,1}) and a
@@ -259,7 +288,7 @@ class LimitlessFlashDrainEngine(
         Log.i(
             TAG,
             "drain finished ($reason): appended<=${pageLedger?.lastAppendedPageIndex ?: -1} " +
-                "acked<=$lastAckedPageIndex end=$endPage",
+                "acked<=${ackGate.lastAckedPageIndex} end=$endPage",
         )
         pageLedger = null
     }
@@ -271,17 +300,22 @@ class LimitlessFlashDrainEngine(
         stallCheckTask = null
         fragmentBuffer.clear()
         pageLedger = null
-        ackBarrierFailed = false
+        pendingFinishReason = null
         if (phase == Phase.DRAINING) {
-            Log.i(TAG, "drain aborted ($reason): acked<=$lastAckedPageIndex")
+            Log.i(TAG, "drain aborted ($reason): acked<=${ackGate.lastAckedPageIndex}")
             setBoolPref("pendantDraining", false)
         }
+        ackGate = LimitlessAckCommitGate(-1)
         phase = Phase.IDLE
     }
 
     // ── IO helpers ──
 
-    private fun write(address: String, data: ByteArray) {
+    private fun write(
+        address: String,
+        data: ByteArray,
+        completion: ((Result<Unit>) -> Unit)? = null,
+    ) {
         OmiBleManager.instance.writeCharacteristic(
             address,
             limitlessServiceUuid(),
@@ -289,6 +323,7 @@ class LimitlessFlashDrainEngine(
             data,
         ) { result ->
             result.exceptionOrNull()?.let { Log.w(TAG, "TX write failed: ${it.message}") }
+            executor.execute { completion?.invoke(result) }
         }
     }
 

--- a/app/android/app/src/main/kotlin/com/friend/ios/limitless/LimitlessPageDeduplicator.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/limitless/LimitlessPageDeduplicator.kt
@@ -1,0 +1,29 @@
+package com.friend.ios.limitless
+
+/**
+ * Persists the highest durable page for one device/session. Callers supply the
+ * storage seam so the production writer can use synchronous SharedPreferences
+ * commits while JVM tests use an in-memory store.
+ */
+internal class LimitlessPageDeduplicator(
+    private val readWatermark: (String) -> Int,
+    private val writeWatermark: (String, Int) -> Boolean,
+) {
+    fun isDurable(identity: String, pageIndex: Int): Boolean = readWatermark(identity) >= pageIndex
+
+    fun appendOnce(
+        identity: String,
+        pageIndex: Int,
+        appendDurably: () -> Boolean,
+        rollback: () -> Unit,
+    ): Boolean {
+        if (isDurable(identity, pageIndex)) return true
+        if (!appendDurably()) {
+            rollback()
+            return false
+        }
+        if (writeWatermark(identity, pageIndex)) return true
+        rollback()
+        return false
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/BleReconnectBackoffTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/BleReconnectBackoffTest.kt
@@ -1,0 +1,40 @@
+package com.friend.ios.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BleReconnectBackoffTest {
+    @Test
+    fun repeatedFailuresBackOffAndCap() {
+        assertEquals(500L, BleReconnectBackoff.delayMillis(attempt = 0, jitterUnit = 0.5))
+        assertEquals(1_000L, BleReconnectBackoff.delayMillis(attempt = 1, jitterUnit = 0.5))
+        assertEquals(8_000L, BleReconnectBackoff.delayMillis(attempt = 4, jitterUnit = 0.5))
+        assertEquals(30_000L, BleReconnectBackoff.delayMillis(attempt = 6, jitterUnit = 0.5))
+        assertEquals(30_000L, BleReconnectBackoff.delayMillis(attempt = 100, jitterUnit = 0.5))
+    }
+
+    @Test
+    fun jitterStaysBoundedAndSeparatesReconnectStorms() {
+        val low = BleReconnectBackoff.delayMillis(attempt = 4, jitterUnit = 0.0)
+        val middle = BleReconnectBackoff.delayMillis(attempt = 4, jitterUnit = 0.5)
+        val high = BleReconnectBackoff.delayMillis(attempt = 4, jitterUnit = 1.0)
+
+        assertEquals(6_400L, low)
+        assertEquals(8_000L, middle)
+        assertEquals(9_600L, high)
+        assertTrue(low < middle && middle < high)
+    }
+
+    @Test
+    fun physicalConnectDoesNotResetBackoffBeforeTheSessionIsStable() {
+        val state = BleReconnectState()
+
+        assertEquals(BleReconnectAttempt(number = 1, delayMillis = 500), state.recordFailure(jitterUnit = 0.5))
+        state.markTransportConnected()
+        assertEquals(BleReconnectAttempt(number = 2, delayMillis = 1_000), state.recordFailure(jitterUnit = 0.5))
+
+        state.markStable()
+        assertEquals(BleReconnectAttempt(number = 1, delayMillis = 500), state.recordFailure(jitterUnit = 0.5))
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/GattOperationQueueTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/GattOperationQueueTest.kt
@@ -1,0 +1,341 @@
+package com.friend.ios.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GattOperationQueueTest {
+    private class FakeScheduler {
+        private data class Scheduled(val task: () -> Unit, var cancelled: Boolean = false)
+
+        private val scheduled = mutableListOf<Scheduled>()
+
+        fun schedule(@Suppress("UNUSED_PARAMETER") delayMillis: Long, task: () -> Unit): () -> Unit {
+            val item = Scheduled(task)
+            scheduled.add(item)
+            return { item.cancelled = true }
+        }
+
+        fun runNext() {
+            scheduled.firstOrNull { !it.cancelled }?.also {
+                it.cancelled = true
+                it.task()
+            }
+        }
+    }
+
+    private fun key(
+        kind: GattOperationKind,
+        target: String = "",
+        address: String = "aa:bb:cc:dd:ee:ff",
+    ) = GattOperationKey(address, kind, target)
+
+    @Test
+    fun writeWithResponseWinsWhenCharacteristicAdvertisesBothModes() {
+        assertEquals(
+            GattWriteMode.WITH_RESPONSE,
+            preferredGattWriteMode(
+                supportsWrite = true,
+                supportsWriteWithoutResponse = true,
+            ),
+        )
+        assertEquals(
+            GattWriteMode.WITHOUT_RESPONSE,
+            preferredGattWriteMode(
+                supportsWrite = false,
+                supportsWriteWithoutResponse = true,
+            ),
+        )
+        assertEquals(
+            null,
+            preferredGattWriteMode(
+                supportsWrite = false,
+                supportsWriteWithoutResponse = false,
+            ),
+        )
+    }
+
+    @Test
+    fun serializesCommandsUntilMatchingCallbackArrives() {
+        val scheduler = FakeScheduler()
+        val starts = mutableListOf<String>()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+        val first = key(GattOperationKind.READ_CHARACTERISTIC, "battery")
+        val second = key(GattOperationKind.WRITE_CHARACTERISTIC, "control")
+
+        queue.enqueue(first, start = { starts.add("first"); true })
+        queue.enqueue(second, start = { starts.add("second"); true })
+
+        assertEquals(listOf("first"), starts)
+        assertTrue(queue.complete(first))
+        assertEquals(listOf("first", "second"), starts)
+        assertTrue(queue.complete(second))
+        assertEquals(0, queue.pendingCount())
+    }
+
+    @Test
+    fun activeOperationIsDistinguishedFromQueuedDuplicate() {
+        val scheduler = FakeScheduler()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+        val discovery = key(GattOperationKind.DISCOVER_SERVICES)
+        val read = key(GattOperationKind.READ_CHARACTERISTIC, "battery")
+
+        queue.enqueue(read, start = { true })
+        queue.enqueue(discovery, start = { true })
+
+        assertTrue(queue.contains(discovery))
+        assertFalse(queue.isActive(discovery))
+        assertTrue(queue.complete(read))
+        assertTrue(queue.isActive(discovery))
+        assertTrue(queue.complete(discovery))
+    }
+
+    @Test
+    fun completionCleanupRunsBeforeSameTargetSuccessorStarts() {
+        val scheduler = FakeScheduler()
+        val events = mutableListOf<String>()
+        val operation = key(GattOperationKind.READ_CHARACTERISTIC, "battery")
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+
+        queue.enqueue(operation, start = { events.add("first-start"); true })
+        queue.enqueue(operation, start = { events.add("second-start"); true })
+
+        assertTrue(queue.complete(operation) { events.add("first-cleanup") })
+        assertEquals(listOf("first-start", "first-cleanup", "second-start"), events)
+        assertTrue(queue.complete(operation))
+    }
+
+    @Test
+    fun operationEnqueuedByCompletionWaitsUntilCompletionReturns() {
+        val scheduler = FakeScheduler()
+        val events = mutableListOf<String>()
+        val first = key(GattOperationKind.REQUEST_MTU)
+        val followUp = key(GattOperationKind.WRITE_DESCRIPTOR)
+        lateinit var queue: GattOperationQueue
+        queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+
+        queue.enqueue(first, start = { events.add("first-start"); true })
+        assertTrue(
+            queue.complete(first) {
+                events.add("callback-start")
+                queue.enqueue(followUp, start = { events.add("follow-up-start"); true })
+                events.add("callback-end")
+            },
+        )
+
+        assertEquals(
+            listOf("first-start", "callback-start", "callback-end", "follow-up-start"),
+            events,
+        )
+        assertTrue(queue.complete(followUp))
+    }
+
+    @Test
+    fun staleCallbackCannotCompleteNewerOperation() {
+        val scheduler = FakeScheduler()
+        val starts = mutableListOf<String>()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+        val first = key(GattOperationKind.REQUEST_MTU)
+        val newer = key(GattOperationKind.READ_RSSI)
+
+        queue.enqueue(first, start = { starts.add("mtu"); true })
+        queue.enqueue(newer, start = { starts.add("rssi"); true })
+
+        assertTrue(queue.complete(first))
+        assertEquals(listOf("mtu", "rssi"), starts)
+        assertFalse(queue.complete(first))
+        assertEquals(1, queue.pendingCount())
+        assertTrue(queue.complete(newer))
+    }
+
+    @Test
+    fun timeoutFailsCurrentAndUnblocksQueue() {
+        val scheduler = FakeScheduler()
+        val failures = mutableListOf<GattOperationFailure>()
+        val starts = mutableListOf<String>()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+
+        queue.enqueue(
+            key(GattOperationKind.DISCOVER_SERVICES),
+            start = { starts.add("discovery"); true },
+            onFailure = failures::add,
+        )
+        queue.enqueue(key(GattOperationKind.READ_RSSI), start = { starts.add("rssi"); true })
+
+        scheduler.runNext()
+
+        assertEquals(listOf(GattOperationFailure.TIMED_OUT), failures)
+        assertEquals(listOf("discovery", "rssi"), starts)
+    }
+
+    @Test
+    fun disconnectDrainsAndFailsPendingOperationsForOnlyThatPeripheral() {
+        val scheduler = FakeScheduler()
+        val failures = mutableListOf<GattOperationFailure>()
+        val starts = mutableListOf<String>()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+
+        queue.enqueue(
+            key(GattOperationKind.READ_CHARACTERISTIC, address = "AA:AA:AA:AA:AA:AA"),
+            start = { starts.add("a1"); true },
+            onFailure = failures::add,
+        )
+        queue.enqueue(
+            key(GattOperationKind.WRITE_CHARACTERISTIC, address = "AA:AA:AA:AA:AA:AA"),
+            start = { starts.add("a2"); true },
+            onFailure = failures::add,
+        )
+        val other = key(GattOperationKind.READ_RSSI, address = "BB:BB:BB:BB:BB:BB")
+        queue.enqueue(other, start = { starts.add("b"); true })
+
+        queue.cancelAddress("aa:aa:aa:aa:aa:aa")
+
+        assertEquals(listOf("a1", "b"), starts)
+        assertEquals(
+            listOf(GattOperationFailure.CANCELLED, GattOperationFailure.CANCELLED),
+            failures,
+        )
+        assertTrue(queue.complete(other))
+    }
+
+    @Test
+    fun disconnectStillFailsRemainingOperationsWhenOneCallbackThrows() {
+        val scheduler = FakeScheduler()
+        val failures = mutableListOf<String>()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+        val address = "AA:AA:AA:AA:AA:AA"
+
+        queue.enqueue(
+            key(GattOperationKind.READ_CHARACTERISTIC, address = address),
+            start = { true },
+            onFailure = { throw IllegalStateException("caller failed") },
+        )
+        queue.enqueue(
+            key(GattOperationKind.WRITE_CHARACTERISTIC, address = address),
+            start = { true },
+            onFailure = { failures.add("second") },
+        )
+
+        queue.cancelAddress(address)
+
+        assertEquals(listOf("second"), failures)
+        assertEquals(0, queue.pendingCount())
+    }
+
+    @Test
+    fun rejectedStartFailsAndAdvancesImmediately() {
+        val scheduler = FakeScheduler()
+        val failures = mutableListOf<GattOperationFailure>()
+        val starts = mutableListOf<String>()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+
+        queue.enqueue(
+            key(GattOperationKind.WRITE_DESCRIPTOR),
+            start = { starts.add("descriptor"); false },
+            onFailure = failures::add,
+        )
+        val next = key(GattOperationKind.READ_RSSI)
+        queue.enqueue(next, start = { starts.add("rssi"); true })
+
+        assertEquals(listOf(GattOperationFailure.REJECTED), failures)
+        assertEquals(listOf("descriptor", "rssi"), starts)
+        assertTrue(queue.complete(next))
+    }
+
+    @Test
+    fun periodicRssiIsDeduplicatedAndCannotJumpAheadOfBulkCommands() {
+        val scheduler = FakeScheduler()
+        val starts = mutableListOf<String>()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+        val bulk1 = key(GattOperationKind.WRITE_CHARACTERISTIC, "bulk-1")
+        val bulk2 = key(GattOperationKind.WRITE_CHARACTERISTIC, "bulk-2")
+        val rssi = key(GattOperationKind.READ_RSSI)
+
+        queue.enqueue(bulk1, start = { starts.add("bulk-1"); true })
+        queue.enqueue(bulk2, start = { starts.add("bulk-2"); true })
+        repeat(100) {
+            if (!queue.contains(rssi)) {
+                queue.enqueue(rssi, start = { starts.add("rssi"); true })
+            }
+        }
+
+        assertEquals(3, queue.pendingCount())
+        assertTrue(queue.complete(bulk1))
+        assertEquals(listOf("bulk-1", "bulk-2"), starts)
+        assertTrue(queue.complete(bulk2))
+        assertEquals(listOf("bulk-1", "bulk-2", "rssi"), starts)
+        assertTrue(queue.complete(rssi))
+    }
+
+    @Test
+    fun lateWriteWithoutResponseCallbackCannotReleaseLaterWrite() {
+        val scheduler = FakeScheduler()
+        val starts = mutableListOf<String>()
+        lateinit var queue: GattOperationQueue
+        queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+        val target = "control"
+        val writeWithoutResponse = key(GattOperationKind.WRITE_WITHOUT_RESPONSE, target)
+        val laterWriteWithoutResponse = key(GattOperationKind.WRITE_WITHOUT_RESPONSE, target)
+        val optionalCallback = key(GattOperationKind.WRITE_CHARACTERISTIC, target)
+
+        queue.enqueue(
+            writeWithoutResponse,
+            start = {
+                starts.add("wnr")
+                queue.complete(writeWithoutResponse)
+                true
+            },
+        )
+        queue.enqueue(laterWriteWithoutResponse, start = { starts.add("later-wnr"); true })
+
+        assertEquals(listOf("wnr", "later-wnr"), starts)
+        assertFalse(queue.complete(optionalCallback))
+        assertEquals(1, queue.pendingCount())
+        assertTrue(queue.complete(laterWriteWithoutResponse))
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/NotificationTransitionStateTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/NotificationTransitionStateTest.kt
@@ -1,0 +1,48 @@
+package com.friend.ios.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NotificationTransitionStateTest {
+    @Test
+    fun redundantSameStateRequestsCoalesceIntoOneCccdWrite() {
+        val state = NotificationTransitionState()
+
+        assertEquals(true, state.request(true))
+        assertNull(state.request(true))
+        assertNull(state.complete(attempted = true, success = true))
+        assertNull(state.request(true))
+    }
+
+    @Test
+    fun latestDesiredStateRunsAfterTheActiveTransition() {
+        val state = NotificationTransitionState()
+
+        assertEquals(true, state.request(true))
+        assertNull(state.request(false))
+        assertEquals(false, state.complete(attempted = true, success = true))
+        assertEquals(false, state.currentInFlight())
+        assertNull(state.complete(attempted = false, success = true))
+    }
+
+    @Test
+    fun enableDisableEnableBurstAvoidsAnUnnecessaryToggle() {
+        val state = NotificationTransitionState()
+
+        assertEquals(true, state.request(true))
+        assertNull(state.request(false))
+        assertNull(state.request(true))
+        assertNull(state.complete(attempted = true, success = true))
+        assertNull(state.request(true))
+    }
+
+    @Test
+    fun failedTransitionWaitsForGattSessionRecovery() {
+        val state = NotificationTransitionState()
+
+        assertEquals(true, state.request(true))
+        assertNull(state.complete(attempted = true, success = false))
+        assertNull(state.currentInFlight())
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/RssiDiagnosticsPolicyTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/RssiDiagnosticsPolicyTest.kt
@@ -1,0 +1,46 @@
+package com.friend.ios.ble
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RssiDiagnosticsPolicyTest {
+    @Test
+    fun pollingRequiresAnExplicitMatchingDiagnosticsSubscription() {
+        val policy = RssiDiagnosticsPolicy()
+
+        assertFalse(policy.shouldPoll("AA:BB:CC:DD:EE:FF", isConnected = true))
+
+        policy.subscribe("aa:bb:cc:dd:ee:ff")
+
+        assertTrue(policy.shouldPoll("AA:BB:CC:DD:EE:FF", isConnected = true))
+        assertFalse(policy.shouldPoll("11:22:33:44:55:66", isConnected = true))
+    }
+
+    @Test
+    fun disconnectPausesPollingAndReconnectResumesWithoutResubscribing() {
+        val policy = RssiDiagnosticsPolicy()
+        policy.subscribe("AA:BB:CC:DD:EE:FF")
+
+        assertFalse(policy.shouldPoll("AA:BB:CC:DD:EE:FF", isConnected = false))
+        assertTrue(policy.shouldPoll("AA:BB:CC:DD:EE:FF", isConnected = true))
+    }
+
+    @Test
+    fun onlyTheMatchingDiagnosticsViewCanStopPolling() {
+        val policy = RssiDiagnosticsPolicy()
+        policy.subscribe("AA:BB:CC:DD:EE:FF")
+
+        assertFalse(policy.unsubscribe("11:22:33:44:55:66"))
+        assertTrue(policy.shouldPoll("AA:BB:CC:DD:EE:FF", isConnected = true))
+        assertTrue(policy.unsubscribe("AA:BB:CC:DD:EE:FF"))
+        assertFalse(policy.shouldPoll("AA:BB:CC:DD:EE:FF", isConnected = true))
+    }
+
+    @Test
+    fun missingDiagnosticsRssiCallbackDoesNotForceAReconnect() {
+        assertFalse(shouldRecoverAfterGattTimeout(GattOperationKind.READ_RSSI))
+        assertTrue(shouldRecoverAfterGattTimeout(GattOperationKind.DISCOVER_SERVICES))
+        assertTrue(shouldRecoverAfterGattTimeout(GattOperationKind.WRITE_DESCRIPTOR))
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/limitless/ContiguousFlashPageLedgerTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/limitless/ContiguousFlashPageLedgerTest.kt
@@ -1,0 +1,76 @@
+package com.friend.ios.limitless
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ContiguousFlashPageLedgerTest {
+
+    private fun page(index: Int) =
+        LimitlessProtocol.FlashPage(
+            index = index,
+            session = 1,
+            timestampMs = index.toLong(),
+            opusFrames = listOf(byteArrayOf(index.toByte())),
+        )
+
+    @Test
+    fun laterPageCannotAdvanceAckWatermarkAcrossHole() {
+        val appended = mutableListOf<Int>()
+        val ledger = ContiguousFlashPageLedger(100, 102) {
+            appended += it.index!!
+            true
+        }
+
+        assertEquals(ContiguousFlashPageLedger.OfferResult.PROGRESSED, ledger.offer(page(100)))
+        assertEquals(ContiguousFlashPageLedger.OfferResult.NO_PROGRESS, ledger.offer(page(102)))
+        assertEquals(listOf(100), appended)
+        assertEquals(100, ledger.lastAppendedPageIndex)
+        assertFalse(ledger.isComplete)
+
+        assertEquals(ContiguousFlashPageLedger.OfferResult.PROGRESSED, ledger.offer(page(101)))
+        assertEquals(listOf(100, 101, 102), appended)
+        assertEquals(102, ledger.lastAppendedPageIndex)
+        assertEquals(3, ledger.pagesSinceAck)
+        assertTrue(ledger.isComplete)
+    }
+
+    @Test
+    fun failedAppendDoesNotMakePageAckEligible() {
+        val ledger = ContiguousFlashPageLedger(7, 8) { it.index != 8 }
+
+        assertEquals(ContiguousFlashPageLedger.OfferResult.PROGRESSED, ledger.offer(page(7)))
+        assertEquals(ContiguousFlashPageLedger.OfferResult.APPEND_FAILED, ledger.offer(page(8)))
+        assertEquals(7, ledger.lastAppendedPageIndex)
+        assertFalse(ledger.isComplete)
+    }
+
+    @Test
+    fun duplicatePageIsNotAppendedTwice() {
+        val appended = mutableListOf<Int>()
+        val ledger = ContiguousFlashPageLedger(4, 5) {
+            appended += it.index!!
+            true
+        }
+
+        ledger.offer(page(4))
+        ledger.offer(page(4))
+
+        assertEquals(listOf(4), appended)
+        assertEquals(4, ledger.lastAppendedPageIndex)
+    }
+
+    @Test
+    fun gapBufferIsBounded() {
+        val ledger = ContiguousFlashPageLedger(100, 200) { true }
+
+        for (index in 101..164) {
+            assertEquals(ContiguousFlashPageLedger.OfferResult.NO_PROGRESS, ledger.offer(page(index)))
+        }
+
+        assertEquals(ContiguousFlashPageLedger.OfferResult.BUFFER_LIMIT_REACHED, ledger.offer(page(165)))
+        assertEquals(65, ledger.pendingPageCount)
+        assertEquals(99, ledger.lastAppendedPageIndex)
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/limitless/ContiguousFlashPageLedgerTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/limitless/ContiguousFlashPageLedgerTest.kt
@@ -62,6 +62,17 @@ class ContiguousFlashPageLedgerTest {
     }
 
     @Test
+    fun ackCompletionOnlyClearsPagesCoveredByThatInFlightAck() {
+        val ledger = ContiguousFlashPageLedger(4, 6) { true }
+        ledger.offer(page(4))
+        ledger.offer(page(5))
+        ledger.markAcked(4)
+
+        assertEquals(1, ledger.pagesSinceAck)
+        assertEquals(5, ledger.lastAppendedPageIndex)
+    }
+
+    @Test
     fun gapBufferIsBounded() {
         val ledger = ContiguousFlashPageLedger(100, 200) { true }
 

--- a/app/android/app/src/test/kotlin/com/friend/ios/limitless/LimitlessAckIdempotencyTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/limitless/LimitlessAckIdempotencyTest.kt
@@ -1,0 +1,106 @@
+package com.friend.ios.limitless
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LimitlessAckIdempotencyTest {
+    @Test
+    fun failedAckDoesNotAdvanceDeletionAndRedrainDoesNotAppendTwice() {
+        val watermarks = mutableMapOf<String, Int>()
+        var appends = 0
+        val dedupe = LimitlessPageDeduplicator(
+            readWatermark = { watermarks[it] ?: Int.MIN_VALUE },
+            writeWatermark = { key, value ->
+                watermarks[key] = value
+                true
+            },
+        )
+        val gate = LimitlessAckCommitGate(40)
+        var transportCallback: ((Boolean) -> Unit)? = null
+
+        assertTrue(
+            dedupe.appendOnce(
+                "device-a/session-7",
+                41,
+                {
+                    appends++
+                    true
+                },
+                {},
+            ),
+        )
+        assertEquals(
+            LimitlessAckCommitGate.RequestResult.STARTED,
+            gate.request(41, { true }, { _, callback -> transportCallback = callback }) { _, _ -> },
+        )
+        assertEquals(40, gate.lastAckedPageIndex)
+
+        transportCallback!!(false)
+        assertEquals(40, gate.lastAckedPageIndex)
+        assertTrue(gate.blocked)
+
+        val afterReconnect = LimitlessPageDeduplicator(
+            readWatermark = { watermarks[it] ?: Int.MIN_VALUE },
+            writeWatermark = { key, value ->
+                watermarks[key] = value
+                true
+            },
+        )
+        assertTrue(
+            afterReconnect.appendOnce(
+                "device-a/session-7",
+                41,
+                {
+                    appends++
+                    true
+                },
+                {},
+            ),
+        )
+        assertEquals(1, appends)
+    }
+
+    @Test
+    fun successfulAckAdvancesOnlyAfterCompletion() {
+        val gate = LimitlessAckCommitGate(9)
+        var transportCallback: ((Boolean) -> Unit)? = null
+        var settled = false
+
+        gate.request(10, { true }, { _, callback -> transportCallback = callback }) { success, _ ->
+            settled = success
+        }
+        assertEquals(9, gate.lastAckedPageIndex)
+        assertTrue(gate.inFlight)
+
+        transportCallback!!(true)
+        assertEquals(10, gate.lastAckedPageIndex)
+        assertFalse(gate.inFlight)
+        assertTrue(settled)
+    }
+
+    @Test
+    fun failedWatermarkCommitRollsBackAndRemainsRetryable() {
+        var rollbacks = 0
+        val dedupe = LimitlessPageDeduplicator(
+            readWatermark = { Int.MIN_VALUE },
+            writeWatermark = { _, _ -> false },
+        )
+
+        assertFalse(dedupe.appendOnce("device/session", 1, { true }, { rollbacks++ }))
+        assertEquals(1, rollbacks)
+    }
+
+    @Test
+    fun failedDurableAppendAlsoRollsBackPendingBytes() {
+        var rollbacks = 0
+        val dedupe = LimitlessPageDeduplicator(
+            readWatermark = { Int.MIN_VALUE },
+            writeWatermark = { _, _ -> true },
+        )
+
+        assertFalse(dedupe.appendOnce("device/session", 1, { false }, { rollbacks++ }))
+        assertEquals(1, rollbacks)
+    }
+}

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -381,6 +381,8 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
         drain: _drainEligibleWals,
         autoUploadEnabled: () =>
             !SharedPreferencesUtil().useCustomStt && SharedPreferencesUtil().autoSyncOfflineRecordings,
+        backgroundDeviceRecoveryEnabled: () =>
+            defaultTargetPlatform == TargetPlatform.android && SharedPreferencesUtil().backgroundModeEnabled,
         connectivityChanges: ConnectivityService().onConnectionChange,
         initiallyConnected: ConnectivityService().isConnected,
       );

--- a/app/lib/services/devices/ble_packet_continuity.dart
+++ b/app/lib/services/devices/ble_packet_continuity.dart
@@ -1,0 +1,104 @@
+enum BlePacketDisposition {
+  first,
+  contiguous,
+  gap,
+  duplicate,
+  reset,
+  malformed,
+}
+
+class BlePacketContinuityObservation {
+  final BlePacketDisposition disposition;
+  final int? packetId;
+  final int missingPackets;
+
+  const BlePacketContinuityObservation(this.disposition, {this.packetId, this.missingPackets = 0});
+
+  bool get shouldForward =>
+      disposition != BlePacketDisposition.duplicate && disposition != BlePacketDisposition.malformed;
+}
+
+/// Tracks Omi's 16-bit little-endian live-audio packet ID.
+///
+/// BLE notifications are ordered within a connection, so an exactly repeated
+/// packet is a duplicate and a forward delta greater than one is a measurable
+/// gap. The half-range modular rule distinguishes forward progress from reset:
+/// some high-ID-to-low-ID jumps are inherently ambiguous and are reported as
+/// gaps, but all anomalies except exact adjacent duplicates are forwarded.
+class BlePacketContinuityTracker {
+  int? _lastPacketId;
+  List<int>? _lastPacket;
+
+  BlePacketContinuityObservation observe(List<int> packet) {
+    if (packet.length < 3) {
+      return const BlePacketContinuityObservation(BlePacketDisposition.malformed);
+    }
+
+    final packetId = (packet[0] & 0xFF) | ((packet[1] & 0xFF) << 8);
+    final previous = _lastPacketId;
+    if (previous == null) {
+      _lastPacketId = packetId;
+      _lastPacket = List<int>.from(packet);
+      return BlePacketContinuityObservation(BlePacketDisposition.first, packetId: packetId);
+    }
+
+    final delta = (packetId - previous) & 0xFFFF;
+    if (delta == 0) {
+      if (_packetsEqual(packet, _lastPacket!)) {
+        return BlePacketContinuityObservation(BlePacketDisposition.duplicate, packetId: packetId);
+      }
+
+      // A repeated 16-bit ID with different index/payload can be a firmware
+      // counter reset or another fragment from legacy firmware. Preserve it.
+      _lastPacket = List<int>.from(packet);
+      return BlePacketContinuityObservation(BlePacketDisposition.reset, packetId: packetId);
+    }
+
+    _lastPacketId = packetId;
+    _lastPacket = List<int>.from(packet);
+    if (delta == 1) {
+      return BlePacketContinuityObservation(BlePacketDisposition.contiguous, packetId: packetId);
+    }
+    if (delta < 0x8000) {
+      return BlePacketContinuityObservation(
+        BlePacketDisposition.gap,
+        packetId: packetId,
+        missingPackets: delta - 1,
+      );
+    }
+    return BlePacketContinuityObservation(BlePacketDisposition.reset, packetId: packetId);
+  }
+
+  bool _packetsEqual(List<int> left, List<int> right) {
+    if (left.length != right.length) return false;
+    for (var index = 0; index < left.length; index++) {
+      if (left[index] != right[index]) return false;
+    }
+    return true;
+  }
+}
+
+/// Coalesces continuity warnings so a damaged stream cannot enqueue a log write
+/// for every BLE notification.
+class BlePacketAnomalyLogLimiter {
+  final Duration interval;
+  DateTime? _lastEmission;
+  int _pendingEvents = 0;
+
+  BlePacketAnomalyLogLimiter({this.interval = const Duration(seconds: 10)});
+
+  /// Returns the number of coalesced anomaly events when a warning should be
+  /// emitted, or null when this event should be folded into the next warning.
+  int? record(DateTime now) {
+    _pendingEvents++;
+    final lastEmission = _lastEmission;
+    if (lastEmission != null && now.isBefore(lastEmission.add(interval))) {
+      return null;
+    }
+
+    final events = _pendingEvents;
+    _pendingEvents = 0;
+    _lastEmission = now;
+    return events;
+  }
+}

--- a/app/lib/services/devices/connectors/omi_connection.dart
+++ b/app/lib/services/devices/connectors/omi_connection.dart
@@ -8,6 +8,7 @@ import 'package:version/version.dart';
 
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/services/devices.dart';
+import 'package:omi/services/devices/ble_packet_continuity.dart';
 import 'package:omi/services/devices/connectors/device_connection.dart';
 import 'package:omi/services/devices/models.dart';
 import 'package:omi/services/devices/ring_protocol.dart';
@@ -119,10 +120,24 @@ class OmiDeviceConnection extends DeviceConnection {
   }) async {
     try {
       final stream = transport.getCharacteristicStream(omiServiceUuid, audioDataStreamCharacteristicUuid);
+      final continuity = BlePacketContinuityTracker();
+      final anomalyLogLimiter = BlePacketAnomalyLogLimiter();
 
       Logger.debug('Subscribed to audioBytes stream from Omi Device');
       final subscription = stream.listen((value) {
-        if (value.isNotEmpty) onAudioBytesReceived(value);
+        final observation = continuity.observe(value);
+        if (observation.disposition != BlePacketDisposition.first &&
+            observation.disposition != BlePacketDisposition.contiguous) {
+          final coalescedEvents = anomalyLogLimiter.record(DateTime.now());
+          if (coalescedEvents != null) {
+            Logger.warning(
+              'Omi BLE audio continuity anomaly: type=${observation.disposition.name} '
+              'packetId=${observation.packetId} missing=${observation.missingPackets} '
+              'coalescedEvents=$coalescedEvents bytes=${value.length}',
+            );
+          }
+        }
+        if (observation.shouldForward) onAudioBytesReceived(value);
       });
 
       return subscription;

--- a/app/lib/services/devices/ring_protocol.dart
+++ b/app/lib/services/devices/ring_protocol.dart
@@ -16,7 +16,7 @@ import 'package:omi/services/devices/connectors/device_connection.dart';
 ///     0x01 ACK         [0x01][status]
 ///     0x02 INFO        [0x02][read:u64][write:u64][cap:u32][dropped:u64][pkt_size:u16]
 ///     0x03 DATA        [0x03][raw_bytes...]   <-- not aligned to record boundaries
-///     0x04 DONE        [0x04][status][next_seq:u64]
+///     0x04 DONE        [0x04][status][next_seq:u64](optional [crc32:u32])
 ///     0x05 READ_BEGIN  [0x05][transfer_start_seq:u64][packet_count:u32]
 ///
 ///   Each ring record (packet_size = 444 bytes):
@@ -71,7 +71,11 @@ class RingProtocol {
   static DoneNotification? parseDoneNotification(List<int> value) {
     if (value.isEmpty || value[0] != notifyDone || value.length < 10) return null;
     final bd = ByteData.sublistView(Uint8List.fromList(value));
-    return DoneNotification(status: bd.getUint8(1), nextSeq: bd.getUint64(2, Endian.big));
+    return DoneNotification(
+      status: bd.getUint8(1),
+      nextSeq: bd.getUint64(2, Endian.big),
+      transferCrc32: value.length >= 14 ? bd.getUint32(10, Endian.big) : null,
+    );
   }
 
   /// Parse a NOTIFY_READ_BEGIN (0x05) notification.
@@ -111,6 +115,15 @@ class RingProtocol {
     return (record[0] << 24) | (record[1] << 16) | (record[2] << 8) | record[3];
   }
 
+  /// Record timestamps survive a reboot where the device's current RTC-valid
+  /// flag may be false. Trust plausible embedded capture time rather than
+  /// collapsing old audio onto the retry time.
+  static bool isPlausibleRecordTimestamp(int timestamp, {required int nowSeconds}) {
+    const earliestSupportedTimestamp = 1704067200;
+    const maximumFutureSkewSeconds = 24 * 60 * 60;
+    return timestamp >= earliestSupportedTimestamp && timestamp <= nowSeconds + maximumFutureSkewSeconds;
+  }
+
   /// The pendant may discard records only after the complete transfer reached
   /// durable phone storage. A BLE TX completion or a partial stream is not an
   /// acknowledgement.
@@ -120,8 +133,16 @@ class RingProtocol {
     required bool flushError,
     required bool isCancelled,
     required bool receivedCompleteRange,
+    required bool protocolError,
+    required bool crcVerified,
   }) {
-    return reachedDone && doneOk && !flushError && !isCancelled && receivedCompleteRange;
+    return reachedDone &&
+        doneOk &&
+        !flushError &&
+        !isCancelled &&
+        receivedCompleteRange &&
+        !protocolError &&
+        crcVerified;
   }
 
   /// Validate that READ_BEGIN, DATA, and DONE describe one complete contiguous
@@ -146,10 +167,10 @@ class RingProtocol {
   /// A leading byte of 0 is a no-op padding marker; otherwise it is the
   /// length of the next frame.
   ///
-  /// Boundary uses `>=` to match the firmware's overflow rule in
-  /// transport.c:write_to_storage — at the boundary the firmware writes a
-  /// trailing size byte without its frame (the frame goes to the next 440B
-  /// block); the bytes after it are stale and must not be parsed.
+  /// Boundary uses `>=` for compatibility with legacy 3.0.20 records. That
+  /// firmware can flush a record after writing only a size marker at the exact
+  /// boundary, leaving stale bytes where the frame would be. New firmware
+  /// preserves this no-exact-fit wire invariant.
   static List<List<int>> parseAudioPayload(List<int> audio) {
     final frames = <List<int>>[];
     int offset = 0;
@@ -173,10 +194,30 @@ class RingProtocol {
 class DoneNotification {
   final int status;
   final int nextSeq;
+  final int? transferCrc32;
 
-  const DoneNotification({required this.status, required this.nextSeq});
+  const DoneNotification({required this.status, required this.nextSeq, this.transferCrc32});
 
   bool get isOk => status == 0;
+}
+
+/// Incremental IEEE CRC-32 over raw NOTIFY_DATA payload bytes.
+///
+/// New firmware includes this value in DONE. Legacy 3.0.20 firmware omits it,
+/// so callers verify when present while retaining read compatibility.
+class RingTransferCrc32 {
+  int _crc = 0xFFFFFFFF;
+
+  void add(List<int> bytes) {
+    for (final byte in bytes) {
+      _crc ^= byte & 0xFF;
+      for (var bit = 0; bit < 8; bit++) {
+        _crc = (_crc & 1) != 0 ? (_crc >> 1) ^ 0xEDB88320 : _crc >> 1;
+      }
+    }
+  }
+
+  int get value => (_crc ^ 0xFFFFFFFF) & 0xFFFFFFFF;
 }
 
 /// Decoded NOTIFY_READ_BEGIN payload.

--- a/app/lib/services/devices/ring_protocol.dart
+++ b/app/lib/services/devices/ring_protocol.dart
@@ -111,6 +111,36 @@ class RingProtocol {
     return (record[0] << 24) | (record[1] << 16) | (record[2] << 8) | record[3];
   }
 
+  /// The pendant may discard records only after the complete transfer reached
+  /// durable phone storage. A BLE TX completion or a partial stream is not an
+  /// acknowledgement.
+  static bool canAdvance({
+    required bool reachedDone,
+    required bool doneOk,
+    required bool flushError,
+    required bool isCancelled,
+    required bool receivedCompleteRange,
+  }) {
+    return reachedDone && doneOk && !flushError && !isCancelled && receivedCompleteRange;
+  }
+
+  /// Validate that READ_BEGIN, DATA, and DONE describe one complete contiguous
+  /// record range. This catches missing notification bytes before a cumulative
+  /// ADVANCE command could discard the corresponding SD records.
+  static bool receivedCompleteRange({
+    required int? transferStartSeq,
+    required int? announcedPacketCount,
+    required int? doneNextSeq,
+    required int receivedPacketCount,
+    required int pendingBytes,
+  }) {
+    if (transferStartSeq == null || announcedPacketCount == null || doneNextSeq == null) return false;
+    return announcedPacketCount >= 0 &&
+        doneNextSeq == transferStartSeq + announcedPacketCount &&
+        receivedPacketCount == announcedPacketCount &&
+        pendingBytes == 0;
+  }
+
   /// Parse the 440-byte audio payload of a ring record into opus frames.
   /// Format: [size:1][frame:size]... with zero padding allowed at any point.
   /// A leading byte of 0 is a no-op padding marker; otherwise it is the

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -33,6 +33,9 @@ const _freshSyncCutoffSeconds = 6 * 60 * 60;
 /// size (200 MB), not file count.
 const _syncUploadBatchLimit = 20;
 
+typedef WalPersister = Future<bool> Function(List<Wal> wals);
+typedef WalPathResolver = Future<String?> Function(String? pathOrName);
+
 enum SyncJobTerminalPolicy { wait, acknowledge, retry }
 
 /// The shared WAL acknowledgement boundary for async sync jobs.
@@ -131,8 +134,20 @@ class LocalWalSyncImpl implements LocalWalSync {
 
   final SyncUploadGate? _uploadGateOverride;
   SyncUploadGate get _uploadGate => _uploadGateOverride ?? SyncUploadGate.instance;
+  final WalPersister? _walPersisterOverride;
+  final WalPathResolver _walPathResolver;
+  Future<void>? _freshUploadWake;
+  bool _freshUploadWakePending = false;
+  String? _freshUploadWakeWalId;
 
-  LocalWalSyncImpl(this.listener, {SyncUploadGate? uploadGate}) : _uploadGateOverride = uploadGate;
+  LocalWalSyncImpl(
+    this.listener, {
+    SyncUploadGate? uploadGate,
+    WalPersister? walPersister,
+    WalPathResolver? walPathResolver,
+  })  : _uploadGateOverride = uploadGate,
+        _walPersisterOverride = walPersister,
+        _walPathResolver = walPathResolver ?? Wal.getFilePath;
 
   @visibleForTesting
   List<WalFrame> get testFrames => _frames;
@@ -152,26 +167,116 @@ class LocalWalSyncImpl implements LocalWalSync {
   }
 
   @override
-  Future<void> addExternalWal(Wal wal) async {
+  Future<ExternalWalRegistration> addExternalWal(Wal wal) async {
     final existingIndex = _wals.indexWhere((w) => w.id == wal.id);
     if (existingIndex >= 0) {
-      Logger.debug("LocalWalSync: WAL ${wal.id} already exists, skipping");
-      return;
+      final existing = _wals[existingIndex];
+      if (!await _hasIdenticalFile(existing, wal)) {
+        throw StateError('External WAL identity collision for ${wal.id}');
+      }
+      Logger.debug("LocalWalSync: WAL ${wal.id} already durably registered");
+      await _deleteDuplicateExternalFile(existing, wal);
+      return ExternalWalRegistration.alreadyRegistered;
     }
+
+    // Older ring-sync builds keyed recovered WALs only by timestamp. If one of
+    // those files is byte-identical, it is already durable (and may already
+    // be uploaded); do not manufacture a second conversation from the retry.
+    for (final existing in _wals) {
+      if (existing.device == wal.device &&
+          existing.timerStart == wal.timerStart &&
+          existing.codec == wal.codec &&
+          existing.originalStorage == wal.originalStorage &&
+          await _hasIdenticalFile(existing, wal)) {
+        // Old builds could overwrite a timestamp-named file after it had been
+        // marked synced. Without the upload-time hash, its current bytes are
+        // not proof of what reached the server. Re-register that legacy data
+        // conservatively; source-aware WALs below are immutable and idempotent.
+        if (existing.sourceId == null && existing.status == WalStatus.synced) {
+          Logger.debug("LocalWalSync: synced legacy WAL ${existing.id} has no immutable upload proof; retaining retry");
+          continue;
+        }
+        Logger.debug("LocalWalSync: external WAL ${wal.id} matches legacy durable WAL ${existing.id}");
+        await _deleteDuplicateExternalFile(existing, wal);
+        return ExternalWalRegistration.alreadyRegistered;
+      }
+    }
+
     _wals.add(wal);
-    await _saveWalsToFile();
+    try {
+      await _saveWalsToFile();
+    } catch (_) {
+      _wals.removeWhere((candidate) => identical(candidate, wal));
+      rethrow;
+    }
     listener.onWalUpdated();
     Logger.debug("LocalWalSync: Added external WAL ${wal.id} (${wal.seconds}s)");
     if (_syncLaneForWal(wal, DateTime.now().millisecondsSinceEpoch ~/ 1000) == SyncUploadLane.fresh) {
+      // Registration is the durability boundary used by device-storage sync:
+      // once the manifest is committed, the device may advance its read
+      // pointer. Cloud latency must not hold that acknowledgement hostage.
+      _scheduleFreshUpload(wal);
+    }
+    return ExternalWalRegistration.added;
+  }
+
+  void _scheduleFreshUpload(Wal wal) {
+    _freshUploadWakePending = true;
+    _freshUploadWakeWalId = wal.id;
+    if (_freshUploadWake != null) return;
+    _startFreshUploadWake();
+  }
+
+  void _startFreshUploadWake() {
+    final wake = _drainFreshUploadWakes();
+    _freshUploadWake = wake;
+    unawaited(
+      wake.whenComplete(() {
+        if (!identical(_freshUploadWake, wake)) return;
+        _freshUploadWake = null;
+        // A registration can land after the drain's final pending check but
+        // before this completion callback. Preserve that wake as a new drain.
+        if (_freshUploadWakePending) _startFreshUploadWake();
+      }),
+    );
+  }
+
+  Future<void> _drainFreshUploadWakes() async {
+    do {
+      _freshUploadWakePending = false;
+      final walId = _freshUploadWakeWalId;
       try {
-        // Device-storage recovery persists one WAL at a time. Upload each
-        // fresh chunk immediately instead of waiting for the full ring/flash
-        // backlog to finish downloading.
+        // Device-storage recovery persists one WAL at a time. Coalesce wakes
+        // so a fast BLE drain cannot start duplicate upload loops.
         await syncFreshOnly();
       } catch (error) {
-        Logger.debug('LocalWalSync: fresh upload wake failed for ${wal.id}: $error');
+        Logger.debug('LocalWalSync: fresh upload wake failed for $walId: $error');
       }
-    }
+    } while (_freshUploadWakePending);
+  }
+
+  Future<bool> _hasIdenticalFile(Wal existing, Wal candidate) async {
+    if (existing.filePath == null || candidate.filePath == null) return false;
+    final existingPath = await _walPathResolver(existing.filePath);
+    final candidatePath = await _walPathResolver(candidate.filePath);
+    if (existingPath == null || candidatePath == null) return false;
+    final existingFile = File(existingPath);
+    final candidateFile = File(candidatePath);
+    if (!await existingFile.exists() || !await candidateFile.exists()) return false;
+    if (await existingFile.length() != await candidateFile.length()) return false;
+    if (existingPath == candidatePath) return true;
+
+    final existingBytes = await existingFile.readAsBytes();
+    final candidateBytes = await candidateFile.readAsBytes();
+    return listEquals(existingBytes, candidateBytes);
+  }
+
+  Future<void> _deleteDuplicateExternalFile(Wal existing, Wal candidate) async {
+    if (existing.filePath == null || candidate.filePath == null || existing.filePath == candidate.filePath) return;
+    final candidatePath = await _walPathResolver(candidate.filePath);
+    if (candidatePath == null) return;
+    final candidateFile = File(candidatePath);
+    if (await candidateFile.exists()) await candidateFile.delete();
   }
 
   @override
@@ -382,7 +487,10 @@ class LocalWalSyncImpl implements LocalWalSync {
 
   Future<void> _saveWalsToFile() async {
     Logger.debug('Saving WALs to file');
-    await WalFileManager.saveWals(_wals);
+    final saved = await (_walPersisterOverride?.call(_wals) ?? WalFileManager.saveWals(_wals));
+    if (!saved) {
+      throw StateError('WAL manifest persistence failed');
+    }
   }
 
   Future<bool> _deleteWal(Wal wal) async {

--- a/app/lib/services/wals/recording_transfer_coordinator.dart
+++ b/app/lib/services/wals/recording_transfer_coordinator.dart
@@ -45,7 +45,7 @@ typedef RecordingTransferPass = Future<void> Function();
 typedef RecordingTransferDrain = Future<RecordingTransferDrainResult> Function();
 typedef RecordingTransferCooldownScheduler = void Function(Duration delay, void Function() callback);
 
-/// The single foreground owner for recording recovery.
+/// The single owner for recording recovery.
 ///
 /// It deliberately knows no provider or transport details. Production wires
 /// the seams once, while tests use the same coordinator with fake connectivity,
@@ -57,6 +57,7 @@ class RecordingTransferCoordinator {
     required RecordingTransferPass refreshPending,
     required RecordingTransferDrain drain,
     required bool Function() autoUploadEnabled,
+    bool Function()? backgroundDeviceRecoveryEnabled,
     Stream<bool>? connectivityChanges,
     bool initiallyConnected = true,
     DateTime Function()? clock,
@@ -66,6 +67,7 @@ class RecordingTransferCoordinator {
         _refreshPending = refreshPending,
         _drain = drain,
         _autoUploadEnabled = autoUploadEnabled,
+        _backgroundDeviceRecoveryEnabled = backgroundDeviceRecoveryEnabled ?? _disabled,
         _clock = clock ?? DateTime.now,
         _scheduleCooldown = scheduleCooldown {
     _configured = true;
@@ -78,6 +80,7 @@ class RecordingTransferCoordinator {
         _refreshPending = _noop,
         _drain = _skippedDrain,
         _autoUploadEnabled = _disabled,
+        _backgroundDeviceRecoveryEnabled = _disabled,
         _clock = DateTime.now;
 
   static final RecordingTransferCoordinator instance = RecordingTransferCoordinator._singleton();
@@ -98,6 +101,7 @@ class RecordingTransferCoordinator {
   RecordingTransferPass _refreshPending;
   RecordingTransferDrain _drain;
   bool Function() _autoUploadEnabled;
+  bool Function() _backgroundDeviceRecoveryEnabled;
   final DateTime Function() _clock;
   RecordingTransferCooldownScheduler? _scheduleCooldown;
 
@@ -125,6 +129,7 @@ class RecordingTransferCoordinator {
     required RecordingTransferPass refreshPending,
     required RecordingTransferDrain drain,
     required bool Function() autoUploadEnabled,
+    required bool Function() backgroundDeviceRecoveryEnabled,
     required Stream<bool> connectivityChanges,
     required bool initiallyConnected,
   }) {
@@ -133,6 +138,7 @@ class RecordingTransferCoordinator {
     _refreshPending = refreshPending;
     _drain = drain;
     _autoUploadEnabled = autoUploadEnabled;
+    _backgroundDeviceRecoveryEnabled = backgroundDeviceRecoveryEnabled;
     _configured = true;
     _listenToConnectivity(connectivityChanges, initiallyConnected);
 
@@ -170,15 +176,21 @@ class RecordingTransferCoordinator {
   /// Coalesces concurrent events into a single extra serial pass. Five wakes
   /// during one pass therefore run at most two passes and never parallel drains.
   Future<void> wake(WakeTrigger trigger) {
-    // Recovery is foreground-only. Persisted WAL state is recovered by the
-    // foreground wake, so background connectivity/device callbacks must not
-    // start discovery or a whole-WAL drain.
-    if (!_foreground) return Future.value();
-
     if (!_configured) {
       _wakeBeforeConfigured = _preferWake(_wakeBeforeConfigured, trigger);
       return Future.value();
     }
+
+    // Android's persistent BLE mode is an explicit user opt-in. Its native
+    // reconnect callback may run one recovery pass while Dart is still alive
+    // in the background, but only when automatic uploads are also enabled.
+    // Every other background wake remains suppressed; persisted state is
+    // recovered by the next foreground wake.
+    final allowedBackgroundDeviceReconnect = !_foreground &&
+        trigger == WakeTrigger.deviceConnected &&
+        _backgroundDeviceRecoveryEnabled() &&
+        _autoUploadEnabled();
+    if (!_foreground && !allowedBackgroundDeviceReconnect) return Future.value();
 
     final active = _inFlight;
     if (active != null) {

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -467,7 +468,7 @@ class RingStorageSyncImpl implements RingStorageSync {
   }) async {
     final completer = Completer<bool>();
     final reassembler = RingRecordReassembler();
-    final pendingRecords = <_RecoveredRingRecord>[];
+    final pendingRecords = ListQueue<_RecoveredRingRecord>();
     int recordsConsumed = 0;
     int segment = 0;
     int? previousRecordTimestamp;
@@ -494,7 +495,7 @@ class RingStorageSyncImpl implements RingStorageSync {
         var frameCount = 0;
         while (pendingRecords.isNotEmpty && pendingRecords.first.segment == firstSegment) {
           if (frameCount >= chunkFrames) break;
-          final record = pendingRecords.removeAt(0);
+          final record = pendingRecords.removeFirst();
           chunkRecords.add(record);
           frameCount += record.frames.length;
         }
@@ -753,14 +754,19 @@ class RingStorageSyncImpl implements RingStorageSync {
     final directory = await _documentsDirectoryProvider();
     final filePath = '${directory.path}/${wal.getFileNameByTimeStarts(timerStart, sourceId: sourceId)}';
 
-    final List<int> data = [];
+    var dataLength = 0;
     for (final frame in frames) {
-      final byteFrame = ByteData(frame.length);
-      for (int j = 0; j < frame.length; j++) {
-        byteFrame.setUint8(j, frame[j]);
-      }
-      data.addAll(Uint32List.fromList([frame.length]).buffer.asUint8List());
-      data.addAll(byteFrame.buffer.asUint8List());
+      dataLength += Uint32List.bytesPerElement + frame.length;
+    }
+
+    final data = Uint8List(dataLength);
+    final writer = ByteData.sublistView(data);
+    var offset = 0;
+    for (final frame in frames) {
+      writer.setUint32(offset, frame.length, Endian.little);
+      offset += Uint32List.bytesPerElement;
+      data.setRange(offset, offset + frame.length, frame);
+      offset += frame.length;
     }
 
     final file = File(filePath);

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:path_provider/path_provider.dart';
@@ -9,6 +10,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/models/sync_state.dart';
+import 'package:omi/services/devices/connectors/device_connection.dart';
 import 'package:omi/services/devices/ring_protocol.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/services/wals/wal.dart';
@@ -25,14 +27,21 @@ import 'package:omi/services/wals/wal_interfaces.dart';
 ///   0x01 ACK             [0x01][status]
 ///   0x02 INFO            [0x02][read:u64 BE][write:u64 BE][cap:u32 BE][dropped:u64 BE][pkt_size:u16 BE]
 ///   0x03 DATA            [0x03][raw_bytes...]   <-- not aligned to record boundaries
-///   0x04 DONE            [0x04][status][next_seq:u64 BE]
+///   0x04 DONE            [0x04][status][next_seq:u64 BE](optional [crc32:u32 BE])
 ///   0x05 READ_BEGIN      [0x05][transfer_start_seq:u64 BE][packet_count:u32 BE]
 ///
-/// Data-safety invariant: CMD_RING_ADVANCE is sent ONLY after NOTIFY_DONE arrives
-/// AND every chunk we received during the transfer has been handed to LocalWalSync.
-/// On any failure (cancel, BLE drop, NOTIFY_DONE error status) the ring is left
-/// untouched — the next sync session resumes from the same read_seq.
+/// Data-safety invariant: each bounded source-sequence range is registered in
+/// the atomically persisted local WAL manifest only after READ_BEGIN, byte
+/// count, DONE, and optional CRC all agree. CMD_RING_ADVANCE is sent after that
+/// durable registration. On any failure the current range stays on the device;
+/// previously advanced ranges never need to be downloaded again.
+typedef RingConnectionResolver = Future<DeviceConnection?> Function(String deviceId);
+typedef RingDocumentsDirectoryProvider = Future<Directory> Function();
+
 class RingStorageSyncImpl implements RingStorageSync {
+  static const int defaultPacketsPerRead = 1800;
+  static const Duration defaultInactivityTimeout = Duration(seconds: 15);
+
   List<Wal> _wals = [];
   BtDevice? _device;
 
@@ -42,6 +51,11 @@ class RingStorageSyncImpl implements RingStorageSync {
 
   IWalSyncListener listener;
   LocalWalSync? _localSync;
+  final RingConnectionResolver? _connectionResolverOverride;
+  final RingDocumentsDirectoryProvider _documentsDirectoryProvider;
+  final int _packetsPerRead;
+  final Duration _inactivityTimeout;
+  final int Function() _nowSeconds;
 
   bool _isCancelled = false;
   bool _isSyncing = false;
@@ -54,7 +68,28 @@ class RingStorageSyncImpl implements RingStorageSync {
   @override
   double get currentSpeedKBps => _currentSpeedKBps;
 
-  RingStorageSyncImpl(this.listener);
+  RingStorageSyncImpl(
+    this.listener, {
+    RingConnectionResolver? connectionResolver,
+    RingDocumentsDirectoryProvider? documentsDirectoryProvider,
+    int packetsPerRead = defaultPacketsPerRead,
+    Duration inactivityTimeout = defaultInactivityTimeout,
+    int Function()? nowSeconds,
+  })  : _connectionResolverOverride = connectionResolver,
+        _documentsDirectoryProvider = documentsDirectoryProvider ?? getApplicationDocumentsDirectory,
+        _packetsPerRead = packetsPerRead,
+        _inactivityTimeout = inactivityTimeout,
+        _nowSeconds = nowSeconds ?? _systemNowSeconds {
+    if (packetsPerRead <= 0) throw ArgumentError.value(packetsPerRead, 'packetsPerRead', 'must be positive');
+  }
+
+  static int _systemNowSeconds() => DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+  Future<DeviceConnection?> _ensureConnection(String deviceId) {
+    final resolver = _connectionResolverOverride;
+    if (resolver != null) return resolver(deviceId);
+    return ServiceManager.instance().device.ensureConnection(deviceId);
+  }
 
   @override
   void setLocalSync(LocalWalSync localSync) {
@@ -87,7 +122,7 @@ class RingStorageSyncImpl implements RingStorageSync {
     if (deviceId == null || deviceId.isEmpty) return;
 
     try {
-      final connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+      final connection = await _ensureConnection(deviceId);
       if (connection == null) return;
       // CMD_STOP_SYNC (0x03) — does not persist progress; data stays in the ring.
       await connection.stopStorageSync();
@@ -123,7 +158,7 @@ class RingStorageSyncImpl implements RingStorageSync {
   Future<bool> hasFilesToSync() async {
     if (_device == null) return false;
     try {
-      final connection = await ServiceManager.instance().device.ensureConnection(_device!.id);
+      final connection = await _ensureConnection(_device!.id);
       if (connection == null) return false;
       final status = await connection.getRingStatus();
       final result = status != null && status.unreadPackets > 0;
@@ -154,7 +189,7 @@ class RingStorageSyncImpl implements RingStorageSync {
     }
 
     try {
-      final connection = await ServiceManager.instance().device.ensureConnection(_device!.id);
+      final connection = await _ensureConnection(_device!.id);
       if (connection == null) return;
 
       final status = await connection.getRingStatus();
@@ -255,7 +290,7 @@ class RingStorageSyncImpl implements RingStorageSync {
   Future<void> _clearRingOnDevice() async {
     if (_device == null) return;
     try {
-      final connection = await ServiceManager.instance().device.ensureConnection(_device!.id);
+      final connection = await _ensureConnection(_device!.id);
       if (connection == null) return;
       final ok = await connection.clearRing();
       Logger.debug('RingStorageSync._clearRingOnDevice: ok=$ok');
@@ -335,19 +370,21 @@ class RingStorageSyncImpl implements RingStorageSync {
     return SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
   }
 
-  /// Pull the unread ring contents from the device, parse opus frames, register
-  /// chunks with LocalWalSync, then advance the ring iff NOTIFY_DONE arrived.
-  /// Returns true if the transfer ran to completion (DONE received and acted on).
+  /// Drain the ring in bounded, independently durable transactions.
+  ///
+  /// A full CV1 can take well over an hour to transfer. Keeping one cumulative
+  /// ADVANCE behind the entire backlog means any disconnect replays everything.
+  /// Each range is small enough to retry cheaply, and advances only after that
+  /// exact range is durably represented by local WALs.
   Future<bool> _syncRing(Wal wal, {IWalSyncProgressListener? progress}) async {
     if (_device == null) return false;
-    final connection = await ServiceManager.instance().device.ensureConnection(_device!.id);
+    final connection = await _ensureConnection(_device!.id);
     if (connection == null) throw Exception('Device not connected');
 
     _activeSyncDeviceId = _device!.id;
     _downloadStartTime = DateTime.now();
     _totalBytesDownloaded = 0;
 
-    // Snapshot ring state so we know what range we're consuming.
     final ringInfo = await connection.getRingInfo();
     if (ringInfo == null) {
       Logger.debug('RingStorageSync._syncRing: getRingInfo returned null');
@@ -362,46 +399,131 @@ class RingStorageSyncImpl implements RingStorageSync {
         'ringInfo': ringInfo.toString(),
       });
     }
-    final status = await connection.getRingStatus();
-    final rtcValid = status?.isRtcValid ?? false;
+    final targetWriteSeq = ringInfo.writeSeq;
+    final totalRecords = targetWriteSeq - ringInfo.readSeq;
+    final fps = wal.codec.getFramesPerSecond();
+    final fallbackAnchor = await _resolveFallbackAnchor(wal, ringInfo.readSeq, fps);
+    var nextReadSeq = ringInfo.readSeq;
+    var completedRecords = 0;
+    var completedFrames = 0;
 
+    while (!_isCancelled && nextReadSeq < targetWriteSeq) {
+      final remaining = targetWriteSeq - nextReadSeq;
+      final packetCount = remaining > _packetsPerRead ? _packetsPerRead : remaining;
+      final advancedTo = await _syncRange(
+        connection,
+        wal,
+        startSeq: nextReadSeq,
+        packetCount: packetCount,
+        fallbackAnchor: fallbackAnchor,
+        fallbackFramesBefore: completedFrames,
+        completedRecords: completedRecords,
+        totalRecords: totalRecords,
+        progress: progress,
+      );
+      if (advancedTo == null) return false;
+      nextReadSeq = advancedTo.nextSeq;
+      completedRecords += packetCount;
+      completedFrames += advancedTo.frameCount;
+    }
+
+    return !_isCancelled && nextReadSeq == targetWriteSeq;
+  }
+
+  Future<int> _resolveFallbackAnchor(Wal virtualWal, int initialReadSeq, int fps) async {
+    final localSync = _localSync;
+    if (localSync == null) return virtualWal.timerStart;
+
+    final sourcePattern = RegExp(r'^ring_(\d+)_(\d+)$');
+    Wal? predecessor;
+    for (final wal in await localSync.getAllWals()) {
+      if (wal.device != virtualWal.device || wal.sourceId == null) continue;
+      final match = sourcePattern.firstMatch(wal.sourceId!);
+      if (match == null) continue;
+      final startSeq = int.parse(match.group(1)!);
+      final endSeq = int.parse(match.group(2)!);
+      if (startSeq == initialReadSeq) return wal.timerStart;
+      if (endSeq == initialReadSeq &&
+          (predecessor == null || wal.timerStart + wal.seconds > predecessor.timerStart + predecessor.seconds)) {
+        predecessor = wal;
+      }
+    }
+    if (predecessor != null) {
+      return predecessor.timerStart + predecessor.totalFrames ~/ (fps == 0 ? 1 : fps);
+    }
+    return virtualWal.timerStart;
+  }
+
+  Future<_RingRangeResult?> _syncRange(
+    DeviceConnection connection,
+    Wal wal, {
+    required int startSeq,
+    required int packetCount,
+    required int fallbackAnchor,
+    required int fallbackFramesBefore,
+    required int completedRecords,
+    required int totalRecords,
+    IWalSyncProgressListener? progress,
+  }) async {
     final completer = Completer<bool>();
     final reassembler = RingRecordReassembler();
-    final List<List<int>> bytesData = []; // parsed opus frames awaiting flush
+    final pendingRecords = <_RecoveredRingRecord>[];
     int recordsConsumed = 0;
-    int? firstRecordTs;
-    int chunkTimerStart = 0; // updated as chunks flush
+    int segment = 0;
+    int? previousRecordTimestamp;
+    int fallbackFrames = 0;
     final fps = wal.codec.getFramesPerSecond();
     final chunkFrames = sdcardChunkSizeSecs * fps;
     int? doneNextSeq;
     int? transferStartSeq;
     int? announcedPacketCount;
     bool doneOk = false;
+    bool protocolError = false;
+    bool crcVerified = true;
     bool flushError = false;
-    Future<void>? inFlightFlush;
-    Timer? firstDataTimer;
-    bool firstDataReceived = false;
+    Timer? inactivityTimer;
+    final transferCrc = RingTransferCrc32();
 
     DateTime lastProgressUpdate = DateTime.now();
     const progressInterval = Duration(milliseconds: 200);
 
-    // Flush exactly [chunkFrames] frames at a time; on DONE, flush whatever is left.
-    Future<void> flushChunks({required bool finalFlush}) async {
-      while (bytesData.length >= chunkFrames || (finalFlush && bytesData.isNotEmpty)) {
-        final take = bytesData.length >= chunkFrames ? chunkFrames : bytesData.length;
-        final chunk = bytesData.sublist(0, take);
-        bytesData.removeRange(0, take);
+    Future<void> flushValidatedRange() async {
+      while (pendingRecords.isNotEmpty) {
+        final firstSegment = pendingRecords.first.segment;
+        final chunkRecords = <_RecoveredRingRecord>[];
+        var frameCount = 0;
+        while (pendingRecords.isNotEmpty && pendingRecords.first.segment == firstSegment) {
+          if (frameCount >= chunkFrames) break;
+          final record = pendingRecords.removeAt(0);
+          chunkRecords.add(record);
+          frameCount += record.frames.length;
+        }
+        if (chunkRecords.isEmpty) break;
+
+        final frames = chunkRecords.expand((record) => record.frames).toList(growable: false);
+        final timerStart = chunkRecords.first.timestamp;
+        final sourceStartSeq = chunkRecords.first.sequence;
+        final sourceEndSeq = chunkRecords.last.sequence + 1;
+        final sourceId = 'ring_${sourceStartSeq}_$sourceEndSeq';
         try {
-          final file = await _flushToDisk(wal, chunk, chunkTimerStart);
-          await _registerWithLocalSync(wal, file, chunkTimerStart, chunk.length);
+          final file = await _flushToDisk(wal, frames, timerStart, sourceId);
+          await _registerWithLocalSync(wal, file, timerStart, frames.length, sourceId);
         } catch (e) {
           Logger.debug('RingStorageSync._syncRing: flush error: $e');
           flushError = true;
           rethrow;
         }
-        chunkTimerStart += chunk.length ~/ (fps == 0 ? 1 : fps);
-        if (finalFlush && bytesData.isEmpty) break;
       }
+    }
+
+    void armInactivityTimer() {
+      inactivityTimer?.cancel();
+      inactivityTimer = Timer(_inactivityTimeout, () {
+        if (!completer.isCompleted) {
+          Logger.debug('RingStorageSync: range inactive for ${_inactivityTimeout.inSeconds}s');
+          completer.complete(false);
+        }
+      });
     }
 
     await _notifyStream?.cancel();
@@ -414,6 +536,7 @@ class RingStorageSyncImpl implements RingStorageSync {
           return;
         }
         if (value.isEmpty) return;
+        armInactivityTimer();
 
         final opcode = value[0];
         if (opcode == RingProtocol.notifyAck) {
@@ -426,16 +549,20 @@ class RingStorageSyncImpl implements RingStorageSync {
         }
         if (opcode == RingProtocol.notifyReadBegin) {
           final begin = RingProtocol.parseReadBeginNotification(value);
-          if (begin != null) {
+          if (begin == null || begin.transferStartSeq != startSeq || begin.packetCount != packetCount) {
+            protocolError = true;
+            Logger.debug('RingStorageSync: invalid READ_BEGIN for requested range start=$startSeq count=$packetCount');
+            if (!completer.isCompleted) completer.complete(false);
+          } else if (transferStartSeq != null &&
+              (transferStartSeq != begin.transferStartSeq || announcedPacketCount != begin.packetCount)) {
+            protocolError = true;
+            if (!completer.isCompleted) completer.complete(false);
+          } else {
             transferStartSeq = begin.transferStartSeq;
             announcedPacketCount = begin.packetCount;
             Logger.debug(
               'RingStorageSync: NOTIFY_READ_BEGIN start=${begin.transferStartSeq} count=${begin.packetCount}',
             );
-            if (!firstDataReceived) {
-              firstDataReceived = true;
-              firstDataTimer?.cancel();
-            }
           }
           return;
         }
@@ -448,6 +575,14 @@ class RingStorageSyncImpl implements RingStorageSync {
           }
           doneNextSeq = done.nextSeq;
           doneOk = done.isOk;
+          if (done.transferCrc32 != null) {
+            crcVerified = done.transferCrc32 == transferCrc.value;
+            if (!crcVerified) {
+              Logger.debug(
+                'RingStorageSync: transfer CRC mismatch expected=${done.transferCrc32} actual=${transferCrc.value}',
+              );
+            }
+          }
           Logger.debug('RingStorageSync: NOTIFY_DONE status=${done.status} next_seq=$doneNextSeq');
           if (!completer.isCompleted) completer.complete(true);
           return;
@@ -460,31 +595,45 @@ class RingStorageSyncImpl implements RingStorageSync {
         // NOTIFY_DATA: append payload (skip the leading opcode byte) to the
         // reassembler. The firmware does NOT align chunks to record boundaries.
         final payload = value.sublist(1);
-        if (!firstDataReceived) {
-          firstDataReceived = true;
-          firstDataTimer?.cancel();
+        if (transferStartSeq == null) {
+          protocolError = true;
+          Logger.debug('RingStorageSync: DATA arrived before READ_BEGIN');
+          if (!completer.isCompleted) completer.complete(false);
+          return;
         }
+        transferCrc.add(payload);
         reassembler.append(payload);
         _updateSpeed(payload.length);
 
         for (final record in reassembler.drainRecords()) {
           final ts = RingProtocol.readRecordTimestamp(record);
-
-          // Anchor timerStart on the first usable timestamp.
-          if (firstRecordTs == null) {
-            if (rtcValid && ts > 0) {
-              firstRecordTs = ts;
-              chunkTimerStart = ts;
-            } else {
-              // Fallback: now - estimated duration of the unread region.
-              final estSecs = wal.totalFrames ~/ (fps == 0 ? 1 : fps);
-              firstRecordTs = DateTime.now().millisecondsSinceEpoch ~/ 1000 - estSecs;
-              chunkTimerStart = firstRecordTs!;
-            }
+          final frames = RingProtocol.parseAudioPayload(record.sublist(RingProtocol.timestampBytes));
+          if (frames.isEmpty) {
+            protocolError = true;
+            Logger.debug('RingStorageSync: record ${transferStartSeq! + recordsConsumed} has no decodable frames');
           }
+          final now = _nowSeconds();
+          final effectiveTimestamp = RingProtocol.isPlausibleRecordTimestamp(ts, nowSeconds: now)
+              ? ts
+              : fallbackAnchor + (fallbackFramesBefore + fallbackFrames) ~/ (fps == 0 ? 1 : fps);
 
-          final audio = record.sublist(RingProtocol.timestampBytes);
-          bytesData.addAll(RingProtocol.parseAudioPayload(audio));
+          if (previousRecordTimestamp != null &&
+              (effectiveTimestamp < previousRecordTimestamp! || effectiveTimestamp > previousRecordTimestamp! + 2)) {
+            segment += 1;
+          }
+          previousRecordTimestamp = effectiveTimestamp;
+
+          if (frames.isNotEmpty) {
+            pendingRecords.add(
+              _RecoveredRingRecord(
+                sequence: transferStartSeq! + recordsConsumed,
+                timestamp: effectiveTimestamp,
+                segment: segment,
+                frames: frames,
+              ),
+            );
+          }
+          fallbackFrames += frames.length;
           recordsConsumed += 1;
         }
 
@@ -492,9 +641,8 @@ class RingStorageSyncImpl implements RingStorageSync {
         final now = DateTime.now();
         if (now.difference(lastProgressUpdate) >= progressInterval) {
           lastProgressUpdate = now;
-          if (wal.storageTotalBytes > 0) {
-            final consumedBytes = recordsConsumed * RingProtocol.recordSize;
-            final pct = (consumedBytes / wal.storageTotalBytes).clamp(0.0, 1.0);
+          if (totalRecords > 0) {
+            final pct = ((completedRecords + recordsConsumed) / totalRecords).clamp(0.0, 1.0);
             progress?.onWalSyncedProgress(
               pct,
               speedKBps: _currentSpeedKBps,
@@ -503,28 +651,6 @@ class RingStorageSyncImpl implements RingStorageSync {
               totalFiles: 1,
             );
           }
-        }
-
-        // Flush full chunks as we go (data safety: even if BLE drops mid-stream,
-        // already-flushed chunks land in LocalWalSync and reach the cloud).
-        //
-        // Single in-flight flush at a time. flushChunks loops while bytesData
-        // has >= chunkFrames, so additional NOTIFY_DATA arriving during a flush
-        // are absorbed by the in-flight task's next iteration. Without this
-        // guard, two concurrent flush closures would both read chunkTimerStart
-        // before either updated it, producing overlapping timestamps in
-        // LocalWalSync. We hold the Future so the post-DONE final flush can
-        // await any flush still in flight before draining the tail.
-        if (inFlightFlush == null && bytesData.length >= chunkFrames) {
-          inFlightFlush = () async {
-            try {
-              await flushChunks(finalFlush: false);
-            } catch (_) {
-              if (!completer.isCompleted) completer.complete(false);
-            } finally {
-              inFlightFlush = null;
-            }
-          }();
         }
       },
     );
@@ -539,60 +665,32 @@ class RingStorageSyncImpl implements RingStorageSync {
       }
     });
 
-    firstDataTimer = Timer(const Duration(seconds: 5), () {
-      if (!firstDataReceived && !completer.isCompleted) {
-        Logger.debug('RingStorageSync: no data within 5s');
-        completer.completeError(TimeoutException('No data from device'));
-      }
-    });
+    armInactivityTimer();
 
-    // Kick off the read. No packet_count = stream everything from read_seq.
-    final readOk = await connection.readRingFromSeq(ringInfo.readSeq);
+    final readOk = await connection.readRingFromSeq(startSeq, packetCount: packetCount);
     if (!readOk) {
-      firstDataTimer.cancel();
+      inactivityTimer?.cancel();
       await _notifyStream?.cancel();
       _notifyStream = null;
       throw Exception('Failed to send CMD_RING_READ');
     }
 
     Logger.debug(
-      'RingStorageSync: reading from seq=${ringInfo.readSeq} (write=${ringInfo.writeSeq}, unread=${ringInfo.unreadPackets})',
+      'RingStorageSync: reading bounded range start=$startSeq count=$packetCount',
     );
 
     bool reachedDone = false;
     try {
-      reachedDone = await completer.future.timeout(const Duration(minutes: 30));
-    } on TimeoutException {
-      Logger.debug('RingStorageSync: overall transfer timeout (30m)');
+      reachedDone = await completer.future;
     } catch (e) {
       Logger.debug('RingStorageSync: transfer error: $e');
     } finally {
-      firstDataTimer.cancel();
+      inactivityTimer?.cancel();
       if (_isCancelled) {
         await _requestFirmwareStopSync();
       }
       await _notifyStream?.cancel();
       _notifyStream = null;
-    }
-
-    // Wait for any flush still in flight from the streaming phase before
-    // draining the tail — otherwise the final flush could race the in-flight
-    // one on bytesData and chunkTimerStart.
-    final pendingFlush = inFlightFlush;
-    if (pendingFlush != null) {
-      try {
-        await pendingFlush;
-      } catch (e) {
-        Logger.debug('RingStorageSync: in-flight flush error during settle: $e');
-      }
-    }
-
-    // Flush whatever frames are buffered, even on partial failure — those frames
-    // are safe to upload to cloud regardless. ADVANCE is gated separately.
-    try {
-      await flushChunks(finalFlush: true);
-    } catch (e) {
-      Logger.debug('RingStorageSync: final flush error: $e');
     }
 
     final receivedCompleteRange = RingProtocol.receivedCompleteRange(
@@ -602,12 +700,28 @@ class RingStorageSyncImpl implements RingStorageSync {
       receivedPacketCount: recordsConsumed,
       pendingBytes: reassembler.pendingBytes,
     );
+    final transportComplete =
+        reachedDone && doneOk && !protocolError && crcVerified && !_isCancelled && receivedCompleteRange;
+
+    // No bytes are registered before the complete range and optional CRC have
+    // been validated. A corrupt retry therefore cannot poison an immutable
+    // source identity that would block the next clean retry.
+    if (transportComplete) {
+      try {
+        await flushValidatedRange();
+      } catch (e) {
+        Logger.debug('RingStorageSync: final flush error: $e');
+      }
+    }
+
     final advancedOk = RingProtocol.canAdvance(
       reachedDone: reachedDone,
       doneOk: doneOk,
       flushError: flushError,
       isCancelled: _isCancelled,
       receivedCompleteRange: receivedCompleteRange,
+      protocolError: protocolError,
+      crcVerified: crcVerified,
     );
     if (advancedOk) {
       final ok = await connection.advanceRing(doneNextSeq!);
@@ -617,22 +731,27 @@ class RingStorageSyncImpl implements RingStorageSync {
         'next_seq': doneNextSeq,
         'advance_ok': ok,
       });
-      return ok;
+      return ok ? _RingRangeResult(nextSeq: doneNextSeq!, frameCount: fallbackFrames) : null;
     } else {
       Logger.debug(
         'RingStorageSync: skipping advance (reachedDone=$reachedDone doneOk=$doneOk flushError=$flushError '
-        'cancelled=$_isCancelled completeRange=$receivedCompleteRange records=$recordsConsumed '
-        'pendingBytes=${reassembler.pendingBytes})',
+        'cancelled=$_isCancelled completeRange=$receivedCompleteRange protocolError=$protocolError '
+        'crcVerified=$crcVerified records=$recordsConsumed pendingBytes=${reassembler.pendingBytes})',
       );
-      return false;
+      return null;
     }
   }
 
   /// Write opus frames to disk in WAL format: [frame_length_u32_le][frame_data]...
   /// Identical to StorageSyncImpl._flushToDisk for downstream compatibility.
-  Future<File> _flushToDisk(Wal wal, List<List<int>> frames, int timerStart) async {
-    final directory = await getApplicationDocumentsDirectory();
-    final filePath = '${directory.path}/${wal.getFileNameByTimeStarts(timerStart)}';
+  Future<File> _flushToDisk(
+    Wal wal,
+    List<List<int>> frames,
+    int timerStart,
+    String sourceId,
+  ) async {
+    final directory = await _documentsDirectoryProvider();
+    final filePath = '${directory.path}/${wal.getFileNameByTimeStarts(timerStart, sourceId: sourceId)}';
 
     final List<int> data = [];
     for (final frame in frames) {
@@ -645,15 +764,38 @@ class RingStorageSyncImpl implements RingStorageSync {
     }
 
     final file = File(filePath);
-    // The firmware advances its durable read watermark only after this transfer
-    // completes. Flush the file before registering it and sending that ACK so a
-    // process or OS crash cannot turn an acknowledged range into missing audio.
-    await file.writeAsBytes(data, flush: true);
+    if (await file.exists()) {
+      final existing = await file.readAsBytes();
+      if (!listEquals(existing, data)) {
+        throw StateError('Immutable ring WAL collision for $sourceId');
+      }
+      return file;
+    }
+
+    final temporaryFile = File('$filePath.tmp');
+    try {
+      if (await temporaryFile.exists()) await temporaryFile.delete();
+      await temporaryFile.writeAsBytes(data, flush: true);
+      await temporaryFile.rename(filePath);
+    } catch (_) {
+      if (await temporaryFile.exists()) {
+        try {
+          await temporaryFile.delete();
+        } catch (_) {}
+      }
+      rethrow;
+    }
     Logger.debug('RingStorageSync: wrote ${data.length}B (${frames.length} frames) to $filePath');
     return file;
   }
 
-  Future<void> _registerWithLocalSync(Wal wal, File file, int timerStart, int frameCount) async {
+  Future<void> _registerWithLocalSync(
+    Wal wal,
+    File file,
+    int timerStart,
+    int frameCount,
+    String sourceId,
+  ) async {
     if (_localSync == null) {
       throw StateError('LocalWalSync is unavailable; refusing to acknowledge device records');
     }
@@ -674,9 +816,34 @@ class RingStorageSyncImpl implements RingStorageSync {
       totalFrames: frameCount,
       syncedFrameOffset: 0,
       originalStorage: WalStorage.sdcard,
+      sourceId: sourceId,
     );
 
-    await _localSync!.addExternalWal(localWal);
-    Logger.debug('RingStorageSync: registered chunk (ts=$timerStart, ${seconds}s, $frameCount frames)');
+    final registration = await _localSync!.addExternalWal(localWal);
+    Logger.debug(
+      'RingStorageSync: registered chunk (source=$sourceId, ts=$timerStart, ${seconds}s, '
+      '$frameCount frames, result=${registration.name})',
+    );
   }
+}
+
+class _RecoveredRingRecord {
+  final int sequence;
+  final int timestamp;
+  final int segment;
+  final List<List<int>> frames;
+
+  const _RecoveredRingRecord({
+    required this.sequence,
+    required this.timestamp,
+    required this.segment,
+    required this.frames,
+  });
+}
+
+class _RingRangeResult {
+  final int nextSeq;
+  final int frameCount;
+
+  const _RingRangeResult({required this.nextSeq, required this.frameCount});
 }

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -374,6 +374,8 @@ class RingStorageSyncImpl implements RingStorageSync {
     final fps = wal.codec.getFramesPerSecond();
     final chunkFrames = sdcardChunkSizeSecs * fps;
     int? doneNextSeq;
+    int? transferStartSeq;
+    int? announcedPacketCount;
     bool doneOk = false;
     bool flushError = false;
     Future<void>? inFlightFlush;
@@ -425,6 +427,8 @@ class RingStorageSyncImpl implements RingStorageSync {
         if (opcode == RingProtocol.notifyReadBegin) {
           final begin = RingProtocol.parseReadBeginNotification(value);
           if (begin != null) {
+            transferStartSeq = begin.transferStartSeq;
+            announcedPacketCount = begin.packetCount;
             Logger.debug(
               'RingStorageSync: NOTIFY_READ_BEGIN start=${begin.transferStartSeq} count=${begin.packetCount}',
             );
@@ -591,7 +595,20 @@ class RingStorageSyncImpl implements RingStorageSync {
       Logger.debug('RingStorageSync: final flush error: $e');
     }
 
-    final advancedOk = reachedDone && doneOk && !flushError && !_isCancelled && doneNextSeq != null;
+    final receivedCompleteRange = RingProtocol.receivedCompleteRange(
+      transferStartSeq: transferStartSeq,
+      announcedPacketCount: announcedPacketCount,
+      doneNextSeq: doneNextSeq,
+      receivedPacketCount: recordsConsumed,
+      pendingBytes: reassembler.pendingBytes,
+    );
+    final advancedOk = RingProtocol.canAdvance(
+      reachedDone: reachedDone,
+      doneOk: doneOk,
+      flushError: flushError,
+      isCancelled: _isCancelled,
+      receivedCompleteRange: receivedCompleteRange,
+    );
     if (advancedOk) {
       final ok = await connection.advanceRing(doneNextSeq!);
       Logger.debug('RingStorageSync: advance(seq=$doneNextSeq) -> $ok (records=$recordsConsumed)');
@@ -603,7 +620,9 @@ class RingStorageSyncImpl implements RingStorageSync {
       return ok;
     } else {
       Logger.debug(
-        'RingStorageSync: skipping advance (reachedDone=$reachedDone doneOk=$doneOk flushError=$flushError cancelled=$_isCancelled records=$recordsConsumed)',
+        'RingStorageSync: skipping advance (reachedDone=$reachedDone doneOk=$doneOk flushError=$flushError '
+        'cancelled=$_isCancelled completeRange=$receivedCompleteRange records=$recordsConsumed '
+        'pendingBytes=${reassembler.pendingBytes})',
       );
       return false;
     }
@@ -626,15 +645,17 @@ class RingStorageSyncImpl implements RingStorageSync {
     }
 
     final file = File(filePath);
-    await file.writeAsBytes(data);
+    // The firmware advances its durable read watermark only after this transfer
+    // completes. Flush the file before registering it and sending that ACK so a
+    // process or OS crash cannot turn an acknowledged range into missing audio.
+    await file.writeAsBytes(data, flush: true);
     Logger.debug('RingStorageSync: wrote ${data.length}B (${frames.length} frames) to $filePath');
     return file;
   }
 
   Future<void> _registerWithLocalSync(Wal wal, File file, int timerStart, int frameCount) async {
     if (_localSync == null) {
-      Logger.debug('RingStorageSync: WARNING - LocalWalSync not available, chunk will not be uploaded');
-      return;
+      throw StateError('LocalWalSync is unavailable; refusing to acknowledge device records');
     }
     final fps = wal.codec.getFramesPerSecond();
     final seconds = fps > 0 ? frameCount ~/ fps : 0;

--- a/app/lib/services/wals/wal.dart
+++ b/app/lib/services/wals/wal.dart
@@ -113,6 +113,13 @@ class Wal {
 
   WalStorage? originalStorage;
 
+  /// Stable identity assigned by the durable source transport.
+  ///
+  /// Device-storage recovery uses the source sequence range here so a retry is
+  /// idempotent even when another recording has the same second-resolution
+  /// timestamp. Legacy WALs leave this null and retain their historical ID.
+  String? sourceId;
+
   /// The conversation this WAL belongs to. Stamped when ConversationProcessingStartedEvent
   /// arrives so WALs survive app kill and can be recovered on startup.
   String? conversationId;
@@ -131,7 +138,7 @@ class Wal {
   /// Unix timestamp (seconds) when the audio was uploaded (202 received).
   int uploadedAt;
 
-  String get id => '${device}_$timerStart';
+  String get id => sourceId == null ? '${device}_$timerStart' : '${device}_$sourceId';
 
   /// Single source of truth for how this recording's sync state is shown to the
   /// user. The sync page renders an explicit label + icon for every value so a
@@ -185,6 +192,7 @@ class Wal {
     this.totalFrames = 0,
     this.syncedFrameOffset = 0,
     this.originalStorage,
+    this.sourceId,
     this.conversationId,
     this.retryCount = 0,
     this.lastRetryAt = 0,
@@ -213,6 +221,7 @@ class Wal {
       syncedFrameOffset: json['synced_frame_offset'] ?? 0,
       originalStorage:
           json['original_storage'] != null ? WalStorage.values.asNameMap()[json['original_storage']] : null,
+      sourceId: json['source_id'],
       conversationId: json['conversation_id'],
       retryCount: json['retry_count'] ?? 0,
       lastRetryAt: json['last_retry_at'] ?? 0,
@@ -239,6 +248,7 @@ class Wal {
       'total_frames': totalFrames,
       'synced_frame_offset': syncedFrameOffset,
       'original_storage': originalStorage?.name,
+      'source_id': sourceId,
       'conversation_id': conversationId,
       'retry_count': retryCount,
       'last_retry_at': lastRetryAt,
@@ -253,8 +263,13 @@ class Wal {
     return "audio_${device.replaceAll(RegExp(r'[^a-zA-Z0-9]'), "").toLowerCase()}_${codec}_${sampleRate}_${channel}_fs${frameSize}_${timerStart}.bin";
   }
 
-  getFileNameByTimeStarts(int timestarts) {
-    return "audio_${device.replaceAll(RegExp(r'[^a-zA-Z0-9]'), "").toLowerCase()}_${codec}_${sampleRate}_${channel}_fs${frameSize}_${timestarts}.bin";
+  getFileNameByTimeStarts(int timestarts, {String? sourceId}) {
+    final sourceSuffix = sourceId == null ? '' : '_${sourceId.replaceAll(RegExp(r'[^a-zA-Z0-9_-]'), "")}';
+    // Backend timestamp parsing treats the final underscore-delimited token as
+    // capture epoch seconds, so source identity must precede the timestamp.
+    return "audio_${device.replaceAll(RegExp(r'[^a-zA-Z0-9]'), "").toLowerCase()}_${codec}_${sampleRate}_${channel}_fs$frameSize"
+        "$sourceSuffix"
+        "_$timestarts.bin";
   }
 
   static Future<String?> getFilePath(String? pathOrName) async {

--- a/app/lib/services/wals/wal_interfaces.dart
+++ b/app/lib/services/wals/wal_interfaces.dart
@@ -61,9 +61,11 @@ abstract class IWalService {
 
 enum WalServiceStatus { init, ready, stop }
 
+enum ExternalWalRegistration { added, alreadyRegistered }
+
 // Forward declarations for sync types
 abstract class LocalWalSync implements IWalSync {
-  Future<void> addExternalWal(Wal wal);
+  Future<ExternalWalRegistration> addExternalWal(Wal wal);
   Future<List<Wal>> getAllWals();
   Future<void> deleteAllSyncedWals();
   Future<void> deleteAllPendingWals();

--- a/app/lib/utils/wal_file_manager.dart
+++ b/app/lib/utils/wal_file_manager.dart
@@ -16,6 +16,7 @@ class WalFileManager {
 
   static File? _walFile;
   static File? _walBackupFile;
+  static Future<void> _saveBarrier = Future.value();
 
   static Future<void> init() async {
     final directory = await getApplicationDocumentsDirectory();
@@ -29,14 +30,14 @@ class WalFileManager {
     }
 
     if (_walFile == null || !_walFile!.existsSync()) {
-      Logger.debug('WAL file does not exist, returning empty list');
-      return [];
+      Logger.debug('WAL file does not exist, trying backup');
+      return await _loadFromBackup();
     }
 
     final content = await _walFile!.readAsString();
     if (content.isEmpty) {
-      Logger.debug('WAL file is empty, returning empty list');
-      return [];
+      Logger.debug('WAL file is empty, trying backup');
+      return await _loadFromBackup();
     }
 
     dynamic jsonData;
@@ -47,15 +48,25 @@ class WalFileManager {
       return await _loadFromBackup();
     }
     if (jsonData is! Map<String, dynamic> || jsonData['wals'] is! List) {
-      Logger.debug('Invalid WAL file format, returning empty list');
-      return [];
+      Logger.debug('Invalid WAL file format, trying backup');
+      return await _loadFromBackup();
     }
 
     final walsList = jsonData['wals'] as List;
     return Wal.fromJsonList(walsList);
   }
 
-  static Future<bool> saveWals(List<Wal> wals) async {
+  static Future<bool> saveWals(List<Wal> wals) {
+    // Capture the caller's state before yielding, then serialize rewrites so
+    // concurrent capture/upload callbacks cannot contend for the same temp
+    // file or let an older manifest finish after a newer one.
+    final snapshot = wals.map((wal) => wal.toJson()).toList(growable: false);
+    final operation = _saveBarrier.then((_) => _saveWalsAtomic(snapshot));
+    _saveBarrier = operation.then<void>((_) {}, onError: (error, stackTrace) {});
+    return operation;
+  }
+
+  static Future<bool> _saveWalsAtomic(List<Map<String, dynamic>> snapshot) async {
     if (_walFile == null) {
       await init();
     }
@@ -65,29 +76,43 @@ class WalFileManager {
       return false;
     }
 
-    await _createBackup();
-
     final jsonData = {
       'version': 1,
       'timestamp': DateTime.now().millisecondsSinceEpoch,
-      'wals': wals.map((wal) => wal.toJson()).toList(),
+      'wals': snapshot,
     };
 
     final jsonString = jsonEncode(jsonData);
-    await _walFile!.writeAsString(jsonString);
-
-    Logger.debug('Successfully saved ${wals.length} WALs to file');
-    return true;
-  }
-
-  static Future<void> _createBackup() async {
+    final temporaryFile = File('${_walFile!.path}.tmp');
+    final backupTemporaryFile = _walBackupFile == null ? null : File('${_walBackupFile!.path}.tmp');
     try {
-      if (_walFile != null && _walFile!.existsSync() && _walBackupFile != null) {
-        await _walFile!.copy(_walBackupFile!.path);
+      if (await temporaryFile.exists()) await temporaryFile.delete();
+      await temporaryFile.writeAsString(jsonString, flush: true);
+      // The temporary file lives beside the manifest, so rename is atomic on
+      // the Android/iOS filesystems. Readers see either the previous complete
+      // JSON document or the new complete document, never a partial rewrite.
+      await temporaryFile.rename(_walFile!.path);
+      if (backupTemporaryFile != null && _walBackupFile != null) {
+        if (await backupTemporaryFile.exists()) await backupTemporaryFile.delete();
+        await backupTemporaryFile.writeAsString(jsonString, flush: true);
+        await backupTemporaryFile.rename(_walBackupFile!.path);
       }
-    } on FileSystemException catch (e) {
-      Logger.debug('WalFileManager: Failed to create backup: $e');
+    } catch (_) {
+      if (await temporaryFile.exists()) {
+        try {
+          await temporaryFile.delete();
+        } catch (_) {}
+      }
+      if (backupTemporaryFile != null && await backupTemporaryFile.exists()) {
+        try {
+          await backupTemporaryFile.delete();
+        } catch (_) {}
+      }
+      rethrow;
     }
+
+    Logger.debug('Successfully saved ${snapshot.length} WALs to file');
+    return true;
   }
 
   /// Load WALs from backup file

--- a/app/test/services/wals/recording_transfer_coordinator_test.dart
+++ b/app/test/services/wals/recording_transfer_coordinator_test.dart
@@ -130,6 +130,68 @@ void main() {
       expect(harness.drainPasses, 1);
     });
 
+    test('opted-in background device reconnect runs one recovery pass', () async {
+      final harness = _TransferHarness()..backgroundDeviceRecoveryEnabled = true;
+      addTearDown(harness.dispose);
+
+      harness.coordinator.setForeground(false);
+      await harness.coordinator.wake(WakeTrigger.deviceConnected);
+
+      expect(harness.reconcilePasses, 1);
+      expect(harness.discoveryPasses, 1);
+      expect(harness.drainPasses, 1);
+    });
+
+    test('background device reconnect requires persistent BLE and auto-upload opt-ins', () async {
+      final noPersistentBle = _TransferHarness();
+      final noAutoUpload = _TransferHarness(autoUploadEnabled: false)..backgroundDeviceRecoveryEnabled = true;
+      addTearDown(noPersistentBle.dispose);
+      addTearDown(noAutoUpload.dispose);
+
+      noPersistentBle.coordinator.setForeground(false);
+      noAutoUpload.coordinator.setForeground(false);
+      await noPersistentBle.coordinator.wake(WakeTrigger.deviceConnected);
+      await noAutoUpload.coordinator.wake(WakeTrigger.deviceConnected);
+
+      expect(noPersistentBle.discoveryPasses, 0);
+      expect(noPersistentBle.drainPasses, 0);
+      expect(noAutoUpload.discoveryPasses, 0);
+      expect(noAutoUpload.drainPasses, 0);
+    });
+
+    test('persistent BLE opt-in does not authorize other background wakes', () async {
+      final harness = _TransferHarness()..backgroundDeviceRecoveryEnabled = true;
+      addTearDown(harness.dispose);
+
+      harness.coordinator.setForeground(false);
+      await harness.coordinator.wake(WakeTrigger.connectivityRestored);
+      await harness.coordinator.wake(WakeTrigger.cooldownElapsed);
+      await harness.coordinator.wake(WakeTrigger.userRetry);
+
+      expect(harness.reconcilePasses, 0);
+      expect(harness.discoveryPasses, 0);
+      expect(harness.drainPasses, 0);
+    });
+
+    test('failed background reconnect pass persists for foreground retry without a timer', () async {
+      final harness = _TransferHarness()
+        ..backgroundDeviceRecoveryEnabled = true
+        ..drainFails = true;
+      addTearDown(harness.dispose);
+
+      harness.coordinator.setForeground(false);
+      await harness.coordinator.wake(WakeTrigger.deviceConnected);
+
+      expect(harness.drainPasses, 1);
+      expect(harness.walState, 'miss');
+      expect(harness.scheduledCooldowns, isEmpty);
+      expect(harness.coordinator.nextCooldownAt, isNull);
+
+      harness.coordinator.setForeground(true);
+      await harness.coordinator.wake(WakeTrigger.foregrounded);
+      expect(harness.drainPasses, 2);
+    });
+
     test('startup resumes a pending backlog once without loss or duplication', () async {
       final sharedBacklog = <String>['pending-wal'];
       final drainedWalIds = <String>[];
@@ -218,6 +280,7 @@ class _TransferHarness {
       refreshPending: _refreshPending,
       drain: _drain,
       autoUploadEnabled: () => _autoUploadEnabled,
+      backgroundDeviceRecoveryEnabled: () => backgroundDeviceRecoveryEnabled,
       connectivityChanges: connectivity.stream,
       initiallyConnected: true,
       clock: () => DateTime.utc(2026, 1, 1),
@@ -238,6 +301,7 @@ class _TransferHarness {
   bool drainNeedsReconciliation = false;
   bool drainContended = false;
   bool uploadedWalAwaitingReconcile = false;
+  bool backgroundDeviceRecoveryEnabled = false;
   bool reconciledUploadedWal = false;
   bool reofferedUploadedWal = false;
   String walState = 'miss';

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -1,0 +1,400 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/services/devices/connectors/device_connection.dart';
+import 'package:omi/services/devices/ring_protocol.dart';
+import 'package:omi/services/wals/local_wal_sync.dart';
+import 'package:omi/services/wals/ring_storage_sync.dart';
+import 'package:omi/services/wals/wal.dart';
+import 'package:omi/services/wals/wal_interfaces.dart';
+
+void main() {
+  late Directory directory;
+  late _Listener listener;
+
+  setUp(() async {
+    directory = await Directory.systemTemp.createTemp('omi-ring-sync-test-');
+    listener = _Listener();
+  });
+
+  tearDown(() async {
+    if (await directory.exists()) await directory.delete(recursive: true);
+  });
+
+  LocalWalSyncImpl localSync({WalPersister? persister}) {
+    return LocalWalSyncImpl(
+      listener,
+      walPersister: persister ?? (_) async => true,
+      walPathResolver: (path) async => path == null ? null : '${directory.path}/${path.split('/').last}',
+    );
+  }
+
+  RingStorageSyncImpl ringSync(
+    _FakeRingConnection connection,
+    LocalWalSync local, {
+    int packetsPerRead = 2,
+    int? nowSeconds,
+  }) {
+    final sync = RingStorageSyncImpl(
+      listener,
+      connectionResolver: (_) async => connection,
+      documentsDirectoryProvider: () async => directory,
+      packetsPerRead: packetsPerRead,
+      inactivityTimeout: const Duration(milliseconds: 100),
+      nowSeconds: () => nowSeconds ?? _FakeRingConnection.baseTimestamp + 10000,
+    );
+    sync.setDevice(_device());
+    sync.setLocalSync(local);
+    return sync;
+  }
+
+  Wal virtualWal(int records) => Wal(
+        timerStart: _FakeRingConnection.baseTimestamp,
+        codec: BleAudioCodec.opus,
+        seconds: records,
+        status: WalStatus.miss,
+        storage: WalStorage.sdcard,
+        device: 'cv1-test',
+        deviceModel: 'Omi',
+        storageTotalBytes: records * RingProtocol.recordSize,
+        totalFrames: records,
+      );
+
+  test('large backlog drains as independently durable bounded ranges', () async {
+    final connection = _FakeRingConnection(readSeq: 100, writeSeq: 107);
+    final local = localSync();
+    final wal = virtualWal(7);
+
+    await ringSync(connection, local).syncWal(wal: wal);
+
+    expect(connection.reads,
+        [(start: 100, count: 2), (start: 102, count: 2), (start: 104, count: 2), (start: 106, count: 1)]);
+    expect(connection.successfulAdvances, [102, 104, 106, 107]);
+    expect(local.testWals.map((wal) => wal.sourceId), [
+      'ring_100_102',
+      'ring_102_104',
+      'ring_104_106',
+      'ring_106_107',
+    ]);
+    expect(wal.status, WalStatus.synced);
+  });
+
+  test('interrupted range keeps its cursor and retry resumes after the last durable advance', () async {
+    final local = localSync();
+    final firstConnection = _FakeRingConnection(readSeq: 200, writeSeq: 205, truncateStartSeq: 202);
+    final wal = virtualWal(5);
+
+    await ringSync(firstConnection, local).syncWal(wal: wal);
+
+    expect(firstConnection.successfulAdvances, [202]);
+    expect(local.testWals.map((wal) => wal.sourceId), ['ring_200_202']);
+    expect(wal.status, WalStatus.miss);
+
+    final resumedConnection = _FakeRingConnection(readSeq: 202, writeSeq: 205);
+    await ringSync(resumedConnection, local).syncWal(wal: wal);
+
+    expect(resumedConnection.reads, [(start: 202, count: 2), (start: 204, count: 1)]);
+    expect(resumedConnection.successfulAdvances, [204, 205]);
+    expect(local.testWals.map((wal) => wal.sourceId), [
+      'ring_200_202',
+      'ring_202_204',
+      'ring_204_205',
+    ]);
+    expect(wal.status, WalStatus.synced);
+  });
+
+  test('failed manifest persistence rolls back registration and prevents ADVANCE', () async {
+    final connection = _FakeRingConnection(readSeq: 300, writeSeq: 301);
+    final local = localSync(persister: (_) async => false);
+    final wal = virtualWal(1);
+
+    await ringSync(connection, local).syncWal(wal: wal);
+
+    expect(connection.advanceAttempts, isEmpty);
+    expect(local.testWals, isEmpty);
+    expect(wal.status, WalStatus.miss);
+  });
+
+  test('CRC mismatch prevents registration and ADVANCE', () async {
+    final connection = _FakeRingConnection(readSeq: 400, writeSeq: 402, corruptCrc: true);
+    final local = localSync();
+    final wal = virtualWal(2);
+
+    await ringSync(connection, local).syncWal(wal: wal);
+
+    expect(connection.advanceAttempts, isEmpty);
+    expect(local.testWals, isEmpty);
+    expect(wal.status, WalStatus.miss);
+
+    final retry = _FakeRingConnection(readSeq: 400, writeSeq: 402);
+    await ringSync(retry, local).syncWal(wal: wal);
+
+    expect(retry.successfulAdvances, [402]);
+    expect(local.testWals.map((wal) => wal.sourceId), ['ring_400_402']);
+  });
+
+  test('capture timestamp discontinuity becomes a separate immutable WAL segment', () async {
+    final connection = _FakeRingConnection(
+      readSeq: 500,
+      writeSeq: 502,
+      timestamps: {
+        500: _FakeRingConnection.baseTimestamp + 500,
+        501: _FakeRingConnection.baseTimestamp + 620,
+      },
+    );
+    final local = localSync();
+
+    await ringSync(connection, local).syncWal(wal: virtualWal(2));
+
+    expect(local.testWals.map((wal) => wal.timerStart), [
+      _FakeRingConnection.baseTimestamp + 500,
+      _FakeRingConnection.baseTimestamp + 620,
+    ]);
+    expect(connection.successfulAdvances, [502]);
+  });
+
+  test('failed ADVANCE retries the immutable range without duplicating its WAL', () async {
+    final local = localSync();
+    final firstConnection = _FakeRingConnection(readSeq: 600, writeSeq: 602, failAdvance: true);
+    final wal = virtualWal(2);
+
+    await ringSync(firstConnection, local).syncWal(wal: wal);
+
+    expect(firstConnection.advanceAttempts, [602]);
+    expect(firstConnection.successfulAdvances, isEmpty);
+    expect(local.testWals, hasLength(1));
+    final originalBytes = await File('${directory.path}/${local.testWals.single.filePath}').readAsBytes();
+
+    final retryConnection = _FakeRingConnection(readSeq: 600, writeSeq: 602);
+    await ringSync(retryConnection, local).syncWal(wal: wal);
+
+    expect(retryConnection.successfulAdvances, [602]);
+    expect(local.testWals, hasLength(1));
+    expect(await File('${directory.path}/${local.testWals.single.filePath}').readAsBytes(), originalBytes);
+  });
+
+  test('invalid RTC fallback is monotonic across ranges and sequence identity survives retry time changes', () async {
+    final local = localSync();
+    final invalidTimestamps = {for (var seq = 700; seq < 704; seq++) seq: 0};
+    final firstConnection = _FakeRingConnection(
+      readSeq: 700,
+      writeSeq: 704,
+      timestamps: invalidTimestamps,
+      framesPerRecord: 100,
+      failAdvance: true,
+    );
+    final wal = virtualWal(4)
+      ..totalFrames = 400
+      ..timerStart = 1799999996;
+
+    await ringSync(firstConnection, local, nowSeconds: 1800000000).syncWal(wal: wal);
+
+    expect(local.testWals.single.sourceId, 'ring_700_702');
+    expect(local.testWals.single.timerStart, 1799999996);
+
+    final retry = _FakeRingConnection(
+      readSeq: 700,
+      writeSeq: 704,
+      timestamps: invalidTimestamps,
+      framesPerRecord: 100,
+    );
+    await ringSync(retry, local, nowSeconds: 1800000100).syncWal(wal: wal);
+
+    expect(retry.successfulAdvances, [702, 704]);
+    expect(local.testWals.map((wal) => wal.sourceId), ['ring_700_702', 'ring_702_704']);
+    expect(local.testWals.map((wal) => wal.timerStart), [1799999996, 1799999998]);
+  });
+
+  test('byte-identical legacy timestamp WAL is reused instead of uploaded twice', () async {
+    final local = localSync();
+    final legacyFile = File('${directory.path}/legacy.bin')..writeAsBytesSync([1, 2, 3, 4]);
+    final candidateFile = File('${directory.path}/range.bin')..writeAsBytesSync([1, 2, 3, 4]);
+    local.testWals = [
+      Wal(
+        timerStart: 1700000800,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        device: 'cv1-test',
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: legacyFile.path.split('/').last,
+      ),
+    ];
+    final candidate = Wal(
+      timerStart: 1700000800,
+      codec: BleAudioCodec.opus,
+      seconds: 1,
+      device: 'cv1-test',
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      filePath: candidateFile.path.split('/').last,
+      sourceId: 'ring_800_802',
+    );
+
+    final result = await local.addExternalWal(candidate);
+
+    expect(result, ExternalWalRegistration.alreadyRegistered);
+    expect(local.testWals, hasLength(1));
+    expect(await candidateFile.exists(), isFalse);
+  });
+
+  test('synced legacy WAL without immutable upload proof is conservatively registered again', () async {
+    final local = localSync();
+    File('${directory.path}/legacy.bin').writeAsBytesSync([1, 2, 3, 4]);
+    File('${directory.path}/range.bin').writeAsBytesSync([1, 2, 3, 4]);
+    local.testWals = [
+      Wal(
+        timerStart: 1700000900,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        device: 'cv1-test',
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: 'legacy.bin',
+      ),
+    ];
+    final candidate = Wal(
+      timerStart: 1700000900,
+      codec: BleAudioCodec.opus,
+      seconds: 1,
+      device: 'cv1-test',
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      filePath: 'range.bin',
+      sourceId: 'ring_900_902',
+    );
+
+    final result = await local.addExternalWal(candidate);
+
+    expect(result, ExternalWalRegistration.added);
+    expect(local.testWals, hasLength(2));
+    expect(await File('${directory.path}/range.bin').exists(), isTrue);
+  });
+}
+
+BtDevice _device() => BtDevice(name: 'Omi', id: 'cv1-test', type: DeviceType.omi, rssi: -40);
+
+class _Listener implements IWalSyncListener {
+  @override
+  void onWalSynced(Wal wal, {ServerConversation? conversation}) {}
+
+  @override
+  void onWalUpdated() {}
+}
+
+class _FakeRingConnection implements DeviceConnection {
+  static const int baseTimestamp = 1710000000;
+
+  int readSeq;
+  final int writeSeq;
+  final int? truncateStartSeq;
+  final bool corruptCrc;
+  final bool failAdvance;
+  final int framesPerRecord;
+  final Map<int, int> timestamps;
+  final reads = <({int start, int count})>[];
+  final advanceAttempts = <int>[];
+  final successfulAdvances = <int>[];
+  final StreamController<List<int>> _notifications = StreamController<List<int>>.broadcast(sync: true);
+
+  _FakeRingConnection({
+    required this.readSeq,
+    required this.writeSeq,
+    this.truncateStartSeq,
+    this.corruptCrc = false,
+    this.failAdvance = false,
+    this.framesPerRecord = 1,
+    this.timestamps = const {},
+  });
+
+  @override
+  Future<RingInfo?> getRingInfo() async => RingInfo(
+        readSeq: readSeq,
+        writeSeq: writeSeq,
+        capacityPackets: 1000000,
+        droppedPackets: 0,
+        packetSize: RingProtocol.recordSize,
+      );
+
+  @override
+  Future<StreamSubscription?> getBleStorageBytesListener({
+    required void Function(List<int>) onStorageBytesReceived,
+  }) async =>
+      _notifications.stream.listen(onStorageBytesReceived);
+
+  @override
+  Future<bool> readRingFromSeq(int startSeq, {int? packetCount}) async {
+    final count = packetCount!;
+    reads.add((start: startSeq, count: count));
+    scheduleMicrotask(() {
+      _notifications.add(_readBegin(startSeq, count));
+      final requested = <int>[];
+      for (var seq = startSeq; seq < startSeq + count; seq++) {
+        requested.addAll(_record(seq, timestamps[seq] ?? baseTimestamp + seq));
+      }
+      final sent =
+          truncateStartSeq == startSeq ? requested.sublist(0, requested.length - RingProtocol.recordSize) : requested;
+      final crc = RingTransferCrc32()..add(sent);
+      for (var offset = 0; offset < sent.length; offset += 137) {
+        final end = (offset + 137).clamp(0, sent.length);
+        _notifications.add([RingProtocol.notifyData, ...sent.sublist(offset, end)]);
+      }
+      _notifications.add(_done(startSeq + count, corruptCrc ? crc.value ^ 0xFFFFFFFF : crc.value));
+    });
+    return true;
+  }
+
+  @override
+  Future<bool> advanceRing(int newReadSeq) async {
+    advanceAttempts.add(newReadSeq);
+    if (failAdvance) return false;
+    readSeq = newReadSeq;
+    successfulAdvances.add(newReadSeq);
+    return true;
+  }
+
+  @override
+  Future<bool> stopStorageSync() async => true;
+
+  static List<int> _readBegin(int startSeq, int count) {
+    final bytes = ByteData(13)
+      ..setUint8(0, RingProtocol.notifyReadBegin)
+      ..setUint64(1, startSeq, Endian.big)
+      ..setUint32(9, count, Endian.big);
+    return bytes.buffer.asUint8List();
+  }
+
+  static List<int> _done(int nextSeq, int crc) {
+    final bytes = ByteData(14)
+      ..setUint8(0, RingProtocol.notifyDone)
+      ..setUint8(1, 0)
+      ..setUint64(2, nextSeq, Endian.big)
+      ..setUint32(10, crc, Endian.big);
+    return bytes.buffer.asUint8List();
+  }
+
+  List<int> _record(int sequence, int timestamp) {
+    final bytes = Uint8List(RingProtocol.recordSize);
+    ByteData.sublistView(bytes).setUint32(0, timestamp, Endian.big);
+    var offset = RingProtocol.timestampBytes;
+    for (var frame = 0; frame < framesPerRecord; frame++) {
+      bytes[offset++] = 3;
+      bytes[offset++] = sequence & 0xFF;
+      bytes[offset++] = (sequence >> 8) & 0xFF;
+      bytes[offset++] = frame & 0xFF;
+    }
+    return bytes;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -84,6 +84,48 @@ void main() {
     expect(wal.status, WalStatus.synced);
   });
 
+  test('durable ring WAL uses exact little-endian length-prefixed frame bytes', () async {
+    const startSeq = 0x1234;
+    final connection = _FakeRingConnection(readSeq: startSeq, writeSeq: startSeq + 2, framesPerRecord: 2);
+    final local = localSync();
+
+    await ringSync(connection, local).syncWal(wal: virtualWal(2));
+
+    expect(connection.successfulAdvances, [startSeq + 2]);
+    expect(local.testWals, hasLength(1));
+    final bytes = await File('${directory.path}/${local.testWals.single.filePath}').readAsBytes();
+    expect(bytes, [
+      3,
+      0,
+      0,
+      0,
+      0x34,
+      0x12,
+      0,
+      3,
+      0,
+      0,
+      0,
+      0x34,
+      0x12,
+      1,
+      3,
+      0,
+      0,
+      0,
+      0x35,
+      0x12,
+      0,
+      3,
+      0,
+      0,
+      0,
+      0x35,
+      0x12,
+      1,
+    ]);
+  });
+
   test('interrupted range keeps its cursor and retry resumes after the last durable advance', () async {
     final local = localSync();
     final firstConnection = _FakeRingConnection(readSeq: 200, writeSeq: 205, truncateStartSeq: 202);

--- a/app/test/unit/ble_packet_continuity_test.dart
+++ b/app/test/unit/ble_packet_continuity_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/services/devices/ble_packet_continuity.dart';
+
+List<int> _packet(int id) => [id & 0xFF, (id >> 8) & 0xFF, 0, 0xAA];
+
+void main() {
+  group('BlePacketContinuityTracker', () {
+    test('accepts contiguous IDs across the uint16 wrap', () {
+      final tracker = BlePacketContinuityTracker();
+
+      expect(tracker.observe(_packet(0xFFFE)).disposition, BlePacketDisposition.first);
+      expect(tracker.observe(_packet(0xFFFF)).disposition, BlePacketDisposition.contiguous);
+      expect(tracker.observe(_packet(0)).disposition, BlePacketDisposition.contiguous);
+    });
+
+    test('reports the exact number of missing packets', () {
+      final tracker = BlePacketContinuityTracker();
+      tracker.observe(_packet(100));
+
+      final observation = tracker.observe(_packet(104));
+
+      expect(observation.disposition, BlePacketDisposition.gap);
+      expect(observation.missingPackets, 3);
+      expect(observation.shouldForward, isTrue);
+    });
+
+    test('suppresses an exact adjacent duplicate without moving the cursor', () {
+      final tracker = BlePacketContinuityTracker();
+      tracker.observe(_packet(200));
+
+      final duplicate = tracker.observe(_packet(200));
+      final next = tracker.observe(_packet(201));
+
+      expect(duplicate.disposition, BlePacketDisposition.duplicate);
+      expect(duplicate.shouldForward, isFalse);
+      expect(next.disposition, BlePacketDisposition.contiguous);
+    });
+
+    test('forwards a reused ID when the index or payload differs', () {
+      final tracker = BlePacketContinuityTracker();
+      tracker.observe(_packet(200));
+
+      final reused = tracker.observe([200, 0, 1, 0xBB]);
+
+      expect(reused.disposition, BlePacketDisposition.reset);
+      expect(reused.shouldForward, isTrue);
+    });
+
+    test('forwards a backward reset instead of creating a long outage', () {
+      final tracker = BlePacketContinuityTracker();
+      tracker.observe(_packet(5000));
+
+      final reset = tracker.observe(_packet(1));
+
+      expect(reset.disposition, BlePacketDisposition.reset);
+      expect(reset.shouldForward, isTrue);
+      expect(tracker.observe(_packet(2)).disposition, BlePacketDisposition.contiguous);
+    });
+
+    test('uses modular half-range classification for ambiguous high-ID wrap gaps', () {
+      final tracker = BlePacketContinuityTracker();
+      tracker.observe(_packet(50000));
+
+      final ambiguous = tracker.observe(_packet(1));
+
+      expect(ambiguous.disposition, BlePacketDisposition.gap);
+      expect(ambiguous.missingPackets, 15536);
+      expect(ambiguous.shouldForward, isTrue);
+    });
+
+    test('rejects malformed packets without changing continuity', () {
+      final tracker = BlePacketContinuityTracker();
+      tracker.observe(_packet(10));
+
+      expect(tracker.observe([1, 2]).disposition, BlePacketDisposition.malformed);
+      expect(tracker.observe(_packet(11)).disposition, BlePacketDisposition.contiguous);
+    });
+  });
+
+  group('BlePacketAnomalyLogLimiter', () {
+    test('emits immediately then coalesces notification-rate anomalies', () {
+      final limiter = BlePacketAnomalyLogLimiter(interval: const Duration(seconds: 10));
+      final start = DateTime.utc(2026, 1, 1);
+
+      expect(limiter.record(start), 1);
+      expect(limiter.record(start.add(const Duration(seconds: 1))), isNull);
+      expect(limiter.record(start.add(const Duration(seconds: 9))), isNull);
+      expect(limiter.record(start.add(const Duration(seconds: 10))), 3);
+    });
+  });
+}

--- a/app/test/unit/local_wal_sync_test.dart
+++ b/app/test/unit/local_wal_sync_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -12,6 +13,8 @@ import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/services/audio_sources/audio_source.dart';
 import 'package:omi/services/wals/flash_page_wal_sync.dart';
 import 'package:omi/services/wals/local_wal_sync.dart';
+import 'package:omi/services/wals/sync_rate_limiter.dart';
+import 'package:omi/services/wals/sync_upload_gate.dart';
 import 'package:omi/services/wals/wal.dart';
 import 'package:omi/services/wals/wal_interfaces.dart';
 
@@ -500,6 +503,109 @@ void main() {
       await freshSync.addExternalWal(wal);
 
       expect(freshSync.testWals.map((w) => w.id), contains(wal.id));
+    });
+
+    test('external registration waits for manifest, not upload, and coalesces the next wake', () async {
+      SyncRateLimiter.instance.clear();
+      final manifestCommit = Completer<bool>();
+      final uploadStarted = Completer<void>();
+      final secondUploadStarted = Completer<void>();
+      final releaseUpload = Completer<void>();
+      final backgroundManifestSaved = Completer<void>();
+      final uploadBatches = <List<String>>[];
+      var manifestWrites = 0;
+      final fileName = 'external_wal_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final secondFileName = 'external_wal_next_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final file = File('${Directory.systemTemp.path}/$fileName');
+      final secondFile = File('${Directory.systemTemp.path}/$secondFileName');
+      await file.writeAsBytes([1, 2, 3], flush: true);
+      await secondFile.writeAsBytes([4, 5, 6], flush: true);
+      addTearDown(() async {
+        if (await file.exists()) await file.delete();
+        if (await secondFile.exists()) await secondFile.delete();
+      });
+
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        fairUseStatusLoader: () async => {'stage': 'none'},
+        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+          uploadBatches.add(files.map((file) => file.uri.pathSegments.last).toList());
+          if (uploadBatches.length == 1) uploadStarted.complete();
+          if (uploadBatches.length == 2) secondUploadStarted.complete();
+          await releaseUpload.future;
+          return UploadFilesResult.queued('test-job-${uploadBatches.length}');
+        },
+      );
+      final externalSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: gate,
+        walPersister: (_) {
+          manifestWrites++;
+          if (manifestWrites == 1) return manifestCommit.future;
+          if (manifestWrites >= 5 && !backgroundManifestSaved.isCompleted) {
+            backgroundManifestSaved.complete();
+          }
+          return Future.value(true);
+        },
+      );
+      final wal = Wal(
+        timerStart: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: fileName,
+        device: 'test-device',
+        sourceId: 'ring_1_2',
+        conversationId: 'conversation-1',
+      );
+
+      var registrationCompleted = false;
+      final registrationFuture = externalSync.addExternalWal(wal).whenComplete(() => registrationCompleted = true);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(manifestWrites, 1);
+      expect(registrationCompleted, isFalse);
+
+      manifestCommit.complete(true);
+      expect(
+        await registrationFuture.timeout(const Duration(seconds: 1)),
+        ExternalWalRegistration.added,
+      );
+      await uploadStarted.future.timeout(const Duration(seconds: 1));
+      expect(releaseUpload.isCompleted, isFalse);
+      expect(uploadBatches, [
+        [fileName],
+      ]);
+
+      final secondWal = Wal(
+        timerStart: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: secondFileName,
+        device: 'test-device',
+        sourceId: 'ring_2_3',
+        conversationId: 'conversation-1',
+      );
+      expect(
+        await externalSync.addExternalWal(secondWal).timeout(const Duration(seconds: 1)),
+        ExternalWalRegistration.added,
+      );
+      expect(uploadBatches, [
+        [fileName],
+      ]);
+
+      releaseUpload.complete();
+      await secondUploadStarted.future.timeout(const Duration(seconds: 1));
+      await backgroundManifestSaved.future.timeout(const Duration(seconds: 1));
+      expect(uploadBatches, [
+        [fileName],
+        [secondFileName],
+      ]);
     });
   });
 

--- a/app/test/unit/omi_audio_continuity_binding_test.dart
+++ b/app/test/unit/omi_audio_continuity_binding_test.dart
@@ -1,0 +1,77 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/devices/connectors/omi_connection.dart';
+import 'package:omi/services/devices/transports/device_transport.dart';
+
+class _FakeOmiTransport extends DeviceTransport {
+  final _audio = StreamController<List<int>>.broadcast();
+  final _state = StreamController<DeviceTransportState>.broadcast();
+
+  void emitAudio(List<int> packet) => _audio.add(packet);
+
+  @override
+  String get deviceId => 'fake-omi';
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> dispose() async {
+    await _audio.close();
+    await _state.close();
+  }
+
+  @override
+  Stream<List<int>> getCharacteristicStream(String serviceUuid, String characteristicUuid) => _audio.stream;
+
+  @override
+  Stream<DeviceTransportState> get connectionStateStream => _state.stream;
+
+  @override
+  Future<bool> isConnected() async => true;
+
+  @override
+  Future<bool> ping() async => true;
+
+  @override
+  Future<List<int>> readCharacteristic(String serviceUuid, String characteristicUuid) async => const [];
+
+  @override
+  Future<void> writeCharacteristic(String serviceUuid, String characteristicUuid, List<int> data) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('Omi audio binding suppresses only malformed and exact adjacent duplicates', () async {
+    final transport = _FakeOmiTransport();
+    final device = BtDevice(name: 'Omi', id: 'fake-omi', type: DeviceType.omi, rssi: -50);
+    final connection = OmiDeviceConnection(device, transport);
+    final received = <List<int>>[];
+    final subscription = await connection.performGetBleAudioBytesListener(onAudioBytesReceived: received.add);
+    const first = [10, 0, 0, 0xAA];
+    const sameIdDifferentIndex = [10, 0, 1, 0xBB];
+
+    transport.emitAudio(first);
+    transport.emitAudio(first);
+    transport.emitAudio(sameIdDifferentIndex);
+    transport.emitAudio([1, 2]);
+    transport.emitAudio([11, 0, 0, 0xCC]);
+    await pumpEventQueue();
+
+    expect(received, [
+      first,
+      sameIdDifferentIndex,
+      [11, 0, 0, 0xCC]
+    ]);
+
+    await subscription?.cancel();
+    await connection.disconnect();
+    await transport.dispose();
+  });
+}

--- a/app/test/unit/ring_protocol_test.dart
+++ b/app/test/unit/ring_protocol_test.dart
@@ -149,6 +149,114 @@ void main() {
     });
   });
 
+  group('RingProtocol.canAdvance', () {
+    test('allows deletion only after a complete durable transfer', () {
+      expect(
+        RingProtocol.canAdvance(
+          reachedDone: true,
+          doneOk: true,
+          flushError: false,
+          isCancelled: false,
+          receivedCompleteRange: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects transport completion without application completion', () {
+      expect(
+        RingProtocol.canAdvance(
+          reachedDone: false,
+          doneOk: false,
+          flushError: false,
+          isCancelled: false,
+          receivedCompleteRange: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects a completed transfer when durable flush failed', () {
+      expect(
+        RingProtocol.canAdvance(
+          reachedDone: true,
+          doneOk: true,
+          flushError: true,
+          isCancelled: false,
+          receivedCompleteRange: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects a cancelled transfer', () {
+      expect(
+        RingProtocol.canAdvance(
+          reachedDone: true,
+          doneOk: true,
+          flushError: false,
+          isCancelled: true,
+          receivedCompleteRange: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('RingProtocol.receivedCompleteRange', () {
+    test('accepts an exact contiguous READ_BEGIN through DONE range', () {
+      expect(
+        RingProtocol.receivedCompleteRange(
+          transferStartSeq: 100,
+          announcedPacketCount: 20,
+          doneNextSeq: 120,
+          receivedPacketCount: 20,
+          pendingBytes: 0,
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects a missing record even when DONE arrived', () {
+      expect(
+        RingProtocol.receivedCompleteRange(
+          transferStartSeq: 100,
+          announcedPacketCount: 20,
+          doneNextSeq: 120,
+          receivedPacketCount: 19,
+          pendingBytes: 0,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects trailing partial record bytes', () {
+      expect(
+        RingProtocol.receivedCompleteRange(
+          transferStartSeq: 100,
+          announcedPacketCount: 20,
+          doneNextSeq: 120,
+          receivedPacketCount: 20,
+          pendingBytes: 17,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects DONE watermark inconsistent with announced count', () {
+      expect(
+        RingProtocol.receivedCompleteRange(
+          transferStartSeq: 100,
+          announcedPacketCount: 20,
+          doneNextSeq: 121,
+          receivedPacketCount: 20,
+          pendingBytes: 0,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('RingProtocol.readRecordTimestamp', () {
     test('reads 4-byte big-endian timestamp prefix', () {
       // 0x6824B5C0 = epoch 2026-05-13 21:47:12 UTC

--- a/app/test/unit/ring_protocol_test.dart
+++ b/app/test/unit/ring_protocol_test.dart
@@ -79,6 +79,18 @@ void main() {
       expect(done.status, 0);
       expect(done.nextSeq, 12345);
       expect(done.isOk, isTrue);
+      expect(done.transferCrc32, isNull);
+    });
+
+    test('decodes optional transfer CRC32 extension', () {
+      final bd = ByteData(14)
+        ..setUint8(0, 0x04)
+        ..setUint8(1, 0)
+        ..setUint64(2, 12345, Endian.big)
+        ..setUint32(10, 0xCBF43926, Endian.big);
+      final done = RingProtocol.parseDoneNotification(bd.buffer.asUint8List())!;
+      expect(done.nextSeq, 12345);
+      expect(done.transferCrc32, 0xCBF43926);
     });
 
     test('non-zero status surfaces as isOk=false', () {
@@ -158,6 +170,8 @@ void main() {
           flushError: false,
           isCancelled: false,
           receivedCompleteRange: true,
+          protocolError: false,
+          crcVerified: true,
         ),
         isTrue,
       );
@@ -171,6 +185,8 @@ void main() {
           flushError: false,
           isCancelled: false,
           receivedCompleteRange: false,
+          protocolError: false,
+          crcVerified: true,
         ),
         isFalse,
       );
@@ -184,6 +200,8 @@ void main() {
           flushError: true,
           isCancelled: false,
           receivedCompleteRange: true,
+          protocolError: false,
+          crcVerified: true,
         ),
         isFalse,
       );
@@ -197,9 +215,37 @@ void main() {
           flushError: false,
           isCancelled: true,
           receivedCompleteRange: true,
+          protocolError: false,
+          crcVerified: true,
         ),
         isFalse,
       );
+    });
+
+    test('rejects a CRC mismatch', () {
+      expect(
+        RingProtocol.canAdvance(
+          reachedDone: true,
+          doneOk: true,
+          flushError: false,
+          isCancelled: false,
+          receivedCompleteRange: true,
+          protocolError: false,
+          crcVerified: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('RingTransferCrc32', () {
+    test('matches the standard IEEE CRC-32 golden vector across fragments', () {
+      final crc = RingTransferCrc32()
+        ..add('123'.codeUnits)
+        ..add('456'.codeUnits)
+        ..add('789'.codeUnits);
+
+      expect(crc.value, 0xCBF43926);
     });
   });
 
@@ -315,21 +361,16 @@ void main() {
       expect(frames, isEmpty);
     });
 
-    test('drops a frame that would end exactly at the buffer boundary (firmware overflow guard)', () {
-      // [size=2][0xAA, 0xBB] — the frame would end exactly at audio.length.
-      // The firmware (transport.c:write_to_storage) never writes a frame ending
-      // exactly at the last byte: a size byte at the boundary with no room for
-      // its frame is an overflow artifact, and the bytes after it are stale from
-      // a previous write. The parser's >= guard drops it; parsing the stale
-      // region as opus otherwise yields OpusException -4 "corrupted stream".
+    test('drops a boundary-aligned frame for legacy record compatibility', () {
+      // Legacy 3.0.20 may leave a size marker followed by stale bytes when a
+      // frame would consume the complete payload.
       final frames = RingProtocol.parseAudioPayload([2, 0xAA, 0xBB]);
       expect(frames, isEmpty);
     });
 
-    test('drops the boundary-aligned last frame in tightly-packed input (440B exactly)', () {
-      // 40 frames of [size=10][10B] = 40 * 11 = 440 bytes — the 40th frame would
-      // end precisely at audio.length. The firmware never emits such a frame, so
-      // the >= boundary guard drops it: 39 frames survive, the last being #38.
+    test('drops the boundary-aligned last frame in tightly-packed legacy input', () {
+      // 40 frames of [size=10][10B] = 440 bytes. The final frame shape is
+      // indistinguishable from a legacy stale-tail artifact and is rejected.
       final audio = <int>[];
       for (int i = 0; i < 40; i++) {
         audio.add(10);

--- a/app/test/unit/wal_recovery_test.dart
+++ b/app/test/unit/wal_recovery_test.dart
@@ -66,6 +66,38 @@ void main() {
     });
   });
 
+  group('Wal source identity', () {
+    test('sequence-range sourceId persists and owns retry identity', () {
+      final wal = Wal(
+        timerStart: 1700000000,
+        codec: BleAudioCodec.opus,
+        seconds: 10,
+        device: 'cv1',
+        sourceId: 'ring_100_200',
+      );
+
+      final restored = Wal.fromJson(wal.toJson());
+
+      expect(restored.sourceId, 'ring_100_200');
+      expect(restored.id, 'cv1_ring_100_200');
+    });
+
+    test('legacy WAL identity remains timestamp-based when sourceId is absent', () {
+      final wal = Wal(timerStart: 1700000000, codec: BleAudioCodec.opus, seconds: 10, device: 'cv1');
+
+      expect(wal.id, 'cv1_1700000000');
+    });
+
+    test('source-aware filename keeps backend timestamp as the final token', () {
+      final wal = Wal(timerStart: 1700000000, codec: BleAudioCodec.opus, seconds: 10, device: 'cv1');
+
+      final filename = wal.getFileNameByTimeStarts(1700000000, sourceId: 'ring_100_200');
+
+      expect(filename, endsWith('_ring_100_200_1700000000.bin'));
+      expect(int.parse(filename.split('_').last.replaceFirst('.bin', '')), 1700000000);
+    });
+  });
+
   group('stampConversationId', () {
     late LocalWalSyncImpl sync;
     late _FakeListener listener;

--- a/app/test/unit/wal_upload_resilience_test.dart
+++ b/app/test/unit/wal_upload_resilience_test.dart
@@ -48,6 +48,7 @@ Wal _makeWal({
   WalStatus status = WalStatus.miss,
   WalStorage storage = WalStorage.disk,
   String? filePath = 'audio_1000.bin',
+  String? sourceId,
 }) {
   return Wal(
     timerStart: timerStart,
@@ -57,6 +58,7 @@ Wal _makeWal({
     storage: storage,
     device: 'omi',
     filePath: filePath,
+    sourceId: sourceId,
   );
 }
 
@@ -106,6 +108,62 @@ void main() {
   // -------------------------------------------------------------------------
   // getMissingWals — status filter
   // -------------------------------------------------------------------------
+
+  group('atomic WAL manifest', () {
+    test('failed temporary write preserves the previous complete manifest', () async {
+      final original = _makeWal(timerStart: 1000);
+      expect(await WalFileManager.saveWals([original]), isTrue);
+
+      // A directory at the temporary-file path deterministically fails the
+      // rewrite before rename. The production manifest must remain readable.
+      await Directory('${tempDir.path}/wals.json.tmp').create();
+
+      await expectLater(WalFileManager.saveWals([_makeWal(timerStart: 2000)]), throwsA(isA<FileSystemException>()));
+
+      final restored = await WalFileManager.loadWals();
+      expect(restored.map((wal) => wal.timerStart), [1000]);
+    });
+
+    test('successful rewrite leaves no partial manifest beside the committed file', () async {
+      expect(await WalFileManager.saveWals([_makeWal(timerStart: 3000)]), isTrue);
+
+      expect(File('${tempDir.path}/wals.json').existsSync(), isTrue);
+      expect(File('${tempDir.path}/wals.json.tmp').existsSync(), isFalse);
+      expect(File('${tempDir.path}/wals_backup.json.tmp').existsSync(), isFalse);
+      expect((await WalFileManager.loadWals()).single.timerStart, 3000);
+    });
+
+    test('backup recovery retains the newest durably acknowledged ring range', () async {
+      final first = _makeWal(timerStart: 3000, sourceId: 'ring_100_200');
+      final acknowledged = _makeWal(timerStart: 4000, sourceId: 'ring_200_300');
+
+      expect(await WalFileManager.saveWals([first]), isTrue);
+      expect(await WalFileManager.saveWals([first, acknowledged]), isTrue);
+      await File('${tempDir.path}/wals.json').writeAsString('{corrupted', flush: true);
+
+      final recovered = await WalFileManager.loadWals();
+      expect(recovered.map((wal) => wal.sourceId), ['ring_100_200', 'ring_200_300']);
+    });
+
+    test('backup recovery retains the newest range when the primary manifest is missing', () async {
+      final acknowledged = _makeWal(timerStart: 5000, sourceId: 'ring_300_400');
+
+      expect(await WalFileManager.saveWals([acknowledged]), isTrue);
+      await File('${tempDir.path}/wals.json').delete();
+
+      final recovered = await WalFileManager.loadWals();
+      expect(recovered.single.sourceId, 'ring_300_400');
+    });
+
+    test('concurrent callers commit in invocation order without sharing a temp writer', () async {
+      final olderWrite = WalFileManager.saveWals([_makeWal(timerStart: 4000)]);
+      final newerWrite = WalFileManager.saveWals([_makeWal(timerStart: 5000)]);
+
+      await Future.wait([olderWrite, newerWrite]);
+
+      expect((await WalFileManager.loadWals()).single.timerStart, 5000);
+    });
+  });
 
   group('getMissingWals', () {
     test('returns only miss WALs, excludes synced and corrupted', () async {


### PR DESCRIPTION
## Summary

- serialize Android BLE GATT operations, bind callbacks to the active connection session, retry transient busy states, and use bounded reconnect backoff
- preserve contiguous Limitless flash acknowledgments so a missing page is never acknowledged past
- make Limitless page appends retry-idempotent with durable per-device/session watermarks and interrupted-append rollback
- advance the Limitless destructive pendant ACK watermark only after the BLE write callback succeeds
- validate CV1 notification continuity and complete ring ranges before advancing the pendant
- make WAL creation, upload, reconciliation, restart recovery, and retry ownership transactional and memory-bounded
- when Android Background Mode and automatic upload are both explicitly enabled, allow only a native `deviceConnected` wake to resume backlog recovery in the background

## Why

The old Android path mixed concurrent GATT operations, accepted stale callbacks after reconnect, treated notification arrival as implicit continuity, and allowed multiple sync observers to race. A partial or failed drain could therefore look successful, while a busy or screen-off phone could leave a large pendant backlog retrying inefficiently.

Limitless flash recovery also advanced its local deletion watermark immediately after starting an asynchronous BLE ACK. If the audio fsync succeeded but the ACK failed or the connection became ambiguous, the pendant retained the page and the next drain appended the same durable audio again. The writer now records an append checkpoint before writing, fsyncs audio, and atomically replaces that checkpoint with a device/session page watermark. A restart truncates an interrupted append, while a completed page is skipped on redrain. Pendant deletion advances only from a successful GATT completion callback.

## Behavior and rollout

- failed or partial CV1 ranges remain on the pendant and retry from the same durable sequence
- locally written WALs are flushed and registered before the cumulative `ADVANCE`
- uploaded WALs reconcile before they can be offered again
- Limitless ACK failure/disconnect leaves the pendant watermark unchanged and redrain does not duplicate durable audio
- Limitless interrupted writer transactions roll back to their recorded file offset before retry
- background recovery remains opt-in and Android-only; connectivity, cooldown, and user-retry wakes still wait for foreground
- failures during a background pass schedule no background timer and remain retryable on the next foreground wake

Candidate testing on the Galaxy reached 98.7 KiB/s during CV1 backlog transfer. The shared durable-sync layer is intentionally included here because it owns the app-side acknowledgment contract used by both mobile platforms.

## Validation

- `make preflight`: deterministic manifest, hygiene, architecture, and invariant checks passed; local worktree PR-metadata discovery is unavailable because the task branch differs from the existing fork PR branch
- focused Limitless ACK/idempotency JVM regressions added for failed ACK + redrain, successful ACK completion, interrupted append rollback, and in-flight ACK coverage
- GitHub Mobile App Checks: generated files, analyzer + Flutter tests, and Android dev-debug APK compile smoke passed at `b76f2415eaa811ad5bd703faa078664df7005e47`
- prior branch validation remains: `bash app/test.sh`, Android BLE/Limitless unit tests, analyzer ratchet, focused continuity/ring/WAL/background-policy tests, integrated Galaxy/CV1 testing, and preflight

Failure-Class: none
