### PR TITLE
SCA-127: discover all exact-SHA planner checks

### DIFF
--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -126,9 +126,9 @@ def github_check_status(repository: str, sha: str, check_name: str) -> tuple[str
         [
             "gh",
             "api",
-            f"repos/{repository}/commits/{sha}/check-runs?filter=latest",
-            "--jq",
-            f'.check_runs[] | select(.name=="{check_name}") | [.status, (.conclusion // "")] | @tsv',
+            "--paginate",
+            "--slurp",
+            f"repos/{repository}/commits/{sha}/check-runs?filter=all&per_page=100",
         ],
         text=True,
         stdout=subprocess.PIPE,
@@ -138,13 +138,49 @@ def github_check_status(repository: str, sha: str, check_name: str) -> tuple[str
         error = result.stderr.strip() or result.stdout.strip() or "unknown gh api error"
         return None, None, error
 
-    output = result.stdout.strip()
-    first = next((line for line in output.splitlines() if line.strip()), "")
-    if not first:
+    try:
+        pages = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None, None, "gh api returned invalid check-runs JSON"
+
+    if not isinstance(pages, list):
+        return None, None, "gh api returned invalid check-runs pages"
+
+    matching_runs: list[dict[str, object]] = []
+    for page in pages:
+        if not isinstance(page, dict):
+            return None, None, "gh api returned an invalid check-runs page"
+        check_runs = page.get("check_runs")
+        if not isinstance(check_runs, list):
+            return None, None, "gh api returned an invalid check-runs payload"
+        for check_run in check_runs:
+            if not isinstance(check_run, dict):
+                return None, None, "gh api returned an invalid check run"
+            if check_run.get("name") == check_name:
+                matching_runs.append(check_run)
+
+    if not matching_runs:
         return None, None, None
-    parts = first.split("\t", 1)
-    status = parts[0] if parts else None
-    conclusion = parts[1] if len(parts) > 1 else None
+
+    # `filter=latest` can omit an exact-SHA check run. Request every page and
+    # choose the newest matching run ourselves so a later rerun cannot be
+    # hidden by the API filter. `started_at` is primary so a newer in-progress
+    # rerun is never masked by an older completed success; the remaining fields
+    # make ordering deterministic when timestamps collide or are unavailable.
+    latest = max(
+        matching_runs,
+        key=lambda check_run: (
+            str(check_run.get("started_at") or ""),
+            str(check_run.get("completed_at") or ""),
+            str(check_run.get("id") or ""),
+        ),
+    )
+    status = latest.get("status")
+    conclusion = latest.get("conclusion")
+    if status is not None and not isinstance(status, str):
+        return None, None, "gh api returned a check run with an invalid status"
+    if conclusion is not None and not isinstance(conclusion, str):
+        return None, None, "gh api returned a check run with an invalid conclusion"
     return status, conclusion, None
 
 
@@ -382,7 +418,9 @@ def main() -> int:
     latest_change_age = latest_change_age_seconds(changes)
     if latest_change_age is None:
         set_output("should_release", "false")
-        set_output("reason", "Waiting for desktop release quiet window: could not determine latest releasable change age.")
+        set_output(
+            "reason", "Waiting for desktop release quiet window: could not determine latest releasable change age."
+        )
         return 0
     if latest_change_age < AUTO_RELEASE_QUIET_SECONDS:
         wait_seconds = AUTO_RELEASE_QUIET_SECONDS - latest_change_age

--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -9,6 +9,7 @@ import os
 import re
 import subprocess
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 CODEMAGIC_CHECK_NAME = "Release OMI Desktop (Swift)"
@@ -121,6 +122,31 @@ def latest_releasable_desktop_sha(paths: list[str]) -> str | None:
         return None
 
 
+def check_run_sort_key(check_run: dict[str, object]) -> tuple[tuple[datetime, datetime, int] | None, str | None]:
+    """Return a validated, deterministic ordering key for one GitHub check run."""
+    check_run_id = check_run.get("id")
+    if type(check_run_id) is not int or check_run_id <= 0:
+        return None, "gh api returned a check run with an invalid id"
+
+    timestamps: list[datetime] = []
+    for field_name, allow_none in (("started_at", False), ("completed_at", True)):
+        value = check_run.get(field_name)
+        if value is None and allow_none:
+            timestamps.append(datetime.min.replace(tzinfo=timezone.utc))
+            continue
+        if not isinstance(value, str):
+            return None, f"gh api returned a check run with an invalid {field_name}"
+        try:
+            timestamp = datetime.fromisoformat(value[:-1] + "+00:00" if value.endswith("Z") else value)
+        except ValueError:
+            return None, f"gh api returned a check run with an invalid {field_name}"
+        if timestamp.tzinfo is None:
+            return None, f"gh api returned a check run with an invalid {field_name}"
+        timestamps.append(timestamp.astimezone(timezone.utc))
+
+    return (timestamps[0], timestamps[1], check_run_id), None
+
+
 def github_check_status(repository: str, sha: str, check_name: str) -> tuple[str | None, str | None, str | None]:
     result = subprocess.run(
         [
@@ -146,7 +172,7 @@ def github_check_status(repository: str, sha: str, check_name: str) -> tuple[str
     if not isinstance(pages, list):
         return None, None, "gh api returned invalid check-runs pages"
 
-    matching_runs: list[dict[str, object]] = []
+    matching_runs: list[tuple[tuple[datetime, datetime, int], dict[str, object]]] = []
     for page in pages:
         if not isinstance(page, dict):
             return None, None, "gh api returned an invalid check-runs page"
@@ -157,7 +183,11 @@ def github_check_status(repository: str, sha: str, check_name: str) -> tuple[str
             if not isinstance(check_run, dict):
                 return None, None, "gh api returned an invalid check run"
             if check_run.get("name") == check_name:
-                matching_runs.append(check_run)
+                sort_key, sort_key_error = check_run_sort_key(check_run)
+                if sort_key_error:
+                    return None, None, sort_key_error
+                assert sort_key is not None
+                matching_runs.append((sort_key, check_run))
 
     if not matching_runs:
         return None, None, None
@@ -167,14 +197,7 @@ def github_check_status(repository: str, sha: str, check_name: str) -> tuple[str
     # hidden by the API filter. `started_at` is primary so a newer in-progress
     # rerun is never masked by an older completed success; the remaining fields
     # make ordering deterministic when timestamps collide or are unavailable.
-    latest = max(
-        matching_runs,
-        key=lambda check_run: (
-            str(check_run.get("started_at") or ""),
-            str(check_run.get("completed_at") or ""),
-            str(check_run.get("id") or ""),
-        ),
-    )
+    latest = max(matching_runs, key=lambda run: run[0])[1]
     status = latest.get("status")
     conclusion = latest.get("conclusion")
     if status is not None and not isinstance(status, str):

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import json
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -70,6 +72,60 @@ def _parse_push_filter(workflow_text: str) -> tuple[list[str], set[str]]:
 
 
 class DesktopCandidateSourceCheckTests(unittest.TestCase):
+    def test_github_check_status_reads_all_exact_sha_runs_and_chooses_the_newest_match(self) -> None:
+        response = [
+            {
+                "check_runs": [
+                    {
+                        "id": 101,
+                        "name": "Release Eligibility",
+                        "status": "completed",
+                        "conclusion": "failure",
+                        "started_at": "2026-07-25T21:00:00Z",
+                        "completed_at": "2026-07-25T21:02:00Z",
+                    },
+                    {
+                        "id": 102,
+                        "name": "Unrelated check",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "started_at": "2026-07-25T21:03:00Z",
+                        "completed_at": "2026-07-25T21:04:00Z",
+                    },
+                ]
+            },
+            {
+                "check_runs": [
+                    {
+                        "id": 103,
+                        "name": "Release Eligibility",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "started_at": "2026-07-25T21:28:00Z",
+                        "completed_at": "2026-07-25T21:28:16Z",
+                    }
+                ]
+            },
+        ]
+        completed = subprocess.CompletedProcess([], 0, stdout=json.dumps(response), stderr="")
+
+        with patch.object(planner.subprocess, "run", return_value=completed) as run:
+            status, conclusion, error = planner.github_check_status(REPOSITORY, SOURCE_SHA, "Release Eligibility")
+
+        self.assertEqual((status, conclusion, error), ("completed", "success", None))
+        run.assert_called_once_with(
+            [
+                "gh",
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{REPOSITORY}/commits/{SOURCE_SHA}/check-runs?filter=all&per_page=100",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
     def test_codemagic_config_is_a_releasable_desktop_input(self) -> None:
         expected_args = [
             "diff",

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -126,6 +126,36 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
             stderr=subprocess.PIPE,
         )
 
+    def test_github_check_status_uses_numeric_id_to_break_timestamp_ties(self) -> None:
+        response = [
+            {
+                "check_runs": [
+                    {
+                        "id": 99_999_999_999,
+                        "name": "Release Eligibility",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "started_at": "2026-07-25T21:28:00Z",
+                        "completed_at": "2026-07-25T21:28:16Z",
+                    },
+                    {
+                        "id": 100_000_000_000,
+                        "name": "Release Eligibility",
+                        "status": "completed",
+                        "conclusion": "failure",
+                        "started_at": "2026-07-25T21:28:00Z",
+                        "completed_at": "2026-07-25T21:28:16Z",
+                    },
+                ]
+            }
+        ]
+        completed = subprocess.CompletedProcess([], 0, stdout=json.dumps(response), stderr="")
+
+        with patch.object(planner.subprocess, "run", return_value=completed):
+            status, conclusion, error = planner.github_check_status(REPOSITORY, SOURCE_SHA, "Release Eligibility")
+
+        self.assertEqual((status, conclusion, error), ("completed", "failure", None))
+
     def test_codemagic_config_is_a_releasable_desktop_input(self) -> None:
         expected_args = [
             "diff",


### PR DESCRIPTION
## Summary
- query every page of exact-SHA check runs instead of using the suppressive `filter=latest` lookup
- select the latest matching run deterministically and fail closed on malformed API data
- cover gh command construction and slurped-response parsing in the planner regression suite

## Validation
- `python3 .github/scripts/run_checks.py --lane local --base origin/main --head HEAD --skip-pr-body-checks`
- exact incident SHA lookup returns `Release Eligibility`: `completed/success`

Closes SCA-127

Failure-Class: FC-release-build-config-source-binding