### PR TITLE
SCA-115: promote development-qualified Pusher images

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -321,9 +321,14 @@ checks:
     reason: "#9988: Pusher's Kubernetes deadline and workflow wait must cover chart-derived availability at the HPA ceiling"
   - id: pusher-rollout-quality-gate
     command: ["python3", "backend/scripts/verify_pusher_rollout_gate.py"]
-    triggers: ["backend/charts/pusher/**", "backend/utils/metrics.py", "backend/routers/pusher.py", "backend/utils/readiness.py", "backend/scripts/verify_pusher_rollout_gate.py", "backend/tests/unit/test_verify_pusher_rollout_gate.py", ".github/checks-manifest.yaml"]
+    triggers: ["backend/charts/pusher/**", "backend/utils/metrics.py", "backend/routers/pusher.py", "backend/utils/readiness.py", ".github/workflows/gcp_backend_pusher.yml", ".github/workflows/gcp_backend_pusher_auto_deploy.yml", "backend/scripts/verify_pusher_rollout_gate.py", "backend/tests/unit/test_verify_pusher_rollout_gate.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-39: static preflight that fails closed when a pusher rollout cannot be verified safe (capacity, image identity, readiness/health split, telemetry)"
+  - id: pusher-dev-bake-observability
+    command: ["python3", "backend/scripts/verify_pusher_dev_observability.py"]
+    triggers: ["backend/charts/pusher/dev_omi_pusher_values.yaml", "backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml", "backend/charts/monitoring/dashboards/gke/pusher.json", "backend/utils/metrics.py", "backend/scripts/verify_pusher_dev_observability.py", "backend/tests/unit/test_verify_pusher_dev_observability.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-115: dev Pusher bake must retain isolated scrape plus connection, drain, and reconnect-circuit visibility"
   - id: shared-config-migration-preflight
     command: ["python3", "backend/scripts/verify_shared_config_migration.py", "preflight"]
     triggers: ["backend/charts/pusher/**", "backend/scripts/verify_shared_config_migration.py", "backend/tests/unit/test_verify_shared_config_migration.py", ".github/checks-manifest.yaml"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -321,7 +321,7 @@ checks:
     reason: "#9988: Pusher's Kubernetes deadline and workflow wait must cover chart-derived availability at the HPA ceiling"
   - id: pusher-rollout-quality-gate
     command: ["python3", "backend/scripts/verify_pusher_rollout_gate.py"]
-    triggers: ["backend/charts/pusher/**", "backend/utils/metrics.py", "backend/routers/pusher.py", "backend/utils/readiness.py", ".github/workflows/gcp_backend_pusher.yml", ".github/workflows/gcp_backend_pusher_auto_deploy.yml", "backend/scripts/verify_pusher_rollout_gate.py", "backend/tests/unit/test_verify_pusher_rollout_gate.py", ".github/checks-manifest.yaml"]
+    triggers: ["backend/charts/pusher/**", "backend/utils/metrics.py", "backend/routers/pusher.py", "backend/utils/readiness.py", ".github/workflows/gcp_backend_pusher.yml", ".github/workflows/gcp_backend_pusher_auto_deploy.yml", "backend/scripts/verify_pusher_rollout_gate.py", "backend/scripts/verify_pusher_source_closure.py", "backend/pusher/Dockerfile", "backend/tests/unit/test_verify_pusher_rollout_gate.py", "backend/tests/unit/test_pusher_deployment_control_workflow.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-39: static preflight that fails closed when a pusher rollout cannot be verified safe (capacity, image identity, readiness/health split, telemetry)"
   - id: pusher-dev-bake-observability

--- a/.github/scripts/check-deployment-concurrency.py
+++ b/.github/scripts/check-deployment-concurrency.py
@@ -458,7 +458,9 @@ def validate_pusher_config_preflight(name: str, text: str) -> list[str]:
         return [f"{name}: pusher deploy must verify the backend runtime ConfigMap before Helm"]
 
     chart_indexes = [
-        index for index, line in enumerate(block) if PUSHER_CHART_MARKER in line and not line.lstrip().startswith("#")
+        index
+        for index, line in enumerate(block)
+        if PUSHER_CHART_MARKER in line and "helm" in line and not line.lstrip().startswith("#")
     ]
     if not chart_indexes:
         return []
@@ -869,6 +871,13 @@ jobs:
 """
     if validate_pusher_config_preflight("fixture.yml", reference_preflight):
         raise PolicyError("valid pusher reference preflight was rejected")
+    qualification_source_diff = reference_preflight.replace(
+        "      - run: helm upgrade ./backend/charts/pusher\n",
+        "      - run: git diff --quiet qualified current -- backend/pusher backend/charts/pusher\n"
+        "      - run: helm upgrade ./backend/charts/pusher\n",
+    )
+    if validate_pusher_config_preflight("fixture.yml", qualification_source_diff):
+        raise PolicyError("a non-Helm Pusher source comparison was treated as a deploy mutation")
     missing_preflight = pusher_deploy.replace(
         "kubectl -n ${{ vars.ENV }}-omi-backend get configmap ${{ vars.ENV }}-omi-backend-config >/dev/null\n",
         "",

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -23,6 +23,14 @@ on:
         description: 'Service to deploy'
         required: false
         default: 'pusher'
+      pusher_image_digest:
+        description: 'Production Pusher only: exact digest from a successful automatic development qualification'
+        required: false
+        default: ''
+      pusher_dev_qualification_run_id:
+        description: 'Production Pusher only: successful gcp_backend_pusher_auto_deploy.yml run ID that qualified the digest'
+        required: false
+        default: ''
 
 # The LLM Gateway path reapplies shared backend-secrets; standalone pusher only
 # mutates its own GKE release and therefore keeps a separate environment lock.
@@ -38,6 +46,7 @@ jobs:
   deploy:
     environment: ${{ github.event.inputs.environment }}
     permissions:
+      actions: 'read'
       contents: 'read'
       id-token: 'write'
 
@@ -84,6 +93,54 @@ jobs:
           echo "CHECKED_OUT_SHA=$CHECKED_OUT_SHA" >> "$GITHUB_ENV"
           echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_ENV"
 
+      - name: Select development-qualified Pusher digest for production
+        if: env.SERVICE == 'pusher' && github.event.inputs.environment == 'prod'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_DIGEST: ${{ github.event.inputs.pusher_image_digest }}
+          QUALIFICATION_RUN_ID: ${{ github.event.inputs.pusher_dev_qualification_run_id }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$REQUESTED_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "Production Pusher requires pusher_image_digest=sha256:<64 lowercase hex>." >&2
+            exit 1
+          fi
+          if [[ ! "$QUALIFICATION_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Production Pusher requires a numeric successful development qualification run ID." >&2
+            exit 1
+          fi
+          QUALIFICATION_DIR="$RUNNER_TEMP/pusher-dev-qualification-$QUALIFICATION_RUN_ID"
+          mkdir -p "$QUALIFICATION_DIR"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$QUALIFICATION_RUN_ID" > "$QUALIFICATION_DIR/run.json"
+          EXPECTED_WORKFLOW_ID="$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/gcp_backend_pusher_auto_deploy.yml" --jq .id)"
+          gh run download "$QUALIFICATION_RUN_ID" -n pusher-dev-qualification --dir "$QUALIFICATION_DIR"
+          mapfile -t EVIDENCE_FILES < <(find "$QUALIFICATION_DIR" -type f -name pusher-dev-qualification.json -print)
+          if [[ "${#EVIDENCE_FILES[@]}" -ne 1 ]]; then
+            echo "Expected exactly one Pusher development qualification artifact." >&2
+            exit 1
+          fi
+          DEV_PUSHER_REPOSITORY="gcr.io/based-hardware-dev/pusher"
+          python3 backend/scripts/verify_pusher_promotion_evidence.py \
+            --evidence "${EVIDENCE_FILES[0]}" \
+            --run-json "$QUALIFICATION_DIR/run.json" \
+            --expected-digest "$REQUESTED_DIGEST" \
+            --expected-repository "$DEV_PUSHER_REPOSITORY" \
+            --expected-workflow-id "$EXPECTED_WORKFLOW_ID" \
+            --expected-run-id "$QUALIFICATION_RUN_ID"
+          QUALIFIED_SOURCE_SHA="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["source_sha"])' "${EVIDENCE_FILES[0]}")"
+          if ! git cat-file -e "${QUALIFIED_SOURCE_SHA}^{commit}" || ! git merge-base --is-ancestor "$QUALIFIED_SOURCE_SHA" origin/main; then
+            echo "Development qualification source is not a commit on fresh origin/main." >&2
+            exit 1
+          fi
+          if ! git diff --quiet "$QUALIFIED_SOURCE_SHA" "$CHECKED_OUT_SHA" -- backend/pusher backend/charts/pusher; then
+            echo "Current main changed Pusher source or chart since the selected dev qualification; run a new dev bake." >&2
+            exit 1
+          fi
+          {
+            echo "PUSHER_DEV_IMAGE_REPOSITORY=$DEV_PUSHER_REPOSITORY"
+            echo "PUSHER_IMAGE_DIGEST=$REQUESTED_DIGEST"
+          } >> "$GITHUB_ENV"
+
       - name: Google Auth
         id: auth
         uses: 'google-github-actions/auth@v3'
@@ -129,9 +186,11 @@ jobs:
         run: gcloud auth configure-docker
 
       - name: Set up Docker Buildx
+        if: env.SERVICE == 'llm-gateway' || github.event.inputs.environment != 'prod'
         uses: docker/setup-buildx-action@v4
 
       - name: Build and Push Docker image
+        if: env.SERVICE == 'llm-gateway' || github.event.inputs.environment != 'prod'
         run: |
           if [[ "${{ env.SERVICE }}" == "llm-gateway" ]]; then
             docker build -t gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${IMAGE_TAG} -f backend/Dockerfile .
@@ -145,6 +204,50 @@ jobs:
               --image gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${IMAGE_TAG}
           fi
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${IMAGE_TAG}
+
+      - name: Resolve immutable development Pusher image
+        if: env.SERVICE == 'pusher' && github.event.inputs.environment != 'prod'
+        run: |
+          set -euo pipefail
+          PUSHER_IMAGE_REPOSITORY="gcr.io/${{ vars.GCP_PROJECT_ID }}/pusher"
+          PUSHER_IMAGE_DIGEST="$(gcloud container images describe "${PUSHER_IMAGE_REPOSITORY}:${IMAGE_TAG}" --format='value(image_summary.digest)')"
+          if [[ ! "$PUSHER_IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "Pusher image did not resolve to an exact digest after push." >&2
+            exit 1
+          fi
+          {
+            echo "PUSHER_IMAGE_REPOSITORY=$PUSHER_IMAGE_REPOSITORY"
+            echo "PUSHER_IMAGE_DIGEST=$PUSHER_IMAGE_DIGEST"
+            echo "PUSHER_IMAGE_REFERENCE=${PUSHER_IMAGE_REPOSITORY}@${PUSHER_IMAGE_DIGEST}"
+          } >> "$GITHUB_ENV"
+
+      - name: Promote qualified Pusher digest into the production registry
+        if: env.SERVICE == 'pusher' && github.event.inputs.environment == 'prod'
+        run: |
+          set -euo pipefail
+          test -n "$PUSHER_DEV_IMAGE_REPOSITORY"
+          test -n "$PUSHER_IMAGE_DIGEST"
+          PUSHER_IMAGE_REPOSITORY="gcr.io/${{ vars.GCP_PROJECT_ID }}/pusher"
+          SOURCE_IMAGE="${PUSHER_DEV_IMAGE_REPOSITORY}@${PUSHER_IMAGE_DIGEST}"
+          PROMOTION_TAG="promotion-${PUSHER_IMAGE_DIGEST#sha256:}"
+          gcloud container images describe "$SOURCE_IMAGE" --format='value(image_summary.digest)' | grep -Fx "$PUSHER_IMAGE_DIGEST"
+          gcloud container images add-tag --quiet "$SOURCE_IMAGE" "${PUSHER_IMAGE_REPOSITORY}:${PROMOTION_TAG}"
+          PROMOTED_DIGEST="$(gcloud container images describe "${PUSHER_IMAGE_REPOSITORY}:${PROMOTION_TAG}" --format='value(image_summary.digest)')"
+          if [[ "$PROMOTED_DIGEST" != "$PUSHER_IMAGE_DIGEST" ]]; then
+            echo "Registry promotion did not preserve the development-qualified digest." >&2
+            exit 1
+          fi
+          {
+            echo "PUSHER_IMAGE_REPOSITORY=$PUSHER_IMAGE_REPOSITORY"
+            echo "PUSHER_IMAGE_REFERENCE=${PUSHER_IMAGE_REPOSITORY}@${PUSHER_IMAGE_DIGEST}"
+          } >> "$GITHUB_ENV"
+
+      - name: Verify Pusher static rollout controls
+        if: env.SERVICE == 'pusher'
+        run: |
+          python3 backend/scripts/verify_pusher_rollout_budget.py
+          python3 backend/scripts/verify_pusher_rollout_gate.py preflight
+          python3 backend/scripts/verify_pusher_dev_observability.py
 
       - name: Get GKE credentials
         uses: google-github-actions/get-gke-credentials@v3
@@ -179,6 +282,21 @@ jobs:
             echo "sync_tasks_invoker_sa=${SYNC_TASKS_INVOKER_SA}"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Preflight existing pusher ConfigMap and Secret references
+        if: env.SERVICE == 'pusher'
+        run: |
+          python3 -m pip install -q pyyaml
+          python3 backend/scripts/verify_pusher_config_references.py \
+            --environment ${{ vars.ENV }} --namespace ${{ vars.ENV }}-omi-backend
+
+      - name: Verify live Pusher surge capacity and digest render
+        if: env.SERVICE == 'pusher'
+        run: |
+          python3 backend/scripts/verify_pusher_live_deployment_gate.py \
+            --environment ${{ vars.ENV }} \
+            --namespace ${{ vars.ENV }}-omi-backend \
+            --image "$PUSHER_IMAGE_REFERENCE"
+
       - name: Apply non-secret pusher runtime config
         if: env.SERVICE == 'pusher'
         env:
@@ -209,7 +327,7 @@ jobs:
           X_OAUTH_REDIRECT_URI: ${{ vars.X_OAUTH_REDIRECT_URI }}
         run: backend/scripts/deploy-backend-config.sh
 
-      - name: Preflight pusher ConfigMap and Secret references
+      - name: Verify reconciled pusher ConfigMap and Secret references
         if: env.SERVICE == 'pusher'
         run: |
           python3 -m pip install -q pyyaml
@@ -250,7 +368,7 @@ jobs:
             fi
             python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service llm-gateway
           else
-            helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-pusher ./backend/charts/pusher -f ./backend/charts/pusher/${{ vars.ENV }}_omi_pusher_values.yaml --set-string "image.tag=${IMAGE_TAG}"
+            helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-pusher ./backend/charts/pusher -f ./backend/charts/pusher/${{ vars.ENV }}_omi_pusher_values.yaml --set-string "image.repository=${PUSHER_IMAGE_REPOSITORY}" --set-string "image.digest=${PUSHER_IMAGE_DIGEST}" --set-string image.tag= --set-string image.pullPolicy=IfNotPresent
             # Must cover the chart-derived Pusher rollout budget (fourteen
             # availability waves at the current production HPA ceiling).
             if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-pusher --timeout=9600s; then

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -319,15 +319,7 @@ jobs:
         run: |
           python3 -m pip install -q pyyaml
           python3 backend/scripts/verify_pusher_config_references.py \
-            --environment ${{ vars.ENV }} --namespace ${{ vars.ENV }}-omi-backend
-
-      - name: Verify live Pusher surge capacity and digest render
-        if: env.SERVICE == 'pusher' && github.event.inputs.skip_live_capacity_gate != 'true'
-        run: |
-          python3 backend/scripts/verify_pusher_live_deployment_gate.py \
-            --environment ${{ vars.ENV }} \
-            --namespace ${{ vars.ENV }}-omi-backend \
-            --image "$PUSHER_IMAGE_REFERENCE"
+            --environment ${{ vars.ENV }} --namespace ${{ vars.ENV }}-omi-backend --render-only
 
       - name: Apply non-secret pusher runtime config
         if: env.SERVICE == 'pusher'
@@ -365,6 +357,14 @@ jobs:
           python3 -m pip install -q pyyaml
           python3 backend/scripts/verify_pusher_config_references.py \
             --environment ${{ vars.ENV }} --namespace ${{ vars.ENV }}-omi-backend
+
+      - name: Verify live Pusher surge capacity and digest render
+        if: env.SERVICE == 'pusher' && github.event.inputs.skip_live_capacity_gate != 'true'
+        run: |
+          python3 backend/scripts/verify_pusher_live_deployment_gate.py \
+            --environment ${{ vars.ENV }} \
+            --namespace ${{ vars.ENV }}-omi-backend \
+            --image "$PUSHER_IMAGE_REFERENCE"
 
       - name: Deploy Pusher to GKE cluster using Helm
         env:

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -31,6 +31,19 @@ on:
         description: 'Production Pusher only: successful gcp_backend_pusher_auto_deploy.yml run ID that qualified the digest'
         required: false
         default: ''
+      skip_live_capacity_gate:
+        description: 'Break-glass: deploy without the live surge-capacity gate (still requires a merged main SHA and immutable digest)'
+        required: false
+        default: false
+        type: boolean
+      break_glass_confirm:
+        description: 'Type skip-live-capacity-gate when skip_live_capacity_gate is set'
+        required: false
+        default: ''
+      break_glass_reason:
+        description: 'Why the live capacity gate is unavailable (required with skip_live_capacity_gate)'
+        required: false
+        default: ''
 
 # The LLM Gateway path reapplies shared backend-secrets; standalone pusher only
 # mutates its own GKE release and therefore keeps a separate environment lock.
@@ -64,6 +77,18 @@ jobs:
           fi
           if [[ "${{ env.SERVICE }}" == "llm-gateway" && "${{ github.event.inputs.environment }}" != "development" ]]; then
             echo "LLM Gateway deploys are dev-only until the prod launch checklist is explicitly completed."
+            exit 1
+          fi
+
+      - name: Validate live-capacity-gate break-glass inputs
+        if: env.SERVICE == 'pusher' && github.event.inputs.skip_live_capacity_gate == 'true'
+        run: |
+          if [[ "${{ github.event.inputs.break_glass_confirm }}" != "skip-live-capacity-gate" ]]; then
+            echo "ERROR: skip_live_capacity_gate requires break_glass_confirm=skip-live-capacity-gate." >&2
+            exit 1
+          fi
+          if [[ -z "${{ github.event.inputs.break_glass_reason }}" ]]; then
+            echo "ERROR: skip_live_capacity_gate requires a non-empty break_glass_reason." >&2
             exit 1
           fi
 
@@ -132,8 +157,15 @@ jobs:
             echo "Development qualification source is not a commit on fresh origin/main." >&2
             exit 1
           fi
-          if ! git diff --quiet "$QUALIFIED_SOURCE_SHA" "$CHECKED_OUT_SHA" -- backend/pusher backend/charts/pusher; then
-            echo "Current main changed Pusher source or chart since the selected dev qualification; run a new dev bake." >&2
+          # Compare the full Pusher image source closure, not a hardcoded subset.
+          # The Dockerfile COPYs backend/{config,database,models,routers,services,
+          # utils,pusher}/, so a change to any of those after qualification would
+          # silently ship a stale digest. Derive the paths from the Dockerfile
+          # itself so this never drifts from what the image actually baked in.
+          mapfile -t PUSHER_SOURCE_PATHS < <(python3 backend/scripts/verify_pusher_source_closure.py)
+          if ! git diff --quiet "$QUALIFIED_SOURCE_SHA" "$CHECKED_OUT_SHA" -- "${PUSHER_SOURCE_PATHS[@]}"; then
+            echo "Current main changed Pusher image source or chart since the selected dev qualification; run a new dev bake." >&2
+            git diff --stat "$QUALIFIED_SOURCE_SHA" "$CHECKED_OUT_SHA" -- "${PUSHER_SOURCE_PATHS[@]}" >&2 || true
             exit 1
           fi
           {
@@ -290,7 +322,7 @@ jobs:
             --environment ${{ vars.ENV }} --namespace ${{ vars.ENV }}-omi-backend
 
       - name: Verify live Pusher surge capacity and digest render
-        if: env.SERVICE == 'pusher'
+        if: env.SERVICE == 'pusher' && github.event.inputs.skip_live_capacity_gate != 'true'
         run: |
           python3 backend/scripts/verify_pusher_live_deployment_gate.py \
             --environment ${{ vars.ENV }} \
@@ -462,6 +494,27 @@ jobs:
       # If required, use the Cloud Run url output in later steps
       - name: Show Output
         run: echo "${{ env.SERVICE }} deployed to ${{ github.event.inputs.environment }}"
+
+      - name: Record live-capacity-gate break-glass use
+        if: always() && env.SERVICE == 'pusher' && github.event.inputs.skip_live_capacity_gate == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Match the repo's break-glass audit convention from gcp_backend.yml.
+          # The gate being unusable is the defect; this issue tracks fixing it.
+          gh issue create --repo "$GITHUB_REPOSITORY" \
+            --title "Pusher live capacity gate bypassed for ${CHECKED_OUT_SHA:0:10} (${{ github.event.inputs.environment }})" \
+            --body "$(printf '%s\n' \
+              "Pusher deploy ran without the live surge-capacity gate." \
+              "" \
+              "- SHA: \`${CHECKED_OUT_SHA}\` (verified ancestor of main)" \
+              "- Environment: ${{ github.event.inputs.environment }}" \
+              "- Operator: @${GITHUB_ACTOR}" \
+              "- Reason: ${{ github.event.inputs.break_glass_reason }}" \
+              "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              "" \
+              "The gate being unusable is the defect. Fix the gate, then close this.")" || true
 
       - name: Generate deployment summary
         if: always() && github.event.inputs.environment == 'prod'

--- a/.github/workflows/gcp_backend_pusher_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_pusher_auto_deploy.yml
@@ -12,6 +12,9 @@ on:
       - 'backend/utils/conversations/lifecycle.py'
       - 'backend/utils/metrics.py'
       - 'backend/utils/observability/journeys.py'
+      - 'backend/scripts/verify_pusher_live_deployment_gate.py'
+      - 'backend/scripts/verify_pusher_dev_observability.py'
+      - 'backend/scripts/verify_pusher_promotion_evidence.py'
       - '.github/workflows/gcp_backend_pusher_auto_deploy.yml'
 
 # Share the development pusher lock with manual deployments.
@@ -56,11 +59,28 @@ jobs:
 
       - name: Build and Push Docker image
         run: |
-          docker build -t gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7} -f backend/pusher/Dockerfile .
+          PUSHER_IMAGE_REPOSITORY="gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}"
+          docker build -t "${PUSHER_IMAGE_REPOSITORY}:${GITHUB_SHA::7}" -f backend/pusher/Dockerfile .
           python3 backend/scripts/runtime_image_contracts.py smoke \
             --dockerfile backend/pusher/Dockerfile \
-            --image gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}
-          docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${GITHUB_SHA::7}
+            --image "${PUSHER_IMAGE_REPOSITORY}:${GITHUB_SHA::7}"
+          docker push "${PUSHER_IMAGE_REPOSITORY}:${GITHUB_SHA::7}"
+          PUSHER_IMAGE_DIGEST="$(gcloud container images describe "${PUSHER_IMAGE_REPOSITORY}:${GITHUB_SHA::7}" --format='value(image_summary.digest)')"
+          if [[ ! "$PUSHER_IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "Pusher image did not resolve to an exact digest after push." >&2
+            exit 1
+          fi
+          {
+            echo "PUSHER_IMAGE_REPOSITORY=$PUSHER_IMAGE_REPOSITORY"
+            echo "PUSHER_IMAGE_DIGEST=$PUSHER_IMAGE_DIGEST"
+            echo "PUSHER_IMAGE_REFERENCE=${PUSHER_IMAGE_REPOSITORY}@${PUSHER_IMAGE_DIGEST}"
+          } >> "$GITHUB_ENV"
+
+      - name: Verify Pusher static rollout controls
+        run: |
+          python3 backend/scripts/verify_pusher_rollout_budget.py
+          python3 backend/scripts/verify_pusher_rollout_gate.py preflight
+          python3 backend/scripts/verify_pusher_dev_observability.py
 
       - name: Get GKE credentials
         uses: google-github-actions/get-gke-credentials@v3
@@ -75,12 +95,56 @@ jobs:
           python3 backend/scripts/verify_pusher_config_references.py \
             --environment ${{ vars.ENV }} --namespace ${{ vars.ENV }}-omi-backend
 
+      - name: Verify live Pusher surge capacity and digest render
+        run: |
+          python3 backend/scripts/verify_pusher_live_deployment_gate.py \
+            --environment ${{ vars.ENV }} \
+            --namespace ${{ vars.ENV }}-omi-backend \
+            --image "$PUSHER_IMAGE_REFERENCE"
+
       - name: Deploy Pusher to GKE cluster using Helm
         run: |
-          helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-pusher ./backend/charts/pusher -f ./backend/charts/pusher/${{ vars.ENV }}_omi_pusher_values.yaml --set-string "image.tag=${GITHUB_SHA::7}"
+          helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-pusher ./backend/charts/pusher -f ./backend/charts/pusher/${{ vars.ENV }}_omi_pusher_values.yaml --set-string "image.repository=${PUSHER_IMAGE_REPOSITORY}" --set-string "image.digest=${PUSHER_IMAGE_DIGEST}" --set-string image.tag= --set-string image.pullPolicy=IfNotPresent
           # Must cover the chart-derived Pusher rollout budget; the CI guard
           # recalculates the required value from committed chart inputs.
-          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-pusher --timeout=9600s
+          if ! kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-pusher --timeout=9600s; then
+            python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service pusher || true
+            exit 1
+          fi
+          python3 backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service pusher
+
+      - name: Record successful development Pusher qualification
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          Path("pusher-dev-qualification.json").write_text(
+              json.dumps(
+                  {
+                      "schema_version": 1,
+                      "environment": "development",
+                      "image_digest": os.environ["PUSHER_IMAGE_DIGEST"],
+                      "image_repository": os.environ["PUSHER_IMAGE_REPOSITORY"],
+                      "run_id": int(os.environ["GITHUB_RUN_ID"]),
+                      "source_sha": os.environ["GITHUB_SHA"],
+                      "workflow": "gcp_backend_pusher_auto_deploy.yml",
+                  },
+                  sort_keys=True,
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload development Pusher qualification
+        uses: actions/upload-artifact@v7
+        with:
+          name: pusher-dev-qualification
+          path: pusher-dev-qualification.json
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Show Output
         run: echo "Pusher deployed to development environment"

--- a/.github/workflows/gcp_backend_pusher_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_pusher_auto_deploy.yml
@@ -3,15 +3,19 @@ name: Auto Deploy Backend Pusher to GKE (Development)
 on:
   push:
     branches: [ "main" ]
+    # Keep this list in lockstep with the final-stage COPY source closure
+    # emitted by backend/scripts/verify_pusher_source_closure.py. A change to
+    # any copied source invalidates the development qualification artifact.
     paths:
+      - 'backend/config/**'
+      - 'backend/database/**'
+      - 'backend/models/**'
+      - 'backend/routers/**'
+      - 'backend/services/**'
+      - 'backend/utils/**'
       - 'backend/pusher/**'
       - 'backend/charts/pusher/**'
-      - 'backend/database/conversation_finalization_jobs.py'
-      - 'backend/routers/pusher.py'
-      - 'backend/services/conversation_finalization.py'
-      - 'backend/utils/conversations/lifecycle.py'
-      - 'backend/utils/metrics.py'
-      - 'backend/utils/observability/journeys.py'
+      - 'backend/scripts/verify_pusher_source_closure.py'
       - 'backend/scripts/verify_pusher_live_deployment_gate.py'
       - 'backend/scripts/verify_pusher_dev_observability.py'
       - 'backend/scripts/verify_pusher_promotion_evidence.py'

--- a/backend/charts/monitoring/dashboards/gke/pusher.json
+++ b/backend/charts/monitoring/dashboards/gke/pusher.json
@@ -1550,6 +1550,166 @@
       ],
       "title": "Memory usage (% Limit)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "pusher_ready{job=\"pusher-metrics\"}",
+          "legendFormat": "ready {{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "pusher_drain_in_progress{job=\"pusher-metrics\"}",
+          "legendFormat": "draining {{pod}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Readiness and drain (per pod)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "pusher_circuit_breaker_state{job=\"backend-listen-metrics\"}",
+          "legendFormat": "circuit state {{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(pusher_circuit_breaker_rejections_total{job=\"backend-listen-metrics\"}[5m]))",
+          "legendFormat": "rejections / second",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Reconnect circuit breaker",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/backend/docs/pusher_rolling_update_operations.md
+++ b/backend/docs/pusher_rolling_update_operations.md
@@ -158,11 +158,15 @@ Render dev and prod and eyeball the values that drive availability:
 ```bash
 helm template pusher backend/charts/pusher \
   -f backend/charts/pusher/dev_omi_pusher_values.yaml \
-  --set image.tag=<immutable-tag> > /tmp/pusher-dev.yaml
+  --set-string image.digest=sha256:<64-lowercase-hex> \
+  --set-string image.tag= \
+  --set-string image.pullPolicy=IfNotPresent > /tmp/pusher-dev.yaml
 
 helm template pusher backend/charts/pusher \
   -f backend/charts/pusher/prod_omi_pusher_values.yaml \
-  --set image.tag=<immutable-tag> > /tmp/pusher-prod.yaml
+  --set-string image.digest=sha256:<64-lowercase-hex> \
+  --set-string image.tag= \
+  --set-string image.pullPolicy=IfNotPresent > /tmp/pusher-prod.yaml
 ```
 
 Confirm in the rendered output: `readinessProbe.httpGet.path: /ready`,
@@ -201,7 +205,29 @@ rollout cannot be judged healthy against telemetry that does not exist. It does
 not scrape live values; use `... rollback --env <env>` for the rollback-mode
 contract check. Do not weaken the chart to make a check pass; fix the input.
 
-### 3. Shared ConfigMap/Secret migration guard (required on key changes)
+### 3. Live production gate and development-qualified digest promotion
+
+The automatic development Pusher workflow builds once, resolves the pushed
+`sha256` digest, runs the ConfigMap reference and live capacity gates, waits for
+the rollout, and only then uploads `pusher-dev-qualification`. Production remains
+manual: it requires that digest plus the successful development run ID. The
+production workflow downloads the attestation, verifies its exact GitHub run and
+main source SHA, rejects Pusher source/chart drift since that bake, copies the
+same digest into the production registry, and deploys `repository@sha256:...`.
+It never rebuilds a production Pusher image.
+
+Immediately before Helm, `verify_pusher_live_deployment_gate.py` renders that
+exact digest and reads only Kubernetes metadata. It fails closed unless the next
+`maxSurge` wave fits on a Ready, schedulable node matching Pusher's affinity and
+tolerations. This is capacity evidence, not a claim that the rollout has product
+traffic or user-success proof.
+
+The dev Pusher dashboard is backed by the isolated dev Prometheus scrape. It
+shows existing connection, readiness/drain, and backend-listen reconnect-circuit
+signals without creating traffic. Pod health alone is not product-success
+evidence.
+
+### 4. Shared ConfigMap/Secret migration guard (required on key changes)
 
 The 2026-07-22 production Pusher outage was a *non-atomic cross-resource
 migration*: the shared key `REDIS_DB_HOST` stopped materializing in its source
@@ -231,7 +257,9 @@ ConfigMap/Secret source or key the proposed state removes or reclassifies.
   # Render the proposed state (--rendered is repeatable across envs/workloads):
   helm template pusher backend/charts/pusher \
       -f backend/charts/pusher/prod_omi_pusher_values.yaml \
-      --set image.tag=<immutable-tag> > /tmp/pusher-prod.yaml
+      --set-string image.digest=sha256:<64-lowercase-hex> \
+      --set-string image.tag= \
+      --set-string image.pullPolicy=IfNotPresent > /tmp/pusher-prod.yaml
 
   # Capture the CURRENT live key names in the guard's inventory format
   # ({configmaps: {<obj>: [key,...]}, secrets: {...}} — names only, never values):
@@ -369,22 +397,16 @@ finalization drain) end to end before any prod consideration.
 
 How to qualify on dev (pusher dev: 1-3 pods, `maxUnavailable: 0 / maxSurge: 1`):
 
-1. **Render and preflight** exactly as in the
-   [Operator runbook](#operator-runbook), against the dev values and the dev
-   immutable tag.
-2. **Exercise the choreography under synthetic load.** Use privacy-safe
-   synthetic pusher capability checks that reuse the existing LLM-gateway smoke
-   precedent (the family that validates a ready Kubernetes workload, its
-   ingress/ILB attachment, and a Cloud Run VPC smoke route via
-   `backend/scripts/verify-llm-gateway-serving.py` and
-   `probe-llm-gateway-from-cloud-run.sh`). The pusher equivalents must open a
-   WebSocket session, confirm `/ready` flips to 503 on drain, confirm new
-   connections go to a healthy pod, and confirm background finalization
-   completes inside the grace window — without using real user data.
-3. **Hold the minimum capability/session counts and bounded error/latency
-   thresholds** from [Rollout quality gates (fail-closed)](#rollout-quality-gates-fail-closed).
-   Dev must serve the minimum session/capability counts, not just run for an
-   elapsed time.
+1. **Build once and render the digest** exactly as in the
+   [Operator runbook](#operator-runbook). The automatic workflow records its
+   digest only after the development rollout succeeds.
+2. **Observe the passive bake.** Use the dev Pusher dashboard's connection,
+   readiness/drain, and reconnect-circuit panels. Do not manufacture traffic or
+   infer product success only from readiness.
+3. **Use the resulting attestation for a manual production request.** Supply
+   the exact digest and development qualification run ID; the production workflow
+   validates the evidence, live ConfigMap references, exact digest render, and
+   real next-wave capacity before Helm mutation.
 4. **Record the evidence** (commands, output, gate result) in the PR, per the
    root `AGENTS.md` Definition of Done.
 
@@ -397,28 +419,11 @@ proof gated on SCA-40 and a healthy pusher prod baseline.
 
 ---
 
-## Relationship to SCA-40
+## Follow-up deployment controls
 
-This hardening is deliberately scoped to **native `RollingUpdate` availability**
-and does not duplicate SCA-40's work. SCA-40 owns and is still building:
-
-- **Digest chart support** (`image.digest` / `@sha256`) so a rollout pins an
-  immutable image by content digest, not just a mutable tag.
-- **Chart-only / reuse-image deploy mode** so a chart change can be applied
-  without rebuilding or re-pushing the image.
-- The immediate **`REDIS_DB_HOST` recovery preflight.**
-- **Rollback evidence** recording.
-
-Consequences for this document:
-
-- This PR does **not** add an `image.digest` chart field, a digest-promotion
-  pipeline, a chart-only deploy mode, or a rollback-evidence recorder.
-- Build-once **digest promotion** (deploying the same built image across stages by
-  digest) is deferred to stack on SCA-40; it is out of scope here.
-- The rollback described in the [Operator runbook](#operator-runbook) is
-  re-pointing the chart at the prior immutable **tag**, which is safe by the
-  N/N-1 contract. Digest-pinned rollback and recorded rollback evidence arrive
-  with SCA-40.
-
-In short: this hardening makes the native rolling update honest and bounded;
-SCA-40 makes image identity and rollback evidence durable.
+SCA-115 completes the bounded follow-up to the native RollingUpdate hardening:
+digest identity is selected from a completed dev rollout, promotion preserves
+that exact manifest digest, and the production workflow gates the live cluster's
+next surge capacity before changing the Pusher release. The existing rollback
+contract remains a separate operator action; this workflow does not auto-roll
+back traffic or data.

--- a/backend/scripts/verify_pusher_dev_observability.py
+++ b/backend/scripts/verify_pusher_dev_observability.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Keep Pusher dev-bake telemetry visible without treating health as success.
+
+This source-only gate proves the development Prometheus instance has an
+environment-isolated Pusher scrape and that its dashboard exposes connection,
+drain, and backend-listen reconnect-circuit signals.  It deliberately does not
+query a live Prometheus API or generate traffic.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DEV_VALUES = ROOT / "backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml"
+PUSHER_VALUES = ROOT / "backend/charts/pusher/dev_omi_pusher_values.yaml"
+DASHBOARD = ROOT / "backend/charts/monitoring/dashboards/gke/pusher.json"
+METRICS = ROOT / "backend/utils/metrics.py"
+EXPECTED_METRICS = (
+    "pusher_active_ws_connections",
+    "pusher_ready",
+    "pusher_drain_in_progress",
+    "pusher_circuit_breaker_state",
+    "pusher_circuit_breaker_rejections_total",
+)
+
+
+def pusher_scrape_block(values: str) -> str | None:
+    match = re.search(r"(?ms)^\s*- job_name: pusher-metrics\n(?P<block>.*?)(?=^\s*- job_name:|\Z)", values)
+    return match.group(0) if match else None
+
+
+def dashboard_expressions(payload: dict) -> set[str]:
+    expressions: set[str] = set()
+    for panel in payload.get("panels", []):
+        if not isinstance(panel, dict):
+            continue
+        for target in panel.get("targets", []):
+            if isinstance(target, dict) and isinstance(target.get("expr"), str):
+                expressions.add(target["expr"])
+    return expressions
+
+
+def validate(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    pusher_values = (root / PUSHER_VALUES.relative_to(ROOT)).read_text(encoding="utf-8")
+    for annotation in ('prometheus.io/scrape: "true"', 'prometheus.io/port: "8080"', 'prometheus.io/path: "/metrics"'):
+        if annotation not in pusher_values:
+            errors.append(f"dev Pusher chart must keep {annotation} for the isolated development scrape")
+
+    scrape = pusher_scrape_block((root / DEV_VALUES.relative_to(ROOT)).read_text(encoding="utf-8"))
+    if scrape is None:
+        errors.append("development Prometheus must define the pusher-metrics scrape job")
+    else:
+        for fragment in (
+            "credentials_file: /etc/prometheus/secrets/metrics-scrape-token/token",
+            "__meta_kubernetes_pod_annotation_prometheus_io_scrape",
+            "regex: pusher",
+        ):
+            if fragment not in scrape:
+                errors.append(f"development pusher-metrics scrape must include {fragment!r}")
+
+    metric_text = (root / METRICS.relative_to(ROOT)).read_text(encoding="utf-8")
+    for metric in EXPECTED_METRICS:
+        if f"'{metric}'" not in metric_text:
+            errors.append(f"Pusher dev-bake dashboard signal {metric!r} is not emitted")
+
+    try:
+        dashboard = json.loads((root / DASHBOARD.relative_to(ROOT)).read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"Pusher dashboard is not valid JSON: {exc}")
+    else:
+        expressions = "\n".join(dashboard_expressions(dashboard))
+        for metric in EXPECTED_METRICS:
+            if metric not in expressions:
+                errors.append(f"Pusher dashboard must expose development-visible {metric!r}")
+    return errors
+
+
+def main() -> int:
+    errors = validate()
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}")
+        return 1
+    print("OK: dev Pusher bake has isolated scrape and connection/drain/reconnect visibility.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/verify_pusher_live_deployment_gate.py
+++ b/backend/scripts/verify_pusher_live_deployment_gate.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Fail closed before a Pusher Helm mutation when live capacity cannot surge.
+
+This command is deliberately read-only.  It renders the exact digest-pinned
+chart input, reads Kubernetes metadata, and proves that the desired surge pods
+can fit on currently Ready, schedulable nodes that satisfy Pusher's placement
+constraints.  It never reads ConfigMap/Secret payloads and never creates a
+resource or sends application traffic.
+"""
+
+from __future__ import annotations
+
+import argparse
+from decimal import Decimal, InvalidOperation
+import json
+import math
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+IMAGE_RE = re.compile(r"^(?P<repository>[a-z0-9][a-z0-9._/-]*)@(?P<digest>sha256:[a-f0-9]{64})$")
+MEMORY_FACTORS = {
+    "": 1,
+    "Ki": 1024,
+    "Mi": 1024**2,
+    "Gi": 1024**3,
+    "Ti": 1024**4,
+    "K": 1000,
+    "M": 1000**2,
+    "G": 1000**3,
+    "T": 1000**4,
+}
+
+
+class GateError(ValueError):
+    """A required deployment-control input is missing or cannot be trusted."""
+
+
+@dataclass(frozen=True)
+class Resources:
+    cpu_millicores: int
+    memory_bytes: int
+
+    def add(self, other: "Resources") -> "Resources":
+        return Resources(self.cpu_millicores + other.cpu_millicores, self.memory_bytes + other.memory_bytes)
+
+    def fits_in(self, other: "Resources") -> bool:
+        return self.cpu_millicores <= other.cpu_millicores and self.memory_bytes <= other.memory_bytes
+
+    def subtract(self, other: "Resources") -> "Resources":
+        return Resources(self.cpu_millicores - other.cpu_millicores, self.memory_bytes - other.memory_bytes)
+
+
+ZERO = Resources(0, 0)
+
+
+def parse_image_reference(image: str) -> tuple[str, str]:
+    match = IMAGE_RE.fullmatch(image)
+    if match is None:
+        raise GateError("Pusher deployment image must be an exact repository@sha256 digest, never a mutable tag")
+    return match.group("repository"), match.group("digest")
+
+
+def _decimal(value: object, field: str) -> Decimal:
+    if not isinstance(value, (str, int, float)):
+        raise GateError(f"{field} must be a Kubernetes quantity")
+    try:
+        return Decimal(str(value))
+    except InvalidOperation as exc:
+        raise GateError(f"{field} must be a Kubernetes quantity, got {value!r}") from exc
+
+
+def parse_cpu(value: object, field: str) -> int:
+    raw = str(value)
+    quantity = _decimal(raw[:-1], field) if raw.endswith("m") else _decimal(raw, field) * 1000
+    if quantity < 0 or quantity != quantity.to_integral_value():
+        raise GateError(f"{field} must resolve to a non-negative whole millicore quantity")
+    return int(quantity)
+
+
+def parse_memory(value: object, field: str) -> int:
+    raw = str(value)
+    suffix = next(
+        (candidate for candidate in sorted(MEMORY_FACTORS, key=len, reverse=True) if raw.endswith(candidate)), None
+    )
+    if suffix is None:
+        raise GateError(f"{field} must be a Kubernetes memory quantity")
+    number = raw[: -len(suffix)] if suffix else raw
+    quantity = _decimal(number, field) * MEMORY_FACTORS[suffix]
+    if quantity < 0 or quantity != quantity.to_integral_value():
+        raise GateError(f"{field} must resolve to a non-negative whole byte quantity")
+    return int(quantity)
+
+
+def resource_requests(container: dict[str, Any], *, required: bool, context: str) -> Resources:
+    resources = container.get("resources")
+    requests = resources.get("requests") if isinstance(resources, dict) else None
+    if not isinstance(requests, dict):
+        if required:
+            raise GateError(f"{context} must define cpu and memory resource requests")
+        return ZERO
+    cpu = requests.get("cpu")
+    memory = requests.get("memory")
+    if required and (cpu is None or memory is None):
+        raise GateError(f"{context} must define cpu and memory resource requests")
+    return Resources(
+        parse_cpu(cpu, f"{context}.resources.requests.cpu") if cpu is not None else 0,
+        parse_memory(memory, f"{context}.resources.requests.memory") if memory is not None else 0,
+    )
+
+
+def pod_requests(pod: dict[str, Any]) -> Resources:
+    spec = pod.get("spec") if isinstance(pod.get("spec"), dict) else {}
+    app = ZERO
+    for container in spec.get("containers", []) if isinstance(spec.get("containers"), list) else []:
+        if isinstance(container, dict):
+            app = app.add(resource_requests(container, required=False, context="existing pod container"))
+    init = ZERO
+    for container in spec.get("initContainers", []) if isinstance(spec.get("initContainers"), list) else []:
+        if isinstance(container, dict):
+            candidate = resource_requests(container, required=False, context="existing init container")
+            init = Resources(
+                max(init.cpu_millicores, candidate.cpu_millicores), max(init.memory_bytes, candidate.memory_bytes)
+            )
+    overhead = spec.get("overhead") if isinstance(spec.get("overhead"), dict) else {}
+    return Resources(
+        max(app.cpu_millicores, init.cpu_millicores)
+        + (parse_cpu(overhead["cpu"], "pod overhead cpu") if "cpu" in overhead else 0),
+        max(app.memory_bytes, init.memory_bytes)
+        + (parse_memory(overhead["memory"], "pod overhead memory") if "memory" in overhead else 0),
+    )
+
+
+def node_allocatable(node: dict[str, Any]) -> Resources:
+    status = node.get("status") if isinstance(node.get("status"), dict) else {}
+    values = status.get("allocatable") if isinstance(status.get("allocatable"), dict) else {}
+    if "cpu" not in values or "memory" not in values:
+        raise GateError(f"node {node_name(node)!r} does not expose cpu and memory allocatable capacity")
+    return Resources(
+        parse_cpu(values["cpu"], "node allocatable cpu"), parse_memory(values["memory"], "node allocatable memory")
+    )
+
+
+def node_name(node: dict[str, Any]) -> str:
+    metadata = node.get("metadata") if isinstance(node.get("metadata"), dict) else {}
+    name = metadata.get("name")
+    if not isinstance(name, str) or not name:
+        raise GateError("cluster returned a node without metadata.name")
+    return name
+
+
+def _ready(node: dict[str, Any]) -> bool:
+    status = node.get("status") if isinstance(node.get("status"), dict) else {}
+    conditions = status.get("conditions") if isinstance(status.get("conditions"), list) else []
+    return any(
+        isinstance(item, dict) and item.get("type") == "Ready" and item.get("status") == "True" for item in conditions
+    )
+
+
+def _expression_matches(labels: dict[str, str], expression: dict[str, Any]) -> bool:
+    key = expression.get("key")
+    operator = expression.get("operator")
+    values = expression.get("values", [])
+    if not isinstance(key, str) or not isinstance(operator, str) or not isinstance(values, list):
+        raise GateError("Pusher node affinity contains an invalid match expression")
+    actual = labels.get(key)
+    if operator == "In":
+        return actual in values
+    if operator == "NotIn":
+        return actual is None or actual not in values
+    if operator == "Exists":
+        return actual is not None
+    if operator == "DoesNotExist":
+        return actual is None
+    if operator in {"Gt", "Lt"}:
+        if actual is None or len(values) != 1:
+            return False
+        try:
+            return int(actual) > int(values[0]) if operator == "Gt" else int(actual) < int(values[0])
+        except (TypeError, ValueError):
+            return False
+    raise GateError(f"Pusher node affinity uses unsupported operator {operator!r}")
+
+
+def _tolerates(taint: dict[str, Any], tolerations: list[dict[str, Any]]) -> bool:
+    effect = taint.get("effect")
+    if effect not in {"NoSchedule", "NoExecute"}:
+        return True
+    key = taint.get("key")
+    value = taint.get("value")
+    for item in tolerations:
+        if item.get("key") != key or item.get("effect") not in {None, "", effect}:
+            continue
+        operator = item.get("operator", "Equal")
+        if operator == "Exists" or (operator == "Equal" and item.get("value") == value):
+            return True
+    return False
+
+
+def node_matches_pod(node: dict[str, Any], pod_spec: dict[str, Any]) -> bool:
+    if not _ready(node) or pod_spec.get("nodeName"):
+        return False
+    spec = node.get("spec") if isinstance(node.get("spec"), dict) else {}
+    if spec.get("unschedulable"):
+        return False
+    metadata = node.get("metadata") if isinstance(node.get("metadata"), dict) else {}
+    labels = metadata.get("labels") if isinstance(metadata.get("labels"), dict) else {}
+    labels = {str(key): str(value) for key, value in labels.items()}
+    node_selector = pod_spec.get("nodeSelector") if isinstance(pod_spec.get("nodeSelector"), dict) else {}
+    if any(labels.get(str(key)) != str(value) for key, value in node_selector.items()):
+        return False
+    affinity = pod_spec.get("affinity") if isinstance(pod_spec.get("affinity"), dict) else {}
+    node_affinity = affinity.get("nodeAffinity") if isinstance(affinity.get("nodeAffinity"), dict) else {}
+    required = node_affinity.get("requiredDuringSchedulingIgnoredDuringExecution")
+    if isinstance(required, dict):
+        terms = required.get("nodeSelectorTerms")
+        if not isinstance(terms, list) or not terms:
+            raise GateError("Pusher required node affinity must contain at least one nodeSelectorTerm")
+        if not any(
+            isinstance(term, dict)
+            and all(_expression_matches(labels, expression) for expression in term.get("matchExpressions", []))
+            for term in terms
+        ):
+            return False
+    tolerations = pod_spec.get("tolerations") if isinstance(pod_spec.get("tolerations"), list) else []
+    tolerations = [item for item in tolerations if isinstance(item, dict)]
+    taints = spec.get("taints") if isinstance(spec.get("taints"), list) else []
+    return all(not isinstance(taint, dict) or _tolerates(taint, tolerations) for taint in taints)
+
+
+def surge_count(current_deployment: dict[str, Any], desired_deployment: dict[str, Any]) -> int:
+    status = current_deployment.get("status") if isinstance(current_deployment.get("status"), dict) else {}
+    spec = current_deployment.get("spec") if isinstance(current_deployment.get("spec"), dict) else {}
+    replicas = status.get("replicas", spec.get("replicas", 1))
+    if not isinstance(replicas, int) or replicas < 1:
+        raise GateError("live Pusher deployment must report at least one current replica")
+    desired_spec = desired_deployment.get("spec") if isinstance(desired_deployment.get("spec"), dict) else {}
+    strategy = desired_spec.get("strategy") if isinstance(desired_spec.get("strategy"), dict) else {}
+    rolling = strategy.get("rollingUpdate") if isinstance(strategy.get("rollingUpdate"), dict) else {}
+    value = rolling.get("maxSurge")
+    if isinstance(value, int):
+        surge = value
+    elif isinstance(value, str) and value.endswith("%"):
+        try:
+            surge = math.ceil(replicas * int(value[:-1]) / 100)
+        except ValueError as exc:
+            raise GateError("rendered Pusher maxSurge must be an integer or percentage") from exc
+    elif isinstance(value, str):
+        try:
+            surge = int(value)
+        except ValueError as exc:
+            raise GateError("rendered Pusher maxSurge must be an integer or percentage") from exc
+    else:
+        raise GateError("rendered Pusher Deployment is missing RollingUpdate maxSurge")
+    if surge < 1:
+        raise GateError("rendered Pusher maxSurge must provide at least one surge pod")
+    return surge
+
+
+def capacity_evidence(
+    desired_deployment: dict[str, Any],
+    current_deployment: dict[str, Any],
+    nodes: list[dict[str, Any]],
+    pods: list[dict[str, Any]],
+) -> tuple[list[str], dict[str, int]]:
+    """Return fail-closed capacity findings for the next exact Pusher surge wave."""
+
+    desired_spec = desired_deployment.get("spec") if isinstance(desired_deployment.get("spec"), dict) else {}
+    template = desired_spec.get("template") if isinstance(desired_spec.get("template"), dict) else {}
+    pod_spec = template.get("spec") if isinstance(template.get("spec"), dict) else {}
+    containers = pod_spec.get("containers") if isinstance(pod_spec.get("containers"), list) else []
+    pusher = next((item for item in containers if isinstance(item, dict) and item.get("name") == "pusher"), None)
+    if pusher is None:
+        raise GateError("rendered Pusher Deployment is missing its primary pusher container")
+    requested = resource_requests(pusher, required=True, context="rendered pusher container")
+    surge = surge_count(current_deployment, desired_deployment)
+    needed = Resources(requested.cpu_millicores * surge, requested.memory_bytes * surge)
+    usage = {node_name(node): ZERO for node in nodes}
+    for pod in pods:
+        spec = pod.get("spec") if isinstance(pod.get("spec"), dict) else {}
+        status = pod.get("status") if isinstance(pod.get("status"), dict) else {}
+        node = spec.get("nodeName")
+        if not isinstance(node, str) or node not in usage or status.get("phase") in {"Succeeded", "Failed"}:
+            continue
+        usage[node] = usage[node].add(pod_requests(pod))
+    candidates: list[tuple[str, Resources]] = []
+    for node in nodes:
+        if not node_matches_pod(node, pod_spec):
+            continue
+        name = node_name(node)
+        candidates.append((name, node_allocatable(node).subtract(usage[name])))
+    if not candidates:
+        return (["no Ready, schedulable node satisfies the rendered Pusher node affinity and tolerations"], {})
+    fitting = [(name, available) for name, available in candidates if needed.fits_in(available)]
+    details = {
+        "candidate_nodes": len(candidates),
+        "fitting_nodes": len(fitting),
+        "surge_pods": surge,
+        "required_cpu_millicores": needed.cpu_millicores,
+        "required_memory_bytes": needed.memory_bytes,
+    }
+    if fitting:
+        return [], details
+    return (
+        [
+            "insufficient schedulable Pusher headroom for the next surge wave: "
+            f"need {needed.cpu_millicores}m CPU and {needed.memory_bytes} bytes memory for {surge} surge pod(s)"
+        ],
+        details,
+    )
+
+
+def kubectl_json(arguments: list[str]) -> dict[str, Any]:
+    result = subprocess.run(["kubectl", *arguments, "-o", "json"], check=False, capture_output=True, text=True)
+    if result.returncode:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        raise GateError(detail[-1] if detail else "kubectl metadata query failed")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise GateError("kubectl did not return JSON metadata") from exc
+    if not isinstance(payload, dict):
+        raise GateError("kubectl did not return an object")
+    return payload
+
+
+def render_deployment(root: Path, environment: str, image: str) -> dict[str, Any]:
+    repository, digest = parse_image_reference(image)
+    chart = root / "backend/charts/pusher"
+    values = chart / f"{environment}_omi_pusher_values.yaml"
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            f"{environment}-omi-pusher",
+            str(chart),
+            "-f",
+            str(values),
+            "--set-string",
+            f"image.repository={repository}",
+            "--set-string",
+            f"image.digest={digest}",
+            "--set-string",
+            "image.tag=",
+            "--set-string",
+            "image.pullPolicy=IfNotPresent",
+        ],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode:
+        raise GateError(result.stderr.strip() or "helm template failed")
+    documents = [
+        item
+        for item in yaml.safe_load_all(result.stdout)
+        if isinstance(item, dict) and item.get("kind") == "Deployment"
+    ]
+    if len(documents) != 1:
+        raise GateError("digest-pinned Pusher render must contain exactly one Deployment")
+    container = next(
+        (
+            item
+            for item in documents[0].get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+            if isinstance(item, dict) and item.get("name") == "pusher"
+        ),
+        None,
+    )
+    if not isinstance(container, dict) or container.get("image") != image:
+        raise GateError("rendered Pusher Deployment did not preserve the exact requested digest identity")
+    return documents[0]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--environment", required=True, choices=("dev", "prod"))
+    parser.add_argument("--namespace", required=True)
+    parser.add_argument("--image", required=True, help="Exact repository@sha256 image selected for this deployment")
+    parser.add_argument("--root", type=Path, default=ROOT)
+    args = parser.parse_args()
+
+    try:
+        deployment = render_deployment(args.root.resolve(), args.environment, args.image)
+        current = kubectl_json(["-n", args.namespace, "get", "deployment", f"{args.environment}-omi-pusher"])
+        nodes = kubectl_json(["get", "nodes"]).get("items")
+        pods = kubectl_json(["get", "pods", "--all-namespaces"]).get("items")
+        if not isinstance(nodes, list) or not isinstance(pods, list):
+            raise GateError("cluster metadata list response is malformed")
+        failures, evidence = capacity_evidence(
+            deployment,
+            current,
+            [item for item in nodes if isinstance(item, dict)],
+            [item for item in pods if isinstance(item, dict)],
+        )
+    except GateError as exc:
+        failures = [str(exc)]
+        evidence = {}
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}")
+        return 1
+    print(
+        "OK: live Pusher capacity gate passed: "
+        f"{evidence['fitting_nodes']}/{evidence['candidate_nodes']} matching nodes fit "
+        f"{evidence['surge_pods']} surge pod(s) requiring {evidence['required_cpu_millicores']}m CPU and "
+        f"{evidence['required_memory_bytes']} bytes memory."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/verify_pusher_promotion_evidence.py
+++ b/backend/scripts/verify_pusher_promotion_evidence.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Validate the immutable Pusher artifact selected from a dev qualification run.
+
+The production workflow downloads a small, non-secret attestation artifact from
+the selected development Pusher deployment run.  This verifier binds the digest
+to that successful run's immutable source identity before the workflow can copy
+the image to the production registry or mutate the production Helm release.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+DIGEST_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
+SHA_RE = re.compile(r"^[a-f0-9]{40}$")
+SCHEMA_VERSION = 1
+
+
+class EvidenceError(ValueError):
+    """The selected development run cannot prove a safe promotion."""
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise EvidenceError(f"could not read JSON evidence {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise EvidenceError(f"{path}: expected a JSON object")
+    return value
+
+
+def validate(
+    evidence: dict[str, Any],
+    run: dict[str, Any],
+    *,
+    expected_digest: str,
+    expected_repository: str,
+    expected_workflow_id: int,
+    expected_run_id: int,
+) -> list[str]:
+    """Return every missing immutable-promotion proof without exposing secrets."""
+
+    errors: list[str] = []
+    expected_fields = {
+        "schema_version",
+        "environment",
+        "image_digest",
+        "image_repository",
+        "run_id",
+        "source_sha",
+        "workflow",
+    }
+    if set(evidence) != expected_fields:
+        errors.append("qualification evidence has an unexpected schema")
+    if evidence.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"qualification evidence must use schema_version={SCHEMA_VERSION}")
+    if evidence.get("environment") != "development":
+        errors.append("qualification evidence must be from the development environment")
+    if evidence.get("workflow") != "gcp_backend_pusher_auto_deploy.yml":
+        errors.append("qualification evidence must be emitted by the automatic dev Pusher workflow")
+
+    digest = evidence.get("image_digest")
+    if not isinstance(digest, str) or not DIGEST_RE.fullmatch(digest):
+        errors.append("qualification evidence must contain an exact sha256 image_digest")
+    elif digest != expected_digest:
+        errors.append("requested production digest does not match development qualification evidence")
+    if not DIGEST_RE.fullmatch(expected_digest):
+        errors.append("requested production digest must be an exact sha256 digest")
+
+    if evidence.get("image_repository") != expected_repository:
+        errors.append("qualification evidence repository does not match the development Pusher registry")
+    if evidence.get("run_id") != expected_run_id:
+        errors.append("qualification evidence run_id does not match the selected workflow run")
+
+    source_sha = evidence.get("source_sha")
+    if not isinstance(source_sha, str) or not SHA_RE.fullmatch(source_sha):
+        errors.append("qualification evidence must contain a full lowercase source SHA")
+    if run.get("id") != expected_run_id:
+        errors.append("selected workflow API result does not match the requested run id")
+    if run.get("workflow_id") != expected_workflow_id:
+        errors.append("selected workflow run is not the automatic dev Pusher workflow")
+    if run.get("event") != "push" or run.get("head_branch") != "main":
+        errors.append("selected workflow run must be a main push qualification")
+    if run.get("status") != "completed" or run.get("conclusion") != "success":
+        errors.append("selected workflow run did not complete successfully")
+    if isinstance(source_sha, str) and run.get("head_sha") != source_sha:
+        errors.append("qualification evidence source SHA does not match the successful workflow run")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--run-json", type=Path, required=True)
+    parser.add_argument("--expected-digest", required=True)
+    parser.add_argument("--expected-repository", required=True)
+    parser.add_argument("--expected-workflow-id", type=int, required=True)
+    parser.add_argument("--expected-run-id", type=int, required=True)
+    args = parser.parse_args()
+
+    try:
+        failures = validate(
+            load_json(args.evidence),
+            load_json(args.run_json),
+            expected_digest=args.expected_digest,
+            expected_repository=args.expected_repository,
+            expected_workflow_id=args.expected_workflow_id,
+            expected_run_id=args.expected_run_id,
+        )
+    except EvidenceError as exc:
+        failures = [str(exc)]
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}")
+        return 1
+    print("OK: selected Pusher digest is bound to a successful development qualification run.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/verify_pusher_source_closure.py
+++ b/backend/scripts/verify_pusher_source_closure.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Emit the full Pusher image source closure for promotion freshness checks.
+
+Parses the final-stage COPY instructions from the registered Pusher Dockerfile
+and prints the repo-relative source paths — plus the Helm chart directory — that
+must be unchanged between a development-qualified SHA and the checked-out
+production SHA.  Using the Dockerfile's own COPY closure instead of a hardcoded
+two-directory subset prevents a stale digest from silently deploying newer shared
+backend source (for example ``backend/utils/apps.py``) that the image baked in.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _logical_docker_lines(path: Path) -> list[str]:
+    """Fold Dockerfile continuation lines and strip comments/blanks."""
+    logical_lines: list[str] = []
+    pending = ""
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        pending = f"{pending}{stripped}" if pending else stripped
+        if pending.endswith("\\"):
+            pending = pending[:-1].rstrip() + " "
+            continue
+        logical_lines.append(pending)
+        pending = ""
+    if pending:
+        logical_lines.append(pending)
+    return logical_lines
+
+
+def final_stage_copy_sources(dockerfile: Path) -> list[str]:
+    """Return repo-relative source paths copied in the Dockerfile's final stage."""
+    stages: list[list[str]] = []
+    current: list[str] | None = None
+    for line in _logical_docker_lines(dockerfile):
+        if line.upper().startswith("FROM "):
+            current = []
+            stages.append(current)
+            continue
+        if current is not None:
+            current.append(line)
+    if not stages:
+        raise SystemExit(f"{dockerfile}: no Docker stage found")
+
+    sources: list[str] = []
+    for line in stages[-1]:
+        if not line.upper().startswith("COPY "):
+            continue
+        tokens = shlex.split(line[5:])
+        # Skip multi-stage --from= copies (those reference builder artifacts,
+        # not repo source that can drift between qualification and deploy).
+        if any(token.startswith("--from=") for token in tokens):
+            continue
+        tokens = [token for token in tokens if not token.startswith("--")]
+        if len(tokens) < 2:
+            raise SystemExit(f"cannot parse COPY instruction in {dockerfile}: {line}")
+        sources.extend(tokens[:-1])
+    return sources
+
+
+def main() -> int:
+    dockerfile = ROOT / "backend/pusher/Dockerfile"
+    image_sources = final_stage_copy_sources(dockerfile)
+    # The Helm chart is a deployment input separate from the Docker image,
+    # but a chart change also invalidates a dev qualification.
+    paths = sorted(set(image_sources) | {"backend/charts/pusher"})
+    print(" ".join(paths))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -587,7 +587,8 @@
         "backend/scripts/verify_pusher_rollout_budget.py",
         "backend/scripts/verify_pusher_live_deployment_gate.py",
         "backend/scripts/verify_pusher_promotion_evidence.py",
-        "backend/scripts/verify_pusher_dev_observability.py"
+        "backend/scripts/verify_pusher_dev_observability.py",
+        "backend/scripts/verify_pusher_source_closure.py"
       ],
       "tests": [
         "tests/unit/test_verify_pusher_rollout_budget.py",
@@ -601,7 +602,9 @@
         "Pusher's Kubernetes progress deadline and CI rollout wait both cover every configured healthy-availability wave at the committed HPA ceiling",
         "a chart change to Pusher startup/readiness/min-ready, HPA, or RollingUpdate inputs cannot silently make a healthy rollout appear failed",
         "production Pusher deploys only an exact digest attested by a successful automatic development rollout and never rebuilds that production artifact",
-        "the live deployment gate rejects missing matching-node surge capacity before Helm can mutate the release"
+        "the live deployment gate rejects missing matching-node surge capacity before Helm can mutate the release",
+        "the prod freshness check compares the full Dockerfile COPY source closure so a post-qualification change to any shared backend module cannot ship a stale digest",
+        "the live capacity gate has a confirm-and-reason break-glass hatch that records a tracking issue, matching the repo's gated-surface contract"
       ]
     },
     {

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -584,13 +584,24 @@
         "backend/charts/pusher/**",
         ".github/workflows/gcp_backend_pusher.yml",
         ".github/workflows/gcp_backend_pusher_auto_deploy.yml",
-        "backend/scripts/verify_pusher_rollout_budget.py"
+        "backend/scripts/verify_pusher_rollout_budget.py",
+        "backend/scripts/verify_pusher_live_deployment_gate.py",
+        "backend/scripts/verify_pusher_promotion_evidence.py",
+        "backend/scripts/verify_pusher_dev_observability.py"
       ],
-      "tests": ["tests/unit/test_verify_pusher_rollout_budget.py"],
+      "tests": [
+        "tests/unit/test_verify_pusher_rollout_budget.py",
+        "tests/unit/test_verify_pusher_live_deployment_gate.py",
+        "tests/unit/test_verify_pusher_promotion_evidence.py",
+        "tests/unit/test_verify_pusher_dev_observability.py",
+        "tests/unit/test_pusher_deployment_control_workflow.py"
+      ],
       "checks": [],
       "invariants": [
         "Pusher's Kubernetes progress deadline and CI rollout wait both cover every configured healthy-availability wave at the committed HPA ceiling",
-        "a chart change to Pusher startup/readiness/min-ready, HPA, or RollingUpdate inputs cannot silently make a healthy rollout appear failed"
+        "a chart change to Pusher startup/readiness/min-ready, HPA, or RollingUpdate inputs cannot silently make a healthy rollout appear failed",
+        "production Pusher deploys only an exact digest attested by a successful automatic development rollout and never rebuilds that production artifact",
+        "the live deployment gate rejects missing matching-node surge capacity before Helm can mutate the release"
       ]
     },
     {

--- a/backend/tests/unit/test_pusher_auto_deploy_paths.py
+++ b/backend/tests/unit/test_pusher_auto_deploy_paths.py
@@ -24,5 +24,8 @@ def test_pusher_auto_deploy_tracks_its_shared_lifecycle_and_observability_import
         'backend/utils/conversations/lifecycle.py',
         'backend/utils/metrics.py',
         'backend/utils/observability/journeys.py',
+        'backend/scripts/verify_pusher_live_deployment_gate.py',
+        'backend/scripts/verify_pusher_dev_observability.py',
+        'backend/scripts/verify_pusher_promotion_evidence.py',
         '.github/workflows/gcp_backend_pusher_auto_deploy.yml',
     }

