### PR TITLE
fix(ci): support Windows in manifest preflight

### DIFF
--- a/.github/scripts/run_checks.py
+++ b/.github/scripts/run_checks.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import Any
 
-VALID_PLATFORMS = {"all", "macos", "linux"}
+VALID_PLATFORMS = {"all", "macos", "linux", "windows"}
 
 
 def detect_platform() -> str:
@@ -26,6 +26,8 @@ def detect_platform() -> str:
         return "macos"
     if system == "Linux":
         return "linux"
+    if system == "Windows":
+        return "windows"
     return system.lower()
 
 

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -16,6 +16,7 @@ from collections import Counter
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
+from unittest.mock import patch
 
 from run_checks import (
     VALID_PLATFORMS,
@@ -286,6 +287,7 @@ class ManifestContractTests(unittest.TestCase):
 
 
 class RunnerBehaviorTests(unittest.TestCase):
+    @unittest.skipIf(os.name == "nt", "requires a POSIX shell")
     def test_firestore_contention_runner_uses_uv_without_backend_venv(self) -> None:
         source = REPO_ROOT / "backend/testing/desktop_beta_admission/run.sh"
         with tempfile.TemporaryDirectory() as tmp:
@@ -553,13 +555,17 @@ class PlatformTests(unittest.TestCase):
         manifest = Manifest(
             checks=(
                 Check(
-                    id="bad", command=("true",), triggers=("all",), lanes=("ci",), reason="t", platforms=("windows",)
+                    id="bad", command=("true",), triggers=("all",), lanes=("ci",), reason="t", platforms=("plan9",)
                 ),
             ),
             exempt=(),
         )
         errors = validate_manifest(manifest, REPO_ROOT)
         self.assertTrue(any("invalid platforms" in e for e in errors))
+
+    def test_detect_platform_maps_windows(self):
+        with patch("run_checks._platform_mod.system", return_value="Windows"):
+            self.assertEqual(detect_platform(), "windows")
 
     def test_detect_platform_returns_known_value(self):
         plat = detect_platform()


### PR DESCRIPTION
## What changed and why

Treat native Windows as a supported check-manifest platform. `detect_platform()` already returned `windows`, but manifest validation rejected that value, so every Windows `scripts/pr-preflight` run failed its own contract test. The POSIX Firestore runner harness is now skipped on Windows, where `bash` resolves to the WSL launcher rather than the POSIX environment the test requires.

## Product invariants affected

none

## How it was verified

- Reproduced both failures on unmodified `main`: `windows` was rejected, and the POSIX runner test launched Windows' WSL `bash.exe`.
- `python .github/scripts/test_run_checks.py`: 27 tests passed with the single POSIX-only case skipped.
- `scripts/pr-preflight --pr-body-file ...`: all 11 selected checks passed on `platform=windows`.

This exercises the real Windows preflight path end to end, not only the platform helper.

## Tests

`test_detect_platform_maps_windows` pins the supported platform mapping. The existing host-platform test now runs successfully on Windows, while the Firestore shell harness remains covered on POSIX CI.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

