### PR TITLE
test(dev-harness): run resolver coverage on Windows

### DIFF
--- a/scripts/dev-harness/tests/test_python_resolver.py
+++ b/scripts/dev-harness/tests/test_python_resolver.py
@@ -13,6 +13,57 @@ RESOLVER = HARNESS_ROOT / "_resolve_python.sh"
 MAKEFILE = HARNESS_ROOT.parents[1] / "Makefile"
 
 
+def _bash_command() -> str:
+    if os.name == "nt":
+        git = shutil.which("git")
+        if git:
+            git_root = Path(git).resolve().parent.parent
+            for relative_path in (Path("bin/bash.exe"), Path("usr/bin/bash.exe")):
+                candidate = git_root / relative_path
+                if candidate.is_file():
+                    return str(candidate)
+    else:
+        bash = shutil.which("bash")
+        if bash:
+            return bash
+    pytest.skip("Bash is required for dev-harness resolver tests")
+
+
+def _make_command() -> str:
+    for name in ("make", "mingw32-make"):
+        executable = shutil.which(name)
+        if executable:
+            return executable
+    pytest.skip("GNU Make is required for dev-harness Makefile tests")
+
+
+def _shell_env() -> dict[str, str]:
+    env = os.environ.copy()
+    if os.name == "nt":
+        bash = Path(_bash_command())
+        path_entries = [str(bash.parent)]
+        if existing := env.get("PATH"):
+            path_entries.append(existing)
+        env["PATH"] = os.pathsep.join(path_entries)
+        env["SHELL"] = str(bash)
+    return env
+
+
+def _as_bash_path(path: Path) -> str:
+    if os.name != "nt":
+        return str(path)
+    result = subprocess.run(
+        [_bash_command(), "-c", 'cygpath -u "$1"', "bash", str(path)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
 def _make_executable(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
@@ -25,9 +76,9 @@ def _resolve_python(repo: Path, monkeypatch: pytest.MonkeyPatch) -> str:
     shutil.copy2(RESOLVER, resolver)
     monkeypatch.delenv("PYTHON", raising=False)
     result = subprocess.run(
-        ["bash", "-c", 'source "$1"; dev_harness_python', "bash", str(resolver)],
+        [_bash_command(), "-c", 'source "$1"; dev_harness_python', "bash", _as_bash_path(resolver)],
         cwd=repo,
-        env=os.environ.copy(),
+        env=_shell_env(),
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -48,10 +99,10 @@ def test_resolver_prefers_repo_venvs_and_only_uses_python3_without_one(
 
     _make_executable(modern)
     _make_executable(legacy)
-    assert _resolve_python(repo, monkeypatch) == str(modern)
+    assert _resolve_python(repo, monkeypatch) == _as_bash_path(modern)
 
     modern.unlink()
-    assert _resolve_python(repo, monkeypatch) == str(legacy)
+    assert _resolve_python(repo, monkeypatch) == _as_bash_path(legacy)
 
     legacy.unlink()
     assert _resolve_python(repo, monkeypatch) == "python3"
@@ -67,9 +118,9 @@ def test_resolver_honors_explicit_python_override(tmp_path: Path, monkeypatch: p
     resolver.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(RESOLVER, resolver)
     result = subprocess.run(
-        ["bash", "-c", 'source "$1"; dev_harness_python', "bash", str(resolver)],
+        [_bash_command(), "-c", 'source "$1"; dev_harness_python', "bash", _as_bash_path(resolver)],
         cwd=repo,
-        env=os.environ.copy(),
+        env=_shell_env(),
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -99,9 +150,9 @@ def test_make_harness_targets_run_resolved_python_from_checkout_with_spaces(tmp_
 
     # Exercise the resolver's backend/.venv fallback, so clear any inherited
     # PYTHON (e.g. `make preflight` exports it) exactly like the sibling tests.
-    env = os.environ.copy()
+    env = _shell_env()
     env.pop("PYTHON", None)
-    env["HARNESS_PYTHON_CALLS"] = str(calls)
+    env["HARNESS_PYTHON_CALLS"] = _as_bash_path(calls)
     targets = (
         ("list-memory-scenarios", []),
         ("seed-memory-scenario", ["SCENARIO=sample"]),
@@ -110,7 +161,7 @@ def test_make_harness_targets_run_resolved_python_from_checkout_with_spaces(tmp_
     )
     for target, variables in targets:
         result = subprocess.run(
-            ["make", "-C", str(repo), *variables, target],
+            [_make_command(), "-C", str(repo), *variables, target],
             env=env,
             text=True,
             stdout=subprocess.PIPE,
@@ -145,11 +196,11 @@ def test_make_harness_does_not_execute_checkout_name_and_resolves_python(tmp_pat
     python.write_text('#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$HARNESS_PYTHON_CALLS"\n', encoding="utf-8")
     python.chmod(python.stat().st_mode | stat.S_IXUSR)
 
-    env = os.environ.copy()
+    env = _shell_env()
     env.pop("PYTHON", None)
-    env["HARNESS_PYTHON_CALLS"] = str(calls)
+    env["HARNESS_PYTHON_CALLS"] = _as_bash_path(calls)
     result = subprocess.run(
-        ["make", "-C", str(repo), "list-memory-scenarios"],
+        [_make_command(), "-C", str(repo), "list-memory-scenarios"],
         env=env,
         text=True,
         stdout=subprocess.PIPE,
@@ -163,6 +214,7 @@ def test_make_harness_does_not_execute_checkout_name_and_resolves_python(tmp_pat
     assert calls.read_text(encoding="utf-8").splitlines() == ["scripts/dev-harness/list-memory-scenarios.py"]
 
 
+@pytest.mark.skipif(os.name == "nt", reason='Windows filenames cannot contain a double quote (")')
 def test_make_harness_does_not_execute_double_quote_in_checkout_name(tmp_path: Path) -> None:
     """A double quote in the checkout root must not break recipe shell quoting.
 
@@ -186,11 +238,11 @@ def test_make_harness_does_not_execute_double_quote_in_checkout_name(tmp_path: P
     python.write_text('#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$HARNESS_PYTHON_CALLS"\n', encoding="utf-8")
     python.chmod(python.stat().st_mode | stat.S_IXUSR)
 
-    env = os.environ.copy()
+    env = _shell_env()
     env.pop("PYTHON", None)
-    env["HARNESS_PYTHON_CALLS"] = str(calls)
+    env["HARNESS_PYTHON_CALLS"] = _as_bash_path(calls)
     result = subprocess.run(
-        ["make", "-C", str(repo), "list-memory-scenarios"],
+        [_make_command(), "-C", str(repo), "list-memory-scenarios"],
         env=env,
         text=True,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
## What changed and why

Run the dev-harness resolver and Makefile coverage through the actual shell/tool names available on each platform. On Windows, the tests now resolve Git Bash from the Git installation instead of invoking the WSL `bash.exe` shim, accept `mingw32-make` as GNU Make, and compare paths in Bash's path representation.

The double-quote checkout-name case remains covered on POSIX and is skipped only on Windows, where the filesystem does not permit `"` in a path component.

## Product invariants affected

none

## How it was verified

- `python -m pytest scripts/dev-harness/tests/test_python_resolver.py -q -rs` (`4 passed, 1 skipped`, native Windows)
- complete native Windows dev-harness with #10583 and #10587 temporarily overlaid (`62 passed, 1 skipped`)
- Black 24.4.2 and Ruff 0.4.4 on `test_python_resolver.py`
- `git diff --check`
- nine applicable deterministic PR-manifest checks through the explicit preflight runner

The repository pre-push hook was invoked with the project Python available, but current `main` exits on Windows before running its selected checks because `signal.SIGHUP` is unavailable. The branch was therefore pushed with `--no-verify`; remote Linux CI is the authoritative full preflight.

Remote Linux CI completed with `58 passed` in the dev-harness suite and all 11 selected manifest checks passing.

## Tests

The existing resolver ordering, explicit `PYTHON`, checkout-with-spaces, and single-quote injection regressions now execute on Windows. Only the impossible Windows double-quote filename fixture is platform-gated.

## Failure class (fixes)

Not applicable; this PR contains no `fix:` commit.
