### PR TITLE
fix(release): paginate planner check lookup

### DIFF
--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -115,7 +115,12 @@ def github_check_status(repository: str, sha: str, check_name: str) -> tuple[str
         [
             "gh",
             "api",
-            f"repos/{repository}/commits/{sha}/check-runs?filter=latest",
+            # A busy source SHA can accumulate more than GitHub's default 30
+            # check runs (for example, planner and deployment backstops). Scan
+            # every page so an older required source gate is not misreported as
+            # missing after later checks arrive.
+            f"repos/{repository}/commits/{sha}/check-runs?filter=latest&per_page=100",
+            "--paginate",
             "--jq",
             f'.check_runs[] | select(.name=="{check_name}") | [.status, (.conclusion // "")] | @tsv',
         ],

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -101,6 +102,35 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertEqual(
             checked,
             [(SOURCE_SHA, check_name) for check_name in planner.REQUIRED_SOURCE_CHECK_NAMES],
+        )
+
+    def test_required_source_check_is_found_beyond_the_default_first_check_run_page(self) -> None:
+        required_name = "Release Eligibility"
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="completed\tsuccess\n",
+            stderr="",
+        )
+
+        with patch.object(planner.subprocess, "run", return_value=completed) as run:
+            self.assertEqual(
+                planner.github_check_status(REPOSITORY, SOURCE_SHA, required_name),
+                ("completed", "success", None),
+            )
+
+        run.assert_called_once_with(
+            [
+                "gh",
+                "api",
+                f"repos/{REPOSITORY}/commits/{SOURCE_SHA}/check-runs?filter=latest&per_page=100",
+                "--paginate",
+                "--jq",
+                f'.check_runs[] | select(.name=="{required_name}") | [.status, (.conclusion // "")] | @tsv',
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
 
     def test_each_missing_skipped_or_failed_exact_source_check_blocks_the_gate(self) -> None:


### PR DESCRIPTION
## Summary
- Paginate GitHub check-run lookups used by the desktop release planner.
- Prevent required exact-SHA gates from disappearing after the default check-run page fills.

## Product invariants affected

none

## Failure class

Failure-Class: none

This is an isolated pagination defect; the shared planner lookup now scans every page and its direct regression test protects the boundary.

## Verification
- `python3 .github/scripts/test_plan_desktop_release.py`
- Queried the patched lookup against `c6c1eb5c1ed01e8d9bafa5bb719b91d36a29672e`; all three exact-SHA required checks returned `completed/success`.
- `make preflight`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

