### PR TITLE
fix(preflight): decode Git content as UTF-8 on Windows

### DIFF
--- a/.github/scripts/check_deployment_secret_boundary.py
+++ b/.github/scripts/check_deployment_secret_boundary.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import Iterable
 
-
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_POLICY = ROOT / "config" / "deployment-setting-classification.json"
 EXPRESSION = re.compile(r"\$\{\{\s*(secrets|vars)\.([A-Z][A-Z0-9_]*)\s*}}")
@@ -62,11 +61,7 @@ def _deployment_paths(root: Path) -> set[str]:
             paths.add(relative)
     charts = root / "backend" / "charts"
     if charts.is_dir():
-        paths.update(
-            repository_relative_path(path, root)
-            for path in charts.glob("*/*_values.yaml")
-            if path.is_file()
-        )
+        paths.update(repository_relative_path(path, root) for path in charts.glob("*/*_values.yaml") if path.is_file())
     return paths
 
 
@@ -80,7 +75,7 @@ def _base_paths(root: Path, base: str) -> set[str]:
         ["git", "ls-tree", "-r", "--name-only", base],
         cwd=root,
         check=True,
-        text=True,
+        encoding="utf-8",
         stdout=subprocess.PIPE,
         env=_git_environment(),
     )
@@ -88,7 +83,8 @@ def _base_paths(root: Path, base: str) -> set[str]:
     return {
         path
         for path in paths
-        if path.startswith(".github/workflows/") and path.endswith((".yml", ".yaml"))
+        if path.startswith(".github/workflows/")
+        and path.endswith((".yml", ".yaml"))
         or path == "backend/deploy/runtime_env.yaml"
         or re.fullmatch(r"backend/charts/[^/]+/[^/]+_values\.yaml", path) is not None
     }
@@ -98,7 +94,7 @@ def _read_base_file(root: Path, base: str, relative_path: str) -> str | None:
     result = subprocess.run(
         ["git", "show", f"{base}:{relative_path}"],
         cwd=root,
-        text=True,
+        encoding="utf-8",
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
         env=_git_environment(),
@@ -280,7 +276,9 @@ def validate_bindings(
     # Public build configuration is an explicit migration target, not legacy
     # debt. Reject it even when a pre-ratchet line still exists in the base.
     to_validate = new_or_changed | {
-        binding for binding in current if binding.source == "github_secrets" and _classification(policy, binding.name) == "public_build"
+        binding
+        for binding in current
+        if binding.source == "github_secrets" and _classification(policy, binding.name) == "public_build"
     }
     for binding in sorted(to_validate):
         kind = _classification(policy, binding.name)
@@ -291,7 +289,9 @@ def validate_bindings(
         if kind in expected or _exception_allows(policy, binding):
             continue
         if binding.source == "github_secrets" and kind == "public_build":
-            errors.append(f"{binding.path}: public_build setting {binding.name} must use vars.{binding.name}, not secrets.{binding.name}")
+            errors.append(
+                f"{binding.path}: public_build setting {binding.name} must use vars.{binding.name}, not secrets.{binding.name}"
+            )
         else:
             expected_text = " or ".join(sorted(expected))
             errors.append(

--- a/.github/scripts/check_product_file_line_count_ratchet.py
+++ b/.github/scripts/check_product_file_line_count_ratchet.py
@@ -137,7 +137,9 @@ def validate_baseline(value: Any, shard_relative: str | None = None) -> dict[str
         if not isinstance(relative, str) or not is_product_source(relative):
             raise ValueError(f"baseline contains unsupported source path: {relative!r}")
         if shard_relative is not None and baseline_shard_relative(relative) != shard_relative:
-            raise ValueError(f"baseline path {relative!r} belongs in {baseline_shard_relative(relative)}, not {shard_relative}")
+            raise ValueError(
+                f"baseline path {relative!r} belongs in {baseline_shard_relative(relative)}, not {shard_relative}"
+            )
         if not isinstance(count, int) or isinstance(count, bool) or count < THRESHOLD:
             raise ValueError(f"baseline count for {relative} must be an integer at least {THRESHOLD}")
     for relative, justification in justifications.items():
@@ -179,9 +181,7 @@ def load_baseline_shards(root: Path) -> dict[str, dict[str, Any]]:
     legacy = baseline_path(root)
     if legacy.is_file():
         return {LEGACY_BASELINE_RELATIVE: load_baseline_file(legacy)}
-    raise ValueError(
-        f"no baseline shards found under {BASELINE_DIRECTORY_RELATIVE} and legacy baseline is absent"
-    )
+    raise ValueError(f"no baseline shards found under {BASELINE_DIRECTORY_RELATIVE} and legacy baseline is absent")
 
 
 def aggregate_baseline_shards(shards: dict[str, dict[str, Any]]) -> dict[str, Any]:
@@ -315,7 +315,7 @@ def baseline_at_ref(root: Path, ref: str) -> dict[str, Any] | None:
         ["git", "ls-tree", "-r", "--name-only", ref, "--", BASELINE_DIRECTORY_RELATIVE],
         cwd=root,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
         check=False,
         env=env,
     )
@@ -333,7 +333,7 @@ def baseline_at_ref(root: Path, ref: str) -> dict[str, Any] | None:
                 ["git", "show", f"{ref}:{shard_relative}"],
                 cwd=root,
                 capture_output=True,
-                text=True,
+                encoding="utf-8",
                 check=False,
                 env=env,
             )
@@ -349,7 +349,7 @@ def baseline_at_ref(root: Path, ref: str) -> dict[str, Any] | None:
         ["git", "show", f"{ref}:{LEGACY_BASELINE_RELATIVE}"],
         cwd=root,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
         check=False,
         env=env,
     )
@@ -444,7 +444,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--root", help="Repository root (default: inferred from this script)")
     parser.add_argument("--changed-files", type=Path, help="Newline-delimited repository-relative changed paths")
     parser.add_argument("--base", help="Git ref used to validate explicit baseline raises")
-    parser.add_argument("--bootstrap", action="store_true", help="Create initial sharded snapshots when no baseline exists")
+    parser.add_argument(
+        "--bootstrap", action="store_true", help="Create initial sharded snapshots when no baseline exists"
+    )
     parser.add_argument(
         "--update-baseline",
         action="store_true",

--- a/.github/scripts/deferred-work-marker-count.py
+++ b/.github/scripts/deferred-work-marker-count.py
@@ -104,7 +104,7 @@ def added_lines(base: str, path: str) -> list[tuple[int, str]]:
         check=False,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
+        encoding="utf-8",
     )
     if result.returncode:
         raise RuntimeError(result.stderr.strip() or f"git diff failed for {path}")
@@ -170,7 +170,7 @@ def marker_counts_at_base(base: str, path: str) -> Counter[str]:
         check=False,
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
-        text=True,
+        encoding="utf-8",
     )
     if result.returncode:
         return Counter()

--- a/.github/scripts/test_check_deployment_secret_boundary.py
+++ b/.github/scripts/test_check_deployment_secret_boundary.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path, PurePosixPath, PureWindowsPath
-
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CHECKER_PATH = REPO_ROOT / ".github" / "scripts" / "check_deployment_secret_boundary.py"
@@ -49,7 +49,7 @@ class DeploymentSecretBoundaryFixture(unittest.TestCase):
             ["git", "config", "user.name", "Boundary Test"], cwd=self.root, check=True, env=git_environment()
         )
         self.write("config/deployment-setting-classification.json", json.dumps(POLICY))
