### PR TITLE
fix(desktop): sync each agent-VM row with its own column set (#10602)

### DIFF
--- a/desktop/macos/agent-cloud/agent.mjs
+++ b/desktop/macos/agent-cloud/agent.mjs
@@ -1251,7 +1251,28 @@ function startServer() {
             return;
           }
 
-          const cols = Object.keys(rows[0]);
+          // The desktop serializes each row with its NULL columns omitted
+          // (AgentSyncService skips .null so the VM applies its own defaults), so
+          // column sets differ row to row. Taking the whole batch's schema from
+          // rows[0] wrote every row with row 0's columns: a batch whose first
+          // screenshot was not yet OCR'd stripped ocrText/embedding from the other
+          // 99 rows that did have them — and /sync still answered success, so the
+          // desktop advanced its cursor and never resent them. Group by column set
+          // and write each row with exactly the columns it carries.
+          const columnGroups = new Map();
+          for (const row of rows) {
+            const rowCols = Object.keys(row).sort();
+            if (rowCols.length === 0) continue;  // all-NULL row carries nothing to write
+            const key = JSON.stringify(rowCols);
+            const group = columnGroups.get(key);
+            if (group) {
+              group.rows.push(row);
+            } else {
+              columnGroups.set(key, { cols: rowCols, rows: [row] });
+            }
+          }
+          const groups = [...columnGroups.values()];
+          const cols = [...new Set(groups.flatMap((g) => g.cols))];
 
           // Auto-add any columns missing from the table (handles schema migrations
           // where the VM has an older database than the desktop app).
@@ -1265,34 +1286,41 @@ function startServer() {
             }
           }
 
-          const placeholders = cols.map(() => "?").join(", ");
-          const sql = `INSERT OR REPLACE INTO "${table}" (${cols.map(c => `"${c}"`).join(", ")}) VALUES (${placeholders})`;
-
-          const stmt = db.prepare(sql);
-          const insertMany = db.transaction((rowList) => {
-            for (const row of rowList) {
-              const values = cols.map((col) => {
-                const val = row[col];
-                // Decode base64 embedding columns back to Buffer
-                if (col === "embedding" && typeof val === "string" && val.length > 0) {
-                  return Buffer.from(val, "base64");
-                }
-                if (val === null || val === undefined) return null;
-                return val;
-              });
-              stmt.run(...values);
-            }
+          const prepared = groups.map(({ cols: groupCols, rows: groupRows }) => {
+            const placeholders = groupCols.map(() => "?").join(", ");
+            const sql = `INSERT OR REPLACE INTO "${table}" (${groupCols.map(c => `"${c}"`).join(", ")}) VALUES (${placeholders})`;
+            return { cols: groupCols, rows: groupRows, stmt: db.prepare(sql) };
           });
 
-          insertMany(rows);
+          const insertMany = db.transaction((groupList) => {
+            let inserted = 0;
+            for (const { cols: groupCols, rows: groupRows, stmt } of groupList) {
+              for (const row of groupRows) {
+                const values = groupCols.map((col) => {
+                  const val = row[col];
+                  // Decode base64 embedding columns back to Buffer
+                  if (col === "embedding" && typeof val === "string" && val.length > 0) {
+                    return Buffer.from(val, "base64");
+                  }
+                  if (val === null || val === undefined) return null;
+                  return val;
+                });
+                stmt.run(...values);
+                inserted++;
+              }
+            }
+            return inserted;
+          });
+
+          const applied = insertMany(prepared);
 
           // FTS is kept in sync by triggers on the content tables.
           // INSERT OR REPLACE fires DELETE then INSERT triggers, which update FTS automatically.
 
           lastActivityAt = Date.now();
-          log(`Sync: ${rows.length} rows → ${table}`);
+          log(`Sync: ${applied} rows → ${table} (${groups.length} column set${groups.length === 1 ? "" : "s"})`);
           res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ applied: rows.length, table }));
