### PR TITLE
fix(ci): make pre-push portable on Windows

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -49,6 +49,11 @@ checks:
     triggers: [".github/workflows/desktop_qualify_beta.yml", ".github/scripts/check-release-process-guards.py", "scripts/run-release-process-guards.sh", "backend/tests/unit/test_desktop_release_scripts.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-174: qualification must check out the exact release tag inside its isolated source directory; the guard and its focused behavioral test run on every relevant diff"
+  - id: preflight-runner-portability
+    command: ["python3", ".github/scripts/test_preflight_runner.py"]
+    triggers: [".github/scripts/preflight_runner.py", ".github/scripts/test_preflight_runner.py", ".github/scripts/run_checks.py", ".github/scripts/test_run_checks.py", "scripts/pre-push-singleflight", "scripts/pre-push", "scripts/pr-preflight", ".github/workflows/windows-preflight-portability.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the single-flight pre-push gate must manage child processes and launch Bash checks on native Windows and POSIX hosts"
   - id: failure-class-retirement-author
     command: ["python3", ".github/scripts/test_failure_class_retirement.py"]
     triggers: [".github/scripts/failure_class_retirement.py", ".github/scripts/test_failure_class_retirement.py", ".github/workflows/repo-hygiene.yml", "scripts/failure-class", ".github/checks-manifest.yaml"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -51,7 +51,7 @@ checks:
     reason: "SCA-174: qualification must check out the exact release tag inside its isolated source directory; the guard and its focused behavioral test run on every relevant diff"
   - id: preflight-runner-portability
     command: ["python3", ".github/scripts/test_preflight_runner.py"]
-    triggers: [".github/scripts/preflight_runner.py", ".github/scripts/test_preflight_runner.py", ".github/scripts/run_checks.py", ".github/scripts/test_run_checks.py", "scripts/pre-push-singleflight", "scripts/pre-push", "scripts/pr-preflight", ".github/workflows/windows-preflight-portability.yml", ".github/checks-manifest.yaml"]
+    triggers: [".github/scripts/preflight_runner.py", ".github/scripts/pr_preflight.py", ".github/scripts/test_preflight_runner.py", ".github/scripts/run_checks.py", ".github/scripts/test_run_checks.py", "scripts/pre-push-singleflight", "scripts/pre-push", "scripts/pr-preflight", ".github/workflows/windows-preflight-portability.yml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "the single-flight pre-push gate must manage child processes and launch Bash checks on native Windows and POSIX hosts"
   - id: failure-class-retirement-author

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -49,6 +49,11 @@ checks:
     triggers: [".github/workflows/desktop_qualify_beta.yml", ".github/scripts/check-release-process-guards.py", "scripts/run-release-process-guards.sh", "backend/tests/unit/test_desktop_release_scripts.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-174: qualification must check out the exact release tag inside its isolated source directory; the guard and its focused behavioral test run on every relevant diff"
+  - id: pre-push-worktree-fallback
+    command: ["bash", "scripts/test-pre-push-worktree-fallback.sh"]
+    triggers: ["scripts/pre-push", "scripts/pre-push-singleflight", "scripts/pr-preflight", ".github/scripts/preflight_runner.py", ".github/scripts/pr_preflight.py", "scripts/test-pre-push-worktree-fallback.sh", ".github/workflows/windows-preflight-portability.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#10293: the pre-push hook chain must resolve the repo root in linked worktrees where git rev-parse --show-toplevel exits 128, not abort into a --no-verify push"
   - id: preflight-runner-portability
     command: ["python3", ".github/scripts/test_preflight_runner.py"]
     triggers: [".github/scripts/preflight_runner.py", ".github/scripts/pr_preflight.py", ".github/scripts/test_preflight_runner.py", ".github/scripts/run_checks.py", ".github/scripts/test_run_checks.py", "scripts/pre-push-singleflight", "scripts/pre-push", "scripts/pr-preflight", ".github/workflows/windows-preflight-portability.yml", ".github/checks-manifest.yaml"]

--- a/.github/scripts/pr_preflight.py
+++ b/.github/scripts/pr_preflight.py
@@ -23,6 +23,18 @@ class Check:
     reason: str
 
 
+def _resolve_repo_root() -> Path:
+    # The pre-push gate cd's to the repo root before invoking this script, and
+    # git runs hooks at the work-tree top, so fall back to the working directory
+    # when `git rev-parse --show-toplevel` cannot resolve a work tree: a linked
+    # worktree whose git context resolves to a git dir exits 128 here ("this
+    # operation must be run in a work tree") and would otherwise abort the gate.
+    try:
+        return Path(run_git(Path.cwd(), "rev-parse", "--show-toplevel"))
+    except subprocess.CalledProcessError:
+        return Path.cwd()
+
+
 def run_git(root: Path, *args: str) -> str:
     result = subprocess.run(
         ["git", *args],
@@ -161,7 +173,7 @@ def main() -> int:
     if bool(args.repository) != bool(args.pr_number):
         print("FAIL: --repository and --pr-number must be supplied together", file=sys.stderr)
         return 2
-    root = (args.root or Path(run_git(Path.cwd(), "rev-parse", "--show-toplevel"))).resolve()
+    root = (args.root or _resolve_repo_root()).resolve()
     started = time.monotonic()
     try:
         merge_base = run_git(root, "merge-base", args.base, args.head)

--- a/.github/scripts/pr_preflight.py
+++ b/.github/scripts/pr_preflight.py
@@ -31,6 +31,7 @@ def run_git(root: Path, *args: str) -> str:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        encoding="utf-8",
     )
     return result.stdout.strip()
 
@@ -254,6 +255,7 @@ def main() -> int:
                 check=False,
                 stdout=subprocess.PIPE,
                 text=True,
+                encoding="utf-8",
             ).stdout.strip()
         skip_changelog = (
             "no-changelog-needed" in labels

--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ctypes
 import hashlib
 import json
 import os
@@ -16,35 +17,180 @@ from pathlib import Path
 
 POLL_SECONDS = 0.2
 STATUS_INTERVAL_SECONDS = 5.0
+OWNED_SIGNAL_NAMES = ("SIGINT", "SIGTERM", "SIGHUP", "SIGBREAK")
+IS_WINDOWS = os.name == "nt"
+HAS_PROCESS_GROUPS = os.name != "nt" and hasattr(os, "killpg")
+WINDOWS_STILL_ACTIVE = 259
+WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+WINDOWS_PROCESS_SET_QUOTA = 0x0100
+WINDOWS_PROCESS_TERMINATE = 0x0001
+WINDOWS_ERROR_ACCESS_DENIED = 5
+WINDOWS_JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9
+WINDOWS_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+WINDOWS_CHILD_BOOTSTRAP_FLAG = "--windows-child-bootstrap"
 
-# Signals forwarded to the owned child. SIGHUP is POSIX-only and is simply absent
-# on Windows, so the set is resolved against the host rather than assumed —
-# referencing signal.SIGHUP unconditionally raised AttributeError before any
-# pre-push check could run.
-FORWARDED_SIGNAL_NAMES = ("SIGINT", "SIGTERM", "SIGHUP")
+
+class WindowsJob:
+    """Own a Windows process tree and terminate it when the job closes."""
+
+    def __init__(self) -> None:
+        if not IS_WINDOWS:
+            raise RuntimeError("Windows jobs are only available on Windows")
+
+        from ctypes import wintypes
+
+        class BasicLimitInformation(ctypes.Structure):
+            _fields_ = [
+                ("PerProcessUserTimeLimit", ctypes.c_int64),
+                ("PerJobUserTimeLimit", ctypes.c_int64),
+                ("LimitFlags", wintypes.DWORD),
+                ("MinimumWorkingSetSize", ctypes.c_size_t),
+                ("MaximumWorkingSetSize", ctypes.c_size_t),
+                ("ActiveProcessLimit", wintypes.DWORD),
+                ("Affinity", ctypes.c_size_t),
+                ("PriorityClass", wintypes.DWORD),
+                ("SchedulingClass", wintypes.DWORD),
+            ]
+
+        class IoCounters(ctypes.Structure):
+            _fields_ = [
+                ("ReadOperationCount", ctypes.c_uint64),
+                ("WriteOperationCount", ctypes.c_uint64),
+                ("OtherOperationCount", ctypes.c_uint64),
+                ("ReadTransferCount", ctypes.c_uint64),
+                ("WriteTransferCount", ctypes.c_uint64),
+                ("OtherTransferCount", ctypes.c_uint64),
+            ]
+
+        class ExtendedLimitInformation(ctypes.Structure):
+            _fields_ = [
+                ("BasicLimitInformation", BasicLimitInformation),
+                ("IoInfo", IoCounters),
+                ("ProcessMemoryLimit", ctypes.c_size_t),
+                ("JobMemoryLimit", ctypes.c_size_t),
+                ("PeakProcessMemoryUsed", ctypes.c_size_t),
+                ("PeakJobMemoryUsed", ctypes.c_size_t),
+            ]
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        create_job = kernel32.CreateJobObjectW
+        create_job.argtypes = [ctypes.c_void_p, wintypes.LPCWSTR]
+        create_job.restype = wintypes.HANDLE
+        set_information = kernel32.SetInformationJobObject
+        set_information.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            wintypes.DWORD,
+        ]
+        set_information.restype = wintypes.BOOL
+        self._open_process = kernel32.OpenProcess
+        self._open_process.argtypes = [
+            wintypes.DWORD,
+            wintypes.BOOL,
+            wintypes.DWORD,
+        ]
+        self._open_process.restype = wintypes.HANDLE
+        self._assign_process = kernel32.AssignProcessToJobObject
+        self._assign_process.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+        self._assign_process.restype = wintypes.BOOL
+        self._terminate_job = kernel32.TerminateJobObject
+        self._terminate_job.argtypes = [wintypes.HANDLE, wintypes.UINT]
+        self._terminate_job.restype = wintypes.BOOL
+        self._close_handle = kernel32.CloseHandle
+        self._close_handle.argtypes = [wintypes.HANDLE]
+        self._close_handle.restype = wintypes.BOOL
+
+        self._handle = create_job(None, None)
+        self.assigned = False
+        if not self._handle:
+            raise self._last_error("CreateJobObjectW failed")
+
+        limits = ExtendedLimitInformation()
+        limits.BasicLimitInformation.LimitFlags = WINDOWS_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        if not set_information(
+            self._handle,
+            WINDOWS_JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
+            ctypes.byref(limits),
+            ctypes.sizeof(limits),
+        ):
+            error = self._last_error("SetInformationJobObject failed")
+            self.close()
+            raise error
+
+    @staticmethod
+    def _last_error(message: str) -> OSError:
+        error_code = ctypes.get_last_error()
+        return OSError(error_code, f"{message}: {ctypes.FormatError(error_code).strip()}")
+
+    def assign(self, pid: int) -> None:
+        process = self._open_process(
+            WINDOWS_PROCESS_SET_QUOTA | WINDOWS_PROCESS_TERMINATE,
+            False,
+            pid,
+        )
+        if not process:
+            raise self._last_error(f"OpenProcess({pid}) failed")
+        try:
+            if not self._assign_process(self._handle, process):
+                raise self._last_error(f"AssignProcessToJobObject({pid}) failed")
+        finally:
+            self._close_handle(process)
+        self.assigned = True
+
+    def terminate(self, exit_code: int = 1) -> bool:
+        if not self._handle or not self.assigned:
+            return False
+        return bool(self._terminate_job(self._handle, exit_code))
+
+    def close(self) -> None:
+        if self._handle:
+            self._close_handle(self._handle)
+            self._handle = None
 
 
-def forwardable_signals() -> tuple[int, ...]:
-    """Return the forwardable signals this platform actually defines."""
-    resolved = (getattr(signal, name, None) for name in FORWARDED_SIGNAL_NAMES)
-    return tuple(signum for signum in resolved if signum is not None)
+def owned_signals(module: object = signal) -> tuple[int, ...]:
+    """Return only the forwarding signals the current host defines."""
+    return tuple(signum for name in OWNED_SIGNAL_NAMES if isinstance((signum := getattr(module, name, None)), int))
 
 
-def signal_child(child: subprocess.Popen, signum: int) -> None:
-    """Forward a signal to the child, preferring its process group where supported.
+def child_launch_command(command: list[str]) -> list[str]:
+    """Delay Windows command execution until the parent assigns its Job Object."""
+    if not IS_WINDOWS:
+        return command
+    return [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        WINDOWS_CHILD_BOOTSTRAP_FLAG,
+        *command,
+    ]
 
-    The child is started with ``start_new_session=True``, so on POSIX it leads its
-    own process group and ``os.killpg`` reaches the whole tree. Windows has no
-    ``os.killpg``; fall back to signalling the process directly.
-    """
-    killpg = getattr(os, "killpg", None)
+
+def run_windows_child_bootstrap(command: list[str]) -> int:
+    """Forward stdin after the Job Object assignment barrier is released."""
+    if not command:
+        return 2
+    return subprocess.run(command, input=sys.stdin.buffer.read()).returncode
+
+
+def signal_child(
+    child: subprocess.Popen[str],
+    signum: int,
+    windows_job: WindowsJob | None = None,
+) -> None:
+    """Forward to the POSIX child group or terminate the Windows process tree."""
     try:
-        if killpg is not None:
-            killpg(child.pid, signum)
+        if windows_job is not None and windows_job.terminate():
+            return
+        if child.poll() is not None:
+            return
+        if HAS_PROCESS_GROUPS:
+            os.killpg(child.pid, signum)
         else:
-            child.send_signal(signum)
-    except (ProcessLookupError, OSError):
+            child.terminate()
+    except OSError:
         pass
+
 
 
 def atomic_json(path: Path, value: dict) -> None:
@@ -61,9 +207,66 @@ def read_json(path: Path) -> dict:
         return {}
 
 
-def process_exists(pid: int) -> bool:
+def windows_process_status(pid: int) -> tuple[bool, int | None]:
+    """Return Windows liveness and immutable process creation ticks."""
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    open_process = kernel32.OpenProcess
+    open_process.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    open_process.restype = wintypes.HANDLE
+    get_exit_code = kernel32.GetExitCodeProcess
+    get_exit_code.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+    get_exit_code.restype = wintypes.BOOL
+    get_process_times = kernel32.GetProcessTimes
+    get_process_times.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+    ]
+    get_process_times.restype = wintypes.BOOL
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+
+    handle = open_process(WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not handle:
+        return ctypes.get_last_error() == WINDOWS_ERROR_ACCESS_DENIED, None
+    try:
+        exit_code = wintypes.DWORD()
+        if not get_exit_code(handle, ctypes.byref(exit_code)):
+            return True, None
+        if exit_code.value != WINDOWS_STILL_ACTIVE:
+            return False, None
+
+        creation = wintypes.FILETIME()
+        exit_time = wintypes.FILETIME()
+        kernel_time = wintypes.FILETIME()
+        user_time = wintypes.FILETIME()
+        if not get_process_times(
+            handle,
+            ctypes.byref(creation),
+            ctypes.byref(exit_time),
+            ctypes.byref(kernel_time),
+            ctypes.byref(user_time),
+        ):
+            return True, None
+        creation_ticks = (creation.dwHighDateTime << 32) | creation.dwLowDateTime
+        return True, creation_ticks
+    finally:
+        close_handle(handle)
+
+
+def process_exists(pid: int, expected_creation_ticks: int | None = None) -> bool:
     if pid <= 0:
         return False
+    if IS_WINDOWS:
+        exists, creation_ticks = windows_process_status(pid)
+        if expected_creation_ticks is not None:
+            return exists and creation_ticks == expected_creation_ticks
+        return exists
     try:
         os.kill(pid, 0)
         return True
@@ -110,7 +313,8 @@ def remove_stale_lock(lock_dir: Path, expected_pid: int) -> bool:
     owner = read_json(lock_dir / "owner.json")
     if int(owner.get("pid") or 0) != expected_pid:
         return False
-    if process_exists(expected_pid):
+    expected_creation_ticks = int(owner.get("process_creation_ticks") or 0) or None
+    if process_exists(expected_pid, expected_creation_ticks):
         return False
     try:
         shutil.rmtree(lock_dir)
@@ -133,8 +337,9 @@ def join_existing(state_dir: Path, wanted_fingerprint: str) -> int | None:
             time.sleep(POLL_SECONDS)
         return None
     active_pid = int(owner.get("pid") or 0)
+    active_creation_ticks = int(owner.get("process_creation_ticks") or 0) or None
     active_fingerprint = str(owner.get("fingerprint") or "")
-    if not process_exists(active_pid):
+    if not process_exists(active_pid, active_creation_ticks):
         if remove_stale_lock(lock_dir, active_pid):
             return None
     log_path = state_dir / "preflight.log"
@@ -152,7 +357,7 @@ def join_existing(state_dir: Path, wanted_fingerprint: str) -> int | None:
     print(f"Joining identical preflight PID {active_pid}; live log: {log_path}")
     next_status = 0.0
     while lock_dir.exists():
-        if not process_exists(active_pid):
+        if not process_exists(active_pid, active_creation_ticks):
             remove_stale_lock(lock_dir, active_pid)
             break
         now = time.monotonic()
@@ -187,6 +392,7 @@ def run_owned(
     started_wall = time.time()
     phase = "starting"
     child: subprocess.Popen[str] | None = None
+    windows_job: WindowsJob | None = None
 
     def write_status() -> None:
         atomic_json(
@@ -202,26 +408,33 @@ def run_owned(
         )
 
     def forward_signal(signum: int, _frame: object) -> None:
-        if child is not None and child.poll() is None:
-            signal_child(child, signum)
+        if child is not None:
+            signal_child(child, signum, windows_job)
 
-    previous_handlers = {signum: signal.signal(signum, forward_signal) for signum in forwardable_signals()}
+    previous_handlers = {signum: signal.signal(signum, forward_signal) for signum in owned_signals()}
     exit_code = 1
     try:
+        if IS_WINDOWS:
+            windows_job = WindowsJob()
         print(f"Pre-push single-flight log: {log_path}")
         log_path.write_text("", encoding="utf-8")
         os.chmod(log_path, 0o600)
         write_status()
         child = subprocess.Popen(
-            command,
+            child_launch_command(command),
             cwd=root,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            encoding="utf-8",
+            errors="backslashreplace",
             bufsize=1,
-            start_new_session=True,
+            start_new_session=HAS_PROCESS_GROUPS,
+            creationflags=(subprocess.CREATE_NEW_PROCESS_GROUP if IS_WINDOWS else 0),
         )
+        if windows_job is not None:
+            windows_job.assign(child.pid)
         if child.stdin:
             child.stdin.write(stdin_data)
             child.stdin.close()
@@ -250,6 +463,16 @@ def run_owned(
         )
         return exit_code
     finally:
+        if child is not None and child.poll() is None:
+            signal_child(child, signal.SIGTERM, windows_job)
+            try:
+                child.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                child.kill()
+                child.wait()
+        if windows_job is not None:
+            windows_job.terminate()
+            windows_job.close()
         for signum, handler in previous_handlers.items():
             signal.signal(signum, handler)
         shutil.rmtree(lock_dir, ignore_errors=True)
@@ -263,6 +486,9 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    if sys.argv[1:2] == [WINDOWS_CHILD_BOOTSTRAP_FLAG]:
+        return run_windows_child_bootstrap(sys.argv[2:])
+
     args = parse_args()
     command = list(args.command)
     if command and command[0] == "--":
@@ -279,7 +505,15 @@ def main() -> int:
     state_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     os.chmod(state_dir, 0o700)
     lock_dir = state_dir / "lock"
-    owner = {"pid": os.getpid(), "fingerprint": wanted_fingerprint, "started_at_epoch": time.time()}
+    owner = {
+        "pid": os.getpid(),
+        "fingerprint": wanted_fingerprint,
+        "started_at_epoch": time.time(),
+    }
+    if IS_WINDOWS:
+        _, process_creation_ticks = windows_process_status(os.getpid())
+        if process_creation_ticks is not None:
+            owner["process_creation_ticks"] = process_creation_ticks
 
     while not acquire(lock_dir, owner):
         joined = join_existing(state_dir, wanted_fingerprint)

--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 POLL_SECONDS = 0.2
 STATUS_INTERVAL_SECONDS = 5.0
-OWNED_SIGNAL_NAMES = ("SIGINT", "SIGTERM", "SIGHUP", "SIGBREAK")
+FORWARDED_SIGNAL_NAMES = ("SIGINT", "SIGTERM", "SIGHUP", "SIGBREAK")
 IS_WINDOWS = os.name == "nt"
 HAS_PROCESS_GROUPS = os.name != "nt" and hasattr(os, "killpg")
 WINDOWS_STILL_ACTIVE = 259
@@ -149,9 +149,9 @@ class WindowsJob:
             self._handle = None
 
 
-def owned_signals(module: object = signal) -> tuple[int, ...]:
+def forwardable_signals(module: object = signal) -> tuple[int, ...]:
     """Return only the forwarding signals the current host defines."""
-    return tuple(signum for name in OWNED_SIGNAL_NAMES if isinstance((signum := getattr(module, name, None)), int))
+    return tuple(signum for name in FORWARDED_SIGNAL_NAMES if isinstance((signum := getattr(module, name, None)), int))
 
 
 def child_launch_command(command: list[str]) -> list[str]:
@@ -179,18 +179,16 @@ def signal_child(
     windows_job: WindowsJob | None = None,
 ) -> None:
     """Forward to the POSIX child group or terminate the Windows process tree."""
+    killpg = getattr(os, "killpg", None)
     try:
         if windows_job is not None and windows_job.terminate():
             return
-        if child.poll() is not None:
-            return
-        if HAS_PROCESS_GROUPS:
-            os.killpg(child.pid, signum)
+        if killpg is not None:
+            killpg(child.pid, signum)
         else:
-            child.terminate()
+            child.send_signal(signum)
     except OSError:
         pass
-
 
 
 def atomic_json(path: Path, value: dict) -> None:
@@ -414,10 +412,13 @@ def run_owned(
         )
 
     def forward_signal(signum: int, _frame: object) -> None:
-        if child is not None:
-            signal_child(child, signum, windows_job)
+        if child is None:
+            return
+        if windows_job is None and child.poll() is not None:
+            return
+        signal_child(child, signum, windows_job)
 
-    previous_handlers = {signum: signal.signal(signum, forward_signal) for signum in owned_signals()}
+    previous_handlers = {signum: signal.signal(signum, forward_signal) for signum in forwardable_signals()}
     exit_code = 1
     try:
         if IS_WINDOWS:

--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -492,6 +492,28 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def resolve_repo_root() -> Path:
+    # Git runs hooks with the working directory at the top of the invoking work
+    # tree, and the pre-push dispatcher cd's to the repo root before invoking
+    # this runner. Fall back to that working directory when `git rev-parse
+    # --show-toplevel` cannot resolve a work tree: in a linked worktree whose
+    # git context resolves to a git dir rather than a work tree, show-toplevel
+    # exits 128 ("this operation must be run in a work tree") and this runner
+    # would otherwise abort the gate, forcing a --no-verify push.
+    try:
+        toplevel = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+        ).stdout.strip()
+    except subprocess.CalledProcessError:
+        toplevel = ""
+    return Path(toplevel or Path.cwd()).resolve()
+
+
 def main() -> int:
     if sys.argv[1:2] == [WINDOWS_CHILD_BOOTSTRAP_FLAG]:
         return run_windows_child_bootstrap(sys.argv[2:])
@@ -503,13 +525,7 @@ def main() -> int:
     if not command:
         print("FAIL: preflight runner requires a command after --", file=sys.stderr)
         return 2
-    root = Path(
-        subprocess.check_output(
-            ["git", "rev-parse", "--show-toplevel"],
-            text=True,
-            encoding="utf-8",
-        ).strip()
-    ).resolve()
+    root = resolve_repo_root()
     # Git supplies ref updates on a pipe. Manual preflight runs inherit a TTY;
     # treating that as empty input avoids waiting forever for an interactive EOF.
     stdin_data = "" if sys.stdin.isatty() else sys.stdin.read()

--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -280,7 +280,12 @@ def default_state_dir(root: Path, name: str) -> Path:
     override = os.getenv("OMI_PREFLIGHT_STATE_DIR")
     if override:
         return Path(override).resolve() / name
-    git_dir = subprocess.check_output(["git", "rev-parse", "--absolute-git-dir"], cwd=root, text=True).strip()
+    git_dir = subprocess.check_output(
+        ["git", "rev-parse", "--absolute-git-dir"],
+        cwd=root,
+        text=True,
+        encoding="utf-8",
+    ).strip()
     return Path(git_dir) / "omi-preflight" / name
 
 
@@ -292,6 +297,7 @@ def fingerprint(root: Path, command: list[str], stdin_data: str) -> str:
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
         text=True,
+        encoding="utf-8",
     ).stdout.strip()
     digest = hashlib.sha256()
     for value in (str(root.resolve()), head, "\0".join(command), stdin_data):
@@ -496,7 +502,13 @@ def main() -> int:
     if not command:
         print("FAIL: preflight runner requires a command after --", file=sys.stderr)
         return 2
-    root = Path(subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()).resolve()
+    root = Path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            text=True,
+            encoding="utf-8",
+        ).strip()
+    ).resolve()
     # Git supplies ref updates on a pipe. Manual preflight runs inherit a TTY;
     # treating that as empty input avoids waiting forever for an interactive EOF.
     stdin_data = "" if sys.stdin.isatty() else sys.stdin.read()

--- a/.github/scripts/run_checks.py
+++ b/.github/scripts/run_checks.py
@@ -7,7 +7,9 @@ import argparse
 import fnmatch
 import glob
 import json
+import os
 import platform as _platform_mod
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -29,6 +31,21 @@ def detect_platform() -> str:
     if system == "Windows":
         return "windows"
     return system.lower()
+
+
+def bash_executable() -> str:
+    override = os.environ.get("OMI_BASH_EXECUTABLE")
+    if override:
+        return override
+    if os.name == "nt":
+        git = shutil.which("git")
+        if git:
+            git_root = Path(git).resolve().parent.parent
+            for relative_path in (Path("bin/bash.exe"), Path("usr/bin/bash.exe")):
+                candidate = git_root / relative_path
+                if candidate.is_file():
+                    return str(candidate)
+    return shutil.which("bash") or "bash"
 
 
 @dataclass(frozen=True)
@@ -260,6 +277,31 @@ def resolve_checks(
     ]
 
 
+def resolve_explicit_checks(
+    manifest: Manifest,
+    check_ids: list[str],
+    lane: str,
+    *,
+    include_pr_body_checks: bool,
+    platform: str,
+) -> list[CheckSelection]:
+    """Resolve named manifest checks without duplicating their commands in callers."""
+    checks_by_id = {check.id: check for check in manifest.checks}
+    selections: list[CheckSelection] = []
+    for check_id in dict.fromkeys(check_ids):
+        check = checks_by_id.get(check_id)
+        if check is None:
+            raise ValueError(f"unknown check id: {check_id}")
+        if lane not in check.lanes:
+            raise ValueError(f"{check_id}: check is not available in the {lane} lane")
+        if not include_pr_body_checks and check.requires_pr_body:
+            raise ValueError(f"{check_id}: check requires pull-request metadata")
+        if not _platform_matches(check, platform):
+            raise ValueError(f"{check_id}: check does not support platform {platform}")
+        selections.append(CheckSelection(check=check, matched_paths=()))
+    return selections
+
+
 def skipped_platform_checks(manifest: Manifest, files: list[str], lane: str, platform: str) -> list[Check]:
     """Checks that match lane+triggers but are skipped due to platform."""
     return [
@@ -290,12 +332,18 @@ def command_for_check(
         "{pr_body_file}": str(pr_body_file),
     }
     command: list[str] = []
-    for token in check.command:
+    for index, token in enumerate(check.command):
         if token == "{skip_changelog}":
             if skip_changelog:
                 command.append("--skip")
             continue
-        command.append(replacements.get(token, token))
+        resolved = replacements.get(token, token)
+        if index == 0:
+            if resolved == "python3":
+                resolved = sys.executable
+            elif resolved == "bash":
+                resolved = bash_executable()
+        command.append(resolved)
     return command
 
 
@@ -348,6 +396,12 @@ def parse_args() -> argparse.Namespace:
         help="Exclude checks declared as requiring pull-request metadata.",
     )
     parser.add_argument("--skip-changelog", action="store_true")
+    parser.add_argument(
+        "--check-id",
+        action="append",
+        default=[],
+        help="Run a named manifest check regardless of path triggers; repeat for multiple checks.",
+    )
     parser.add_argument("--list", action="store_true")
     parser.add_argument("--root", type=Path)
     parser.add_argument(
@@ -389,14 +443,28 @@ def main() -> int:
         print(f"FAIL: could not resolve manifest checks: {exc}", file=sys.stderr)
         return 2
     detected_platform = args.platform or detect_platform()
-    selections = resolve_check_selections(
-        manifest,
-        files,
-        args.lane,
-        include_pr_body_checks=not args.skip_pr_body_checks,
-        platform=detected_platform,
-        exclusive_platform=args.exclusive_platform,
-    )
+    try:
+        selections = (
+            resolve_explicit_checks(
+                manifest,
+                args.check_id,
+                args.lane,
+                include_pr_body_checks=not args.skip_pr_body_checks,
+                platform=detected_platform,
+            )
+            if args.check_id
+            else resolve_check_selections(
+                manifest,
+                files,
+                args.lane,
+                include_pr_body_checks=not args.skip_pr_body_checks,
+                platform=detected_platform,
+                exclusive_platform=args.exclusive_platform,
+            )
+        )
+    except ValueError as exc:
+        print(f"FAIL: could not select manifest checks: {exc}", file=sys.stderr)
+        return 2
     checks = [selection.check for selection in selections]
     if args.output == "json":
         print(
@@ -424,10 +492,11 @@ def main() -> int:
     )
     for check in checks:
         print(f"  SELECTED {check.id}: {check.reason}")
-    for skip in skipped_platform_checks(manifest, files, args.lane, detected_platform):
-        print(
-            f"  SKIPPED {skip.id}: platform-only (requires {', '.join(skip.platforms)}, running on {detected_platform})"
-        )
+    if not args.check_id:
+        for skip in skipped_platform_checks(manifest, files, args.lane, detected_platform):
+            print(
+                f"  SKIPPED {skip.id}: platform-only (requires {', '.join(skip.platforms)}, running on {detected_platform})"
+            )
     if args.list:
         return 0
 

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -7,6 +7,7 @@ from contextlib import redirect_stderr
 import io
 import json
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -180,8 +181,11 @@ class SelectionTests(unittest.TestCase):
         )
 
     def test_make_preflight_resolves_pr_metadata_before_running_checks(self) -> None:
+        make = shutil.which("make")
+        if make is None:
+            self.skipTest("requires make")
         result = subprocess.run(
-            ["make", "-n", "preflight"],
+            [make, "-n", "preflight"],
             cwd=REPO_ROOT,
             check=False,
             stdout=subprocess.PIPE,
@@ -256,6 +260,8 @@ class SelectionTests(unittest.TestCase):
                 [
                     sys.executable,
                     "desktop/macos/scripts/check-e2e-flow-coverage.py",
+                    "--formatter-binary",
+                    "none",
                     "--strict",
                     "desktop/macos/Desktop/Sources/Providers/UncoveredRoutingSurface.swift",
                 ],
@@ -546,7 +552,7 @@ class SignalPortabilityTests(unittest.TestCase):
 
     def test_forwarding_swallows_dead_child(self) -> None:
         child = Mock(pid=4321)
-        with patch.object(os, "killpg", side_effect=ProcessLookupError):
+        with patch.object(os, "killpg", side_effect=ProcessLookupError, create=True):
             preflight_runner.signal_child(child, signal.SIGTERM)  # must not raise
 
 

--- a/.github/scripts/test_preflight_runner.py
+++ b/.github/scripts/test_preflight_runner.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ctypes
 import importlib.util
 import os
 from pathlib import Path
@@ -11,7 +12,6 @@ import signal
 import subprocess
 import sys
 import tempfile
-import time
 import types
 import unittest
 from unittest import mock
@@ -50,6 +50,35 @@ def windows_path_without_python(bash: str, git: str) -> str:
             str(Path(os.environ["SystemRoot"]) / "System32"),
         ]
     )
+
+
+def wait_for_windows_process_exit(pid: int, timeout_ms: int = 10_000) -> bool:
+    """Wait on a process handle instead of polling wall-clock time."""
+    if os.name != "nt":
+        raise RuntimeError("Windows process waits are only available on Windows")
+
+    from ctypes import wintypes
+
+    synchronize = 0x00100000
+    wait_object_0 = 0
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    open_process = kernel32.OpenProcess
+    open_process.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    open_process.restype = wintypes.HANDLE
+    wait_for_single_object = kernel32.WaitForSingleObject
+    wait_for_single_object.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    wait_for_single_object.restype = wintypes.DWORD
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+
+    handle = open_process(synchronize, False, pid)
+    if not handle:
+        return not runner.process_exists(pid)
+    try:
+        return wait_for_single_object(handle, timeout_ms) == wait_object_0
+    finally:
+        close_handle(handle)
 
 
 class FakeChild:
@@ -181,54 +210,63 @@ class ProcessExistsTests(unittest.TestCase):
 
     @unittest.skipUnless(os.name == "nt", "native Windows liveness contract")
     def test_windows_liveness_probe_does_not_terminate_the_target(self) -> None:
-        child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import sys; sys.stdin.buffer.read()"],
+            stdin=subprocess.PIPE,
+        )
         try:
             self.assertTrue(runner.process_exists(child.pid))
             self.assertIsNone(child.poll())
         finally:
             child.terminate()
             child.wait(timeout=10)
+            if child.stdin is not None:
+                child.stdin.close()
 
     @unittest.skipUnless(os.name == "nt", "native Windows process-tree contract")
     def test_windows_job_terminates_descendants(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            go_path = root / "go"
-            child_pid_path = root / "child.pid"
-            parent_code = (
-                "import pathlib, subprocess, sys, time;"
-                f"go=pathlib.Path({str(go_path)!r});"
-                f"child_pid=pathlib.Path({str(child_pid_path)!r});"
-                "\nwhile not go.exists(): time.sleep(0.02)"
-                "\nchild=subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])"
-                "\nchild_pid.write_text(str(child.pid), encoding='utf-8')"
-                "\ntime.sleep(30)"
-            )
-            parent = subprocess.Popen([sys.executable, "-c", parent_code])
-            job = runner.WindowsJob()
-            descendant_pid = 0
-            try:
-                job.assign(parent.pid)
-                go_path.touch()
-                deadline = time.monotonic() + 5
-                while not child_pid_path.exists() and time.monotonic() < deadline:
-                    time.sleep(0.02)
-                self.assertTrue(child_pid_path.exists(), "descendant did not start")
-                descendant_pid = int(child_pid_path.read_text(encoding="utf-8"))
-                self.assertTrue(runner.process_exists(descendant_pid))
+        parent_code = (
+            "import subprocess, sys;"
+            "sys.stdin.buffer.read(1);"
+            "child=subprocess.Popen("
+            "[sys.executable, '-c', 'import sys; sys.stdin.buffer.read()'],"
+            "stdin=subprocess.PIPE"
+            ");"
+            "print(child.pid, flush=True);"
+            "sys.stdin.buffer.read()"
+        )
+        parent = subprocess.Popen(
+            [sys.executable, "-c", parent_code],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+        )
+        job = runner.WindowsJob()
+        descendant_pid = 0
+        try:
+            job.assign(parent.pid)
+            assert parent.stdin is not None
+            assert parent.stdout is not None
+            parent.stdin.write("g")
+            parent.stdin.flush()
+            descendant_pid = int(parent.stdout.readline())
+            self.assertTrue(runner.process_exists(descendant_pid))
 
-                self.assertTrue(job.terminate())
+            self.assertTrue(job.terminate())
+            parent.wait(timeout=10)
+            self.assertTrue(wait_for_windows_process_exit(descendant_pid))
+            self.assertFalse(runner.process_exists(descendant_pid))
+        finally:
+            job.terminate()
+            job.close()
+            if parent.poll() is None:
+                parent.terminate()
                 parent.wait(timeout=10)
-                deadline = time.monotonic() + 5
-                while runner.process_exists(descendant_pid) and time.monotonic() < deadline:
-                    time.sleep(0.02)
-                self.assertFalse(runner.process_exists(descendant_pid))
-            finally:
-                job.terminate()
-                job.close()
-                if parent.poll() is None:
-                    parent.terminate()
-                    parent.wait(timeout=10)
+            if parent.stdin is not None:
+                parent.stdin.close()
+            if parent.stdout is not None:
+                parent.stdout.close()
 
 
 class LaunchContractTests(unittest.TestCase):
@@ -255,6 +293,10 @@ class LaunchContractTests(unittest.TestCase):
         self.assertIn('PYTHON_EXECUTABLE="${OMI_PYTHON_EXECUTABLE:-}"', pre_push)
         self.assertIn(
             'CI_PREDICTION_SELECTION=$("$PYTHON_EXECUTABLE" scripts/pre_push_ci_prediction.py',
+            pre_push,
+        )
+        self.assertIn(
+            '"$PYTHON_EXECUTABLE" .github/scripts/check_failure_class_guard_ratchet.py',
             pre_push,
         )
         self.assertIn('"$PWD/backend/.venv/Scripts/python.exe"', pre_push)

--- a/.github/scripts/test_preflight_runner.py
+++ b/.github/scripts/test_preflight_runner.py
@@ -56,10 +56,14 @@ class FakeChild:
     def __init__(self, returncode: int | None = None) -> None:
         self.pid = 4321
         self.returncode = returncode
+        self.signals: list[int] = []
         self.terminated = False
 
     def poll(self) -> int | None:
         return self.returncode
+
+    def send_signal(self, signum: int) -> None:
+        self.signals.append(signum)
 
     def terminate(self) -> None:
         self.terminated = True
@@ -75,19 +79,19 @@ class FakeWindowsJob:
         return self.terminated
 
 
-class OwnedSignalTests(unittest.TestCase):
+class ForwardableSignalTests(unittest.TestCase):
     def test_skips_signals_the_host_does_not_define(self) -> None:
         windows_signal = types.SimpleNamespace(SIGINT=2, SIGTERM=15, SIGBREAK=21)
 
-        self.assertEqual(runner.owned_signals(windows_signal), (2, 15, 21))
+        self.assertEqual(runner.forwardable_signals(windows_signal), (2, 15, 21))
 
     def test_registers_sighup_when_the_host_defines_it(self) -> None:
         posix_signal = types.SimpleNamespace(SIGINT=2, SIGTERM=15, SIGHUP=1)
 
-        self.assertEqual(runner.owned_signals(posix_signal), (2, 15, 1))
+        self.assertEqual(runner.forwardable_signals(posix_signal), (2, 15, 1))
 
     def test_every_selected_signal_is_registrable_on_this_host(self) -> None:
-        for signum in runner.owned_signals():
+        for signum in runner.forwardable_signals():
             previous = signal.getsignal(signum)
             signal.signal(signum, previous)
 
@@ -96,32 +100,28 @@ class SignalChildTests(unittest.TestCase):
     def test_posix_signals_the_whole_child_process_group(self) -> None:
         child = FakeChild()
 
-        with (
-            mock.patch.object(runner, "HAS_PROCESS_GROUPS", True),
-            mock.patch.object(runner.os, "killpg", create=True) as killpg,
-        ):
+        with mock.patch.object(runner.os, "killpg", create=True) as killpg:
             runner.signal_child(child, signal.SIGINT)
 
         killpg.assert_called_once_with(child.pid, signal.SIGINT)
-        self.assertFalse(child.terminated)
+        self.assertEqual(child.signals, [])
 
-    def test_hosts_without_process_groups_terminate_the_child(self) -> None:
+    def test_hosts_without_process_groups_forward_to_the_child(self) -> None:
         child = FakeChild()
 
-        with mock.patch.object(runner, "HAS_PROCESS_GROUPS", False):
+        with mock.patch.object(runner.os, "killpg", None, create=True):
             runner.signal_child(child, signal.SIGINT)
 
-        self.assertTrue(child.terminated)
+        self.assertEqual(child.signals, [signal.SIGINT])
 
     def test_windows_job_terminates_the_process_tree(self) -> None:
         child = FakeChild()
         job = FakeWindowsJob()
 
-        with mock.patch.object(runner, "HAS_PROCESS_GROUPS", False):
-            runner.signal_child(child, signal.SIGINT, job)
+        runner.signal_child(child, signal.SIGINT, job)
 
         self.assertEqual(job.calls, 1)
-        self.assertFalse(child.terminated)
+        self.assertEqual(child.signals, [])
 
     def test_windows_job_still_terminates_descendants_after_root_exit(self) -> None:
         child = FakeChild(returncode=0)
@@ -131,21 +131,17 @@ class SignalChildTests(unittest.TestCase):
 
         self.assertEqual(job.calls, 1)
 
-    def test_exited_child_is_left_alone(self) -> None:
-        child = FakeChild(returncode=0)
-
-        with mock.patch.object(runner, "HAS_PROCESS_GROUPS", False):
-            runner.signal_child(child, signal.SIGINT)
-
-        self.assertFalse(child.terminated)
-
     def test_dead_child_does_not_raise(self) -> None:
         child = FakeChild()
 
-        with (
-            mock.patch.object(runner, "HAS_PROCESS_GROUPS", True),
-            mock.patch.object(runner.os, "killpg", side_effect=ProcessLookupError, create=True),
-        ):
+        with mock.patch.object(runner.os, "killpg", side_effect=ProcessLookupError, create=True):
+            runner.signal_child(child, signal.SIGTERM)
+
+    def test_dead_child_without_process_groups_does_not_raise(self) -> None:
+        child = mock.Mock(pid=4321)
+        child.send_signal.side_effect = ProcessLookupError
+
+        with mock.patch.object(runner.os, "killpg", None, create=True):
             runner.signal_child(child, signal.SIGTERM)
 
 

--- a/.github/scripts/test_preflight_runner.py
+++ b/.github/scripts/test_preflight_runner.py
@@ -18,6 +18,7 @@ from unittest import mock
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 MODULE_PATH = SCRIPT_DIR / "preflight_runner.py"
+PR_PREFLIGHT_MODULE_PATH = SCRIPT_DIR / "pr_preflight.py"
 REPO_ROOT = SCRIPT_DIR.parents[1]
 WRAPPER_PATH = REPO_ROOT / "scripts" / "pre-push-singleflight"
 PRE_PUSH_PATH = REPO_ROOT / "scripts" / "pre-push"
@@ -412,6 +413,100 @@ class LaunchContractTests(unittest.TestCase):
 
         self.assertEqual(completed.returncode, 0, completed.stdout)
         self.assertIn(r"bad:\xa1", completed.stdout)
+
+    @unittest.skipUnless(os.name == "nt", "native Windows Git encoding contract")
+    def test_runner_handles_utf8_git_worktree_path_without_utf8_mode(self) -> None:
+        git = shutil.which("git")
+        self.assertIsNotNone(git)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo-\u96ea"
+            root.mkdir()
+            subprocess.run(
+                [git, "init", "--quiet"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+            )
+            env = os.environ.copy()
+            env["PYTHONUTF8"] = "0"
+            env["PYTHONIOENCODING"] = "utf-8"
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    "--name",
+                    "unicode-path",
+                    "--",
+                    sys.executable,
+                    "-c",
+                    "print('unicode-path-ok')",
+                ],
+                cwd=root,
+                env=env,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=False,
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stdout)
+        self.assertIn("unicode-path-ok", completed.stdout)
+
+    @unittest.skipUnless(os.name == "nt", "native Windows Git encoding contract")
+    def test_pr_preflight_handles_utf8_git_worktree_path_without_utf8_mode(self) -> None:
+        git = shutil.which("git")
+        self.assertIsNotNone(git)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo-\u96ea"
+            root.mkdir()
+            subprocess.run(
+                [git, "init", "--quiet"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                [
+                    git,
+                    "-c",
+                    "user.name=Omi portability test",
+                    "-c",
+                    "user.email=portability@example.invalid",
+                    "commit",
+                    "--allow-empty",
+                    "--quiet",
+                    "-m",
+                    "initial",
+                ],
+                cwd=root,
+                check=True,
+                capture_output=True,
+            )
+            env = os.environ.copy()
+            env["PYTHONUTF8"] = "0"
+            env["PYTHONIOENCODING"] = "utf-8"
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PR_PREFLIGHT_MODULE_PATH),
+                    "--base",
+                    "HEAD",
+                    "--head",
+                    "HEAD",
+                    "--list",
+                ],
+                cwd=root,
+                env=env,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=False,
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stdout)
+        self.assertIn("PR preflight:", completed.stdout)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_preflight_runner.py
+++ b/.github/scripts/test_preflight_runner.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Portability contract tests for the pre-push single-flight runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import types
+import unittest
+from unittest import mock
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+MODULE_PATH = SCRIPT_DIR / "preflight_runner.py"
+REPO_ROOT = SCRIPT_DIR.parents[1]
+WRAPPER_PATH = REPO_ROOT / "scripts" / "pre-push-singleflight"
+PRE_PUSH_PATH = REPO_ROOT / "scripts" / "pre-push"
+PR_PREFLIGHT_PATH = REPO_ROOT / "scripts" / "pr-preflight"
+SPEC = importlib.util.spec_from_file_location("preflight_runner", MODULE_PATH)
+assert SPEC and SPEC.loader
+runner = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = runner
+SPEC.loader.exec_module(runner)
+
+
+def find_hook_bash() -> str | None:
+    if os.name == "nt":
+        git = shutil.which("git")
+        if git:
+            git_root = Path(git).resolve().parent.parent
+            for relative_path in (Path("bin/bash.exe"), Path("usr/bin/bash.exe")):
+                candidate = git_root / relative_path
+                if candidate.is_file():
+                    return str(candidate)
+    return shutil.which("bash")
+
+
+def windows_path_without_python(bash: str, git: str) -> str:
+    return os.pathsep.join(
+        [
+            str(Path(git).parent),
+            str(Path(bash).parent),
+            str(Path(os.environ["SystemRoot"]) / "System32"),
+        ]
+    )
+
+
+class FakeChild:
+    def __init__(self, returncode: int | None = None) -> None:
+        self.pid = 4321
+        self.returncode = returncode
+        self.terminated = False
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+
+class FakeWindowsJob:
+    def __init__(self, terminated: bool = True) -> None:
+        self.terminated = terminated
+        self.calls = 0
+
+    def terminate(self, exit_code: int = 1) -> bool:
+        self.calls += 1
+        return self.terminated
+
+
+class OwnedSignalTests(unittest.TestCase):
+    def test_skips_signals_the_host_does_not_define(self) -> None:
+        windows_signal = types.SimpleNamespace(SIGINT=2, SIGTERM=15, SIGBREAK=21)
+
+        self.assertEqual(runner.owned_signals(windows_signal), (2, 15, 21))
+
+    def test_registers_sighup_when_the_host_defines_it(self) -> None:
+        posix_signal = types.SimpleNamespace(SIGINT=2, SIGTERM=15, SIGHUP=1)
+
+        self.assertEqual(runner.owned_signals(posix_signal), (2, 15, 1))
+
+    def test_every_selected_signal_is_registrable_on_this_host(self) -> None:
+        for signum in runner.owned_signals():
+            previous = signal.getsignal(signum)
+            signal.signal(signum, previous)
+
+
+class SignalChildTests(unittest.TestCase):
+    def test_posix_signals_the_whole_child_process_group(self) -> None:
+        child = FakeChild()
+
+        with (
+            mock.patch.object(runner, "HAS_PROCESS_GROUPS", True),
+            mock.patch.object(runner.os, "killpg", create=True) as killpg,
+        ):
+            runner.signal_child(child, signal.SIGINT)
+
+        killpg.assert_called_once_with(child.pid, signal.SIGINT)
+        self.assertFalse(child.terminated)
+
+    def test_hosts_without_process_groups_terminate_the_child(self) -> None:
+        child = FakeChild()
+
+        with mock.patch.object(runner, "HAS_PROCESS_GROUPS", False):
+            runner.signal_child(child, signal.SIGINT)
+
+        self.assertTrue(child.terminated)
+
+    def test_windows_job_terminates_the_process_tree(self) -> None:
+        child = FakeChild()
+        job = FakeWindowsJob()
+
+        with mock.patch.object(runner, "HAS_PROCESS_GROUPS", False):
+            runner.signal_child(child, signal.SIGINT, job)
+
+        self.assertEqual(job.calls, 1)
+        self.assertFalse(child.terminated)
+
+    def test_windows_job_still_terminates_descendants_after_root_exit(self) -> None:
+        child = FakeChild(returncode=0)
+        job = FakeWindowsJob()
+
+        runner.signal_child(child, signal.SIGINT, job)
+
+        self.assertEqual(job.calls, 1)
+
+    def test_exited_child_is_left_alone(self) -> None:
+        child = FakeChild(returncode=0)
+
+        with mock.patch.object(runner, "HAS_PROCESS_GROUPS", False):
+            runner.signal_child(child, signal.SIGINT)
+
+        self.assertFalse(child.terminated)
+
+    def test_dead_child_does_not_raise(self) -> None:
+        child = FakeChild()
+
+        with (
+            mock.patch.object(runner, "HAS_PROCESS_GROUPS", True),
+            mock.patch.object(runner.os, "killpg", side_effect=ProcessLookupError, create=True),
+        ):
+            runner.signal_child(child, signal.SIGTERM)
+
+
+class ProcessExistsTests(unittest.TestCase):
+    def test_windows_never_calls_os_kill(self) -> None:
+        with (
+            mock.patch.object(runner, "IS_WINDOWS", True),
+            mock.patch.object(runner, "windows_process_status", return_value=(True, 123)) as probe,
+            mock.patch.object(
+                runner.os,
+                "kill",
+                side_effect=AssertionError("os.kill is destructive on Windows"),
+            ),
+        ):
+            self.assertTrue(runner.process_exists(99))
+
+        probe.assert_called_once_with(99)
+
+    def test_windows_pid_reuse_does_not_match_the_lock_owner(self) -> None:
+        with (
+            mock.patch.object(runner, "IS_WINDOWS", True),
+            mock.patch.object(runner, "windows_process_status", return_value=(True, 456)),
+        ):
+            self.assertFalse(runner.process_exists(99, expected_creation_ticks=123))
+            self.assertTrue(runner.process_exists(99, expected_creation_ticks=456))
+
+    def test_windows_unknown_creation_time_does_not_match_the_lock_owner(self) -> None:
+        with (
+            mock.patch.object(runner, "IS_WINDOWS", True),
+            mock.patch.object(runner, "windows_process_status", return_value=(True, None)),
+        ):
+            self.assertFalse(runner.process_exists(99, expected_creation_ticks=123))
+
+    def test_live_and_dead_pids(self) -> None:
+        self.assertTrue(runner.process_exists(os.getpid()))
+        self.assertFalse(runner.process_exists(0))
+
+    @unittest.skipUnless(os.name == "nt", "native Windows liveness contract")
+    def test_windows_liveness_probe_does_not_terminate_the_target(self) -> None:
+        child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+        try:
+            self.assertTrue(runner.process_exists(child.pid))
+            self.assertIsNone(child.poll())
+        finally:
+            child.terminate()
+            child.wait(timeout=10)
+
+    @unittest.skipUnless(os.name == "nt", "native Windows process-tree contract")
+    def test_windows_job_terminates_descendants(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            go_path = root / "go"
+            child_pid_path = root / "child.pid"
+            parent_code = (
+                "import pathlib, subprocess, sys, time;"
+                f"go=pathlib.Path({str(go_path)!r});"
+                f"child_pid=pathlib.Path({str(child_pid_path)!r});"
+                "\nwhile not go.exists(): time.sleep(0.02)"
+                "\nchild=subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])"
+                "\nchild_pid.write_text(str(child.pid), encoding='utf-8')"
+                "\ntime.sleep(30)"
+            )
+            parent = subprocess.Popen([sys.executable, "-c", parent_code])
+            job = runner.WindowsJob()
+            descendant_pid = 0
+            try:
+                job.assign(parent.pid)
+                go_path.touch()
+                deadline = time.monotonic() + 5
+                while not child_pid_path.exists() and time.monotonic() < deadline:
+                    time.sleep(0.02)
+                self.assertTrue(child_pid_path.exists(), "descendant did not start")
+                descendant_pid = int(child_pid_path.read_text(encoding="utf-8"))
+                self.assertTrue(runner.process_exists(descendant_pid))
+
+                self.assertTrue(job.terminate())
+                parent.wait(timeout=10)
+                deadline = time.monotonic() + 5
+                while runner.process_exists(descendant_pid) and time.monotonic() < deadline:
+                    time.sleep(0.02)
+                self.assertFalse(runner.process_exists(descendant_pid))
+            finally:
+                job.terminate()
+                job.close()
+                if parent.poll() is None:
+                    parent.terminate()
+                    parent.wait(timeout=10)
+
+
+class LaunchContractTests(unittest.TestCase):
+    def test_windows_launch_uses_a_job_assignment_barrier(self) -> None:
+        command = ["bash", "scripts/pre-push"]
+
+        with mock.patch.object(runner, "IS_WINDOWS", True):
+            launch_command = runner.child_launch_command(command)
+
+        self.assertEqual(launch_command[0], sys.executable)
+        self.assertEqual(launch_command[2], runner.WINDOWS_CHILD_BOOTSTRAP_FLAG)
+        self.assertEqual(launch_command[3:], command)
+
+    def test_wrapper_and_backend_python_paths_are_explicit(self) -> None:
+        """Static tripwire for the interpreter boundaries exercised below."""
+        wrapper = WRAPPER_PATH.read_text(encoding="utf-8")
+        pre_push = PRE_PUSH_PATH.read_text(encoding="utf-8")
+        pr_preflight = PR_PREFLIGHT_PATH.read_text(encoding="utf-8")
+
+        self.assertIn(' -- "$BASH_EXECUTABLE" scripts/pre-push "$@"', wrapper)
+        self.assertIn("export PYTHONUTF8=1", wrapper)
+        self.assertIn('export OMI_BASH_EXECUTABLE="$BASH_EXECUTABLE"', wrapper)
+        self.assertIn('export OMI_PYTHON_EXECUTABLE="$PREFLIGHT_PYTHON"', wrapper)
+        self.assertIn('PYTHON_EXECUTABLE="${OMI_PYTHON_EXECUTABLE:-}"', pre_push)
+        self.assertIn(
+            'CI_PREDICTION_SELECTION=$("$PYTHON_EXECUTABLE" scripts/pre_push_ci_prediction.py',
+            pre_push,
+        )
+        self.assertIn('"$PWD/backend/.venv/Scripts/python.exe"', pre_push)
+        self.assertIn('PYRIGHT_PYTHON="$BACKEND_PYTHON" bash scripts/typecheck.sh', pre_push)
+        self.assertIn(
+            'exec "$PYTHON_EXECUTABLE" .github/scripts/pr_preflight.py "$@"',
+            pr_preflight,
+        )
+
+    @unittest.skipUnless(os.name == "nt", "native Windows interpreter contract")
+    def test_pr_preflight_uses_explicit_python_without_python3_on_path(self) -> None:
+        bash = find_hook_bash()
+        git = shutil.which("git")
+        self.assertIsNotNone(bash)
+        self.assertIsNotNone(git)
+
+        env = os.environ.copy()
+        env["OMI_PYTHON_EXECUTABLE"] = Path(sys.executable).as_posix()
+        env["PATH"] = windows_path_without_python(bash, git)
+        python3_probe = subprocess.run(
+            [bash, "-c", "command -v python3"],
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+        self.assertNotEqual(python3_probe.returncode, 0, python3_probe.stdout)
+
+        completed = subprocess.run(
+            [bash, str(PR_PREFLIGHT_PATH), "--help"],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("usage:", completed.stdout)
+
+    @unittest.skipUnless(os.name == "nt", "native Windows wrapper contract")
+    def test_wrapper_launches_pre_push_without_python3_on_path(self) -> None:
+        bash = find_hook_bash()
+        git = shutil.which("git")
+        self.assertIsNotNone(bash)
+        self.assertIsNotNone(git)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            scripts = root / "scripts"
+            github_scripts = root / ".github" / "scripts"
+            scripts.mkdir(parents=True)
+            github_scripts.mkdir(parents=True)
+            subprocess.run(
+                [git, "init", "--quiet", str(root)],
+                check=True,
+                capture_output=True,
+            )
+            shutil.copy2(WRAPPER_PATH, scripts / "pre-push-singleflight")
+            shutil.copy2(MODULE_PATH, github_scripts / "preflight_runner.py")
+            proof_path = root / "wrapper-proof.txt"
+            (scripts / "pre-push").write_text(
+                "#!/usr/bin/env bash\n"
+                "set -euo pipefail\n"
+                'printf "%s\\n" "$OMI_PYTHON_EXECUTABLE" > "$PROOF_PATH"\n'
+                'printf "wrapper-ok\\n"\n',
+                encoding="utf-8",
+            )
+
+            env = os.environ.copy()
+            env["BACKEND_PYTHON"] = Path(sys.executable).as_posix()
+            env["OMI_PREFLIGHT_STATE_DIR"] = (root / "state").as_posix()
+            env["PATH"] = windows_path_without_python(bash, git)
+            env["PROOF_PATH"] = proof_path.as_posix()
+            python3_probe = subprocess.run(
+                [bash, "-c", "command -v python3"],
+                env=env,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=False,
+            )
+            self.assertNotEqual(python3_probe.returncode, 0, python3_probe.stdout)
+            completed = subprocess.run(
+                [bash, str(scripts / "pre-push-singleflight"), "fork"],
+                cwd=root,
+                env=env,
+                input="",
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertIn("wrapper-ok", completed.stdout)
+            self.assertEqual(
+                proof_path.read_text(encoding="utf-8").strip(),
+                Path(sys.executable).as_posix(),
+            )
+
+    def test_runner_launches_bash_on_this_host(self) -> None:
+        bash = find_hook_bash()
+        self.assertIsNotNone(bash)
+
+        with tempfile.TemporaryDirectory() as state_dir:
+            env = {**os.environ, "OMI_PREFLIGHT_STATE_DIR": state_dir}
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    "--name",
+                    "bash-launch",
+                    "--",
+                    bash,
+                    "-c",
+                    "printf bash-ok",
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=False,
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stdout)
+        self.assertIn("bash-ok", completed.stdout)
+
+    def test_invalid_utf8_child_output_is_escaped_without_aborting(self) -> None:
+        with tempfile.TemporaryDirectory() as state_dir:
+            env = {**os.environ, "OMI_PREFLIGHT_STATE_DIR": state_dir}
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    "--name",
+                    "invalid-utf8",
+                    "--",
+                    sys.executable,
+                    "-c",
+                    "import sys; sys.stdout.buffer.write(b'bad:\\xa1\\n'); sys.stdout.buffer.flush()",
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=False,
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stdout)
+        self.assertIn(r"bad:\xa1", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -455,10 +455,20 @@ chmod +x "{python}"
             guard.parent.mkdir(parents=True, exist_ok=True)
             guard.write_text("# fixture\n", encoding="utf-8")
 
-            result = subprocess.run(["bash", str(copied_runner)], text=True, capture_output=True, check=False)
+            bash = bash_executable()
+            result = subprocess.run(
+                [bash, str(copied_runner)],
+                text=True,
+                capture_output=True,
+                encoding="utf-8",
+                check=False,
+            )
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertEqual((root / "guard-args.txt").read_text(encoding="utf-8").strip(), str(guard))
+            self.assertEqual(
+                (root / "guard-args.txt").read_text(encoding="utf-8").strip(),
+                shell_path(guard, bash),
+            )
 
         self.assertRegex(
             (REPO_ROOT / "backend/requirements.txt").read_text(encoding="utf-8"),

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -22,11 +22,14 @@ from run_checks import (
     VALID_PLATFORMS,
     Check,
     Manifest,
+    bash_executable,
+    command_for_check,
     detect_platform,
     execute_checks,
     load_manifest,
     resolve_check_selections,
     resolve_checks,
+    resolve_explicit_checks,
     skipped_platform_checks,
     validate_manifest,
 )
@@ -36,6 +39,21 @@ REPO_ROOT = SCRIPT_DIR.parents[1]
 MANIFEST_PATH = REPO_ROOT / ".github/checks-manifest.yaml"
 WORKFLOWS_DIR = REPO_ROOT / ".github/workflows"
 SCRIPT_REFERENCE_RE = re.compile(r"(?P<path>(?:\.github|backend|desktop/macos)/scripts/[A-Za-z0-9_.-]+\.py)")
+
+
+def shell_path(path: Path, bash: str) -> str:
+    if os.name != "nt":
+        return str(path)
+    result = subprocess.run(
+        [bash, "-c", 'cygpath -u "$1"', "bash", str(path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode:
+        raise RuntimeError(result.stderr)
+    return result.stdout.strip()
 
 
 def load_deferred_marker_module():
@@ -283,6 +301,7 @@ class RunnerBehaviorTests(unittest.TestCase):
     @unittest.skipIf(os.name == "nt", "requires a POSIX shell")
     def test_firestore_contention_runner_uses_uv_without_backend_venv(self) -> None:
         source = REPO_ROOT / "backend/testing/desktop_beta_admission/run.sh"
+        bash = bash_executable()
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             runner = root / "backend/testing/desktop_beta_admission/run.sh"
@@ -308,8 +327,15 @@ esac
                 path.chmod(0o755)
 
             env = os.environ.copy()
-            env["PATH"] = f"{fake_bin}:/usr/bin:/bin"
-            result = subprocess.run(["bash", str(runner)], text=True, capture_output=True, env=env, check=False)
+            env["PATH"] = f"{shell_path(fake_bin, bash)}:/usr/bin:/bin"
+            result = subprocess.run(
+                [bash, str(runner)],
+                text=True,
+                capture_output=True,
+                encoding="utf-8",
+                env=env,
+                check=False,
+            )
 
             self.assertEqual(result.returncode, 0, result.stderr)
             captured = capture.read_text(encoding="utf-8")
@@ -476,7 +502,7 @@ class PlatformTests(unittest.TestCase):
         manifest = Manifest(
             checks=(Check(id="portable", command=("true",), triggers=("all",), lanes=("ci",), reason="t"),), exempt=()
         )
-        for plat in ("macos", "linux"):
+        for plat in ("macos", "linux", "windows"):
             selected = resolve_checks(manifest, ["any/file"], "ci", platform=plat)
             self.assertEqual([c.id for c in selected], ["portable"])
 
@@ -563,6 +589,73 @@ class PlatformTests(unittest.TestCase):
     def test_detect_platform_returns_known_value(self):
         plat = detect_platform()
         self.assertIn(plat, VALID_PLATFORMS - {"all"})
+
+    def test_interpreter_commands_use_resolved_executables(self):
+        python_check = Check(
+            id="python-interpreter",
+            command=("python3", "check.py", "bash"),
+            triggers=("all",),
+            lanes=("local", "ci"),
+            reason="test",
+        )
+        python_command = command_for_check(
+            python_check,
+            changed_files_path=Path("changed.txt"),
+            base="base",
+            head="head",
+            pr_body_file=Path("body.md"),
+            skip_changelog=False,
+        )
+        bash_check = Check(
+            id="bash-interpreter",
+            command=("bash", "check.sh", "python3"),
+            triggers=("all",),
+            lanes=("local", "ci"),
+            reason="test",
+        )
+        bash_command = command_for_check(
+            bash_check,
+            changed_files_path=Path("changed.txt"),
+            base="base",
+            head="head",
+            pr_body_file=Path("body.md"),
+            skip_changelog=False,
+        )
+
+        self.assertEqual(python_command, [sys.executable, "check.py", "bash"])
+        self.assertEqual(bash_command, [bash_executable(), "check.sh", "python3"])
+
+    def test_explicit_check_ids_preserve_manifest_commands(self):
+        manifest = Manifest(
+            checks=(
+                Check(
+                    id="portable",
+                    command=("python3", "check.py"),
+                    triggers=("never/**",),
+                    lanes=("ci",),
+                    reason="test",
+                ),
+            ),
+            exempt=(),
+        )
+
+        selections = resolve_explicit_checks(
+            manifest,
+            ["portable"],
+            "ci",
+            include_pr_body_checks=True,
+            platform="windows",
+        )
+
+        self.assertEqual([selection.check.id for selection in selections], ["portable"])
+        with self.assertRaisesRegex(ValueError, "unknown check id"):
+            resolve_explicit_checks(
+                manifest,
+                ["missing"],
+                "ci",
+                include_pr_body_checks=True,
+                platform="windows",
+            )
 
 
 class DeferredMarkerTests(unittest.TestCase):

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -414,6 +414,40 @@ esac
                 )
             self.assertEqual(result, 1)
 
+    def test_python3_command_uses_current_interpreter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            marker = root / "interpreter.txt"
+            probe = root / "probe.py"
+            probe.write_text(
+                "from pathlib import Path\n"
+                "import sys\n"
+                f"Path({str(marker)!r}).write_text(sys.executable, encoding='utf-8')\n",
+                encoding="utf-8",
+            )
+            changed = root / "changed.txt"
+            changed.write_text("example.txt\n", encoding="utf-8")
+            body = root / "body.txt"
+            body.write_text("", encoding="utf-8")
+            check = Check("python", ("python3", str(probe)), ("all",), ("local",), "fixture")
+
+            with (
+                patch.dict(os.environ, {"PATH": ""}),
+                redirect_stdout(StringIO()),
+                redirect_stderr(StringIO()),
+            ):
+                result = execute_checks(
+                    root,
+                    [check],
+                    changed_files_path=changed,
+                    base="base",
+                    head="HEAD",
+                    pr_body_file=body,
+                )
+
+            self.assertEqual(result, 0)
+            self.assertEqual(marker.read_text(encoding="utf-8"), sys.executable)
+
     def test_release_process_guard_uses_locked_pyyaml_in_every_declared_lane(self) -> None:
         """The guard must never depend on a runner-global PyYAML install."""
         manifest = load_manifest(MANIFEST_PATH)

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -617,9 +617,7 @@ class PlatformTests(unittest.TestCase):
     def test_invalid_platform_rejected_by_validation(self):
         manifest = Manifest(
             checks=(
-                Check(
-                    id="bad", command=("true",), triggers=("all",), lanes=("ci",), reason="t", platforms=("plan9",)
-                ),
+                Check(id="bad", command=("true",), triggers=("all",), lanes=("ci",), reason="t", platforms=("plan9",)),
             ),
             exempt=(),
         )

--- a/.github/workflows/windows-preflight-portability.yml
+++ b/.github/workflows/windows-preflight-portability.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/checks-manifest.yaml'
       - '.github/scripts/preflight_runner.py'
+      - '.github/scripts/pr_preflight.py'
       - '.github/scripts/run_checks.py'
       - '.github/scripts/test_preflight_runner.py'
       - '.github/scripts/test_run_checks.py'
@@ -19,6 +20,7 @@ on:
     paths:
       - '.github/checks-manifest.yaml'
       - '.github/scripts/preflight_runner.py'
+      - '.github/scripts/pr_preflight.py'
       - '.github/scripts/run_checks.py'
       - '.github/scripts/test_preflight_runner.py'
       - '.github/scripts/test_run_checks.py'

--- a/.github/workflows/windows-preflight-portability.yml
+++ b/.github/workflows/windows-preflight-portability.yml
@@ -15,6 +15,7 @@ on:
       - 'scripts/pre-push'
       - 'scripts/pre-push-singleflight'
       - 'scripts/pr-preflight'
+      - 'scripts/test-pre-push-worktree-fallback.sh'
   pull_request:
     branches: [main]
     paths:
@@ -29,6 +30,7 @@ on:
       - 'scripts/pre-push'
       - 'scripts/pre-push-singleflight'
       - 'scripts/pr-preflight'
+      - 'scripts/test-pre-push-worktree-fallback.sh'
 
 permissions:
   contents: read
@@ -64,5 +66,6 @@ jobs:
           --base HEAD
           --head HEAD
           --platform windows
+          --check-id pre-push-worktree-fallback
           --check-id preflight-runner-portability
           --check-id check-manifest-contract

--- a/.github/workflows/windows-preflight-portability.yml
+++ b/.github/workflows/windows-preflight-portability.yml
@@ -40,10 +40,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Resolve supported Python minor
+        id: python-version
+        shell: pwsh
+        run: |
+          $parts = (Get-Content backend/.python-version -Raw).Trim().Split('.')
+          if ($parts.Count -lt 2) {
+            throw 'backend/.python-version must contain at least major.minor'
+          }
+          "version=$($parts[0]).$($parts[1])" >> $env:GITHUB_OUTPUT
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version-file: backend/.python-version
+          python-version: ${{ steps.python-version.outputs.version }}
 
       - name: Run Windows portability checks from the manifest
         run: >-

--- a/.github/workflows/windows-preflight-portability.yml
+++ b/.github/workflows/windows-preflight-portability.yml
@@ -1,0 +1,56 @@
+name: Windows Preflight Portability
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/checks-manifest.yaml'
+      - '.github/scripts/preflight_runner.py'
+      - '.github/scripts/run_checks.py'
+      - '.github/scripts/test_preflight_runner.py'
+      - '.github/scripts/test_run_checks.py'
+      - '.github/workflows/windows-preflight-portability.yml'
+      - 'backend/.python-version'
+      - 'scripts/pre-push'
+      - 'scripts/pre-push-singleflight'
+      - 'scripts/pr-preflight'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/checks-manifest.yaml'
+      - '.github/scripts/preflight_runner.py'
+      - '.github/scripts/run_checks.py'
+      - '.github/scripts/test_preflight_runner.py'
+      - '.github/scripts/test_run_checks.py'
+      - '.github/workflows/windows-preflight-portability.yml'
+      - 'backend/.python-version'
+      - 'scripts/pre-push'
+      - 'scripts/pre-push-singleflight'
+      - 'scripts/pr-preflight'
+
+permissions:
+  contents: read
+
+jobs:
+  portability:
+    name: Native Windows process and launcher contracts
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: backend/.python-version
+
+      - name: Run Windows portability checks from the manifest
+        run: >-
+          python .github/scripts/run_checks.py
+          --lane ci
+          --base HEAD
+          --head HEAD
+          --platform windows
+          --check-id preflight-runner-portability
+          --check-id check-manifest-contract

--- a/scripts/pr-preflight
+++ b/scripts/pr-preflight
@@ -2,7 +2,12 @@
 
 set -euo pipefail
 
-ROOT="$(git rev-parse --show-toplevel)"
+# Fall back to the working directory when `git rev-parse --show-toplevel` cannot
+# resolve a work tree: in a linked worktree whose git context resolves to a git
+# dir (show-toplevel exits 128, "this operation must be run in a work tree"),
+# this would otherwise abort. The pre-push gate cd's to the repo root before
+# invoking this script, and hooks run at the work-tree top, so pwd is the root.
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$ROOT"
 
 PYTHON_EXECUTABLE="${OMI_PYTHON_EXECUTABLE:-}"

--- a/scripts/pr-preflight
+++ b/scripts/pr-preflight
@@ -4,4 +4,13 @@ set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
-exec python3 .github/scripts/pr_preflight.py "$@"
+
+PYTHON_EXECUTABLE="${OMI_PYTHON_EXECUTABLE:-}"
+if [[ -z "$PYTHON_EXECUTABLE" || ! -x "$PYTHON_EXECUTABLE" ]]; then
+  PYTHON_EXECUTABLE="$(command -v python3 || command -v python || true)"
+fi
+if [[ -z "$PYTHON_EXECUTABLE" || ! -x "$PYTHON_EXECUTABLE" ]]; then
+  echo "FAIL: PR preflight requires Python 3, but no executable was found." >&2
+  exit 1
+fi
+exec "$PYTHON_EXECUTABLE" .github/scripts/pr_preflight.py "$@"

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -2,7 +2,12 @@
 
 set -eo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+# Git runs hooks with the working directory at the top of the invoking work
+# tree, so fall back to it when `git rev-parse --show-toplevel` cannot resolve a
+# work tree. In a linked worktree whose git context resolves to a git dir rather
+# than a work tree, show-toplevel exits 128 ("this operation must be run in a
+# work tree") and this gate would otherwise abort, forcing a --no-verify push.
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 PUSH_REMOTE="${1:-origin}"
 BASE_REMOTE="${PRE_PUSH_BASE_REMOTE:-origin}"

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -81,7 +81,34 @@ FAST_BACKEND_TESTS=$(mktemp "${TMPDIR:-/tmp}/omi-pre-push-fast-backend-tests.XXX
 RELEASE_GUARD_TESTS=$(mktemp "${TMPDIR:-/tmp}/omi-pre-push-release-guard-tests.XXXXXX")
 trap 'rm -f "$CHANGED_FILES_LIST" "$SELECTED_BACKEND_TESTS" "$SELECTED_BACKEND_TESTS_REASON" "$FAST_BACKEND_TESTS" "$RELEASE_GUARD_TESTS"' EXIT
 printf '%s\n' "${CHANGED_FILES[@]}" > "$CHANGED_FILES_LIST"
-BACKEND_PYTHON="$PWD/backend/.venv/bin/python"
+
+PYTHON_EXECUTABLE="${OMI_PYTHON_EXECUTABLE:-}"
+if [[ -z "$PYTHON_EXECUTABLE" || ! -x "$PYTHON_EXECUTABLE" ]]; then
+  for python_candidate in "${BACKEND_PYTHON:-}" "$PWD/backend/.venv/bin/python" "$PWD/backend/.venv/Scripts/python.exe"; do
+    if [[ -n "$python_candidate" && -x "$python_candidate" ]]; then
+      PYTHON_EXECUTABLE="$python_candidate"
+      break
+    fi
+  done
+fi
+if [[ -z "$PYTHON_EXECUTABLE" || ! -x "$PYTHON_EXECUTABLE" ]]; then
+  PYTHON_EXECUTABLE="$(command -v python3 || command -v python || true)"
+fi
+if [[ -z "$PYTHON_EXECUTABLE" || ! -x "$PYTHON_EXECUTABLE" ]]; then
+  echo "FAIL: pre-push requires Python 3, but no executable was found." >&2
+  exit 1
+fi
+export OMI_PYTHON_EXECUTABLE="$PYTHON_EXECUTABLE"
+
+BACKEND_PYTHON="${BACKEND_PYTHON:-}"
+if [[ -z "$BACKEND_PYTHON" ]]; then
+  for backend_python_candidate in "$PWD/backend/.venv/bin/python" "$PWD/backend/.venv/Scripts/python.exe"; do
+    if [[ -x "$backend_python_candidate" ]]; then
+      BACKEND_PYTHON="$backend_python_candidate"
+      break
+    fi
+  done
+fi
 
 declare -a CI_PREDICTION_VERIFIED=()
 declare -a CI_PREDICTION_DEFERRED=()
@@ -129,11 +156,11 @@ print_ci_prediction_summary() {
 }
 
 require_backend_python() {
-  if [[ -x "$BACKEND_PYTHON" ]]; then
+  if [[ -n "$BACKEND_PYTHON" && -x "$BACKEND_PYTHON" ]]; then
     return 0
   fi
-  echo "FAIL: a selected backend check requires backend/.venv/bin/python, but it was not found." >&2
-  echo "      Create it with: make setup" >&2
+  echo "FAIL: a selected backend check requires a usable backend Python." >&2
+  echo "      Set BACKEND_PYTHON or run: make setup" >&2
   return 1
 }
 
@@ -163,7 +190,7 @@ changed_matches() {
   return 1
 }
 
-CI_PREDICTION_SELECTION=$(python3 scripts/pre_push_ci_prediction.py --changed-files "$CHANGED_FILES_LIST" --base "$BASE_REF")
+CI_PREDICTION_SELECTION=$("$PYTHON_EXECUTABLE" scripts/pre_push_ci_prediction.py --changed-files "$CHANGED_FILES_LIST" --base "$BASE_REF")
 if ci_prediction_selected "app-ci-only"; then
   ci_prediction_note_deferred "full Flutter analyzer/tests and platform compiles"
 fi
@@ -266,8 +293,8 @@ check_optional_formatters() {
   if [ "${#python_files[@]}" -gt 0 ]; then
     if command -v black >/dev/null 2>&1; then
       black_cmd=(black)
-    elif python3 -m black --version >/dev/null 2>&1; then
-      black_cmd=(python3 -m black)
+    elif "$PYTHON_EXECUTABLE" -m black --version >/dev/null 2>&1; then
+      black_cmd=("$PYTHON_EXECUTABLE" -m black)
     fi
 
     if [ "${#black_cmd[@]}" -gt 0 ]; then
@@ -280,7 +307,7 @@ check_optional_formatters() {
 
   if [ "${#arb_files[@]}" -gt 0 ]; then
     echo "==> ARB JSON formatting (${#arb_files[@]} file(s))"
-    python3 - "${arb_files[@]}" <<'PY'
+    "$PYTHON_EXECUTABLE" - "${arb_files[@]}" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -404,15 +431,8 @@ check_desktop_flow_lint_if_needed() {
     return
   fi
 
-  if ! command -v python3 >/dev/null 2>&1; then
-    echo "FAIL: desktop E2E flow metadata checks require python3 and PyYAML." >&2
-    echo "      Install Python 3 and run: python3 -m pip install PyYAML" >&2
-    echo "      Deliberate hatch: PRE_PUSH_SKIP_DESKTOP_FLOW_LINT=1 git push" >&2
-    return 1
-  fi
-
   echo "==> desktop E2E flow metadata lint"
-  python3 desktop/macos/scripts/desktop-flow-lint.py
+  "$PYTHON_EXECUTABLE" desktop/macos/scripts/desktop-flow-lint.py
   ci_prediction_note_verified "desktop E2E flow metadata and bridge-action references"
 }
 
@@ -486,7 +506,7 @@ check_backend_typecheck_if_needed() {
   require_backend_python
   (
     cd backend
-    bash scripts/typecheck.sh
+    PYRIGHT_PYTHON="$BACKEND_PYTHON" bash scripts/typecheck.sh
   )
 }
 
@@ -608,7 +628,7 @@ check_runtime_image_source_closure_if_needed() {
     return
   fi
 
-    python3 backend/scripts/runtime_image_contracts.py check
+  "$PYTHON_EXECUTABLE" backend/scripts/runtime_image_contracts.py check
 }
 
 check_openapi_contract_if_needed() {
@@ -810,9 +830,9 @@ check_gauntlet_evidence_if_needed() {
 }
 
 run_step check_pr_preflight
-run_step python3 .github/scripts/check-desktop-prod-promotion-policy.py
-run_step python3 .github/scripts/check-deployment-concurrency.py --self-test
-run_step python3 .github/scripts/check-deployment-concurrency.py
+run_step "$PYTHON_EXECUTABLE" .github/scripts/check-desktop-prod-promotion-policy.py
+run_step "$PYTHON_EXECUTABLE" .github/scripts/check-deployment-concurrency.py --self-test
+run_step "$PYTHON_EXECUTABLE" .github/scripts/check-deployment-concurrency.py
 run_step check_backend_runtime_env_if_needed
 run_step check_backend_typecheck_if_needed
 run_step check_runtime_image_source_closure_if_needed

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -220,7 +220,7 @@ check_pr_preflight() {
     fi
     echo "Skipping shared PR preflight because PRE_PUSH_SKIP_PR_PREFLIGHT=1."
     echo "==> failure-class guard-artifact ratchet (mandatory under preflight hatch)"
-    python3 .github/scripts/check_failure_class_guard_ratchet.py \
+    "$PYTHON_EXECUTABLE" .github/scripts/check_failure_class_guard_ratchet.py \
       --pr-body-file "$OMI_PR_BODY_FILE"
     ci_prediction_note_verified "failure-class guard-artifact ratchet (mandatory under PRE_PUSH_SKIP_PR_PREFLIGHT=1)"
     ci_prediction_note_skipped "shared PR contract and hygiene (PRE_PUSH_SKIP_PR_PREFLIGHT=1)"

--- a/scripts/pre-push-singleflight
+++ b/scripts/pre-push-singleflight
@@ -2,7 +2,13 @@
 
 set -euo pipefail
 
-ROOT="$(git rev-parse --show-toplevel)"
+# Git runs hooks with the working directory at the top of the invoking work
+# tree, so fall back to it when `git rev-parse --show-toplevel` cannot resolve a
+# work tree. In a linked worktree whose git context resolves to a git dir rather
+# than a work tree, show-toplevel exits 128 ("this operation must be run in a
+# work tree") and this script — dispatched from a hook whose ROOT fallback
+# already survived — would otherwise abort here, forcing a --no-verify push.
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$ROOT"
 
 BASH_EXECUTABLE="${BASH:-}"

--- a/scripts/pre-push-singleflight
+++ b/scripts/pre-push-singleflight
@@ -4,4 +4,37 @@ set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
-exec python3 .github/scripts/preflight_runner.py --name pre-push -- scripts/pre-push "$@"
+
+BASH_EXECUTABLE="${BASH:-}"
+if [[ -z "$BASH_EXECUTABLE" || ! -x "$BASH_EXECUTABLE" ]]; then
+  BASH_EXECUTABLE="$(command -v bash || true)"
+fi
+if [[ -z "$BASH_EXECUTABLE" || ! -x "$BASH_EXECUTABLE" ]]; then
+  echo "FAIL: pre-push requires Bash, but no executable was found." >&2
+  exit 1
+fi
+
+PREFLIGHT_PYTHON="${BACKEND_PYTHON:-}"
+if [[ -z "$PREFLIGHT_PYTHON" || ! -x "$PREFLIGHT_PYTHON" ]]; then
+  for candidate in "$ROOT/backend/.venv/bin/python" "$ROOT/backend/.venv/Scripts/python.exe"; do
+    if [[ -x "$candidate" ]]; then
+      PREFLIGHT_PYTHON="$candidate"
+      export BACKEND_PYTHON="$candidate"
+      break
+    fi
+  done
+fi
+if [[ -z "$PREFLIGHT_PYTHON" || ! -x "$PREFLIGHT_PYTHON" ]]; then
+  PREFLIGHT_PYTHON="$(command -v python3 || command -v python || true)"
+fi
+if [[ -z "$PREFLIGHT_PYTHON" || ! -x "$PREFLIGHT_PYTHON" ]]; then
+  echo "FAIL: pre-push requires Python 3, but no executable was found." >&2
+  exit 1
+fi
+
+export PYTHONUTF8=1
+export OMI_BASH_EXECUTABLE="$BASH_EXECUTABLE"
+export OMI_PYTHON_EXECUTABLE="$PREFLIGHT_PYTHON"
+export PATH="$(dirname "$PREFLIGHT_PYTHON"):$(dirname "$BASH_EXECUTABLE"):$PATH"
+exec "$PREFLIGHT_PYTHON" .github/scripts/preflight_runner.py \
+  --name pre-push -- "$BASH_EXECUTABLE" scripts/pre-push "$@"

--- a/scripts/test-pre-push-worktree-fallback.sh
+++ b/scripts/test-pre-push-worktree-fallback.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# Regression for #10293: `make setup` and the pre-push hook aborted with
+# "fatal: this operation must be run in a work tree" inside linked worktrees.
+#
+# #10401 fixed the Makefile and the installed hook dispatcher, but the scripts
+# the dispatcher hands off to (scripts/pre-push, scripts/pre-push-singleflight,
+# scripts/pr-preflight) and the Python entrypoints they exec
+# (.github/scripts/preflight_runner.py, .github/scripts/pr_preflight.py) still
+# resolved the repo root with an unguarded `git rev-parse --show-toplevel`. When
+# the invoking git context resolves to a git dir rather than a work tree,
+# show-toplevel exits 128 and each of those aborted the gate, forcing a
+# --no-verify push that silently bypasses local checks.
+#
+# A bare GIT_DIR reproduces the exact condition (show-toplevel exits 128) while
+# the working directory is a real work tree, so the fallback to it is correct.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+ROOT_CANON="$(cd "$ROOT" && pwd -P)"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/omi-pre-push-wt.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+BARE="$TMPDIR/bare.git"
+git init -q --bare "$BARE"
+BARE_ENV="$BARE"
+if command -v cygpath >/dev/null 2>&1; then
+  BARE_ENV="$(cygpath -am "$BARE")"
+fi
+
+# Sanity: confirm the reproduction actually triggers the 128 condition, so a
+# future git that stops failing here turns this into a visible skip rather than a
+# silently vacuous pass.
+if GIT_DIR="$BARE_ENV" git -C "$ROOT" rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "SKIP: this git does not surface the show-toplevel work-tree failure; cannot reproduce #10293." >&2
+  exit 0
+fi
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# A stub Python that reports the working directory it was exec'd in, so the shell
+# resolvers can be exercised without running the full gate. The current launchers
+# resolve explicit interpreter variables before PATH, so inject both contracts.
+STUB_BIN="$TMPDIR/bin"
+mkdir -p "$STUB_BIN"
+STUB_PYTHON="$STUB_BIN/python3"
+cat >"$STUB_PYTHON" <<'EOF'
+#!/usr/bin/env bash
+printf 'CWD=%s\n' "$(pwd -P)"
+EOF
+chmod +x "$STUB_PYTHON"
+
+# scripts/pre-push-singleflight and scripts/pr-preflight both resolve the root and
+# cd into it before launching Python. Under the 128 condition they must reach the
+# injected stub instead of aborting at resolution.
+for script in pre-push-singleflight pr-preflight; do
+  out="$(
+    cd "$ROOT" &&
+      GIT_DIR="$BARE_ENV" \
+        BACKEND_PYTHON="$STUB_PYTHON" \
+        OMI_PYTHON_EXECUTABLE="$STUB_PYTHON" \
+        PATH="$STUB_BIN:$PATH" \
+        bash "$ROOT/scripts/$script" 2>&1
+  )" \
+    || fail "scripts/$script aborted under the work-tree failure: $out"
+  case "$out" in
+    *"must be run in a work tree"*) fail "scripts/$script still aborts with the work-tree failure: $out" ;;
+    "CWD=$ROOT_CANON") : ;;
+    *) fail "scripts/$script resolved the wrong root under the work-tree failure: $out" ;;
+  esac
+done
+
+# scripts/pre-push resolves the root, cd's into it, then fails fast on a missing
+# base ref (this bare repo has no origin/main). The point is that it gets past
+# resolution: the abort must be the base-ref failure, never the work-tree fatal.
+out="$(cd "$ROOT" && GIT_DIR="$BARE_ENV" bash "$ROOT/scripts/pre-push" origin file://"$BARE" </dev/null 2>&1)" && true
+case "$out" in
+  *"must be run in a work tree"*) fail "scripts/pre-push still aborts with the work-tree failure: $out" ;;
+  *"cannot find"*) : ;;
+  *) fail "scripts/pre-push did not reach the base-ref check under the work-tree failure: $out" ;;
+esac
+
+# The Python entrypoints resolve the root directly. Prefer the interpreter already
+# selected by the launcher, then the repository venv, then the host command.
+PYTHON_EXECUTABLE="${OMI_PYTHON_EXECUTABLE:-${BACKEND_PYTHON:-}}"
+if [[ -z "$PYTHON_EXECUTABLE" || ! -x "$PYTHON_EXECUTABLE" ]]; then
+  for candidate in "$ROOT/backend/.venv/bin/python" "$ROOT/backend/.venv/Scripts/python.exe"; do
+    if [[ -x "$candidate" ]]; then
+      PYTHON_EXECUTABLE="$candidate"
+      break
+    fi
+  done
+fi
+if [[ -z "$PYTHON_EXECUTABLE" || ! -x "$PYTHON_EXECUTABLE" ]]; then
+  PYTHON_EXECUTABLE=""
+  for command_name in python3 python py; do
+    candidate="$(command -v "$command_name" || true)"
+    if [[ -n "$candidate" && -x "$candidate" ]] &&
+      "$candidate" -c "import pathlib" >/dev/null 2>&1; then
+      PYTHON_EXECUTABLE="$candidate"
+      break
+    fi
+  done
+fi
+[[ -n "$PYTHON_EXECUTABLE" && -x "$PYTHON_EXECUTABLE" ]] ||
+  fail "no Python interpreter is available for the entrypoint probes"
+
+# Both helpers must return the working directory rather than raise
+# CalledProcessError. Compare inside Python so POSIX and Windows path spellings
+# cannot make equivalent paths look different to the shell.
+for probe in \
+  "import preflight_runner as m; print(m.resolve_repo_root() == pathlib.Path.cwd().resolve())" \
+  "import pr_preflight as m; print(m._resolve_repo_root().resolve() == pathlib.Path.cwd().resolve())"; do
+  out="$(
+    cd "$ROOT" &&
+      GIT_DIR="$BARE_ENV" PYTHONUTF8=1 "$PYTHON_EXECUTABLE" -c \
+        "import pathlib, sys; sys.path.insert(0, str(pathlib.Path.cwd() / '.github' / 'scripts')); $probe"
+  )" \
+    || fail "python resolver aborted under the work-tree failure: $probe"
+  [ "$out" = "True" ] || fail "python resolver returned wrong root ($out) for: $probe"
+done
+
+echo "pre-push linked-worktree repo-root fallback test passed."


### PR DESCRIPTION
Fixes #9724.
Fixes #10293.

## Summary

- make the single-flight runner register only host-supported signals and replace destructive Windows `os.kill(pid, 0)` probing
- launch the extensionless pre-push script through Git Bash and carry one explicit Python executable across every hook boundary, including the `PRE_PUSH_SKIP_PR_PREFLIGHT=1` failure-class hatch
- contain the Windows command tree in a kill-on-close Job Object, with a bootstrap barrier that assigns the job before the real command can spawn
- bind stale-lock identity to Windows process creation ticks so PID reuse cannot impersonate the prior owner
- decode Git metadata as UTF-8 so native Windows locales can resolve non-ASCII worktree paths
- make the check manifest Windows-aware and add a path-scoped native Windows workflow that executes the manifest-owned portability checks
- preserve the mainline `forwardable_signals` and direct-child fallback contracts while extending Windows ownership to the full process tree
- restore the linked-worktree repo-root fallback across all five downstream shell/Python pre-push entrypoints, so a `show-toplevel` exit 128 does not force contributors toward `--no-verify`
- keep native process tests event-driven with pipe handshakes and `WaitForSingleObject`, without wall-clock polling or leaked handles

## Root cause

The pre-push control plane assumed POSIX signals, process groups, executable script launching, virtualenv layout, and `python3` naming at native Windows boundaries. It also let Python decode Git's UTF-8 output with the active Windows code page, so a worktree path containing non-ASCII characters could fail before any check ran.

A second gap remained after #10401: the installed hook dispatcher could recover when `git rev-parse --show-toplevel` failed in a linked worktree, but `scripts/pre-push`, `scripts/pre-push-singleflight`, `scripts/pr-preflight`, `.github/scripts/preflight_runner.py`, and `.github/scripts/pr_preflight.py` repeated the unguarded lookup and aborted later in the same chain.

Fixing only the first Windows exception or only the Makefile/dispatcher boundary would expose the next launch, liveness, decoding, root-resolution, or hatch failure. This PR closes that reachable portability chain.

## Attribution

The linked-worktree root-resolution slice preserves Nik Shevchenko's original #10491 implementation through the rebased commit lineage, with `Co-authored-by: Nik Shevchenko <kodjima33@gmail.com>`. Its regression was adapted to the explicit Windows Python launcher introduced by this PR and registered in both manifest lanes plus native Windows CI.

## Verification

- rebased onto current `origin/main` (`ffc13daf4c`) and reran the native Windows checks
- native Windows manifest run: `pre-push-worktree-fallback`, `preflight-runner-portability`, and `check-manifest-contract` -> 3 checks passed
- native Windows: `test_preflight_runner.py` -> 23 tests passed with `ResourceWarning` promoted to an error, including a real Job Object parent/descendant termination proof, explicit hatch interpreter coverage, and runner/direct PR-preflight execution from a Chinese worktree path with `PYTHONUTF8=0`
- native Windows: a temporary Git repository ran the real `pre-push-singleflight -> preflight_runner -> pre-push` chain with no `python3` on `PATH`
- native Windows: `test_run_checks.py` -> 33 tests passed, 1 POSIX-only fixture skipped; the real manifest subprocess path also resolved `python3` to the active interpreter with an empty `PATH`
- native Windows: full `test_pr_preflight.py` -> 26 tests passed, 3 explicit host-capability skips
- native Windows: `test-pre-push-worktree-fallback.sh` passed against all five downstream root resolvers under the reproduced exit-128 condition
- `test_pre_push_ci_prediction.py` -> 14 tests passed
- `scripts/test-pre-push-diff-base.sh` passed under Git Bash
- `bash -n` passed for all four touched shell scripts
- Black 26.5.1 passed for the touched Python files with the repository's 120-column/no-string-normalization settings
- actionlint 1.7.12 passed for the Windows workflow
- `python -m py_compile` passed for all touched Python files
- `scripts/failure-class validate --base origin/main --head HEAD ...` passed with `Failure-Class: none`
- `git diff --check origin/main...HEAD` passed

GNU Make is not installed on the local Windows host, so `scripts/test-make-setup.sh` could not be rerun there. The new regression exercises every downstream root resolver directly on native Windows; Linux CI remains authoritative for the existing Make fixture and the full manifest.

The committed diff changes the manifest, so the legacy local selector intentionally attempts every manifest check. On native Windows that broad run currently stops while collecting the existing `dev-harness-unit-tests` because its qualification module imports POSIX-only `fcntl`; the path-scoped Windows workflow therefore executes the portability contracts by manifest check ID, while Linux CI remains the full-manifest authority.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none
