### PR TITLE
fix(backend): keep execute_tool off the event loop

### DIFF
--- a/backend/routers/agent_tools.py
+++ b/backend/routers/agent_tools.py
@@ -302,13 +302,15 @@ async def execute_tool(
     }
     agent_config_context.set(config)
 
-    # Find the tool
+    # Find the tool. `load_app_tools` reads Redis plus one Firestore document
+    # per enabled app, so it must not run on the event loop — see the canonical
+    # path in utils/retrieval/agentic.py.
     all_tools = list(CORE_TOOLS)
     try:
-        app_tools = load_app_tools(uid)
+        app_tools = await run_blocking(db_executor, load_app_tools, uid)
         all_tools.extend(app_tools)
-    except Exception as e:
-        logger.error(f"⚠️ Error loading app tools: {e}")
+    except Exception as error:
+        logger.error("⚠️ Error loading app tools error_type=%s", type(error).__name__)
 
     target = None
     for t in all_tools:
@@ -327,10 +329,16 @@ async def execute_tool(
         if hasattr(target, "coroutine") and target.coroutine is not None:
             result = await target.coroutine(**params)
         else:
+            # Every CORE_TOOLS entry is a sync @tool that fans out to Firestore
+            # and Pinecone, so invoking it here would park the whole event loop
+            # for the duration. `run_blocking` copies the current context, so
+            # `agent_config_context` still resolves inside the worker thread.
             # Pass config as second arg (LangChain RunnableConfig), not as tool input
-            result = target.invoke(params, config=config)
+            result = await run_blocking(db_executor, target.invoke, params, config=config)
         result = preserve_chat_memory_tool_result_boundary(body.tool_name, str(result))
         return {"result": result}
-    except Exception as e:
-        logger.error(f"❌ Error executing tool {body.tool_name}: {e}")
-        return {"error": str(e)}
+    except Exception as error:
+        # Never echo the exception text: it can embed the caller's tool params,
+        # which carry user content (pydantic renders `input_value=...`).
+        logger.error("❌ Error executing tool %s error_type=%s", body.tool_name, type(error).__name__)
+        return {"error": sanitize(str(error))}

--- a/backend/routers/agent_tools.py
+++ b/backend/routers/agent_tools.py
@@ -338,7 +338,7 @@ async def execute_tool(
         result = preserve_chat_memory_tool_result_boundary(body.tool_name, str(result))
         return {"result": result}
     except Exception as error:
-        # Never echo the exception text: it can embed the caller's tool params,
-        # which carry user content (pydantic renders `input_value=...`).
+        # Exception text can embed caller params (pydantic renders
+        # `input_value=...`), so keep it off both the log and response planes.
         logger.error("❌ Error executing tool %s error_type=%s", body.tool_name, type(error).__name__)
-        return {"error": sanitize(str(error))}
+        return {"error": "Tool execution failed"}

--- a/backend/tests/unit/test_chat_memory_tool_caller.py
+++ b/backend/tests/unit/test_chat_memory_tool_caller.py
@@ -24,9 +24,9 @@ def test_agent_execute_tool_route_guards_memory_tool_result_before_returning_to_
 
     assert 'from utils.retrieval.tool_result_boundaries import preserve_chat_memory_tool_result_boundary' in contents
     assert 'result = preserve_chat_memory_tool_result_boundary(body.tool_name, str(result))' in contents
-    assert contents.index('result = target.invoke(params, config=config)') < contents.index(
-        'result = preserve_chat_memory_tool_result_boundary(body.tool_name, str(result))'
-    )
+    assert contents.index(
+        'result = await run_blocking(db_executor, target.invoke, params, config=config)'
+    ) < contents.index('result = preserve_chat_memory_tool_result_boundary(body.tool_name, str(result))')
     assert contents.index(
         'result = preserve_chat_memory_tool_result_boundary(body.tool_name, str(result))'
     ) < contents.index('return {"result": result}')

--- a/backend/tests/unit/test_tools_agent_route_response_shape.py
+++ b/backend/tests/unit/test_tools_agent_route_response_shape.py
@@ -1,5 +1,10 @@
 import asyncio
 import importlib
+import contextvars
+import functools
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 import os
 import sys
 import types
@@ -307,3 +312,75 @@ def test_agent_execute_tool_route_fail_closed_response_shape_for_partial_memory_
     assert response.result == 'No memories available for this request.'
     assert response.error is None
     assert 'SYSTEM:' not in response.result
+
+
+class _BlockingTool:
+    """A sync LangChain-shaped tool, like every entry in CORE_TOOLS."""
+
+    def __init__(self, started, release):
+        self.name = 'blocking_tool'
+        self.description = ''
+        self.args_schema = None
+        self.coroutine = None
+        self._started = started
+        self._release = release
+
+    def invoke(self, params, config=None):
+        self._started.set()
+        self._release.wait(3)
+        return 'done'
+
+
+def test_execute_tool_runs_sync_tools_off_the_event_loop(loaded_route_modules):
+    """`execute_tool` used to call `target.invoke(...)` directly.
+
+    Every CORE_TOOLS entry is a sync @tool that fans out to Firestore/Pinecone,
+    so one agent VM calling /v1/agent/execute-tool parked the entire backend
+    event loop for the duration of that scan — every other connection, /health,
+    and the HPA metrics endpoint froze with it.
+
+    The seam: while the tool is still inside `invoke`, this coroutine must get
+    control back. If the tool runs on the loop it cannot, and the wait_for
+    below expires instead.
+    """
+    _tools_router, agent_tools, agentic, _memories_service = loaded_route_modules
+    started = threading.Event()
+    release = threading.Event()
+    agentic.CORE_TOOLS[:] = [_BlockingTool(started, release)]
+
+    # The shared fixture stubs `run_blocking` to call fn() inline, which would
+    # erase the very seam under test. Restore the real offload (including the
+    # contextvar copy `agent_config_context` depends on) for this case only.
+    pool = ThreadPoolExecutor(max_workers=2)
+
+    async def _real_run_blocking(executor, fn, *args, **kwargs):
+        loop = asyncio.get_running_loop()
+        ctx = contextvars.copy_context()
+        call = functools.partial(ctx.run, functools.partial(fn, *args, **kwargs))
+        return await loop.run_in_executor(executor, call)
+
+    agent_tools.run_blocking = _real_run_blocking
+    agent_tools.db_executor = pool
+
+    async def scenario():
+        task = asyncio.create_task(
+            agent_tools.execute_tool(
+                agent_tools.ExecuteToolRequest(tool_name='blocking_tool', params={}), uid='uid-block'
+            )
+        )
+        # Reached only if the loop is still scheduling while invoke() blocks.
+        # If the tool runs on the loop, this coroutine cannot resume until
+        # invoke() returns on its own 3s timeout, so `release` is set far too
+        # late and the elapsed time below records the full block.
+        while not started.is_set():
+            await asyncio.sleep(0.005)
+        release.set()
+        return await task
+
+    began = time.monotonic()
+    raw_response = asyncio.run(scenario())
+    elapsed = time.monotonic() - began
+
+    assert raw_response == {'result': 'done'}
+    pool.shutdown(wait=False)
+    assert elapsed < 1.0, f'event loop was blocked for {elapsed:.2f}s by a sync tool invoke'

--- a/backend/tests/unit/test_tools_agent_route_response_shape.py
+++ b/backend/tests/unit/test_tools_agent_route_response_shape.py
@@ -331,6 +331,29 @@ class _BlockingTool:
         return 'done'
 
 
+class _FailingTool(_FakeTool):
+    def invoke(self, params, config=None):
+        raise ValueError(f"invalid input_value={params['private_text']}")
+
+
+def test_execute_tool_does_not_echo_user_input_from_exceptions(loaded_route_modules):
+    _tools_router, agent_tools, agentic, _memories_service = loaded_route_modules
+    agentic.CORE_TOOLS[:] = [_FailingTool('failing_tool', None)]
+
+    raw_response = asyncio.run(
+        agent_tools.execute_tool(
+            agent_tools.ExecuteToolRequest(
+                tool_name='failing_tool',
+                params={'private_text': 'private medical note'},
+            ),
+            uid='uid-private',
+        )
+    )
+
+    assert raw_response == {'error': 'Tool execution failed'}
+    assert 'private medical note' not in str(raw_response)
+
+
 def test_execute_tool_runs_sync_tools_off_the_event_loop(loaded_route_modules):
     """`execute_tool` used to call `target.invoke(...)` directly.
 


### PR DESCRIPTION
## Problem

`POST /v1/agent/execute-tool` is `async def`, but ran two blocking calls directly on the event loop:

- `load_app_tools(uid)` — a Redis read plus one Firestore document read **per enabled app**
- `target.invoke(params, config=config)` — every `CORE_TOOLS` entry is a sync `@tool` that fans out to Firestore/Pinecone, and `get_conversations_tool` accepts `limit` up to 5000

One agent VM calling this endpoint parked the whole backend event loop for the duration of that scan: every other connection, `/health`, and the HPA metrics endpoint froze with it. This is the "silent poison" class `backend/AGENTS.md` → Common Gotchas #3 describes.

The canonical path one file over already does both correctly — `utils/retrieval/agentic.py:707` (`await run_blocking(db_executor, load_app_tools, uid)`) and `:331` (`await tool_obj.ainvoke(...)`). This router was the drift.

Not caught by `scan_async_blockers.py`: its DB detector is import-aware over `database.*` names, and neither `load_app_tools` nor `t.invoke` is one.

## Change

Both calls now go through `run_blocking(db_executor, ...)`, which copies the current context so `agent_config_context` still resolves inside the worker thread (verified: `utils/executors.py:89` uses `contextvars.copy_context()`).

Also stops echoing raw exception text. Pydantic renders `input_value=<...>`, so a `ValidationError` from caller-supplied params wrote user content verbatim into backend logs and returned it over the wire under HTTP 200. The log line now carries `error_type` only and the response returns a fixed `Tool execution failed` category. Sanitizing free-form text was insufficient because ordinary user prose contains no token pattern to redact.

## Product invariants

None matched by these paths.

Failure-Class: none

## Verification

- `pytest tests/unit/test_tools_agent_route_response_shape.py tests/unit/test_agent_vm_async.py tests/unit/test_agent_tool_geolocation_async.py tests/unit/test_chat_memory_tool_caller.py` — 18 passed
- The new test is **behavioral, not a static tripwire**: a sync tool blocks inside `invoke` while the test coroutine tries to regain control. Confirmed to fail on the unfixed router with `assert 3.006059459061362 < 1.0`; the whole file runs in 0.08s with the fix.
- Note the shared fixture stubs `run_blocking` to call `fn()` inline, which would erase the seam under test, so this case restores a real `ThreadPoolExecutor` offload including the contextvar copy.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