-        self.write(".github/workflows/deploy.yml", "name: test\n")
+        self.write(".github/workflows/deploy.yml", "name: test\n# utf-8 guard: \u2603\n")
         self.commit("baseline")
 
     def tearDown(self) -> None:
@@ -90,7 +90,9 @@ jobs:
     def test_rejects_public_build_setting_from_github_secret(self) -> None:
         self.write(".github/workflows/deploy.yml", "BUILD: ${{ secrets.FAKE_PUBLIC_BUILD }}\n")
 
-        self.assertIn("public_build setting FAKE_PUBLIC_BUILD must use vars.FAKE_PUBLIC_BUILD", "\n".join(self.errors()))
+        self.assertIn(
+            "public_build setting FAKE_PUBLIC_BUILD must use vars.FAKE_PUBLIC_BUILD", "\n".join(self.errors())
+        )
 
     def test_rejects_config_external_secret_mapping(self) -> None:
         self.write(
@@ -102,12 +104,17 @@ jobs:
 """,
         )
 
-        self.assertIn("external_secret binding FAKE_RUNTIME_CONFIG is config; expected secret", "\n".join(self.errors()))
+        self.assertIn(
+            "external_secret binding FAKE_RUNTIME_CONFIG is config; expected secret", "\n".join(self.errors())
+        )
 
     def test_rejects_secret_from_github_variable(self) -> None:
         self.write(".github/workflows/deploy.yml", "TOKEN: ${{ vars.FAKE_SERVER_SECRET }}\n")
 
-        self.assertIn("github_vars binding FAKE_SERVER_SECRET is secret; expected config or public_build", "\n".join(self.errors()))
+        self.assertIn(
+            "github_vars binding FAKE_SERVER_SECRET is secret; expected config or public_build",
+            "\n".join(self.errors()),
+        )
 
     def test_rejects_config_loaded_from_secret_manager(self) -> None:
         self.write(
@@ -133,7 +140,9 @@ jobs:
         policy["exceptions"] = {"FAKE_RUNTIME_CONFIG": {"owner": "platform"}}
         self.write("config/deployment-setting-classification.json", json.dumps(policy))
 
-        errors = CHECKER.validate_policy(CHECKER.load_policy(self.root / "config/deployment-setting-classification.json"))
+        errors = CHECKER.validate_policy(
+            CHECKER.load_policy(self.root / "config/deployment-setting-classification.json")
+        )
 
         self.assertIn("exception FAKE_RUNTIME_CONFIG is missing reason", errors)
         self.assertIn("exception FAKE_RUNTIME_CONFIG is missing expires", errors)
@@ -150,6 +159,22 @@ jobs:
             CHECKER.repository_relative_path(windows_path, windows_root),
             CHECKER.repository_relative_path(posix_path, posix_root),
         )
+
+    @mock.patch.object(CHECKER.subprocess, "run")
+    def test_base_git_reads_decode_utf8_explicitly(self, run: mock.Mock) -> None:
+        run.side_effect = [
+            subprocess.CompletedProcess([], 0, stdout=".github/workflows/deploy.yml\n"),
+            subprocess.CompletedProcess([], 0, stdout="# utf-8 guard: \u2603\n"),
+        ]
+
+        self.assertEqual(CHECKER._base_paths(self.root, "HEAD"), {".github/workflows/deploy.yml"})
+        self.assertEqual(
+            CHECKER._read_base_file(self.root, "HEAD", ".github/workflows/deploy.yml"),
+            "# utf-8 guard: \u2603\n",
+        )
+        self.assertEqual(len(run.call_args_list), 2)
+        for call in run.call_args_list:
+            self.assertEqual(call.kwargs["encoding"], "utf-8")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_check_product_file_line_count_ratchet.py
+++ b/.github/scripts/test_check_product_file_line_count_ratchet.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 SPEC = importlib.util.spec_from_file_location(
@@ -131,9 +132,7 @@ class ProductFileLineCountRatchetTests(unittest.TestCase):
             },
         )
         with self.assertRaisesRegex(ValueError, "belongs in"):
-            RATCHET.validate_baseline(
-                baseline({router: 1600}), RATCHET.baseline_shard_relative(floating_control_bar)
-            )
+            RATCHET.validate_baseline(baseline({router: 1600}), RATCHET.baseline_shard_relative(floating_control_bar))
         with self.assertRaisesRegex(ValueError, "duplicate baseline entry"):
             RATCHET.aggregate_baseline_shards(
                 {
@@ -187,6 +186,29 @@ class ProductFileLineCountRatchetTests(unittest.TestCase):
 
         self.assertEqual(legacy_ref, legacy)
         self.assertEqual(sharded_ref, legacy)
+
+    def test_baseline_git_reads_decode_utf8_explicitly(self) -> None:
+        router = "backend/routers/large.py"
+        expected = baseline({router: 1600}, {router: "Unicode guard: \u96ea"})
+        shard_relative = RATCHET.baseline_shard_relative(router)
+        completed = subprocess.CompletedProcess
+
+        with patch.object(
+            RATCHET.subprocess,
+            "run",
+            side_effect=[
+                completed([], 0, stdout=f"{shard_relative}\n", stderr=""),
+                completed([], 0, stdout=RATCHET.serialize_baseline(expected), stderr=""),
+                completed([], 0, stdout="", stderr=""),
+                completed([], 0, stdout=RATCHET.serialize_baseline(expected), stderr=""),
+            ],
+        ) as run:
+            self.assertEqual(RATCHET.baseline_at_ref(self.root, "sharded"), expected)
+            self.assertEqual(RATCHET.baseline_at_ref(self.root, "legacy"), expected)
+
+        self.assertEqual(len(run.call_args_list), 4)
+        for call in run.call_args_list:
+            self.assertEqual(call.kwargs.get("encoding"), "utf-8")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -16,6 +16,7 @@ from collections import Counter
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
+from unittest.mock import patch
 
 from run_checks import (
     VALID_PLATFORMS,
@@ -109,9 +110,7 @@ def non_self_running_reason(source: str) -> str | None:
             for cmp_ in getattr(node.test, "comparators", [])
         )
     ]
-    invoking_blocks = [
-        node for node in main_blocks if any(isinstance(inner, ast.Call) for inner in ast.walk(node))
-    ]
+    invoking_blocks = [node for node in main_blocks if any(isinstance(inner, ast.Call) for inner in ast.walk(node))]
     if not invoking_blocks:
         return "has no __main__ block invoking a test runner, so the interpreter runs no cases"
 
@@ -222,10 +221,7 @@ class ManifestContractTests(unittest.TestCase):
     def test_pytest_only_module_is_reported_as_non_self_running(self) -> None:
         """The guard above must fail on the real historical shape it exists to catch."""
         pytest_only = (
-            "from pathlib import Path\n"
-            "\n"
-            "def test_something(tmp_path: Path) -> None:\n"
-            "    assert True\n"
+            "from pathlib import Path\n" "\n" "def test_something(tmp_path: Path) -> None:\n" "    assert True\n"
         )
         self.assertIn("has no __main__", non_self_running_reason(pytest_only) or "")
 
@@ -259,9 +255,7 @@ class ManifestContractTests(unittest.TestCase):
             'if __name__ == "__main__":\n'
             "    unittest.main()\n"
         )
-        self.assertIn(
-            "no TestCase subclass", non_self_running_reason(unittest_main_without_test_case) or ""
-        )
+        self.assertIn("no TestCase subclass", non_self_running_reason(unittest_main_without_test_case) or "")
 
         # Script-style: a module whose __main__ runs its own assertions is fine.
         script_style = (
@@ -567,6 +561,18 @@ class PlatformTests(unittest.TestCase):
 
 
 class DeferredMarkerTests(unittest.TestCase):
+    def test_git_content_reads_are_utf8(self) -> None:
+        module = load_deferred_marker_module()
+        completed = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        with patch.object(module.subprocess, "run", return_value=completed) as run:
+            self.assertEqual(module.added_lines("origin/main", "fixture.txt"), [])
+            self.assertEqual(module.marker_counts_at_base("origin/main", "fixture.txt"), Counter())
+
+        content_reads = [call for call in run.call_args_list if call.args[0][1] in {"diff", "show"}]
+        self.assertEqual(len(content_reads), 2)
+        for call in content_reads:
+            self.assertEqual(call.kwargs.get("encoding"), "utf-8")
+
     def test_new_marker_requires_tracking_issue(self) -> None:
         module = load_deferred_marker_module()
         marker = "TO" + "DO"

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -293,13 +293,13 @@ class RunnerBehaviorTests(unittest.TestCase):
             capture = root / "node-args.txt"
             for name, body in {
                 "uv": "#!/bin/sh\nexit 99\n",
-                "node": f'''#!/bin/sh
+                "node": f"""#!/bin/sh
 case "$1" in
   -p) echo 22 ;;
   *emulator_config.mjs) printf '45678 45679\\n' ;;
   *supervise.mjs) printf '%s\\n' "$@" > "{capture}" ;;
 esac
