### PR TITLE
SCA-129: bind macOS candidate tags to merged main

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -346,9 +346,19 @@ checks:
     reason: "#9843 Rung-0: desktop Swift CI must pin its toolchain and cache on Package.resolved"
   - id: desktop-candidate-source-gate
     command: ["python3", ".github/scripts/test_plan_desktop_release.py"]
-    triggers: [".github/scripts/plan-desktop-release.py", ".github/scripts/test_plan_desktop_release.py", ".github/workflows/desktop_auto_release.yml"]
+    triggers: [".github/scripts/plan-desktop-release.py", ".github/scripts/test_plan_desktop_release.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "candidate tags require successful Release Eligibility and both Desktop Swift checks for the exact newest queued releasable desktop SHA"
+  - id: desktop-candidate-source-identity
+    command: ["python3", ".github/scripts/test_desktop_release_source_identity.py"]
+    triggers: [".github/scripts/desktop-release-source-identity.py", ".github/scripts/test_desktop_release_source_identity.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-129 keeps a current-main candidate bound to the checked desktop source while rejecting a newer releasable desktop change"
+  - id: desktop-candidate-tag-transaction
+    command: ["python3", ".github/scripts/test_publish_desktop_candidate_tag.py"]
+    triggers: [".github/scripts/publish-desktop-candidate-tag.py", ".github/scripts/test_publish_desktop_candidate_tag.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-129 requires GitHub to atomically verify live main before creating an immutable candidate tag"
   - id: desktop-manifest-routes
     command: ["python3", ".github/scripts/test_desktop_manifest_routes.py"]
     triggers: [".github/workflows/desktop-swift-ci.yml", ".github/checks-manifest.yaml", ".github/scripts/run_checks.py", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_desktop_manifest_routes.py"]

--- a/.github/failure-classes/FC-release-build-config-source-binding.json
+++ b/.github/failure-classes/FC-release-build-config-source-binding.json
@@ -3,6 +3,10 @@
   "id": "FC-release-build-config-source-binding",
   "violated_contract": "An immutable desktop release tag must contain the artifact-producing build configuration and release-control revision that selected it, and the exact tagged source must have the checks required by the release gate.",
   "canonical_prevention": "Treat build configuration and release-control files as desktop candidate inputs, keep the planner and exact-SHA CI producer path sets aligned, and enforce that alignment with contract tests.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/test_desktop_release_source_identity.py",
+    ".github/scripts/test_publish_desktop_candidate_tag.py"
+  ],
   "evidence_prs": [10356],
   "scope_hints": [
     "codemagic.yaml",

--- a/.github/scripts/desktop-release-source-identity.py
+++ b/.github/scripts/desktop-release-source-identity.py
@@ -6,11 +6,21 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
 from pathlib import Path
 
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 SCHEMA = "desktop-release-planner-source-identity/v1"
+DESKTOP_RELEASE_PATHS = (
+    "desktop/macos",
+    "codemagic.yaml",
+    ".github/scripts/plan-desktop-release.py",
+    ".github/scripts/desktop-release-source-identity.py",
+    ".github/scripts/publish-desktop-candidate-tag.py",
+    ".github/workflows/desktop_auto_release.yml",
+    ".github/workflows/desktop-swift-ci.yml",
+)
 
 
 def require_sha(name: str, value: str) -> str:
@@ -19,21 +29,105 @@ def require_sha(name: str, value: str) -> str:
     return value
 
 
+def releasable_desktop_paths(paths: list[str]) -> list[str]:
+    """Filter a Git path list with the planner's release-input policy."""
+    releasable = []
+    for path in paths:
+        if not path:
+            continue
+        if path == "desktop/macos/CHANGELOG.json":
+            continue
+        if path == "desktop/macos/AGENTS.md":
+            continue
+        if path.startswith("desktop/macos/changelog/"):
+            continue
+        if path.startswith("desktop/macos/Backend-Rust/"):
+            continue
+        releasable.append(path)
+    return releasable
+
+
+def git(repository_root: Path, args: list[str], *, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repository_root), *args],
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.strip()
+
+
+def ensure_candidate_history_is_safe(
+    *,
+    repository_root: Path,
+    planned_source_sha: str,
+    candidate_source_sha: str,
+    changelog_commit: str = "",
+    changelog_parent_sha: str = "",
+) -> None:
+    """Reject a current-main candidate that contains a newer releasable change.
+
+    The planner deliberately gates the latest desktop-changing source rather
+    than every later main commit. A candidate may therefore include later
+    backend/docs-only commits, but it must still descend from the gated source
+    and contain no newer releasable desktop input.
+    """
+    try:
+        git(
+            repository_root,
+            ["merge-base", "--is-ancestor", planned_source_sha, candidate_source_sha],
+        )
+    except subprocess.CalledProcessError as error:
+        raise ValueError("candidate main must descend from the planner source SHA") from error
+
+    changed_paths = git(
+        repository_root,
+        [
+            "diff",
+            "--name-only",
+            "--diff-filter=ACDMR",
+            f"{planned_source_sha}..{candidate_source_sha}",
+            "--",
+            *DESKTOP_RELEASE_PATHS,
+        ],
+    ).splitlines()
+    newer_releasable_paths = releasable_desktop_paths(changed_paths)
+    if newer_releasable_paths:
+        raise ValueError(
+            "candidate main contains newer releasable desktop changes after the planner source: "
+            + ", ".join(newer_releasable_paths)
+        )
+
+    if changelog_commit:
+        try:
+            git(
+                repository_root,
+                ["merge-base", "--is-ancestor", changelog_commit, candidate_source_sha],
+            )
+        except subprocess.CalledProcessError as error:
+            raise ValueError("merged changelog commit must be reachable from the candidate main") from error
+        actual_parent = git(repository_root, ["rev-parse", f"{changelog_commit}^1"])
+        if actual_parent != changelog_parent_sha:
+            raise ValueError("merged changelog parent does not match its recorded source SHA")
+
+
 def build_evidence(
     *,
     planned_source_sha: str,
     candidate_source_sha: str,
     origin_main_sha: str,
-    first_parent_sha: str = "",
+    changelog_parent_sha: str = "",
     changelog_commit: str = "",
     changelog_pr: str = "",
 ) -> dict[str, object]:
     """Prove the candidate tag targets the source currently merged on main.
 
-    A consolidated changelog is merged with a regular GitHub merge commit, so
-    its first parent must be the CI-gated planner source. A no-op
-    consolidation does not create that PR and may tag the planner source only
-    when it is still the exact main tip. Either path rejects source drift.
+    A candidate always resolves to fresh main. The current main may contain
+    later non-desktop commits, which are admitted only after the caller proves
+    ancestry and confirms there is no newer releasable desktop input. A
+    consolidated changelog records its own parent, not the merge commit's first
+    parent: concurrent non-desktop main commits are valid merge parents.
     """
     planned_source_sha = require_sha("planned_source_sha", planned_source_sha)
     candidate_source_sha = require_sha("candidate_source_sha", candidate_source_sha)
@@ -42,13 +136,13 @@ def build_evidence(
     if candidate_source_sha != origin_main_sha:
         raise ValueError("candidate_source_sha must exactly match fresh origin/main")
 
-    if changelog_commit or changelog_pr or first_parent_sha:
-        if not (changelog_commit and changelog_pr and first_parent_sha):
+    if changelog_commit or changelog_pr or changelog_parent_sha:
+        if not (changelog_commit and changelog_pr and changelog_parent_sha):
             raise ValueError("merged changelog evidence requires commit, PR URL, and first parent")
         changelog_commit = require_sha("changelog_commit", changelog_commit)
-        first_parent_sha = require_sha("first_parent_sha", first_parent_sha)
-        if first_parent_sha != planned_source_sha:
-            raise ValueError("merged changelog first parent must match the planner source SHA")
+        changelog_parent_sha = require_sha("changelog_parent_sha", changelog_parent_sha)
+        if changelog_parent_sha != planned_source_sha:
+            raise ValueError("merged changelog parent must match the planner source SHA")
         if not re.fullmatch(r"https://github\.com/[^/]+/[^/]+/pull/[1-9][0-9]*", changelog_pr):
             raise ValueError("changelog_pr must be a canonical GitHub pull request URL")
         return {
@@ -59,11 +153,9 @@ def build_evidence(
             "origin_main_sha": origin_main_sha,
             "changelog_commit": changelog_commit,
             "changelog_pr": changelog_pr,
-            "first_parent_sha": first_parent_sha,
+            "changelog_parent_sha": changelog_parent_sha,
         }
 
-    if candidate_source_sha != planned_source_sha:
-        raise ValueError("direct candidate source must match the planner source SHA")
     return {
         "schema": SCHEMA,
         "mode": "direct",
@@ -78,18 +170,31 @@ def main() -> int:
     parser.add_argument("--planned-source-sha", required=True)
     parser.add_argument("--candidate-source-sha", required=True)
     parser.add_argument("--origin-main-sha", required=True)
-    parser.add_argument("--first-parent-sha", default="")
+    parser.add_argument("--changelog-parent-sha", default="")
     parser.add_argument("--changelog-commit", default="")
     parser.add_argument("--changelog-pr", default="")
+    parser.add_argument("--repository-root", default=".")
     parser.add_argument("--output", required=True)
     args = parser.parse_args()
 
     try:
+        planned_source_sha = require_sha("planned_source_sha", args.planned_source_sha)
+        candidate_source_sha = require_sha("candidate_source_sha", args.candidate_source_sha)
+        changelog_parent_sha = args.changelog_parent_sha
+        if args.changelog_commit or args.changelog_pr or changelog_parent_sha:
+            changelog_parent_sha = require_sha("changelog_parent_sha", changelog_parent_sha)
+        ensure_candidate_history_is_safe(
+            repository_root=Path(args.repository_root),
+            planned_source_sha=planned_source_sha,
+            candidate_source_sha=candidate_source_sha,
+            changelog_commit=args.changelog_commit,
+            changelog_parent_sha=changelog_parent_sha,
+        )
         evidence = build_evidence(
-            planned_source_sha=args.planned_source_sha,
-            candidate_source_sha=args.candidate_source_sha,
+            planned_source_sha=planned_source_sha,
+            candidate_source_sha=candidate_source_sha,
             origin_main_sha=args.origin_main_sha,
-            first_parent_sha=args.first_parent_sha,
+            changelog_parent_sha=changelog_parent_sha,
             changelog_commit=args.changelog_commit,
             changelog_pr=args.changelog_pr,
         )

--- a/.github/scripts/desktop-release-source-identity.py
+++ b/.github/scripts/desktop-release-source-identity.py
@@ -81,22 +81,38 @@ def ensure_candidate_history_is_safe(
     except subprocess.CalledProcessError as error:
         raise ValueError("candidate main must descend from the planner source SHA") from error
 
-    changed_paths = git(
+    # A range endpoint diff hides a desktop change that a later commit reverts.
+    # The planner selects sources from first-parent history, so examine every
+    # first-parent commit after the planned source with the same release-input
+    # policy. Any newer releasable change must force a new exact-SHA gate even
+    # when its net tree effect is later undone.
+    commits_after_planned_source = git(
         repository_root,
-        [
-            "diff",
-            "--name-only",
-            "--diff-filter=ACDMR",
-            f"{planned_source_sha}..{candidate_source_sha}",
-            "--",
-            *DESKTOP_RELEASE_PATHS,
-        ],
+        ["rev-list", "--first-parent", f"{planned_source_sha}..{candidate_source_sha}"],
     ).splitlines()
-    newer_releasable_paths = releasable_desktop_paths(changed_paths)
-    if newer_releasable_paths:
+    newer_releasable_changes: list[str] = []
+    for commit_sha in commits_after_planned_source:
+        changed_paths = git(
+            repository_root,
+            [
+                "diff-tree",
+                "--no-commit-id",
+                "--name-only",
+                "--diff-filter=ACDMR",
+                "-r",
+                f"{commit_sha}^1",
+                commit_sha,
+                "--",
+                *DESKTOP_RELEASE_PATHS,
+            ],
+        ).splitlines()
+        newer_releasable_changes.extend(
+            f"{commit_sha}:{path}" for path in releasable_desktop_paths(changed_paths)
+        )
+    if newer_releasable_changes:
         raise ValueError(
             "candidate main contains newer releasable desktop changes after the planner source: "
-            + ", ".join(newer_releasable_paths)
+            + ", ".join(newer_releasable_changes)
         )
 
     if changelog_commit:

--- a/.github/scripts/desktop-release-source-identity.py
+++ b/.github/scripts/desktop-release-source-identity.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Build fail-closed evidence for a macOS candidate tag's source identity."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SCHEMA = "desktop-release-planner-source-identity/v1"
+
+
+def require_sha(name: str, value: str) -> str:
+    if not SHA_RE.fullmatch(value):
+        raise ValueError(f"{name} must be a 40-character lowercase SHA")
+    return value
+
+
+def build_evidence(
+    *,
+    planned_source_sha: str,
+    candidate_source_sha: str,
+    origin_main_sha: str,
+    first_parent_sha: str = "",
+    changelog_commit: str = "",
+    changelog_pr: str = "",
+) -> dict[str, object]:
+    """Prove the candidate tag targets the source currently merged on main.
+
+    A consolidated changelog is merged with a regular GitHub merge commit, so
+    its first parent must be the CI-gated planner source. A no-op
+    consolidation does not create that PR and may tag the planner source only
+    when it is still the exact main tip. Either path rejects source drift.
+    """
+    planned_source_sha = require_sha("planned_source_sha", planned_source_sha)
+    candidate_source_sha = require_sha("candidate_source_sha", candidate_source_sha)
+    origin_main_sha = require_sha("origin_main_sha", origin_main_sha)
+
+    if candidate_source_sha != origin_main_sha:
+        raise ValueError("candidate_source_sha must exactly match fresh origin/main")
+
+    if changelog_commit or changelog_pr or first_parent_sha:
+        if not (changelog_commit and changelog_pr and first_parent_sha):
+            raise ValueError("merged changelog evidence requires commit, PR URL, and first parent")
+        changelog_commit = require_sha("changelog_commit", changelog_commit)
+        first_parent_sha = require_sha("first_parent_sha", first_parent_sha)
+        if first_parent_sha != planned_source_sha:
+            raise ValueError("merged changelog first parent must match the planner source SHA")
+        if not re.fullmatch(r"https://github\.com/[^/]+/[^/]+/pull/[1-9][0-9]*", changelog_pr):
+            raise ValueError("changelog_pr must be a canonical GitHub pull request URL")
+        return {
+            "schema": SCHEMA,
+            "mode": "merged-changelog",
+            "planned_source_sha": planned_source_sha,
+            "candidate_source_sha": candidate_source_sha,
+            "origin_main_sha": origin_main_sha,
+            "changelog_commit": changelog_commit,
+            "changelog_pr": changelog_pr,
+            "first_parent_sha": first_parent_sha,
+        }
+
+    if candidate_source_sha != planned_source_sha:
+        raise ValueError("direct candidate source must match the planner source SHA")
+    return {
+        "schema": SCHEMA,
+        "mode": "direct",
+        "planned_source_sha": planned_source_sha,
+        "candidate_source_sha": candidate_source_sha,
+        "origin_main_sha": origin_main_sha,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--planned-source-sha", required=True)
+    parser.add_argument("--candidate-source-sha", required=True)
+    parser.add_argument("--origin-main-sha", required=True)
+    parser.add_argument("--first-parent-sha", default="")
+    parser.add_argument("--changelog-commit", default="")
+    parser.add_argument("--changelog-pr", default="")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    try:
+        evidence = build_evidence(
+            planned_source_sha=args.planned_source_sha,
+            candidate_source_sha=args.candidate_source_sha,
+            origin_main_sha=args.origin_main_sha,
+            first_parent_sha=args.first_parent_sha,
+            changelog_commit=args.changelog_commit,
+            changelog_pr=args.changelog_pr,
+        )
+    except ValueError as error:
+        parser.error(str(error))
+
+    Path(args.output).write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"desktop release source identity verified for {evidence['candidate_source_sha']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -32,6 +32,7 @@ DESKTOP_RELEASE_PATHS = (
     "desktop/macos",
     "codemagic.yaml",
     ".github/scripts/plan-desktop-release.py",
+    ".github/scripts/desktop-release-source-identity.py",
     ".github/workflows/desktop_auto_release.yml",
     ".github/workflows/desktop-swift-ci.yml",
 )

--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -33,6 +33,7 @@ DESKTOP_RELEASE_PATHS = (
     "codemagic.yaml",
     ".github/scripts/plan-desktop-release.py",
     ".github/scripts/desktop-release-source-identity.py",
+    ".github/scripts/publish-desktop-candidate-tag.py",
     ".github/workflows/desktop_auto_release.yml",
     ".github/workflows/desktop-swift-ci.yml",
 )

--- a/.github/scripts/publish-desktop-candidate-tag.py
+++ b/.github/scripts/publish-desktop-candidate-tag.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Atomically publish an annotated macOS candidate tag against live main."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ZERO_OID = "0" * 40
+TAGGER_NAME = "github-actions[bot]"
+TAGGER_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
+
+REPOSITORY_ID_QUERY = """
+query RepositoryId($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) { id }
+}
+"""
+
+UPDATE_REFS_MUTATION = """
+mutation PublishCandidateTag(
+  $repositoryId: ID!,
+  $mainBefore: GitObjectID!,
+  $mainAfter: GitObjectID!,
+  $tagName: GitRefname!,
+  $tagObject: GitObjectID!,
+  $zeroOid: GitObjectID!
+) {
+  updateRefs(input: {
+    repositoryId: $repositoryId,
+    refUpdates: [
+      {
+        name: "refs/heads/main",
+        beforeOid: $mainBefore,
+        afterOid: $mainAfter,
+        force: false
+      },
+      {
+        name: $tagName,
+        beforeOid: $zeroOid,
+        afterOid: $tagObject,
+        force: false
+      }
+    ]
+  }) {
+    clientMutationId
+  }
+}
+"""
+
+
+def run_gh_json(args: list[str], payload: dict[str, object]) -> dict[str, object]:
+    """Call the authenticated GitHub CLI without exposing structured input to a shell."""
+    result = subprocess.run(
+        ["gh", *args, "--input", "-"],
+        check=True,
+        input=json.dumps(payload),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        decoded = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise ValueError("GitHub API returned invalid JSON") from error
+    if not isinstance(decoded, dict):
+        raise ValueError("GitHub API returned an unexpected JSON payload")
+    if decoded.get("errors"):
+        raise ValueError(f"GitHub GraphQL rejected the ref transaction: {decoded['errors']}")
+    return decoded
+
+
+def repository_id(repository: str) -> str:
+    owner, separator, name = repository.partition("/")
+    if not owner or not separator or not name or "/" in name:
+        raise ValueError("repository must be in owner/name form")
+    response = run_gh_json(
+        ["api", "graphql"],
+        {"query": REPOSITORY_ID_QUERY, "variables": {"owner": owner, "name": name}},
+    )
+    data = response.get("data")
+    if not isinstance(data, dict) or not isinstance(data.get("repository"), dict):
+        raise ValueError("GitHub did not return a repository node")
+    identifier = data["repository"].get("id")
+    if not isinstance(identifier, str) or not identifier:
+        raise ValueError("GitHub did not return a repository ID")
+    return identifier
+
+
+def create_annotated_tag_object(
+    *, repository: str, release_tag: str, candidate_sha: str, evidence: str, timestamp: str
+) -> str:
+    response = run_gh_json(
+        ["api", "--method", "POST", f"repos/{repository}/git/tags"],
+        {
+            "tag": release_tag,
+            "message": evidence,
+            "object": candidate_sha,
+            "type": "commit",
+            "tagger": {"name": TAGGER_NAME, "email": TAGGER_EMAIL, "date": timestamp},
+        },
+    )
+    tag_object_sha = response.get("sha")
+    if not isinstance(tag_object_sha, str) or len(tag_object_sha) != 40:
+        raise ValueError("GitHub did not return the annotated tag object SHA")
+    return tag_object_sha
+
+
+def atomic_publish_tag_ref(
+    *, repository_id_value: str, release_tag: str, candidate_sha: str, tag_object_sha: str
+) -> None:
+    """Publish only if live main still points at the identity-validated SHA.
+
+    GitHub's `updateRefs` mutation evaluates every `beforeOid` and applies all
+    ref updates as one transaction. Keeping main unchanged still makes its
+    current OID a server-enforced precondition for adding the immutable tag.
+    """
+    run_gh_json(
+        ["api", "graphql"],
+        {
+            "query": UPDATE_REFS_MUTATION,
+            "variables": {
+                "repositoryId": repository_id_value,
+                "mainBefore": candidate_sha,
+                "mainAfter": candidate_sha,
+                "tagName": f"refs/tags/{release_tag}",
+                "tagObject": tag_object_sha,
+                "zeroOid": ZERO_OID,
+            },
+        },
+    )
+
+
+def publish_candidate_tag(*, repository: str, release_tag: str, candidate_sha: str, evidence: str, timestamp: str) -> None:
+    repo_id = repository_id(repository)
+    # A tag object alone is unreachable and is not a candidate. The only
+    # candidate-creating action is the atomic ref transaction below.
+    tag_object_sha = create_annotated_tag_object(
+        repository=repository,
+        release_tag=release_tag,
+        candidate_sha=candidate_sha,
+        evidence=evidence,
+        timestamp=timestamp,
+    )
+    atomic_publish_tag_ref(
+        repository_id_value=repo_id,
+        release_tag=release_tag,
+        candidate_sha=candidate_sha,
+        tag_object_sha=tag_object_sha,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--candidate-sha", required=True)
+    parser.add_argument("--evidence", type=Path, required=True)
+    args = parser.parse_args()
+
+    evidence = args.evidence.read_text(encoding="utf-8")
+    timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    publish_candidate_tag(
+        repository=args.repository,
+        release_tag=args.release_tag,
+        candidate_sha=args.candidate_sha,
+        evidence=evidence,
+        timestamp=timestamp,
+    )
+    print(f"Published immutable candidate tag {args.release_tag} at {args.candidate_sha}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_desktop_release_source_identity.py
+++ b/.github/scripts/test_desktop_release_source_identity.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Regression tests for macOS release planner source identity evidence."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("desktop-release-source-identity.py")
+SPEC = importlib.util.spec_from_file_location("desktop_release_source_identity", SCRIPT)
+assert SPEC and SPEC.loader
+identity = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(identity)
+
+PLANNED_SHA = "a" * 40
+CANDIDATE_SHA = "b" * 40
+CHANGELOG_SHA = "c" * 40
+PR_URL = "https://github.com/BasedHardware/omi/pull/12345"
+
+
+class DesktopReleaseSourceIdentityTests(unittest.TestCase):
+    def test_merged_changelog_records_the_exact_main_candidate_sha(self) -> None:
+        evidence = identity.build_evidence(
+            planned_source_sha=PLANNED_SHA,
+            candidate_source_sha=CANDIDATE_SHA,
+            origin_main_sha=CANDIDATE_SHA,
+            first_parent_sha=PLANNED_SHA,
+            changelog_commit=CHANGELOG_SHA,
+            changelog_pr=PR_URL,
+        )
+
+        self.assertEqual(evidence["schema"], "desktop-release-planner-source-identity/v1")
+        self.assertEqual(evidence["mode"], "merged-changelog")
+        self.assertEqual(evidence["candidate_source_sha"], CANDIDATE_SHA)
+        self.assertEqual(evidence["origin_main_sha"], CANDIDATE_SHA)
+
+    def test_rejects_candidate_that_is_not_the_fresh_main_tip(self) -> None:
+        with self.assertRaisesRegex(ValueError, "exactly match fresh origin/main"):
+            identity.build_evidence(
+                planned_source_sha=PLANNED_SHA,
+                candidate_source_sha=CANDIDATE_SHA,
+                origin_main_sha="d" * 40,
+                first_parent_sha=PLANNED_SHA,
+                changelog_commit=CHANGELOG_SHA,
+                changelog_pr=PR_URL,
+            )
+
+    def test_rejects_changelog_merge_when_main_drifted_from_the_gated_source(self) -> None:
+        with self.assertRaisesRegex(ValueError, "first parent must match the planner source SHA"):
+            identity.build_evidence(
+                planned_source_sha=PLANNED_SHA,
+                candidate_source_sha=CANDIDATE_SHA,
+                origin_main_sha=CANDIDATE_SHA,
+                first_parent_sha="d" * 40,
+                changelog_commit=CHANGELOG_SHA,
+                changelog_pr=PR_URL,
+            )
+
+    def test_direct_path_allows_only_an_unchanged_planner_source(self) -> None:
+        evidence = identity.build_evidence(
+            planned_source_sha=PLANNED_SHA,
+            candidate_source_sha=PLANNED_SHA,
+            origin_main_sha=PLANNED_SHA,
+        )
+        self.assertEqual(evidence["mode"], "direct")
+
+        with self.assertRaisesRegex(ValueError, "direct candidate source must match"):
+            identity.build_evidence(
+                planned_source_sha=PLANNED_SHA,
+                candidate_source_sha=CANDIDATE_SHA,
+                origin_main_sha=CANDIDATE_SHA,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_desktop_release_source_identity.py
+++ b/.github/scripts/test_desktop_release_source_identity.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -26,7 +28,7 @@ class DesktopReleaseSourceIdentityTests(unittest.TestCase):
             planned_source_sha=PLANNED_SHA,
             candidate_source_sha=CANDIDATE_SHA,
             origin_main_sha=CANDIDATE_SHA,
-            first_parent_sha=PLANNED_SHA,
+            changelog_parent_sha=PLANNED_SHA,
             changelog_commit=CHANGELOG_SHA,
             changelog_pr=PR_URL,
         )
@@ -42,36 +44,117 @@ class DesktopReleaseSourceIdentityTests(unittest.TestCase):
                 planned_source_sha=PLANNED_SHA,
                 candidate_source_sha=CANDIDATE_SHA,
                 origin_main_sha="d" * 40,
-                first_parent_sha=PLANNED_SHA,
+                changelog_parent_sha=PLANNED_SHA,
                 changelog_commit=CHANGELOG_SHA,
                 changelog_pr=PR_URL,
             )
 
-    def test_rejects_changelog_merge_when_main_drifted_from_the_gated_source(self) -> None:
-        with self.assertRaisesRegex(ValueError, "first parent must match the planner source SHA"):
+    def test_rejects_changelog_commit_with_a_different_recorded_parent(self) -> None:
+        with self.assertRaisesRegex(ValueError, "changelog parent must match the planner source SHA"):
             identity.build_evidence(
                 planned_source_sha=PLANNED_SHA,
                 candidate_source_sha=CANDIDATE_SHA,
                 origin_main_sha=CANDIDATE_SHA,
-                first_parent_sha="d" * 40,
+                changelog_parent_sha="d" * 40,
                 changelog_commit=CHANGELOG_SHA,
                 changelog_pr=PR_URL,
             )
 
-    def test_direct_path_allows_only_an_unchanged_planner_source(self) -> None:
+    def test_direct_path_records_current_main_after_non_desktop_commits(self) -> None:
         evidence = identity.build_evidence(
             planned_source_sha=PLANNED_SHA,
-            candidate_source_sha=PLANNED_SHA,
-            origin_main_sha=PLANNED_SHA,
+            candidate_source_sha=CANDIDATE_SHA,
+            origin_main_sha=CANDIDATE_SHA,
         )
         self.assertEqual(evidence["mode"], "direct")
+        self.assertEqual(evidence["candidate_source_sha"], CANDIDATE_SHA)
 
-        with self.assertRaisesRegex(ValueError, "direct candidate source must match"):
-            identity.build_evidence(
-                planned_source_sha=PLANNED_SHA,
-                candidate_source_sha=CANDIDATE_SHA,
-                origin_main_sha=CANDIDATE_SHA,
+    def _git(self, repository: Path, *args: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(repository), *args],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ).stdout.strip()
+
+    def _commit(self, repository: Path, path: str, contents: str, message: str) -> str:
+        file_path = repository / path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(contents, encoding="utf-8")
+        self._git(repository, "add", path)
+        self._git(repository, "commit", "-m", message)
+        return self._git(repository, "rev-parse", "HEAD")
+
+    def _repository_with_planned_source(self) -> tuple[tempfile.TemporaryDirectory[str], Path, str]:
+        directory = tempfile.TemporaryDirectory()
+        repository = Path(directory.name)
+        self._git(repository, "init")
+        self._git(repository, "config", "user.name", "Release test")
+        self._git(repository, "config", "user.email", "release-test@example.com")
+        planned_source_sha = self._commit(
+            repository,
+            "desktop/macos/Desktop/Sources/App.swift",
+            "let releaseSource = true\n",
+            "desktop source",
+        )
+        return directory, repository, planned_source_sha
+
+    def test_non_desktop_main_commit_after_planned_source_is_valid(self) -> None:
+        directory, repository, planned_source_sha = self._repository_with_planned_source()
+        with directory:
+            candidate_source_sha = self._commit(
+                repository,
+                "docs/release-note.md",
+                "No desktop source change.\n",
+                "docs only",
             )
+            identity.ensure_candidate_history_is_safe(
+                repository_root=repository,
+                planned_source_sha=planned_source_sha,
+                candidate_source_sha=candidate_source_sha,
+            )
+
+    def test_newer_desktop_change_after_planned_source_fails_closed(self) -> None:
+        directory, repository, planned_source_sha = self._repository_with_planned_source()
+        with directory:
+            candidate_source_sha = self._commit(
+                repository,
+                "desktop/macos/Desktop/Sources/Newer.swift",
+                "let newerDesktopChange = true\n",
+                "newer desktop source",
+            )
+            with self.assertRaisesRegex(ValueError, "newer releasable desktop changes"):
+                identity.ensure_candidate_history_is_safe(
+                    repository_root=repository,
+                    planned_source_sha=planned_source_sha,
+                    candidate_source_sha=candidate_source_sha,
+                )
+
+    def test_stale_changelog_parent_fails_closed(self) -> None:
+        directory, repository, planned_source_sha = self._repository_with_planned_source()
+        with directory:
+            stale_parent_sha = self._commit(
+                repository,
+                "docs/concurrent-main.md",
+                "A later non-desktop commit.\n",
+                "concurrent main",
+            )
+            candidate_source_sha = self._commit(
+                repository,
+                "desktop/macos/changelog/2026-07-25.json",
+                "{}\n",
+                "stale changelog",
+            )
+            with self.assertRaisesRegex(ValueError, "changelog parent does not match"):
+                identity.ensure_candidate_history_is_safe(
+                    repository_root=repository,
+                    planned_source_sha=planned_source_sha,
+                    candidate_source_sha=candidate_source_sha,
+                    changelog_commit=candidate_source_sha,
+                    changelog_parent_sha=planned_source_sha,
+                )
+            self.assertNotEqual(stale_parent_sha, planned_source_sha)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_desktop_release_source_identity.py
+++ b/.github/scripts/test_desktop_release_source_identity.py
@@ -131,6 +131,28 @@ class DesktopReleaseSourceIdentityTests(unittest.TestCase):
                     candidate_source_sha=candidate_source_sha,
                 )
 
+    def test_reverted_newer_desktop_change_after_planned_source_still_fails_closed(self) -> None:
+        directory, repository, planned_source_sha = self._repository_with_planned_source()
+        with directory:
+            self._commit(
+                repository,
+                "desktop/macos/Desktop/Sources/App.swift",
+                "let releaseSource = false\n",
+                "newer desktop source",
+            )
+            candidate_source_sha = self._commit(
+                repository,
+                "desktop/macos/Desktop/Sources/App.swift",
+                "let releaseSource = true\n",
+                "revert newer desktop source",
+            )
+            with self.assertRaisesRegex(ValueError, "newer releasable desktop changes"):
+                identity.ensure_candidate_history_is_safe(
+                    repository_root=repository,
+                    planned_source_sha=planned_source_sha,
+                    candidate_source_sha=candidate_source_sha,
+                )
+
     def test_stale_changelog_parent_fails_closed(self) -> None:
         directory, repository, planned_source_sha = self._repository_with_planned_source()
         with directory:

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -166,6 +166,7 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
             "desktop/macos",
             "codemagic.yaml",
             ".github/scripts/plan-desktop-release.py",
+            ".github/scripts/desktop-release-source-identity.py",
             ".github/workflows/desktop_auto_release.yml",
             ".github/workflows/desktop-swift-ci.yml",
         ]
@@ -345,7 +346,7 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertIn(LATEST_TAG, lines[1])
         self.assertEqual(sleep.call_args_list, [((30,), {}), ((30,), {})])
 
-    def test_workflow_has_no_input_manual_trigger_and_tags_the_changelog_commit(self) -> None:
+    def test_workflow_has_no_input_manual_trigger_and_tags_only_the_merged_main_source(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         # workflow_dispatch stays bare (no manual inputs). Continuous deployment:
         # auto-release fires on macOS-affecting merges to main (push); the schedule
@@ -359,10 +360,12 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertIn("ref: ${{ steps.recheck.outputs.source_sha }}", workflow)
         self.assertEqual(workflow.count("--source-check-wait-seconds 720"), 2)
         self.assertEqual(workflow.count("--source-check-poll-seconds 30"), 2)
-        self.assertLess(
-            workflow.index('git commit -m "chore: consolidate changelog for v${VERSION}"'),
-            workflow.index('git tag "$RELEASE_TAG"'),
-        )
+        self.assertLess(workflow.index("Create and regular-merge PR to sync changelog back to main"), workflow.index("Tag exact main source"))
+        self.assertIn('git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main', workflow)
+        self.assertIn('test "$CANDIDATE_SHA" = "$MAIN_SHA"', workflow)
+        self.assertIn('test "$(git rev-parse "${CANDIDATE_SHA}^1")" = "$PLANNED_SOURCE_SHA"', workflow)
+        self.assertIn('git tag -a "$RELEASE_TAG" "$CANDIDATE_SHA" -F "$EVIDENCE_PATH"', workflow)
+        self.assertIn('test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$CANDIDATE_SHA"', workflow)
 
     def test_candidate_creation_has_no_selfhosted_pre_tag_gate(self) -> None:
         # Continuous deployment: candidate creation (tag-release) must depend only

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -167,6 +167,7 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
             "codemagic.yaml",
             ".github/scripts/plan-desktop-release.py",
             ".github/scripts/desktop-release-source-identity.py",
+            ".github/scripts/publish-desktop-candidate-tag.py",
             ".github/workflows/desktop_auto_release.yml",
             ".github/workflows/desktop-swift-ci.yml",
         ]
@@ -360,11 +361,16 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertIn("ref: ${{ steps.recheck.outputs.source_sha }}", workflow)
         self.assertEqual(workflow.count("--source-check-wait-seconds 720"), 2)
         self.assertEqual(workflow.count("--source-check-poll-seconds 30"), 2)
-        self.assertLess(workflow.index("Create and regular-merge PR to sync changelog back to main"), workflow.index("Tag exact main source"))
+        self.assertLess(
+            workflow.index("Create and regular-merge PR to sync changelog back to main"),
+            workflow.index("Atomically tag exact live main source"),
+        )
         self.assertIn('git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main', workflow)
-        self.assertIn('test "$CANDIDATE_SHA" = "$MAIN_SHA"', workflow)
-        self.assertIn('test "$(git rev-parse "${CANDIDATE_SHA}^1")" = "$PLANNED_SOURCE_SHA"', workflow)
-        self.assertIn('git tag -a "$RELEASE_TAG" "$CANDIDATE_SHA" -F "$EVIDENCE_PATH"', workflow)
+        self.assertEqual(workflow.count('CANDIDATE_SHA="$MAIN_SHA"'), 2)
+        self.assertIn('BRANCH="changelog/v${VERSION}-${PLANNED_SOURCE_SHA:0:12}"', workflow)
+        self.assertIn('CHANGELOG_PARENT_SHA="$(git rev-parse "${CHANGELOG_COMMIT}^1")"', workflow)
+        self.assertIn('--changelog-parent-sha "$CHANGELOG_PARENT_SHA"', workflow)
+        self.assertIn('python3 .github/scripts/publish-desktop-candidate-tag.py', workflow)
         self.assertIn('test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$CANDIDATE_SHA"', workflow)
 
     def test_candidate_creation_has_no_selfhosted_pre_tag_gate(self) -> None:

--- a/.github/scripts/test_publish_desktop_candidate_tag.py
+++ b/.github/scripts/test_publish_desktop_candidate_tag.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Behavioral contract tests for atomic macOS candidate-tag publication."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).with_name("publish-desktop-candidate-tag.py")
+SPEC = importlib.util.spec_from_file_location("publish_desktop_candidate_tag", SCRIPT)
+assert SPEC and SPEC.loader
+publisher = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(publisher)
+
+REPOSITORY = "BasedHardware/omi"
+REPOSITORY_ID = "R_kgDOGHExample"
+CANDIDATE_SHA = "a" * 40
+TAG_OBJECT_SHA = "b" * 40
+RELEASE_TAG = "v1.2.3+10203-macos"
+
+
+class PublishDesktopCandidateTagTests(unittest.TestCase):
+    def test_ref_transaction_requires_live_main_and_an_unused_tag(self) -> None:
+        with patch.object(publisher, "run_gh_json", return_value={"data": {"updateRefs": {}}}) as run_gh:
+            publisher.atomic_publish_tag_ref(
+                repository_id_value=REPOSITORY_ID,
+                release_tag=RELEASE_TAG,
+                candidate_sha=CANDIDATE_SHA,
+                tag_object_sha=TAG_OBJECT_SHA,
+            )
+
+        args, payload = run_gh.call_args.args
+        self.assertEqual(args, ["api", "graphql"])
+        self.assertIn("updateRefs", payload["query"])
+        self.assertEqual(
+            payload["variables"],
+            {
+                "repositoryId": REPOSITORY_ID,
+                "mainBefore": CANDIDATE_SHA,
+                "mainAfter": CANDIDATE_SHA,
+                "tagName": f"refs/tags/{RELEASE_TAG}",
+                "tagObject": TAG_OBJECT_SHA,
+                "zeroOid": publisher.ZERO_OID,
+            },
+        )
+
+    def test_main_advance_rejection_cannot_report_a_published_candidate(self) -> None:
+        responses = [
+            {"data": {"repository": {"id": REPOSITORY_ID}}},
+            {"sha": TAG_OBJECT_SHA},
+            subprocess.CalledProcessError(1, ["gh", "api", "graphql"], stderr="main beforeOid mismatch"),
+        ]
+        with patch.object(publisher, "run_gh_json", side_effect=responses):
+            with self.assertRaises(subprocess.CalledProcessError):
+                publisher.publish_candidate_tag(
+                    repository=REPOSITORY,
+                    release_tag=RELEASE_TAG,
+                    candidate_sha=CANDIDATE_SHA,
+                    evidence="immutable planner evidence\n",
+                    timestamp="2026-07-25T00:00:00Z",
+                )
+
+    def test_annotated_tag_carries_the_identity_evidence_before_the_ref_transaction(self) -> None:
+        responses = [
+            {"data": {"repository": {"id": REPOSITORY_ID}}},
+            {"sha": TAG_OBJECT_SHA},
+            {"data": {"updateRefs": {}}},
+        ]
+        with patch.object(publisher, "run_gh_json", side_effect=responses) as run_gh:
+            publisher.publish_candidate_tag(
+                repository=REPOSITORY,
+                release_tag=RELEASE_TAG,
+                candidate_sha=CANDIDATE_SHA,
+                evidence="immutable planner evidence\n",
+                timestamp="2026-07-25T00:00:00Z",
+            )
+
+        tag_args, tag_payload = run_gh.call_args_list[1].args
+        self.assertEqual(tag_args, ["api", "--method", "POST", f"repos/{REPOSITORY}/git/tags"])
+        self.assertEqual(tag_payload["object"], CANDIDATE_SHA)
+        self.assertEqual(tag_payload["message"], "immutable planner evidence\n")
+        self.assertEqual(tag_payload["tagger"]["name"], publisher.TAGGER_NAME)
+        self.assertEqual(tag_payload["tagger"]["date"], "2026-07-25T00:00:00Z")
+        self.assertEqual(run_gh.call_args_list[2].args[1]["variables"]["mainBefore"], CANDIDATE_SHA)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -19,6 +19,7 @@ on:
       - 'desktop/macos/**'
       - 'codemagic.yaml'
       - '.github/scripts/plan-desktop-release.py'
+      - '.github/scripts/desktop-release-source-identity.py'
       - '.github/workflows/desktop_auto_release.yml'
       - '.github/workflows/desktop-swift-ci.yml'
   schedule:
@@ -159,39 +160,66 @@ jobs:
             --date "$TODAY" \
             --write
 
-      - name: Commit changelog and create tag
+      - name: Commit changelog and prepare sync branch
         if: steps.recheck.outputs.should_release == 'true'
+        id: changelog
         run: |
+          set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
-          RELEASE_TAG="${{ steps.version.outputs.release_tag }}"
+          BRANCH="changelog/v${VERSION}"
+          PLANNED_SOURCE_SHA="${{ steps.recheck.outputs.source_sha }}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # A rerun after the changelog PR merged must reuse that immutable
+          # branch commit. Rebuilding it would sever the evidence chain to the
+          # normal, regular merge already present on main.
+          if git ls-remote --exit-code origin "refs/heads/$BRANCH" >/dev/null; then
+            git fetch --no-tags origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+            CHANGELOG_COMMIT="$(git rev-parse "origin/$BRANCH^{commit}")"
+            test "$(git rev-parse "${CHANGELOG_COMMIT}^1")" = "$PLANNED_SOURCE_SHA"
+            git checkout -B "$BRANCH" "$CHANGELOG_COMMIT"
+            {
+              echo "changed=true"
+              echo "commit=$CHANGELOG_COMMIT"
+              echo "reused=true"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           git add desktop/macos/CHANGELOG.json desktop/macos/changelog
-          git commit -m "chore: consolidate changelog for v${VERSION}" || echo "No changelog changes to commit"
+          if git diff --cached --quiet; then
+            # Nothing needed to move through a PR. The direct tag path below
+            # still requires the planner SHA to be the fresh main tip.
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-          # The planner checked and this job checked out the newest queued
-          # releasable desktop source SHA.
-          # Tag this commit so Codemagic receives the consolidated release notes too.
-          # NOTE: commit message must NOT contain [skip ci].
-          git tag "$RELEASE_TAG"
-          git push origin "$RELEASE_TAG"
+          git commit -m "chore: consolidate changelog for v${VERSION}"
+          CHANGELOG_COMMIT="$(git rev-parse HEAD)"
+          git checkout -B "$BRANCH" "$CHANGELOG_COMMIT"
+          git push origin "$BRANCH"
+          {
+            echo "changed=true"
+            echo "commit=$CHANGELOG_COMMIT"
+            echo "reused=false"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Create and auto-merge PR to sync changelog back to main
-        if: steps.recheck.outputs.should_release == 'true'
+      - name: Create and regular-merge PR to sync changelog back to main
+        if: steps.recheck.outputs.should_release == 'true' && steps.changelog.outputs.changed == 'true'
+        id: changelog-pr
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "Omi Bot token not available; cannot auto-merge changelog PR."
+            echo "Omi Bot token not available; cannot merge changelog PR."
             exit 1
           fi
 
           VERSION="${{ steps.version.outputs.version }}"
           BRANCH="changelog/v${VERSION}"
-
-          git checkout -B "$BRANCH"
-          git push --force-with-lease origin "$BRANCH"
 
           PR_NUMBER=$(gh pr list \
             --head "$BRANCH" \
@@ -201,17 +229,103 @@ jobs:
             --jq '.[0].number')
 
           if [ -z "$PR_NUMBER" ]; then
-            PR_URL=$(gh pr create \
-              --title "Update desktop changelog for v${VERSION} [skip ci]" \
-              --body "Auto-generated: consolidates unreleased changelog fragments into v${VERSION} and regenerates CHANGELOG.json." \
+            PR_NUMBER=$(gh pr list \
+              --head "$BRANCH" \
               --base main \
-              --head "$BRANCH")
-            PR_NUMBER=$(echo "$PR_URL" | awk -F/ '{print $NF}')
+              --state merged \
+              --json number \
+              --jq '.[0].number')
+            if [ -z "$PR_NUMBER" ]; then
+              PR_URL=$(gh pr create \
+                --title "Update desktop changelog for v${VERSION} [skip ci]" \
+                --body "Auto-generated: consolidates unreleased changelog fragments into v${VERSION} and regenerates CHANGELOG.json." \
+                --base main \
+                --head "$BRANCH")
+              PR_NUMBER=$(echo "$PR_URL" | awk -F/ '{print $NF}')
+            fi
           fi
 
-          # Merge changelog PR in protected branches:
-          # 1) admin merge if allowed, 2) auto-merge if repo supports it, 3) regular merge if already mergeable.
-          gh pr merge "$PR_NUMBER" --merge --admin || \
-          gh pr merge "$PR_NUMBER" --merge --auto || \
-          gh pr merge "$PR_NUMBER" --merge || \
-          echo "Changelog PR #$PR_NUMBER requires manual merge."
+          PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
+          if [ "$PR_STATE" != "MERGED" ]; then
+            # This remains a regular merge. If the bot lacks the protected
+            # branch override, the workflow must fail before it can create a
+            # tag instead of tagging a side branch.
+            gh pr merge "$PR_NUMBER" --merge --admin || gh pr merge "$PR_NUMBER" --merge
+          fi
+
+          PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
+          test "$PR_STATE" = "MERGED"
+          MERGED_MAIN_SHA=$(gh pr view "$PR_NUMBER" --json mergeCommit --jq '.mergeCommit.oid')
+          PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
+          test -n "$MERGED_MAIN_SHA"
+          {
+            echo "number=$PR_NUMBER"
+            echo "url=$PR_URL"
+            echo "merged_main_sha=$MERGED_MAIN_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Bind immutable planner evidence to fresh main
+        if: steps.recheck.outputs.should_release == 'true'
+        id: identity
+        run: |
+          set -euo pipefail
+          PLANNED_SOURCE_SHA="${{ steps.recheck.outputs.source_sha }}"
+          CHANGELOG_CHANGED="${{ steps.changelog.outputs.changed }}"
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          MAIN_SHA="$(git rev-parse 'origin/main^{commit}')"
+
+          if [ "$CHANGELOG_CHANGED" = true ]; then
+            CANDIDATE_SHA="${{ steps.changelog-pr.outputs.merged_main_sha }}"
+            CHANGELOG_COMMIT="${{ steps.changelog.outputs.commit }}"
+            CHANGELOG_PR="${{ steps.changelog-pr.outputs.url }}"
+            test "$CANDIDATE_SHA" = "$MAIN_SHA"
+            test "$(git rev-parse "${CANDIDATE_SHA}^1")" = "$PLANNED_SOURCE_SHA"
+            test "$(git rev-parse "${CANDIDATE_SHA}^2")" = "$CHANGELOG_COMMIT"
+            python3 .github/scripts/desktop-release-source-identity.py \
+              --planned-source-sha "$PLANNED_SOURCE_SHA" \
+              --candidate-source-sha "$CANDIDATE_SHA" \
+              --origin-main-sha "$MAIN_SHA" \
+              --first-parent-sha "$PLANNED_SOURCE_SHA" \
+              --changelog-commit "$CHANGELOG_COMMIT" \
+              --changelog-pr "$CHANGELOG_PR" \
+              --output "$RUNNER_TEMP/desktop-release-source-identity.json"
+          else
+            CANDIDATE_SHA="$PLANNED_SOURCE_SHA"
+            test "$CANDIDATE_SHA" = "$MAIN_SHA"
+            python3 .github/scripts/desktop-release-source-identity.py \
+              --planned-source-sha "$PLANNED_SOURCE_SHA" \
+              --candidate-source-sha "$CANDIDATE_SHA" \
+              --origin-main-sha "$MAIN_SHA" \
+              --output "$RUNNER_TEMP/desktop-release-source-identity.json"
+          fi
+
+          {
+            echo "candidate_sha=$CANDIDATE_SHA"
+            echo "evidence_path=$RUNNER_TEMP/desktop-release-source-identity.json"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Retain immutable planner source evidence
+        if: steps.recheck.outputs.should_release == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: desktop-release-planner-source-identity-${{ steps.version.outputs.release_tag }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.identity.outputs.evidence_path }}
+          if-no-files-found: error
+          overwrite: false
+
+      - name: Tag exact main source
+        if: steps.recheck.outputs.should_release == 'true'
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${{ steps.version.outputs.release_tag }}"
+          CANDIDATE_SHA="${{ steps.identity.outputs.candidate_sha }}"
+          EVIDENCE_PATH="${{ steps.identity.outputs.evidence_path }}"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null; then
+            echo "Refusing to reuse existing immutable candidate tag $RELEASE_TAG" >&2
+            exit 1
+          fi
+          test "$(git rev-parse 'origin/main^{commit}')" = "$CANDIDATE_SHA"
+          git tag -a "$RELEASE_TAG" "$CANDIDATE_SHA" -F "$EVIDENCE_PATH"
+          test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$CANDIDATE_SHA"
+          git push origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -20,6 +20,7 @@ on:
       - 'codemagic.yaml'
       - '.github/scripts/plan-desktop-release.py'
       - '.github/scripts/desktop-release-source-identity.py'
+      - '.github/scripts/publish-desktop-candidate-tag.py'
       - '.github/workflows/desktop_auto_release.yml'
       - '.github/workflows/desktop-swift-ci.yml'
   schedule:
@@ -166,15 +167,19 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
-          BRANCH="changelog/v${VERSION}"
           PLANNED_SOURCE_SHA="${{ steps.recheck.outputs.source_sha }}"
+          # A version-only changelog branch can belong to an earlier planner
+          # source after a retry. Binding the branch to the immutable source
+          # avoids rewriting that stale branch or confusing its PR with this
+          # candidate; published tags are never touched by this recovery path.
+          BRANCH="changelog/v${VERSION}-${PLANNED_SOURCE_SHA:0:12}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # A rerun after the changelog PR merged must reuse that immutable
-          # branch commit. Rebuilding it would sever the evidence chain to the
-          # normal, regular merge already present on main.
+          # A rerun for the same source must reuse its immutable branch commit.
+          # The source-qualified branch name intentionally ignores stale legacy
+          # `changelog/v<version>` branches from an older planner source.
           if git ls-remote --exit-code origin "refs/heads/$BRANCH" >/dev/null; then
             git fetch --no-tags origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
             CHANGELOG_COMMIT="$(git rev-parse "origin/$BRANCH^{commit}")"
@@ -219,7 +224,8 @@ jobs:
           fi
 
           VERSION="${{ steps.version.outputs.version }}"
-          BRANCH="changelog/v${VERSION}"
+          PLANNED_SOURCE_SHA="${{ steps.recheck.outputs.source_sha }}"
+          BRANCH="changelog/v${VERSION}-${PLANNED_SOURCE_SHA:0:12}"
 
           PR_NUMBER=$(gh pr list \
             --head "$BRANCH" \
@@ -275,23 +281,20 @@ jobs:
           MAIN_SHA="$(git rev-parse 'origin/main^{commit}')"
 
           if [ "$CHANGELOG_CHANGED" = true ]; then
-            CANDIDATE_SHA="${{ steps.changelog-pr.outputs.merged_main_sha }}"
             CHANGELOG_COMMIT="${{ steps.changelog.outputs.commit }}"
             CHANGELOG_PR="${{ steps.changelog-pr.outputs.url }}"
-            test "$CANDIDATE_SHA" = "$MAIN_SHA"
-            test "$(git rev-parse "${CANDIDATE_SHA}^1")" = "$PLANNED_SOURCE_SHA"
-            test "$(git rev-parse "${CANDIDATE_SHA}^2")" = "$CHANGELOG_COMMIT"
+            CHANGELOG_PARENT_SHA="$(git rev-parse "${CHANGELOG_COMMIT}^1")"
+            CANDIDATE_SHA="$MAIN_SHA"
             python3 .github/scripts/desktop-release-source-identity.py \
               --planned-source-sha "$PLANNED_SOURCE_SHA" \
               --candidate-source-sha "$CANDIDATE_SHA" \
               --origin-main-sha "$MAIN_SHA" \
-              --first-parent-sha "$PLANNED_SOURCE_SHA" \
+              --changelog-parent-sha "$CHANGELOG_PARENT_SHA" \
               --changelog-commit "$CHANGELOG_COMMIT" \
               --changelog-pr "$CHANGELOG_PR" \
               --output "$RUNNER_TEMP/desktop-release-source-identity.json"
           else
-            CANDIDATE_SHA="$PLANNED_SOURCE_SHA"
-            test "$CANDIDATE_SHA" = "$MAIN_SHA"
+            CANDIDATE_SHA="$MAIN_SHA"
             python3 .github/scripts/desktop-release-source-identity.py \
               --planned-source-sha "$PLANNED_SOURCE_SHA" \
               --candidate-source-sha "$CANDIDATE_SHA" \
@@ -313,19 +316,28 @@ jobs:
           if-no-files-found: error
           overwrite: false
 
-      - name: Tag exact main source
+      - name: Atomically tag exact live main source
         if: steps.recheck.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           RELEASE_TAG="${{ steps.version.outputs.release_tag }}"
           CANDIDATE_SHA="${{ steps.identity.outputs.candidate_sha }}"
           EVIDENCE_PATH="${{ steps.identity.outputs.evidence_path }}"
 
-          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null; then
-            echo "Refusing to reuse existing immutable candidate tag $RELEASE_TAG" >&2
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "Omi Bot token not available; cannot atomically publish a candidate tag." >&2
             exit 1
           fi
-          test "$(git rev-parse 'origin/main^{commit}')" = "$CANDIDATE_SHA"
-          git tag -a "$RELEASE_TAG" "$CANDIDATE_SHA" -F "$EVIDENCE_PATH"
+          # `updateRefs` publishes the tag only when GitHub still observes
+          # main at CANDIDATE_SHA; its `beforeOid` check and tag creation are
+          # one server-side atomic transaction, not a cached-ref comparison.
+          python3 .github/scripts/publish-desktop-candidate-tag.py \
+            --repository "${{ github.repository }}" \
+            --release-tag "$RELEASE_TAG" \
+            --candidate-sha "$CANDIDATE_SHA" \
+            --evidence "$EVIDENCE_PATH"
+
+          git fetch --no-tags origin "+refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
           test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$CANDIDATE_SHA"
-          git push origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"

--- a/desktop/macos/docs/release.md
+++ b/desktop/macos/docs/release.md
@@ -1,6 +1,6 @@
 # Desktop release
 
-Normal path: merge `main` → `Build Desktop Release Candidate` waits a bounded time for the three exact-SHA source checks, then creates one immutable tag → trusted qualification promotes that exact artifact to Beta automatically. If an immutable `v*-macos` tag already owns the selected source SHA, the planner exits without another tag; an active or published normal candidate is preserved, and an anomalous lifecycle remains blocked rather than duplicated.
+Normal path: merge `main` → `Build Desktop Release Candidate` waits a bounded time for the three exact-SHA source checks. If it consolidates changelog fragments, it regular-merges the generated changelog PR first, then creates one immutable tag on that exact fresh `origin/main` merge SHA; the annotated tag carries the planner source-identity evidence. Without changelog changes, the planner tags only the unchanged fresh `main` SHA. Trusted qualification then promotes that exact artifact to Beta automatically. If an immutable `v*-macos` tag already owns the selected source SHA, the planner exits without another tag; an active or published normal candidate is preserved, and an anomalous lifecycle remains blocked rather than duplicated.
 
 `omi-desktop-swift-release` starts only from Codemagic's native `v*-macos` tag trigger. Never start the normal candidate lane with a direct Codemagic `/builds` API POST; that API is reserved for the isolated preview workflow. For bounded, read-only candidate status polling, run from the repository root:
 


### PR DESCRIPTION
## Summary

- permit a candidate tag on current `main` when only non-desktop commits follow the CI-gated desktop source, while rejecting every later releasable desktop history event, including a revert
- bind changelog sync branches to the planned source and retain source ancestry evidence
- atomically create the immutable tag only when GitHub still observes `main` at the validated candidate SHA

## Verification

- `python3 .github/scripts/test_desktop_release_source_identity.py`
- `python3 .github/scripts/test_publish_desktop_candidate_tag.py`
- `python3 .github/scripts/test_plan_desktop_release.py`
- `make preflight` (61 checks)

Replacement head: `80b7d54716`

Failure-Class: FC-release-build-config-source-binding
