### PR TITLE
fix(desktop): record an outcome on every terminal chat tool call

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6269,
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6268,
     "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2861
   },
   "raise_justifications": {

--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -713,11 +713,16 @@ class AnalyticsManager {
     String(value.trimmingCharacters(in: .whitespacesAndNewlines).prefix(128))
   }
 
-  /// Track individual tool calls made by the Claude agent
-  func chatToolCallCompleted(toolName: String, durationMs: Int) {
+  /// Track individual tool calls made by the Claude agent.
+  ///
+  /// Fires for every terminal status, not only success — a failed tool call
+  /// previously emitted nothing, so tool reliability was unmeasurable. Filter
+  /// on `outcome == "completed"` for the pre-existing success-only meaning.
+  func chatToolCallCompleted(toolName: String, durationMs: Int, outcome: String) {
     let props: [String: Any] = [
       "tool_name": ChatTelemetryDimension.toolName(toolName),
       "duration_ms": durationMs,
+      "outcome": ChatTelemetryDimension.toolOutcome(outcome),
     ]
     PostHogManager.shared.track("chat_tool_call_completed", properties: props)
   }

--- a/desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
@@ -159,6 +159,21 @@ enum ChatTelemetryDimension {
     return base
   }
 
+  /// Closed outcome vocabulary for a terminal tool call. `ToolCallStatus`
+  /// collapses `cancelled`/`interrupted` into `.failed` for UI purposes, but
+  /// telemetry must keep them apart: a user Stop is not a tool defect, and
+  /// merging them would repeat the "stop counted as error" mistake that made
+  /// the legacy `chat_agent_error` corpus unreadable. Anything unrecognized
+  /// reports `completed`, matching `ToolCallStatus.fromBridgeStatus`.
+  static func toolOutcome(_ bridgeStatus: String) -> String {
+    switch bridgeStatus {
+    case "failed": return "failed"
+    case "cancelled": return "cancelled"
+    case "interrupted": return "interrupted"
+    default: return "completed"
+    }
+  }
+
   static func screenFailureCode(_ rawValue: String) -> String {
     let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     return allowedScreenFailureCodes.contains(normalized)

--- a/desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
@@ -164,13 +164,14 @@ enum ChatTelemetryDimension {
   /// telemetry must keep them apart: a user Stop is not a tool defect, and
   /// merging them would repeat the "stop counted as error" mistake that made
   /// the legacy `chat_agent_error` corpus unreadable. Anything unrecognized
-  /// reports `completed`, matching `ToolCallStatus.fromBridgeStatus`.
+  /// reports `unknown` rather than inflating successful completions.
   static func toolOutcome(_ bridgeStatus: String) -> String {
     switch bridgeStatus {
+    case "completed": return "completed"
     case "failed": return "failed"
     case "cancelled": return "cancelled"
     case "interrupted": return "interrupted"
-    default: return "completed"
+    default: return "unknown"
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -4272,10 +4272,9 @@ class ChatProvider: ObservableObject {
           } else if toolStatus != .running,
             let startTime = toolTiming.toolStartTimes.removeValue(forKey: trackedId)
           {
-            if toolStatus == .completed {
-              let durationMs = Int(Date().timeIntervalSince(startTime) * 1000)
-              AnalyticsManager.shared.chatToolCallCompleted(toolName: name, durationMs: durationMs)
-            }
+            let durationMs = Int(Date().timeIntervalSince(startTime) * 1000)
+            AnalyticsManager.shared.chatToolCallCompleted(
+              toolName: name, durationMs: durationMs, outcome: status)
           }
           let transitions = await stallDetector.step(kind: detectorKind, atMs: nowMs)
           self.applyStallTransitions(messageId: aiMessageId, transitions: transitions)

--- a/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
@@ -24,10 +24,9 @@ final class ChatQueryTelemetryTests: XCTestCase {
     XCTAssertEqual(ChatTelemetryDimension.toolOutcome("interrupted"), "interrupted")
     XCTAssertEqual(ChatTelemetryDimension.toolOutcome("completed"), "completed")
 
-    // Unknown adapter vocabulary must not leak; it reads as completed, the same
-    // default `ToolCallStatus.fromBridgeStatus` applies.
-    XCTAssertEqual(ChatTelemetryDimension.toolOutcome("some_new_status"), "completed")
-    XCTAssertEqual(ChatTelemetryDimension.toolOutcome(""), "completed")
+    // Unknown adapter vocabulary must not leak or inflate successful calls.
+    XCTAssertEqual(ChatTelemetryDimension.toolOutcome("some_new_status"), "unknown")
+    XCTAssertEqual(ChatTelemetryDimension.toolOutcome(""), "unknown")
   }
 
   /// User Stop is not a tool defect. `ToolCallStatus` deliberately collapses

--- a/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
@@ -13,6 +13,39 @@ private final class ChatTestGenerationBox {
 }
 
 final class ChatQueryTelemetryTests: XCTestCase {
+  /// A failed tool call used to emit nothing at all: the call site removed the
+  /// start time and then gated the event on `toolStatus == .completed`, so 30
+  /// days of `chat_tool_call_completed` carried only successes and tool
+  /// reliability could not be measured. Every terminal bridge status must now
+  /// map to a bounded outcome.
+  func testEveryTerminalBridgeStatusReportsABoundedToolOutcome() {
+    XCTAssertEqual(ChatTelemetryDimension.toolOutcome("failed"), "failed")
+    XCTAssertEqual(ChatTelemetryDimension.toolOutcome("cancelled"), "cancelled")
+    XCTAssertEqual(ChatTelemetryDimension.toolOutcome("interrupted"), "interrupted")
+    XCTAssertEqual(ChatTelemetryDimension.toolOutcome("completed"), "completed")
+
+    // Unknown adapter vocabulary must not leak; it reads as completed, the same
+    // default `ToolCallStatus.fromBridgeStatus` applies.
+    XCTAssertEqual(ChatTelemetryDimension.toolOutcome("some_new_status"), "completed")
+    XCTAssertEqual(ChatTelemetryDimension.toolOutcome(""), "completed")
+  }
+
+  /// User Stop is not a tool defect. `ToolCallStatus` deliberately collapses
+  /// cancelled/interrupted into `.failed` for the UI, so the telemetry
+  /// dimension must stay independent of it or a Stop would count as a failure.
+  func testStopIsDistinguishableFromFailureEvenThoughBothMapToFailedStatus() {
+    XCTAssertEqual(ChatProvider.mapBridgeToolStatus("cancelled"), .failed)
+    XCTAssertEqual(ChatProvider.mapBridgeToolStatus("interrupted"), .failed)
+    XCTAssertEqual(ChatProvider.mapBridgeToolStatus("failed"), .failed)
+
+    XCTAssertNotEqual(
+      ChatTelemetryDimension.toolOutcome("cancelled"),
+      ChatTelemetryDimension.toolOutcome("failed"))
+    XCTAssertNotEqual(
+      ChatTelemetryDimension.toolOutcome("interrupted"),
+      ChatTelemetryDimension.toolOutcome("failed"))
+  }
+
   func testKernelContextTimeoutDoesNotInterruptAnUnstartedAgentQuery() {
     XCTAssertFalse(ChatProvider.shouldInterruptTimedOutAgentQuery(queryStarted: false))
     XCTAssertTrue(ChatProvider.shouldInterruptTimedOutAgentQuery(queryStarted: true))

--- a/desktop/macos/agent/src/adapters/acp.ts
+++ b/desktop/macos/agent/src/adapters/acp.ts
@@ -793,7 +793,7 @@ export class AcpRuntimeAdapter implements RuntimeAdapter {
         sink({
           type: "tool_activity",
           name: title,
-          status: status === "completed" ? "completed" : "failed",
+          status,
           toolUseId: toolCallId,
         });
 

--- a/desktop/macos/agent/src/adapters/local-subprocess.ts
+++ b/desktop/macos/agent/src/adapters/local-subprocess.ts
@@ -491,7 +491,14 @@ export class LocalSubprocessRuntimeAdapter implements RuntimeAdapter {
           input: recordValue(event.input),
         };
       case "tool_activity": {
-        const status = event.status === "completed" || event.status === "failed" ? event.status : "started";
+        const status =
+          event.status === "progress"
+          || event.status === "completed"
+          || event.status === "failed"
+          || event.status === "cancelled"
+          || event.status === "interrupted"
+            ? event.status
+            : "started";
         return {
           type: "tool_activity",
           name: stringValue(event.name),

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -641,7 +641,7 @@ export interface RuntimeFailurePayload {
 export interface ToolActivityMessage extends QueryScopedOutbound {
   type: "tool_activity";
   name: string;
-  status: "started" | "progress" | "completed" | "failed";
+  status: "started" | "progress" | "completed" | "failed" | "cancelled" | "interrupted";
   toolUseId?: string;
   input?: Record<string, unknown>;
 }

--- a/desktop/macos/agent/src/runtime/kernel-support.ts
+++ b/desktop/macos/agent/src/runtime/kernel-support.ts
@@ -592,7 +592,9 @@ export function canonicalAdapterEventType(event: OutboundMessageDraft): string |
     case "tool_activity":
       if (event.status === "started") return "tool.started";
       if (event.status === "completed") return "tool.completed";
-      if (event.status === "failed") return "tool.failed";
+      if (event.status === "failed" || event.status === "cancelled" || event.status === "interrupted") {
+        return "tool.failed";
+      }
       return "tool.updated";
     case "tool_use":
       return "tool.started";

--- a/desktop/macos/agent/tests/acp-tool-activity.test.ts
+++ b/desktop/macos/agent/tests/acp-tool-activity.test.ts
@@ -143,7 +143,7 @@ describe("AcpRuntimeAdapter tool activity translation", () => {
     ]);
   });
 
-  it("maps ACP failed and cancelled tool updates to failed activity", () => {
+  it("preserves ACP failed and cancelled tool outcomes", () => {
     const harness = translateHarness();
 
     harness.translate({
@@ -169,7 +169,7 @@ describe("AcpRuntimeAdapter tool activity translation", () => {
       {
         type: "tool_activity",
         name: "Bash",
-        status: "failed",
+        status: "cancelled",
         toolUseId: "tool-cancelled",
       },
     ]);

--- a/desktop/macos/agent/tests/local-subprocess-adapter.test.ts
+++ b/desktop/macos/agent/tests/local-subprocess-adapter.test.ts
@@ -172,6 +172,15 @@ describe("env-command local subprocess adapters", () => {
         writeResponse(proc, request, {
           type: "event",
           event: {
+            type: "tool_activity",
+            name: "omi_tool",
+            status: "interrupted",
+            toolUseId: "tool-1",
+          },
+        });
+        writeResponse(proc, request, {
+          type: "event",
+          event: {
             type: "tool_result_display",
             name: "omi_tool",
             toolUseId: "tool-1",
@@ -251,8 +260,10 @@ describe("env-command local subprocess adapters", () => {
       "text_delta",
       "thinking_delta",
       "tool_activity",
+      "tool_activity",
       "tool_result_display",
     ]);
+    expect(events[3]).toMatchObject({ type: "tool_activity", status: "interrupted" });
     expect(requests.map((request) => request.type)).toEqual(["open", "resume", "execute"]);
     await adapter.stop();
   });

--- a/desktop/macos/changelog/unreleased/20260725-tool-call-outcome-telemetry.json
+++ b/desktop/macos/changelog/unreleased/20260725-tool-call-outcome-telemetry.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved internal diagnostics so failed chat tool calls are recorded alongside successful ones"
+}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -5,6 +5,7 @@ description: Hermetic chat in Home tab — send/receive with Rust OMI_LLM_STUB=1
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
+  - desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift


### PR DESCRIPTION
## Problem

`chat_tool_call_completed` fired only on success. The call site removed the tool's start time for any terminal status, then gated the event on `toolStatus == .completed`, so a failed, cancelled, or interrupted tool call consumed its start time and emitted nothing.

Found by querying the live PostHog corpus (project 302298, Omi desktop macOS, 30 days): **23,682 `chat_tool_call_completed` events containing only successes**, and no tool-failure event anywhere in the project. Tool failure rate was not merely unmeasured but structurally unmeasurable — no dashboard could ever show a tool regression, and the `tool_stall` errors (p50 102s) had no per-tool attribution.

## Change

`chat_tool_call_completed` now fires for every terminal status and carries a bounded `outcome`.

The subtlety worth reviewing: `ToolCallStatus.fromBridgeStatus` maps `failed`, `cancelled`, and `interrupted` all to `.failed`. Emitting naively would have counted user Stops as tool failures — the same mistake that made the legacy `chat_agent_error` corpus unreadable, where 530 of 1,893 events over 30 days were user Stops recorded as errors. `ChatTelemetryDimension.toolOutcome` keeps the three apart and is deliberately independent of `ToolCallStatus`, with a test pinning that independence.

The bridge now preserves `cancelled` and `interrupted` from ACP and local subprocess adapters through the Swift callback. Previously ACP collapsed cancellation into failure and the subprocess adapter converted cancellation/interruption back to `started`, making the new outcome dimension inaccurate. Unknown future statuses are bounded to `unknown` rather than inflating successful completions.

**Event semantics change:** the event now counts all terminal calls, not just successes. Filter `outcome == "completed"` for the previous meaning. No in-repo consumer reads this event (`web/admin/lib/response-reliability.ts` reads `chat_agent_error` only), but an external PostHog dashboard counting it raw will see a superset.

## Product invariants

- **INV-AGENT-***: adapter lifecycle status is preserved through the existing outbound protocol; canonical cancelled/interrupted events remain failure-terminal in the runtime journal.
- **INV-CHAT-1**: path-matched via `Providers/ChatProvider.swift`. Telemetry call site only — no chat write-path, projection, or timeline behavior changed.
- **INV-AUTH-1**: path-matched. No auth behavior changed.

Failure-Class: none

## Verification

- `npm test -- --run tests/acp-tool-activity.test.ts tests/local-subprocess-adapter.test.ts` — 13/13 pass
- `npm run build` — TypeScript green
- `xcrun swift test --package-path Desktop --filter ChatQueryTelemetryTests` — 27/27 pass
- Failure mode pinned at both adapter boundaries and at the telemetry mapping.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
