### PR TITLE
SCA-121: Harden macOS candidate planner

### DIFF
--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -505,6 +505,7 @@ def check_codemagic_release_publishers() -> list[str]:
 def main() -> int:
     errors: list[str] = []
     errors.extend(check_desktop_codemagic_release())
+    errors.extend(check_desktop_candidate_trigger_authority())
     errors.extend(check_codemagic_release_publishers())
     errors.extend(check_desktop_preview_publishing())
     errors.extend(check_desktop_qualification_runner())
@@ -687,6 +688,48 @@ def check_desktop_codemagic_release() -> list[str]:
         if required_fragment not in desktop_workflow_body:
             errors.append(f"desktop release is missing signed smoke result artifact fragment: {required_fragment}")
 
+    return errors
+
+
+def check_desktop_candidate_trigger_authority() -> list[str]:
+    """Keep the normal candidate lane on Codemagic's native immutable-tag trigger."""
+    errors: list[str] = []
+    codemagic = ROOT / "codemagic.yaml"
+    candidate_workflow = ROOT / ".github/workflows/desktop_auto_release.yml"
+    preview_workflow = ROOT / ".github/workflows/desktop_publish_preview.yml"
+    if not codemagic.exists() or not candidate_workflow.exists() or not preview_workflow.exists():
+        return ["desktop candidate trigger guard is missing its checked-in release surfaces"]
+
+    codemagic_text = codemagic.read_text(encoding="utf-8")
+    match = re.search(
+        r"\n  omi-desktop-swift-release:\n(?P<body>.*?)(?=\n  [A-Za-z0-9_-]+:\n|\Z)",
+        codemagic_text,
+        flags=re.DOTALL,
+    )
+    required_trigger = (
+        "    triggering:\n"
+        "      events:\n"
+        "        - tag\n"
+        "      tag_patterns:\n"
+        '        - pattern: "v*-macos"\n'
+        "          include: true"
+    )
+    if match is None or required_trigger not in match.group("body"):
+        errors.append("normal omi-desktop-swift-release candidate lane must natively trigger on v*-macos tags")
+
+    direct_build_endpoint = "https://api.codemagic.io/builds"
+    for workflow in sorted((ROOT / ".github/workflows").glob("*.yml")):
+        if direct_build_endpoint not in workflow.read_text(encoding="utf-8"):
+            continue
+        if workflow != preview_workflow:
+            errors.append(
+                f"normal desktop candidate lane must not start Codemagic with a direct builds API POST: "
+                f"{workflow.relative_to(ROOT)}"
+            )
+
+    preview_text = preview_workflow.read_text(encoding="utf-8")
+    if direct_build_endpoint not in preview_text or 'workflowId: "omi-desktop-swift-preview"' not in preview_text:
+        errors.append("the only checked-in direct Codemagic build API caller must remain the isolated preview lane")
     return errors
 
 

--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -17,6 +19,9 @@ REQUIRED_SOURCE_CHECK_NAMES = (
     "Desktop Swift Release Compile",
 )
 RECENT_TAG_WITHOUT_CHECK_SECONDS = 10 * 60
+SOURCE_CHECK_WAIT_SECONDS = 12 * 60
+SOURCE_CHECK_POLL_SECONDS = 30
+MAX_SOURCE_STATUS_POLLS = 20
 # Short debounce so a merge is tagged within ~a minute instead of waiting ten.
 # The one-active-release fence (Codemagic build status on the latest tag) already
 # collapses rapid bursts to the newest SHA while a build runs, so this window only
@@ -29,6 +34,12 @@ DESKTOP_RELEASE_PATHS = (
     ".github/workflows/desktop_auto_release.yml",
     ".github/workflows/desktop-swift-ci.yml",
 )
+
+
+class SourceCheckGate:
+    def __init__(self, state: str, reason: str | None = None) -> None:
+        self.state = state
+        self.reason = reason
 
 
 def run(args: list[str], *, check: bool = True) -> str:
@@ -141,21 +152,138 @@ def codemagic_check_status(repository: str, sha: str) -> tuple[str | None, str |
     return github_check_status(repository, sha, CODEMAGIC_CHECK_NAME)
 
 
-def required_source_checks_reason(repository: str, sha: str) -> str | None:
+def required_source_checks_gate(repository: str, sha: str) -> SourceCheckGate:
     for check_name in REQUIRED_SOURCE_CHECK_NAMES:
         status, conclusion, error = github_check_status(repository, sha, check_name)
         if error:
-            return f"could not read required check {check_name} for source SHA {sha}: {error}"
-        if status is None:
-            return f"required check {check_name} is missing for exact source SHA {sha}"
-        if status != "completed":
-            return f"required check {check_name} for exact source SHA {sha} is {status}"
-        if conclusion != "success":
-            return (
-                f"required check {check_name} for exact source SHA {sha} "
-                f"completed with {conclusion or 'no conclusion'}"
+            return SourceCheckGate(
+                "waiting", f"could not read required check {check_name} for source SHA {sha}: {error}"
             )
-    return None
+        if status is None:
+            return SourceCheckGate("waiting", f"required check {check_name} is missing for exact source SHA {sha}")
+        if status != "completed":
+            return SourceCheckGate("waiting", f"required check {check_name} for exact source SHA {sha} is {status}")
+        if conclusion != "success":
+            return SourceCheckGate(
+                "blocked",
+                f"required check {check_name} for exact source SHA {sha} "
+                f"completed with {conclusion or 'no conclusion'}",
+            )
+    return SourceCheckGate("ready")
+
+
+def wait_for_required_source_checks(
+    repository: str, sha: str, *, wait_seconds: int, poll_seconds: int
+) -> SourceCheckGate:
+    """Re-evaluate only transient exact-SHA source-check states for a bounded time."""
+    gate = required_source_checks_gate(repository, sha)
+    if gate.state != "waiting" or wait_seconds == 0:
+        return gate
+
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return SourceCheckGate(
+                "blocked",
+                f"timed out after {wait_seconds}s waiting for required exact-SHA checks: {gate.reason}",
+            )
+        time.sleep(min(poll_seconds, remaining))
+        gate = required_source_checks_gate(repository, sha)
+        if gate.state != "waiting":
+            return gate
+
+
+def candidate_tags_for_source(sha: str) -> list[str]:
+    tags = git(["tag", "-l", "v*-macos", "--points-at", sha]).splitlines()
+    return sorted((tag for tag in tags if tag), key=version_sort_key, reverse=True)
+
+
+def github_candidate_release_published(repository: str, tag: str) -> tuple[bool | None, str | None]:
+    result = subprocess.run(
+        ["gh", "release", "view", tag, "--repo", repository, "--json", "tagName,isDraft,publishedAt"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        error = result.stderr.strip() or result.stdout.strip() or "unknown gh release view error"
+        if "not found" in error.lower():
+            return False, None
+        return None, error
+    try:
+        release = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None, "gh release view returned invalid JSON"
+    if not isinstance(release, dict) or release.get("tagName") != tag:
+        return None, "gh release view did not return the requested tag"
+    return release.get("isDraft") is False and isinstance(release.get("publishedAt"), str), None
+
+
+def normal_candidate_lifecycle(repository: str, source_sha: str, tag: str) -> tuple[str, str]:
+    """Return the tag-triggered candidate lifecycle without mutating it."""
+    status, conclusion, error = codemagic_check_status(repository, source_sha)
+    if error:
+        return "unknown", f"could not read normal candidate check for {tag}: {error}"
+    if status and status != "completed":
+        return "active", f"{CODEMAGIC_CHECK_NAME} for {tag} is {status}"
+
+    published, release_error = github_candidate_release_published(repository, tag)
+    if release_error:
+        return "unknown", f"could not read candidate release for {tag}: {release_error}"
+    if published:
+        return "published", f"immutable candidate release {tag} is published"
+    if status is None:
+        return "waiting", f"immutable tag {tag} is awaiting the normal tag-triggered Codemagic check"
+    return (
+        "blocked",
+        f"{CODEMAGIC_CHECK_NAME} for {tag} completed ({conclusion or 'no conclusion'}) without a published candidate",
+    )
+
+
+def existing_source_candidate_reason(repository: str, source_sha: str) -> str | None:
+    tags = candidate_tags_for_source(source_sha)
+    if not tags:
+        return None
+
+    tag = tags[0]
+    lifecycle, detail = normal_candidate_lifecycle(repository, source_sha, tag)
+    if lifecycle in {"active", "published"}:
+        return (
+            f"immutable candidate tag {tag} already owns exact source SHA {source_sha}; "
+            f"normal candidate lifecycle is {lifecycle} ({detail})."
+        )
+    return (
+        f"immutable candidate tag {tag} already owns exact source SHA {source_sha}; "
+        f"refusing a duplicate candidate while its normal lifecycle is {lifecycle} ({detail})."
+    )
+
+
+def source_candidate_status(repository: str, source_sha: str) -> tuple[str, str, str]:
+    """Return one bounded, read-only candidate lifecycle observation for a source SHA."""
+    tags = candidate_tags_for_source(source_sha)
+    if not tags:
+        return "waiting", "", "no immutable v*-macos candidate tag exists for this source SHA"
+    tag = tags[0]
+    lifecycle, detail = normal_candidate_lifecycle(repository, source_sha, tag)
+    return lifecycle, tag, detail
+
+
+def watch_source_candidate(repository: str, source_sha: str, *, max_polls: int, poll_seconds: int) -> int:
+    """Print only candidate lifecycle transitions using bounded read-only calls."""
+    previous: tuple[str, str, str] | None = None
+    for poll in range(max_polls):
+        observation = source_candidate_status(repository, source_sha)
+        if observation != previous:
+            lifecycle, tag, detail = observation
+            print(
+                "Desktop candidate status changed: "
+                f"source_sha={source_sha} tag={tag or 'none'} lifecycle={lifecycle}; {detail}"
+            )
+            previous = observation
+        if poll + 1 < max_polls:
+            time.sleep(poll_seconds)
+    return 0
 
 
 def active_release_reason(repository: str, latest_tag: str | None) -> str | None:
@@ -194,7 +322,30 @@ def set_output(name: str, value: str) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repository", required=True)
+    parser.add_argument("--source-check-wait-seconds", type=int, default=SOURCE_CHECK_WAIT_SECONDS)
+    parser.add_argument("--source-check-poll-seconds", type=int, default=SOURCE_CHECK_POLL_SECONDS)
+    parser.add_argument("--watch-source-sha")
+    parser.add_argument("--watch-max-polls", type=int, default=1)
+    parser.add_argument("--watch-poll-seconds", type=int, default=SOURCE_CHECK_POLL_SECONDS)
     args = parser.parse_args()
+
+    if args.source_check_wait_seconds < 0:
+        parser.error("--source-check-wait-seconds must be non-negative")
+    if args.source_check_poll_seconds <= 0:
+        parser.error("--source-check-poll-seconds must be positive")
+    if args.watch_source_sha:
+        if not re.fullmatch(r"[0-9a-f]{40}", args.watch_source_sha):
+            parser.error("--watch-source-sha must be a full lowercase SHA")
+        if not 1 <= args.watch_max_polls <= MAX_SOURCE_STATUS_POLLS:
+            parser.error(f"--watch-max-polls must be between 1 and {MAX_SOURCE_STATUS_POLLS}")
+        if args.watch_poll_seconds < 0:
+            parser.error("--watch-poll-seconds must be non-negative")
+        return watch_source_candidate(
+            args.repository,
+            args.watch_source_sha,
+            max_polls=args.watch_max_polls,
+            poll_seconds=args.watch_poll_seconds,
+        )
 
     latest_tag = latest_desktop_tag()
     changes = releasable_desktop_changes_since(latest_tag)
@@ -222,6 +373,12 @@ def main() -> int:
         for path in changes:
             print(f"  - {path}")
 
+    existing_candidate = existing_source_candidate_reason(args.repository, source_sha)
+    if existing_candidate:
+        set_output("should_release", "false")
+        set_output("reason", f"Desktop candidate already exists: {existing_candidate}")
+        return 0
+
     latest_change_age = latest_change_age_seconds(changes)
     if latest_change_age is None:
         set_output("should_release", "false")
@@ -237,10 +394,19 @@ def main() -> int:
         )
         return 0
 
-    source_check_reason = required_source_checks_reason(args.repository, source_sha)
-    if source_check_reason:
+    source_check_gate = wait_for_required_source_checks(
+        args.repository,
+        source_sha,
+        wait_seconds=args.source_check_wait_seconds,
+        poll_seconds=args.source_check_poll_seconds,
+    )
+    if source_check_gate.state == "waiting":
         set_output("should_release", "false")
-        set_output("reason", f"Desktop candidate source gate blocked: {source_check_reason}.")
+        set_output("reason", f"Waiting for required exact-SHA checks: {source_check_gate.reason}.")
+        return 0
+    if source_check_gate.state == "blocked":
+        set_output("should_release", "false")
+        set_output("reason", f"Desktop candidate source gate blocked: {source_check_gate.reason}.")
         return 0
 
     active_reason = active_release_reason(args.repository, latest_tag)

--- a/.github/scripts/test_check_release_process_guards.py
+++ b/.github/scripts/test_check_release_process_guards.py
@@ -338,6 +338,50 @@ def test_mobile_codemagic_trigger_guard_rejects_github_dispatcher(tmp_path, monk
     assert any("must not be dispatched through GitHub Actions" in error for error in errors), errors
 
 
+def _desktop_candidate_trigger_guard_root(tmp_path: Path, monkeypatch) -> tuple[Path, Path]:
+    codemagic = tmp_path / "codemagic.yaml"
+    candidate = tmp_path / ".github/workflows/desktop_auto_release.yml"
+    preview = tmp_path / ".github/workflows/desktop_publish_preview.yml"
+    candidate.parent.mkdir(parents=True)
+    shutil.copy2(REPO_ROOT / "codemagic.yaml", codemagic)
+    shutil.copy2(REPO_ROOT / ".github/workflows/desktop_auto_release.yml", candidate)
+    shutil.copy2(REPO_ROOT / ".github/workflows/desktop_publish_preview.yml", preview)
+    monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
+    return codemagic, candidate
+
+
+def test_desktop_candidate_trigger_guard_keeps_native_tag_lane_and_preview_exception(tmp_path, monkeypatch):
+    _desktop_candidate_trigger_guard_root(tmp_path, monkeypatch)
+
+    assert GUARDS.check_desktop_candidate_trigger_authority() == []
+
+
+def test_desktop_candidate_trigger_guard_rejects_non_tag_normal_trigger(tmp_path, monkeypatch):
+    codemagic, _ = _desktop_candidate_trigger_guard_root(tmp_path, monkeypatch)
+    _mutate(
+        codemagic,
+        "    triggering:\n      events:\n        - tag\n      tag_patterns:\n        - pattern: \"v*-macos\"\n          include: true\n",
+        "    triggering:\n      events:\n        - push\n      branch_patterns:\n        - pattern: main\n          include: true\n",
+    )
+
+    errors = GUARDS.check_desktop_candidate_trigger_authority()
+
+    assert any("must natively trigger on v*-macos tags" in error for error in errors), errors
+
+
+def test_desktop_candidate_trigger_guard_rejects_direct_build_api_for_normal_lane(tmp_path, monkeypatch):
+    _, candidate = _desktop_candidate_trigger_guard_root(tmp_path, monkeypatch)
+    candidate.write_text(
+        candidate.read_text(encoding="utf-8")
+        + "\n# forbidden normal-candidate dispatcher\n# https://api.codemagic.io/builds\n",
+        encoding="utf-8",
+    )
+
+    errors = GUARDS.check_desktop_candidate_trigger_authority()
+
+    assert any("must not start Codemagic with a direct builds API POST" in error for error in errors), errors
+
+
 @pytest.mark.parametrize(
     ("old", "new"),
     (

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import os
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
@@ -96,14 +98,16 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
             return "completed", "success", None
 
         with patch.object(planner, "github_check_status", side_effect=successful_check):
-            self.assertIsNone(planner.required_source_checks_reason(REPOSITORY, SOURCE_SHA))
+            gate = planner.required_source_checks_gate(REPOSITORY, SOURCE_SHA)
+
+        self.assertEqual(gate.state, "ready")
 
         self.assertEqual(
             checked,
             [(SOURCE_SHA, check_name) for check_name in planner.REQUIRED_SOURCE_CHECK_NAMES],
         )
 
-    def test_each_missing_skipped_or_failed_exact_source_check_blocks_the_gate(self) -> None:
+    def test_missing_or_nonterminal_exact_source_checks_wait_for_re_evaluation(self) -> None:
         for blocked_name in (
             "Release Eligibility",
             "Desktop Swift Build & Tests",
@@ -111,19 +115,65 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         ):
             for blocked_status, blocked_conclusion, expected in (
                 (None, None, "missing"),
-                ("completed", "skipped", "skipped"),
-                ("completed", "failure", "failure"),
+                ("in_progress", None, "in_progress"),
             ):
                 with self.subTest(check=blocked_name, conclusion=blocked_conclusion):
+
                     def check_status(_repository: str, _sha: str, check_name: str):
                         if check_name == blocked_name:
                             return blocked_status, blocked_conclusion, None
                         return "completed", "success", None
 
                     with patch.object(planner, "github_check_status", side_effect=check_status):
-                        reason = planner.required_source_checks_reason(REPOSITORY, SOURCE_SHA) or ""
-                    self.assertIn(blocked_name, reason)
-                    self.assertIn(expected, reason)
+                        gate = planner.required_source_checks_gate(REPOSITORY, SOURCE_SHA)
+                    self.assertEqual(gate.state, "waiting")
+                    self.assertIn(blocked_name, gate.reason or "")
+                    self.assertIn(expected, gate.reason or "")
+
+    def test_failed_exact_source_check_blocks_the_gate(self) -> None:
+        for blocked_conclusion in ("skipped", "failure", "cancelled"):
+            with self.subTest(conclusion=blocked_conclusion):
+
+                def check_status(_repository: str, _sha: str, check_name: str):
+                    if check_name == "Desktop Swift Build & Tests":
+                        return "completed", blocked_conclusion, None
+                    return "completed", "success", None
+
+                with patch.object(planner, "github_check_status", side_effect=check_status):
+                    gate = planner.required_source_checks_gate(REPOSITORY, SOURCE_SHA)
+                self.assertEqual(gate.state, "blocked")
+                self.assertIn("Desktop Swift Build & Tests", gate.reason or "")
+                self.assertIn(blocked_conclusion, gate.reason or "")
+
+    def test_transient_check_state_is_bounded_then_times_out_as_blocked(self) -> None:
+        waiting = planner.SourceCheckGate("waiting", "required check is missing for exact source SHA")
+        with (
+            patch.object(planner, "required_source_checks_gate", return_value=waiting),
+            patch.object(planner.time, "monotonic", side_effect=(100, 100, 121)),
+            patch.object(planner.time, "sleep") as sleep,
+        ):
+            gate = planner.wait_for_required_source_checks(REPOSITORY, SOURCE_SHA, wait_seconds=20, poll_seconds=10)
+
+        self.assertEqual(gate.state, "blocked")
+        self.assertIn("timed out after 20s", gate.reason or "")
+        sleep.assert_called_once_with(10)
+
+    def test_existing_exact_source_tag_preserves_active_or_published_candidate(self) -> None:
+        for lifecycle in ("active", "published"):
+            with self.subTest(lifecycle=lifecycle):
+                with (
+                    patch.object(planner, "candidate_tags_for_source", return_value=[LATEST_TAG]),
+                    patch.object(
+                        planner,
+                        "normal_candidate_lifecycle",
+                        return_value=(lifecycle, f"normal candidate is {lifecycle}"),
+                    ),
+                ):
+                    reason = planner.existing_source_candidate_reason(REPOSITORY, SOURCE_SHA)
+
+                self.assertIn(LATEST_TAG, reason or "")
+                self.assertIn("already owns exact source SHA", reason or "")
+                self.assertIn(lifecycle, reason or "")
 
     def test_backend_or_docs_commit_after_desktop_commit_keeps_exact_releasable_source(self) -> None:
         checked_shas: list[str] = []
@@ -142,7 +192,12 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
                 patch.object(planner, "releasable_desktop_changes_since", return_value=[RELEASABLE_PATH]),
                 patch.object(planner, "latest_change_age_seconds", return_value=601),
                 patch.object(planner, "git", side_effect=fake_git),
-                patch.object(planner, "required_source_checks_reason", side_effect=lambda _, sha: checked_shas.append(sha)),
+                patch.object(planner, "existing_source_candidate_reason", return_value=None),
+                patch.object(
+                    planner,
+                    "wait_for_required_source_checks",
+                    side_effect=lambda _, sha, **__: checked_shas.append(sha) or planner.SourceCheckGate("ready"),
+                ),
                 patch.object(planner, "active_release_reason", return_value=None),
                 patch.object(sys, "argv", [str(SCRIPT), "--repository", REPOSITORY]),
                 patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_path)}, clear=False),
@@ -154,6 +209,55 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertIn(f"source_sha={SOURCE_SHA}", outputs)
         self.assertNotIn(f"source_sha={LATER_NON_DESKTOP_SHA}", outputs)
         self.assertIn("should_release=true", outputs)
+
+    def test_duplicate_planner_invocation_does_not_create_another_tag_for_the_same_source(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output_path = Path(directory) / "github-output"
+            with (
+                patch.object(planner, "latest_desktop_tag", return_value=LATEST_TAG),
+                patch.object(planner, "releasable_desktop_changes_since", return_value=[RELEASABLE_PATH]),
+                patch.object(planner, "latest_releasable_desktop_sha", return_value=SOURCE_SHA),
+                patch.object(
+                    planner,
+                    "candidate_tags_for_source",
+                    return_value=[LATEST_TAG],
+                ),
+                patch.object(planner, "normal_candidate_lifecycle", return_value=("active", "candidate is active")),
+                patch.object(planner, "wait_for_required_source_checks") as wait,
+                patch.object(sys, "argv", [str(SCRIPT), "--repository", REPOSITORY]),
+                patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_path)}, clear=False),
+            ):
+                self.assertEqual(planner.main(), 0)
+            outputs = output_path.read_text(encoding="utf-8")
+
+        wait.assert_not_called()
+        self.assertIn("should_release=false", outputs)
+        self.assertIn("Desktop candidate already exists", outputs)
+        self.assertIn(LATEST_TAG, outputs)
+
+    def test_read_only_status_watcher_reports_only_lifecycle_transitions(self) -> None:
+        observations = [
+            ("waiting", "", "no immutable candidate tag exists"),
+            ("waiting", "", "no immutable candidate tag exists"),
+            ("active", LATEST_TAG, "Release OMI Desktop (Swift) is in_progress"),
+        ]
+        output = io.StringIO()
+        with (
+            patch.object(planner, "source_candidate_status", side_effect=observations),
+            patch.object(planner.time, "sleep") as sleep,
+            redirect_stdout(output),
+        ):
+            self.assertEqual(
+                planner.watch_source_candidate(REPOSITORY, SOURCE_SHA, max_polls=3, poll_seconds=30),
+                0,
+            )
+
+        lines = output.getvalue().splitlines()
+        self.assertEqual(len(lines), 2)
+        self.assertIn("lifecycle=waiting", lines[0])
+        self.assertIn("lifecycle=active", lines[1])
+        self.assertIn(LATEST_TAG, lines[1])
+        self.assertEqual(sleep.call_args_list, [((30,), {}), ((30,), {})])
 
     def test_workflow_has_no_input_manual_trigger_and_tags_the_changelog_commit(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
@@ -167,7 +271,12 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertNotIn("break_glass", workflow)
         self.assertIn("source_sha: ${{ steps.plan.outputs.source_sha }}", workflow)
         self.assertIn("ref: ${{ steps.recheck.outputs.source_sha }}", workflow)
-        self.assertLess(workflow.index('git commit -m "chore: consolidate changelog for v${VERSION}"'), workflow.index('git tag "$RELEASE_TAG"'))
+        self.assertEqual(workflow.count("--source-check-wait-seconds 720"), 2)
+        self.assertEqual(workflow.count("--source-check-poll-seconds 30"), 2)
+        self.assertLess(
+            workflow.index('git commit -m "chore: consolidate changelog for v${VERSION}"'),
+            workflow.index('git tag "$RELEASE_TAG"'),
+        )
 
     def test_candidate_creation_has_no_selfhosted_pre_tag_gate(self) -> None:
         # Continuous deployment: candidate creation (tag-release) must depend only

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -64,7 +64,9 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           python3 .github/scripts/plan-desktop-release.py \
-            --repository "${{ github.repository }}"
+            --repository "${{ github.repository }}" \
+            --source-check-wait-seconds 720 \
+            --source-check-poll-seconds 30
 
       - name: Show release plan
         run: echo "${{ steps.plan.outputs.reason }}"
@@ -109,7 +111,9 @@ jobs:
           fi
 
           python3 .github/scripts/plan-desktop-release.py \
-            --repository "${{ github.repository }}"
+            --repository "${{ github.repository }}" \
+            --source-check-wait-seconds 720 \
+            --source-check-poll-seconds 30
 
       - name: Checkout exact releasable desktop source
         if: steps.recheck.outputs.should_release == 'true'

--- a/desktop/macos/docs/release.md
+++ b/desktop/macos/docs/release.md
@@ -1,6 +1,18 @@
 # Desktop release
 
-Normal path: merge `main` → the daily `Build Desktop Release Candidate` workflow creates one immutable tag → trusted qualification promotes that exact artifact to Beta automatically.
+Normal path: merge `main` → `Build Desktop Release Candidate` waits a bounded time for the three exact-SHA source checks, then creates one immutable tag → trusted qualification promotes that exact artifact to Beta automatically. If an immutable `v*-macos` tag already owns the selected source SHA, the planner exits without another tag; an active or published normal candidate is preserved, and an anomalous lifecycle remains blocked rather than duplicated.
+
+`omi-desktop-swift-release` starts only from Codemagic's native `v*-macos` tag trigger. Never start the normal candidate lane with a direct Codemagic `/builds` API POST; that API is reserved for the isolated preview workflow. For bounded, read-only candidate status polling, run from the repository root:
+
+```bash
+python3 .github/scripts/plan-desktop-release.py \
+  --repository BasedHardware/omi \
+  --watch-source-sha <40-character-source-sha> \
+  --watch-max-polls 5 \
+  --watch-poll-seconds 30
+```
+
+The watcher reports only lifecycle transitions and never creates tags or builds, dispatches qualification, promotes channels, or changes release pointers.
 
 If a signed, qualified candidate did not reach Beta, run **Recover Qualified Desktop Beta** with `release_tag`, `confirm=recover-beta`, and a short `reason`. The backend rechecks immutable evidence, qualification, admission state, and the pointer transaction; the workflow run is the recovery audit record.
 

--- a/docs/doc/developer/desktop-updates.mdx
+++ b/docs/doc/developer/desktop-updates.mdx
@@ -18,6 +18,9 @@ creating an immutable, non-live GitHub candidate. The
 trusted macOS qualifier is dispatched on that immutable candidate tag, checks
 out the same tag, and records qualification evidence bound to its exact source
 SHA and the two signed artifact digests in its exact GitHub Actions artifact.
+The normal `omi-desktop-swift-release` build starts only through Codemagic's
+native immutable `v*-macos` tag trigger; a direct Codemagic build API request
+is not a normal-candidate entry point.
 It may attach a byte-identical `qualification-evidence-<tag>.json` release
 copy for operator convenience, but that copy is never authority. The one narrow
 `BETA_PROMOTION_TOKEN` bearer capability authorizes both reservation at


### PR DESCRIPTION
## Summary

- Re-evaluate missing or nonterminal exact-SHA source checks for up to 12 minutes; terminal failures and timeouts remain explicit blocks.
- Preserve an existing immutable exact-source candidate instead of creating a duplicate tag, and add a bounded read-only lifecycle watcher.
- Guard and document the native `v*-macos` Codemagic trigger as the sole normal candidate entry point; direct `/builds` API use remains preview-only.

## Failure class

Failure-Class: FC-release-build-config-source-binding

## Verification

- `python3 .github/scripts/test_plan_desktop_release.py`
- `backend/.venv/bin/python -m pytest -q .github/scripts/test_check_release_process_guards.py -k 'desktop_candidate_trigger'`
- `python3 .github/scripts/check-release-process-guards.py`
- `actionlint .github/workflows/desktop_auto_release.yml`
- `make preflight`

## No-side-effect boundary

This PR only changes future candidate planning and read-only status observation. It creates no tags, Codemagic builds, qualification runs, promotions, channel-pointer changes, releases, deployments, or production/Beta/Stable mutations.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