-''',
+""",
                 "java": "#!/bin/sh\necho '    java.version = 21.0.1' >&2\n",
             }.items():
                 path = fake_bin / name


### PR DESCRIPTION
## What changed and why

Decode Git repository content explicitly as UTF-8 in three deterministic preflight guards instead of using the Windows host locale:

- deployment secret-boundary reads from `git ls-tree` and `git show`;
- deferred-work marker reads from `git diff` and `git show`;
- product file line-count ratchet reads baseline paths and both sharded and legacy JSON blobs from `git ls-tree` and `git show`.

Git repository paths and blobs are UTF-8 data, but Python's `text=True` used the active Windows code page (GBK in the reproduced environment). A valid Unicode source comment or baseline justification could therefore crash these guards before they enforced policy.

## Product invariants affected

none

## How it was verified

- Before the deployment fix on native Windows, `python .github/scripts/check_deployment_secret_boundary.py --base HEAD` failed with `UnicodeDecodeError: 'gbk' codec can't decode byte ...`; the same production command passed after the fix.
- Before the deferred-marker fix, native Windows `scripts/pr-preflight` crashed while decoding a real Unicode TypeScript diff.
- Before the line-ratchet fix, native Windows preflight crashed in `baseline_at_ref()` while decoding a real baseline shard; the same production command now passes without `PYTHONUTF8`.
- `python .github/scripts/test_check_deployment_secret_boundary.py` -> 9 passed.
- `python .github/scripts/test_run_checks.py DeferredMarkerTests` -> 3 passed.
- `python .github/scripts/test_check_product_file_line_count_ratchet.py` -> 9 passed.
- Native Windows `scripts/pr-preflight --pr-body-file ...` in an integration worktree with #10594 applied -> all 15 selected checks passed without `PYTHONUTF8`.
- Black 26.5.1 with the repository's 120-column configuration, Ruff 0.4.4, and `git diff --check` passed on all changed Python files.

## Tests

The deployment fixture commits UTF-8 workflow content, exercising the real `git show` path. Mocked subprocess contracts require all seven Git content reads across the three guards to pass `encoding="utf-8"`; the line-ratchet contract covers both sharded and legacy baseline paths, so Linux CI also rejects a future return to locale-driven decoding.

## Failure class (fixes)

Failure-Class: none

## Root cause and durable guard (bug fixes)

Python inherited the Windows locale when `subprocess.run(..., text=True)` decoded Git output. All affected guards now declare strict UTF-8 decoding at the Git boundary, with production-path and configuration-contract regression coverage.