--- a/backend/tests/unit/test_pusher_auto_deploy_paths.py
+++ b/backend/tests/unit/test_pusher_auto_deploy_paths.py
@@ -16,14 +16,15 @@ def test_pusher_auto_deploy_tracks_its_shared_lifecycle_and_observability_import
         paths.add(line.split("'", 2)[1])
 
     assert paths == {
+        'backend/config/**',
+        'backend/database/**',
+        'backend/models/**',
+        'backend/routers/**',
+        'backend/services/**',
+        'backend/utils/**',
         'backend/pusher/**',
         'backend/charts/pusher/**',
-        'backend/database/conversation_finalization_jobs.py',
-        'backend/routers/pusher.py',
-        'backend/services/conversation_finalization.py',
-        'backend/utils/conversations/lifecycle.py',
-        'backend/utils/metrics.py',
-        'backend/utils/observability/journeys.py',
+        'backend/scripts/verify_pusher_source_closure.py',
         'backend/scripts/verify_pusher_live_deployment_gate.py',
         'backend/scripts/verify_pusher_dev_observability.py',
         'backend/scripts/verify_pusher_promotion_evidence.py',

--- a/backend/tests/unit/test_pusher_deployment_control_workflow.py
+++ b/backend/tests/unit/test_pusher_deployment_control_workflow.py
@@ -46,6 +46,32 @@ def test_prod_pusher_requires_successful_dev_attestation_and_never_rebuilds() ->
     assert 'image.tag=${IMAGE_TAG}' not in MANUAL[helm - 300 : helm + 500]
 
 
+def test_prod_pusher_compares_full_dockerfile_source_closure_not_subset() -> None:
+    """The prod freshness check must derive comparison paths from the Dockerfile's
+    COPY instructions, not a hardcoded two-directory subset.  Otherwise a change
+    to a shared backend module (e.g. backend/utils/apps.py) would silently ship
+    a stale digest."""
+    assert "verify_pusher_source_closure.py" in MANUAL
+    assert "PUSHER_SOURCE_PATHS" in MANUAL
+    assert '"${PUSHER_SOURCE_PATHS[@]}"' in MANUAL
+    # The stale hardcoded subset must not be present.
+    assert "backend/pusher backend/charts/pusher" not in MANUAL
+
+
+def test_live_capacity_gate_has_break_glass_hatch() -> None:
+    """Every gated surface must have a break-glass hatch (AGENTS.md L122-L129).
+    The live surge-capacity gate queries cluster metadata and can fail during an
+    urgent rollout, so it must be skippable with confirm-and-reason."""
+    gate = MANUAL.index("Verify live Pusher surge capacity and digest render")
+    # The if: condition is on the line AFTER the - name: line, not before it.
+    gate_if = MANUAL.index("\n        if:", gate)
+    assert "github.event.inputs.skip_live_capacity_gate != 'true'" in MANUAL[gate : gate_if + 200]
+    assert "skip_live_capacity_gate:" in MANUAL
+    assert "break_glass_confirm:" in MANUAL
+    assert "break_glass_reason:" in MANUAL
+    assert "Record live-capacity-gate break-glass use" in MANUAL
+
+
 def test_real_config_and_capacity_gates_precede_every_pusher_helm_mutation() -> None:
     for workflow in (MANUAL, AUTO):
         config = workflow.index("verify_pusher_config_references.py")

--- a/backend/tests/unit/test_pusher_deployment_control_workflow.py
+++ b/backend/tests/unit/test_pusher_deployment_control_workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import runpy
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -58,6 +59,16 @@ def test_prod_pusher_compares_full_dockerfile_source_closure_not_subset() -> Non
     assert "backend/pusher backend/charts/pusher" not in MANUAL
 
 
+def test_dev_auto_qualification_covers_every_pusher_dockerfile_source_input() -> None:
+    """A source change that can alter the Pusher image must trigger a new dev bake."""
+    closure = runpy.run_path(str(ROOT / "backend/scripts/verify_pusher_source_closure.py"))
+    source_paths = closure["final_stage_copy_sources"](ROOT / "backend/pusher/Dockerfile")
+
+    for source_path in source_paths:
+        assert f"'{source_path}**'" in AUTO, f"development qualification does not trigger for {source_path}"
+    assert "'backend/charts/pusher/**'" in AUTO
+
+
 def test_live_capacity_gate_has_break_glass_hatch() -> None:
     """Every gated surface must have a break-glass hatch (AGENTS.md L122-L129).
     The live surge-capacity gate queries cluster metadata and can fail during an
@@ -73,17 +84,18 @@ def test_live_capacity_gate_has_break_glass_hatch() -> None:
 
 
 def test_real_config_and_capacity_gates_precede_every_pusher_helm_mutation() -> None:
-    for workflow in (MANUAL, AUTO):
-        config = workflow.index("verify_pusher_config_references.py")
-        live = workflow.rindex("verify_pusher_live_deployment_gate.py")
-        helm = workflow.index("helm -n ${{ vars.ENV }}-omi-backend upgrade --install")
+    auto_config = AUTO.index("verify_pusher_config_references.py")
+    auto_live = AUTO.index("verify_pusher_live_deployment_gate.py", auto_config)
+    auto_helm = AUTO.index("helm -n ${{ vars.ENV }}-omi-backend upgrade --install")
+    assert auto_config < auto_live < auto_helm
+    assert "--image \"$PUSHER_IMAGE_REFERENCE\"" in AUTO[auto_live:auto_helm]
 
-        assert config < live < helm
-        assert "--image \"$PUSHER_IMAGE_REFERENCE\"" in workflow[live:helm]
+    render_only = MANUAL.index("Preflight existing pusher ConfigMap and Secret references")
+    apply_config = MANUAL.index("Apply non-secret pusher runtime config")
+    reconciled_config = MANUAL.index("Verify reconciled pusher ConfigMap and Secret references")
+    live = MANUAL.index("Verify live Pusher surge capacity and digest render", reconciled_config)
+    helm = MANUAL.index("helm -n ${{ vars.ENV }}-omi-backend upgrade --install")
 
-    assert MANUAL.index("Verify live Pusher surge capacity and digest render") < MANUAL.index(
-        "Apply non-secret pusher runtime config"
-    )
-    assert MANUAL.index("Apply non-secret pusher runtime config") < MANUAL.index(
-        "Verify reconciled pusher ConfigMap and Secret references"
-    )
+    assert render_only < apply_config < reconciled_config < live < helm
+    assert "--render-only" in MANUAL[render_only:apply_config]
+    assert "--image \"$PUSHER_IMAGE_REFERENCE\"" in MANUAL[live:helm]

--- a/backend/tests/unit/test_pusher_deployment_control_workflow.py
+++ b/backend/tests/unit/test_pusher_deployment_control_workflow.py
@@ -1,0 +1,63 @@
+"""Workflow-level regression tests for Pusher artifact promotion and live gates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+MANUAL = (ROOT / ".github/workflows/gcp_backend_pusher.yml").read_text(encoding="utf-8")
+AUTO = (ROOT / ".github/workflows/gcp_backend_pusher_auto_deploy.yml").read_text(encoding="utf-8")
+
+
+def test_dev_bake_attests_the_pushed_digest_only_after_rollout_success() -> None:
+    build = AUTO.index("- name: Build and Push Docker image")
+    resolve = AUTO.index("PUSHER_IMAGE_DIGEST=\"$(gcloud container images describe", build)
+    helm = AUTO.index('image.digest=${PUSHER_IMAGE_DIGEST}')
+    rollout = AUTO.index("kubectl -n ${{ vars.ENV }}-omi-backend rollout status")
+    report = AUTO.index(
+        "backend/scripts/deploy_status_report.py --env ${{ vars.ENV }} --include-gke --gke-service pusher"
+    )
+    record = AUTO.index("Record successful development Pusher qualification")
+    upload = AUTO.index("Upload development Pusher qualification")
+
+    assert resolve < helm < rollout < report < record < upload
+    assert '"source_sha": os.environ["GITHUB_SHA"]' in AUTO
+    assert '"image_digest": os.environ["PUSHER_IMAGE_DIGEST"]' in AUTO
+    assert "--set-string image.tag=" in AUTO
+    assert "--set-string image.pullPolicy=IfNotPresent" in AUTO
+
+
+def test_prod_pusher_requires_successful_dev_attestation_and_never_rebuilds() -> None:
+    selection = MANUAL.index("Select development-qualified Pusher digest for production")
+    build = MANUAL.index("- name: Build and Push Docker image")
+    promotion = MANUAL.index("Promote qualified Pusher digest into the production registry")
+    helm = MANUAL.index('image.digest=${PUSHER_IMAGE_DIGEST}')
+
+    assert "pusher_image_digest:" in MANUAL
+    assert "pusher_dev_qualification_run_id:" in MANUAL
+    assert "gh run download" in MANUAL
+    assert "verify_pusher_promotion_evidence.py" in MANUAL
+    assert "gcloud container images add-tag --quiet" in MANUAL
+    assert selection < promotion < helm
+    assert (
+        "if: env.SERVICE == 'llm-gateway' || github.event.inputs.environment != 'prod'"
+        in MANUAL[build - 100 : build + 300]
+    )
+    assert 'image.tag=${IMAGE_TAG}' not in MANUAL[helm - 300 : helm + 500]
+
+
+def test_real_config_and_capacity_gates_precede_every_pusher_helm_mutation() -> None:
+    for workflow in (MANUAL, AUTO):
+        config = workflow.index("verify_pusher_config_references.py")
+        live = workflow.rindex("verify_pusher_live_deployment_gate.py")
+        helm = workflow.index("helm -n ${{ vars.ENV }}-omi-backend upgrade --install")
+
+        assert config < live < helm
+        assert "--image \"$PUSHER_IMAGE_REFERENCE\"" in workflow[live:helm]
+
+    assert MANUAL.index("Verify live Pusher surge capacity and digest render") < MANUAL.index(
+        "Apply non-secret pusher runtime config"
+    )
+    assert MANUAL.index("Apply non-secret pusher runtime config") < MANUAL.index(
+        "Verify reconciled pusher ConfigMap and Secret references"
+    )

--- a/backend/tests/unit/test_verify_pusher_config_references.py
+++ b/backend/tests/unit/test_verify_pusher_config_references.py
@@ -161,11 +161,12 @@ def test_standalone_pusher_reconciles_non_secret_config_before_preflight():
 
     resolve_index = workflow.index("- name: Resolve production pusher runtime targets")
     reconcile_index = workflow.index("- name: Apply non-secret pusher runtime config")
-    preflight_index = workflow.index("- name: Preflight pusher ConfigMap and Secret references")
+    existing_preflight_index = workflow.index("- name: Preflight existing pusher ConfigMap and Secret references")
+    preflight_index = workflow.index("- name: Verify reconciled pusher ConfigMap and Secret references")
     helm_index = workflow.index("helm -n ${{ vars.ENV }}-omi-backend upgrade --install")
     reconcile = workflow[reconcile_index:preflight_index]
 
-    assert resolve_index < reconcile_index < preflight_index < helm_index
+    assert resolve_index < existing_preflight_index < reconcile_index < preflight_index < helm_index
     assert all(f"          {name}:" in reconcile for name in required_config | prod_only_config)
     assert "backend/scripts/deploy-backend-config.sh" in reconcile
     assert "secrets." not in reconcile

--- a/backend/tests/unit/test_verify_pusher_dev_observability.py
+++ b/backend/tests/unit/test_verify_pusher_dev_observability.py
@@ -1,0 +1,74 @@
+"""Regression coverage for isolated Pusher development-bake telemetry."""
+
+from __future__ import annotations
+
+import runpy
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "backend/scripts/verify_pusher_dev_observability.py"
+FILES = (
+    "backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml",
+    "backend/charts/pusher/dev_omi_pusher_values.yaml",
+    "backend/charts/monitoring/dashboards/gke/pusher.json",
+    "backend/utils/metrics.py",
+)
+
+
+@pytest.fixture(scope="module")
+def verifier() -> SimpleNamespace:
+    return SimpleNamespace(**runpy.run_path(str(SCRIPT)))
+
+
+@pytest.fixture
+def fixture_root(tmp_path: Path) -> Path:
+    for relative in FILES:
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(ROOT / relative, target)
+    return tmp_path
+
+
+def replace_once(path: Path, before: str, after: str) -> None:
+    source = path.read_text(encoding="utf-8")
+    assert source.count(before) == 1
+    path.write_text(source.replace(before, after, 1), encoding="utf-8")
+
+
+def test_dev_pusher_bake_observability_contract_passes(verifier: SimpleNamespace) -> None:
+    assert verifier.validate(ROOT) == []
+
+
+@pytest.mark.parametrize(
+    ("relative", "before", "after", "expected"),
+    [
+        (
+            "backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml",
+            "- job_name: pusher-metrics",
+            "- job_name: removed-pusher-metrics",
+            "must define the pusher-metrics scrape job",
+        ),
+        (
+            "backend/charts/pusher/dev_omi_pusher_values.yaml",
+            'prometheus.io/scrape: "true"',
+            'prometheus.io/scrape: "false"',
+            "isolated development scrape",
+        ),
+        (
+            "backend/charts/monitoring/dashboards/gke/pusher.json",
+            "pusher_drain_in_progress",
+            "removed_drain_metric",
+            "development-visible 'pusher_drain_in_progress'",
+        ),
+    ],
+)
+def test_rejects_missing_scrape_or_bake_signal(
+    verifier: SimpleNamespace, fixture_root: Path, relative: str, before: str, after: str, expected: str
+) -> None:
+    replace_once(fixture_root / relative, before, after)
+
+    assert any(expected in error for error in verifier.validate(fixture_root))

--- a/backend/tests/unit/test_verify_pusher_live_deployment_gate.py
+++ b/backend/tests/unit/test_verify_pusher_live_deployment_gate.py
@@ -1,0 +1,118 @@
+"""Pure capacity tests for the read-only live Pusher deployment gate."""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "verify_pusher_live_deployment_gate.py"
+
+
+@pytest.fixture(scope="module")
+def gate() -> SimpleNamespace:
+    return SimpleNamespace(**runpy.run_path(str(SCRIPT)))
+
+
+def node(*, cpu: str = "4", memory: str = "16Gi", labels: dict[str, str] | None = None, ready: bool = True) -> dict:
+    return {
+        "metadata": {"name": "pusher-node", "labels": labels or {"service": "pusher", "env": "prod", "version": "v3"}},
+        "spec": {},
+        "status": {
+            "allocatable": {"cpu": cpu, "memory": memory},
+            "conditions": [{"type": "Ready", "status": "True" if ready else "False"}],
+        },
+    }
+
+
+def desired(*, max_surge: int = 2) -> dict:
+    return {
+        "spec": {
+            "strategy": {"rollingUpdate": {"maxSurge": max_surge}},
+            "template": {
+                "spec": {
+                    "affinity": {
+                        "nodeAffinity": {
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                "nodeSelectorTerms": [
+                                    {
+                                        "matchExpressions": [
+                                            {"key": "service", "operator": "In", "values": ["pusher"]},
+                                            {"key": "env", "operator": "In", "values": ["prod"]},
+                                            {"key": "version", "operator": "In", "values": ["v3"]},
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "containers": [{"name": "pusher", "resources": {"requests": {"cpu": "700m", "memory": "4Gi"}}}],
+                }
+            },
+        }
+    }
+
+
+def existing_pod(cpu: str, memory: str) -> dict:
+    return {
+        "spec": {
+            "nodeName": "pusher-node",
+            "containers": [{"resources": {"requests": {"cpu": cpu, "memory": memory}}}],
+        },
+        "status": {"phase": "Running"},
+    }
+
+
+def test_requires_exact_digest_identity(gate: SimpleNamespace) -> None:
+    with pytest.raises(gate.GateError, match="exact repository@sha256"):
+        gate.parse_image_reference("gcr.io/based-hardware/pusher:latest")
+
+
+def test_reports_real_headroom_for_the_rendered_surge_wave(gate: SimpleNamespace) -> None:
+    failures, evidence = gate.capacity_evidence(
+        desired(), {"status": {"replicas": 12}}, [node()], [existing_pod("1", "4Gi")]
+    )
+
+    assert failures == []
+    assert evidence["surge_pods"] == 2
+    assert evidence["fitting_nodes"] == 1
+    assert evidence["required_cpu_millicores"] == 1400
+    assert evidence["required_memory_bytes"] == 8 * 1024**3
+
+
+def test_fails_closed_when_matching_node_lacks_next_surge_capacity(gate: SimpleNamespace) -> None:
+    failures, evidence = gate.capacity_evidence(
+        desired(),
+        {"status": {"replicas": 12}},
+        [node(cpu="2", memory="10Gi")],
+        [existing_pod("1", "4Gi")],
+    )
+
+    assert evidence["fitting_nodes"] == 0
+    assert any("insufficient schedulable Pusher headroom" in failure for failure in failures)
+
+
+def test_fails_closed_when_no_ready_node_matches_pusher_affinity(gate: SimpleNamespace) -> None:
+    failures, evidence = gate.capacity_evidence(
+        desired(),
+        {"status": {"replicas": 12}},
+        [node(labels={"service": "backend", "env": "prod", "version": "v3"})],
+        [],
+    )
+
+    assert evidence == {}
+    assert failures == ["no Ready, schedulable node satisfies the rendered Pusher node affinity and tolerations"]
+
+
+def test_counts_init_container_peak_and_pod_overhead(gate: SimpleNamespace) -> None:
+    pod = {
+        "spec": {
+            "containers": [{"resources": {"requests": {"cpu": "500m", "memory": "1Gi"}}}],
+            "initContainers": [{"resources": {"requests": {"cpu": "900m", "memory": "2Gi"}}}],
+            "overhead": {"cpu": "100m", "memory": "64Mi"},
+        }
+    }
+
+    assert gate.pod_requests(pod) == gate.Resources(1000, 2 * 1024**3 + 64 * 1024**2)

--- a/backend/tests/unit/test_verify_pusher_live_deployment_gate.py
+++ b/backend/tests/unit/test_verify_pusher_live_deployment_gate.py
@@ -70,6 +70,42 @@ def test_requires_exact_digest_identity(gate: SimpleNamespace) -> None:
         gate.parse_image_reference("gcr.io/based-hardware/pusher:latest")
 
 
+def test_render_fails_closed_when_digest_identity_is_not_preserved(
+    gate: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    expected_digest = "a" * 64
+    rendered_digest = "b" * 64
+    rendered = f"""\
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: pusher
+          image: gcr.io/example/pusher@sha256:{rendered_digest}
+"""
+    monkeypatch.setattr(
+        gate.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=rendered, stderr=""),
+    )
+
+    with pytest.raises(gate.GateError, match="did not preserve the exact requested digest identity"):
+        gate.render_deployment(Path("."), "prod", f"gcr.io/example/pusher@sha256:{expected_digest}")
+
+
+def test_kubectl_query_failure_fails_closed(gate: SimpleNamespace, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        gate.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="", stderr="forbidden"),
+    )
+
+    with pytest.raises(gate.GateError, match="forbidden"):
+        gate.kubectl_json(["get", "nodes"])
+
+
 def test_reports_real_headroom_for_the_rendered_surge_wave(gate: SimpleNamespace) -> None:
     failures, evidence = gate.capacity_evidence(
         desired(), {"status": {"replicas": 12}}, [node()], [existing_pod("1", "4Gi")]
@@ -92,6 +128,11 @@ def test_fails_closed_when_matching_node_lacks_next_surge_capacity(gate: SimpleN
 
     assert evidence["fitting_nodes"] == 0
     assert any("insufficient schedulable Pusher headroom" in failure for failure in failures)
+
+
+def test_fails_closed_when_rendered_max_surge_is_zero(gate: SimpleNamespace) -> None:
+    with pytest.raises(gate.GateError, match="at least one surge pod"):
+        gate.capacity_evidence(desired(max_surge=0), {"status": {"replicas": 12}}, [node()], [])
 
 
 def test_fails_closed_when_no_ready_node_matches_pusher_affinity(gate: SimpleNamespace) -> None:

--- a/backend/tests/unit/test_verify_pusher_promotion_evidence.py
+++ b/backend/tests/unit/test_verify_pusher_promotion_evidence.py
@@ -1,0 +1,99 @@
+"""Behavioral regression tests for Pusher dev-to-prod digest qualification."""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "verify_pusher_promotion_evidence.py"
+DIGEST = "sha256:" + "a" * 64
+SOURCE_SHA = "b" * 40
+RUN_ID = 321
+WORKFLOW_ID = 654
+REPOSITORY = "gcr.io/based-hardware-dev/pusher"
+
+
+@pytest.fixture(scope="module")
+def verifier() -> SimpleNamespace:
+    return SimpleNamespace(**runpy.run_path(str(SCRIPT)))
+
+
+@pytest.fixture
+def evidence() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "environment": "development",
+        "image_digest": DIGEST,
+        "image_repository": REPOSITORY,
+        "run_id": RUN_ID,
+        "source_sha": SOURCE_SHA,
+        "workflow": "gcp_backend_pusher_auto_deploy.yml",
+    }
+
+
+@pytest.fixture
+def run() -> dict[str, object]:
+    return {
+        "id": RUN_ID,
+        "workflow_id": WORKFLOW_ID,
+        "event": "push",
+        "head_branch": "main",
+        "head_sha": SOURCE_SHA,
+        "status": "completed",
+        "conclusion": "success",
+    }
+
+
+def validate(verifier: SimpleNamespace, evidence: dict[str, object], run: dict[str, object]) -> list[str]:
+    return verifier.validate(
+        evidence,
+        run,
+        expected_digest=DIGEST,
+        expected_repository=REPOSITORY,
+        expected_workflow_id=WORKFLOW_ID,
+        expected_run_id=RUN_ID,
+    )
+
+
+def test_accepts_an_exact_digest_from_the_successful_main_dev_run(
+    verifier: SimpleNamespace, evidence: dict[str, object], run: dict[str, object]
+) -> None:
+    assert validate(verifier, evidence, run) == []
+
+
+@pytest.mark.parametrize(
+    ("target", "key", "value", "expected"),
+    [
+        ("evidence", "image_digest", "sha256:short", "exact sha256"),
+        ("evidence", "image_digest", "sha256:" + "c" * 64, "requested production digest"),
+        ("evidence", "run_id", RUN_ID + 1, "run_id does not match"),
+        ("evidence", "source_sha", "C" * 40, "full lowercase source SHA"),
+        ("run", "workflow_id", WORKFLOW_ID + 1, "not the automatic dev Pusher workflow"),
+        ("run", "event", "workflow_dispatch", "main push qualification"),
+        ("run", "conclusion", "failure", "did not complete successfully"),
+        ("run", "head_sha", "d" * 40, "does not match the successful workflow run"),
+    ],
+)
+def test_rejects_missing_or_mismatched_qualification_proof(
+    verifier: SimpleNamespace,
+    evidence: dict[str, object],
+    run: dict[str, object],
+    target: str,
+    key: str,
+    value: object,
+    expected: str,
+) -> None:
+    (evidence if target == "evidence" else run)[key] = value
+
+    assert any(expected in error for error in validate(verifier, evidence, run))
+
+
+def test_rejects_ambiguous_evidence_schema(
+    verifier: SimpleNamespace, evidence: dict[str, object], run: dict[str, object]
+) -> None:
+    evidence["untrusted"] = True
+
+    assert any("unexpected schema" in error for error in validate(verifier, evidence, run))

--- a/backend/tests/unit/test_verify_pusher_source_closure.py
+++ b/backend/tests/unit/test_verify_pusher_source_closure.py
@@ -1,0 +1,91 @@
+"""Tests for the Pusher image source-closure derivation used in prod promotion.
+
+The prod freshness gate must compare the full Dockerfile COPY source closure,
+not a hardcoded two-directory subset, so that a post-qualification change to any
+shared backend module (e.g. ``backend/utils/apps.py``) forces a new dev bake.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPT = REPO / "backend/scripts/verify_pusher_source_closure.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("verify_pusher_source_closure", SCRIPT)
+    assert spec and spec.loader, "could not load verify_pusher_source_closure.py"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["verify_pusher_source_closure"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_source_closure_includes_all_dockerfile_copy_dirs() -> None:
+    module = _load_module()
+    dockerfile = REPO / "backend/pusher/Dockerfile"
+    sources = module.final_stage_copy_sources(dockerfile)
+    # Every directory the final-stage COPY copies into the runtime image.
+    assert sorted(sources) == sorted(
+        [
+            "backend/config/",
+            "backend/database/",
+            "backend/models/",
+            "backend/routers/",
+            "backend/services/",
+            "backend/utils/",
+            "backend/pusher/",
+        ]
+    )
+
+
+def test_source_closure_cli_output_includes_chart_dir() -> None:
+    """The CLI output (used by the workflow) must also include the Helm chart dir."""
+    import subprocess
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=str(REPO),
+    )
+    paths = set(result.stdout.strip().split())
+    assert "backend/charts/pusher" in paths
+    # Must cover all Dockerfile COPY source dirs.
+    for expected in [
+        "backend/config/",
+        "backend/database/",
+        "backend/models/",
+        "backend/routers/",
+        "backend/services/",
+        "backend/utils/",
+        "backend/pusher/",
+    ]:
+        assert expected in paths, f"source closure missing {expected}"
+
+
+def test_source_closure_excludes_builder_stage_copies() -> None:
+    """Multi-stage --from= copies reference builder artifacts, not repo source."""
+    import tempfile
+
+    module = _load_module()
+    with tempfile.NamedTemporaryFile(mode="w", suffix="Dockerfile", delete=False) as f:
+        f.write(
+            "FROM base AS builder\n"
+            "COPY backend/pusher/pylock.toml /tmp/pylock.toml\n"
+            "FROM base\n"
+            "COPY --from=builder /opt/venv /opt/venv\n"
+            "COPY backend/config/ ./config/\n"
+            "COPY backend/pusher/ ./pusher/\n"
+        )
+        f.flush()
+        sources = module.final_stage_copy_sources(Path(f.name))
+    assert "backend/config/" in sources
+    assert "backend/pusher/" in sources
+    # Builder-stage copies must NOT be included.
+    assert "/opt/venv" not in sources
+    assert "backend/pusher/pylock.toml" not in sources


### PR DESCRIPTION
## Summary

- Build Pusher once in development, deploy its resolved manifest digest, and publish SHA-bound development qualification evidence.
- Require a successful development qualification for manual production Pusher promotion; promote and deploy the exact digest without rebuilding it.
- Add fail-closed rendered-image, ConfigMap/Secret reference, and live surge-capacity gates before Pusher Helm mutation, plus development dashboard coverage for connections, drain, readiness, and reconnect circuit breakers.

## Verification

- `make preflight`
- `scripts/pr-preflight --suggest`
- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_pusher_auto_deploy_paths.py backend/tests/unit/test_pusher_deployment_control_workflow.py backend/tests/unit/test_verify_pusher_rollout_gate.py backend/tests/unit/test_verify_pusher_rollout_budget.py backend/tests/unit/test_verify_pusher_config_references.py backend/tests/unit/test_verify_pusher_promotion_evidence.py backend/tests/unit/test_verify_pusher_live_deployment_gate.py backend/tests/unit/test_verify_pusher_dev_observability.py backend/tests/unit/test_rendered_deployment_contract.py backend/tests/unit/test_workflow_contracts.py .github/scripts/test_check_direct_backend_production_admission.py`

Closes SCA-115

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



Failure-Class: none
