### PR TITLE
fix(ios): serialize BLE recovery and reclaim CV1 after DFU

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -204,6 +204,11 @@ checks:
     triggers: ["app/scripts/rayban_dat.sh", "app/ios/Podfile", "app/ios/rayban_dat_plugin_boundary.rb", "app/ios/test/rayban_dat_build_wrapper_test.rb", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "Ray-Ban DAT builds must strip mcumgr before CocoaPods and restore the exact default graph even after interruption"
+  - id: ios-ble-gatt-operation-scheduler
+    command: ["bash", "app/ios/test/run_ble_gatt_scheduler_tests.sh"]
+    triggers: ["app/ios/Runner/Ble/**", "app/ios/Runner.xcodeproj/project.pbxproj", "app/ios/test/BleGattOperationSchedulerTests.swift", "app/ios/test/BleManagerDependencyTypecheckStubs.swift", "app/ios/test/ble_gatt_project_graph_test.rb", "app/ios/test/run_ble_gatt_scheduler_tests.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "PR #5796 shipped characteristic-keyed completions and PR #6085 shipped RSSI-as-keepalive; the tested native boundary keeps CV1 commands session-bound, serialized, and free of unconditional polling"
   - id: deferred-work-markers
     command: ["python3", ".github/scripts/deferred-work-marker-count.py", "--changed-files", "{changed_files}", "--base", "{base}", "--check-new"]
     triggers: ["all"]

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		42B17C622F69B9CF00BFDA9D /* OmiBleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */; };
 		42B17C642F69B9E100BFDA9D /* BleHostApiImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C632F69B9E100BFDA9D /* BleHostApiImpl.swift */; };
 		C0D3B1E00000000000000002 /* BleGattOperationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3B1E00000000000000001 /* BleGattOperationScheduler.swift */; };
+		C0D3B1E10000000000000002 /* BleNotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3B1E10000000000000001 /* BleNotificationRouter.swift */; };
 		42B17C7C2F69BC6600BFDA9D /* PigeonCommunicator.g.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C7B2F69BC6600BFDA9D /* PigeonCommunicator.g.swift */; };
 		42BABFB82F2A81B100E78A3C /* OmiRecordingAudioDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BABFB62F2A81B100E78A3C /* OmiRecordingAudioDevice.swift */; };
 		42BABFB92F2A81B100E78A3C /* OmiPhoneCallsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BABFB72F2A81B100E78A3C /* OmiPhoneCallsPlugin.swift */; };
@@ -76,6 +77,7 @@
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		99ADCEC5933A6FA3EE3AAE5D /* OmiBleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */; };
 		C0D3B1E00000000000000003 /* BleGattOperationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3B1E00000000000000001 /* BleGattOperationScheduler.swift */; };
+		C0D3B1E10000000000000003 /* BleNotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3B1E10000000000000001 /* BleNotificationRouter.swift */; };
 		9A25BD940EC94B21766CB950 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E5BBFB39079A4743502BBEE /* Pods_Runner.framework */; };
 		9A26EFBA2ABCE6C441ADBE8E /* OmiCallCoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BABFC62F2A81B100E78A3C /* OmiCallCoordinatorProtocol.swift */; };
 		9A519AEFA12F139B0082101F /* Base.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = CF2F518C2EC08EA60025B331 /* Base.xcconfig */; };
@@ -208,6 +210,7 @@
 		42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmiBleManager.swift; sourceTree = "<group>"; };
 		42B17C632F69B9E100BFDA9D /* BleHostApiImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BleHostApiImpl.swift; sourceTree = "<group>"; };
 		C0D3B1E00000000000000001 /* BleGattOperationScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BleGattOperationScheduler.swift; sourceTree = "<group>"; };
+		C0D3B1E10000000000000001 /* BleNotificationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BleNotificationRouter.swift; sourceTree = "<group>"; };
 		42B17C7B2F69BC6600BFDA9D /* PigeonCommunicator.g.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PigeonCommunicator.g.swift; sourceTree = "<group>"; };
 		42BABFB62F2A81B100E78A3C /* OmiRecordingAudioDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmiRecordingAudioDevice.swift; sourceTree = "<group>"; };
 		42BABFB72F2A81B100E78A3C /* OmiPhoneCallsPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmiPhoneCallsPlugin.swift; sourceTree = "<group>"; };
@@ -493,6 +496,7 @@
 			isa = PBXGroup;
 			children = (
 				C0D3B1E00000000000000001 /* BleGattOperationScheduler.swift */,
+				C0D3B1E10000000000000001 /* BleNotificationRouter.swift */,
 				42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */,
 				42B17C632F69B9E100BFDA9D /* BleHostApiImpl.swift */,
 			);
@@ -928,6 +932,7 @@
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				C0D3B1E00000000000000002 /* BleGattOperationScheduler.swift in Sources */,
+				C0D3B1E10000000000000002 /* BleNotificationRouter.swift in Sources */,
 				42B17C622F69B9CF00BFDA9D /* OmiBleManager.swift in Sources */,
 				BAADF00DF00DF00DF00DF0D2 /* BatchAudioWriter.swift in Sources */,
 				BAADF00DF00DF00DF00DF0D4 /* BaseBatchAudioWriter.swift in Sources */,
@@ -973,6 +978,7 @@
 			files = (
 				873C99F3D85C142369688A1D /* AppDelegate.swift in Sources */,
 				C0D3B1E00000000000000003 /* BleGattOperationScheduler.swift in Sources */,
+				C0D3B1E10000000000000003 /* BleNotificationRouter.swift in Sources */,
 				99ADCEC5933A6FA3EE3AAE5D /* OmiBleManager.swift in Sources */,
 				0658C1BEFC86B56785C10A69 /* BatchAudioWriter.swift in Sources */,
 				BB125CDB70C0DB5AAFB15E9C /* BaseBatchAudioWriter.swift in Sources */,
@@ -2986,6 +2992,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_IDENTIFIER)";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		42A7BA4C2E788F0100138969 /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42A7BA4B2E788F0100138969 /* WatchConnectivity.framework */; };
 		42B17C622F69B9CF00BFDA9D /* OmiBleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */; };
 		42B17C642F69B9E100BFDA9D /* BleHostApiImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C632F69B9E100BFDA9D /* BleHostApiImpl.swift */; };
+		C0D3B1E00000000000000002 /* BleGattOperationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3B1E00000000000000001 /* BleGattOperationScheduler.swift */; };
 		42B17C7C2F69BC6600BFDA9D /* PigeonCommunicator.g.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C7B2F69BC6600BFDA9D /* PigeonCommunicator.g.swift */; };
 		42BABFB82F2A81B100E78A3C /* OmiRecordingAudioDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BABFB62F2A81B100E78A3C /* OmiRecordingAudioDevice.swift */; };
 		42BABFB92F2A81B100E78A3C /* OmiPhoneCallsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BABFB72F2A81B100E78A3C /* OmiPhoneCallsPlugin.swift */; };
@@ -74,6 +75,7 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		99ADCEC5933A6FA3EE3AAE5D /* OmiBleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */; };
+		C0D3B1E00000000000000003 /* BleGattOperationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3B1E00000000000000001 /* BleGattOperationScheduler.swift */; };
 		9A25BD940EC94B21766CB950 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E5BBFB39079A4743502BBEE /* Pods_Runner.framework */; };
 		9A26EFBA2ABCE6C441ADBE8E /* OmiCallCoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BABFC62F2A81B100E78A3C /* OmiCallCoordinatorProtocol.swift */; };
 		9A519AEFA12F139B0082101F /* Base.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = CF2F518C2EC08EA60025B331 /* Base.xcconfig */; };
@@ -205,6 +207,7 @@
 		42A7BA4B2E788F0100138969 /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = System/Library/Frameworks/WatchConnectivity.framework; sourceTree = SDKROOT; };
 		42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmiBleManager.swift; sourceTree = "<group>"; };
 		42B17C632F69B9E100BFDA9D /* BleHostApiImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BleHostApiImpl.swift; sourceTree = "<group>"; };
+		C0D3B1E00000000000000001 /* BleGattOperationScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BleGattOperationScheduler.swift; sourceTree = "<group>"; };
 		42B17C7B2F69BC6600BFDA9D /* PigeonCommunicator.g.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PigeonCommunicator.g.swift; sourceTree = "<group>"; };
 		42BABFB62F2A81B100E78A3C /* OmiRecordingAudioDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmiRecordingAudioDevice.swift; sourceTree = "<group>"; };
 		42BABFB72F2A81B100E78A3C /* OmiPhoneCallsPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmiPhoneCallsPlugin.swift; sourceTree = "<group>"; };
@@ -489,6 +492,7 @@
 		BAADF00DF00DF00DF00DFB01 /* Ble */ = {
 			isa = PBXGroup;
 			children = (
+				C0D3B1E00000000000000001 /* BleGattOperationScheduler.swift */,
 				42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */,
 				42B17C632F69B9E100BFDA9D /* BleHostApiImpl.swift */,
 			);
@@ -923,6 +927,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+				C0D3B1E00000000000000002 /* BleGattOperationScheduler.swift in Sources */,
 				42B17C622F69B9CF00BFDA9D /* OmiBleManager.swift in Sources */,
 				BAADF00DF00DF00DF00DF0D2 /* BatchAudioWriter.swift in Sources */,
 				BAADF00DF00DF00DF00DF0D4 /* BaseBatchAudioWriter.swift in Sources */,
@@ -967,6 +972,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				873C99F3D85C142369688A1D /* AppDelegate.swift in Sources */,
+				C0D3B1E00000000000000003 /* BleGattOperationScheduler.swift in Sources */,
 				99ADCEC5933A6FA3EE3AAE5D /* OmiBleManager.swift in Sources */,
 				0658C1BEFC86B56785C10A69 /* BatchAudioWriter.swift in Sources */,
 				BB125CDB70C0DB5AAFB15E9C /* BaseBatchAudioWriter.swift in Sources */,

--- a/app/ios/Runner/Ble/BleGattOperationScheduler.swift
+++ b/app/ios/Runner/Ble/BleGattOperationScheduler.swift
@@ -1,0 +1,302 @@
+import Dispatch
+import Foundation
+
+enum BleGattOperationKind: Equatable {
+  case readValue
+  case writeWithResponse
+  case writeWithoutResponse
+  case setNotifications(Bool)
+  case readRssi
+}
+
+enum BleGattReadAdmission: Equatable {
+  case start
+  case rejectNotifying
+
+  static func evaluate(isNotifying: Bool) -> BleGattReadAdmission {
+    isNotifying ? .rejectNotifying : .start
+  }
+}
+
+enum BleGattNotificationStateAdmission: Equatable {
+  case complete
+  case ignoreMismatchedState
+
+  static func evaluate(
+    requestedEnabled: Bool,
+    actualIsNotifying: Bool
+  ) -> BleGattNotificationStateAdmission {
+    requestedEnabled == actualIsNotifying ? .complete : .ignoreMismatchedState
+  }
+}
+
+struct BleGattTarget: Equatable {
+  let serviceUuid: String
+  let characteristicUuid: String
+  let instanceId: UInt64
+
+  static let rssi = BleGattTarget(serviceUuid: "", characteristicUuid: "rssi", instanceId: 0)
+}
+
+struct BleGattOperationToken: Equatable {
+  let id: UInt64
+  let sessionId: UInt64
+  let kind: BleGattOperationKind
+  let target: BleGattTarget
+}
+
+enum BleGattOperationSchedulerError: Error, Equatable, LocalizedError {
+  case disconnected
+  case sessionReplaced
+  case timedOut
+
+  var errorDescription: String? {
+    switch self {
+    case .disconnected:
+      return "Peripheral disconnected before the BLE operation completed"
+    case .sessionReplaced:
+      return "BLE connection session was replaced"
+    case .timedOut:
+      return "BLE operation timed out"
+    }
+  }
+}
+
+struct BleGattTimeoutCancellation {
+  let cancel: () -> Void
+}
+
+/// Serializes CoreBluetooth operations for one peripheral connection.
+///
+/// CoreBluetooth callbacks do not carry request IDs. Keeping one request in flight
+/// and binding it to a connection session, operation kind, and characteristic
+/// instance prevents a late or unrelated callback from completing the wrong caller.
+final class BleGattOperationScheduler {
+  typealias Completion = (Result<Data?, Error>) -> Void
+  typealias TimeoutScheduler = (TimeInterval, @escaping () -> Void) -> BleGattTimeoutCancellation
+
+  private struct PendingOperation {
+    let token: BleGattOperationToken
+    let fatalOnTimeout: Bool
+    let start: (BleGattOperationToken) -> Void
+    let completion: Completion
+  }
+
+  private let timeout: TimeInterval
+  private let scheduleTimeout: TimeoutScheduler
+  private let onFatalTimeout: (BleGattOperationToken) -> Void
+
+  private var nextOperationId: UInt64 = 0
+  private(set) var sessionId: UInt64 = 0
+  private(set) var isSessionActive = false
+  private var pending: [PendingOperation] = []
+  private var active: PendingOperation?
+  private var timeoutCancellation: BleGattTimeoutCancellation?
+
+  var activeToken: BleGattOperationToken? { active?.token }
+  var pendingCount: Int { pending.count }
+
+  init(
+    timeout: TimeInterval = 10,
+    scheduleTimeout: @escaping TimeoutScheduler = BleGattOperationScheduler.scheduleOnMainQueue,
+    onFatalTimeout: @escaping (BleGattOperationToken) -> Void = { _ in }
+  ) {
+    self.timeout = timeout
+    self.scheduleTimeout = scheduleTimeout
+    self.onFatalTimeout = onFatalTimeout
+  }
+
+  func beginSession() {
+    isSessionActive = false
+    drain(with: BleGattOperationSchedulerError.sessionReplaced)
+    sessionId &+= 1
+    isSessionActive = true
+  }
+
+  func endSession(with error: Error = BleGattOperationSchedulerError.disconnected) {
+    isSessionActive = false
+    drain(with: error)
+    sessionId &+= 1
+  }
+
+  @discardableResult
+  func enqueue(
+    kind: BleGattOperationKind,
+    target: BleGattTarget,
+    fatalOnTimeout: Bool = true,
+    start: @escaping (BleGattOperationToken) -> Void,
+    completion: @escaping Completion
+  ) -> BleGattOperationToken? {
+    guard isSessionActive else {
+      completion(.failure(BleGattOperationSchedulerError.disconnected))
+      return nil
+    }
+
+    nextOperationId &+= 1
+    let token = BleGattOperationToken(
+      id: nextOperationId, sessionId: sessionId, kind: kind, target: target)
+    pending.append(
+      PendingOperation(
+        token: token,
+        fatalOnTimeout: fatalOnTimeout,
+        start: start,
+        completion: completion
+      ))
+    startNextIfNeeded()
+    return token
+  }
+
+  func contains(kind: BleGattOperationKind, target: BleGattTarget) -> Bool {
+    if active?.token.kind == kind, active?.token.target == target {
+      return true
+    }
+    return pending.contains { $0.token.kind == kind && $0.token.target == target }
+  }
+
+  /// Resolve only the exact operation currently in flight.
+  ///
+  /// A callback from another characteristic, another operation kind, or a
+  /// previous connection session is deliberately ignored.
+  @discardableResult
+  func completeExpected(
+    sessionId: UInt64,
+    kind: BleGattOperationKind,
+    target: BleGattTarget,
+    result: Result<Data?, Error>
+  ) -> Bool {
+    guard let operation = active else { return false }
+    let token = operation.token
+    guard token.sessionId == sessionId, token.kind == kind, token.target == target else {
+      return false
+    }
+    complete(token: token, result: result)
+    return true
+  }
+
+  @discardableResult
+  func complete(token: BleGattOperationToken, result: Result<Data?, Error>) -> Bool {
+    guard let operation = active, operation.token == token else { return false }
+    timeoutCancellation?.cancel()
+    timeoutCancellation = nil
+    active = nil
+    operation.completion(result)
+    startNextIfNeeded()
+    return true
+  }
+
+  /// Fail the exact active operation and every queued dependent operation
+  /// without starting anything else on the compromised connection session.
+  @discardableResult
+  func failExpectedAndInvalidate(
+    sessionId: UInt64,
+    kind: BleGattOperationKind,
+    target: BleGattTarget,
+    error: Error
+  ) -> Bool {
+    guard let operation = active else { return false }
+    let token = operation.token
+    guard token.sessionId == sessionId, token.kind == kind, token.target == target else {
+      return false
+    }
+
+    isSessionActive = false
+    drain(with: error)
+    self.sessionId &+= 1
+    return true
+  }
+
+  private func startNextIfNeeded() {
+    guard isSessionActive, active == nil, !pending.isEmpty else { return }
+    let operation = pending.removeFirst()
+    active = operation
+    let token = operation.token
+    timeoutCancellation = scheduleTimeout(timeout) { [weak self] in
+      self?.handleTimeout(token: token)
+    }
+    operation.start(token)
+  }
+
+  private func handleTimeout(token: BleGattOperationToken) {
+    guard let timedOutOperation = active, timedOutOperation.token == token else { return }
+
+    if !timedOutOperation.fatalOnTimeout {
+      timeoutCancellation = nil
+      active = nil
+      timedOutOperation.completion(.failure(BleGattOperationSchedulerError.timedOut))
+      startNextIfNeeded()
+      return
+    }
+
+    let operations = [active].compactMap { $0 } + pending
+    timeoutCancellation = nil
+    active = nil
+    pending.removeAll()
+    isSessionActive = false
+    sessionId &+= 1
+
+    for operation in operations {
+      operation.completion(.failure(BleGattOperationSchedulerError.timedOut))
+    }
+    onFatalTimeout(token)
+  }
+
+  private func drain(with error: Error) {
+    timeoutCancellation?.cancel()
+    timeoutCancellation = nil
+    let operations = [active].compactMap { $0 } + pending
+    active = nil
+    pending.removeAll()
+    for operation in operations {
+      operation.completion(.failure(error))
+    }
+  }
+
+  private static func scheduleOnMainQueue(
+    interval: TimeInterval,
+    action: @escaping () -> Void
+  ) -> BleGattTimeoutCancellation {
+    let workItem = DispatchWorkItem(block: action)
+    DispatchQueue.main.asyncAfter(deadline: .now() + interval, execute: workItem)
+    return BleGattTimeoutCancellation(cancel: workItem.cancel)
+  }
+}
+
+enum BleReconnectBackoff {
+  static func delay(forAttempt attempt: Int) -> TimeInterval {
+    let boundedAttempt = min(max(attempt, 0), 6)
+    return min(30, 0.5 * pow(2, Double(boundedAttempt)))
+  }
+}
+
+/// Owns reconnect backoff across the complete BLE readiness lifecycle.
+///
+/// A CoreBluetooth transport connection is not yet a usable device: service and
+/// characteristic discovery can still fail. Only `deviceReady()` resets the
+/// accumulated failures.
+final class BleReconnectLifecycle {
+  enum Phase: Equatable {
+    case idle
+    case waitingToReconnect
+    case transportConnected
+    case ready
+  }
+
+  private(set) var phase: Phase = .idle
+  private(set) var failureCount = 0
+
+  func transportConnected() {
+    phase = .transportConnected
+  }
+
+  func nextReconnectDelay() -> TimeInterval {
+    let delay = BleReconnectBackoff.delay(forAttempt: failureCount)
+    failureCount = min(failureCount + 1, 6)
+    phase = .waitingToReconnect
+    return delay
+  }
+
+  func deviceReady() {
+    failureCount = 0
+    phase = .ready
+  }
+}

--- a/app/ios/Runner/Ble/BleGattOperationScheduler.swift
+++ b/app/ios/Runner/Ble/BleGattOperationScheduler.swift
@@ -307,6 +307,52 @@ enum BleReconnectBackoff {
   }
 }
 
+enum BleReconnectTrigger {
+  case unexpectedDisconnect
+  case failedConnect
+}
+
+enum BleReconnectDispatch: Equatable {
+  case connectNow
+  case retryWithBackoff
+  case waitForPowerOn
+}
+
+/// Keeps a CoreBluetooth connection request pending before iOS suspends the
+/// app. A pending `connect` is system-owned and does not time out, so an
+/// unexpected disconnect must reissue it synchronously. Actual connection
+/// failures still use bounded backoff to avoid a retry storm.
+enum BleReconnectDispatchPolicy {
+  static func action(
+    after trigger: BleReconnectTrigger,
+    centralIsPoweredOn: Bool
+  ) -> BleReconnectDispatch {
+    guard centralIsPoweredOn else {
+      return .waitForPowerOn
+    }
+    return trigger == .unexpectedDisconnect ? .connectNow : .retryWithBackoff
+  }
+}
+
+/// Owns the identity boundary for peripherals that may be reconnected without
+/// another user action. CoreBluetooth restoration is equivalent to a prior
+/// successful connection even when this process has not received `didConnect`.
+final class BleReconnectEligibility {
+  private var eligiblePeripheralUuids: Set<String> = []
+
+  func recordConnected(_ peripheralUuid: String) {
+    eligiblePeripheralUuids.insert(peripheralUuid)
+  }
+
+  func recordRestored(_ peripheralUuid: String) {
+    eligiblePeripheralUuids.insert(peripheralUuid)
+  }
+
+  func contains(_ peripheralUuid: String) -> Bool {
+    eligiblePeripheralUuids.contains(peripheralUuid)
+  }
+}
+
 /// Owns reconnect backoff across the complete BLE readiness lifecycle.
 ///
 /// A CoreBluetooth transport connection is not yet a usable device: service and

--- a/app/ios/Runner/Ble/BleGattOperationScheduler.swift
+++ b/app/ios/Runner/Ble/BleGattOperationScheduler.swift
@@ -30,12 +30,51 @@ enum BleGattNotificationStateAdmission: Equatable {
   }
 }
 
