### PR TITLE
test: add replay LLM gateway fake-upstream seam

### DIFF
--- a/backend/testing/replay_harness_llm_gateway_fake_upstream/README.md
+++ b/backend/testing/replay_harness_llm_gateway_fake_upstream/README.md
@@ -1,0 +1,34 @@
+# Replay Harness LLM Gateway Fake-Upstream Oracle
+
+**LIFECYCLE: permanent** — a deterministic, advisory structural test for the
+LLM gateway's real route and provider terminal path. Run it with:
+
+```bash
+npm run test:replay-llm-fake-upstream
+```
+
+The oracle starts a loopback-only OpenAI-compatible fake upstream and injects
+that upstream only through FastAPI's test dependency override. It then drives
+the real gateway router, route resolver, executor, and
+`OpenAICompatibleChatCompletionProvider`. Normal provider construction and
+routing remain unchanged outside this test process.
+
+## Contract
+
+The fake upstream proves only that:
+
+1. the real provider adapter uses the expected chat-completions path;
+2. a routed gateway request completes exactly one bounded local round trip;
+3. gateway and upstream event ordering remains stable; and
+4. an incoming request cannot choose or redirect the upstream target.
+
+It intentionally does **not** establish OpenAI or Anthropic SSE fidelity,
+provider conformance, production endpoint behavior, client compatibility, a
+release gate, capture/replay, or Phase 0B.
+
+## Data safety
+
+The fake retains only endpoint path shape, event labels, request/response
+schema keys, status/error classes, request count, and a bounded-timing result.
+It never logs or persists prompt content, completions, token values, provider
+bodies, header values, credentials, or identifiers.

--- a/backend/testing/replay_harness_llm_gateway_fake_upstream/__init__.py
+++ b/backend/testing/replay_harness_llm_gateway_fake_upstream/__init__.py
@@ -1,0 +1,1 @@
+"""Hermetic, local-only LLM gateway fake-upstream oracle."""

