### PR TITLE
fix(agent-proxy): stop persisting an unresolved VM IP as a ready address

### DIFF
--- a/backend/agent-proxy/main.py
+++ b/backend/agent-proxy/main.py
@@ -161,38 +161,43 @@ async def _start_vm_and_wait(vm_name: str, zone: str) -> str:
 
     t0 = time.monotonic()
     token = await run_blocking(critical_executor, _get_gce_access_token)
+    instance_url = f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}"
     start_url = (
         f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}/start"
     )
 
     async with httpx.AsyncClient(timeout=180) as client:
-        resp = await client.post(start_url, headers={"Authorization": f"Bearer {token}"}, content=b"")
-        if resp.status_code not in (200, 204):
-            raise Exception(f"GCE start failed: {resp.status_code} {resp.text}")
-        t_start = time.monotonic() - t0
-        logger.info(f"[vm-start] {vm_name} start API call: {t_start:.1f}s")
+        instance_resp = await client.get(instance_url, headers={"Authorization": f"Bearer {token}"})
+        already_running = instance_resp.status_code == 200 and instance_resp.json().get("status") == "RUNNING"
+        if already_running:
+            logger.info(f"[vm-start] {vm_name} is already RUNNING; resolving its external IP")
+        else:
+            resp = await client.post(start_url, headers={"Authorization": f"Bearer {token}"}, content=b"")
+            if resp.status_code not in (200, 204):
+                raise Exception(f"GCE start failed: {resp.status_code} {resp.text}")
+            t_start = time.monotonic() - t0
+            logger.info(f"[vm-start] {vm_name} start API call: {t_start:.1f}s")
 
-        op_name = resp.json().get("name")
-        if not op_name:
-            raise Exception("Missing operation name in GCE start response")
+            op_name = resp.json().get("name")
+            if not op_name:
+                raise Exception("Missing operation name in GCE start response")
 
-        op_url = f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/operations/{op_name}"
-        for i in range(24):
-            await asyncio.sleep(5)
-            token = await run_blocking(critical_executor, _get_gce_access_token)
-            status_resp = await client.get(op_url, headers={"Authorization": f"Bearer {token}"})
-            status = status_resp.json()
-            if status.get("status") == "DONE":
-                if "error" in status:
-                    raise Exception(f"GCE start operation failed: {status['error']}")
-                t_op = time.monotonic() - t0
-                logger.info(f"[vm-start] {vm_name} operation done after {i + 1} polls: {t_op:.1f}s")
-                break
+            op_url = (
+                f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/operations/{op_name}"
+            )
+            for i in range(24):
+                await asyncio.sleep(5)
+                token = await run_blocking(critical_executor, _get_gce_access_token)
+                status_resp = await client.get(op_url, headers={"Authorization": f"Bearer {token}"})
+                status = status_resp.json()
+                if status.get("status") == "DONE":
+                    if "error" in status:
+                        raise Exception(f"GCE start operation failed: {status['error']}")
+                    t_op = time.monotonic() - t0
+                    logger.info(f"[vm-start] {vm_name} operation done after {i + 1} polls: {t_op:.1f}s")
+                    break
 
         # Poll for a valid external IP (may take a few seconds after operation completes)
-        instance_url = (
-            f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}"
-        )
         ip = None
         for attempt in range(6):
             token = await run_blocking(critical_executor, _get_gce_access_token)
