### PR TITLE
fix(dev-harness): repair isolated Typesense lifecycle

### DIFF
--- a/scripts/dev-harness/dev_harness/cli.py
+++ b/scripts/dev-harness/dev_harness/cli.py
@@ -647,7 +647,7 @@ def _typesense_command(cfg: config.HarnessConfig) -> list[str]:
         "--name",
         _typesense_container_name(cfg),
         "-p",
-        f"127.0.0.1:{cfg.typesense_port}:{cfg.typesense_port}",
+        f"127.0.0.1:{cfg.typesense_port}:{config.TYPESENSE_CONTAINER_PORT}",
         "-v",
         f"{typesense_dir}:/data",
         f"typesense/typesense:{config.TYPESENSE_PINNED_VERSION}",

--- a/scripts/dev-harness/dev_harness/config.py
+++ b/scripts/dev-harness/dev_harness/config.py
@@ -18,6 +18,9 @@ BACKEND_PORT = 8000
 DESKTOP_BACKEND_PORT = 10201
 REDIS_PORT = 6380
 TYPESENSE_PORT = 8108
+# The official container listens on its internal default unless an explicit
+# --api-port is supplied. Harness instances vary only the loopback host port.
+TYPESENSE_CONTAINER_PORT = 8108
 TYPESENSE_PINNED_VERSION = "27.1"
 LOCAL_TYPESENSE_API_KEY = "local-typesense-api-key-not-real"
 LOCAL_FIREBASE_API_KEY = "local-firebase-auth-emulator-api-key"

--- a/scripts/dev-harness/dev_harness/qualification.py
+++ b/scripts/dev-harness/dev_harness/qualification.py
@@ -9,13 +9,14 @@ import os
 import secrets
 import shutil
 import signal
+import subprocess
 import tempfile
 import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
 
-from . import safety
+from . import config, safety
 
 LEASE_SCHEMA_VERSION = 1
 LEASE_OWNER = "omi-desktop-qualification"