--- a/backend/testing/replay_harness_llm_gateway_fake_upstream/oracle.py
+++ b/backend/testing/replay_harness_llm_gateway_fake_upstream/oracle.py
@@ -1,0 +1,262 @@
+"""Loopback-only structural oracle for the LLM gateway provider terminal path.
+
+This is not a provider conformance suite. It drives the real FastAPI gateway,
+route resolver, executor, and OpenAI-compatible provider adapter against a
+controlled local fake upstream. Printed evidence is intentionally restricted
+to path shape, event ordering, schema keys, status/error classes, and a bounded
+timing outcome. The fake never retains prompts, completions, token values,
+provider bodies, headers, credentials, or identifiers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import threading
+import time
+import warnings
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+# The pinned Starlette/httpx combination emits an import-time warning. The
+# oracle's stdout is reserved for its structural evidence JSON.
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from starlette.testclient import TestClient
+
+from llm_gateway.gateway.executor import ProviderRegistry
+from llm_gateway.gateway.providers import OpenAICompatibleChatCompletionProvider
+from llm_gateway.main import app
+from llm_gateway.routers import dependencies
+
+GATEWAY_PATH = "/v1/chat/completions"
+ROUND_TRIP_DEADLINE_SECONDS = 5.0
+MAX_LOOPBACK_REQUEST_BYTES = 16 * 1024
+EXPECTED_PROVIDER_REQUEST_KEYS = ("messages", "model", "reasoning_effort", "stream")
+EXPECTED_GATEWAY_RESPONSE_KEYS = ("choices", "created", "id", "model", "object")
+
+
+class OracleFailure(AssertionError):
+    """A bounded structural assertion failed."""
+
+
+@dataclass
+class _LoopbackOpenAI:
+    """Local fake upstream that retains only allowlisted structural evidence."""
+
+    endpoint_path: str = GATEWAY_PATH
+    events: list[str] = field(default_factory=list)
+    request_schema_keys: tuple[str, ...] = ()
+    request_count: int = 0
+    _server: ThreadingHTTPServer | None = None
+    _thread: threading.Thread | None = None
+    _handler_failure: BaseException | None = None
+
+    @property
+    def base_url(self) -> str:
+        if self._server is None:
+            raise RuntimeError("loopback upstream has not started")
+        return f"http://127.0.0.1:{self._server.server_address[1]}/v1"
+
+    def __enter__(self) -> "_LoopbackOpenAI":
+        upstream = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+                try:
+                    if self.path.split("?", 1)[0] != upstream.endpoint_path:
+                        raise OracleFailure("provider adapter used an unexpected upstream path")
+                    upstream.events.append("upstream_request")
+                    upstream.request_count += 1
+
+                    # Parse one bounded body, then retain only its top-level schema
+                    # keys. No body values are captured or logged.
+                    content_length = int(self.headers.get("Content-Length", "0"))
+                    if content_length <= 0 or content_length > MAX_LOOPBACK_REQUEST_BYTES:
+                        raise OracleFailure("provider adapter sent an invalid request size")
+                    request_body = json.loads(self.rfile.read(content_length))
+                    if not isinstance(request_body, dict):
+                        raise OracleFailure("provider adapter sent a non-object request")
+                    upstream.request_schema_keys = tuple(sorted(request_body))
+                    if upstream.request_schema_keys != EXPECTED_PROVIDER_REQUEST_KEYS:
+                        raise OracleFailure("provider request schema changed unexpectedly")
+
+                    response_body = {
+                        "id": "loopback",
+                        "object": "chat.completion",
+                        "created": 0,
+                        "model": "loopback",
+                        "choices": [{"index": 0, "message": {"role": "assistant"}, "finish_reason": "stop"}],
+                    }
+                    encoded_response = json.dumps(response_body, separators=(",", ":")).encode("utf-8")
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(encoded_response)))
+                    self.end_headers()
+                    self.wfile.write(encoded_response)
+                    upstream.events.append("upstream_response")
+                except BaseException as error:
+                    upstream._handler_failure = error
+                    self.send_response(500)
+                    self.end_headers()
+
+            def log_message(self, _format: str, *_args: object) -> None:
+                # BaseHTTPRequestHandler would otherwise print request details.
+                return None
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, _exc_type: Any, _exc: Any, _traceback: Any) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=ROUND_TRIP_DEADLINE_SECONDS)
+        if self._handler_failure is not None:
+            raise self._handler_failure
+
+
+@contextmanager
+def _temporary_environment(values: Mapping[str, str]) -> Iterator[None]:
+    previous = {key: os.environ.get(key) for key in values}
+    os.environ.update(values)
+    try:
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+@contextmanager
+def _bounded_evidence_logging() -> Iterator[None]:
+    """Keep oracle output inside the structural-evidence allowlist."""
+
+    loggers = [logging.getLogger("llm_gateway.gateway.metrics")]
+    previous_levels = [logger.level for logger in loggers]
+    for logger in loggers:
+        logger.setLevel(logging.CRITICAL)
+    try:
+        yield
+    finally:
+        for logger, previous_level in zip(loggers, previous_levels):
+            logger.setLevel(previous_level)
+
+
+def _status_class(status_code: int) -> str:
+    return f"{status_code // 100}xx"
+
+
+def _valid_gateway_request() -> dict[str, object]:
+    # Empty content proves only the route contract and prevents prompt capture.
+    return {"model": "omi:auto:chat-structured", "messages": [{"role": "user", "content": ""}]}
+
+
+def run_oracle() -> dict[str, Any]:
+    """Run the gateway against its controlled loopback upstream."""
+
+    previous_overrides = dict(app.dependency_overrides)
+    registry: ProviderRegistry | None = None
+    try:
+        with _temporary_environment(
+            {
+                "OMI_LLM_GATEWAY_SERVICE_TOKEN": "loopback-test-token",
+                "OPENAI_API_KEY": "loopback-test-key",
+            }
+        ), _bounded_evidence_logging(), _LoopbackOpenAI() as upstream:
+            registry = ProviderRegistry(
+                {
+                    "openai": OpenAICompatibleChatCompletionProvider(base_url=upstream.base_url),
+                }
+            )
+            # This override is test-owned. Production construction remains the
+            # cached registry in llm_gateway.routers.dependencies.
+            app.dependency_overrides[dependencies.get_provider_registry] = lambda: registry
+
+            with TestClient(app) as client:
+                started_at = time.monotonic()
+                response = client.post(
+                    GATEWAY_PATH,
+                    json=_valid_gateway_request(),
+                    headers={
+                        "Authorization": "Bearer loopback-test-token",
+                        "X-Omi-Service-Caller": "backend",
+                    },
+                )
+                if time.monotonic() - started_at > ROUND_TRIP_DEADLINE_SECONDS:
+                    raise OracleFailure("gateway loopback round trip exceeded its bounded deadline")
+                if _status_class(response.status_code) != "2xx":
+                    raise OracleFailure("gateway did not return a successful status class")
+                response_body = response.json()
+                if not isinstance(response_body, dict):
+                    raise OracleFailure("gateway returned a non-object response")
+                response_schema_keys = tuple(sorted(response_body))
+                if response_schema_keys != EXPECTED_GATEWAY_RESPONSE_KEYS:
+                    raise OracleFailure("gateway response schema changed unexpectedly")
+                upstream.events.append("gateway_response")
+
+                # An external caller cannot change the provider target. The router
+                # rejects this unknown field before the provider terminal path runs.
+                redirect_response = client.post(
+                    GATEWAY_PATH,
+                    json={**_valid_gateway_request(), "upstream_url": upstream.base_url},
+                    headers={
+                        "Authorization": "Bearer loopback-test-token",
+                        "X-Omi-Service-Caller": "backend",
+                    },
+                )
+                if _status_class(redirect_response.status_code) != "4xx":
+                    raise OracleFailure("gateway accepted an incoming upstream target")
+                redirect_body = redirect_response.json()
+                error = redirect_body.get("error") if isinstance(redirect_body, dict) else None
+                error_class = error.get("code") if isinstance(error, dict) else None
+                if error_class != "invalid_request":
+                    raise OracleFailure("gateway used an unexpected redirect rejection class")
+                if upstream.request_count != 1:
+                    raise OracleFailure("incoming upstream target reached the provider terminal path")
+                upstream.events.append("redirect_rejected")
+
+                expected_events = ["upstream_request", "upstream_response", "gateway_response", "redirect_rejected"]
+                if upstream.events != expected_events:
+                    raise OracleFailure("gateway and provider terminal event ordering changed")
+
+                return {
+                    "oracle": "replay-llm-gateway-fake-upstream",
+                    "endpoint_path": upstream.endpoint_path,
+                    "event_order": upstream.events,
+                    "request_schema_keys": upstream.request_schema_keys,
+                    "response_schema_keys": response_schema_keys,
+                    "status_classes": ["2xx", "4xx"],
+                    "error_classes": [error_class],
+                    "provider_request_count": upstream.request_count,
+                    "bounded_round_trip": "within_5_seconds",
+                }
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(previous_overrides)
+        if registry is not None:
+            asyncio.run(registry.aclose())
+
+
+def main() -> int:
+    try:
+        evidence = run_oracle()
+    except Exception as error:
+        print(f"Replay LLM gateway fake-upstream oracle failed: {type(error).__name__}")
+        return 1
+    print(json.dumps(evidence, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/testing/replay_harness_llm_gateway_fake_upstream/run.sh
+++ b/backend/testing/replay_harness_llm_gateway_fake_upstream/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run the advisory LLM gateway oracle against its loopback fake upstream.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$repo_root"
+
+if [[ ! -x backend/.venv/bin/python ]]; then
+  echo "Missing backend/.venv. Run make setup first." >&2
+  exit 1
+fi
+
+PYTHONPATH=backend backend/.venv/bin/python -m testing.replay_harness_llm_gateway_fake_upstream.oracle

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:sync-cloud-tasks-stack:emulator": "backend/testing/sync_cloud_tasks_stack/run.sh",
     "test:replay-harness-phase0a:emulator": "backend/testing/replay_harness_phase0a/run.sh",
     "test:replay-stt-wire-fidelity": "backend/testing/replay_harness_stt_wire_fidelity/run.sh",
+    "test:replay-llm-fake-upstream": "backend/testing/replay_harness_llm_gateway_fake_upstream/run.sh",
     "test:memory-vector-repair-outbox:emulator": "firebase emulators:exec --only firestore --project demo-memory \"python3 backend/scripts/vector_repair_outbox_emulator_test.py\"",
     "test:memory-vector-repair-outbox-rules:emulator": "firebase emulators:exec --only firestore --project demo-memory \"node backend/scripts/firestore_rules_emulator_test.mjs\"",
     "test:memory-vector-repair-outbox-lease:emulator": "firebase emulators:exec --only firestore --project demo-memory \"python3 backend/scripts/vector_repair_outbox_lease_emulator_test.py\"",


### PR DESCRIPTION
## Summary

- adds a test-owned, loopback fake-upstream oracle at the LLM gateway/provider terminal boundary;
- exercises the real gateway router, resolver, executor, and OpenAI-compatible adapter against a controlled fake;
- proves an incoming `upstream_url` is rejected before provider routing, leaving normal production routes/configuration unchanged.

## Scope

This is a deterministic fake-upstream prerequisite only. It does not call real providers, capture provider/user payloads, add a production override, or implement the OpenAI/Anthropic SSE fidelity matrix.

Evidence is structural-only: endpoint path, status/error class, event ordering, bounded timing, and schema-key names. No prompts, completions, token values, provider bodies, header values, credentials, or identifiers are retained.

## Verification

Final head: `c9c374e3b890d6a7265358d970f561af9df35d68`

- `npm run test:replay-llm-fake-upstream`
- focused gateway suite: `58 passed`
- `make preflight`
- `scripts/pr-preflight --pr-body-file /tmp/omi-pr-body-10585.md`

## Follow-up

The separate SSE terminal-marker, midstream-fault, status-map, and Anthropic sequencing oracle remains out of scope.

Closes #10585


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