+          res.end(JSON.stringify({ applied, table }));
         } catch (err) {
           log(`Sync error: ${err.message}`);
           res.writeHead(500, { "Content-Type": "application/json" });

--- a/desktop/macos/agent-cloud/package.json
+++ b/desktop/macos/agent-cloud/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "node agent.mjs --serve",
+    "test": "node sync-e2e.mjs",
     "cli": "node agent.mjs",
     "deploy": "bash scripts/deploy.sh",
     "upload-db": "bash scripts/upload-db.sh"

--- a/desktop/macos/agent-cloud/sync-e2e.mjs
+++ b/desktop/macos/agent-cloud/sync-e2e.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// End-to-end regression test for the /sync endpoint's per-row column handling.
+//
+// Runs the real agent.mjs server against a real SQLite file and POSTs a batch
+// shaped exactly like AgentSyncService's payload (NULL columns omitted per row).
+// Before the column-set grouping fix, the batch schema came from rows[0], so a
+// first row that was not yet OCR'd stripped ocrText/embedding from every other
+// row in the batch while /sync still reported success.
+//
+// Run: npm test   (from desktop/macos/agent-cloud)
+
+import Database from "better-sqlite3";
+import { spawn } from "child_process";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PORT = 8791;
+const TOKEN = "sync-e2e-token";
+
+const workDir = mkdtempSync(join(tmpdir(), "omi-agent-sync-e2e-"));
+const dbPath = join(workDir, "omi.db");
+
+const failures = [];
+function check(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+function seedDatabase() {
+  const db = new Database(dbPath);
+  db.exec(`CREATE TABLE screenshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp DATETIME NOT NULL,
+    appName TEXT NOT NULL,
+    windowTitle TEXT,
+    imagePath TEXT NOT NULL DEFAULT '',
+    ocrText TEXT,
+    isIndexed INTEGER NOT NULL DEFAULT 0,
+    embedding BLOB
+  )`);
+  // The VM always opens a database uploaded from the desktop, which already has
+  // screenshots. Seed one so the fixture matches that shape.
+  db.prepare(
+    "INSERT INTO screenshots (id, timestamp, appName, imagePath, ocrText) VALUES (100, ?, ?, ?, ?)"
+  ).run("2026-07-20 09:00:00", "Finder", "/seed.png", "seed row");
+  db.close();
+}
+
+async function startServer() {
+  const child = spawn(process.execPath, [join(__dirname, "agent.mjs"), "--serve"], {
+    env: { ...process.env, DB_PATH: dbPath, AUTH_TOKEN: TOKEN, PORT: String(PORT) },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const logs = [];
+  child.stdout.on("data", (d) => logs.push(d.toString()));
+  child.stderr.on("data", (d) => logs.push(d.toString()));
+
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      const resp = await fetch(`http://127.0.0.1:${PORT}/health`);
+      if (resp.ok) return { child, logs };
+    } catch {
+      // not listening yet
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  child.kill();
+  throw new Error(`server did not become healthy:\n${logs.join("")}`);
+}
+
+function sync(rows) {
+  return fetch(`http://127.0.0.1:${PORT}/sync`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ table: "screenshots", rows }),
+  }).then((r) => r.json());
+}
+
+let server;
+try {
+  seedDatabase();
+  server = await startServer();
+
+  const embedding = Buffer.alloc(12, 7).toString("base64");
+
+  // Row 1 is captured but not yet OCR'd or embedded; rows 2 and 3 are populated.
+  const applied = await sync([
+    { id: 1, timestamp: "2026-07-25 10:00:00", appName: "Chrome", imagePath: "/a.png", isIndexed: 0 },
+    { id: 2, timestamp: "2026-07-25 10:00:05", appName: "Chrome", imagePath: "/b.png", isIndexed: 1, ocrText: "quarterly revenue plan", embedding },
+    { id: 3, timestamp: "2026-07-25 10:00:10", appName: "Slack", imagePath: "/c.png", isIndexed: 1, ocrText: "ship the sync fix", windowTitle: "#eng" },
+  ]);
+  check(applied.applied === 3, `expected applied=3, got ${JSON.stringify(applied)}`);
+
+  // Reverse order: the populated row first, a bare row after.
+  await sync([
+    { id: 4, timestamp: "2026-07-25 11:00:00", appName: "Chrome", imagePath: "/d.png", isIndexed: 1, ocrText: "row four text" },
+    { id: 5, timestamp: "2026-07-25 11:00:05", appName: "Chrome", imagePath: "/e.png", isIndexed: 0 },
+  ]);
+
+  const db = new Database(dbPath, { readonly: true });
+  const row = (id) => db.prepare("SELECT * FROM screenshots WHERE id = ?").get(id);
+
+  const two = row(2);
+  check(two.ocrText === "quarterly revenue plan", `row 2 ocrText: ${JSON.stringify(two.ocrText)}`);
+  check(two.embedding?.length === 12, `row 2 embedding: ${two.embedding?.length}`);
+
+  const three = row(3);
+  check(three.ocrText === "ship the sync fix", `row 3 ocrText: ${JSON.stringify(three.ocrText)}`);
+  check(three.windowTitle === "#eng", `row 3 windowTitle: ${JSON.stringify(three.windowTitle)}`);
+
+  // A row that omits a column must not inherit the previous row's value, and the
+  // previous row must keep its own.
+  check(row(4).ocrText === "row four text", `row 4 ocrText: ${JSON.stringify(row(4).ocrText)}`);
+  check(row(5).ocrText === null, `row 5 ocrText: ${JSON.stringify(row(5).ocrText)}`);
+
+  // The pre-existing row is untouched by an unrelated batch.
+  check(row(100).ocrText === "seed row", `row 100 ocrText: ${JSON.stringify(row(100).ocrText)}`);
+  db.close();
+} finally {
+  server?.child.kill();
+  rmSync(workDir, { recursive: true, force: true });
+}
+
+if (failures.length > 0) {
+  console.error("FAIL: /sync dropped columns the desktop sent");
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log("PASS: /sync writes each row with its own column set");

--- a/desktop/macos/changelog/unreleased/20260725-agent-cloud-sync-columns.json
+++ b/desktop/macos/changelog/unreleased/20260725-agent-cloud-sync-columns.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed cloud agent sync dropping screen text and search embeddings, which made some screenshots unfindable by the agent"
+}

--- a/desktop/macos/tests/test-agent-cloud-sync.sh
+++ b/desktop/macos/tests/test-agent-cloud-sync.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Runs the agent-cloud /sync end-to-end regression test (sync-e2e.mjs): the real
+# agent.mjs server, a real SQLite file, and a desktop-shaped batch whose rows omit
+# different NULL columns. Guards against the batch schema being taken from one row.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENT_CLOUD="$SCRIPT_DIR/../agent-cloud"
+
+if ! command -v node > /dev/null 2>&1; then
+  echo "SKIP: node not installed"
+  exit 0
+fi
+
+# The VM's runtime deps are not vendored; install them on first run. Without them
+# agent.mjs cannot start, so skip rather than fail an unrelated desktop change.
+if [ ! -d "$AGENT_CLOUD/node_modules/better-sqlite3" ]; then
+  if ! (cd "$AGENT_CLOUD" && npm install --no-audit --no-fund --silent); then
+    echo "SKIP: could not install agent-cloud dependencies (node $(node -v))"
+    exit 0
+  fi
+fi
+
+(cd "$AGENT_CLOUD" && node sync-e2e.mjs)


### PR DESCRIPTION
## Summary

Fixes #10602 — the agent VM's `/sync` endpoint dropped columns the desktop had populated.

The desktop serializes each row with its NULL columns omitted (`AgentSyncService.swift:523` skips `.null` so the VM applies its own defaults), so column sets differ row to row inside one batch. `agent.mjs` derived the whole batch's schema from `Object.keys(rows[0])` and applied it to all 100 rows.

**Failure:** a `screenshots` batch whose first row was captured but not yet OCR'd/embedded omits `ocrText` and `embedding`, so the other 99 rows — which do have them — were inserted without them. Because it is `INSERT OR REPLACE` (delete + insert), values already on the VM were wiped as well. `/sync` still answered `{"applied": 100}`, so the desktop advanced its cursor and the rows were never resent. `semantic_search` (`WHERE embedding IS NOT NULL`) then silently returns nothing for those screenshots and `screenshots_fts` has no text to match. The converse held too: a column present only on row 0 was written as `NULL` over real data on the rest.

**Fix:** group the batch by column set and prepare one statement per group, so every row is written with exactly the columns it carries. The union of all column sets still drives the missing-column `ALTER TABLE`, and `applied` now counts rows actually inserted.

The fix stays inside `agent.mjs` on purpose: the VM's hot-update path (`checkAndApplyUpdate`) downloads only `agent.mjs`, so a new sibling module would not reach a running VM.

## Verification

- `desktop/macos/agent-cloud/sync-e2e.mjs` (new): starts the **real** `agent.mjs --serve` against a real SQLite file and POSTs a desktop-shaped batch over HTTP, then reads the rows back.
  - Fails on the pre-fix code: `row 2 ocrText: null`, `row 2 embedding: undefined`, `row 3 ocrText: null`, `row 3 windowTitle: null`.
  - Passes on the fix, including the converse order (populated row first, bare row second) and leaving a pre-existing row untouched.
- `desktop/macos/tests/test-agent-cloud-sync.sh` (new) runs it from the auto-discovered desktop launcher-test lane. agent-cloud's runtime deps are not vendored, so it installs them on first run and skips loudly (`SKIP: could not install agent-cloud dependencies`) rather than failing an unrelated desktop change when no prebuilt `better-sqlite3` exists for the runner's Node — verified in both states locally (Node 22: runs and passes; Node 26: skips).
- `make preflight`, `scripts/pr-preflight --suggest`.

## Adjacent finding (not fixed here)

`openDatabase()` creates `idx_screenshots_date_local ON screenshots(date(timestamp, 'localtime'))`. `date(..., 'localtime')` is non-deterministic, so SQLite rejects the index — but only when the table already has rows. On the usual path (an uploaded `omi.db` with screenshots) `CREATE INDEX` fails and is swallowed by the surrounding `try`, so nothing breaks. If the table is **empty** at open time, the index is created successfully and every later `INSERT` into `screenshots` fails with `non-deterministic use of date() in an index` — permanently, since the index persists in the database file. Reproduced with the bundled `better-sqlite3` (SQLite 3.49.2). Left out of this PR to keep the sync-path change reviewable.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

