### PR TITLE
fix(backend): cascade every subcollection when a conversation is deleted

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-database.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-database.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "backend/database/conversations.py": 1646,
-    "backend/database/users.py": 1992
+    "backend/database/users.py": 1972
   },
   "raise_justifications": {
     "backend/database/conversations.py": "Public shared-chat uses the existing conversation storage format for bounded, safe transcript decoding; extraction would duplicate crypto/storage invariants. +15 for the shared is_soft_deleted tombstone-eligibility predicate that eligible_merge_target and the reprocess guard converge on (#10119/#10262). +30 for the permanent, atomic Firestore conversation analytics marker: it belongs beside the authoritative conversation document path and cannot use Redis because retries must remain duplicate-safe across cache loss (SCA-99).",

--- a/backend/database/_client.py
+++ b/backend/database/_client.py
@@ -7,7 +7,13 @@ from google.cloud import firestore
 from database.document_ids import document_id_from_seed
 from database.google_credentials import prepare_google_credentials
 
-__all__ = ["db", "document_id_from_seed", "get_firestore_client", "get_users_uid"]
+__all__ = [
+    "db",
+    "delete_collection_recursive",
+    "document_id_from_seed",
+    "get_firestore_client",
+    "get_users_uid",
+]
 
 _firestore_client = None
 _firestore_client_lock = Lock()
@@ -49,6 +55,32 @@ class _LazyFirestoreClient:
 
 
 db = _LazyFirestoreClient()
+
+
+def delete_collection_recursive(collection_ref: Any, *, client: Any, batch_size: int = 450) -> None:
+    """Delete every document under a collection, descending into nested subcollections first.
+
+    Firestore does not cascade: deleting a document leaves its subcollections in
+    place as data no query can reach (the parent no longer exists, so it is not
+    returned by a collection query either). Any caller that deletes a parent
+    document must purge its children through this helper.
+    """
+    while True:
+        docs = list(collection_ref.limit(batch_size).stream())
+        if not docs:
+            return
+
+        for doc in docs:
+            for sub in doc.reference.collections():
+                delete_collection_recursive(sub, client=client, batch_size=batch_size)
+
+        batch = client.batch()
+        for doc in docs:
+            batch.delete(doc.reference)
+        batch.commit()
+
+        if len(docs) < batch_size:
+            return
 
 
 def get_users_uid() -> list[str]:

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -18,7 +18,7 @@ from models.conversation_enums import ConversationStatus, PostProcessingModel, P
 from models.conversation_photo import ConversationPhoto
 from models.transcript_segment import TranscriptSegment
 from utils import encryption
-from ._client import db, get_firestore_client
+from ._client import db, delete_collection_recursive, get_firestore_client
 from .helpers import set_data_protection_level, prepare_for_write, prepare_for_read, with_photos
 from utils.other.storage import list_audio_chunks
 
@@ -979,18 +979,18 @@ def delete_conversation_photos(uid: str, conversation_id: str) -> int:
 
 
 def delete_conversation(uid, conversation_id):
-    """
-    Delete a conversation and its photos subcollection.
+    """Delete a conversation and every subcollection underneath it.
 
-    Args:
-        uid: User ID
-        conversation_id: Conversation ID
+    Firestore does not cascade, and a conversation owns more than ``photos``: the per-provider
+    post-processing transcripts (verbatim segment text), the Hume emotion predictions, and the
+    analytics marker. Purging only photos left those behind as data no query can reach — not even
+    the account-deletion wipe, which walks *existing* documents and never sees a deleted parent.
+    Children are enumerated live, so a subcollection added later is purged too.
     """
-    # Delete photos subcollection first
-    delete_conversation_photos(uid, conversation_id)
-
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
+    for sub in conversation_ref.collections():
+        delete_collection_recursive(sub, client=db)
     conversation_ref.delete()
 
 

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -5,7 +5,7 @@ from typing import Literal, Optional, TypedDict
 from google.api_core.exceptions import NotFound
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter, transactional
-from ._client import db, document_id_from_seed
+from ._client import db, delete_collection_recursive, document_id_from_seed
 from database.firestore_cache import CachePolicy, get_or_fetch, invalidate
 from database.read_boundary import parse_snapshot_or_none, parse_snapshot_strict
 from database.redis_db import try_acquire_client_device_write_lock, try_acquire_user_platform_write_lock
@@ -1150,26 +1150,6 @@ def update_person_speech_samples_version(uid: str, person_id: str, version: int)
     return True
 
 
-def _delete_collection_recursive(collection_ref, batch_size: int = 450):
-    """Delete every document under a collection, descending into nested subcollections first."""
-    while True:
-        docs = list(collection_ref.limit(batch_size).stream())
-        if not docs:
-            return
-
-        for doc in docs:
-            for sub in doc.reference.collections():
-                _delete_collection_recursive(sub, batch_size)
-
-        batch = db.batch()
-        for doc in docs:
-            batch.delete(doc.reference)
-        batch.commit()
-
-        if len(docs) < batch_size:
-            return
-
-
 def delete_user_data(uid: str):
     user_ref = db.collection('users').document(uid)
     root_exists = user_ref.get().exists
@@ -1184,7 +1164,7 @@ def delete_user_data(uid: str):
     # messages, and any future additions).
     for sub in user_ref.collections():
         logger.info(f"Deleting subcollection {sub.id} for user {uid}")
-        _delete_collection_recursive(sub)
+        delete_collection_recursive(sub, client=db)
 
     if root_exists:
         logger.info(f"Deleting user document: {uid}")

--- a/backend/tests/unit/memory_import_isolation.py
+++ b/backend/tests/unit/memory_import_isolation.py
@@ -71,6 +71,7 @@ def drop_stale_module(module_name: str, expected_file: str) -> None:
 def make_database_client_stub() -> ModuleType:
     client_mod = types.ModuleType("database._client")
     client_mod.db = MagicMock()
+    client_mod.delete_collection_recursive = MagicMock()
     client_mod.get_firestore_client = lambda: client_mod.db
 
     def _document_id_from_seed(seed: str) -> str:

--- a/backend/tests/unit/test_claim_deletion_wipe_txn.py
+++ b/backend/tests/unit/test_claim_deletion_wipe_txn.py
@@ -43,6 +43,7 @@ def _install_stub(name, mod):
 # not use the db singleton at all (it receives doc_ref as an argument).
 _fake_client_mod = types.ModuleType('database._client')
 setattr(_fake_client_mod, 'db', MagicMock())
+setattr(_fake_client_mod, 'delete_collection_recursive', MagicMock())
 setattr(_fake_client_mod, 'document_id_from_seed', MagicMock())
 _install_stub('database._client', _fake_client_mod)
 

--- a/backend/tests/unit/test_delete_conversation_cascade.py
+++ b/backend/tests/unit/test_delete_conversation_cascade.py
@@ -1,0 +1,158 @@
+"""Regression test: deleting a conversation must purge every subcollection under it.
+
+``delete_conversation`` used to purge only the ``photos`` subcollection before
+deleting the document. A conversation owns more children than that — the
+per-provider post-processing transcripts (``deepgram_streaming``,
+``soniox_streaming``, ``speechmatics_streaming``, ``fal_whisperx``, which store
+verbatim ``TranscriptSegment`` text), the Hume emotion predictions, and the
+``analytics_markers`` marker written by the memory-extraction telemetry. Firestore
+does not cascade, so those survived the delete as documents no query can reach:
+the account-deletion wipe walks *existing* documents, and the deleted conversation
+is not one, so its orphans could never be removed either.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from database import conversations as conversations_db
+
+
+class _FakeBatch:
+    def __init__(self, store: "_FakeFirestore"):
+        self._store = store
+        self._pending: list[_FakeDocumentReference] = []
+
+    def delete(self, doc_ref: "_FakeDocumentReference") -> None:
+        self._pending.append(doc_ref)
+
+    def commit(self) -> None:
+        for doc_ref in self._pending:
+            doc_ref.delete()
+        self._pending = []
+
+
+class _FakeQuery:
+    def __init__(self, collection: "_FakeCollectionReference", limit: int | None = None):
+        self._collection = collection
+        self._limit = limit
+
+    def limit(self, count: int) -> "_FakeQuery":
+        return _FakeQuery(self._collection, count)
+
+    def stream(self):
+        docs = [doc for doc in self._collection.documents.values() if doc.exists]
+        return docs if self._limit is None else docs[: self._limit]
+
+
+class _FakeDocumentReference:
+    def __init__(self, path: str, store: "_FakeFirestore"):
+        self.path = path
+        self._store = store
+        self.exists = True
+        self.subcollections: dict[str, _FakeCollectionReference] = {}
+
+    # Snapshots streamed out of a query carry `.reference`; the fake document is
+    # its own snapshot so the production loop reads the same attribute it does
+    # against the real SDK.
+    @property
+    def reference(self) -> "_FakeDocumentReference":
+        return self
+
+    def collection(self, name: str) -> "_FakeCollectionReference":
+        if name not in self.subcollections:
+            self.subcollections[name] = _FakeCollectionReference(f"{self.path}/{name}", self._store)
+        return self.subcollections[name]
+
+    def collections(self):
+        # Firestore only lists subcollections that still hold documents.
+        return [sub for sub in self.subcollections.values() if any(d.exists for d in sub.documents.values())]
+
+    def delete(self) -> None:
+        self.exists = False
+        self._store.deleted.append(self.path)
+
+
+class _FakeCollectionReference:
+    def __init__(self, path: str, store: "_FakeFirestore"):
+        self.path = path
+        self._store = store
+        self.documents: dict[str, _FakeDocumentReference] = {}
+
+    def document(self, doc_id: str) -> _FakeDocumentReference:
+        if doc_id not in self.documents:
+            self.documents[doc_id] = _FakeDocumentReference(f"{self.path}/{doc_id}", self._store)
+        return self.documents[doc_id]
+
+    def limit(self, count: int) -> _FakeQuery:
+        return _FakeQuery(self, count)
+
+    def stream(self):
+        return _FakeQuery(self).stream()
+
+
+class _FakeFirestore:
+    def __init__(self):
+        self.root: dict[str, _FakeCollectionReference] = {}
+        self.deleted: list[str] = []
+
+    def collection(self, name: str) -> _FakeCollectionReference:
+        if name not in self.root:
+            self.root[name] = _FakeCollectionReference(name, self)
+        return self.root[name]
+
+    def batch(self) -> _FakeBatch:
+        return _FakeBatch(self)
+
+
+def _seed_conversation(store: _FakeFirestore) -> _FakeDocumentReference:
+    conversation = store.collection('users').document('uid-1').collection('conversations').document('conv-1')
+    conversation.collection('photos').document('photo-1')
+    conversation.collection('deepgram_streaming').document('seg-1')
+    conversation.collection('deepgram_streaming').document('seg-2')
+    conversation.collection('fal_whisperx').document('seg-1')
+    conversation.collection('analytics_markers').document('conversation_memories_extracted')
+    return conversation
+
+
+@pytest.fixture
+def store(monkeypatch) -> _FakeFirestore:
+    fake = _FakeFirestore()
+    monkeypatch.setattr(conversations_db, 'db', fake)
+    return fake
+
+
+def test_delete_conversation_purges_every_subcollection(store):
+    """Before the fix only `photos` was purged; the transcript segments and the
+    analytics marker survived as unreachable documents."""
+    conversation = _seed_conversation(store)
+
+    conversations_db.delete_conversation('uid-1', 'conv-1')
+
+    assert not conversation.exists
+    survivors = [
+        doc.path for sub in conversation.subcollections.values() for doc in sub.documents.values() if doc.exists
+    ]
+    assert survivors == []
+
+
+def test_delete_conversation_descends_into_nested_subcollections(store):
+    """A child document with its own children is purged depth-first, so nothing is
+    left dangling under a document that is itself about to be deleted."""
+    conversation = _seed_conversation(store)
+    nested = conversation.collection('photos').document('photo-1').collection('ocr').document('line-1')
+
+    conversations_db.delete_conversation('uid-1', 'conv-1')
+
+    assert not nested.exists
+    # Depth-first: the nested document goes before the parent that owns it.
+    assert store.deleted.index(nested.path) < store.deleted.index('users/uid-1/conversations/conv-1/photos/photo-1')
+
+
+def test_delete_conversation_without_children_still_deletes_the_document(store):
+    conversation = store.collection('users').document('uid-1').collection('conversations').document('conv-1')
+
+    conversations_db.delete_conversation('uid-1', 'conv-1')
+
+    assert not conversation.exists
+    assert store.deleted == ['users/uid-1/conversations/conv-1']

--- a/backend/tests/unit/test_desktop_migration.py
+++ b/backend/tests/unit/test_desktop_migration.py
@@ -139,6 +139,7 @@ _ensure_package_path("database", BACKEND_DIR / "database")
 client_stub = _stub_module("database._client")
 mock_db = MagicMock()
 client_stub.db = mock_db
+client_stub.delete_collection_recursive = MagicMock()
 client_stub.document_id_from_seed = MagicMock(return_value="seed-id")
 
 # Stub database.helpers (used by chat.py)

--- a/backend/tests/unit/test_tools_rest_memory_runtime_adapter.py
+++ b/backend/tests/unit/test_tools_rest_memory_runtime_adapter.py
@@ -34,6 +34,7 @@ def memory_services_module():
 
     client_mod = ModuleType('database._client')
     client_mod.db = object()
+    client_mod.delete_collection_recursive = lambda ref, *, client, batch_size=450: None
     client_mod.document_id_from_seed = lambda seed: seed
 
     with stub_modules(

--- a/backend/tests/unit/test_users_add_sample_transaction.py
+++ b/backend/tests/unit/test_users_add_sample_transaction.py
@@ -24,6 +24,7 @@ def users_db():
     """Load a fresh database.users against stubbed database._client + firestore chain."""
     client_stub = ModuleType("database._client")
     client_stub.db = MagicMock(name="db")
+    client_stub.delete_collection_recursive = MagicMock(name="delete_collection_recursive")
     client_stub.document_id_from_seed = MagicMock(name="document_id_from_seed")
 
     firestore_stub = ModuleType("google.cloud.firestore")

--- a/backend/tests/unit/test_users_missing_doc_guards.py
+++ b/backend/tests/unit/test_users_missing_doc_guards.py
@@ -41,7 +41,12 @@ def users():
     fakes = {
         "google.cloud.firestore": firestore,
         "google.cloud.firestore_v1": firestore_v1,
-        "database._client": _module("database._client", db=MagicMock(), document_id_from_seed=lambda seed: "id"),
+        "database._client": _module(
+            "database._client",
+            db=MagicMock(),
+            delete_collection_recursive=MagicMock(),
+            document_id_from_seed=lambda seed: "id",
+        ),
         "database.firestore_cache": _module(
             "database.firestore_cache", CachePolicy=MagicMock(), get_or_fetch=MagicMock(), invalidate=MagicMock()
         ),


### PR DESCRIPTION
## Bug

Deleting a conversation left most of its child data in Firestore permanently.

`database.conversations.delete_conversation()` purged only the `photos` subcollection and then deleted the document. Firestore does not cascade, and a conversation owns more children than photos:

- `deepgram_streaming` / `soniox_streaming` / `speechmatics_streaming` / `fal_whisperx` — the per-provider post-processing transcripts written by `store_model_segments_result`, i.e. **verbatim `TranscriptSegment` text**
- the Hume emotion predictions written by `store_model_emotion_predictions_result`
- `analytics_markers/conversation_memories_extracted` — the marker added five hours ago by #10543 (`try_claim_conversation_memory_analytics`), so every conversation with extracted memories now grows one

Everything but photos survived `DELETE /v1/conversations/{id}` — and survived it *permanently*. `users.delete_user_data()` walks each collection with `limit().stream()`, which returns only **existing** documents; a deleted conversation is not one, so the wipe never descends into the orphans it left behind. Neither the delete endpoint nor "delete my account" can reach that data afterwards.

## Fix

`delete_conversation()` now enumerates the conversation's children live (`conversation_ref.collections()`) and purges each recursively before deleting the document, so a subcollection added later is covered by construction rather than by remembering to add another special case.

The recursive purge account deletion already used moves to `database/_client.py` as `delete_collection_recursive(ref, *, client)` and is shared by both callers instead of being duplicated. `delete_conversation_photos()` is unchanged — its other callers (`lifecycle.py`, `merge_conversations.py`) still use it.

## What I tested

- **New regression test** `backend/tests/unit/test_delete_conversation_cascade.py` (3 tests) — drives production `delete_conversation` against an in-memory Firestore fake. **2 of 3 fail on the pre-fix code** (the transcript segments and the analytics marker survive; a nested child is left dangling) and all 3 pass on the fix.
- **Full backend unit suite** via `backend/test.sh` (740 files, one process per file): exit 0.
- Adjacent suites re-run individually: `test_account_deletion.py` (34), `test_delete_account_purge_storage.py` (5), `test_conversation_recordings_purge.py`, `test_merge_conversations_canonical_delete.py`, `test_listen_fallback_removal.py`, `test_dev_api_lock_bypass.py`, `test_developer_from_segments_idempotency.py`, `test_conversation_memories_telemetry.py` (18) — all pass.
- `make preflight` green.

Not exercised against live Firestore (no prod write from a watchdog run); the behaviour is proven through the production code path with the storage layer faked.

## Known follow-up (not in this PR)

Conversations deleted **before** this lands still have orphaned children, and account deletion cannot see them because its walk is query-based. Reaching those needs `list_documents()` (which does return references to non-existent parents) in the account-deletion walk — a change to the irreversible wipe path that deserves its own review.

Failure-Class: none

🤖 automated by the hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