@@ -161,8 +162,54 @@ def _validated_owned_records(
     return validated, process_manifest, port_manifest
 
 
+def _is_exact_typesense_docker_proxy(record: dict[str, object], lease_id: str | None) -> bool:
+    """Prove Docker's external port proxy belongs to this exact lease container."""
+
+    if lease_id is None or str(record.get("service", "")) != "typesense":
+        return False
+    port = int(str(record["port"]))
+    container = f"omi-dev-harness-{lease_id}-typesense"
+    expected_prefix = [
+        "docker",
+        "run",
+        "--rm",
+        "--name",
+        container,
+        "-p",
+        f"127.0.0.1:{port}:{config.TYPESENSE_CONTAINER_PORT}",
+    ]
+    command = record.get("command")
+    if not isinstance(command, list) or command[: len(expected_prefix)] != expected_prefix:
+        return False
+    try:
+        inspected = subprocess.run(
+            ["docker", "inspect", "--format", "{{json .}}", container],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        payload = json.loads(inspected.stdout) if inspected.returncode == 0 else {}
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict) or payload.get("Name") != f"/{container}":
+        return False
+    if not isinstance(payload.get("State"), dict) or payload["State"].get("Running") is not True:
+        return False
+    network = payload.get("NetworkSettings")
+    ports = network.get("Ports") if isinstance(network, dict) else None
+    bindings = ports.get(f"{config.TYPESENSE_CONTAINER_PORT}/tcp") if isinstance(ports, dict) else None
+    return isinstance(bindings, list) and any(
+        isinstance(binding, dict)
+        and binding.get("HostIp") == "127.0.0.1"
+        and binding.get("HostPort") == str(port)
+        for binding in bindings
+    )
+
+
 def _validated_signal(
-    record: dict[str, object], process_manifest: Path, port_manifest: Path, sig: signal.Signals
+    record: dict[str, object], process_manifest: Path, port_manifest: Path, sig: signal.Signals, lease_id: str | None = None
 ) -> None:
     """Signal only a current supervisor whose listener children still prove lease lineage."""
 
@@ -176,9 +223,11 @@ def _validated_signal(
     safety.validate_port_owner(
         port, pid=pid, port_manifest=port_manifest, process_manifest=None, service=service
     )
-    for listener_pid in safety.listening_pids(port):
-        if os.getpgid(listener_pid) != process_group or not safety.is_descendant_of(listener_pid, pid):
-            raise QualificationLeaseError("Refusing to signal a qualification listener whose lease lineage is unproven")
+    listeners = safety.listening_pids(port)
+    if listeners and not _is_exact_typesense_docker_proxy(record, lease_id):
+        for listener_pid in listeners:
+            if os.getpgid(listener_pid) != process_group or not safety.is_descendant_of(listener_pid, pid):
+                raise QualificationLeaseError("Refusing to signal a qualification listener whose lease lineage is unproven")
     try:
         os.killpg(process_group, sig)
     except (ProcessLookupError, PermissionError) as exc:
@@ -206,12 +255,14 @@ def _wait_for_ports_to_close(records: list[dict[str, object]], seconds: float) -
     return open_ports
 
 
-def _stop_owned_records(records: list[dict[str, object]], process_manifest: Path, port_manifest: Path) -> None:
+def _stop_owned_records(
+    records: list[dict[str, object]], process_manifest: Path, port_manifest: Path, lease_id: str
+) -> None:
     for sig, wait_seconds in STOP_PHASES:
         for record in records:
             pid = int(record["pid"])
             if safety.process_exists(pid):
-                _validated_signal(record, process_manifest, port_manifest, sig)
+                _validated_signal(record, process_manifest, port_manifest, sig, lease_id)
         open_ports = _wait_for_ports_to_close(records, wait_seconds)
         if not open_ports:
             return
@@ -314,7 +365,7 @@ def acquire(
                     f"Qualification lease {old_id!r} is held by live PID {old_owner}; refusing concurrent stack use"
                 )
             records, process_manifest, port_manifest = _validated_owned_records(old_state, old_repo, old_id, old_token)
-            _stop_owned_records(records, process_manifest, port_manifest)
+            _stop_owned_records(records, process_manifest, port_manifest, old_id)
             _safe_remove_state(old_state, old_repo, old_id)
             old_logs = root / "logs" / old_id
             if old_logs.is_dir():
@@ -372,7 +423,7 @@ def release(
         records, process_manifest, port_manifest = _validated_owned_records(
             state_root, recorded_repo, recorded_id, recorded_token
         )
-        _stop_owned_records(records, process_manifest, port_manifest)
+        _stop_owned_records(records, process_manifest, port_manifest, recorded_id)
         path.unlink(missing_ok=True)
         _mark_completed(state_root, recorded_repo, recorded_id, recorded_token)
         _prune(

--- a/scripts/dev-harness/tests/test_qualification_lease.py
+++ b/scripts/dev-harness/tests/test_qualification_lease.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import socket
 import subprocess
 import sys
@@ -124,3 +125,90 @@ def test_supervisor_dead_with_recorded_port_still_open_retains_incomplete_lease(
         assert not (root / "state" / lease_id / qualification.COMPLETION_FILENAME).exists()
     finally:
         listener.close()
+
+
+def test_docker_typesense_proxy_listener_is_reclaimed_only_with_exact_container_binding(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Docker owns the host listener outside the supervisor's process group."""
+    lease_id, supervisor_pid, proxy_pid, port = "qualification-typesense", 42424, 51515, 49199
+    container = f"omi-dev-harness-{lease_id}-typesense"
+    record = {
+        "service": "typesense",
+        "pid": supervisor_pid,
+        "process_group": supervisor_pid,
+        "port": port,
+        "command": [
+            "docker",
+            "run",
+            "--rm",
+            "--name",
+            container,
+            "-p",
+            f"127.0.0.1:{port}:8108",
+        ],
+    }
+    signalled: list[tuple[int, signal.Signals]] = []
+    monkeypatch.setattr(safety, "validate_owned_pid", lambda *args, **kwargs: None)
+    monkeypatch.setattr(safety, "validate_port_owner", lambda *args, **kwargs: None)
+    monkeypatch.setattr(safety, "listening_pids", lambda observed_port: (proxy_pid,) if observed_port == port else ())
+    monkeypatch.setattr(safety, "is_descendant_of", lambda child, parent: False)
+    monkeypatch.setattr(qualification.os, "getpgid", lambda pid: supervisor_pid if pid == supervisor_pid else proxy_pid)
+    monkeypatch.setattr(qualification.os, "killpg", lambda pid, sig: signalled.append((pid, sig)))
+    monkeypatch.setattr(
+        qualification.subprocess,
+        "run",
+        lambda _args, **kwargs: subprocess.CompletedProcess(
+            ["docker", "inspect"],
+            0,
+            stdout=json.dumps(
+                {
+                    "Name": f"/{container}",
+                    "State": {"Running": True},
+                    "NetworkSettings": {
+                        "Ports": {"8108/tcp": [{"HostIp": "127.0.0.1", "HostPort": str(port)}]}
+                    },
+                }
+            ),
+        ),
+    )
+
+    qualification._validated_signal(
+        record, tmp_path / "processes.json", tmp_path / "ports.json", signal.SIGTERM, lease_id
+    )
+
+    assert signalled == [(supervisor_pid, signal.SIGTERM)]
+
+
+def test_external_typesense_listener_without_exact_docker_binding_is_not_signalled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    lease_id, supervisor_pid, proxy_pid, port = "qualification-typesense", 42424, 51515, 49199
+    record = {
+        "service": "typesense",
+        "pid": supervisor_pid,
+        "process_group": supervisor_pid,
+        "port": port,
+        "command": [
+            "docker",
+            "run",
+            "--name",
+            f"omi-dev-harness-{lease_id}-typesense",
+            "-p",
+            f"127.0.0.1:{port}:8108",
+        ],
+    }
+    signalled: list[tuple[int, signal.Signals]] = []
+    monkeypatch.setattr(safety, "validate_owned_pid", lambda *args, **kwargs: None)
+    monkeypatch.setattr(safety, "validate_port_owner", lambda *args, **kwargs: None)
+    monkeypatch.setattr(safety, "listening_pids", lambda observed_port: (proxy_pid,) if observed_port == port else ())
+    monkeypatch.setattr(safety, "is_descendant_of", lambda child, parent: False)
+    monkeypatch.setattr(qualification.os, "getpgid", lambda pid: supervisor_pid if pid == supervisor_pid else proxy_pid)
+    monkeypatch.setattr(qualification.os, "killpg", lambda pid, sig: signalled.append((pid, sig)))
+
+    with pytest.raises(qualification.QualificationLeaseError, match="lease lineage is unproven"):
+        qualification._validated_signal(
+            record, tmp_path / "processes.json", tmp_path / "ports.json", signal.SIGTERM, lease_id
+        )
+
+    assert signalled == []

--- a/scripts/dev-harness/tests/test_typesense_runtime.py
+++ b/scripts/dev-harness/tests/test_typesense_runtime.py
@@ -116,13 +116,17 @@ def test_native_override_missing_binary_fails_loud(monkeypatch: pytest.MonkeyPat
         cli._typesense_command(cfg)
 
 
-def test_docker_command_keeps_pinned_image(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_docker_command_keeps_pinned_image_and_maps_host_port_to_typesense_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.setenv("OMI_TYPESENSE_RUNTIME", "docker")
+    monkeypatch.setenv("OMI_HARNESS_PORT_OFFSET", "1000")
     cfg = _cfg(tmp_path, monkeypatch)
 
     command = cli._typesense_command(cfg)
 
     assert command[0] == "docker"
+    assert f"127.0.0.1:{cfg.typesense_port}:8108" in command
     assert f"typesense/typesense:{config.TYPESENSE_PINNED_VERSION}" in command
 
 


### PR DESCRIPTION
## Summary
- map each isolated Typesense host port to the container's fixed internal listener port `8108`
- prove Docker proxy ownership with exact lease/container/binding evidence before finalization signals the recorded supervisor
- preserve fail-closed behavior for unproven listeners

## Failure evidence
M1 qualification run 30169072747 used a lease-derived Typesense host port. Docker was mapping that host port to the same port inside the container, although Typesense listens on `8108`; health checks therefore saw a closed connection. Cleanup then correctly refused an unproven Docker proxy listener.

## Verification
- `bash scripts/dev-harness/run-tests.sh` — 58 passed
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh` — passed
- `git diff --check origin/main...HEAD` — passed

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