@@ -239,8 +244,11 @@ def _update_firestore_vm(uid: str, ip: str | None, status: str) -> None:
     hard-resets a healthy VM, then writes the same placeholder back. Nothing
     else repairs the field, so the user is stuck in that loop permanently.
     """
+    if status == "ready" and not _is_usable_vm_ip(ip):
+        raise ValueError(f"refusing to persist ready agentVm without usable ip for uid={uid}")
+
     update = {"agentVm.status": status}
-    if ip:
+    if ip is not None:
         if not _is_usable_vm_ip(ip):
             raise ValueError(f"refusing to persist unusable agentVm.ip for uid={uid}")
         update["agentVm.ip"] = ip
@@ -508,7 +516,7 @@ async def agent_ws(websocket: WebSocket):
 
     # Fast path: if Firestore says ready with an IP, try connecting directly (skip GCE check).
     # Only fall back to GCE check + restart if the VM isn't reachable.
-    if vm.get("status") == "ready" and vm_ip:
+    if vm.get("status") == "ready" and _is_usable_vm_ip(vm_ip):
         try:
             async with httpx.AsyncClient(timeout=3) as client:
                 resp = await client.get(f"http://{vm_ip}:8080/health")

--- a/backend/agent-proxy/main.py
+++ b/backend/agent-proxy/main.py
@@ -42,6 +42,10 @@ logger = logging.getLogger(__name__)
 
 HISTORY_LIMIT = 10
 GCE_PROJECT = "based-hardware"
+# Legacy placeholder that earlier builds persisted as agentVm.ip when the GCE
+# IP poll timed out. Never written any more; still read so already-poisoned
+# records heal on the next connect instead of resetting a healthy VM forever.
+UNRESOLVED_VM_IP = "unknown"
 VM_KEEPALIVE_INTERVAL = 120  # seconds — ping VM every 2 min during active WS
 
 # Encryption — optional; required for users with enhanced data protection.
@@ -210,15 +214,35 @@ async def _start_vm_and_wait(vm_name: str, zone: str) -> str:
         if not ip:
             t_fail = time.monotonic() - t0
             logger.error(f"[vm-start] {vm_name} failed to get IP after 6 attempts: {t_fail:.1f}s")
-            ip = "unknown"
+            raise RuntimeError(f"VM {vm_name} started but never reported an external IP")
 
         return ip
 
 
+def _is_usable_vm_ip(ip: Any) -> bool:
+    """True when `ip` is an address the proxy can actually dial.
+
+    `UNRESOLVED_VM_IP` is truthy, so a stored placeholder satisfies every
+    `if ip:` reader on the connect path while resolving to nothing.
+    """
+    return isinstance(ip, str) and bool(ip) and ip != UNRESOLVED_VM_IP
+
+
 def _update_firestore_vm(uid: str, ip: str | None, status: str) -> None:
-    """Update the user's agentVm fields in Firestore."""
+    """Update the user's agentVm fields in Firestore.
+
+    `agentVm.ip` is the address every later connect dials, so this writer is
+    the one place that decides what may become that address. A placeholder
+    must never be persisted: it is truthy, so it passes the `status == "ready"
+    and vm_ip` fast path, fails the health probe, and sends `_ensure_vm_running`
+    down the `health_failed` branch — which finds GCE reporting RUNNING and
+    hard-resets a healthy VM, then writes the same placeholder back. Nothing
+    else repairs the field, so the user is stuck in that loop permanently.
+    """
     update = {"agentVm.status": status}
     if ip:
+        if not _is_usable_vm_ip(ip):
+            raise ValueError(f"refusing to persist unusable agentVm.ip for uid={uid}")
         update["agentVm.ip"] = ip
     _get_firestore_db().collection('users').document(uid).update(update)
 
@@ -254,7 +278,10 @@ async def _ensure_vm_running(uid: str, vm: Dict[str, Any], health_failed: bool =
     zone = cast(str, vm.get("zone", "us-central1-a"))
     fs_status = cast(str, vm.get("status", ""))
 
-    if fs_status == "ready":
+    # A record whose stored IP is the legacy placeholder can never be repaired by
+    # the reset branch below — it writes the same value back. Fall through to a
+    # full restart so `_start_vm_and_wait` resolves a real address.
+    if fs_status == "ready" and _is_usable_vm_ip(vm.get("ip")):
         # Verify it's actually running
         try:
             gce_status = await _check_gce_status(vm_name, zone)

--- a/backend/routers/agent_tools.py
+++ b/backend/routers/agent_tools.py
@@ -87,38 +87,43 @@ async def _start_vm_and_wait(vm_name: str, zone: str) -> str:
 
     t0 = time.monotonic()
     token = await run_blocking(db_executor, _get_gce_access_token)
+    instance_url = f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}"
     start_url = (
         f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}/start"
     )
 
     async with httpx.AsyncClient(timeout=180) as client:
-        resp = await client.post(start_url, headers={"Authorization": f"Bearer {token}"}, content=b"")
-        if resp.status_code not in (200, 204):
-            raise Exception(f"GCE start failed: {resp.status_code} {sanitize(resp.text)}")
-        t_start = time.monotonic() - t0
-        logger.info(f"[vm-start] {vm_name} start API call: {t_start:.1f}s")
+        instance_resp = await client.get(instance_url, headers={"Authorization": f"Bearer {token}"})
+        already_running = instance_resp.status_code == 200 and instance_resp.json().get("status") == "RUNNING"
+        if already_running:
+            logger.info(f"[vm-start] {vm_name} is already RUNNING; resolving its external IP")
+        else:
+            resp = await client.post(start_url, headers={"Authorization": f"Bearer {token}"}, content=b"")
+            if resp.status_code not in (200, 204):
+                raise Exception(f"GCE start failed: {resp.status_code} {sanitize(resp.text)}")
+            t_start = time.monotonic() - t0
+            logger.info(f"[vm-start] {vm_name} start API call: {t_start:.1f}s")
 