-struct BleGattTarget: Equatable {
+struct BleGattTarget: Equatable, Hashable {
   let serviceUuid: String
   let characteristicUuid: String
   let instanceId: UInt64
 
   static let rssi = BleGattTarget(serviceUuid: "", characteristicUuid: "rssi", instanceId: 0)
+}
+
+/// Coalesces notification requests for one characteristic into the latest desired state.
+///
+/// CoreBluetooth callbacks identify the characteristic but not the request that
+/// initiated the state change. Keep one transition in flight and launch at most
+/// one follow-up transition after its callback.
+final class BleGattNotificationTransitionState {
+  private var confirmed: Bool?
+  private var desired: Bool?
+  private var inFlight: Bool?
+
+  init(confirmed: Bool? = nil) {
+    self.confirmed = confirmed
+  }
+
+  func request(_ enabled: Bool) -> Bool? {
+    desired = enabled
+    guard inFlight == nil, confirmed != enabled else { return nil }
+    inFlight = enabled
+    return enabled
+  }
+
+  var currentInFlight: Bool? { inFlight }
+
+  /// Returns the next desired transition, already marked as in flight.
+  ///
+  /// A failed transition waits for connection-session recovery instead of
+  /// retrying against a CoreBluetooth session that may no longer be usable.
+  func complete(attempted: Bool, success: Bool) -> Bool? {
+    guard inFlight == attempted else { return nil }
+    inFlight = nil
+    guard success else { return nil }
+    confirmed = attempted
+
+    guard let next = desired, next != confirmed else { return nil }
+    inFlight = next
+    return next
+  }
 }
 
 struct BleGattOperationToken: Equatable {

--- a/app/ios/Runner/Ble/BleHostApiImpl.swift
+++ b/app/ios/Runner/Ble/BleHostApiImpl.swift
@@ -2,109 +2,111 @@ import Flutter
 
 /// Bridges Pigeon BleHostApi calls to OmiBleManager.
 final class BleHostApiImpl: BleHostApi {
-    private let bleManager: OmiBleManager
+  private let bleManager: OmiBleManager
 
-    init(bleManager: OmiBleManager) {
-        self.bleManager = bleManager
-    }
+  init(bleManager: OmiBleManager) {
+    self.bleManager = bleManager
+  }
 
-    func startScan(timeout timeoutSeconds: Int64, serviceUuids: [String]) throws {
-        bleManager.startScan(timeout: Int(timeoutSeconds), serviceUuids: serviceUuids)
-    }
+  func startScan(timeout timeoutSeconds: Int64, serviceUuids: [String]) throws {
+    bleManager.startScan(timeout: Int(timeoutSeconds), serviceUuids: serviceUuids)
+  }
 
-    func stopScan() throws {
-        bleManager.stopScan()
-    }
+  func stopScan() throws {
+    bleManager.stopScan()
+  }
 
-    func manageDevice(uuid: String, requiresBond: Bool) throws {
-        bleManager.connectPeripheral(uuid: uuid)
-    }
+  func manageDevice(uuid: String, requiresBond: Bool) throws {
+    bleManager.connectPeripheral(uuid: uuid)
+  }
 
-    func unmanageDevice(uuid: String) throws {
-        bleManager.disconnectPeripheral(uuid: uuid)
-    }
+  func unmanageDevice(uuid: String) throws {
+    bleManager.disconnectPeripheral(uuid: uuid)
+  }
 
-    func requestBond(uuid: String, completion: @escaping (Result<Bool, Error>) -> Void) {
-        // iOS handles bonding automatically at the OS level
-        completion(.success(true))
-    }
+  func requestBond(uuid: String, completion: @escaping (Result<Bool, Error>) -> Void) {
+    // iOS handles bonding automatically at the OS level
+    completion(.success(true))
+  }
 
-    func readCharacteristic(
-        peripheralUuid: String,
-        serviceUuid: String,
-        characteristicUuid: String,
-        completion: @escaping (Result<FlutterStandardTypedData, Error>) -> Void
-    ) {
-        bleManager.readCharacteristic(
-            peripheralUuid: peripheralUuid,
-            serviceUuid: serviceUuid,
-            characteristicUuid: characteristicUuid,
-            completion: completion
-        )
-    }
+  func readCharacteristic(
+    peripheralUuid: String,
+    serviceUuid: String,
+    characteristicUuid: String,
+    completion: @escaping (Result<FlutterStandardTypedData, Error>) -> Void
+  ) {
+    bleManager.readCharacteristic(
+      peripheralUuid: peripheralUuid,
+      serviceUuid: serviceUuid,
+      characteristicUuid: characteristicUuid,
+      completion: completion
+    )
+  }
 
-    func writeCharacteristic(
-        peripheralUuid: String,
-        serviceUuid: String,
-        characteristicUuid: String,
-        data: FlutterStandardTypedData,
-        completion: @escaping (Result<Void, Error>) -> Void
-    ) {
-        bleManager.writeCharacteristic(
-            peripheralUuid: peripheralUuid,
-            serviceUuid: serviceUuid,
-            characteristicUuid: characteristicUuid,
-            data: data,
-            completion: completion
-        )
-    }
+  func writeCharacteristic(
+    peripheralUuid: String,
+    serviceUuid: String,
+    characteristicUuid: String,
+    data: FlutterStandardTypedData,
+    completion: @escaping (Result<Void, Error>) -> Void
+  ) {
+    bleManager.writeCharacteristic(
+      peripheralUuid: peripheralUuid,
+      serviceUuid: serviceUuid,
+      characteristicUuid: characteristicUuid,
+      data: data,
+      completion: completion
+    )
+  }
 
-    func subscribeCharacteristic(peripheralUuid: String, serviceUuid: String, characteristicUuid: String) throws {
-        bleManager.subscribeCharacteristic(peripheralUuid: peripheralUuid, serviceUuid: serviceUuid, characteristicUuid: characteristicUuid)
-    }
+  func subscribeCharacteristic(peripheralUuid: String, serviceUuid: String, characteristicUuid: String) throws {
+    bleManager.subscribeCharacteristic(
+      peripheralUuid: peripheralUuid, serviceUuid: serviceUuid, characteristicUuid: characteristicUuid)
+  }
 
-    func unsubscribeCharacteristic(peripheralUuid: String, serviceUuid: String, characteristicUuid: String) throws {
-        bleManager.unsubscribeCharacteristic(peripheralUuid: peripheralUuid, serviceUuid: serviceUuid, characteristicUuid: characteristicUuid)
-    }
+  func unsubscribeCharacteristic(peripheralUuid: String, serviceUuid: String, characteristicUuid: String) throws {
+    bleManager.unsubscribeCharacteristic(
+      peripheralUuid: peripheralUuid, serviceUuid: serviceUuid, characteristicUuid: characteristicUuid)
+  }
 
-    func getBluetoothState() throws -> String {
-        return bleManager.getBluetoothState()
-    }
+  func getBluetoothState() throws -> String {
+    return bleManager.getBluetoothState()
+  }
 
-    func enableBluetooth(completion: @escaping (Result<Bool, Error>) -> Void) {
-        // iOS can't enable Bluetooth programmatically — the OS prompts the user.
-        // Report the current power state so Dart can react accordingly.
-        completion(.success(bleManager.getBluetoothState() == "on"))
-    }
+  func enableBluetooth(completion: @escaping (Result<Bool, Error>) -> Void) {
+    // iOS can't enable Bluetooth programmatically — the OS prompts the user.
+    // Report the current power state so Dart can react accordingly.
+    completion(.success(bleManager.getBluetoothState() == "on"))
+  }
 
-    func isPeripheralConnected(uuid: String) throws -> Bool {
-        return bleManager.isPeripheralConnected(uuid: uuid)
-    }
+  func isPeripheralConnected(uuid: String) throws -> Bool {
+    return bleManager.isPeripheralConnected(uuid: uuid)
+  }
 
-    // ── Diagnostics ──
+  // ── Diagnostics ──
 
-    func startRssiStreaming(uuid: String) throws {
-        bleManager.isRssiStreamingEnabled = true
-    }
+  func startRssiStreaming(uuid: String) throws {
+    bleManager.startRssiStreaming(uuid: uuid)
+  }
 
-    func stopRssiStreaming(uuid: String) throws {
-        bleManager.isRssiStreamingEnabled = false
-    }
+  func stopRssiStreaming(uuid: String) throws {
+    bleManager.stopRssiStreaming(uuid: uuid)
+  }
 
-    func getDeviceDiagnostics(uuid: String, completion: @escaping (Result<BleDeviceDiagnostics, Error>) -> Void) {
-        completion(.success(bleManager.getDeviceDiagnostics(uuid: uuid)))
-    }
+  func getDeviceDiagnostics(uuid: String, completion: @escaping (Result<BleDeviceDiagnostics, Error>) -> Void) {
+    completion(.success(bleManager.getDeviceDiagnostics(uuid: uuid)))
+  }
 
-    func getBatteryHistory(uuid: String, completion: @escaping (Result<[BleBatteryPoint], Error>) -> Void) {
-        completion(.success(bleManager.getBatteryHistory(uuid: uuid)))
-    }
+  func getBatteryHistory(uuid: String, completion: @escaping (Result<[BleBatteryPoint], Error>) -> Void) {
+    completion(.success(bleManager.getBatteryHistory(uuid: uuid)))
+  }
 
-    func hasCompanionDeviceAssociation() throws -> Bool {
-        return true // iOS uses state restoration
-    }
+  func hasCompanionDeviceAssociation() throws -> Bool {
+    return true  // iOS uses state restoration
+  }
 
-    func requestCompanionDeviceAssociation(deviceAddress: String, completion: @escaping (Result<String, Error>) -> Void) {
-        // No-op on iOS — state restoration handles background reconnection
-        completion(.success(""))
-    }
+  func requestCompanionDeviceAssociation(deviceAddress: String, completion: @escaping (Result<String, Error>) -> Void) {
+    // No-op on iOS — state restoration handles background reconnection
+    completion(.success(""))
+  }
 }

--- a/app/ios/Runner/Ble/BleNotificationRouter.swift
+++ b/app/ios/Runner/Ble/BleNotificationRouter.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+enum BleNotificationRoute: Equatable {
+  case limitlessFlash
+  case batchAudio
+  case dart
+}
+
+/// Keeps unrelated BLE notifications off the native batch-capture hot paths.
+///
+/// Both native handlers consult UserDefaults (and may parse JSON) before they
+/// can reject a packet. Ring-sync traffic is much hotter than audio, so routing
+/// by the protocol's fixed service/characteristic identity first prevents that
+/// policy work from running for every storage notification.
+enum BleNotificationRouter {
+  private static let omiServiceUuid = "19b10000-e8f2-537e-4f6c-d104768a1214"
+  private static let omiAudioCharacteristicUuid = "19b10001-e8f2-537e-4f6c-d104768a1214"
+  private static let friendPendantServiceUuid = "1a3fd0e7-b1f3-ac9e-2e49-b647b2c4f8da"
+  private static let friendPendantAudioCharacteristicUuid = "01000000-1111-1111-1111-111111111111"
+  private static let limitlessServiceUuid = "632de001-604c-446b-a80f-7963e950f3fb"
+  private static let limitlessReceiveCharacteristicUuid = "632de003-604c-446b-a80f-7963e950f3fb"
+
+  static func route(serviceUuid: String, characteristicUuid: String) -> BleNotificationRoute {
+    let service = serviceUuid.lowercased()
+    let characteristic = characteristicUuid.lowercased()
+
+    if service == limitlessServiceUuid, characteristic == limitlessReceiveCharacteristicUuid {
+      return .limitlessFlash
+    }
+    if (service == omiServiceUuid && characteristic == omiAudioCharacteristicUuid)
+      || (service == friendPendantServiceUuid
+        && characteristic == friendPendantAudioCharacteristicUuid)
+    {
+      return .batchAudio
+    }
+    return .dart
+  }
+}

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -92,6 +92,19 @@ final class OmiBleManager: NSObject {
   /// Queued scan request if Bluetooth wasn't ready when startScan was called.
   private var pendingScan: (timeout: Int, serviceUuids: [String])?
 
+  #if DEBUG
+    private struct NotificationWindow {
+      var count = 0
+      var bytes = 0
+      var maxValueLength = 0
+    }
+
+    private var notificationWindowStartedAt = Date()
+    private var notificationWindows: [String: NotificationWindow] = [:]
+    private var pigeonNotificationsInFlight = 0
+    private var peakPigeonNotificationsInFlight = 0
+  #endif
+
   // MARK: - Initialization
 
   private override init() {
@@ -930,6 +943,48 @@ final class OmiBleManager: NSObject {
     }
     operationSchedulers[peripheralUuid]?.endSession()
   }
+
+  #if DEBUG
+    private func recordNotificationMetric(characteristicUuid: String, valueLength: Int) {
+      var window = notificationWindows[characteristicUuid] ?? NotificationWindow()
+      window.count += 1
+      window.bytes += valueLength
+      window.maxValueLength = max(window.maxValueLength, valueLength)
+      notificationWindows[characteristicUuid] = window
+
+      let elapsed = Date().timeIntervalSince(notificationWindowStartedAt)
+      guard elapsed >= 5 else { return }
+
+      for (characteristic, values) in notificationWindows.sorted(by: { $0.key < $1.key }) {
+        NSLog(
+          "[OmiBleMetrics] window=%.3fs characteristic=%@ notifications=%d bytes=%d max_value=%d "
+            + "notifications_per_sec=%.1f bytes_per_sec=%.1f pigeon_in_flight=%d pigeon_peak=%d",
+          elapsed,
+          characteristic,
+          values.count,
+          values.bytes,
+          values.maxValueLength,
+          Double(values.count) / elapsed,
+          Double(values.bytes) / elapsed,
+          pigeonNotificationsInFlight,
+          peakPigeonNotificationsInFlight
+        )
+      }
+      notificationWindows.removeAll(keepingCapacity: true)
+      notificationWindowStartedAt = Date()
+      peakPigeonNotificationsInFlight = pigeonNotificationsInFlight
+    }
+
+    private func recordPigeonNotificationSent() {
+      pigeonNotificationsInFlight += 1
+      peakPigeonNotificationsInFlight = max(
+        peakPigeonNotificationsInFlight, pigeonNotificationsInFlight)
+    }
+
+    private func recordPigeonNotificationCompleted() {
+      pigeonNotificationsInFlight = max(0, pigeonNotificationsInFlight - 1)
+    }
+  #endif
 }
 
 // MARK: - CBCentralManagerDelegate
@@ -1227,40 +1282,55 @@ extension OmiBleManager: CBPeripheralDelegate {
     // Handle notification
     guard let data = characteristic.value, !data.isEmpty else { return }
 
+    #if DEBUG
+      recordNotificationMetric(characteristicUuid: charUuid, valueLength: data.count)
+    #endif
+
     if characteristic.uuid == OmiBleManager.batteryLevelCharUuid, let firstByte = data.first {
       persistBatteryReading(uuid: uuid, level: Int(firstByte))
     }
 
-    // Limitless Transcribe Later: while batch mode targets this pendant's RX
-    // characteristic, the flash-drain engine consumes the packet natively.
-    if LimitlessFlashDrainEngine.shared.handle(
-      peripheralUuid: uuid,
-      serviceUuid: serviceUuid,
-      characteristicUuid: charUuid,
-      value: data
-    ) {
-      return
-    }
-
-    // Batch (offline) mode: store audio natively and skip the Dart forward so the
-    // Flutter engine stays idle. Returns true only for the configured audio
-    // characteristic while batch mode is on; everything else falls through.
-    if OmiBatchAudioWriter.shared.handle(
-      peripheralUuid: uuid,
-      serviceUuid: serviceUuid,
-      characteristicUuid: charUuid,
-      value: data
-    ) {
-      return
+    // Route by fixed protocol identity before consulting native capture policy.
+    // Ring sync can deliver hundreds of notifications per second; asking both
+    // batch handlers to read UserDefaults before rejecting every storage packet
+    // needlessly occupies CoreBluetooth's main-queue callback.
+    switch BleNotificationRouter.route(serviceUuid: serviceUuid, characteristicUuid: charUuid) {
+    case .limitlessFlash:
+      if LimitlessFlashDrainEngine.shared.handle(
+        peripheralUuid: uuid,
+        serviceUuid: serviceUuid,
+        characteristicUuid: charUuid,
+        value: data
+      ) {
+        return
+      }
+    case .batchAudio:
+      if OmiBatchAudioWriter.shared.handle(
+        peripheralUuid: uuid,
+        serviceUuid: serviceUuid,
+        characteristicUuid: charUuid,
+        value: data
+      ) {
+        return
+      }
+    case .dart:
+      break
     }
 
     let typedData = FlutterStandardTypedData(bytes: data)
+    #if DEBUG
+      recordPigeonNotificationSent()
+    #endif
     flutterApi?.onCharacteristicValueUpdated(
       peripheralUuid: uuid,
       serviceUuid: serviceUuid,
       characteristicUuid: charUuid,
       value: typedData
-    ) { _ in }
+    ) { [weak self] _ in
+      #if DEBUG
+        self?.recordPigeonNotificationCompleted()
+      #endif
+    }
   }
 
   func peripheral(

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -25,6 +25,14 @@ final class OmiBleManager: NSObject {
   /// One serialized CoreBluetooth operation queue per peripheral.
   private var operationSchedulers: [String: BleGattOperationScheduler] = [:]
 
+  private struct NotificationTransitionKey: Hashable {
+    let peripheralUuid: String
+    let target: BleGattTarget
+  }
+
+  /// Latest requested CCCD state per characteristic in the active connection session.
+  private var notificationTransitions: [NotificationTransitionKey: BleGattNotificationTransitionState] = [:]
+
   private struct CharacteristicContext {
     let peripheralUuid: String
     let sessionId: UInt64
@@ -533,6 +541,7 @@ final class OmiBleManager: NSObject {
     let scheduler = operationScheduler(for: uuid)
     scheduler.beginSession()
     characteristicContexts = characteristicContexts.filter { $0.value.peripheralUuid != uuid }
+    notificationTransitions = notificationTransitions.filter { $0.key.peripheralUuid != uuid }
     pendingWritesWithoutResponse.removeValue(forKey: uuid)
   }
 
@@ -573,18 +582,33 @@ final class OmiBleManager: NSObject {
       return
     }
 
+    let key = NotificationTransitionKey(peripheralUuid: peripheralUuid, target: context.target)
+    let transitionState =
+      notificationTransitions[key]
+      ?? BleGattNotificationTransitionState(confirmed: characteristic.isNotifying)
+    notificationTransitions[key] = transitionState
+    guard let transition = transitionState.request(enabled) else { return }
+
+    startNotificationTransition(
+      transition,
+      key: key,
+      peripheral: peripheral,
+      characteristic: characteristic,
+      context: context
+    )
+  }
+
+  private func startNotificationTransition(
+    _ enabled: Bool,
+    key: NotificationTransitionKey,
+    peripheral: CBPeripheral,
+    characteristic: CBCharacteristic,
+    context: CharacteristicContext
+  ) {
+    let peripheralUuid = key.peripheralUuid
+    let characteristicUuid = context.target.characteristicUuid
     let scheduler = operationScheduler(for: peripheralUuid)
     let requestedKind = BleGattOperationKind.setNotifications(enabled)
-    if scheduler.contains(kind: requestedKind, target: context.target) {
-      return
-    }
-    let oppositeChangeIsQueued = scheduler.contains(
-      kind: .setNotifications(!enabled),
-      target: context.target
-    )
-    if characteristic.isNotifying == enabled, !oppositeChangeIsQueued {
-      return
-    }
 
     scheduler.enqueue(
       kind: requestedKind,
@@ -599,13 +623,40 @@ final class OmiBleManager: NSObject {
         }
         peripheral.setNotifyValue(enabled, for: characteristic)
       },
-      completion: { result in
-        if case .failure(let error) = result {
+      completion: { [weak self, weak peripheral] result in
+        guard let self else { return }
+        let success: Bool
+        switch result {
+        case .success:
+          success = true
+        case .failure(let error):
+          success = false
           NSLog(
             "[OmiBle] Failed to set notification state for \(characteristicUuid): "
               + error.localizedDescription
           )
         }
+
+        guard
+          let next = self.notificationTransitions[key]?.complete(
+            attempted: enabled,
+            success: success
+          ),
+          let peripheral,
+          peripheral.state == .connected,
+          self.characteristicContexts[ObjectIdentifier(characteristic)]?.sessionId
+            == context.sessionId
+        else {
+          return
+        }
+
+        self.startNotificationTransition(
+          next,
+          key: key,
+          peripheral: peripheral,
+          characteristic: characteristic,
+          context: context
+        )
       }
     )
   }
@@ -871,6 +922,9 @@ final class OmiBleManager: NSObject {
     }
     discoveredServices.removeValue(forKey: peripheralUuid)
     pendingWritesWithoutResponse.removeValue(forKey: peripheralUuid)
+    notificationTransitions = notificationTransitions.filter {
+      $0.key.peripheralUuid != peripheralUuid
+    }
     characteristicContexts = characteristicContexts.filter {
       $0.value.peripheralUuid != peripheralUuid
     }

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -69,8 +69,8 @@ final class OmiBleManager: NSObject {
   /// Connection start time per peripheral UUID.
   private var connectionStartTimes: [String: Int64] = [:]
 
-  /// Tracks peripherals that have connected at least once (for reconnection counting).
-  private var everConnected: Set<String> = []
+  /// Tracks peripherals that have connected or were restored by CoreBluetooth.
+  private let reconnectEligibility = BleReconnectEligibility()
 
   /// Most recent RSSI sample per peripheral, captured in didReadRSSI. Used to
   /// annotate disconnect events so we can tell range/interference-driven drops
@@ -215,14 +215,14 @@ final class OmiBleManager: NSObject {
   /// Re-issue `connect()` on any previously-connected peripheral that isn't
   /// currently connected and wasn't manually disconnected. Scan-discovered
   /// peripherals that never completed a connection are excluded via the
-  /// `everConnected` guard so we don't try to connect to unrelated devices
+  /// reconnect-eligibility guard so we don't try to connect to unrelated devices
   /// picked up during a scan. Safe to call whenever the app returns to the
   /// foreground — `centralManager.connect` is idempotent and pending connects
   /// cost nothing while iOS waits at the chipset level.
   func reconnectStalePeripherals() {
     guard centralManager.state == .poweredOn else { return }
     for (uuid, peripheral) in peripherals {
-      guard everConnected.contains(uuid) else { continue }
+      guard reconnectEligibility.contains(uuid) else { continue }
       if manuallyDisconnected.contains(uuid) { continue }
       if peripheral.state == .connected || peripheral.state == .connecting { continue }
       NSLog(
@@ -547,6 +547,25 @@ final class OmiBleManager: NSObject {
     }
     reconnectWorkItems[uuid] = workItem
     DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+  }
+
+  /// Reissue the system-owned connection request before iOS suspends us after
+  /// a background disconnect. CoreBluetooth keeps a pending request alive; a
+  /// delayed work item may never run once the app is suspended.
+  private func requestPersistentReconnect(for peripheral: CBPeripheral) {
+    let uuid = peripheralUuidString(peripheral)
+    guard
+      !manuallyDisconnected.contains(uuid),
+      centralManager.state == .poweredOn,
+      peripheral.state == .disconnected
+    else {
+      return
+    }
+
+    reconnectWorkItems.removeValue(forKey: uuid)?.cancel()
+    NSLog("[OmiBle] Reissuing persistent reconnect for \(uuid)")
+    peripheral.delegate = self
+    centralManager.connect(peripheral, options: nil)
   }
 
   private func activateSession(for peripheral: CBPeripheral) {
@@ -1014,6 +1033,7 @@ extension OmiBleManager: CBCentralManagerDelegate {
       var uuids: [String] = []
       for peripheral in restoredPeripherals {
         let uuid = peripheralUuidString(peripheral)
+        reconnectEligibility.recordRestored(uuid)
         peripheral.delegate = self
         peripherals[uuid] = peripheral
         uuids.append(uuid)
@@ -1059,12 +1079,12 @@ extension OmiBleManager: CBCentralManagerDelegate {
     NSLog("[OmiBle] didConnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid)")
 
     // Track reconnections (not first connect)
-    if everConnected.contains(uuid) {
+    if reconnectEligibility.contains(uuid) {
       incrementReconnectionCount(uuid: uuid)
       // Backfill the prior unexpected event with how long it took to recover.
       backfillTimeToReconnect(uuid: uuid)
     }
-    everConnected.insert(uuid)
+    reconnectEligibility.recordConnected(uuid)
     connectionStartTimes[uuid] = Int64(Date().timeIntervalSince1970 * 1000)
     cancelScheduledReconnect(uuid: uuid, resetAttempt: false)
     reconnectLifecycle(for: uuid).transportConnected()
@@ -1101,8 +1121,18 @@ extension OmiBleManager: CBCentralManagerDelegate {
       _ in
     }
 
-    if !isManual, everConnected.contains(uuid) {
-      scheduleReconnect(for: peripheral)
+    if !isManual, reconnectEligibility.contains(uuid) {
+      switch BleReconnectDispatchPolicy.action(
+        after: .failedConnect,
+        centralIsPoweredOn: central.state == .poweredOn
+      ) {
+      case .retryWithBackoff:
+        scheduleReconnect(for: peripheral)
+      case .connectNow:
+        requestPersistentReconnect(for: peripheral)
+      case .waitForPowerOn:
+        break
+      }
     }
   }
 
@@ -1140,9 +1170,21 @@ extension OmiBleManager: CBCentralManagerDelegate {
       _ in
     }
 
-    // Auto-reconnect unless manually disconnected
+    // Register a persistent CoreBluetooth connection request synchronously.
+    // Waiting even 500 ms here is long enough for iOS to suspend a background
+    // app after Bluetooth is turned off, stranding the reconnect until launch.
     if !isManual {
-      scheduleReconnect(for: peripheral)
+      switch BleReconnectDispatchPolicy.action(
+        after: .unexpectedDisconnect,
+        centralIsPoweredOn: central.state == .poweredOn
+      ) {
+      case .connectNow:
+        requestPersistentReconnect(for: peripheral)
+      case .retryWithBackoff:
+        scheduleReconnect(for: peripheral)
+      case .waitForPowerOn:
+        break
+      }
     }
   }
 }

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -7,817 +7,1298 @@ import UIKit
 ///
 /// Replaces flutter_blue_plus on iOS for better battery efficiency and background reliability.
 final class OmiBleManager: NSObject {
-    static let shared = OmiBleManager()
+  static let shared = OmiBleManager()
 
-    static let restoreIdentifier = "com.omi.ble.restore"
+  static let restoreIdentifier = "com.omi.ble.restore"
 
-    // MARK: - Properties
+  // MARK: - Properties
 
-    private var centralManager: CBCentralManager!
-    private(set) var flutterApi: BleFlutterApi?
+  private var centralManager: CBCentralManager!
+  private(set) var flutterApi: BleFlutterApi?
 
-    /// Connected/connecting peripherals keyed by UUID string.
-    private var peripherals: [String: CBPeripheral] = [:]
+  /// Connected/connecting peripherals keyed by UUID string.
+  private var peripherals: [String: CBPeripheral] = [:]
 
-    /// Discovered services per peripheral, keyed by peripheral UUID.
-    private var discoveredServices: [String: [CBService]] = [:]
+  /// Discovered services per peripheral, keyed by peripheral UUID.
+  private var discoveredServices: [String: [CBService]] = [:]
 
-    /// Pending read completions keyed by "peripheralUuid:serviceUuid:charUuid".
-    private var readCompletions: [String: (Result<FlutterStandardTypedData, Error>) -> Void] = [:]
+  /// One serialized CoreBluetooth operation queue per peripheral.
+  private var operationSchedulers: [String: BleGattOperationScheduler] = [:]
 
-    /// Pending write completions keyed by "peripheralUuid:serviceUuid:charUuid".
-    private var writeCompletions: [String: (Result<Void, Error>) -> Void] = [:]
+  private struct CharacteristicContext {
+    let peripheralUuid: String
+    let sessionId: UInt64
+    let target: BleGattTarget
+  }
 
-    /// Whether the user explicitly disconnected (suppress auto-reconnect).
-    private var manuallyDisconnected: Set<String> = []
+  /// Binds delegate callbacks to the exact characteristic object and connection session.
+  private var characteristicContexts: [ObjectIdentifier: CharacteristicContext] = [:]
+  private var nextCharacteristicInstanceId: UInt64 = 0
 
-    /// RSSI keep-alive timer — periodic reads prevent connection supervision timeout.
-    private var rssiTimer: Timer?
+  private struct PendingWriteWithoutResponse {
+    let token: BleGattOperationToken
+    let characteristic: CBCharacteristic
+    let data: Data
+  }
 
-    /// When true, RSSI reads are forwarded to Flutter for the diagnostics graph.
-    var isRssiStreamingEnabled = false
+  private var pendingWritesWithoutResponse: [String: PendingWriteWithoutResponse] = [:]
 
-    /// Connection start time per peripheral UUID.
-    private var connectionStartTimes: [String: Int64] = [:]
+  /// Whether the user explicitly disconnected (suppress auto-reconnect).
+  private var manuallyDisconnected: Set<String> = []
 
-    /// Tracks peripherals that have connected at least once (for reconnection counting).
-    private var everConnected: Set<String> = []
+  /// Bounded reconnect state prevents fixed-delay retry storms during RF outages.
+  private var reconnectLifecycles: [String: BleReconnectLifecycle] = [:]
+  private var reconnectWorkItems: [String: DispatchWorkItem] = [:]
 
-    /// Most recent RSSI sample per peripheral, captured in didReadRSSI. Used to
-    /// annotate disconnect events so we can tell range/interference-driven drops
-    /// apart from disconnects with healthy signal.
-    private var lastRssi: [String: Int64] = [:]
+  /// RSSI diagnostics timer. Connection supervision is owned by the controller;
+  /// polling RSSI is not a keep-alive and stays off outside the diagnostics view.
+  private var rssiTimer: Timer?
+  private var rssiPeripheralUuid: String?
 
-    /// Sliding window of recent (timestamp_ms, rssi) samples per peripheral, used
-    /// to classify the trajectory before a disconnect (fading vs. sudden vs. gap).
-    /// Capped at rssiHistoryLimit — beyond that we drop the oldest.
-    private var rssiHistory: [String: [(ts: Int64, rssi: Int64)]] = [:]
+  /// When true, RSSI reads are forwarded to Flutter for the diagnostics graph.
+  private var isRssiStreamingEnabled = false
 
-    /// Timestamp of the most recently persisted unexpected disconnect per peripheral.
-    /// On the next successful didConnect we backfill `timeToReconnectMs` on that event.
-    private var pendingReconnectForEvent: [String: Int64] = [:]
+  /// Connection start time per peripheral UUID.
+  private var connectionStartTimes: [String: Int64] = [:]
 
-    /// Scanning state.
-    private var isScanning = false
-    private var scanTimer: Timer?
-    /// Queued scan request if Bluetooth wasn't ready when startScan was called.
-    private var pendingScan: (timeout: Int, serviceUuids: [String])?
+  /// Tracks peripherals that have connected at least once (for reconnection counting).
+  private var everConnected: Set<String> = []
 
-    // MARK: - Initialization
+  /// Most recent RSSI sample per peripheral, captured in didReadRSSI. Used to
+  /// annotate disconnect events so we can tell range/interference-driven drops
+  /// apart from disconnects with healthy signal.
+  private var lastRssi: [String: Int64] = [:]
 
-    private override init() {
-        super.init()
-        NSLog("[OmiBle] Initializing OmiBleManager with restore ID: \(OmiBleManager.restoreIdentifier)")
-        centralManager = CBCentralManager(
-            delegate: self,
-            queue: nil,
-            options: [
-                CBCentralManagerOptionRestoreIdentifierKey: OmiBleManager.restoreIdentifier,
-                CBCentralManagerOptionShowPowerAlertKey: true,
-            ]
-        )
-        NSLog("[OmiBle] CBCentralManager created")
+  /// Sliding window of recent (timestamp_ms, rssi) samples per peripheral, used
+  /// to classify the trajectory before a disconnect (fading vs. sudden vs. gap).
+  /// Capped at rssiHistoryLimit — beyond that we drop the oldest.
+  private var rssiHistory: [String: [(ts: Int64, rssi: Int64)]] = [:]
+
+  /// Timestamp of the most recently persisted unexpected disconnect per peripheral.
+  /// On the next successful didConnect we backfill `timeToReconnectMs` on that event.
+  private var pendingReconnectForEvent: [String: Int64] = [:]
+
+  /// Scanning state.
+  private var isScanning = false
+  private var scanTimer: Timer?
+  /// Queued scan request if Bluetooth wasn't ready when startScan was called.
+  private var pendingScan: (timeout: Int, serviceUuids: [String])?
+
+  // MARK: - Initialization
+
+  private override init() {
+    super.init()
+    NSLog("[OmiBle] Initializing OmiBleManager with restore ID: \(OmiBleManager.restoreIdentifier)")
+    centralManager = CBCentralManager(
+      delegate: self,
+      queue: nil,
+      options: [
+        CBCentralManagerOptionRestoreIdentifierKey: OmiBleManager.restoreIdentifier,
+        CBCentralManagerOptionShowPowerAlertKey: true,
+      ]
+    )
+    NSLog("[OmiBle] CBCentralManager created")
+  }
+
+  func setFlutterApi(_ api: BleFlutterApi) {
+    flutterApi = api
+  }
+
+  // MARK: - Scanning
+
+  func startScan(timeout: Int, serviceUuids: [String]) {
+    NSLog(
+      "[OmiBle] startScan called, state=\(getBluetoothState()), timeout=\(timeout), serviceUuids=\(serviceUuids)"
+    )
+
+    // Queue the scan if Bluetooth isn't ready yet — it will fire once poweredOn
+    guard centralManager.state == .poweredOn else {
+      NSLog("[OmiBle] BT not ready, queuing scan")
+      pendingScan = (timeout: timeout, serviceUuids: serviceUuids)
+      return
     }
 
-    func setFlutterApi(_ api: BleFlutterApi) {
-        flutterApi = api
+    pendingScan = nil
+    let cbuuids: [CBUUID]? = serviceUuids.isEmpty ? nil : serviceUuids.map { CBUUID(string: $0) }
+    isScanning = true
+    NSLog("[OmiBle] Starting BLE scan with services=\(String(describing: cbuuids))")
+    centralManager.scanForPeripherals(
+      withServices: cbuuids,
+      options: [
+        CBCentralManagerScanOptionAllowDuplicatesKey: false
+      ])
+
+    scanTimer?.invalidate()
+    if timeout > 0 {
+      scanTimer = Timer.scheduledTimer(withTimeInterval: TimeInterval(timeout), repeats: false) {
+        [weak self] _ in
+        self?.stopScan()
+      }
+    }
+  }
+
+  func stopScan() {
+    guard isScanning else { return }
+    isScanning = false
+    scanTimer?.invalidate()
+    scanTimer = nil
+    centralManager.stopScan()
+  }
+
+  // MARK: - Connection
+
+  func connectPeripheral(uuid: String) {
+    manuallyDisconnected.remove(uuid)
+    cancelScheduledReconnect(uuid: uuid, resetAttempt: true)
+
+    if let peripheral = peripherals[uuid] {
+      if peripheral.state == .connected {
+        NSLog("[OmiBle] connectPeripheral: \(uuid) already connected, skipping")
+        return
+      }
+      centralManager.connect(peripheral, options: nil)
+      return
     }
 
-    // MARK: - Scanning
+    // Try to retrieve a known peripheral
+    guard let cbUuid = UUID(uuidString: uuid) else { return }
+    let retrieved = centralManager.retrievePeripherals(withIdentifiers: [cbUuid])
+    if let peripheral = retrieved.first {
+      peripheral.delegate = self
+      peripherals[uuid] = peripheral
+      centralManager.connect(peripheral, options: nil)
+    }
+  }
 
-    func startScan(timeout: Int, serviceUuids: [String]) {
-        NSLog("[OmiBle] startScan called, state=\(getBluetoothState()), timeout=\(timeout), serviceUuids=\(serviceUuids)")
+  func disconnectPeripheral(uuid: String) {
+    manuallyDisconnected.insert(uuid)
+    cancelScheduledReconnect(uuid: uuid, resetAttempt: true)
+    persistDisconnectEvent(
+      uuid: uuid, reason: "manual", reasonCode: 0, isManual: true, eventType: "disconnect")
+    guard let peripheral = peripherals[uuid] else { return }
+    centralManager.cancelPeripheralConnection(peripheral)
+  }
 
-        // Queue the scan if Bluetooth isn't ready yet — it will fire once poweredOn
-        guard centralManager.state == .poweredOn else {
-            NSLog("[OmiBle] BT not ready, queuing scan")
-            pendingScan = (timeout: timeout, serviceUuids: serviceUuids)
-            return
+  func disconnectAllPeripherals() {
+    for (uuid, peripheral) in peripherals {
+      manuallyDisconnected.insert(uuid)
+      cancelScheduledReconnect(uuid: uuid, resetAttempt: true)
+      centralManager.cancelPeripheralConnection(peripheral)
+    }
+  }
+
+  func isPeripheralConnected(uuid: String) -> Bool {
+    return peripherals[uuid]?.state == .connected
+  }
+
+  /// Re-issue `connect()` on any previously-connected peripheral that isn't
+  /// currently connected and wasn't manually disconnected. Scan-discovered
+  /// peripherals that never completed a connection are excluded via the
+  /// `everConnected` guard so we don't try to connect to unrelated devices
+  /// picked up during a scan. Safe to call whenever the app returns to the
+  /// foreground — `centralManager.connect` is idempotent and pending connects
+  /// cost nothing while iOS waits at the chipset level.
+  func reconnectStalePeripherals() {
+    guard centralManager.state == .poweredOn else { return }
+    for (uuid, peripheral) in peripherals {
+      guard everConnected.contains(uuid) else { continue }
+      if manuallyDisconnected.contains(uuid) { continue }
+      if peripheral.state == .connected || peripheral.state == .connecting { continue }
+      NSLog(
+        "[OmiBle] Re-issuing connect on foreground for \(uuid), state=\(peripheral.state.rawValue)")
+      cancelScheduledReconnect(uuid: uuid, resetAttempt: false)
+      peripheral.delegate = self
+      centralManager.connect(peripheral, options: nil)
+    }
+  }
+
+  // MARK: - Characteristic Operations
+
+  func readCharacteristic(
+    peripheralUuid: String,
+    serviceUuid: String,
+    characteristicUuid: String,
+    completion: @escaping (Result<FlutterStandardTypedData, Error>) -> Void
+  ) {
+    guard
+      let characteristic = findCharacteristic(
+        peripheralUuid: peripheralUuid, serviceUuid: serviceUuid,
+        characteristicUuid: characteristicUuid)
+    else {
+      completion(
+        .failure(PigeonError(code: "NOT_FOUND", message: "Characteristic not found", details: nil)))
+      return
+    }
+
+    guard let peripheral = peripherals[peripheralUuid], peripheral.state == .connected,
+      let context = characteristicContexts[ObjectIdentifier(characteristic)]
+    else {
+      completion(
+        .failure(
+          PigeonError(code: "DISCONNECTED", message: "Peripheral disconnected", details: nil)))
+      return
+    }
+
+    // CoreBluetooth uses the same delegate callback for reads and notifications
+    // and provides no request identifier. Reading an actively-notifying
+    // characteristic would make the response fundamentally ambiguous.
+    guard BleGattReadAdmission.evaluate(isNotifying: characteristic.isNotifying) == .start else {
+      completion(.failure(readWhileNotifyingError()))
+      return
+    }
+
+    let scheduler = operationScheduler(for: peripheralUuid)
+    scheduler.enqueue(
+      kind: .readValue,
+      target: context.target,
+      start: { [weak self, weak peripheral] token in
+        guard let self, let peripheral, peripheral.state == .connected else {
+          self?.operationSchedulers[peripheralUuid]?.complete(
+            token: token,
+            result: .failure(BleGattOperationSchedulerError.disconnected)
+          )
+          return
         }
-
-        pendingScan = nil
-        let cbuuids: [CBUUID]? = serviceUuids.isEmpty ? nil : serviceUuids.map { CBUUID(string: $0) }
-        isScanning = true
-        NSLog("[OmiBle] Starting BLE scan with services=\(String(describing: cbuuids))")
-        centralManager.scanForPeripherals(withServices: cbuuids, options: [
-            CBCentralManagerScanOptionAllowDuplicatesKey: false,
-        ])
-
-        scanTimer?.invalidate()
-        if timeout > 0 {
-            scanTimer = Timer.scheduledTimer(withTimeInterval: TimeInterval(timeout), repeats: false) { [weak self] _ in
-                self?.stopScan()
-            }
+        guard BleGattReadAdmission.evaluate(isNotifying: characteristic.isNotifying) == .start
+        else {
+          scheduler.complete(token: token, result: .failure(self.readWhileNotifyingError()))
+          return
         }
-    }
-
-    func stopScan() {
-        guard isScanning else { return }
-        isScanning = false
-        scanTimer?.invalidate()
-        scanTimer = nil
-        centralManager.stopScan()
-    }
-
-    // MARK: - Connection
-
-    func connectPeripheral(uuid: String) {
-        manuallyDisconnected.remove(uuid)
-
-        if let peripheral = peripherals[uuid] {
-            if peripheral.state == .connected {
-                NSLog("[OmiBle] connectPeripheral: \(uuid) already connected, skipping")
-                return
-            }
-            centralManager.connect(peripheral, options: nil)
-            return
+        peripheral.readValue(for: characteristic)
+      },
+      completion: { result in
+        switch result {
+        case .success(let data):
+          completion(.success(FlutterStandardTypedData(bytes: data ?? Data())))
+        case .failure(let error):
+          completion(.failure(error))
         }
+      }
+    )
+  }
 
-        // Try to retrieve a known peripheral
-        guard let cbUuid = UUID(uuidString: uuid) else { return }
-        let retrieved = centralManager.retrievePeripherals(withIdentifiers: [cbUuid])
-        if let peripheral = retrieved.first {
-            peripheral.delegate = self
-            peripherals[uuid] = peripheral
-            centralManager.connect(peripheral, options: nil)
+  func writeCharacteristic(
+    peripheralUuid: String,
+    serviceUuid: String,
+    characteristicUuid: String,
+    data: FlutterStandardTypedData,
+    completion: @escaping (Result<Void, Error>) -> Void
+  ) {
+    guard
+      let characteristic = findCharacteristic(
+        peripheralUuid: peripheralUuid, serviceUuid: serviceUuid,
+        characteristicUuid: characteristicUuid)
+    else {
+      completion(
+        .failure(PigeonError(code: "NOT_FOUND", message: "Characteristic not found", details: nil)))
+      return
+    }
+
+    guard let peripheral = peripherals[peripheralUuid], peripheral.state == .connected,
+      let context = characteristicContexts[ObjectIdentifier(characteristic)]
+    else {
+      completion(
+        .failure(
+          PigeonError(code: "DISCONNECTED", message: "Peripheral disconnected", details: nil)))
+      return
+    }
+
+    let writeType: CBCharacteristicWriteType =
+      characteristic.properties.contains(.write) ? .withResponse : .withoutResponse
+    let scheduler = operationScheduler(for: peripheralUuid)
+    let kind: BleGattOperationKind =
+      writeType == .withResponse ? .writeWithResponse : .writeWithoutResponse
+
+    scheduler.enqueue(
+      kind: kind,
+      target: context.target,
+      start: { [weak self, weak peripheral] token in
+        guard let self, let peripheral, peripheral.state == .connected else {
+          self?.operationSchedulers[peripheralUuid]?.complete(
+            token: token,
+            result: .failure(BleGattOperationSchedulerError.disconnected)
+          )
+          return
         }
-    }
-
-    func disconnectPeripheral(uuid: String) {
-        manuallyDisconnected.insert(uuid)
-        persistDisconnectEvent(uuid: uuid, reason: "manual", reasonCode: 0, isManual: true, eventType: "disconnect")
-        guard let peripheral = peripherals[uuid] else { return }
-        centralManager.cancelPeripheralConnection(peripheral)
-    }
-
-    func disconnectAllPeripherals() {
-        for (uuid, peripheral) in peripherals {
-            manuallyDisconnected.insert(uuid)
-            centralManager.cancelPeripheralConnection(peripheral)
-        }
-    }
-
-    func isPeripheralConnected(uuid: String) -> Bool {
-        return peripherals[uuid]?.state == .connected
-    }
-
-    /// Re-issue `connect()` on any previously-connected peripheral that isn't
-    /// currently connected and wasn't manually disconnected. Scan-discovered
-    /// peripherals that never completed a connection are excluded via the
-    /// `everConnected` guard so we don't try to connect to unrelated devices
-    /// picked up during a scan. Safe to call whenever the app returns to the
-    /// foreground — `centralManager.connect` is idempotent and pending connects
-    /// cost nothing while iOS waits at the chipset level.
-    func reconnectStalePeripherals() {
-        guard centralManager.state == .poweredOn else { return }
-        for (uuid, peripheral) in peripherals {
-            guard everConnected.contains(uuid) else { continue }
-            if manuallyDisconnected.contains(uuid) { continue }
-            // Only skip if already connected. For peripherals in .connecting state,
-            // re-issue connect() to kick CoreBluetooth — the pending attempt may be
-            // silently waiting in congested RF. connect() is idempotent on iOS.
-            if peripheral.state == .connected { continue }
-            NSLog("[OmiBle] Re-issuing connect on foreground for \(uuid), state=\(peripheral.state.rawValue)")
-            peripheral.delegate = self
-            centralManager.connect(peripheral, options: nil)
-        }
-    }
-
-    // MARK: - Characteristic Operations
-
-    func readCharacteristic(
-        peripheralUuid: String,
-        serviceUuid: String,
-        characteristicUuid: String,
-        completion: @escaping (Result<FlutterStandardTypedData, Error>) -> Void
-    ) {
-        guard let characteristic = findCharacteristic(peripheralUuid: peripheralUuid, serviceUuid: serviceUuid, characteristicUuid: characteristicUuid) else {
-            completion(.failure(PigeonError(code: "NOT_FOUND", message: "Characteristic not found", details: nil)))
-            return
-        }
-
-        let key = "\(peripheralUuid):\(serviceUuid):\(characteristicUuid)".lowercased()
-        readCompletions[key] = completion
-
-        peripherals[peripheralUuid]?.readValue(for: characteristic)
-    }
-
-    func writeCharacteristic(
-        peripheralUuid: String,
-        serviceUuid: String,
-        characteristicUuid: String,
-        data: FlutterStandardTypedData,
-        completion: @escaping (Result<Void, Error>) -> Void
-    ) {
-        guard let characteristic = findCharacteristic(peripheralUuid: peripheralUuid, serviceUuid: serviceUuid, characteristicUuid: characteristicUuid) else {
-            completion(.failure(PigeonError(code: "NOT_FOUND", message: "Characteristic not found", details: nil)))
-            return
-        }
-
-        let key = "\(peripheralUuid):\(serviceUuid):\(characteristicUuid)".lowercased()
-        let writeType: CBCharacteristicWriteType = characteristic.properties.contains(.write) ? .withResponse : .withoutResponse
 
         if writeType == .withResponse {
-            writeCompletions[key] = completion
+          peripheral.writeValue(data.data, for: characteristic, type: .withResponse)
+          return
         }
 
-        peripherals[peripheralUuid]?.writeValue(data.data, for: characteristic, type: writeType)
-
-        if writeType == .withoutResponse {
-            completion(.success(()))
-        }
-    }
-
-    func subscribeCharacteristic(peripheralUuid: String, serviceUuid: String, characteristicUuid: String) {
-        guard let characteristic = findCharacteristic(peripheralUuid: peripheralUuid, serviceUuid: serviceUuid, characteristicUuid: characteristicUuid) else { return }
-        peripherals[peripheralUuid]?.setNotifyValue(true, for: characteristic)
-    }
-
-    func unsubscribeCharacteristic(peripheralUuid: String, serviceUuid: String, characteristicUuid: String) {
-        guard let characteristic = findCharacteristic(peripheralUuid: peripheralUuid, serviceUuid: serviceUuid, characteristicUuid: characteristicUuid) else { return }
-        peripherals[peripheralUuid]?.setNotifyValue(false, for: characteristic)
-    }
-
-    // MARK: - Bluetooth State
-
-    func getBluetoothState() -> String {
-        switch centralManager.state {
-        case .poweredOn: return "on"
-        case .poweredOff: return "off"
-        case .unauthorized: return "unauthorized"
-        case .unsupported: return "unsupported"
-        case .resetting: return "resetting"
-        case .unknown: return "unknown"
-        @unknown default: return "unknown"
-        }
-    }
-
-    // MARK: - RSSI Keep-Alive
-
-    private func startRssiKeepAlive(for peripheral: CBPeripheral) {
-        stopRssiKeepAlive()
-        rssiTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { [weak self, weak peripheral] _ in
-            guard let peripheral = peripheral, peripheral.state == .connected else {
-                self?.stopRssiKeepAlive()
-                return
-            }
-            peripheral.readRSSI()
-        }
-    }
-
-    private func stopRssiKeepAlive() {
-        rssiTimer?.invalidate()
-        rssiTimer = nil
-    }
-
-    // MARK: - Private Helpers
-
-    private func findCharacteristic(peripheralUuid: String, serviceUuid: String, characteristicUuid: String) -> CBCharacteristic? {
-        guard let services = discoveredServices[peripheralUuid] else { return nil }
-        let sUuid = CBUUID(string: serviceUuid)
-        let cUuid = CBUUID(string: characteristicUuid)
-
-        guard let service = services.first(where: { $0.uuid == sUuid }) else { return nil }
-        return service.characteristics?.first(where: { $0.uuid == cUuid })
-    }
-
-    private func peripheralUuidString(_ peripheral: CBPeripheral) -> String {
-        return peripheral.identifier.uuidString
-    }
-
-    /// Normalize a CBUUID to its full 128-bit string representation.
-    /// CoreBluetooth returns "180A" for standard 16-bit UUIDs but Dart sends
-    /// "0000180a-0000-1000-8000-00805f9b34fb". This ensures consistent keys.
-    private func fullUuidString(_ uuid: CBUUID) -> String {
-        if uuid.data.count == 2 {
-            // 16-bit UUID → expand to 128-bit Bluetooth Base UUID
-            let short = uuid.uuidString // e.g. "180A"
-            return "0000\(short)-0000-1000-8000-00805F9B34FB".lowercased()
-        } else if uuid.data.count == 4 {
-            // 32-bit UUID → expand
-            let short = uuid.uuidString
-            return "\(short)-0000-1000-8000-00805F9B34FB".lowercased()
-        }
-        return uuid.uuidString.lowercased()
-    }
-
-    // MARK: - Diagnostics Persistence
-
-    private static let batteryHistoryKeyPrefix = "battery_history_"
-    private static let maxBatteryHistoryEntries = 2000
-    private static let batteryHistoryRetentionMs: Int64 = 7 * 24 * 3600 * 1000
-
-    private static let batteryLevelCharUuid = CBUUID(string: "2A19")
-
-    private static let diagnosticsKeyPrefix = "ble_diagnostics_disconnect_history_"
-    private static let reconnectCountKeyPrefix = "ble_diagnostics_reconnect_count_"
-    private static let failToConnectCountKeyPrefix = "ble_diagnostics_fail_to_connect_count_"
-    private static let maxDisconnectHistory = 20
-    private static let rssiHistoryLimit = 10
-    private static let rssiTrendWindowMs: Int64 = 15_000
-    private static let rssiTrendFadingDropDb: Int64 = 10
-
-    /// Classify the RSSI trajectory in the window before `nowMs`. See `rssiTrend`
-    /// on BleDisconnectEvent for the semantics of each label.
-    private static func classifyRssiTrend(samples: [(ts: Int64, rssi: Int64)], nowMs: Int64) -> String {
-        let windowStart = nowMs - rssiTrendWindowMs
-        let recent = samples.filter { $0.ts >= windowStart }
-        // No recent samples — keep-alive wasn't running, so we can't say.
-        if recent.isEmpty { return "gap" }
-        if recent.count < 3 { return "unknown" }
-        // Compare the average of the oldest third to the newest third. A drop of
-        // ≥rssiTrendFadingDropDb dB indicates a fading signal (walk-away).
-        let third = max(1, recent.count / 3)
-        let oldestAvg = recent.prefix(third).map { $0.rssi }.reduce(0, +) / Int64(third)
-        let newestAvg = recent.suffix(third).map { $0.rssi }.reduce(0, +) / Int64(third)
-        let dropDb = oldestAvg - newestAvg // RSSI is negative; larger drop = more negative newer value
-        if dropDb >= rssiTrendFadingDropDb { return "fading" }
-        return "sudden"
-    }
-
-    private static func historyKey(_ uuid: String) -> String { "\(diagnosticsKeyPrefix)\(uuid)" }
-    private static func reconnectKey(_ uuid: String) -> String { "\(reconnectCountKeyPrefix)\(uuid)" }
-    private static func failToConnectKey(_ uuid: String) -> String { "\(failToConnectCountKeyPrefix)\(uuid)" }
-
-    /// Sample the UIApplication state from whatever thread we're on. The BLE
-    /// callbacks run on the main queue already (centralManager was created with
-    /// queue: nil) so this is safe, but we guard anyway for restoration paths.
-    private func currentAppState() -> String {
-        let state: UIApplication.State
-        if Thread.isMainThread {
-            state = UIApplication.shared.applicationState
+        if peripheral.canSendWriteWithoutResponse {
+          peripheral.writeValue(data.data, for: characteristic, type: .withoutResponse)
+          scheduler.complete(token: token, result: .success(nil))
         } else {
-            state = DispatchQueue.main.sync { UIApplication.shared.applicationState }
+          self.pendingWritesWithoutResponse[peripheralUuid] = PendingWriteWithoutResponse(
+            token: token,
+            characteristic: characteristic,
+            data: data.data
+          )
         }
-        switch state {
-        case .active: return "foreground"
-        case .inactive: return "inactive"
-        case .background: return "background"
-        @unknown default: return ""
+      },
+      completion: { result in
+        switch result {
+        case .success:
+          completion(.success(()))
+        case .failure(let error):
+          completion(.failure(error))
         }
+      }
+    )
+  }
+
+  func subscribeCharacteristic(
+    peripheralUuid: String, serviceUuid: String, characteristicUuid: String
+  ) {
+    setNotificationState(
+      true,
+      peripheralUuid: peripheralUuid,
+      serviceUuid: serviceUuid,
+      characteristicUuid: characteristicUuid
+    )
+  }
+
+  func unsubscribeCharacteristic(
+    peripheralUuid: String, serviceUuid: String, characteristicUuid: String
+  ) {
+    setNotificationState(
+      false,
+      peripheralUuid: peripheralUuid,
+      serviceUuid: serviceUuid,
+      characteristicUuid: characteristicUuid
+    )
+  }
+
+  // MARK: - Bluetooth State
+
+  func getBluetoothState() -> String {
+    switch centralManager.state {
+    case .poweredOn: return "on"
+    case .poweredOff: return "off"
+    case .unauthorized: return "unauthorized"
+    case .unsupported: return "unsupported"
+    case .resetting: return "resetting"
+    case .unknown: return "unknown"
+    @unknown default: return "unknown"
+    }
+  }
+
+  // MARK: - RSSI Diagnostics
+
+  func startRssiStreaming(uuid: String) {
+    isRssiStreamingEnabled = true
+    rssiPeripheralUuid = uuid
+    guard let peripheral = peripherals[uuid], peripheral.state == .connected else { return }
+    startRssiDiagnostics(for: peripheral)
+  }
+
+  func stopRssiStreaming(uuid: String) {
+    guard rssiPeripheralUuid == nil || rssiPeripheralUuid == uuid else { return }
+    isRssiStreamingEnabled = false
+    rssiPeripheralUuid = nil
+    stopRssiDiagnostics()
+  }
+
+  private func startRssiDiagnostics(for peripheral: CBPeripheral) {
+    guard isRssiStreamingEnabled, rssiPeripheralUuid == peripheralUuidString(peripheral) else {
+      return
+    }
+    stopRssiDiagnostics(clearSelection: false)
+    enqueueRssiRead(for: peripheral)
+    rssiTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) {
+      [weak self, weak peripheral] _ in
+      guard let self, let peripheral, peripheral.state == .connected else {
+        self?.stopRssiDiagnostics(clearSelection: false)
+        return
+      }
+      self.enqueueRssiRead(for: peripheral)
+    }
+  }
+
+  private func enqueueRssiRead(for peripheral: CBPeripheral) {
+    let uuid = peripheralUuidString(peripheral)
+    guard let sessionId = operationSchedulers[uuid]?.sessionId else { return }
+    let scheduler = operationScheduler(for: uuid)
+    guard !scheduler.contains(kind: .readRssi, target: .rssi) else { return }
+
+    scheduler.enqueue(
+      kind: .readRssi,
+      target: .rssi,
+      fatalOnTimeout: false,
+      start: { [weak self, weak peripheral] token in
+        guard let self, let peripheral, peripheral.state == .connected,
+          self.operationSchedulers[uuid]?.sessionId == sessionId
+        else {
+          self?.operationSchedulers[uuid]?.complete(
+            token: token,
+            result: .failure(BleGattOperationSchedulerError.disconnected)
+          )
+          return
+        }
+        peripheral.readRSSI()
+      },
+      completion: { result in
+        if case .failure(let error) = result {
+          NSLog("[OmiBle] RSSI read failed for \(uuid): \(error.localizedDescription)")
+        }
+      }
+    )
+  }
+
+  private func stopRssiDiagnostics(clearSelection: Bool = true) {
+    rssiTimer?.invalidate()
+    rssiTimer = nil
+    if clearSelection {
+      rssiPeripheralUuid = nil
+    }
+  }
+
+  // MARK: - Private Helpers
+
+  private func readWhileNotifyingError() -> PigeonError {
+    PigeonError(
+      code: "READ_WHILE_NOTIFYING",
+      message: "Cannot safely read an actively notifying characteristic",
+      details: nil
+    )
+  }
+
+  private func operationScheduler(for peripheralUuid: String) -> BleGattOperationScheduler {
+    if let scheduler = operationSchedulers[peripheralUuid] {
+      return scheduler
     }
 
-    private static func bleReasonString(from error: Error?) -> String {
-        guard let cbError = error as? CBError else { return "clean_disconnect" }
-        switch cbError.code {
-        case .connectionTimeout: return "connection_timeout"
-        case .peripheralDisconnected: return "remote_device_terminated"
-        case .connectionFailed: return "connection_failed_instant_passed"
-        default: return "gatt_error_\(cbError.code.rawValue)"
-        }
-    }
-
-    /// Append a disconnect/fail event to the per-device history ring buffer.
-    /// `eventType` is "disconnect" for an established link lost, or "fail_to_connect"
-    /// for a connect attempt that never reached didConnect.
-    private func persistDisconnectEvent(
-        uuid: String,
-        reason: String?,
-        reasonCode: Int,
-        isManual: Bool,
-        eventType: String
-    ) {
-        let defaults = UserDefaults.standard
-        let key = OmiBleManager.historyKey(uuid)
-        var history = defaults.array(forKey: key) as? [[String: Any]] ?? []
-
-        let now = Int64(Date().timeIntervalSince1970 * 1000)
-        let startedAt = connectionStartTimes[uuid] ?? 0
-        let durationMs: Int64 = (eventType == "disconnect" && startedAt > 0) ? (now - startedAt) : 0
-
-        let trend = OmiBleManager.classifyRssiTrend(samples: rssiHistory[uuid] ?? [], nowMs: now)
-        let event: [String: Any] = [
-            "timestamp": now,
-            "reason": isManual ? "manual" : (reason ?? "unknown"),
-            "reasonCode": reasonCode,
-            "isManual": isManual,
-            "eventType": eventType,
-            "lastRssi": lastRssi[uuid] ?? 0,
-            "connectionDurationMs": durationMs,
-            "appState": currentAppState(),
-            "timeToReconnectMs": 0,
-            "rssiTrend": trend,
-        ]
-        history.append(event)
-
-        if history.count > OmiBleManager.maxDisconnectHistory {
-            history = Array(history.suffix(OmiBleManager.maxDisconnectHistory))
-        }
-
-        defaults.set(history, forKey: key)
-
-        // Remember this event's timestamp so the next successful didConnect can
-        // backfill timeToReconnectMs. Only track unexpected (non-manual) events.
-        if !isManual {
-            pendingReconnectForEvent[uuid] = now
-        }
-    }
-
-    /// On successful didConnect, find the most recent unexpected event for this
-    /// peripheral and write the reconnect-latency value into it.
-    private func backfillTimeToReconnect(uuid: String) {
-        guard let markerTs = pendingReconnectForEvent.removeValue(forKey: uuid) else { return }
-        let defaults = UserDefaults.standard
-        let key = OmiBleManager.historyKey(uuid)
-        guard var history = defaults.array(forKey: key) as? [[String: Any]] else { return }
-
-        // Walk backwards for the matching timestamp. History is small (≤20).
-        let now = Int64(Date().timeIntervalSince1970 * 1000)
-        for i in stride(from: history.count - 1, through: 0, by: -1) {
-            if let ts = history[i]["timestamp"] as? Int64, ts == markerTs {
-                var event = history[i]
-                event["timeToReconnectMs"] = max(Int64(0), now - markerTs)
-                history[i] = event
-                defaults.set(history, forKey: key)
-                return
-            }
-        }
-    }
-
-    private func incrementReconnectionCount(uuid: String) {
-        let defaults = UserDefaults.standard
-        let key = OmiBleManager.reconnectKey(uuid)
-        let count = defaults.integer(forKey: key)
-        defaults.set(count + 1, forKey: key)
-    }
-
-    private func incrementFailToConnectCount(uuid: String) {
-        let defaults = UserDefaults.standard
-        let key = OmiBleManager.failToConnectKey(uuid)
-        let count = defaults.integer(forKey: key)
-        defaults.set(count + 1, forKey: key)
-    }
-
-    func getDeviceDiagnostics(uuid: String) -> BleDeviceDiagnostics {
-        let defaults = UserDefaults.standard
-        let history = defaults.array(forKey: OmiBleManager.historyKey(uuid)) as? [[String: Any]] ?? []
-        let reconnectCount = defaults.integer(forKey: OmiBleManager.reconnectKey(uuid))
-        let failToConnectCount = defaults.integer(forKey: OmiBleManager.failToConnectKey(uuid))
-
-        let events = history.map { obj -> BleDisconnectEvent in
-            BleDisconnectEvent(
-                timestamp: obj["timestamp"] as? Int64 ?? 0,
-                reason: obj["reason"] as? String ?? "unknown",
-                reasonCode: Int64(obj["reasonCode"] as? Int ?? -1),
-                isManual: obj["isManual"] as? Bool ?? false,
-                eventType: obj["eventType"] as? String ?? "disconnect",
-                lastRssi: obj["lastRssi"] as? Int64 ?? 0,
-                connectionDurationMs: obj["connectionDurationMs"] as? Int64 ?? 0,
-                appState: obj["appState"] as? String ?? "",
-                timeToReconnectMs: obj["timeToReconnectMs"] as? Int64 ?? 0,
-                rssiTrend: obj["rssiTrend"] as? String ?? ""
-            )
-        }
-
-        let connectedAt = connectionStartTimes[uuid] ?? 0
-
-        return BleDeviceDiagnostics(
-            disconnectHistory: events,
-            reconnectionCount: Int64(reconnectCount),
-            connectedAt: connectedAt,
-            failToConnectCount: Int64(failToConnectCount)
+    let scheduler = BleGattOperationScheduler(
+      onFatalTimeout: { [weak self] token in
+        guard let self else { return }
+        NSLog(
+          "[OmiBle] GATT operation timed out for \(peripheralUuid), "
+            + "session=\(token.sessionId), operation=\(token.id)"
         )
+        self.pendingWritesWithoutResponse.removeValue(forKey: peripheralUuid)
+        if let peripheral = self.peripherals[peripheralUuid], peripheral.state != .disconnected {
+          self.centralManager.cancelPeripheralConnection(peripheral)
+        }
+      }
+    )
+    operationSchedulers[peripheralUuid] = scheduler
+    return scheduler
+  }
+
+  private func cancelScheduledReconnect(uuid: String, resetAttempt: Bool) {
+    reconnectWorkItems.removeValue(forKey: uuid)?.cancel()
+    if resetAttempt {
+      reconnectLifecycles.removeValue(forKey: uuid)
+    }
+  }
+
+  private func reconnectLifecycle(for uuid: String) -> BleReconnectLifecycle {
+    if let lifecycle = reconnectLifecycles[uuid] {
+      return lifecycle
+    }
+    let lifecycle = BleReconnectLifecycle()
+    reconnectLifecycles[uuid] = lifecycle
+    return lifecycle
+  }
+
+  private func scheduleReconnect(for peripheral: CBPeripheral) {
+    let uuid = peripheralUuidString(peripheral)
+    guard !manuallyDisconnected.contains(uuid), centralManager.state == .poweredOn else { return }
+
+    reconnectWorkItems.removeValue(forKey: uuid)?.cancel()
+    let lifecycle = reconnectLifecycle(for: uuid)
+    let attempt = lifecycle.failureCount + 1
+    let delay = lifecycle.nextReconnectDelay()
+
+    let workItem = DispatchWorkItem { [weak self, weak peripheral] in
+      guard let self, let peripheral else { return }
+      self.reconnectWorkItems.removeValue(forKey: uuid)
+      guard !self.manuallyDisconnected.contains(uuid),
+        self.centralManager.state == .poweredOn,
+        peripheral.state == .disconnected
+      else {
+        return
+      }
+      NSLog("[OmiBle] Reconnect attempt \(attempt) for \(uuid)")
+      peripheral.delegate = self
+      self.centralManager.connect(peripheral, options: nil)
+    }
+    reconnectWorkItems[uuid] = workItem
+    DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+  }
+
+  private func activateSession(for peripheral: CBPeripheral) {
+    let uuid = peripheralUuidString(peripheral)
+    let scheduler = operationScheduler(for: uuid)
+    scheduler.beginSession()
+    characteristicContexts = characteristicContexts.filter { $0.value.peripheralUuid != uuid }
+    pendingWritesWithoutResponse.removeValue(forKey: uuid)
+  }
+
+  private func registerCharacteristics(for peripheral: CBPeripheral, service: CBService) {
+    let uuid = peripheralUuidString(peripheral)
+    let scheduler = operationScheduler(for: uuid)
+    for characteristic in service.characteristics ?? [] {
+      nextCharacteristicInstanceId &+= 1
+      let target = BleGattTarget(
+        serviceUuid: fullUuidString(service.uuid),
+        characteristicUuid: fullUuidString(characteristic.uuid),
+        instanceId: nextCharacteristicInstanceId
+      )
+      characteristicContexts[ObjectIdentifier(characteristic)] = CharacteristicContext(
+        peripheralUuid: uuid,
+        sessionId: scheduler.sessionId,
+        target: target
+      )
+    }
+  }
+
+  private func setNotificationState(
+    _ enabled: Bool,
+    peripheralUuid: String,
+    serviceUuid: String,
+    characteristicUuid: String
+  ) {
+    guard
+      let characteristic = findCharacteristic(
+        peripheralUuid: peripheralUuid,
+        serviceUuid: serviceUuid,
+        characteristicUuid: characteristicUuid
+      ),
+      let peripheral = peripherals[peripheralUuid],
+      peripheral.state == .connected,
+      let context = characteristicContexts[ObjectIdentifier(characteristic)]
+    else {
+      return
     }
 
-    // MARK: - Battery History
+    let scheduler = operationScheduler(for: peripheralUuid)
+    let requestedKind = BleGattOperationKind.setNotifications(enabled)
+    if scheduler.contains(kind: requestedKind, target: context.target) {
+      return
+    }
+    let oppositeChangeIsQueued = scheduler.contains(
+      kind: .setNotifications(!enabled),
+      target: context.target
+    )
+    if characteristic.isNotifying == enabled, !oppositeChangeIsQueued {
+      return
+    }
 
-    private static func batteryHistoryKey(_ uuid: String) -> String { "\(batteryHistoryKeyPrefix)\(uuid)" }
-
-    private func persistBatteryReading(uuid: String, level: Int) {
-        let defaults = UserDefaults.standard
-        let key = OmiBleManager.batteryHistoryKey(uuid)
-        var history = defaults.array(forKey: key) as? [[String: Any]] ?? []
-
-        let now = Int64(Date().timeIntervalSince1970 * 1000)
-        let cutoff = now - OmiBleManager.batteryHistoryRetentionMs
-        history.removeAll { ($0["ts"] as? Int64 ?? 0) < cutoff }
-
-        history.append(["ts": now, "level": level])
-
-        if history.count > OmiBleManager.maxBatteryHistoryEntries {
-            history = Array(history.suffix(OmiBleManager.maxBatteryHistoryEntries))
+    scheduler.enqueue(
+      kind: requestedKind,
+      target: context.target,
+      start: { [weak self, weak peripheral] token in
+        guard let peripheral, peripheral.state == .connected else {
+          self?.operationSchedulers[peripheralUuid]?.complete(
+            token: token,
+            result: .failure(BleGattOperationSchedulerError.disconnected)
+          )
+          return
         }
+        peripheral.setNotifyValue(enabled, for: characteristic)
+      },
+      completion: { result in
+        if case .failure(let error) = result {
+          NSLog(
+            "[OmiBle] Failed to set notification state for \(characteristicUuid): "
+              + error.localizedDescription
+          )
+        }
+      }
+    )
+  }
 
+  private func findCharacteristic(
+    peripheralUuid: String, serviceUuid: String, characteristicUuid: String
+  )
+    -> CBCharacteristic?
+  {
+    guard let services = discoveredServices[peripheralUuid] else { return nil }
+    let sUuid = CBUUID(string: serviceUuid)
+    let cUuid = CBUUID(string: characteristicUuid)
+
+    guard let service = services.first(where: { $0.uuid == sUuid }) else { return nil }
+    return service.characteristics?.first(where: { $0.uuid == cUuid })
+  }
+
+  private func peripheralUuidString(_ peripheral: CBPeripheral) -> String {
+    return peripheral.identifier.uuidString
+  }
+
+  /// Normalize a CBUUID to its full 128-bit string representation.
+  /// CoreBluetooth returns "180A" for standard 16-bit UUIDs but Dart sends
+  /// "0000180a-0000-1000-8000-00805f9b34fb". This ensures consistent keys.
+  private func fullUuidString(_ uuid: CBUUID) -> String {
+    if uuid.data.count == 2 {
+      // 16-bit UUID → expand to 128-bit Bluetooth Base UUID
+      let short = uuid.uuidString  // e.g. "180A"
+      return "0000\(short)-0000-1000-8000-00805F9B34FB".lowercased()
+    } else if uuid.data.count == 4 {
+      // 32-bit UUID → expand
+      let short = uuid.uuidString
+      return "\(short)-0000-1000-8000-00805F9B34FB".lowercased()
+    }
+    return uuid.uuidString.lowercased()
+  }
+
+  // MARK: - Diagnostics Persistence
+
+  private static let batteryHistoryKeyPrefix = "battery_history_"
+  private static let maxBatteryHistoryEntries = 2000
+  private static let batteryHistoryRetentionMs: Int64 = 7 * 24 * 3600 * 1000
+
+  private static let batteryLevelCharUuid = CBUUID(string: "2A19")
+
+  private static let diagnosticsKeyPrefix = "ble_diagnostics_disconnect_history_"
+  private static let reconnectCountKeyPrefix = "ble_diagnostics_reconnect_count_"
+  private static let failToConnectCountKeyPrefix = "ble_diagnostics_fail_to_connect_count_"
+  private static let maxDisconnectHistory = 20
+  private static let rssiHistoryLimit = 10
+  private static let rssiTrendWindowMs: Int64 = 15_000
+  private static let rssiTrendFadingDropDb: Int64 = 10
+
+  /// Classify the RSSI trajectory in the window before `nowMs`. See `rssiTrend`
+  /// on BleDisconnectEvent for the semantics of each label.
+  private static func classifyRssiTrend(samples: [(ts: Int64, rssi: Int64)], nowMs: Int64) -> String {
+    let windowStart = nowMs - rssiTrendWindowMs
+    let recent = samples.filter { $0.ts >= windowStart }
+    // No recent samples — keep-alive wasn't running, so we can't say.
+    if recent.isEmpty { return "gap" }
+    if recent.count < 3 { return "unknown" }
+    // Compare the average of the oldest third to the newest third. A drop of
+    // ≥rssiTrendFadingDropDb dB indicates a fading signal (walk-away).
+    let third = max(1, recent.count / 3)
+    let oldestAvg = recent.prefix(third).map { $0.rssi }.reduce(0, +) / Int64(third)
+    let newestAvg = recent.suffix(third).map { $0.rssi }.reduce(0, +) / Int64(third)
+    let dropDb = oldestAvg - newestAvg  // RSSI is negative; larger drop = more negative newer value
+    if dropDb >= rssiTrendFadingDropDb { return "fading" }
+    return "sudden"
+  }
+
+  private static func historyKey(_ uuid: String) -> String { "\(diagnosticsKeyPrefix)\(uuid)" }
+  private static func reconnectKey(_ uuid: String) -> String { "\(reconnectCountKeyPrefix)\(uuid)" }
+  private static func failToConnectKey(_ uuid: String) -> String {
+    "\(failToConnectCountKeyPrefix)\(uuid)"
+  }
+
+  /// Sample the UIApplication state from whatever thread we're on. The BLE
+  /// callbacks run on the main queue already (centralManager was created with
+  /// queue: nil) so this is safe, but we guard anyway for restoration paths.
+  private func currentAppState() -> String {
+    let state: UIApplication.State
+    if Thread.isMainThread {
+      state = UIApplication.shared.applicationState
+    } else {
+      state = DispatchQueue.main.sync { UIApplication.shared.applicationState }
+    }
+    switch state {
+    case .active: return "foreground"
+    case .inactive: return "inactive"
+    case .background: return "background"
+    @unknown default: return ""
+    }
+  }
+
+  private static func bleReasonString(from error: Error?) -> String {
+    guard let cbError = error as? CBError else { return "clean_disconnect" }
+    switch cbError.code {
+    case .connectionTimeout: return "connection_timeout"
+    case .peripheralDisconnected: return "remote_device_terminated"
+    case .connectionFailed: return "connection_failed_instant_passed"
+    default: return "gatt_error_\(cbError.code.rawValue)"
+    }
+  }
+
+  /// Append a disconnect/fail event to the per-device history ring buffer.
+  /// `eventType` is "disconnect" for an established link lost, or "fail_to_connect"
+  /// for a connect attempt that never reached didConnect.
+  private func persistDisconnectEvent(
+    uuid: String,
+    reason: String?,
+    reasonCode: Int,
+    isManual: Bool,
+    eventType: String
+  ) {
+    let defaults = UserDefaults.standard
+    let key = OmiBleManager.historyKey(uuid)
+    var history = defaults.array(forKey: key) as? [[String: Any]] ?? []
+
+    let now = Int64(Date().timeIntervalSince1970 * 1000)
+    let startedAt = connectionStartTimes[uuid] ?? 0
+    let durationMs: Int64 = (eventType == "disconnect" && startedAt > 0) ? (now - startedAt) : 0
+
+    let trend = OmiBleManager.classifyRssiTrend(samples: rssiHistory[uuid] ?? [], nowMs: now)
+    let event: [String: Any] = [
+      "timestamp": now,
+      "reason": isManual ? "manual" : (reason ?? "unknown"),
+      "reasonCode": reasonCode,
+      "isManual": isManual,
+      "eventType": eventType,
+      "lastRssi": lastRssi[uuid] ?? 0,
+      "connectionDurationMs": durationMs,
+      "appState": currentAppState(),
+      "timeToReconnectMs": 0,
+      "rssiTrend": trend,
+    ]
+    history.append(event)
+
+    if history.count > OmiBleManager.maxDisconnectHistory {
+      history = Array(history.suffix(OmiBleManager.maxDisconnectHistory))
+    }
+
+    defaults.set(history, forKey: key)
+
+    // Remember this event's timestamp so the next successful didConnect can
+    // backfill timeToReconnectMs. Only track unexpected (non-manual) events.
+    if !isManual {
+      pendingReconnectForEvent[uuid] = now
+    }
+  }
+
+  /// On successful didConnect, find the most recent unexpected event for this
+  /// peripheral and write the reconnect-latency value into it.
+  private func backfillTimeToReconnect(uuid: String) {
+    guard let markerTs = pendingReconnectForEvent.removeValue(forKey: uuid) else { return }
+    let defaults = UserDefaults.standard
+    let key = OmiBleManager.historyKey(uuid)
+    guard var history = defaults.array(forKey: key) as? [[String: Any]] else { return }
+
+    // Walk backwards for the matching timestamp. History is small (≤20).
+    let now = Int64(Date().timeIntervalSince1970 * 1000)
+    for i in stride(from: history.count - 1, through: 0, by: -1) {
+      if let ts = history[i]["timestamp"] as? Int64, ts == markerTs {
+        var event = history[i]
+        event["timeToReconnectMs"] = max(Int64(0), now - markerTs)
+        history[i] = event
         defaults.set(history, forKey: key)
+        return
+      }
+    }
+  }
+
+  private func incrementReconnectionCount(uuid: String) {
+    let defaults = UserDefaults.standard
+    let key = OmiBleManager.reconnectKey(uuid)
+    let count = defaults.integer(forKey: key)
+    defaults.set(count + 1, forKey: key)
+  }
+
+  private func incrementFailToConnectCount(uuid: String) {
+    let defaults = UserDefaults.standard
+    let key = OmiBleManager.failToConnectKey(uuid)
+    let count = defaults.integer(forKey: key)
+    defaults.set(count + 1, forKey: key)
+  }
+
+  func getDeviceDiagnostics(uuid: String) -> BleDeviceDiagnostics {
+    let defaults = UserDefaults.standard
+    let history = defaults.array(forKey: OmiBleManager.historyKey(uuid)) as? [[String: Any]] ?? []
+    let reconnectCount = defaults.integer(forKey: OmiBleManager.reconnectKey(uuid))
+    let failToConnectCount = defaults.integer(forKey: OmiBleManager.failToConnectKey(uuid))
+
+    let events = history.map { obj -> BleDisconnectEvent in
+      BleDisconnectEvent(
+        timestamp: obj["timestamp"] as? Int64 ?? 0,
+        reason: obj["reason"] as? String ?? "unknown",
+        reasonCode: Int64(obj["reasonCode"] as? Int ?? -1),
+        isManual: obj["isManual"] as? Bool ?? false,
+        eventType: obj["eventType"] as? String ?? "disconnect",
+        lastRssi: obj["lastRssi"] as? Int64 ?? 0,
+        connectionDurationMs: obj["connectionDurationMs"] as? Int64 ?? 0,
+        appState: obj["appState"] as? String ?? "",
+        timeToReconnectMs: obj["timeToReconnectMs"] as? Int64 ?? 0,
+        rssiTrend: obj["rssiTrend"] as? String ?? ""
+      )
     }
 
-    func getBatteryHistory(uuid: String) -> [BleBatteryPoint] {
-        let defaults = UserDefaults.standard
-        let key = OmiBleManager.batteryHistoryKey(uuid)
-        let history = defaults.array(forKey: key) as? [[String: Any]] ?? []
+    let connectedAt = connectionStartTimes[uuid] ?? 0
 
-        let now = Int64(Date().timeIntervalSince1970 * 1000)
-        let cutoff = now - OmiBleManager.batteryHistoryRetentionMs
+    return BleDeviceDiagnostics(
+      disconnectHistory: events,
+      reconnectionCount: Int64(reconnectCount),
+      connectedAt: connectedAt,
+      failToConnectCount: Int64(failToConnectCount)
+    )
+  }
 
-        return history.compactMap { obj in
-            guard let ts = obj["ts"] as? Int64, let level = obj["level"] as? Int, ts >= cutoff else { return nil }
-            return BleBatteryPoint(timestamp: ts, level: Int64(level))
-        }
+  // MARK: - Battery History
+
+  private static func batteryHistoryKey(_ uuid: String) -> String {
+    "\(batteryHistoryKeyPrefix)\(uuid)"
+  }
+
+  private func persistBatteryReading(uuid: String, level: Int) {
+    let defaults = UserDefaults.standard
+    let key = OmiBleManager.batteryHistoryKey(uuid)
+    var history = defaults.array(forKey: key) as? [[String: Any]] ?? []
+
+    let now = Int64(Date().timeIntervalSince1970 * 1000)
+    let cutoff = now - OmiBleManager.batteryHistoryRetentionMs
+    history.removeAll { ($0["ts"] as? Int64 ?? 0) < cutoff }
+
+    history.append(["ts": now, "level": level])
+
+    if history.count > OmiBleManager.maxBatteryHistoryEntries {
+      history = Array(history.suffix(OmiBleManager.maxBatteryHistoryEntries))
     }
 
-    // MARK: - Audio Batch Helpers
+    defaults.set(history, forKey: key)
+  }
 
-    private func cleanupPeripheral(_ peripheralUuid: String) {
-        stopRssiKeepAlive()
-        discoveredServices.removeValue(forKey: peripheralUuid)
+  func getBatteryHistory(uuid: String) -> [BleBatteryPoint] {
+    let defaults = UserDefaults.standard
+    let key = OmiBleManager.batteryHistoryKey(uuid)
+    let history = defaults.array(forKey: key) as? [[String: Any]] ?? []
 
-        // Clean up pending completions
-        let completionKeys = readCompletions.keys.filter { $0.hasPrefix(peripheralUuid.lowercased()) }
-        for key in completionKeys {
-            readCompletions[key]?(.failure(PigeonError(code: "DISCONNECTED", message: "Peripheral disconnected", details: nil)))
-            readCompletions.removeValue(forKey: key)
-        }
-        let writeKeys = writeCompletions.keys.filter { $0.hasPrefix(peripheralUuid.lowercased()) }
-        for key in writeKeys {
-            writeCompletions[key]?(.failure(PigeonError(code: "DISCONNECTED", message: "Peripheral disconnected", details: nil)))
-            writeCompletions.removeValue(forKey: key)
-        }
+    let now = Int64(Date().timeIntervalSince1970 * 1000)
+    let cutoff = now - OmiBleManager.batteryHistoryRetentionMs
+
+    return history.compactMap { obj in
+      guard let ts = obj["ts"] as? Int64, let level = obj["level"] as? Int, ts >= cutoff else {
+        return nil
+      }
+      return BleBatteryPoint(timestamp: ts, level: Int64(level))
     }
+  }
+
+  // MARK: - Audio Batch Helpers
+
+  private func cleanupPeripheral(_ peripheralUuid: String) {
+    if rssiPeripheralUuid == peripheralUuid {
+      stopRssiDiagnostics(clearSelection: false)
+    }
+    discoveredServices.removeValue(forKey: peripheralUuid)
+    pendingWritesWithoutResponse.removeValue(forKey: peripheralUuid)
+    characteristicContexts = characteristicContexts.filter {
+      $0.value.peripheralUuid != peripheralUuid
+    }
+    operationSchedulers[peripheralUuid]?.endSession()
+  }
 }
 
 // MARK: - CBCentralManagerDelegate
 
 extension OmiBleManager: CBCentralManagerDelegate {
 
-    func centralManagerDidUpdateState(_ central: CBCentralManager) {
-        let state = getBluetoothState()
-        NSLog("[OmiBle] centralManagerDidUpdateState: \(state), flutterApi=\(flutterApi != nil)")
-        flutterApi?.onBluetoothStateChanged(state: state) { _ in }
+  func centralManagerDidUpdateState(_ central: CBCentralManager) {
+    let state = getBluetoothState()
+    NSLog("[OmiBle] centralManagerDidUpdateState: \(state), flutterApi=\(flutterApi != nil)")
+    flutterApi?.onBluetoothStateChanged(state: state) { _ in }
 
-        // Execute queued scan if Bluetooth just became ready
-        if central.state == .poweredOn, let pending = pendingScan {
-            NSLog("[OmiBle] Executing queued scan (timeout=\(pending.timeout))")
-            startScan(timeout: pending.timeout, serviceUuids: pending.serviceUuids)
-        }
+    // Execute queued scan if Bluetooth just became ready
+    if central.state == .poweredOn, let pending = pendingScan {
+      NSLog("[OmiBle] Executing queued scan (timeout=\(pending.timeout))")
+      startScan(timeout: pending.timeout, serviceUuids: pending.serviceUuids)
     }
-
-    func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
-        // Restore previously connected peripherals after app relaunch
-        if let restoredPeripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral] {
-            var uuids: [String] = []
-            for peripheral in restoredPeripherals {
-                let uuid = peripheralUuidString(peripheral)
-                peripheral.delegate = self
-                peripherals[uuid] = peripheral
-                uuids.append(uuid)
-
-                // Re-establish connection if not already connected
-                if peripheral.state != .connected {
-                    central.connect(peripheral, options: nil)
-                } else {
-                    peripheral.discoverServices(nil)
-                }
-            }
-            flutterApi?.onStateRestored(peripheralUuids: uuids) { _ in }
-        }
+    if central.state == .poweredOn {
+      reconnectStalePeripherals()
     }
+  }
 
-    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String: Any], rssi RSSI: NSNumber) {
+  func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
+    // Restore previously connected peripherals after app relaunch
+    if let restoredPeripherals = dict[CBCentralManagerRestoredStatePeripheralsKey]
+      as? [CBPeripheral]
+    {
+      var uuids: [String] = []
+      for peripheral in restoredPeripherals {
         let uuid = peripheralUuidString(peripheral)
         peripheral.delegate = self
         peripherals[uuid] = peripheral
+        uuids.append(uuid)
 
-        let serviceUuids = (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID])?.map { $0.uuidString } ?? []
+        // Re-establish connection if not already connected
+        if peripheral.state != .connected {
+          central.connect(peripheral, options: nil)
+        } else {
+          reconnectLifecycle(for: uuid).transportConnected()
+          activateSession(for: peripheral)
+          peripheral.discoverServices(nil)
+        }
+      }
+      flutterApi?.onStateRestored(peripheralUuids: uuids) { _ in }
+    }
+  }
 
-        let blePeripheral = BlePeripheral(
-            uuid: uuid,
-            name: peripheral.name ?? "",
-            rssi: Int64(RSSI.intValue),
-            serviceUuids: serviceUuids
-        )
+  func centralManager(
+    _ central: CBCentralManager, didDiscover peripheral: CBPeripheral,
+    advertisementData: [String: Any],
+    rssi RSSI: NSNumber
+  ) {
+    let uuid = peripheralUuidString(peripheral)
+    peripheral.delegate = self
+    peripherals[uuid] = peripheral
 
-        flutterApi?.onPeripheralDiscovered(peripheral: blePeripheral) { _ in }
+    let serviceUuids =
+      (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID])?.map { $0.uuidString }
+      ?? []
+
+    let blePeripheral = BlePeripheral(
+      uuid: uuid,
+      name: peripheral.name ?? "",
+      rssi: Int64(RSSI.intValue),
+      serviceUuids: serviceUuids
+    )
+
+    flutterApi?.onPeripheralDiscovered(peripheral: blePeripheral) { _ in }
+  }
+
+  func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+    let uuid = peripheralUuidString(peripheral)
+    NSLog("[OmiBle] didConnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid)")
+
+    // Track reconnections (not first connect)
+    if everConnected.contains(uuid) {
+      incrementReconnectionCount(uuid: uuid)
+      // Backfill the prior unexpected event with how long it took to recover.
+      backfillTimeToReconnect(uuid: uuid)
+    }
+    everConnected.insert(uuid)
+    connectionStartTimes[uuid] = Int64(Date().timeIntervalSince1970 * 1000)
+    cancelScheduledReconnect(uuid: uuid, resetAttempt: false)
+    reconnectLifecycle(for: uuid).transportConnected()
+
+    peripheral.delegate = self
+    activateSession(for: peripheral)
+    peripheral.discoverServices(nil)
+  }
+
+  func centralManager(
+    _ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?
+  ) {
+    let uuid = peripheralUuidString(peripheral)
+    let isManual = manuallyDisconnected.contains(uuid)
+    NSLog(
+      "[OmiBle] didFailToConnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid), error=\(error?.localizedDescription ?? "nil")"
+    )
+    cleanupPeripheral(uuid)
+
+    if !isManual {
+      let reason = Self.bleReasonString(from: error)
+      let code = (error as? CBError)?.code.rawValue ?? -1
+      persistDisconnectEvent(
+        uuid: uuid,
+        reason: reason,
+        reasonCode: Int(code),
+        isManual: false,
+        eventType: "fail_to_connect"
+      )
+      incrementFailToConnectCount(uuid: uuid)
     }
 
-    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
-        let uuid = peripheralUuidString(peripheral)
-        NSLog("[OmiBle] didConnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid)")
-
-        // Track reconnections (not first connect)
-        if everConnected.contains(uuid) {
-            incrementReconnectionCount(uuid: uuid)
-            // Backfill the prior unexpected event with how long it took to recover.
-            backfillTimeToReconnect(uuid: uuid)
-        }
-        everConnected.insert(uuid)
-        connectionStartTimes[uuid] = Int64(Date().timeIntervalSince1970 * 1000)
-
-        peripheral.delegate = self
-        peripheral.discoverServices(nil)
+    flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: error?.localizedDescription) {
+      _ in
     }
 
-    func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
-        let uuid = peripheralUuidString(peripheral)
-        let isManual = manuallyDisconnected.contains(uuid)
-        NSLog("[OmiBle] didFailToConnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid), error=\(error?.localizedDescription ?? "nil")")
-        cleanupPeripheral(uuid)
+    if !isManual, everConnected.contains(uuid) {
+      scheduleReconnect(for: peripheral)
+    }
+  }
 
-        if !isManual {
-            let reason = Self.bleReasonString(from: error)
-            let code = (error as? CBError)?.code.rawValue ?? -1
-            persistDisconnectEvent(
-                uuid: uuid,
-                reason: reason,
-                reasonCode: Int(code),
-                isManual: false,
-                eventType: "fail_to_connect"
-            )
-            incrementFailToConnectCount(uuid: uuid)
-        }
+  func centralManager(
+    _ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?
+  ) {
+    let uuid = peripheralUuidString(peripheral)
+    let isManual = manuallyDisconnected.contains(uuid)
+    NSLog(
+      "[OmiBle] didDisconnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid), error=\(error?.localizedDescription ?? "nil")"
+    )
+    cleanupPeripheral(uuid)
 
-        flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: error?.localizedDescription) { _ in }
+    // Finalize the in-progress batch recording so it's saved + ingestable right away
+    // (a plain BLE disconnect never delivers another packet to trigger the gap finalize).
+    OmiBatchAudioWriter.shared.stop("disconnected")
+    LimitlessFlashDrainEngine.shared.onDeviceDisconnected(uuid)
 
-        // Retry previously-connected peripherals — otherwise a failed connect silently
-        // drops the user. iOS queues this at the chipset level; it's free while waiting.
-        if !isManual, everConnected.contains(uuid) {
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
-                guard let self = self else { return }
-                self.centralManager.connect(peripheral, options: nil)
-            }
-        }
+    if !isManual {
+      let reason = Self.bleReasonString(from: error)
+      let code = (error as? CBError)?.code.rawValue ?? -1
+      // Persist BEFORE clearing connectionStartTimes — the persist step reads
+      // it to compute connection_duration_ms.
+      persistDisconnectEvent(
+        uuid: uuid,
+        reason: reason,
+        reasonCode: Int(code),
+        isManual: false,
+        eventType: "disconnect"
+      )
+    }
+    connectionStartTimes.removeValue(forKey: uuid)
+
+    flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: error?.localizedDescription) {
+      _ in
     }
 
-    func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
-        let uuid = peripheralUuidString(peripheral)
-        let isManual = manuallyDisconnected.contains(uuid)
-        NSLog("[OmiBle] didDisconnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid), error=\(error?.localizedDescription ?? "nil")")
-        cleanupPeripheral(uuid)
-
-        // Finalize the in-progress batch recording so it's saved + ingestable right away
-        // (a plain BLE disconnect never delivers another packet to trigger the gap finalize).
-        OmiBatchAudioWriter.shared.stop("disconnected")
-        LimitlessFlashDrainEngine.shared.onDeviceDisconnected(uuid)
-
-        if !isManual {
-            let reason = Self.bleReasonString(from: error)
-            let code = (error as? CBError)?.code.rawValue ?? -1
-            // Persist BEFORE clearing connectionStartTimes — the persist step reads
-            // it to compute connection_duration_ms.
-            persistDisconnectEvent(
-                uuid: uuid,
-                reason: reason,
-                reasonCode: Int(code),
-                isManual: false,
-                eventType: "disconnect"
-            )
-        }
-        connectionStartTimes.removeValue(forKey: uuid)
-
-        flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: error?.localizedDescription) { _ in }
-
-        // Auto-reconnect unless manually disconnected
-        if !isManual {
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
-                guard let self = self else { return }
-                // iOS handles this at the BLE chipset level — zero CPU/radio cost while waiting
-                self.centralManager.connect(peripheral, options: nil)
-            }
-        }
+    // Auto-reconnect unless manually disconnected
+    if !isManual {
+      scheduleReconnect(for: peripheral)
     }
+  }
 }
 
 // MARK: - CBPeripheralDelegate
 
 extension OmiBleManager: CBPeripheralDelegate {
 
-    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-        let uuid = peripheralUuidString(peripheral)
+  func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+    let uuid = peripheralUuidString(peripheral)
 
-        guard let services = peripheral.services else { return }
-        discoveredServices[uuid] = services
-
-        // Discover characteristics for all services
-        for service in services {
-            peripheral.discoverCharacteristics(nil, for: service)
-        }
+    if let error {
+      NSLog("[OmiBle] Service discovery failed for \(uuid): \(error.localizedDescription)")
+      centralManager.cancelPeripheralConnection(peripheral)
+      return
     }
 
-    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
-        let uuid = peripheralUuidString(peripheral)
+    guard let services = peripheral.services else { return }
+    discoveredServices[uuid] = services
 
-        // Check if all services have had their characteristics discovered
-        guard let services = peripheral.services else { return }
-        let allDiscovered = services.allSatisfy { $0.characteristics != nil }
+    // Discover characteristics for all services
+    for service in services {
+      peripheral.discoverCharacteristics(nil, for: service)
+    }
+  }
 
-        if allDiscovered {
-            let bleServices = services.map { svc in
-                BleService(
-                    uuid: self.fullUuidString(svc.uuid),
-                    characteristicUuids: svc.characteristics?.map { self.fullUuidString($0.uuid) } ?? []
-                )
-            }
-            
-            flutterApi?.onDeviceReady(peripheralUuid: uuid, services: bleServices) { _ in }
-            LimitlessFlashDrainEngine.shared.onDeviceReady(uuid)
-            startRssiKeepAlive(for: peripheral)
-        }
+  func peripheral(
+    _ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?
+  ) {
+    let uuid = peripheralUuidString(peripheral)
+
+    if let error {
+      NSLog(
+        "[OmiBle] Characteristic discovery failed for \(uuid)/\(service.uuid): "
+          + error.localizedDescription
+      )
+      centralManager.cancelPeripheralConnection(peripheral)
+      return
     }
 
-    func peripheral(_ peripheral: CBPeripheral, didReadRSSI RSSI: NSNumber, error: Error?) {
-        guard error == nil else { return }
-        let uuid = peripheralUuidString(peripheral)
-        let value = Int64(RSSI.intValue)
-        // Always remember the latest sample — used to annotate disconnect events
-        // so we can tell signal-driven drops apart from drops with healthy RSSI.
-        lastRssi[uuid] = value
+    registerCharacteristics(for: peripheral, service: service)
 
-        // Append to the trajectory window used by rssiTrend classification.
-        let now = Int64(Date().timeIntervalSince1970 * 1000)
-        var samples = rssiHistory[uuid] ?? []
-        samples.append((ts: now, rssi: value))
-        if samples.count > OmiBleManager.rssiHistoryLimit {
-            samples.removeFirst(samples.count - OmiBleManager.rssiHistoryLimit)
-        }
-        rssiHistory[uuid] = samples
+    // Check if all services have had their characteristics discovered
+    guard let services = peripheral.services else { return }
+    let allDiscovered = services.allSatisfy { $0.characteristics != nil }
 
-        // Forward to Flutter only while the diagnostics screen has subscribed.
-        if isRssiStreamingEnabled {
-            flutterApi?.onRssiUpdate(peripheralUuid: uuid, rssi: value) { _ in }
-        }
+    if allDiscovered {
+      let bleServices = services.map { svc in
+        BleService(
+          uuid: self.fullUuidString(svc.uuid),
+          characteristicUuids: svc.characteristics?.map { self.fullUuidString($0.uuid) } ?? []
+        )
+      }
+
+      flutterApi?.onDeviceReady(peripheralUuid: uuid, services: bleServices) { _ in }
+      reconnectLifecycle(for: uuid).deviceReady()
+      LimitlessFlashDrainEngine.shared.onDeviceReady(uuid)
+      startRssiDiagnostics(for: peripheral)
+    }
+  }
+
+  func peripheral(_ peripheral: CBPeripheral, didReadRSSI RSSI: NSNumber, error: Error?) {
+    let uuid = peripheralUuidString(peripheral)
+    guard let scheduler = operationSchedulers[uuid] else { return }
+    let result: Result<Data?, Error> = error.map { .failure($0) } ?? .success(nil)
+    guard
+      scheduler.completeExpected(
+        sessionId: scheduler.sessionId,
+        kind: .readRssi,
+        target: .rssi,
+        result: result
+      )
+    else {
+      return
+    }
+    guard error == nil else { return }
+
+    let value = Int64(RSSI.intValue)
+    // Always remember the latest sample — used to annotate disconnect events
+    // so we can tell signal-driven drops apart from drops with healthy RSSI.
+    lastRssi[uuid] = value
+
+    // Append to the trajectory window used by rssiTrend classification.
+    let now = Int64(Date().timeIntervalSince1970 * 1000)
+    var samples = rssiHistory[uuid] ?? []
+    samples.append((ts: now, rssi: value))
+    if samples.count > OmiBleManager.rssiHistoryLimit {
+      samples.removeFirst(samples.count - OmiBleManager.rssiHistoryLimit)
+    }
+    rssiHistory[uuid] = samples
+
+    // Forward to Flutter only while the diagnostics screen has subscribed.
+    if isRssiStreamingEnabled {
+      flutterApi?.onRssiUpdate(peripheralUuid: uuid, rssi: value) { _ in }
+    }
+  }
+
+  func peripheral(
+    _ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?
+  ) {
+    let uuid = peripheralUuidString(peripheral)
+    guard let service = characteristic.service else { return }
+    guard let context = characteristicContexts[ObjectIdentifier(characteristic)],
+      context.peripheralUuid == uuid
+    else {
+      NSLog("[OmiBle] Ignoring value callback from a stale characteristic session for \(uuid)")
+      return
     }
 
-    func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
-        let uuid = peripheralUuidString(peripheral)
-        guard let service = characteristic.service else { return }
+    let serviceUuid = fullUuidString(service.uuid)
+    let charUuid = fullUuidString(characteristic.uuid)
 
-        let serviceUuid = fullUuidString(service.uuid)
-        let charUuid = fullUuidString(characteristic.uuid)
-        let key = "\(uuid):\(serviceUuid):\(charUuid)".lowercased()
-
-        // Handle pending read completion
-        if let completion = readCompletions[key] {
-            readCompletions.removeValue(forKey: key)
-            if let error = error {
-                completion(.failure(error))
-            } else {
-                let data = characteristic.value ?? Data()
-                completion(.success(FlutterStandardTypedData(bytes: data)))
-            }
-            return
-        }
-
-        // Handle notification
-        guard let data = characteristic.value, !data.isEmpty else { return }
-
-        if characteristic.uuid == OmiBleManager.batteryLevelCharUuid, let firstByte = data.first {
-            persistBatteryReading(uuid: uuid, level: Int(firstByte))
-        }
-
-        // Limitless Transcribe Later: while batch mode targets this pendant's RX
-        // characteristic, the flash-drain engine consumes the packet natively.
-        if LimitlessFlashDrainEngine.shared.handle(
-            peripheralUuid: uuid,
-            serviceUuid: serviceUuid,
-            characteristicUuid: charUuid,
-            value: data
-        ) {
-            return
-        }
-
-        // Batch (offline) mode: store audio natively and skip the Dart forward so the
-        // Flutter engine stays idle. Returns true only for the configured audio
-        // characteristic while batch mode is on; everything else falls through.
-        if OmiBatchAudioWriter.shared.handle(
-            peripheralUuid: uuid,
-            serviceUuid: serviceUuid,
-            characteristicUuid: charUuid,
-            value: data
-        ) {
-            return
-        }
-
-        let typedData = FlutterStandardTypedData(bytes: data)
-        flutterApi?.onCharacteristicValueUpdated(
-            peripheralUuid: uuid,
-            serviceUuid: serviceUuid,
-            characteristicUuid: charUuid,
-            value: typedData
-        ) { _ in }
+    // A value update can complete a read only when that exact operation,
+    // connection session, and characteristic object are active. If the
+    // characteristic is notifying, preserve the packet as a notification:
+    // CoreBluetooth gives us no safe way to call it a read response.
+    if !characteristic.isNotifying {
+      let result: Result<Data?, Error> =
+        error.map { .failure($0) } ?? .success(characteristic.value ?? Data())
+      if operationSchedulers[uuid]?.completeExpected(
+        sessionId: context.sessionId,
+        kind: .readValue,
+        target: context.target,
+        result: result
+      ) == true {
+        return
+      }
     }
 
-    func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
-        let uuid = peripheralUuidString(peripheral)
-        guard let service = characteristic.service else { return }
-
-        let key = "\(uuid):\(fullUuidString(service.uuid)):\(fullUuidString(characteristic.uuid))".lowercased()
-
-        if let completion = writeCompletions[key] {
-            writeCompletions.removeValue(forKey: key)
-            if let error = error {
-                completion(.failure(error))
-            } else {
-                completion(.success(()))
-            }
-        }
+    if let error {
+      NSLog(
+        "[OmiBle] Characteristic value update failed for \(charUuid): \(error.localizedDescription)"
+      )
+      return
     }
 
-    func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
-        let uuid = peripheralUuidString(peripheral)
-        let charUuid = fullUuidString(characteristic.uuid)
-        if let error = error {
-            NSLog("[OmiBle] Failed to update notification state for \(charUuid): \(error.localizedDescription)")
-        } else {
-            NSLog("[OmiBle] Notification state updated for \(charUuid): isNotifying=\(characteristic.isNotifying)")
-        }
+    // Handle notification
+    guard let data = characteristic.value, !data.isEmpty else { return }
+
+    if characteristic.uuid == OmiBleManager.batteryLevelCharUuid, let firstByte = data.first {
+      persistBatteryReading(uuid: uuid, level: Int(firstByte))
     }
+
+    // Limitless Transcribe Later: while batch mode targets this pendant's RX
+    // characteristic, the flash-drain engine consumes the packet natively.
+    if LimitlessFlashDrainEngine.shared.handle(
+      peripheralUuid: uuid,
+      serviceUuid: serviceUuid,
+      characteristicUuid: charUuid,
+      value: data
+    ) {
+      return
+    }
+
+    // Batch (offline) mode: store audio natively and skip the Dart forward so the
+    // Flutter engine stays idle. Returns true only for the configured audio
+    // characteristic while batch mode is on; everything else falls through.
+    if OmiBatchAudioWriter.shared.handle(
+      peripheralUuid: uuid,
+      serviceUuid: serviceUuid,
+      characteristicUuid: charUuid,
+      value: data
+    ) {
+      return
+    }
+
+    let typedData = FlutterStandardTypedData(bytes: data)
+    flutterApi?.onCharacteristicValueUpdated(
+      peripheralUuid: uuid,
+      serviceUuid: serviceUuid,
+      characteristicUuid: charUuid,
+      value: typedData
+    ) { _ in }
+  }
+
+  func peripheral(
+    _ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?
+  ) {
+    let uuid = peripheralUuidString(peripheral)
+    guard let context = characteristicContexts[ObjectIdentifier(characteristic)],
+      context.peripheralUuid == uuid
+    else {
+      return
+    }
+
+    let result: Result<Data?, Error> = error.map { .failure($0) } ?? .success(nil)
+    _ = operationSchedulers[uuid]?.completeExpected(
+      sessionId: context.sessionId,
+      kind: .writeWithResponse,
+      target: context.target,
+      result: result
+    )
+  }
+
+  func peripheral(
+    _ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic,
+    error: Error?
+  ) {
+    let uuid = peripheralUuidString(peripheral)
+    let charUuid = fullUuidString(characteristic.uuid)
+    guard let context = characteristicContexts[ObjectIdentifier(characteristic)],
+      context.peripheralUuid == uuid
+    else {
+      return
+    }
+    let requestedState = operationSchedulers[uuid]?.activeToken?.kind
+    let completed: Bool
+    switch requestedState {
+    case .setNotifications(let enabled):
+      if let error {
+        completed =
+          operationSchedulers[uuid]?.failExpectedAndInvalidate(
+            sessionId: context.sessionId,
+            kind: .setNotifications(enabled),
+            target: context.target,
+            error: error
+          ) == true
+      } else if BleGattNotificationStateAdmission.evaluate(
+        requestedEnabled: enabled,
+        actualIsNotifying: characteristic.isNotifying
+      ) == .ignoreMismatchedState {
+        completed = false
+      } else {
+        completed =
+          operationSchedulers[uuid]?.completeExpected(
+            sessionId: context.sessionId,
+            kind: .setNotifications(enabled),
+            target: context.target,
+            result: .success(nil)
+          ) == true
+      }
+    default:
+      completed = false
+    }
+
+    guard completed else {
+      NSLog("[OmiBle] Ignoring stale notification-state callback for \(charUuid)")
+      return
+    }
+
+    if let error = error {
+      NSLog(
+        "[OmiBle] Failed to update notification state for \(charUuid): \(error.localizedDescription)"
+      )
+      pendingWritesWithoutResponse.removeValue(forKey: uuid)
+      centralManager.cancelPeripheralConnection(peripheral)
+    } else {
+      NSLog(
+        "[OmiBle] Notification state updated for \(charUuid): isNotifying=\(characteristic.isNotifying)"
+      )
+    }
+  }
+
+  func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
+    let uuid = peripheralUuidString(peripheral)
+    guard let pending = pendingWritesWithoutResponse.removeValue(forKey: uuid),
+      let context = characteristicContexts[ObjectIdentifier(pending.characteristic)],
+      context.peripheralUuid == uuid,
+      context.sessionId == pending.token.sessionId,
+      operationSchedulers[uuid]?.activeToken == pending.token
+    else {
+      return
+    }
+
+    peripheral.writeValue(pending.data, for: pending.characteristic, type: .withoutResponse)
+    operationSchedulers[uuid]?.complete(token: pending.token, result: .success(nil))
+  }
 }

--- a/app/ios/test/BleGattOperationSchedulerTests.swift
+++ b/app/ios/test/BleGattOperationSchedulerTests.swift
@@ -595,6 +595,42 @@ private func testReconnectBackoffIsBounded() {
   expect(BleReconnectBackoff.delay(forAttempt: 100) == 30, "backoff cap must hold for long outages")
 }
 
+private func testUnexpectedDisconnectKeepsPersistentConnectionRequestAlive() {
+  expect(
+    BleReconnectDispatchPolicy.action(
+      after: .unexpectedDisconnect,
+      centralIsPoweredOn: true
+    ) == .connectNow,
+    "unexpected disconnect must reissue connect before a background app can suspend")
+  expect(
+    BleReconnectDispatchPolicy.action(
+      after: .failedConnect,
+      centralIsPoweredOn: true
+    ) == .retryWithBackoff,
+    "an actual connection failure must retain bounded retry backoff")
+  expect(
+    BleReconnectDispatchPolicy.action(
+      after: .unexpectedDisconnect,
+      centralIsPoweredOn: false
+    ) == .waitForPowerOn,
+    "CoreBluetooth work must wait while the central is powered off")
+}
+
+private func testRestoredPeripheralIsImmediatelyReconnectEligible() {
+  let eligibility = BleReconnectEligibility()
+
+  expect(
+    !eligibility.contains("restored"),
+    "an unrelated scan result must not be reconnect eligible")
+  eligibility.recordRestored("restored")
+  expect(
+    eligibility.contains("restored"),
+    "CoreBluetooth restoration must preserve reconnect eligibility before didConnect")
+  expect(
+    !eligibility.contains("unrelated"),
+    "restoration must not make unrelated peripherals reconnect eligible")
+}
+
 private func testReconnectBackoffResetsOnlyAfterDeviceReady() {
   let lifecycle = BleReconnectLifecycle()
 
@@ -639,6 +675,8 @@ private enum BleGattOperationSchedulerTests {
     testNotificationTransitionRunsOppositeLatestState()
     testFailedNotificationTransitionWaitsForSessionRecovery()
     testReconnectBackoffIsBounded()
+    testUnexpectedDisconnectKeepsPersistentConnectionRequestAlive()
+    testRestoredPeripheralIsImmediatelyReconnectEligible()
     testReconnectBackoffResetsOnlyAfterDeviceReady()
     print("BleGattOperationSchedulerTests: PASS")
   }

--- a/app/ios/test/BleGattOperationSchedulerTests.swift
+++ b/app/ios/test/BleGattOperationSchedulerTests.swift
@@ -1,0 +1,605 @@
+import Foundation
+
+private final class ScheduledTimeout {
+  let action: () -> Void
+  var isCancelled = false
+
+  init(action: @escaping () -> Void) {
+    self.action = action
+  }
+}
+
+private final class ManualTimeoutScheduler {
+  private(set) var timeouts: [ScheduledTimeout] = []
+
+  func schedule(_: TimeInterval, action: @escaping () -> Void) -> BleGattTimeoutCancellation {
+    let timeout = ScheduledTimeout(action: action)
+    timeouts.append(timeout)
+    return BleGattTimeoutCancellation {
+      timeout.isCancelled = true
+    }
+  }
+
+  func fireNextActive() {
+    guard let timeout = timeouts.first(where: { !$0.isCancelled }) else {
+      fail("expected an active timeout")
+    }
+    timeout.action()
+  }
+}
+
+private func expect(
+  _ condition: @autoclosure () -> Bool,
+  _ message: String,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  if !condition() {
+    fail(message, file: file, line: line)
+  }
+}
+
+private func fail(
+  _ message: String,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) -> Never {
+  fatalError("\(file):\(line): \(message)")
+}
+
+private func scheduler(
+  clock: ManualTimeoutScheduler,
+  timedOut: @escaping (BleGattOperationToken) -> Void = { _ in }
+) -> BleGattOperationScheduler {
+  BleGattOperationScheduler(
+    timeout: 10,
+    scheduleTimeout: clock.schedule,
+    onFatalTimeout: timedOut
+  )
+}
+
+private let targetA = BleGattTarget(
+  serviceUuid: "service", characteristicUuid: "characteristic", instanceId: 1)
+private let targetB = BleGattTarget(
+  serviceUuid: "service", characteristicUuid: "characteristic", instanceId: 2)
+
+private func testSerializesAndKeepsCompletionsDistinct() {
+  let clock = ManualTimeoutScheduler()
+  let queue = scheduler(clock: clock)
+  queue.beginSession()
+
+  var starts: [UInt64] = []
+  var completions: [String] = []
+
+  let first = queue.enqueue(
+    kind: .readValue,
+    target: targetA,
+    start: { starts.append($0.id) },
+    completion: { result in
+      if case .success(let data) = result {
+        completions.append("first:\(data?.first ?? 0)")
+      }
+    }
+  )
+  let second = queue.enqueue(
+    kind: .readValue,
+    target: targetA,
+    start: { starts.append($0.id) },
+    completion: { result in
+      if case .success(let data) = result {
+        completions.append("second:\(data?.first ?? 0)")
+      }
+    }
+  )
+
+  expect(first != nil && second != nil, "connected session must accept operations")
+  expect(starts == [first!.id], "only one CoreBluetooth operation may be in flight")
+  expect(queue.pendingCount == 1, "second same-characteristic request must remain queued")
+
+  expect(
+    queue.completeExpected(
+      sessionId: first!.sessionId,
+      kind: .readValue,
+      target: targetA,
+      result: .success(Data([11]))
+    ),
+    "first callback should resolve its exact request"
+  )
+  expect(completions == ["first:11"], "first callback must not overwrite the second completion")
+  expect(
+    starts == [first!.id, second!.id], "second request should begin only after the first completes")
+
+  expect(
+    queue.completeExpected(
+      sessionId: second!.sessionId,
+      kind: .readValue,
+      target: targetA,
+      result: .success(Data([22]))
+    ),
+    "second callback should resolve its own request"
+  )
+  expect(completions == ["first:11", "second:22"], "same-target completions must remain distinct")
+}
+
+private func testRejectsWrongKindTargetAndSession() {
+  let clock = ManualTimeoutScheduler()
+  let queue = scheduler(clock: clock)
+  queue.beginSession()
+
+  var completionCount = 0
+  let token = queue.enqueue(
+    kind: .readValue,
+    target: targetA,
+    start: { _ in },
+    completion: { _ in completionCount += 1 }
+  )!
+
+  expect(
+    !queue.completeExpected(
+      sessionId: token.sessionId,
+      kind: .setNotifications(true),
+      target: targetA,
+      result: .success(nil)
+    ),
+    "notification-state callback must not satisfy a read"
+  )
+  expect(
+    !queue.completeExpected(
+      sessionId: token.sessionId,
+      kind: .readValue,
+      target: targetB,
+      result: .success(Data([1]))
+    ),
+    "a different characteristic instance must not satisfy a read"
+  )
+  expect(
+    !queue.completeExpected(
+      sessionId: token.sessionId &+ 1,
+      kind: .readValue,
+      target: targetA,
+      result: .success(Data([1]))
+    ),
+    "a stale connection session must not satisfy a read"
+  )
+  expect(completionCount == 0, "unrelated callbacks must leave the active operation untouched")
+
+  expect(
+    queue.completeExpected(
+      sessionId: token.sessionId,
+      kind: .readValue,
+      target: targetA,
+      result: .success(Data([7]))
+    ),
+    "exact callback should still complete after unrelated callbacks"
+  )
+  expect(completionCount == 1, "operation completion must run exactly once")
+}
+
+private func testTimeoutFailsWholeSessionWithoutStartingQueuedWork() {
+  let clock = ManualTimeoutScheduler()
+  var timedOutToken: BleGattOperationToken?
+  let queue = scheduler(clock: clock) { timedOutToken = $0 }
+  queue.beginSession()
+
+  var starts: [String] = []
+  var failures: [BleGattOperationSchedulerError] = []
+  let first = queue.enqueue(
+    kind: .writeWithResponse,
+    target: targetA,
+    start: { _ in starts.append("first") },
+    completion: {
+      if case .failure(let error as BleGattOperationSchedulerError) = $0 {
+        failures.append(error)
+      }
+    }
+  )!
+  _ = queue.enqueue(
+    kind: .readValue,
+    target: targetB,
+    start: { _ in starts.append("second") },
+    completion: {
+      if case .failure(let error as BleGattOperationSchedulerError) = $0 {
+        failures.append(error)
+      }
+    }
+  )
+
+  clock.fireNextActive()
+
+  expect(starts == ["first"], "queued work must not start on a timed-out CoreBluetooth session")
+  expect(
+    failures == [.timedOut, .timedOut],
+    "timeout must fail active and queued callers deterministically")
+  expect(timedOutToken == first, "timeout hook must identify the exact failed operation")
+  expect(!queue.isSessionActive, "timeout must invalidate the connection session")
+  expect(
+    queue.activeToken == nil && queue.pendingCount == 0, "timeout must leave no orphaned operations"
+  )
+
+  var disconnectedFailure: BleGattOperationSchedulerError?
+  let rejected = queue.enqueue(
+    kind: .readValue,
+    target: targetA,
+    start: { _ in fail("inactive session must not start new work") },
+    completion: {
+      if case .failure(let error as BleGattOperationSchedulerError) = $0 {
+        disconnectedFailure = error
+      }
+    }
+  )
+  expect(rejected == nil, "timed-out session must reject new work until reconnect")
+  expect(disconnectedFailure == .disconnected, "rejected caller must receive an explicit failure")
+}
+
+private func testDiagnosticsRssiTimeoutDoesNotTearDownTheSession() {
+  let clock = ManualTimeoutScheduler()
+  var fatalTimeouts = 0
+  let queue = scheduler(clock: clock) { _ in fatalTimeouts += 1 }
+  queue.beginSession()
+
+  var starts: [BleGattOperationKind] = []
+  var rssiTimedOut = false
+  let rssi = queue.enqueue(
+    kind: .readRssi,
+    target: .rssi,
+    fatalOnTimeout: false,
+    start: { starts.append($0.kind) },
+    completion: { result in
+      if case .failure(BleGattOperationSchedulerError.timedOut) = result {
+        rssiTimedOut = true
+      }
+    }
+  )!
+  let read = queue.enqueue(
+    kind: .readValue,
+    target: targetA,
+    start: { starts.append($0.kind) },
+    completion: { _ in }
+  )!
+
+  clock.fireNextActive()
+
+  expect(rssiTimedOut, "missing diagnostics callback must fail that RSSI sample")
+  expect(fatalTimeouts == 0, "diagnostics timeout must not request a reconnect")
+  expect(queue.isSessionActive, "diagnostics timeout must preserve the healthy GATT session")
+  expect(starts == [.readRssi, .readValue], "queued production work must continue after RSSI timeout")
+  expect(queue.activeToken == read, "the next serialized operation should become active")
+  expect(!queue.complete(token: rssi, result: .success(nil)), "late RSSI callback must remain fenced")
+}
+
+private func testDisconnectCancelsOnceAndFencesLateCallbacks() {
+  let clock = ManualTimeoutScheduler()
+  let queue = scheduler(clock: clock)
+  queue.beginSession()
+
+  var completions: [BleGattOperationSchedulerError] = []
+  let oldToken = queue.enqueue(
+    kind: .readValue,
+    target: targetA,
+    start: { _ in },
+    completion: {
+      if case .failure(let error as BleGattOperationSchedulerError) = $0 {
+        completions.append(error)
+      }
+    }
+  )!
+  _ = queue.enqueue(
+    kind: .setNotifications(true),
+    target: targetB,
+    start: { _ in },
+    completion: {
+      if case .failure(let error as BleGattOperationSchedulerError) = $0 {
+        completions.append(error)
+      }
+    }
+  )
+
+  queue.endSession()
+  expect(
+    completions == [.disconnected, .disconnected], "disconnect must fail every caller exactly once")
+  queue.endSession()
+  expect(completions.count == 2, "duplicate disconnect callbacks must not duplicate completions")
+
+  queue.beginSession()
+  var newCompletionCount = 0
+  let newToken = queue.enqueue(
+    kind: .readValue,
+    target: targetA,
+    start: { _ in },
+    completion: { _ in newCompletionCount += 1 }
+  )!
+  expect(newToken.sessionId != oldToken.sessionId, "reconnect must create a new operation session")
+  expect(
+    !queue.completeExpected(
+      sessionId: oldToken.sessionId,
+      kind: oldToken.kind,
+      target: oldToken.target,
+      result: .success(Data([1]))
+    ),
+    "late callback from the disconnected session must be ignored"
+  )
+  expect(newCompletionCount == 0, "late callback must not complete the new request")
+  expect(
+    queue.completeExpected(
+      sessionId: newToken.sessionId,
+      kind: newToken.kind,
+      target: newToken.target,
+      result: .success(Data([2]))
+    ),
+    "new session callback should complete normally"
+  )
+  expect(newCompletionCount == 1, "new request must complete once")
+}
+
+private func testSessionTransitionRejectsReentrantWork() {
+  let clock = ManualTimeoutScheduler()
+  let queue = scheduler(clock: clock)
+  queue.beginSession()
+
+  var reentrantStartCount = 0
+  var reentrantFailure: BleGattOperationSchedulerError?
+  _ = queue.enqueue(
+    kind: .readValue,
+    target: targetA,
+    start: { _ in },
+    completion: { _ in
+      _ = queue.enqueue(
+        kind: .writeWithResponse,
+        target: targetB,
+        start: { _ in reentrantStartCount += 1 },
+        completion: {
+          if case .failure(let error as BleGattOperationSchedulerError) = $0 {
+            reentrantFailure = error
+          }
+        }
+      )
+    }
+  )
+
+  queue.endSession()
+  expect(reentrantStartCount == 0, "disconnect completion must not start work in the dead session")
+  expect(
+    reentrantFailure == .disconnected, "reentrant work must receive explicit disconnected failure")
+  expect(
+    queue.activeToken == nil && queue.pendingCount == 0,
+    "session transition must leave no orphaned work")
+}
+
+private func testNotificationStateIsSerializedWithDataCommands() {
+  let clock = ManualTimeoutScheduler()
+  let queue = scheduler(clock: clock)
+  queue.beginSession()
+
+  var starts: [BleGattOperationKind] = []
+  let subscribe = queue.enqueue(
+    kind: .setNotifications(true),
+    target: targetA,
+    start: { starts.append($0.kind) },
+    completion: { _ in }
+  )!
+  let write = queue.enqueue(
+    kind: .writeWithResponse,
+    target: targetB,
+    start: { starts.append($0.kind) },
+    completion: { _ in }
+  )!
+
+  expect(starts == [.setNotifications(true)], "CCCD change must serialize with GATT data commands")
+  expect(
+    queue.completeExpected(
+      sessionId: subscribe.sessionId,
+      kind: subscribe.kind,
+      target: subscribe.target,
+      result: .success(nil)
+    ),
+    "CCCD callback should resolve exact subscription operation"
+  )
+  expect(
+    starts == [.setNotifications(true), .writeWithResponse],
+    "write should start after subscription callback")
+  expect(
+    queue.completeExpected(
+      sessionId: write.sessionId,
+      kind: write.kind,
+      target: write.target,
+      result: .success(nil)
+    ),
+    "write callback should resolve after serialized subscription"
+  )
+}
+
+private func testLateEnableCallbackCannotCompleteActiveDisable() {
+  let clock = ManualTimeoutScheduler()
+  let queue = scheduler(clock: clock)
+  queue.beginSession()
+
+  let enable = queue.enqueue(
+    kind: .setNotifications(true),
+    target: targetA,
+    start: { _ in },
+    completion: { _ in }
+  )!
+  let disable = queue.enqueue(
+    kind: .setNotifications(false),
+    target: targetA,
+    start: { _ in },
+    completion: { _ in }
+  )!
+
+  func applyCallback(actualIsNotifying: Bool) -> Bool {
+    guard let active = queue.activeToken,
+      case .setNotifications(let requestedEnabled) = active.kind,
+      BleGattNotificationStateAdmission.evaluate(
+        requestedEnabled: requestedEnabled,
+        actualIsNotifying: actualIsNotifying
+      ) == .complete
+    else {
+      return false
+    }
+    return queue.completeExpected(
+      sessionId: active.sessionId,
+      kind: active.kind,
+      target: active.target,
+      result: .success(nil)
+    )
+  }
+
+  expect(applyCallback(actualIsNotifying: true), "enable callback should complete active enable")
+  expect(queue.activeToken == disable, "disable should become active after enable")
+  expect(
+    !applyCallback(actualIsNotifying: true),
+    "late enable callback must not complete an active disable"
+  )
+  expect(queue.activeToken == disable, "mismatched callback must leave disable in flight")
+  expect(
+    applyCallback(actualIsNotifying: false), "matching disable callback should complete disable")
+  expect(queue.activeToken == nil, "matching disable callback should drain the queue")
+  expect(enable.kind == .setNotifications(true), "test must exercise enable before disable")
+}
+
+private func testNotificationFailureFencesDependentCommands() {
+  struct NotificationFailure: Error {}
+
+  let clock = ManualTimeoutScheduler()
+  let queue = scheduler(clock: clock)
+  queue.beginSession()
+
+  var starts: [BleGattOperationKind] = []
+  var failures = 0
+  let subscribe = queue.enqueue(
+    kind: .setNotifications(true),
+    target: targetA,
+    start: { starts.append($0.kind) },
+    completion: {
+      if case .failure = $0 { failures += 1 }
+    }
+  )!
+  _ = queue.enqueue(
+    kind: .writeWithResponse,
+    target: targetB,
+    start: { starts.append($0.kind) },
+    completion: {
+      if case .failure = $0 { failures += 1 }
+    }
+  )
+
+  expect(
+    queue.failExpectedAndInvalidate(
+      sessionId: subscribe.sessionId,
+      kind: subscribe.kind,
+      target: subscribe.target,
+      error: NotificationFailure()
+    ),
+    "exact subscription error should invalidate the operation session"
+  )
+  expect(
+    starts == [.setNotifications(true)], "dependent write must not run after subscription failure")
+  expect(failures == 2, "subscription failure must reach active and dependent callers")
+  expect(!queue.isSessionActive, "failed subscription must require a clean reconnect")
+}
+
+private func testSubscribeThenSameTargetReadRechecksNotificationState() {
+  struct ReadWhileNotifying: Error {}
+
+  let clock = ManualTimeoutScheduler()
+  let queue = scheduler(clock: clock)
+  queue.beginSession()
+
+  var isNotifying = false
+  var coreBluetoothReadCount = 0
+  var readFailureCount = 0
+  let subscribe = queue.enqueue(
+    kind: .setNotifications(true),
+    target: targetA,
+    start: { _ in },
+    completion: { _ in }
+  )!
+  _ = queue.enqueue(
+    kind: .readValue,
+    target: targetA,
+    start: { token in
+      switch BleGattReadAdmission.evaluate(isNotifying: isNotifying) {
+      case .start:
+        coreBluetoothReadCount += 1
+      case .rejectNotifying:
+        queue.complete(token: token, result: .failure(ReadWhileNotifying()))
+      }
+    },
+    completion: {
+      if case .failure = $0 { readFailureCount += 1 }
+    }
+  )
+
+  isNotifying = true
+  expect(
+    queue.completeExpected(
+      sessionId: subscribe.sessionId,
+      kind: subscribe.kind,
+      target: subscribe.target,
+      result: .success(nil)
+    ),
+    "subscription callback should release the queued read"
+  )
+  expect(
+    coreBluetoothReadCount == 0,
+    "queued read must recheck and avoid CoreBluetooth once notifications start")
+  expect(readFailureCount == 1, "ambiguous read must fail immediately instead of timing out")
+  expect(queue.activeToken == nil, "rejected queued read must not remain stuck in flight")
+  expect(
+    queue.isSessionActive, "safe read rejection must not tear down an otherwise healthy session")
+}
+
+private func testReconnectBackoffIsBounded() {
+  expect(BleReconnectBackoff.delay(forAttempt: 0) == 0.5, "first reconnect should be prompt")
+  expect(BleReconnectBackoff.delay(forAttempt: 1) == 1, "repeated failure should back off")
+  expect(BleReconnectBackoff.delay(forAttempt: 4) == 8, "backoff should grow exponentially")
+  expect(
+    BleReconnectBackoff.delay(forAttempt: 6) == 30, "backoff should cap before becoming excessive")
+  expect(BleReconnectBackoff.delay(forAttempt: 100) == 30, "backoff cap must hold for long outages")
+}
+
+private func testReconnectBackoffResetsOnlyAfterDeviceReady() {
+  let lifecycle = BleReconnectLifecycle()
+
+  lifecycle.transportConnected()
+  expect(
+    lifecycle.phase == .transportConnected,
+    "transport connect should enter setup without claiming ready")
+  expect(lifecycle.nextReconnectDelay() == 0.5, "first setup failure should use the initial delay")
+
+  lifecycle.transportConnected()
+  expect(lifecycle.failureCount == 1, "transport reconnect must preserve the setup failure count")
+  expect(
+    lifecycle.nextReconnectDelay() == 1, "second setup failure should continue exponential backoff")
+
+  lifecycle.transportConnected()
+  expect(lifecycle.failureCount == 2, "another transport reconnect must still preserve backoff")
+  expect(lifecycle.nextReconnectDelay() == 2, "repeated setup failures must keep increasing delay")
+
+  lifecycle.transportConnected()
+  lifecycle.deviceReady()
+  expect(lifecycle.phase == .ready, "successful setup should be the readiness boundary")
+  expect(lifecycle.failureCount == 0, "only device-ready should reset accumulated setup failures")
+  expect(
+    lifecycle.nextReconnectDelay() == 0.5,
+    "failure after a ready session should restart initial backoff")
+}
+
+@main
+private enum BleGattOperationSchedulerTests {
+  static func main() {
+    testSerializesAndKeepsCompletionsDistinct()
+    testRejectsWrongKindTargetAndSession()
+    testTimeoutFailsWholeSessionWithoutStartingQueuedWork()
+    testDiagnosticsRssiTimeoutDoesNotTearDownTheSession()
+    testDisconnectCancelsOnceAndFencesLateCallbacks()
+    testSessionTransitionRejectsReentrantWork()
+    testNotificationStateIsSerializedWithDataCommands()
+    testLateEnableCallbackCannotCompleteActiveDisable()
+    testNotificationFailureFencesDependentCommands()
+    testSubscribeThenSameTargetReadRechecksNotificationState()
+    testReconnectBackoffIsBounded()
+    testReconnectBackoffResetsOnlyAfterDeviceReady()
+    print("BleGattOperationSchedulerTests: PASS")
+  }
+}

--- a/app/ios/test/BleGattOperationSchedulerTests.swift
+++ b/app/ios/test/BleGattOperationSchedulerTests.swift
@@ -549,6 +549,43 @@ private func testSubscribeThenSameTargetReadRechecksNotificationState() {
     queue.isSessionActive, "safe read rejection must not tear down an otherwise healthy session")
 }
 
+private func testNotificationTransitionCoalescesLatestDesiredState() {
+  let state = BleGattNotificationTransitionState(confirmed: false)
+
+  expect(state.request(true) == true, "initial enable should start immediately")
+  expect(state.request(false) == nil, "disable should wait behind the active enable")
+  expect(state.request(true) == nil, "latest enable should replace the queued disable intent")
+  expect(
+    state.complete(attempted: true, success: true) == nil,
+    "completed enable should not launch the superseded disable")
+  expect(state.currentInFlight == nil, "coalesced final state should have no transition in flight")
+  expect(state.request(true) == nil, "confirmed final state should not generate a redundant write")
+}
+
+private func testNotificationTransitionRunsOppositeLatestState() {
+  let state = BleGattNotificationTransitionState(confirmed: false)
+
+  expect(state.request(true) == true, "initial enable should start immediately")
+  expect(state.request(false) == nil, "disable should wait for the active enable callback")
+  expect(
+    state.complete(attempted: true, success: true) == false,
+    "latest opposite state should start after the active transition")
+  expect(state.currentInFlight == false, "follow-up disable should be marked in flight")
+  expect(
+    state.complete(attempted: false, success: true) == nil,
+    "confirmed latest state should finish without another transition")
+}
+
+private func testFailedNotificationTransitionWaitsForSessionRecovery() {
+  let state = BleGattNotificationTransitionState(confirmed: false)
+
+  expect(state.request(true) == true, "initial enable should start immediately")
+  expect(
+    state.complete(attempted: true, success: false) == nil,
+    "failed transition must not retry on the compromised session")
+  expect(state.currentInFlight == nil, "failed transition must release its in-flight marker")
+}
+
 private func testReconnectBackoffIsBounded() {
   expect(BleReconnectBackoff.delay(forAttempt: 0) == 0.5, "first reconnect should be prompt")
   expect(BleReconnectBackoff.delay(forAttempt: 1) == 1, "repeated failure should back off")
@@ -598,6 +635,9 @@ private enum BleGattOperationSchedulerTests {
     testLateEnableCallbackCannotCompleteActiveDisable()
     testNotificationFailureFencesDependentCommands()
     testSubscribeThenSameTargetReadRechecksNotificationState()
+    testNotificationTransitionCoalescesLatestDesiredState()
+    testNotificationTransitionRunsOppositeLatestState()
+    testFailedNotificationTransitionWaitsForSessionRecovery()
     testReconnectBackoffIsBounded()
     testReconnectBackoffResetsOnlyAfterDeviceReady()
     print("BleGattOperationSchedulerTests: PASS")

--- a/app/ios/test/BleManagerDependencyTypecheckStubs.swift
+++ b/app/ios/test/BleManagerDependencyTypecheckStubs.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+final class OmiBatchAudioWriter {
+  static let shared = OmiBatchAudioWriter()
+
+  func stop(_: String) {}
+
+  func handle(
+    peripheralUuid _: String,
+    serviceUuid _: String,
+    characteristicUuid _: String,
+    value _: Data
+  ) -> Bool {
+    false
+  }
+}
+
+final class LimitlessFlashDrainEngine {
+  static let shared = LimitlessFlashDrainEngine()
+
+  func onDeviceDisconnected(_: String) {}
+  func onDeviceReady(_: String) {}
+
+  func handle(
+    peripheralUuid _: String,
+    serviceUuid _: String,
+    characteristicUuid _: String,
+    value _: Data
+  ) -> Bool {
+    false
+  }
+}

--- a/app/ios/test/BleNotificationRouterTests.swift
+++ b/app/ios/test/BleNotificationRouterTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+private func expect(
+  _ actual: BleNotificationRoute,
+  _ expected: BleNotificationRoute,
+  _ message: String,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  guard actual == expected else {
+    fatalError("\(file):\(line): \(message): expected \(expected), got \(actual)")
+  }
+}
+
+private func testRoutesOnlyKnownNativeCaptureCharacteristics() {
+  expect(
+    BleNotificationRouter.route(
+      serviceUuid: "632DE001-604C-446B-A80F-7963E950F3FB",
+      characteristicUuid: "632DE003-604C-446B-A80F-7963E950F3FB"
+    ),
+    .limitlessFlash,
+    "Limitless receive notifications must reach the native flash drain"
+  )
+  expect(
+    BleNotificationRouter.route(
+      serviceUuid: "19B10000-E8F2-537E-4F6C-D104768A1214",
+      characteristicUuid: "19B10001-E8F2-537E-4F6C-D104768A1214"
+    ),
+    .batchAudio,
+    "Omi audio notifications must reach native batch capture"
+  )
+  expect(
+    BleNotificationRouter.route(
+      serviceUuid: "1A3FD0E7-B1F3-AC9E-2E49-B647B2C4F8DA",
+      characteristicUuid: "01000000-1111-1111-1111-111111111111"
+    ),
+    .batchAudio,
+    "Friend pendant audio notifications must reach native batch capture"
+  )
+}
+
+private func testStorageAndControlNotificationsBypassNativeCapturePolicy() {
+  for characteristic in [
+    "30295781-4301-eabd-2904-2849adfeae43",
+    "30295782-4301-eabd-2904-2849adfeae43",
+    "00002a19-0000-1000-8000-00805f9b34fb",
+  ] {
+    expect(
+      BleNotificationRouter.route(
+        serviceUuid: "30295780-4301-eabd-2904-2849adfeae43",
+        characteristicUuid: characteristic
+      ),
+      .dart,
+      "non-audio notification must bypass native capture policy"
+    )
+  }
+}
+
+private func testWrongCharacteristicWithinKnownServiceFallsThrough() {
+  expect(
+    BleNotificationRouter.route(
+      serviceUuid: "632de001-604c-446b-a80f-7963e950f3fb",
+      characteristicUuid: "632de002-604c-446b-a80f-7963e950f3fb"
+    ),
+    .dart,
+    "Limitless TX characteristic is not a native receive hot path"
+  )
+  expect(
+    BleNotificationRouter.route(
+      serviceUuid: "19b10000-e8f2-537e-4f6c-d104768a1214",
+      characteristicUuid: "19b10002-e8f2-537e-4f6c-d104768a1214"
+    ),
+    .dart,
+    "Omi codec notifications must not consult batch capture policy"
+  )
+}
+
+@main
+private enum BleNotificationRouterTests {
+  static func main() {
+    testRoutesOnlyKnownNativeCaptureCharacteristics()
+    testStorageAndControlNotificationsBypassNativeCapturePolicy()
+    testWrongCharacteristicWithinKnownServiceFallsThrough()
+    print("BleNotificationRouterTests: PASS")
+  }
+}

--- a/app/ios/test/ble_gatt_project_graph_test.rb
+++ b/app/ios/test/ble_gatt_project_graph_test.rb
@@ -6,14 +6,19 @@ class BleGattProjectGraphTest < Minitest::Test
   PROJECT = File.expand_path("../Runner.xcodeproj/project.pbxproj", __dir__)
   MANAGER = File.expand_path("../Runner/Ble/OmiBleManager.swift", __dir__)
   SCHEDULER = File.expand_path("../Runner/Ble/BleGattOperationScheduler.swift", __dir__)
+  ROUTER = File.expand_path("../Runner/Ble/BleNotificationRouter.swift", __dir__)
   FILE_REF = "C0D3B1E00000000000000001"
   RUNNER_BUILD_REF = "C0D3B1E00000000000000002"
   RAYBAN_BUILD_REF = "C0D3B1E00000000000000003"
+  ROUTER_FILE_REF = "C0D3B1E10000000000000001"
+  ROUTER_RUNNER_BUILD_REF = "C0D3B1E10000000000000002"
+  ROUTER_RAYBAN_BUILD_REF = "C0D3B1E10000000000000003"
 
   def setup
     @project = File.read(PROJECT)
     @manager = File.read(MANAGER)
     @scheduler = File.read(SCHEDULER)
+    @router = File.read(ROUTER)
   end
 
   def test_scheduler_has_one_file_reference_and_two_target_build_references
@@ -33,6 +38,18 @@ class BleGattProjectGraphTest < Minitest::Test
     refute_includes rayban_sources, RUNNER_BUILD_REF
   end
 
+  def test_notification_router_is_compiled_by_both_phone_targets
+    assert_equal 1, @project.scan(/#{ROUTER_FILE_REF} .* = \{isa = PBXFileReference;/).length
+    assert_equal 2, @project.scan(/fileRef = #{ROUTER_FILE_REF}/).length
+
+    runner_sources = source_phase("97C146EA1CF9000F007C117D")
+    rayban_sources = source_phase("A39438EBCDB909113855E505")
+    assert_includes runner_sources, ROUTER_RUNNER_BUILD_REF
+    refute_includes runner_sources, ROUTER_RAYBAN_BUILD_REF
+    assert_includes rayban_sources, ROUTER_RAYBAN_BUILD_REF
+    refute_includes rayban_sources, ROUTER_RUNNER_BUILD_REF
+  end
+
   # Static integration tripwires complement the behavioral scheduler tests.
   # They make sure the manager does not bypass the tested ownership boundary.
   def test_manager_does_not_restore_characteristic_keyed_completion_ownership
@@ -49,6 +66,12 @@ class BleGattProjectGraphTest < Minitest::Test
     assert_includes @manager, "nextReconnectDelay()"
     assert_includes @manager, "deviceReady()"
     assert_includes @scheduler, "BleReconnectBackoff.delay"
+  end
+
+  def test_manager_routes_before_native_batch_policy
+    assert_includes @manager, "BleNotificationRouter.route("
+    assert_includes @router, "case limitlessFlash"
+    assert_includes @router, "case batchAudio"
   end
 
   private

--- a/app/ios/test/ble_gatt_project_graph_test.rb
+++ b/app/ios/test/ble_gatt_project_graph_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+
+class BleGattProjectGraphTest < Minitest::Test
+  PROJECT = File.expand_path("../Runner.xcodeproj/project.pbxproj", __dir__)
+  MANAGER = File.expand_path("../Runner/Ble/OmiBleManager.swift", __dir__)
+  SCHEDULER = File.expand_path("../Runner/Ble/BleGattOperationScheduler.swift", __dir__)
+  FILE_REF = "C0D3B1E00000000000000001"
+  RUNNER_BUILD_REF = "C0D3B1E00000000000000002"
+  RAYBAN_BUILD_REF = "C0D3B1E00000000000000003"
+
+  def setup
+    @project = File.read(PROJECT)
+    @manager = File.read(MANAGER)
+    @scheduler = File.read(SCHEDULER)
+  end
+
+  def test_scheduler_has_one_file_reference_and_two_target_build_references
+    assert_equal 1, @project.scan(/#{FILE_REF} .* = \{isa = PBXFileReference;/).length
+    assert_equal 2, @project.scan(/fileRef = #{FILE_REF}/).length
+    assert_equal 2, @project.scan(/#{RUNNER_BUILD_REF} \/\* BleGattOperationScheduler\.swift in Sources \*\//).length
+    assert_equal 2, @project.scan(/#{RAYBAN_BUILD_REF} \/\* BleGattOperationScheduler\.swift in Sources \*\//).length
+  end
+
+  def test_scheduler_is_compiled_by_both_phone_targets
+    runner_sources = source_phase("97C146EA1CF9000F007C117D")
+    rayban_sources = source_phase("A39438EBCDB909113855E505")
+
+    assert_includes runner_sources, RUNNER_BUILD_REF
+    refute_includes runner_sources, RAYBAN_BUILD_REF
+    assert_includes rayban_sources, RAYBAN_BUILD_REF
+    refute_includes rayban_sources, RUNNER_BUILD_REF
+  end
+
+  # Static integration tripwires complement the behavioral scheduler tests.
+  # They make sure the manager does not bypass the tested ownership boundary.
+  def test_manager_does_not_restore_characteristic_keyed_completion_ownership
+    refute_includes @manager, "readCompletions"
+    refute_includes @manager, "writeCompletions"
+    assert_includes @manager, "operationScheduler(for:"
+    assert_includes @manager, "completeExpected("
+  end
+
+  def test_manager_does_not_restore_rssi_keepalive_or_fixed_reconnect_spin
+    refute_includes @manager, "startRssiKeepAlive"
+    refute_includes @manager, ".milliseconds(200)"
+    assert_includes @manager, "BleReconnectLifecycle"
+    assert_includes @manager, "nextReconnectDelay()"
+    assert_includes @manager, "deviceReady()"
+    assert_includes @scheduler, "BleReconnectBackoff.delay"
+  end
+
+  private
+
+  def source_phase(identifier)
+    match = @project.match(
+      /^\t\t#{identifier} \/\* Sources \*\/ = \{\n(?<body>.*?)^\t\t\};$/m
+    )
+    refute_nil match, "missing PBXSourcesBuildPhase #{identifier}"
+    match[:body]
+  end
+end

--- a/app/ios/test/run_ble_gatt_scheduler_tests.sh
+++ b/app/ios/test/run_ble_gatt_scheduler_tests.sh
@@ -17,6 +17,13 @@ fi
 
 "$build_dir/BleGattOperationSchedulerTests"
 
+"${swift_compiler[@]}" \
+  "$repo_root/app/ios/Runner/Ble/BleNotificationRouter.swift" \
+  "$repo_root/app/ios/test/BleNotificationRouterTests.swift" \
+  -o "$build_dir/BleNotificationRouterTests"
+
+"$build_dir/BleNotificationRouterTests"
+
 ruby "$repo_root/app/ios/test/ble_gatt_project_graph_test.rb"
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
@@ -35,6 +42,7 @@ if [[ "$(uname -s)" == "Darwin" ]] && flutter_bin="$(command -v flutter)"; then
     -target arm64-apple-ios15.0 \
     -F "$flutter_frameworks" \
     "$repo_root/app/ios/Runner/Ble/BleGattOperationScheduler.swift" \
+    "$repo_root/app/ios/Runner/Ble/BleNotificationRouter.swift" \
     "$repo_root/app/ios/Runner/PigeonCommunicator.g.swift" \
     "$repo_root/app/ios/Runner/Ble/OmiBleManager.swift" \
     "$repo_root/app/ios/test/BleManagerDependencyTypecheckStubs.swift"

--- a/app/ios/test/run_ble_gatt_scheduler_tests.sh
+++ b/app/ios/test/run_ble_gatt_scheduler_tests.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+build_dir="$(mktemp -d "${TMPDIR:-/tmp}/omi-ble-gatt-tests.XXXXXX")"
+trap 'rm -rf -- "$build_dir"' EXIT
+
+swift_compiler=(swiftc)
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  swift_compiler=(xcrun --sdk macosx swiftc)
+fi
+
+"${swift_compiler[@]}" \
+  "$repo_root/app/ios/Runner/Ble/BleGattOperationScheduler.swift" \
+  "$repo_root/app/ios/test/BleGattOperationSchedulerTests.swift" \
+  -o "$build_dir/BleGattOperationSchedulerTests"
+
+"$build_dir/BleGattOperationSchedulerTests"
+
+ruby "$repo_root/app/ios/test/ble_gatt_project_graph_test.rb"
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  xcodebuild -list -project "$repo_root/app/ios/Runner.xcodeproj" >/dev/null
+fi
+
+if [[ "$(uname -s)" == "Darwin" ]] && flutter_bin="$(command -v flutter)"; then
+  flutter_bin="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$flutter_bin")"
+  flutter_root="$(cd "$(dirname "$flutter_bin")/.." && pwd)"
+  ios_sdk="$(xcrun --sdk iphoneos --show-sdk-path)"
+  flutter_frameworks="$flutter_root/bin/cache/artifacts/engine/ios/Flutter.xcframework/ios-arm64"
+  xcrun swiftc \
+    -typecheck \
+    -parse-as-library \
+    -sdk "$ios_sdk" \
+    -target arm64-apple-ios15.0 \
+    -F "$flutter_frameworks" \
+    "$repo_root/app/ios/Runner/Ble/BleGattOperationScheduler.swift" \
+    "$repo_root/app/ios/Runner/PigeonCommunicator.g.swift" \
+    "$repo_root/app/ios/Runner/Ble/OmiBleManager.swift" \
+    "$repo_root/app/ios/test/BleManagerDependencyTypecheckStubs.swift"
+else
+  echo "Flutter SDK unavailable; skipped OmiBleManager iOS typecheck"
+fi

--- a/app/lib/pages/home/firmware_mixin.dart
+++ b/app/lib/pages/home/firmware_mixin.dart
@@ -21,6 +21,26 @@ import 'package:omi/utils/firmware_update_build_policy.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/manifest/manifest.dart';
 
+class FirmwareDfuConnectionHandoff {
+  FirmwareDfuConnectionHandoff({required this.releaseUpdater, required this.resumeDeviceConnection});
+
+  final Future<void> Function() releaseUpdater;
+  final Future<void> Function() resumeDeviceConnection;
+  Future<void>? _finishFuture;
+
+  bool get hasStarted => _finishFuture != null;
+
+  Future<void> finish() => _finishFuture ??= _finish();
+
+  Future<void> _finish() async {
+    try {
+      await releaseUpdater();
+    } finally {
+      await resumeDeviceConnection();
+    }
+  }
+}
+
 mixin FirmwareMixin<T extends StatefulWidget> on State<T> {
   FirmwareUpdateBuildPolicy get firmwareUpdatePolicy => FirmwareUpdateBuildPolicy.current;
 
@@ -36,6 +56,7 @@ mixin FirmwareMixin<T extends StatefulWidget> on State<T> {
   late final mcumgr.FirmwareUpdateManagerFactory? managerFactory =
       firmwareUpdatePolicy.allowsOmiFirmwareUpdate ? mcumgr.FirmwareUpdateManagerFactory() : null;
   mcumgr.FirmwareUpdateManager? _mcuUpdateManager;
+  FirmwareDfuConnectionHandoff? _activeMcuDfuHandoff;
 
   /// Process ZIP file and return firmware image list
   Future<List<mcumgr.Image>> processZipFile(Uint8List zipFileData) async {
@@ -103,69 +124,139 @@ mixin FirmwareMixin<T extends StatefulWidget> on State<T> {
     }
   }
 
+  Future<void> finishDfuSession() async {
+    final handoff = _activeMcuDfuHandoff;
+    if (handoff == null) {
+      await killMcuUpdateManager();
+      return;
+    }
+    await _finishMcuDfuHandoff(handoff);
+  }
+
+  Future<void> _finishMcuDfuHandoff(FirmwareDfuConnectionHandoff handoff) async {
+    try {
+      await handoff.finish();
+    } finally {
+      if (identical(_activeMcuDfuHandoff, handoff)) {
+        _activeMcuDfuHandoff = null;
+      }
+    }
+  }
+
+  Future<void> _completeMcuDfu(FirmwareDfuConnectionHandoff handoff, {required bool successful, Object? error}) async {
+    final isFirstTerminalEvent = !handoff.hasStarted;
+    final finishFuture = _finishMcuDfuHandoff(handoff);
+
+    if (isFirstTerminalEvent && mounted) {
+      setState(() {
+        isInstalling = false;
+        isInstalled = successful;
+      });
+    }
+    if (error != null) {
+      Logger.debug('MCU firmware update failed: $error');
+    }
+
+    try {
+      await finishFuture;
+    } catch (e) {
+      Logger.debug('Failed to restore device connection after MCU firmware update: $e');
+    }
+  }
+
+  Future<void> _completeLegacyDfu(DeviceProvider deviceProvider, {required bool successful, Object? error}) async {
+    if (mounted) {
+      setState(() {
+        isInstalling = false;
+        isInstalled = successful;
+      });
+    }
+    if (error != null) {
+      Logger.debug('Legacy firmware update failed: $error');
+    }
+    try {
+      await deviceProvider.resumeConnectionAfterDFU();
+    } catch (e) {
+      Logger.debug('Failed to restore device connection after legacy firmware update: $e');
+    }
+  }
+
   Future<void> startMCUDfu(BtDevice btDevice, {bool fileInAssets = false, String? zipFilePath}) async {
     if (!firmwareUpdatePolicy.allowsOmiFirmwareUpdate) {
       Logger.debug('MCU firmware updates are unavailable in the Ray-Ban DAT build');
       return;
     }
-    setState(() {
-      isInstalling = true;
-    });
-    await Provider.of<DeviceProvider>(context, listen: false).prepareDFU();
-    await Future.delayed(const Duration(seconds: 2));
-
     String firmwareFile = zipFilePath ?? '${(await getApplicationDocumentsDirectory()).path}/firmware.zip';
     final file = File(firmwareFile);
     if (!await file.exists()) {
       Logger.debug('Firmware file not found: $firmwareFile');
-      if (mounted) {
-        setState(() {
-          isInstalling = false;
-        });
-      }
       return;
     }
     final bytes = await file.readAsBytes();
+    final images = await processZipFile(bytes);
     const configuration = mcumgr.FirmwareUpgradeConfiguration(
       estimatedSwapTime: Duration(seconds: 0),
       eraseAppSettings: true,
       pipelineDepth: 1,
     );
 
-    await killMcuUpdateManager();
-    final updateManager = await managerFactory!.getUpdateManager(btDevice.id);
-    _mcuUpdateManager = updateManager;
-    final images = await processZipFile(bytes);
+    if (!mounted) return;
+    setState(() {
+      isInstalling = true;
+    });
+    final deviceProvider = Provider.of<DeviceProvider>(context, listen: false);
+    final handoff = FirmwareDfuConnectionHandoff(
+      releaseUpdater: killMcuUpdateManager,
+      resumeDeviceConnection: deviceProvider.resumeConnectionAfterDFU,
+    );
+    _activeMcuDfuHandoff = handoff;
 
-    final updateStream = updateManager.setup();
+    try {
+      await deviceProvider.prepareDFU();
+      await Future.delayed(const Duration(seconds: 2));
 
-    updateStream.listen((state) {
-      if (state == mcumgr.FirmwareUpgradeState.success) {
-        Logger.debug('update success');
-        killMcuUpdateManager();
+      await killMcuUpdateManager();
+      final updateManager = await managerFactory!.getUpdateManager(btDevice.id);
+      _mcuUpdateManager = updateManager;
+
+      final updateStream = updateManager.setup();
+
+      updateStream.listen(
+        (state) {
+          if (state == mcumgr.FirmwareUpgradeState.success) {
+            Logger.debug('update success');
+            unawaited(_completeMcuDfu(handoff, successful: true));
+          } else {
+            Logger.debug('update state: $state');
+          }
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          unawaited(_completeMcuDfu(handoff, successful: false, error: error));
+        },
+        onDone: () {
+          unawaited(_completeMcuDfu(handoff, successful: false));
+        },
+      );
+
+      updateManager.progressStream.listen((progress) {
+        Logger.debug('progress: $progress');
+        if (!mounted) return;
         setState(() {
-          isInstalling = false;
-          isInstalled = true;
+          installProgress = (progress.bytesSent / progress.imageSize * 100).round();
         });
-      } else {
-        Logger.debug('update state: $state');
-      }
-    });
-
-    updateManager.progressStream.listen((progress) {
-      Logger.debug('progress: $progress');
-      setState(() {
-        installProgress = (progress.bytesSent / progress.imageSize * 100).round();
       });
-    });
 
-    updateManager.logger.logMessageStream
-        .where((log) => log.level.rawValue > 1) // Filter debug messages
-        .listen((log) {
-      Logger.debug('dfu log: ${log.message}');
-    });
+      updateManager.logger.logMessageStream
+          .where((log) => log.level.rawValue > 1) // Filter debug messages
+          .listen((log) {
+        Logger.debug('dfu log: ${log.message}');
+      });
 
-    await updateManager.update(images, configuration: configuration);
+      await updateManager.update(images, configuration: configuration);
+    } catch (e) {
+      await _completeMcuDfu(handoff, successful: false, error: e);
+      rethrow;
+    }
   }
 
   Future<void> startLegacyDfu(BtDevice btDevice, {bool fileInAssets = false, String? zipFilePath}) async {
@@ -173,54 +264,65 @@ mixin FirmwareMixin<T extends StatefulWidget> on State<T> {
       Logger.debug('Legacy firmware updates are unavailable in the Ray-Ban DAT build');
       return;
     }
+    final deviceProvider = Provider.of<DeviceProvider>(context, listen: false);
+    final firmwareFile = zipFilePath ?? '${(await getApplicationDocumentsDirectory()).path}/firmware.zip';
+    if (!fileInAssets && !await File(firmwareFile).exists()) {
+      Logger.debug('Firmware file not found: $firmwareFile');
+      return;
+    }
+
     setState(() {
       isInstalling = true;
     });
-    await Provider.of<DeviceProvider>(context, listen: false).prepareDFU();
+    await deviceProvider.prepareDFU();
     await Future.delayed(const Duration(seconds: 2));
-    String firmwareFile = zipFilePath ?? '${(await getApplicationDocumentsDirectory()).path}/firmware.zip';
     NordicDfu dfu = NordicDfu();
-    await dfu.startDfu(
-      btDevice.id,
-      firmwareFile,
-      fileInAsset: fileInAssets,
-      numberOfPackets: 8,
-      enableUnsafeExperimentalButtonlessServiceInSecureDfu: true,
-      iosSpecialParameter: const IosSpecialParameter(
-        packetReceiptNotificationParameter: 8,
-        forceScanningForNewAddressInLegacyDfu: true,
-        connectionTimeout: 60,
-      ),
-      androidSpecialParameter: const AndroidSpecialParameter(packetReceiptNotificationsEnabled: true, rebootTime: 1000),
-      onProgressChanged: (deviceAddress, percent, speed, avgSpeed, currentPart, partsTotal) {
-        Logger.debug('deviceAddress: $deviceAddress, percent: $percent');
-        setState(() {
-          installProgress = percent.toInt();
-        });
-      },
-      onError: (deviceAddress, error, errorType, message) {
-        Logger.debug('deviceAddress: $deviceAddress, error: $error, errorType: $errorType, message: $message');
-        setState(() {
-          isInstalling = false;
-        });
-        // Reset firmware update state on error
-        final deviceProvider = Provider.of<DeviceProvider>(context, listen: false);
-        deviceProvider.resetFirmwareUpdateState();
-      },
-      onDeviceConnecting: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDeviceConnecting'),
-      onDeviceConnected: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDeviceConnected'),
-      onDfuProcessStarting: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDfuProcessStarting'),
-      onDfuProcessStarted: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDfuProcessStarted'),
-      onEnablingDfuMode: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onEnablingDfuMode'),
-      onFirmwareValidating: (deviceAddress) => Logger.debug('address: $deviceAddress, onFirmwareValidating'),
-      onDfuCompleted: (deviceAddress) {
-        Logger.debug('deviceAddress: $deviceAddress, onDfuCompleted');
-        setState(() {
-          isInstalling = false;
-          isInstalled = true;
-        });
-      },
-    );
+    try {
+      await dfu.startDfu(
+        btDevice.id,
+        firmwareFile,
+        fileInAsset: fileInAssets,
+        numberOfPackets: 8,
+        enableUnsafeExperimentalButtonlessServiceInSecureDfu: true,
+        iosSpecialParameter: const IosSpecialParameter(
+          packetReceiptNotificationParameter: 8,
+          forceScanningForNewAddressInLegacyDfu: true,
+          connectionTimeout: 60,
+        ),
+        androidSpecialParameter: const AndroidSpecialParameter(
+          packetReceiptNotificationsEnabled: true,
+          rebootTime: 1000,
+        ),
+        onProgressChanged: (deviceAddress, percent, speed, avgSpeed, currentPart, partsTotal) {
+          Logger.debug('deviceAddress: $deviceAddress, percent: $percent');
+          if (!mounted) return;
+          setState(() {
+            installProgress = percent.toInt();
+          });
+        },
+        onError: (deviceAddress, error, errorType, message) {
+          Logger.debug('deviceAddress: $deviceAddress, error: $error, errorType: $errorType, message: $message');
+          unawaited(_completeLegacyDfu(deviceProvider, successful: false, error: message));
+        },
+        onDfuAborted: (deviceAddress) {
+          Logger.debug('deviceAddress: $deviceAddress, onDfuAborted');
+          unawaited(_completeLegacyDfu(deviceProvider, successful: false));
+        },
+        onDeviceConnecting: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDeviceConnecting'),
+        onDeviceConnected: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDeviceConnected'),
+        onDfuProcessStarting: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDfuProcessStarting'),
+        onDfuProcessStarted: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDfuProcessStarted'),
+        onEnablingDfuMode: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onEnablingDfuMode'),
+        onFirmwareValidating: (deviceAddress) => Logger.debug('address: $deviceAddress, onFirmwareValidating'),
+        onDfuCompleted: (deviceAddress) {
+          Logger.debug('deviceAddress: $deviceAddress, onDfuCompleted');
+          unawaited(_completeLegacyDfu(deviceProvider, successful: true));
+        },
+      );
+    } catch (e) {
+      await _completeLegacyDfu(deviceProvider, successful: false, error: e);
+      rethrow;
+    }
   }
 
   Future getLatestVersion({

--- a/app/lib/pages/home/firmware_update.dart
+++ b/app/lib/pages/home/firmware_update.dart
@@ -79,7 +79,7 @@ class _FirmwareUpdateState extends State<FirmwareUpdate> with FirmwareMixin {
 
   @override
   void dispose() {
-    killMcuUpdateManager();
+    finishDfuSession();
     final provider = _deviceProvider;
     if (provider != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -1790,7 +1790,7 @@ class _ManualFirmwareFlashPageState extends State<_ManualFirmwareFlashPage> with
 
   @override
   void dispose() {
-    killMcuUpdateManager();
+    finishDfuSession();
     super.dispose();
   }
 

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -80,12 +80,13 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   Timer? _discoveryTimer;
   final Debouncer _disconnectDebouncer = Debouncer(delay: const Duration(milliseconds: 500));
   final Debouncer _connectDebouncer = Debouncer(delay: const Duration(milliseconds: 100));
+  final DeviceService _deviceService;
 
   void Function(BtDevice device)? onDeviceConnected;
   void Function(BtDevice device, int fileCount, int totalBytes)? onOfflineDataDetected;
 
-  DeviceProvider() {
-    ServiceManager.instance().device.subscribe(this, this);
+  DeviceProvider({DeviceService? deviceService}) : _deviceService = deviceService ?? ServiceManager.instance().device {
+    _deviceService.subscribe(this, this);
   }
 
   void setProviders(CaptureProvider provider, LocalRecordingsProvider recordingsProvider) {
@@ -119,10 +120,6 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       }
     }
     notifyListeners();
-  }
-
-  Future _bleDisconnectDevice(BtDevice btDevice) async {
-    await ServiceManager.instance().device.disconnectDevice();
   }
 
   Future<int> _retrieveBatteryLevel(String deviceId) async {
@@ -373,7 +370,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     _discoveryTimer?.cancel();
     _disconnectDebouncer.cancel();
     _connectDebouncer.cancel();
-    ServiceManager.instance().device.unsubscribe(this);
+    _deviceService.unsubscribe(this);
     super.dispose();
   }
 
@@ -794,12 +791,26 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   @override
   void onStatusChanged(DeviceServiceStatus status) {}
 
-  prepareDFU() {
+  Future<void> prepareDFU() async {
     if (!FirmwareUpdateBuildPolicy.current.allowsOmiFirmwareUpdate || connectedDevice == null) {
       return;
     }
+    final deviceId = connectedDevice!.id;
     setFirmwareUpdateInProgress(true);
-    _bleDisconnectDevice(connectedDevice!);
+    try {
+      await _deviceService.suspendConnectionForDfu(deviceId);
+    } catch (_) {
+      resetFirmwareUpdateState();
+      rethrow;
+    }
+  }
+
+  Future<void> resumeConnectionAfterDFU() async {
+    try {
+      await _deviceService.resumeConnectionAfterDfu();
+    } finally {
+      resetFirmwareUpdateState();
+    }
   }
 
   // Reset firmware update state when update completes or fails

--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -35,10 +35,7 @@ class OmiFeatures {
 abstract class IDeviceServiceSubsciption {
   void onDevices(List<BtDevice> devices);
   void onStatusChanged(DeviceServiceStatus status);
-  void onDeviceConnectionStateChanged(
-    String deviceId,
-    DeviceConnectionState state,
-  );
+  void onDeviceConnectionStateChanged(String deviceId, DeviceConnectionState state);
 }
 
 class DeviceService {
@@ -54,6 +51,9 @@ class DeviceService {
   final Map<Object, IDeviceServiceSubsciption> _subscriptions = {};
 
   DeviceConnection? _connection;
+  String? _dfuSuspendedDeviceId;
+  Future<void>? _dfuSuspendFuture;
+  Future<void>? _dfuResumeFuture;
   List<BtDevice> get devices => _devices;
 
   DeviceServiceStatus get status => _status;
@@ -114,16 +114,12 @@ class DeviceService {
     _connection = null;
 
     var device = _devices.firstWhereOrNull((f) => f.id == id);
-    Logger.debug(
-      '[DeviceService] device lookup result: ${device?.name ?? "NULL"} (locator: ${device?.locator?.kind})',
-    );
+    Logger.debug('[DeviceService] device lookup result: ${device?.name ?? "NULL"} (locator: ${device?.locator?.kind})');
 
     // If device not in discovered list, try to get it from SharedPreferences
     // This allows background reconnection without scanning
     if (device == null) {
-      Logger.debug(
-        '[DeviceService] Device not in discovered list, checking stored device',
-      );
+      Logger.debug('[DeviceService] Device not in discovered list, checking stored device');
       device = _getStoredDevice(id);
       if (device != null) {
         Logger.debug('[DeviceService] Using stored device: ${device.name}');
@@ -131,22 +127,16 @@ class DeviceService {
           _devices.add(device);
         }
       } else {
-        Logger.debug(
-          '[DeviceService] No stored device available for $id, returning',
-        );
+        Logger.debug('[DeviceService] No stored device available for $id, returning');
         return;
       }
     }
 
     _connection = DeviceConnectionFactory.create(device);
     if (_connection != null) {
-      await _connection!.connect(
-        onConnectionStateChanged: onDeviceConnectionStateChanged,
-      );
+      await _connection!.connect(onConnectionStateChanged: onDeviceConnectionStateChanged);
     } else {
-      Logger.debug(
-        '[DeviceService] Failed to create device connection for ${device.id}',
-      );
+      Logger.debug('[DeviceService] Failed to create device connection for ${device.id}');
     }
   }
 
@@ -188,15 +178,9 @@ class DeviceService {
     }
   }
 
-  void onDeviceConnectionStateChanged(
-    String deviceId,
-    DeviceConnectionState state,
-  ) {
+  void onDeviceConnectionStateChanged(String deviceId, DeviceConnectionState state) {
     Logger.debug("device connection state changed...$deviceId...$state");
-    DebugLogManager.logEvent('device_connection_state', {
-      'device_id': deviceId,
-      'state': state.name,
-    });
+    DebugLogManager.logEvent('device_connection_state', {'device_id': deviceId, 'state': state.name});
     for (var s in _subscriptions.values) {
       s.onDeviceConnectionStateChanged(deviceId, state);
     }
@@ -210,15 +194,10 @@ class DeviceService {
 
   final Mutex _mutex = Mutex();
 
-  Future<DeviceConnection?> ensureConnection(
-    String deviceId, {
-    bool force = false,
-  }) async {
+  Future<DeviceConnection?> ensureConnection(String deviceId, {bool force = false}) async {
     await _mutex.acquire();
     try {
-      Logger.debug(
-        "ensureConnection ${_connection?.device.id} ${_connection?.status} $force",
-      );
+      Logger.debug("ensureConnection ${_connection?.device.id} ${_connection?.status} $force");
 
       // Connected to this device — return it
       if (_connection?.device.id == deviceId && _connection?.status == DeviceConnectionState.connected) {
@@ -274,6 +253,63 @@ class DeviceService {
     }
   }
 
+  /// Temporarily relinquishes the normal app BLE connection so a DFU plugin
+  /// can own the peripheral. The matching resume call must use the captured
+  /// device ID because the normal disconnect path clears provider state.
+  Future<void> suspendConnectionForDfu(String deviceId) {
+    if (_dfuSuspendedDeviceId != null) {
+      if (_dfuSuspendedDeviceId != deviceId) {
+        throw StateError('A different device is already suspended for DFU');
+      }
+      return _dfuSuspendFuture ?? Future.value();
+    }
+
+    _dfuSuspendedDeviceId = deviceId;
+    final suspendFuture = _suspendConnectionForDfu();
+    _dfuSuspendFuture = suspendFuture;
+    return suspendFuture;
+  }
+
+  Future<void> _suspendConnectionForDfu() async {
+    try {
+      await disconnectDevice();
+    } catch (_) {
+      _dfuSuspendedDeviceId = null;
+      rethrow;
+    } finally {
+      _dfuSuspendFuture = null;
+    }
+  }
+
+  /// Reclaims normal BLE ownership after any terminal DFU outcome.
+  ///
+  /// Concurrent or repeated terminal callbacks share one reconnect attempt.
+  Future<void> resumeConnectionAfterDfu() {
+    final inFlight = _dfuResumeFuture;
+    if (inFlight != null) return inFlight;
+
+    final deviceId = _dfuSuspendedDeviceId;
+    if (deviceId == null) return Future.value();
+
+    final resumeFuture = _resumeConnectionAfterDfu(deviceId);
+    _dfuResumeFuture = resumeFuture;
+    return resumeFuture;
+  }
+
+  Future<void> _resumeConnectionAfterDfu(String deviceId) async {
+    try {
+      final suspendFuture = _dfuSuspendFuture;
+      if (suspendFuture != null) {
+        await suspendFuture;
+      }
+      if (_dfuSuspendedDeviceId != deviceId) return;
+      await ensureConnection(deviceId, force: true);
+    } finally {
+      _dfuSuspendedDeviceId = null;
+      _dfuResumeFuture = null;
+    }
+  }
+
   Future<void> forgetDevice(String deviceId) async {
     Logger.debug("DeviceService: Forgetting device $deviceId");
     if (_connection != null) {
@@ -288,9 +324,7 @@ class DeviceService {
       try {
         await _connection!.transport.dispose();
       } catch (e) {
-        Logger.debug(
-          "DeviceService: transport dispose during forget failed: $e",
-        );
+        Logger.debug("DeviceService: transport dispose during forget failed: $e");
       }
       _connection = null;
     }

--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -39,6 +39,16 @@ abstract class IDeviceServiceSubsciption {
 }
 
 class DeviceService {
+  DeviceService({
+    List<Duration> dfuReconnectBackoff = const [
+      Duration.zero,
+      Duration(milliseconds: 250),
+      Duration(seconds: 1),
+      Duration(seconds: 2),
+      Duration(seconds: 4),
+    ],
+  }) : _dfuReconnectBackoff = List.unmodifiable(dfuReconnectBackoff);
+
   DeviceServiceStatus _status = DeviceServiceStatus.init;
   List<BtDevice> _devices = [];
 
@@ -54,6 +64,7 @@ class DeviceService {
   String? _dfuSuspendedDeviceId;
   Future<void>? _dfuSuspendFuture;
   Future<void>? _dfuResumeFuture;
+  final List<Duration> _dfuReconnectBackoff;
   List<BtDevice> get devices => _devices;
 
   DeviceServiceStatus get status => _status;
@@ -303,15 +314,40 @@ class DeviceService {
         await suspendFuture;
       }
       if (_dfuSuspendedDeviceId != deviceId) return;
-      await ensureConnection(deviceId, force: true);
+
+      if (_dfuReconnectBackoff.isEmpty) {
+        throw StateError('No DFU reconnect backoff configured');
+      }
+
+      var attempt = 0;
+      while (_dfuSuspendedDeviceId == deviceId) {
+        final backoffIndex = attempt < _dfuReconnectBackoff.length ? attempt : _dfuReconnectBackoff.length - 1;
+        final delay = _dfuReconnectBackoff[backoffIndex];
+        attempt++;
+        if (_dfuSuspendedDeviceId != deviceId) return;
+        if (delay > Duration.zero) await Future<void>.delayed(delay);
+        if (_dfuSuspendedDeviceId != deviceId) return;
+
+        try {
+          final connection = await ensureConnection(deviceId, force: true);
+          if (connection != null) {
+            _dfuSuspendedDeviceId = null;
+            return;
+          }
+        } catch (error) {
+          Logger.debug('DeviceService: DFU reconnect attempt $attempt failed for $deviceId: $error');
+        }
+      }
     } finally {
-      _dfuSuspendedDeviceId = null;
       _dfuResumeFuture = null;
     }
   }
 
   Future<void> forgetDevice(String deviceId) async {
     Logger.debug("DeviceService: Forgetting device $deviceId");
+    if (_dfuSuspendedDeviceId == deviceId) {
+      _dfuSuspendedDeviceId = null;
+    }
     if (_connection != null) {
       if (_connection!.status == DeviceConnectionState.connected) {
         try {

--- a/app/test/providers/device_provider_test.dart
+++ b/app/test/providers/device_provider_test.dart
@@ -1,8 +1,13 @@
+import 'dart:async';
+
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/providers/device_provider.dart';
+import 'package:omi/services/devices.dart';
+import 'package:omi/services/devices/connectors/device_connection.dart';
 import 'package:omi/services/services.dart';
 
 class _TestConnectivityPlatform extends ConnectivityPlatform {
@@ -228,4 +233,88 @@ void main() {
       expect(flag2, true, reason: 'Exactly 20% should not reset flag (needs > 20)');
     });
   });
+
+  group('DFU connection ownership', () {
+    late _DfuTestDeviceService deviceService;
+    late DeviceProvider provider;
+
+    setUp(() {
+      deviceService = _DfuTestDeviceService();
+      provider = DeviceProvider(deviceService: deviceService)
+        ..connectedDevice = BtDevice(name: 'Omi', id: 'device-123', type: DeviceType.omi, rssi: -40);
+    });
+
+    tearDown(() {
+      provider.dispose();
+    });
+
+    test('awaits disconnect then force-reconnects the same device exactly once', () async {
+      final disconnectGate = Completer<void>();
+      final reconnectGate = Completer<void>();
+      deviceService
+        ..disconnectGate = disconnectGate
+        ..reconnectGate = reconnectGate;
+
+      var prepareCompleted = false;
+      final prepareFuture = provider.prepareDFU().then((_) => prepareCompleted = true);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(deviceService.events, ['disconnect']);
+      expect(prepareCompleted, isFalse);
+      expect(provider.isFirmwareUpdateInProgress, isTrue);
+
+      disconnectGate.complete();
+      await prepareFuture;
+
+      final firstResume = provider.resumeConnectionAfterDFU();
+      final duplicateResume = provider.resumeConnectionAfterDFU();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(deviceService.events, ['disconnect', 'reconnect:device-123:true']);
+      expect(provider.isFirmwareUpdateInProgress, isTrue);
+
+      reconnectGate.complete();
+      await Future.wait([firstResume, duplicateResume]);
+      expect(provider.isFirmwareUpdateInProgress, isFalse);
+
+      await provider.resumeConnectionAfterDFU();
+      expect(deviceService.events, ['disconnect', 'reconnect:device-123:true']);
+    });
+
+    test('failed disconnect releases the lease and clears firmware-update state', () async {
+      deviceService.disconnectError = StateError('disconnect failed');
+
+      await expectLater(provider.prepareDFU(), throwsStateError);
+      expect(provider.isFirmwareUpdateInProgress, isFalse);
+
+      deviceService.disconnectError = null;
+      await provider.prepareDFU();
+      await provider.resumeConnectionAfterDFU();
+
+      expect(deviceService.events, ['disconnect', 'disconnect', 'reconnect:device-123:true']);
+      expect(provider.isFirmwareUpdateInProgress, isFalse);
+    });
+  });
+}
+
+class _DfuTestDeviceService extends DeviceService {
+  final List<String> events = [];
+  Completer<void>? disconnectGate;
+  Completer<void>? reconnectGate;
+  Object? disconnectError;
+
+  @override
+  Future<void> disconnectDevice() async {
+    events.add('disconnect');
+    final error = disconnectError;
+    if (error != null) throw error;
+    await disconnectGate?.future;
+  }
+
+  @override
+  Future<DeviceConnection?> ensureConnection(String deviceId, {bool force = false}) async {
+    events.add('reconnect:$deviceId:$force');
+    await reconnectGate?.future;
+    return null;
+  }
 }

--- a/app/test/providers/device_provider_test.dart
+++ b/app/test/providers/device_provider_test.dart
@@ -248,12 +248,15 @@ void main() {
       provider.dispose();
     });
 
-    test('awaits disconnect then force-reconnects the same device exactly once', () async {
+    test('retries null and thrown reconnects while coalescing terminal callbacks', () async {
       final disconnectGate = Completer<void>();
-      final reconnectGate = Completer<void>();
       deviceService
         ..disconnectGate = disconnectGate
-        ..reconnectGate = reconnectGate;
+        ..reconnectResults = [
+          null,
+          StateError('transient reconnect failure'),
+          _DfuTestDeviceConnection(),
+        ];
 
       var prepareCompleted = false;
       final prepareFuture = provider.prepareDFU().then((_) => prepareCompleted = true);
@@ -268,17 +271,57 @@ void main() {
 
       final firstResume = provider.resumeConnectionAfterDFU();
       final duplicateResume = provider.resumeConnectionAfterDFU();
-      await Future<void>.delayed(Duration.zero);
-
-      expect(deviceService.events, ['disconnect', 'reconnect:device-123:true']);
-      expect(provider.isFirmwareUpdateInProgress, isTrue);
-
-      reconnectGate.complete();
       await Future.wait([firstResume, duplicateResume]);
+
+      expect(deviceService.events, [
+        'disconnect',
+        'reconnect:device-123:true',
+        'reconnect:device-123:true',
+        'reconnect:device-123:true',
+      ]);
       expect(provider.isFirmwareUpdateInProgress, isFalse);
 
       await provider.resumeConnectionAfterDFU();
-      expect(deviceService.events, ['disconnect', 'reconnect:device-123:true']);
+      expect(deviceService.events, [
+        'disconnect',
+        'reconnect:device-123:true',
+        'reconnect:device-123:true',
+        'reconnect:device-123:true',
+      ]);
+    });
+
+    test('keeps retrying at the bounded backoff cap until reclaim succeeds', () async {
+      deviceService.reconnectResults = [null, null, null, null, _DfuTestDeviceConnection()];
+      await provider.prepareDFU();
+
+      await provider.resumeConnectionAfterDFU();
+
+      expect(deviceService.events, [
+        'disconnect',
+        'reconnect:device-123:true',
+        'reconnect:device-123:true',
+        'reconnect:device-123:true',
+        'reconnect:device-123:true',
+        'reconnect:device-123:true',
+      ]);
+    });
+
+    test('forgetting the suspended device deliberately abandons reconnect', () async {
+      final reconnectGate = Completer<void>();
+      deviceService
+        ..reconnectGate = reconnectGate
+        ..reconnectResults = [null];
+      await provider.prepareDFU();
+
+      final resumeFuture = provider.resumeConnectionAfterDFU();
+      await Future<void>.delayed(Duration.zero);
+      await deviceService.forgetDevice('device-123');
+      reconnectGate.complete();
+      await resumeFuture;
+
+      await provider.resumeConnectionAfterDFU();
+      expect(deviceService.events.first, 'disconnect');
+      expect(deviceService.events.where((event) => event.startsWith('reconnect:')), isNotEmpty);
     });
 
     test('failed disconnect releases the lease and clears firmware-update state', () async {
@@ -298,9 +341,12 @@ void main() {
 }
 
 class _DfuTestDeviceService extends DeviceService {
+  _DfuTestDeviceService() : super(dfuReconnectBackoff: const [Duration.zero, Duration.zero, Duration.zero]);
+
   final List<String> events = [];
   Completer<void>? disconnectGate;
   Completer<void>? reconnectGate;
+  List<Object?> reconnectResults = [_DfuTestDeviceConnection()];
   Object? disconnectError;
 
   @override
@@ -315,6 +361,14 @@ class _DfuTestDeviceService extends DeviceService {
   Future<DeviceConnection?> ensureConnection(String deviceId, {bool force = false}) async {
     events.add('reconnect:$deviceId:$force');
     await reconnectGate?.future;
-    return null;
+    if (reconnectResults.isEmpty) return null;
+    final result = reconnectResults.removeAt(0);
+    if (result is Object && result is! DeviceConnection) throw result;
+    return result as DeviceConnection?;
   }
+}
+
+class _DfuTestDeviceConnection implements DeviceConnection {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/app/test/unit/firmware_dfu_connection_handoff_test.dart
+++ b/app/test/unit/firmware_dfu_connection_handoff_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/pages/home/firmware_mixin.dart';
+
+void main() {
+  test('DFU handoff releases updater before resuming the device exactly once', () async {
+    final events = <String>[];
+    final handoff = FirmwareDfuConnectionHandoff(
+      releaseUpdater: () async => events.add('release updater'),
+      resumeDeviceConnection: () async => events.add('resume device'),
+    );
+
+    await Future.wait([handoff.finish(), handoff.finish()]);
+    await handoff.finish();
+
+    expect(events, ['release updater', 'resume device']);
+  });
+
+  test('DFU handoff still resumes the device when updater release fails', () async {
+    final events = <String>[];
+    final handoff = FirmwareDfuConnectionHandoff(
+      releaseUpdater: () async {
+        events.add('release updater');
+        throw StateError('release failed');
+      },
+      resumeDeviceConnection: () async => events.add('resume device'),
+    );
+
+    await expectLater(handoff.finish(), throwsStateError);
+
+    expect(events, ['release updater', 'resume device']);
+  });
+}


### PR DESCRIPTION
## Summary

- serialize CoreBluetooth GATT work and reject stale completions from previous sessions
- coalesce notification transitions and route high-rate Omi audio / Limitless flash data through native handlers
- remove RSSI polling as a keepalive while preserving diagnostics-on-demand
- make DFU handoff idempotent and reconnect the exact suspended pendant on every terminal path
- retain the post-DFU reconnect lease across transient nulls and exceptions, retrying with capped backoff until ownership is reclaimed or the device is forgotten
- treat restored peripherals as reconnect-eligible and reissue the first unexpected-disconnect connection request synchronously

## Root cause

The old iOS path could overlap discovery, subscription, writes, and reconnect work. High-rate notifications crossed avoidable Dart/UserDefaults routing, and DFU relinquished BLE ownership without a guaranteed exact-device reclaim.

Three reconnect gaps were present:

1. a CoreBluetooth-restored peripheral was not eligible for the foreground/powered-on reconnect sweep until a fresh `didConnect`;
2. the first unexpected-disconnect retry waited 500 ms on the app queue, which iOS can suspend before the work item runs;
3. the Dart DFU handoff cleared its only suspended-device lease after a transient forced reconnect returned null or threw, so later terminal callbacks became no-ops.

The reconnect policy registers a system-owned pending `connect` synchronously after an ordinary unexpected link drop. Actual failed connection attempts still use bounded exponential backoff. The Dart DFU handoff now keeps one coalesced reclaim operation alive with capped backoff until `ensureConnection` returns ownership; explicitly forgetting the device deliberately abandons the lease.

## Physical validation

Validated on an iPhone 12 Pro Max running iOS 26.5 and one CV1:

- full dual-core CV1 OTA completed from iOS in about 13 seconds; the exact UUID was reclaimed without re-pairing
- foreground reconnect restored usable audio in about 3 seconds
- Bluetooth-off audio recovered into contiguous immutable ranges `961737..962057..962058`
- the recovered files contained 1,335 structurally valid Opus frames / 26.70 seconds with no source-sequence gap or overlap
- pendant storage advanced from 187 KB to 0 B only after the local WAL manifest and files were durable
- live audio resumed after recovery; markers `Jade 572` (background) and `Pearl 641` (final candidate) appeared in transcription
- app reinstall preserved auth and all 731 existing WAL records

### iOS 26 hard-toggle boundary

A Settings Bluetooth power toggle is not equivalent to an ordinary RF/link drop. One background cycle reconnected in 2 seconds, but a repeat with Omi already suspended remained disconnected for 34 seconds until Omi was foregrounded. Foregrounding then recovered immediately, drained the durable backlog, and resumed live audio.

Apple documents that iOS 26 restoration after user Bluetooth toggles is conditional and that Settings power toggles may not relaunch an app. This PR therefore improves the app-controlled reconnect paths without claiming that it can override that OS policy. The firmware/app durability boundary preserves the missing interval for later backfill.

## Validation

- `flutter test --no-pub test/providers/device_provider_test.dart` — 18 passed, including null/throw-then-success, concurrent terminal callback coalescing, capped-backoff continuation, and explicit forget cancellation
- `bash app/ios/test/run_ble_gatt_scheduler_tests.sh` — passed
- `make preflight` / pre-push manifest — 64 selected checks passed
- Flutter generated-output hook deliberately skipped with `PRE_PUSH_SKIP_FLUTTER_GENERATED=1`: the shared Flutter installation reported SDK version `0.0.0-unknown`; full Flutter analyzer/tests and platform compiles remain CI-authoritative

Failure-Class: none