-        op_name = resp.json().get("name")
-        if not op_name:
-            raise Exception("Missing operation name in GCE start response")
+            op_name = resp.json().get("name")
+            if not op_name:
+                raise Exception("Missing operation name in GCE start response")
 
-        op_url = f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/operations/{op_name}"
-        for i in range(24):
-            await asyncio.sleep(5)
-            token = await run_blocking(db_executor, _get_gce_access_token)
-            status_resp = await client.get(op_url, headers={"Authorization": f"Bearer {token}"})
-            status = status_resp.json()
-            if status.get("status") == "DONE":
-                if "error" in status:
-                    raise Exception(f"GCE start operation failed: {status['error']}")
-                t_op = time.monotonic() - t0
-                logger.info(f"[vm-start] {vm_name} operation done after {i + 1} polls: {t_op:.1f}s")
-                break
+            op_url = (
+                f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/operations/{op_name}"
+            )
+            for i in range(24):
+                await asyncio.sleep(5)
+                token = await run_blocking(db_executor, _get_gce_access_token)
+                status_resp = await client.get(op_url, headers={"Authorization": f"Bearer {token}"})
+                status = status_resp.json()
+                if status.get("status") == "DONE":
+                    if "error" in status:
+                        raise Exception(f"GCE start operation failed: {status['error']}")
+                    t_op = time.monotonic() - t0
+                    logger.info(f"[vm-start] {vm_name} operation done after {i + 1} polls: {t_op:.1f}s")
+                    break
 
         # Poll for a valid external IP (may take a few seconds after operation completes)
-        instance_url = (
-            f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}"
-        )
         ip = None
         for attempt in range(6):
             token = await run_blocking(db_executor, _get_gce_access_token)
@@ -164,8 +169,11 @@ def _update_firestore_vm(uid: str, ip: str | None, status: str):
     """
     from database.users import db as firestore_db
 
+    if status == "ready" and not _is_usable_vm_ip(ip):
+        raise ValueError(f"refusing to persist ready agentVm without usable ip for uid={uid}")
+
     update = {"agentVm.status": status}
-    if ip:
+    if ip is not None:
         if not _is_usable_vm_ip(ip):
             raise ValueError(f"refusing to persist unusable agentVm.ip for uid={uid}")
         update["agentVm.ip"] = ip
@@ -228,7 +236,7 @@ async def ensure_vm(background_tasks: BackgroundTasks, uid: str = Depends(get_cu
             background_tasks.add_task(_restart_vm_background, uid, vm_name, zone)
             return {"has_vm": True, "status": "provisioning"}
 
-        if gce_status == "RUNNING" and fs_status != "ready":
+        if gce_status == "RUNNING":
             # A record still holding the legacy placeholder has no dialable
             # address, so reporting it ready would strand the caller. Restart
             # instead: that is the only path that resolves a real IP.
@@ -237,8 +245,9 @@ async def ensure_vm(background_tasks: BackgroundTasks, uid: str = Depends(get_cu
                 await run_blocking(db_executor, _update_firestore_vm, uid, None, "provisioning")
                 background_tasks.add_task(_restart_vm_background, uid, vm_name, zone)
                 return {"has_vm": True, "status": "provisioning"}
-            await run_blocking(db_executor, _update_firestore_vm, uid, vm.get("ip"), "ready")
-            return {"has_vm": True, "status": "ready"}
+            if fs_status != "ready":
+                await run_blocking(db_executor, _update_firestore_vm, uid, vm.get("ip"), "ready")
+                return {"has_vm": True, "status": "ready"}
 
     return {"has_vm": True, "status": fs_status}
 

--- a/backend/routers/agent_tools.py
+++ b/backend/routers/agent_tools.py
@@ -33,6 +33,10 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 GCE_PROJECT = "based-hardware"
+# Legacy placeholder that earlier builds persisted as agentVm.ip when the GCE
+# IP poll timed out. Never written any more; still read so already-poisoned
+# records are re-provisioned instead of being reported ready.
+UNRESOLVED_VM_IP = "unknown"
 
 
 class AgentVmInfo(BaseModel):
@@ -136,17 +140,34 @@ async def _start_vm_and_wait(vm_name: str, zone: str) -> str:
         if not ip:
             t_fail = time.monotonic() - t0
             logger.error(f"[vm-start] {vm_name} failed to get IP after 6 attempts: {t_fail:.1f}s")
-            ip = "unknown"
+            raise RuntimeError(f"VM {vm_name} started but never reported an external IP")
 
         return ip
 
 
+def _is_usable_vm_ip(ip) -> bool:
+    """True when `ip` is an address a caller can actually dial.
+
+    `UNRESOLVED_VM_IP` is truthy, so a stored placeholder satisfies every
+    `if ip:` reader while resolving to nothing.
+    """
+    return isinstance(ip, str) and bool(ip) and ip != UNRESOLVED_VM_IP
+
+
 def _update_firestore_vm(uid: str, ip: str | None, status: str):
-    """Update the user's agentVm fields in Firestore."""
+    """Update the user's agentVm fields in Firestore.
+
+    `agentVm.ip` is the address every later connect dials, so this writer
+    decides what may become that address. A placeholder must never be
+    persisted: it is truthy, so it passes each `if ip:` reader, fails every
+    health probe, and leaves the record permanently unrepairable.
+    """
     from database.users import db as firestore_db
 
     update = {"agentVm.status": status}
     if ip:
+        if not _is_usable_vm_ip(ip):
+            raise ValueError(f"refusing to persist unusable agentVm.ip for uid={uid}")
         update["agentVm.ip"] = ip
     firestore_db.collection('users').document(uid).update(update)
 
@@ -208,6 +229,14 @@ async def ensure_vm(background_tasks: BackgroundTasks, uid: str = Depends(get_cu
             return {"has_vm": True, "status": "provisioning"}
 
         if gce_status == "RUNNING" and fs_status != "ready":
+            # A record still holding the legacy placeholder has no dialable
+            # address, so reporting it ready would strand the caller. Restart
+            # instead: that is the only path that resolves a real IP.
+            if not _is_usable_vm_ip(vm.get("ip")):
+                logger.info(f"[vm-ensure] VM {vm_name} is RUNNING but has no usable IP, restarting...")
+                await run_blocking(db_executor, _update_firestore_vm, uid, None, "provisioning")
+                background_tasks.add_task(_restart_vm_background, uid, vm_name, zone)
+                return {"has_vm": True, "status": "provisioning"}
             await run_blocking(db_executor, _update_firestore_vm, uid, vm.get("ip"), "ready")
             return {"has_vm": True, "status": "ready"}
 

--- a/backend/tests/unit/test_agent_proxy_async_boundaries.py
+++ b/backend/tests/unit/test_agent_proxy_async_boundaries.py
@@ -253,6 +253,50 @@ def test_unresolved_vm_ip_is_never_persisted_as_a_dialable_address(agent_proxy):
 
     with pytest.raises(ValueError):
         agent_proxy._update_firestore_vm("uid-1", agent_proxy.UNRESOLVED_VM_IP, "ready")
+    with pytest.raises(ValueError):
+        agent_proxy._update_firestore_vm("uid-1", None, "ready")
+
+
+@pytest.mark.asyncio
+async def test_running_vm_resolves_ip_without_starting_again(agent_proxy, monkeypatch):
+    class Response:
+        status_code = 200
+
+        def json(self):
+            return {
+                "status": "RUNNING",
+                "networkInterfaces": [{"accessConfigs": [{"natIP": "34.121.9.4"}]}],
+            }
+
+    class Client:
+        def __init__(self):
+            self.post_calls = 0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, _exc_type, _exc, _traceback):
+            return False
+
+        async def get(self, _url, *, headers):
+            assert headers == {"Authorization": "Bearer test-token"}
+            return Response()
+
+        async def post(self, *_args, **_kwargs):
+            self.post_calls += 1
+            return Response()
+
+    client = Client()
+
+    async def direct_run_blocking(_executor, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(agent_proxy, "_get_gce_access_token", lambda: "test-token")
+    monkeypatch.setattr(agent_proxy, "run_blocking", direct_run_blocking)
+    monkeypatch.setattr(agent_proxy.httpx, "AsyncClient", lambda **_kwargs: client)
+
+    assert await agent_proxy._start_vm_and_wait("omi-agent-test", "us-central1-a") == "34.121.9.4"
+    assert client.post_calls == 0
 
 
 def test_agent_proxy_never_assigns_the_unresolved_ip_placeholder():

--- a/backend/tests/unit/test_agent_proxy_async_boundaries.py
+++ b/backend/tests/unit/test_agent_proxy_async_boundaries.py
@@ -233,3 +233,41 @@ def test_static_agent_proxy_uses_managed_blocking_and_named_lifetime_tasks():
         if not isinstance(call.func, ast.Attribute) or call.func.attr != "create_task":
             continue
         assert any(keyword.arg == "name" for keyword in call.keywords)
+
+
+def test_unresolved_vm_ip_is_never_persisted_as_a_dialable_address(agent_proxy):
+    """The placeholder is truthy, so persisting it passed every `if ip:` reader.
+
+    A stored placeholder satisfied the `status == "ready" and vm_ip` fast path,
+    failed the health probe, and drove `_ensure_vm_running(health_failed=True)`
+    into hard-resetting a healthy VM — which wrote the same placeholder back.
+    No writer repaired the field, so the user never recovered.
+    """
+    assert not agent_proxy._is_usable_vm_ip(agent_proxy.UNRESOLVED_VM_IP)
+    assert not agent_proxy._is_usable_vm_ip("")
+    assert not agent_proxy._is_usable_vm_ip(None)
+    assert agent_proxy._is_usable_vm_ip("34.121.9.4")
+
+    # The placeholder is truthy — this is the property that made it dangerous.
+    assert bool(agent_proxy.UNRESOLVED_VM_IP)
+
+    with pytest.raises(ValueError):
+        agent_proxy._update_firestore_vm("uid-1", agent_proxy.UNRESOLVED_VM_IP, "ready")
+
+
+def test_agent_proxy_never_assigns_the_unresolved_ip_placeholder():
+    """`_start_vm_and_wait` must raise rather than return a sentinel address.
+
+    Both callers already route an exception to `status: "error"`, so raising
+    reuses the existing failure path instead of inventing a second one.
+    """
+    source = (AGENT_PROXY_DIR / "main.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not isinstance(node.value, ast.Constant) or node.value.value != "unknown":
+            continue
+        targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        assert targets == ["UNRESOLVED_VM_IP"], f"'unknown' assigned to {targets} at line {node.lineno}"


### PR DESCRIPTION
## Problem

When the GCE external-IP poll timed out, `_start_vm_and_wait` returned the literal string `"unknown"` and the caller wrote it to Firestore alongside `status: "ready"`.

`"unknown"` is truthy, so the poisoned record satisfied every reader:

1. connect takes the fast path (`status == "ready" and vm_ip`)
2. the health probe dials `http://unknown:8080/health` and fails
3. `_ensure_vm_running(health_failed=True)` finds GCE reporting `RUNNING`
4. so it **hard-resets a healthy VM**, then writes `vm.get("ip")` — still `"unknown"` — back with `status: "ready"`

No writer anywhere repaired the field, so every later reconnect reset the user's VM again and never recovered the real address. The field was already known to be dangerous: both copies guard `candidate != "unknown"` when *reading* the GCE response, but nothing guarded the *write*.

## Change

Repairs the ownership boundary rather than the call site, per the failure-class guidance:

- `_update_firestore_vm` owns `agentVm.ip`, so it now refuses any value that is not dialable. A future caller cannot reintroduce the placeholder.
- The poll failure raises instead of returning a sentinel, which reuses the callers' existing `except -> status: "error"` path rather than adding a second one.
- **Already-poisoned records self-heal:** the ready fast path and both vm-ensure `RUNNING` branches require a usable IP. `_start_vm_and_wait` first checks whether GCE is already running; if so it resolves the external IP without issuing a second start request.

Both copies are fixed (`agent-proxy/main.py` and `routers/agent_tools.py`); they were byte-identical.

## Product invariants

None matched by these paths.

Failure-Class: none

## Verification

- `pytest tests/unit/test_agent_proxy_async_boundaries.py tests/unit/test_agent_vm_async.py tests/unit/test_tools_agent_route_response_shape.py tests/unit/test_agent_tool_geolocation_async.py` — 23 passed
- Both new tests confirmed to **fail** on the unfixed source: `'unknown' assigned to ['ip'] at line 213`, plus the writer-rejection `ValueError` case
- The GCE-timeout path itself is not reachable in a hermetic test; it is exercised only against live GCE, so it is covered here by the boundary guard plus the static assertion that the literal is only ever bound to the named constant


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

