### PR TITLE
fix(desktop-windows): scope updater feeds to Windows releases

### DIFF
--- a/.github/failure-classes/FC-platform-unscoped-update-feed.json
+++ b/.github/failure-classes/FC-platform-unscoped-update-feed.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-platform-unscoped-update-feed",
+  "violated_contract": "A desktop update client must select metadata only from a release matching its platform and requested channel; a repository-wide latest release is not a valid selector in a multi-platform repository.",
+  "canonical_prevention": "Resolve update metadata through an explicit platform-and-channel authority, validate the immutable feed at the client trust boundary, and exercise cross-platform release coexistence plus strict stable-channel behavior in contract tests.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_desktop_updates.py",
+    "desktop/windows/src/main/windowsUpdateFeed.test.ts"
+  ],
+  "evidence_prs": [10610],
+  "scope_hints": [
+    "backend/routers/updates.py",
+    "desktop/windows/src/main/updater.ts",
+    "desktop/windows/src/main/windowsUpdateFeed.ts",
+    "desktop/windows/electron-builder.config.mjs"
+  ],
+  "status": "open"
+}

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -53,6 +53,28 @@ routes:
         state: active
   - route_type: http
     method: GET
+    path: /v2/desktop/update-feed/windows
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - public
+        placement: none
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: desktop_update
+      visibility: public_undocumented
+      data_domain: desktop_updates
+      deprecation:
+        state: active
+  - route_type: http
+    method: GET
     path: /v2/desktop/previews/{slug}
     policy:
       review_status: reviewed

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -10,7 +10,7 @@ from typing import Any, Optional, List, Dict, Literal, Tuple
 from xml.sax.saxutils import escape as xml_escape
 
 from fastapi import APIRouter, HTTPException, Header, Query
-from fastapi.responses import RedirectResponse, Response, HTMLResponse
+from fastapi.responses import Response, HTMLResponse
 from pydantic import BaseModel, ConfigDict, Field, StrictBool
 
 from database.desktop_previews import delist_preview, get_current_preview, get_preview_manifest, publish_preview
@@ -58,6 +58,15 @@ class DesktopUpdatePolicyResponse(BaseModel):
     platforms: Optional[List[str]] = Field(
         default=None, description='Platforms this policy applies to (empty/None = all).'
     )
+
+
+class DesktopWindowsUpdateFeedResponse(BaseModel):
+    """Platform-scoped electron-updater feed selected by the backend."""
+
+    requested_channel: Literal["beta", "stable"]
+    served_channel: Literal["beta", "stable"]
+    version: str
+    feed_url: str
 
 
 class ClearCacheResponse(BaseModel):
@@ -355,6 +364,17 @@ def _get_windows_installer_download_url(release: Dict) -> Optional[str]:
     return None
 
 
+def _get_windows_update_feed_url(release: Dict) -> Optional[str]:
+    """Return the immutable GitHub directory containing one Windows latest.yml."""
+    tag_name = release.get("tag_name", "")
+    version_info = _parse_desktop_version(tag_name)
+    if not version_info or not tag_name.lower().endswith("-windows"):
+        return None
+    if not any(asset.get("name") == "latest.yml" for asset in release.get("assets", [])):
+        return None
+    return f"https://github.com/BasedHardware/omi/releases/download/{tag_name}/"
+
+
 def _get_installer_download_url(release: Dict, platform: str) -> Optional[str]:
     """Resolve the manual-download installer asset for one platform."""
     if platform == "windows":
@@ -572,6 +592,17 @@ def _pick_installer_entry(desktop_releases: List[Dict], platform: str, channel: 
         installer_url = _get_installer_download_url(entry["release"], platform)
         if installer_url:
             return entry, installer_url
+    return None
+
+
+def _pick_windows_update_feed_entry(entries: List[Dict], channel: str) -> Optional[Tuple[Dict, str]]:
+    """Pick the newest release in one channel that carries updater metadata."""
+    for entry in entries:
+        if entry["channel"] != channel:
+            continue
+        feed_url = _get_windows_update_feed_url(entry["release"])
+        if feed_url:
+            return entry, feed_url
     return None
 
 
@@ -950,6 +981,53 @@ async def download_beta_desktop_release(
     side-by-side Omi Beta identity once a live beta release ships it.
     """
     return await download_latest_desktop_release(platform=platform, channel="beta", identity="beta")
+
+
+@router.get(
+    "/v2/desktop/update-feed/windows",
+    response_model=DesktopWindowsUpdateFeedResponse,
+)
+async def get_windows_desktop_update_feed(
+    response: Response,
+    channel: str = Query(default="stable", pattern="^(beta|stable)$"),
+):
+    """Resolve one immutable, platform-scoped electron-updater feed.
+
+    The GitHub provider's repository-wide ``/releases/latest`` endpoint can
+    select a macOS release in this multi-platform repository. Windows clients
+    use this endpoint first, then point the generic provider at the selected
+    release directory. Stable never falls through to beta. Beta may fall back
+    to stable while the prerelease slot is empty after a promotion.
+    """
+    response.headers["Cache-Control"] = "no-store"
+    desktop_releases = await _get_live_desktop_releases("windows")
+    picked = _pick_windows_update_feed_entry(desktop_releases, channel)
+    served_channel = channel
+    if picked is None and channel == "beta":
+        picked = _pick_windows_update_feed_entry(desktop_releases, "stable")
+        if picked is not None:
+            served_channel = "stable"
+            record_fallback(
+                component="other",
+                from_mode="desktop_windows_update_feed_beta",
+                to_mode="desktop_windows_update_feed_stable",
+                reason="other",
+                outcome="recovered",
+                log=logger,
+            )
+    if picked is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No Windows update feed found for channel: {channel}",
+            headers={"Cache-Control": "no-store"},
+        )
+    entry, feed_url = picked
+    return {
+        "requested_channel": channel,
+        "served_channel": served_channel,
+        "version": entry["version_info"]["version"],
+        "feed_url": feed_url,
+    }
 
 
 @router.get("/v2/desktop/download/windows")

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -16,6 +16,7 @@ from routers.updates import (
     _get_installer_download_url,
     _get_sparkle_zip_download_url,
     _get_windows_installer_download_url,
+    _get_windows_update_feed_url,
     _parse_changelog_to_changes,
     _parse_desktop_version,
     _preview_download_landing_html,
@@ -289,6 +290,23 @@ class TestAssetHelpers:
         }
         assert _get_windows_installer_download_url(release) is None
 
+    def test_windows_update_feed_uses_immutable_release_directory(self):
+        release = {
+            "tag_name": "v1.0.19-windows",
+            "assets": [{"name": "latest.yml", "browser_download_url": "https://untrusted.example/latest.yml"}],
+        }
+        assert (
+            _get_windows_update_feed_url(release)
+            == "https://github.com/BasedHardware/omi/releases/download/v1.0.19-windows/"
+        )
+
+    def test_windows_update_feed_requires_windows_tag_and_metadata(self):
+        assert _get_windows_update_feed_url({"tag_name": "v1.0.19-windows", "assets": []}) is None
+        assert (
+            _get_windows_update_feed_url({"tag_name": "v0.12.123+12123-macos", "assets": [{"name": "latest.yml"}]})
+            is None
+        )
+
     def test_installer_dispatch_by_platform(self):
         release = {
             "assets": [
@@ -363,6 +381,10 @@ def _dmg_asset(url="https://example.com/omi.dmg"):
 
 def _exe_asset(url="https://example.com/omi-setup.exe"):
     return {"name": "omi-setup.exe", "browser_download_url": url}
+
+
+def _update_feed_asset(url="https://example.com/latest.yml"):
+    return {"name": "latest.yml", "browser_download_url": url}
 
 
 # --- _get_legacy_live_desktop_releases ---
@@ -901,6 +923,112 @@ class TestDownloadEndpoint:
             async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
                 resp = await client.get("/v2/desktop/download/latest?platform=windows&channel=stable")
         assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_windows_update_feed_is_platform_and_stable_channel_scoped(self):
+        mock_releases = [
+            {
+                "channel": "beta",
+                "version_info": {"version": "1.0.19", "build": "0"},
+                "release": {
+                    "tag_name": "v1.0.19-windows",
+                    "assets": [_update_feed_asset()],
+                },
+            },
+            {
+                "channel": "stable",
+                "version_info": {"version": "1.0.1", "build": "0"},
+                "release": {
+                    "tag_name": "v1.0.1-windows",
+                    "assets": [_update_feed_asset()],
+                },
+            },
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/update-feed/windows")
+        assert resp.status_code == 200
+        assert resp.headers["cache-control"] == "no-store"
+        assert resp.json() == {
+            "requested_channel": "stable",
+            "served_channel": "stable",
+            "version": "1.0.1",
+            "feed_url": "https://github.com/BasedHardware/omi/releases/download/v1.0.1-windows/",
+        }
+
+    @pytest.mark.asyncio
+    async def test_windows_update_feed_beta_prefers_prerelease_channel(self):
+        mock_releases = [
+            {
+                "channel": "beta",
+                "version_info": {"version": "1.0.19", "build": "0"},
+                "release": {
+                    "tag_name": "v1.0.19-windows",
+                    "assets": [_update_feed_asset()],
+                },
+            },
+            {
+                "channel": "stable",
+                "version_info": {"version": "1.0.1", "build": "0"},
+                "release": {
+                    "tag_name": "v1.0.1-windows",
+                    "assets": [_update_feed_asset()],
+                },
+            },
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/update-feed/windows?channel=beta")
+        assert resp.status_code == 200
+        assert resp.json()["served_channel"] == "beta"
+        assert resp.json()["feed_url"].endswith("/v1.0.19-windows/")
+
+    @pytest.mark.asyncio
+    async def test_windows_update_feed_beta_falls_back_to_stable(self):
+        mock_releases = [
+            {
+                "channel": "stable",
+                "version_info": {"version": "1.0.1", "build": "0"},
+                "release": {
+                    "tag_name": "v1.0.1-windows",
+                    "assets": [_update_feed_asset()],
+                },
+            },
+        ]
+        with (
+            patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases),
+            patch("routers.updates.record_fallback") as mock_fallback,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/update-feed/windows?channel=beta")
+        assert resp.status_code == 200
+        assert resp.json()["served_channel"] == "stable"
+        assert resp.json()["feed_url"].endswith("/v1.0.1-windows/")
+        mock_fallback.assert_called_once()
+        assert mock_fallback.call_args.kwargs["outcome"] == "recovered"
+
+    @pytest.mark.asyncio
+    async def test_windows_update_feed_stable_never_falls_through_to_beta(self):
+        mock_releases = [
+            {
+                "channel": "beta",
+                "version_info": {"version": "1.0.19", "build": "0"},
+                "release": {
+                    "tag_name": "v1.0.19-windows",
+                    "assets": [_update_feed_asset()],
+                },
+            },
+        ]
+        with (
+            patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases),
+            patch("routers.updates.record_fallback") as mock_fallback,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/update-feed/windows?channel=stable")
+        assert resp.status_code == 404
+        assert resp.headers["cache-control"] == "no-store"
+        assert "channel: stable" in resp.json()["detail"]
+        mock_fallback.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_windows_convenience_route_defaults_to_stable(self):

--- a/desktop/windows/docs/release-pipeline.md
+++ b/desktop/windows/docs/release-pipeline.md
@@ -84,12 +84,20 @@ The bump must not re-trigger the workflow. Three independent guards:
 
 ### Auto-update
 
-`electron-updater` (see `src/main/updater.ts`) reads the feed configured in
-`electron-builder.config.mjs` (`publish:` → GitHub `BasedHardware/omi`, `releaseType:
-release`). Because the workflow marks builds **prerelease**, they are *not*
-auto-pushed to installed apps — users download betas manually. Promoting a build
-to stable (flipping its GitHub release from prerelease to release) is what makes
-`electron-updater` serve it. This matches the macOS beta/stable split.
+`electron-updater` (see `src/main/updater.ts`) does not use GitHub's
+repository-wide `/releases/latest` endpoint in production. This repository also
+publishes macOS releases, so that endpoint can point a Windows client at a macOS
+tag with no `latest.yml`. Before every check, the app asks
+`/v2/desktop/update-feed/windows` for the selected Windows channel and points the
+generic provider at that immutable release directory.
+
+The workflow marks new Windows builds **prerelease**. Stable users receive only
+releases that have been promoted by clearing that flag; beta users receive the
+beta release and safely fall back to stable while the beta slot is empty after a
+promotion. A stable check never falls through to beta. The `publish:` block in
+`electron-builder.config.mjs` remains necessary for electron-builder to generate
+`latest.yml` and packaged update config, but it is replaced at runtime before a
+production check. `OMI_UPDATER_DEV=1` keeps using `dev-app-update.yml`.
 
 > The workflow publishes to the repository it runs in (`${{ github.repository }}`),
 > so on `BasedHardware/omi` the release lands exactly where the feed points. On a

--- a/desktop/windows/electron-builder.config.mjs
+++ b/desktop/windows/electron-builder.config.mjs
@@ -166,10 +166,10 @@ export default {
   // --- AUTO-UPDATE ---
   // electron-updater is wired in src/main/updater.ts (packaged builds only; silent
   // download + install-on-next-quit; NSIS differential updates stay default-on).
-  // The production feed is the GitHub releases where the macOS beta channel lives.
-  // Local testing uses dev-app-update.yml + OMI_UPDATER_DEV=1 (forceDevUpdateConfig)
-  // instead of this feed. releaseType 'release' means only non-prerelease GitHub
-  // releases are served as updates.
+  // This GitHub config makes electron-builder emit latest.yml and app-update.yml.
+  // Before every production check, updater.ts replaces the repository-wide GitHub
+  // provider with the backend-selected immutable Windows release directory. Local
+  // testing keeps dev-app-update.yml + OMI_UPDATER_DEV=1 (forceDevUpdateConfig).
   //
   // NOTE: this block is the UPDATE FEED only — it must never be used as an upload
   // target. electron-builder auto-publishes to it when CI + a git tag are detected,

--- a/desktop/windows/src/main/updater.test.ts
+++ b/desktop/windows/src/main/updater.test.ts
@@ -3,21 +3,30 @@ import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
-// Point the real app-settings store at a throwaway userData dir so the beta
-// opt-in genuinely persists + fires onAppSettingsChanged into the updater's live
-// listener — this test exercises the real glue in updater.ts (init reads the
-// pref; a live flip moves the channel + re-checks), not a re-declared copy.
 const dir = mkdtempSync(join(tmpdir(), 'omi-updater-'))
 
-// Fake electron-updater: a plain object we inspect. checkForUpdates resolves an
-// (unused) result so the listener's re-check is harmless under fake timers.
-// vi.hoisted so the object exists both for the (hoisted) mock factory and the
-// test-body assertions.
+const feedFetch = vi.hoisted(() =>
+  vi.fn(async (input: string | URL | Request) => {
+    const channel = new URL(String(input)).searchParams.get('channel')
+    const version = channel === 'beta' ? '1.0.19' : '1.0.1'
+    return new Response(
+      JSON.stringify({
+        requested_channel: channel,
+        served_channel: channel,
+        version,
+        feed_url: `https://github.com/BasedHardware/omi/releases/download/v${version}-windows/`
+      }),
+      { headers: { 'Content-Type': 'application/json' } }
+    )
+  })
+)
+
 const autoUpdater = vi.hoisted(() => ({
   allowPrerelease: false,
   autoDownload: false,
   autoInstallOnAppQuit: false,
   forceDevUpdateConfig: false,
+  setFeedURL: vi.fn(),
   on: vi.fn(),
   checkForUpdates: vi.fn().mockResolvedValue({ updateInfo: { version: '9.9.9' } }),
   quitAndInstall: vi.fn()
@@ -34,51 +43,109 @@ vi.mock('electron', () => ({
     register: (): boolean => true,
     unregister: (): void => {},
     isRegistered: (): boolean => false
-  }
+  },
+  net: { fetch: feedFetch }
 }))
 vi.mock('./tray', () => ({ setTrayUpdateReady: vi.fn() }))
 
-import { initAutoUpdater, installUpdateNow, getPendingUpdate } from './updater'
+import { checkForUpdatesNow, getPendingUpdate, initAutoUpdater, installUpdateNow } from './updater'
 import { setAppSettings } from './appSettings'
 
-afterAll(() => rmSync(dir, { recursive: true, force: true }))
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
 
-describe('updater beta channel wiring', () => {
-  it('reads the persisted opt-in at init and flips allowPrerelease on live changes', () => {
-    // Fake timers so init's 45s/4h checks stay dormant — the only checkForUpdates
-    // calls we assert on come from the beta-toggle listener.
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('updater feed and beta channel wiring', () => {
+  it('stays Windows-only and switches immutable feeds on live beta changes', async () => {
     vi.useFakeTimers()
 
-    // Persist the opt-in BEFORE init so initAutoUpdater picks up beta at startup.
+    initAutoUpdater(() => null, 'linux')
+    expect(autoUpdater.on).not.toHaveBeenCalled()
+    expect(autoUpdater.setFeedURL).not.toHaveBeenCalled()
+
     setAppSettings({ betaUpdatesEnabled: true })
-    initAutoUpdater(() => null)
+    initAutoUpdater(() => null, 'win32')
     expect(autoUpdater.allowPrerelease).toBe(true)
 
-    // Live opt-out → stable + an immediate re-check.
     autoUpdater.checkForUpdates.mockClear()
+    autoUpdater.setFeedURL.mockClear()
+    feedFetch.mockClear()
     setAppSettings({ betaUpdatesEnabled: false })
+    await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1))
     expect(autoUpdater.allowPrerelease).toBe(false)
-    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1)
+    expect(autoUpdater.setFeedURL).toHaveBeenCalledWith({
+      provider: 'generic',
+      url: 'https://github.com/BasedHardware/omi/releases/download/v1.0.1-windows/'
+    })
 
-    // Live opt-in again → beta + re-check.
     autoUpdater.checkForUpdates.mockClear()
+    autoUpdater.setFeedURL.mockClear()
+    feedFetch.mockClear()
     setAppSettings({ betaUpdatesEnabled: true })
+    await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1))
     expect(autoUpdater.allowPrerelease).toBe(true)
-    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1)
+    expect(autoUpdater.setFeedURL).toHaveBeenCalledWith({
+      provider: 'generic',
+      url: 'https://github.com/BasedHardware/omi/releases/download/v1.0.19-windows/'
+    })
 
-    // An UNRELATED settings write must not touch the lever or re-check.
     autoUpdater.checkForUpdates.mockClear()
+    autoUpdater.setFeedURL.mockClear()
+    feedFetch.mockClear()
     setAppSettings({ closeToTrayNoticeShown: true })
-    expect(autoUpdater.allowPrerelease).toBe(true)
+    await Promise.resolve()
     expect(autoUpdater.checkForUpdates).not.toHaveBeenCalled()
+    expect(autoUpdater.setFeedURL).not.toHaveBeenCalled()
+    expect(feedFetch).not.toHaveBeenCalled()
 
     vi.useRealTimers()
   })
+
+  it('rechecks the new channel after an in-flight check finishes', async () => {
+    const firstCheck = deferred<{ updateInfo: { version: string } }>()
+    autoUpdater.checkForUpdates.mockReset()
+    autoUpdater.checkForUpdates
+      .mockImplementationOnce(() => firstCheck.promise)
+      .mockResolvedValue({ updateInfo: { version: '9.9.9' } })
+    autoUpdater.setFeedURL.mockClear()
+
+    setAppSettings({ betaUpdatesEnabled: false })
+    await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1))
+    setAppSettings({ betaUpdatesEnabled: true })
+    await Promise.resolve()
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1)
+
+    firstCheck.resolve({ updateInfo: { version: '1.0.1' } })
+    await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2))
+    expect(autoUpdater.setFeedURL).toHaveBeenLastCalledWith({
+      provider: 'generic',
+      url: 'https://github.com/BasedHardware/omi/releases/download/v1.0.19-windows/'
+    })
+  })
+
+  it('fails a manual check closed when feed resolution is unavailable', async () => {
+    autoUpdater.checkForUpdates.mockClear()
+    feedFetch.mockRejectedValueOnce(new Error('resolver unavailable'))
+
+    await expect(checkForUpdatesNow()).resolves.toEqual({
+      status: 'error',
+      message: 'resolver unavailable'
+    })
+    expect(autoUpdater.checkForUpdates).not.toHaveBeenCalled()
+  })
 })
 
-// #10509: "Restart to update" used to just quit the app and trust
-// autoInstallOnAppQuit, which installs without ever relaunching — and does
-// nothing at all when no update is staged, so users reopened on the old version.
 describe('installUpdateNow', () => {
   it('does nothing when no update is staged', () => {
     expect(getPendingUpdate()).toBeNull()
@@ -88,15 +155,13 @@ describe('installUpdateNow', () => {
 
   it('installs and relaunches once an update is downloaded', () => {
     const downloaded = autoUpdater.on.mock.calls.find(
-      (c) => c[0] === 'update-downloaded'
+      (call) => call[0] === 'update-downloaded'
     )?.[1] as (info: { version: string }) => void
     expect(downloaded).toBeTypeOf('function')
     downloaded({ version: '2.0.0' })
 
     expect(getPendingUpdate()).toEqual({ version: '2.0.0' })
     expect(installUpdateNow()).toBe(true)
-    // isSilent + isForceRunAfter: install without a wizard, come back up on the
-    // new version instead of leaving the user with a closed app.
     expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, true)
   })
 })

--- a/desktop/windows/src/main/updater.test.ts
+++ b/desktop/windows/src/main/updater.test.ts
@@ -113,12 +113,18 @@ describe('updater feed and beta channel wiring', () => {
     vi.useRealTimers()
   })
 
-  it('rechecks the new channel after an in-flight check finishes', async () => {
-    const firstCheck = deferred<{ updateInfo: { version: string } }>()
+  it('drops an in-flight result and rechecks when the selected channel changes', async () => {
+    const cancellationToken = { cancel: vi.fn() }
+    const firstCheck = deferred<{
+      isUpdateAvailable: true
+      updateInfo: { version: string }
+      cancellationToken: { cancel: ReturnType<typeof vi.fn> }
+    }>()
     autoUpdater.checkForUpdates.mockReset()
     autoUpdater.checkForUpdates
       .mockImplementationOnce(() => firstCheck.promise)
       .mockResolvedValue({ updateInfo: { version: '9.9.9' } })
+    autoUpdater.downloadUpdate.mockClear()
     autoUpdater.setFeedURL.mockClear()
 
     setAppSettings({ betaUpdatesEnabled: false })
@@ -127,8 +133,14 @@ describe('updater feed and beta channel wiring', () => {
     await Promise.resolve()
     expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1)
 
-    firstCheck.resolve({ updateInfo: { version: '1.0.1' } })
+    firstCheck.resolve({
+      isUpdateAvailable: true,
+      updateInfo: { version: '1.0.1' },
+      cancellationToken
+    })
     await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2))
+    expect(cancellationToken.cancel).toHaveBeenCalledOnce()
+    expect(autoUpdater.downloadUpdate).not.toHaveBeenCalledWith(cancellationToken)
     expect(autoUpdater.setFeedURL).toHaveBeenLastCalledWith({
       provider: 'generic',
       url: 'https://github.com/BasedHardware/omi/releases/download/v1.0.19-windows/'
@@ -148,7 +160,7 @@ describe('updater feed and beta channel wiring', () => {
 })
 
 describe('installUpdateNow', () => {
-  it('cancels and ignores a beta download that finishes after opting out', async () => {
+  it('clears and ignores a beta download that finishes after opting out', async () => {
     const betaDownload = deferred<string[]>()
     const cancellationToken = { cancel: vi.fn() }
     autoUpdater.checkForUpdates.mockReset()
@@ -169,14 +181,24 @@ describe('installUpdateNow', () => {
       expect(autoUpdater.downloadUpdate).toHaveBeenCalledWith(cancellationToken)
     )
 
-    setAppSettings({ betaUpdatesEnabled: false })
-    expect(cancellationToken.cancel).toHaveBeenCalledOnce()
     const downloaded = autoUpdater.on.mock.calls.find(
       (call) => call[0] === 'update-downloaded'
     )?.[1] as (info: { version: string }) => void
     downloaded({ version: '2.0.0' })
+    expect(getPendingUpdate()).toEqual({ version: '2.0.0' })
+    expect(autoUpdater.autoInstallOnAppQuit).toBe(true)
+
+    setAppSettings({ betaUpdatesEnabled: false })
+    expect(cancellationToken.cancel).toHaveBeenCalledOnce()
+    expect(getPendingUpdate()).toBeNull()
+    expect(autoUpdater.autoInstallOnAppQuit).toBe(false)
+
+    downloaded({ version: '2.0.0' })
+    expect(getPendingUpdate()).toBeNull()
+
     betaDownload.resolve([])
     await checking
+    downloaded({ version: '2.0.0' })
 
     expect(getPendingUpdate()).toBeNull()
     expect(autoUpdater.autoInstallOnAppQuit).toBe(false)
@@ -189,12 +211,29 @@ describe('installUpdateNow', () => {
     expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled()
   })
 
-  it('installs and relaunches once an update is downloaded', () => {
+  it('installs and relaunches once the current channel update is downloaded', async () => {
+    const stableDownload = deferred<string[]>()
+    const cancellationToken = { cancel: vi.fn() }
+    autoUpdater.checkForUpdates.mockReset()
+    autoUpdater.checkForUpdates.mockResolvedValueOnce({
+      isUpdateAvailable: true,
+      updateInfo: { version: '2.0.0' },
+      cancellationToken
+    })
+    autoUpdater.downloadUpdate.mockReset()
+    autoUpdater.downloadUpdate.mockReturnValueOnce(stableDownload.promise)
+
+    const checking = checkForUpdatesNow()
+    await vi.waitFor(() =>
+      expect(autoUpdater.downloadUpdate).toHaveBeenCalledWith(cancellationToken)
+    )
     const downloaded = autoUpdater.on.mock.calls.find(
       (call) => call[0] === 'update-downloaded'
     )?.[1] as (info: { version: string }) => void
     expect(downloaded).toBeTypeOf('function')
     downloaded({ version: '2.0.0' })
+    stableDownload.resolve([])
+    await checking
 
     expect(getPendingUpdate()).toEqual({ version: '2.0.0' })
     expect(installUpdateNow()).toBe(true)

--- a/desktop/windows/src/main/updater.test.ts
+++ b/desktop/windows/src/main/updater.test.ts
@@ -29,6 +29,7 @@ const autoUpdater = vi.hoisted(() => ({
   setFeedURL: vi.fn(),
   on: vi.fn(),
   checkForUpdates: vi.fn().mockResolvedValue({ updateInfo: { version: '9.9.9' } }),
+  downloadUpdate: vi.fn().mockResolvedValue([]),
   quitAndInstall: vi.fn()
 }))
 vi.mock('electron-updater', () => ({ autoUpdater }))
@@ -147,6 +148,41 @@ describe('updater feed and beta channel wiring', () => {
 })
 
 describe('installUpdateNow', () => {
+  it('cancels and ignores a beta download that finishes after opting out', async () => {
+    const betaDownload = deferred<string[]>()
+    const cancellationToken = { cancel: vi.fn() }
+    autoUpdater.checkForUpdates.mockReset()
+    autoUpdater.checkForUpdates
+      .mockResolvedValueOnce({
+        isUpdateAvailable: true,
+        updateInfo: { version: '2.0.0' },
+        cancellationToken
+      })
+      .mockResolvedValue({ updateInfo: { version: '1.0.1' } })
+    autoUpdater.downloadUpdate.mockReset()
+    autoUpdater.downloadUpdate.mockReturnValueOnce(betaDownload.promise)
+    autoUpdater.autoInstallOnAppQuit = true
+
+    setAppSettings({ betaUpdatesEnabled: true })
+    const checking = checkForUpdatesNow()
+    await vi.waitFor(() =>
+      expect(autoUpdater.downloadUpdate).toHaveBeenCalledWith(cancellationToken)
+    )
+
+    setAppSettings({ betaUpdatesEnabled: false })
+    expect(cancellationToken.cancel).toHaveBeenCalledOnce()
+    const downloaded = autoUpdater.on.mock.calls.find(
+      (call) => call[0] === 'update-downloaded'
+    )?.[1] as (info: { version: string }) => void
+    downloaded({ version: '2.0.0' })
+    betaDownload.resolve([])
+    await checking
+
+    expect(getPendingUpdate()).toBeNull()
+    expect(autoUpdater.autoInstallOnAppQuit).toBe(false)
+    expect(installUpdateNow()).toBe(false)
+  })
+
   it('does nothing when no update is staged', () => {
     expect(getPendingUpdate()).toBeNull()
     expect(installUpdateNow()).toBe(false)

--- a/desktop/windows/src/main/updater.ts
+++ b/desktop/windows/src/main/updater.ts
@@ -1,23 +1,38 @@
 // Auto-update via electron-updater. Silent by design: downloads in the
-// background and installs on the NEXT quit (never force-restarts a listening
-// session). When an update is staged we tell the main window (so it can offer a
-// "restart to update" affordance) and mark the tray tooltip.
+// background and installs on the next quit (never force-restarts a listening
+// session). When an update is staged we tell the main window so it can offer a
+// "restart to update" action and mark the tray tooltip.
 //
-// Gated to packaged builds. For local testing, set OMI_UPDATER_DEV=1 and provide
-// dev-app-update.yml — that flips forceDevUpdateConfig so the updater runs
-// against a dev feed without a real signed release.
-import { app, type BrowserWindow } from 'electron'
+// Production checks first resolve an immutable Windows release directory from
+// the backend, then use electron-updater's generic provider for latest.yml and
+// its installer. This avoids GitHubProvider's repository-wide /releases/latest,
+// which can select a macOS release in this multi-platform repository.
+//
+// For local testing, set OMI_UPDATER_DEV=1 and provide dev-app-update.yml. That
+// keeps electron-updater on the developer-supplied feed.
+import { app, net, type BrowserWindow } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { setTrayUpdateReady } from './tray'
 import { markQuitting } from './lifecycle'
 import { getAppSettings, onAppSettingsChanged } from './appSettings'
-import { betaOptInToAllowPrerelease, resolveBetaChannelChange } from './updaterChannel'
+import { betaOptInToUpdateChannel, resolveBetaChannelChange } from './updaterChannel'
+import {
+  resolveWindowsUpdateFeedUrl,
+  WindowsUpdateFeedSelector,
+  type WindowsUpdateChannel
+} from './windowsUpdateFeed'
 import type { UpdateCheckResult } from '../shared/types'
 
-const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000 // every 4h
+const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000
+const OMI_API_BASE = import.meta.env.VITE_OMI_API_BASE || 'https://api.omi.me'
 
 let started = false
 let pendingUpdate: { version: string } | null = null
+let selectedChannel: WindowsUpdateChannel = 'stable'
+let feedSelector: WindowsUpdateFeedSelector | null = null
+let updateCheckTail: Promise<void> = Promise.resolve()
+
+type ElectronUpdateCheckResult = Awaited<ReturnType<typeof autoUpdater.checkForUpdates>>
 
 /** The update staged for install-on-quit, if any. The update:ready event fires
  * once (usually while nobody is on Settings), so the UI queries this on mount. */
@@ -25,11 +40,26 @@ export function getPendingUpdate(): { version: string } | null {
   return pendingUpdate
 }
 
+async function prepareUpdateFeed(): Promise<void> {
+  if (feedSelector) await feedSelector.prepareSelected()
+}
+
+function runPreparedUpdateCheck(): Promise<ElectronUpdateCheckResult> {
+  const operation = updateCheckTail.then(async (): Promise<ElectronUpdateCheckResult> => {
+    await prepareUpdateFeed()
+    return autoUpdater.checkForUpdates()
+  })
+  updateCheckTail = operation.then(
+    (): undefined => undefined,
+    (): undefined => undefined
+  )
+  return operation
+}
+
 /**
- * Manual update check for Settings → About. In unpackaged dev the updater never
- * started (see initAutoUpdater's guard), so there's nothing to check — return
- * `unsupported` and let the UI say updates install automatically. When active, run
- * a one-shot check: a staged download reports `update-available`, a newer feed
+ * Manual update check for Settings -> About. In unpackaged dev or on an
+ * unsupported platform the updater never starts, so there is nothing to check.
+ * When active, a staged download reports `update-available`, a newer feed
  * version reports `update-available`, otherwise `up-to-date`. Never throws.
  */
 export async function checkForUpdatesNow(): Promise<UpdateCheckResult> {
@@ -37,7 +67,7 @@ export async function checkForUpdatesNow(): Promise<UpdateCheckResult> {
   if (!started) return { status: 'unsupported', version: current }
   if (pendingUpdate) return { status: 'update-available', version: pendingUpdate.version }
   try {
-    const res = await autoUpdater.checkForUpdates()
+    const res = await runPreparedUpdateCheck()
     const found = typeof res?.updateInfo?.version === 'string' ? res.updateInfo.version : undefined
     if (found && found !== current) return { status: 'update-available', version: found }
     return { status: 'up-to-date', version: current }
@@ -49,14 +79,10 @@ export async function checkForUpdatesNow(): Promise<UpdateCheckResult> {
 }
 
 /**
- * Install the staged update now (Settings → About "Restart to update"). Plain
+ * Install the staged update now (Settings -> About "Restart to update"). Plain
  * app.quit() relies on autoInstallOnAppQuit, which runs the NSIS installer
- * *without* relaunching — the app just disappears and the user has to reopen it.
- * quitAndInstall(silent, forceRunAfter) installs and comes back up on the new
- * version, which is what the button promises.
- *
- * Returns false when nothing is actually staged (nothing to install), so the UI
- * can say so instead of quitting the app for no reason.
+ * without relaunching. quitAndInstall(silent, forceRunAfter) installs and comes
+ * back up on the new version, which is what the button promises.
  */
 export function installUpdateNow(): boolean {
   if (!started || !pendingUpdate) return false
@@ -65,10 +91,12 @@ export function installUpdateNow(): boolean {
   return true
 }
 
-export function initAutoUpdater(getMainWindow: () => BrowserWindow | null): void {
-  if (started) return
+export function initAutoUpdater(
+  getMainWindow: () => BrowserWindow | null,
+  platform: NodeJS.Platform = process.platform
+): void {
+  if (started || platform !== 'win32') return
   const devForced = process.env.OMI_UPDATER_DEV === '1'
-  // Only run for real installs (or an explicit dev-forced local test).
   if (!app.isPackaged && !devForced) return
   started = true
 
@@ -76,13 +104,19 @@ export function initAutoUpdater(getMainWindow: () => BrowserWindow | null): void
   autoUpdater.autoInstallOnAppQuit = true
   if (devForced) autoUpdater.forceDevUpdateConfig = true
 
-  // Beta opt-in (Mac's "beta" update channel). GitHub provider only: when the
-  // user opts in we serve GitHub *prerelease* builds (our betas); otherwise only
-  // promoted stable releases. Read the persisted pref at startup, then keep it in
-  // lock-step with live Settings flips (onAppSettingsChanged fires for every
-  // write, so resolveBetaChannelChange filters to actual beta-toggle changes and
-  // triggers an immediate re-check — opting in shouldn't wait for the 4h timer).
-  autoUpdater.allowPrerelease = betaOptInToAllowPrerelease(getAppSettings().betaUpdatesEnabled)
+  selectedChannel = betaOptInToUpdateChannel(getAppSettings().betaUpdatesEnabled)
+  // Kept aligned for dev feeds and electron-updater's public state. Production
+  // channel selection is owned by the backend resolver below.
+  autoUpdater.allowPrerelease = selectedChannel === 'beta'
+  if (!devForced) {
+    feedSelector = new WindowsUpdateFeedSelector(
+      selectedChannel,
+      (channel): Promise<string> => resolveWindowsUpdateFeedUrl(OMI_API_BASE, channel, net.fetch),
+      (feedUrl): void => {
+        autoUpdater.setFeedURL({ provider: 'generic', url: feedUrl })
+      }
+    )
+  }
 
   autoUpdater.on('update-downloaded', (info) => {
     const version = typeof info?.version === 'string' ? info.version : ''
@@ -93,35 +127,41 @@ export function initAutoUpdater(getMainWindow: () => BrowserWindow | null): void
     console.log('[updater] update downloaded and staged for next quit:', version)
   })
 
-  // Never crash the app on an updater failure (offline, feed 404, bad signature…).
   autoUpdater.on('error', (err) => {
     console.warn('[updater] error (non-fatal):', err?.message ?? err)
   })
 
-  const check = (): void => {
-    autoUpdater.checkForUpdates().catch((e) => {
-      console.warn('[updater] check failed (non-fatal):', e?.message ?? e)
-    })
+  const check = async (): Promise<void> => {
+    try {
+      await runPreparedUpdateCheck()
+    } catch (e) {
+      console.warn(
+        '[updater] check failed (non-fatal):',
+        e instanceof Error ? e.message : String(e)
+      )
+    }
   }
-  // Delay the first check so it doesn't compete with startup/renderer load — a
-  // fresh update can trigger a full background download.
-  setTimeout(check, 45_000)
-  setInterval(check, CHECK_INTERVAL_MS)
 
-  // Apply a live "receive beta updates" flip: flip allowPrerelease and re-check
-  // now so the newer channel is picked up immediately, not on the next timer.
-  onAppSettingsChanged((s) => {
-    const { allowPrerelease, changed } = resolveBetaChannelChange(
-      autoUpdater.allowPrerelease,
-      s.betaUpdatesEnabled
-    )
-    if (!changed) return
-    autoUpdater.allowPrerelease = allowPrerelease
+  // Delay the first check so it does not compete with startup/renderer load.
+  setTimeout((): void => {
+    void check()
+  }, 45_000)
+  setInterval((): void => {
+    void check()
+  }, CHECK_INTERVAL_MS)
+
+  // Apply a live beta toggle immediately instead of waiting for the 4h timer.
+  onAppSettingsChanged((settings) => {
+    const change = resolveBetaChannelChange(selectedChannel, settings.betaUpdatesEnabled)
+    if (!change.changed) return
+    selectedChannel = change.channel
+    autoUpdater.allowPrerelease = selectedChannel === 'beta'
+    feedSelector?.select(selectedChannel)
     console.log(
       '[updater] beta channel',
-      allowPrerelease ? 'ON (prereleases included)' : 'OFF (stable only)',
-      '→ re-checking'
+      selectedChannel === 'beta' ? 'ON (prereleases included)' : 'OFF (stable only)',
+      '-> re-checking'
     )
-    check()
+    void check()
   })
 }

--- a/desktop/windows/src/main/updater.ts
+++ b/desktop/windows/src/main/updater.ts
@@ -11,7 +11,7 @@
 // For local testing, set OMI_UPDATER_DEV=1 and provide dev-app-update.yml. That
 // keeps electron-updater on the developer-supplied feed.
 import { app, net, type BrowserWindow } from 'electron'
-import { autoUpdater } from 'electron-updater'
+import { autoUpdater, type CancellationToken } from 'electron-updater'
 import { setTrayUpdateReady } from './tray'
 import { markQuitting } from './lifecycle'
 import { getAppSettings, onAppSettingsChanged } from './appSettings'
@@ -31,6 +31,8 @@ let pendingUpdate: { version: string } | null = null
 let selectedChannel: WindowsUpdateChannel = 'stable'
 let feedSelector: WindowsUpdateFeedSelector | null = null
 let updateCheckTail: Promise<void> = Promise.resolve()
+let activeDownload: { channel: WindowsUpdateChannel; cancellationToken: CancellationToken } | null =
+  null
 
 type ElectronUpdateCheckResult = Awaited<ReturnType<typeof autoUpdater.checkForUpdates>>
 
@@ -47,7 +49,17 @@ async function prepareUpdateFeed(): Promise<void> {
 function runPreparedUpdateCheck(): Promise<ElectronUpdateCheckResult> {
   const operation = updateCheckTail.then(async (): Promise<ElectronUpdateCheckResult> => {
     await prepareUpdateFeed()
-    return autoUpdater.checkForUpdates()
+    const result = await autoUpdater.checkForUpdates()
+    if (!result?.isUpdateAvailable || !result.cancellationToken) return result
+
+    const download = { channel: selectedChannel, cancellationToken: result.cancellationToken }
+    activeDownload = download
+    try {
+      await autoUpdater.downloadUpdate(download.cancellationToken)
+    } finally {
+      if (activeDownload === download) activeDownload = null
+    }
+    return result
   })
   updateCheckTail = operation.then(
     (): undefined => undefined,
@@ -100,7 +112,7 @@ export function initAutoUpdater(
   if (!app.isPackaged && !devForced) return
   started = true
 
-  autoUpdater.autoDownload = true
+  autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = true
   if (devForced) autoUpdater.forceDevUpdateConfig = true
 
@@ -119,11 +131,13 @@ export function initAutoUpdater(
   }
 
   autoUpdater.on('update-downloaded', (info) => {
+    if (activeDownload && activeDownload.channel !== selectedChannel) return
     const version = typeof info?.version === 'string' ? info.version : ''
     pendingUpdate = { version }
     const win = getMainWindow()
     if (win && !win.isDestroyed()) win.webContents.send('update:ready', { version })
     setTrayUpdateReady(true)
+    autoUpdater.autoInstallOnAppQuit = true
     console.log('[updater] update downloaded and staged for next quit:', version)
   })
 
@@ -155,6 +169,10 @@ export function initAutoUpdater(
     const change = resolveBetaChannelChange(selectedChannel, settings.betaUpdatesEnabled)
     if (!change.changed) return
     selectedChannel = change.channel
+    if (activeDownload && activeDownload.channel !== selectedChannel) {
+      autoUpdater.autoInstallOnAppQuit = false
+      activeDownload.cancellationToken.cancel()
+    }
     autoUpdater.allowPrerelease = selectedChannel === 'beta'
     feedSelector?.select(selectedChannel)
     console.log(

--- a/desktop/windows/src/main/updater.ts
+++ b/desktop/windows/src/main/updater.ts
@@ -27,19 +27,33 @@ const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000
 const OMI_API_BASE = import.meta.env.VITE_OMI_API_BASE || 'https://api.omi.me'
 
 let started = false
-let pendingUpdate: { version: string } | null = null
 let selectedChannel: WindowsUpdateChannel = 'stable'
+let channelGeneration = 0
+let pendingUpdate: {
+  version: string
+  channel: WindowsUpdateChannel
+  generation: number
+} | null = null
 let feedSelector: WindowsUpdateFeedSelector | null = null
 let updateCheckTail: Promise<void> = Promise.resolve()
-let activeDownload: { channel: WindowsUpdateChannel; cancellationToken: CancellationToken } | null =
-  null
+let activeDownload: {
+  channel: WindowsUpdateChannel
+  generation: number
+  version: string
+  cancellationToken: CancellationToken
+} | null = null
 
 type ElectronUpdateCheckResult = Awaited<ReturnType<typeof autoUpdater.checkForUpdates>>
+type UpdateAttempt = { channel: WindowsUpdateChannel; generation: number }
+
+function isCurrentAttempt(attempt: UpdateAttempt): boolean {
+  return attempt.channel === selectedChannel && attempt.generation === channelGeneration
+}
 
 /** The update staged for install-on-quit, if any. The update:ready event fires
  * once (usually while nobody is on Settings), so the UI queries this on mount. */
 export function getPendingUpdate(): { version: string } | null {
-  return pendingUpdate
+  return pendingUpdate ? { version: pendingUpdate.version } : null
 }
 
 async function prepareUpdateFeed(): Promise<void> {
@@ -48,18 +62,36 @@ async function prepareUpdateFeed(): Promise<void> {
 
 function runPreparedUpdateCheck(): Promise<ElectronUpdateCheckResult> {
   const operation = updateCheckTail.then(async (): Promise<ElectronUpdateCheckResult> => {
+    if (pendingUpdate && isCurrentAttempt(pendingUpdate)) return null
+    if (activeDownload) {
+      activeDownload.cancellationToken.cancel()
+      activeDownload = null
+    }
+
+    const attempt = { channel: selectedChannel, generation: channelGeneration }
     await prepareUpdateFeed()
+    if (!isCurrentAttempt(attempt)) return null
+
     const result = await autoUpdater.checkForUpdates()
+    if (!isCurrentAttempt(attempt)) {
+      result?.cancellationToken?.cancel()
+      return null
+    }
     if (!result?.isUpdateAvailable || !result.cancellationToken) return result
 
-    const download = { channel: selectedChannel, cancellationToken: result.cancellationToken }
+    const version = typeof result.updateInfo?.version === 'string' ? result.updateInfo.version : ''
+    const download = {
+      ...attempt,
+      version,
+      cancellationToken: result.cancellationToken
+    }
     activeDownload = download
     try {
       await autoUpdater.downloadUpdate(download.cancellationToken)
     } finally {
       if (activeDownload === download) activeDownload = null
     }
-    return result
+    return isCurrentAttempt(download) ? result : null
   })
   updateCheckTail = operation.then(
     (): undefined => undefined,
@@ -113,7 +145,7 @@ export function initAutoUpdater(
   started = true
 
   autoUpdater.autoDownload = false
-  autoUpdater.autoInstallOnAppQuit = true
+  autoUpdater.autoInstallOnAppQuit = false
   if (devForced) autoUpdater.forceDevUpdateConfig = true
 
   selectedChannel = betaOptInToUpdateChannel(getAppSettings().betaUpdatesEnabled)
@@ -131,9 +163,17 @@ export function initAutoUpdater(
   }
 
   autoUpdater.on('update-downloaded', (info) => {
-    if (activeDownload && activeDownload.channel !== selectedChannel) return
+    // electron-updater emits this before downloadUpdate() settles. Accept it
+    // only while the matching channel generation still owns the download.
+    const download = activeDownload
     const version = typeof info?.version === 'string' ? info.version : ''
-    pendingUpdate = { version }
+    if (!download || !isCurrentAttempt(download) || version !== download.version) return
+
+    pendingUpdate = {
+      version,
+      channel: download.channel,
+      generation: download.generation
+    }
     const win = getMainWindow()
     if (win && !win.isDestroyed()) win.webContents.send('update:ready', { version })
     setTrayUpdateReady(true)
@@ -169,9 +209,16 @@ export function initAutoUpdater(
     const change = resolveBetaChannelChange(selectedChannel, settings.betaUpdatesEnabled)
     if (!change.changed) return
     selectedChannel = change.channel
-    if (activeDownload && activeDownload.channel !== selectedChannel) {
-      autoUpdater.autoInstallOnAppQuit = false
-      activeDownload.cancellationToken.cancel()
+    channelGeneration += 1
+    autoUpdater.autoInstallOnAppQuit = false
+    if (activeDownload && !isCurrentAttempt(activeDownload)) {
+      const staleDownload = activeDownload
+      activeDownload = null
+      staleDownload.cancellationToken.cancel()
+    }
+    if (pendingUpdate && !isCurrentAttempt(pendingUpdate)) {
+      pendingUpdate = null
+      setTrayUpdateReady(false)
     }
     autoUpdater.allowPrerelease = selectedChannel === 'beta'
     feedSelector?.select(selectedChannel)

--- a/desktop/windows/src/main/updaterChannel.test.ts
+++ b/desktop/windows/src/main/updaterChannel.test.ts
@@ -1,24 +1,29 @@
 import { describe, it, expect } from 'vitest'
-import { betaOptInToAllowPrerelease, resolveBetaChannelChange } from './updaterChannel'
+import { betaOptInToUpdateChannel, resolveBetaChannelChange } from './updaterChannel'
 
 describe('updaterChannel', () => {
-  it('maps the beta opt-in straight onto allowPrerelease', () => {
-    expect(betaOptInToAllowPrerelease(true)).toBe(true)
-    expect(betaOptInToAllowPrerelease(false)).toBe(false)
-    // Only an explicit true opts in — a junk/undefined value stays stable.
-    expect(betaOptInToAllowPrerelease(undefined as never)).toBe(false)
+  it('maps only an explicit beta opt-in to the beta channel', () => {
+    expect(betaOptInToUpdateChannel(true)).toBe('beta')
+    expect(betaOptInToUpdateChannel(false)).toBe('stable')
+    expect(betaOptInToUpdateChannel(undefined as never)).toBe('stable')
   })
 
-  it('flags a real opt-in change and no-ops when the lever is unchanged', () => {
-    // Off → On: apply prerelease and re-check.
-    expect(resolveBetaChannelChange(false, true)).toEqual({ allowPrerelease: true, changed: true })
-    // On → Off: back to stable, re-check.
-    expect(resolveBetaChannelChange(true, false)).toEqual({ allowPrerelease: false, changed: true })
-    // Unchanged (an unrelated settings write): don't touch the updater or re-check.
-    expect(resolveBetaChannelChange(false, false)).toEqual({
-      allowPrerelease: false,
+  it('flags a real channel move and ignores unrelated settings writes', () => {
+    expect(resolveBetaChannelChange('stable', true)).toEqual({
+      channel: 'beta',
+      changed: true
+    })
+    expect(resolveBetaChannelChange('beta', false)).toEqual({
+      channel: 'stable',
+      changed: true
+    })
+    expect(resolveBetaChannelChange('stable', false)).toEqual({
+      channel: 'stable',
       changed: false
     })
-    expect(resolveBetaChannelChange(true, true)).toEqual({ allowPrerelease: true, changed: false })
+    expect(resolveBetaChannelChange('beta', true)).toEqual({
+      channel: 'beta',
+      changed: false
+    })
   })
 })

--- a/desktop/windows/src/main/updaterChannel.ts
+++ b/desktop/windows/src/main/updaterChannel.ts
@@ -1,30 +1,19 @@
-// Pure mapping between the persisted "receive beta updates" opt-in and
-// electron-updater's GitHub-provider prerelease lever. Kept in its own module —
-// with NO electron / electron-updater imports — so the channel-selection logic is
-// unit-testable in isolation (updater.ts itself can't load under vitest).
-//
-// Why `allowPrerelease` and not a semver channel: our Windows beta pipeline
-// publishes betas as GitHub *prereleases* carrying plain patch semver (e.g.
-// 1.0.5, no `-beta` suffix); "beta-ness" is the GitHub prerelease FLAG. The
-// GitHubProvider serves those only when `allowPrerelease === true`; when false it
-// reads GitHub's /releases/latest, which excludes prereleases. So the boolean
-// opt-in maps straight onto `allowPrerelease` — the Windows analogue of Mac's
-// additive Sparkle "beta" channel (UpdaterViewModel.allowedChannels).
+import type { WindowsUpdateChannel } from './windowsUpdateFeed'
 
-/** The `autoUpdater.allowPrerelease` value for a given beta opt-in. */
-export function betaOptInToAllowPrerelease(optIn: boolean): boolean {
-  return optIn === true
+// Pure mapping between the persisted "receive beta updates" opt-in and the
+// backend-owned Windows release channel. The release workflow marks beta builds
+// with GitHub's prerelease flag while their app version stays plain semver, so
+// the backend is the authority that maps that flag to beta/stable.
+
+export function betaOptInToUpdateChannel(optIn: boolean): WindowsUpdateChannel {
+  return optIn === true ? 'beta' : 'stable'
 }
 
-/** Decide how the updater should react to a settings write. `onAppSettingsChanged`
- *  fires for EVERY app-settings write (hotkey rebinds, toggles, …), so only act
- *  when the beta opt-in actually moves the prerelease lever. `changed` gates both
- *  reassigning `allowPrerelease` and kicking an immediate re-check (so opting in
- *  surfaces a newer beta without waiting for the periodic timer). */
+/** Ignore unrelated app-settings writes and re-check only on a real channel move. */
 export function resolveBetaChannelChange(
-  currentAllowPrerelease: boolean,
+  currentChannel: WindowsUpdateChannel,
   nextOptIn: boolean
-): { allowPrerelease: boolean; changed: boolean } {
-  const allowPrerelease = betaOptInToAllowPrerelease(nextOptIn)
-  return { allowPrerelease, changed: allowPrerelease !== currentAllowPrerelease }
+): { channel: WindowsUpdateChannel; changed: boolean } {
+  const channel = betaOptInToUpdateChannel(nextOptIn)
+  return { channel, changed: channel !== currentChannel }
 }

--- a/desktop/windows/src/main/windowsUpdateFeed.test.ts
+++ b/desktop/windows/src/main/windowsUpdateFeed.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  resolveWindowsUpdateFeedUrl,
+  WindowsUpdateFeedSelector,
+  type WindowsUpdateChannel
+} from './windowsUpdateFeed'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  })
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe('resolveWindowsUpdateFeedUrl', () => {
+  it('requests the selected channel and accepts only an immutable Windows release feed', async () => {
+    const fetchImpl = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
+      jsonResponse({
+        requested_channel: 'beta',
+        served_channel: 'stable',
+        version: '1.0.1',
+        feed_url: 'https://github.com/BasedHardware/omi/releases/download/v1.0.1-windows/'
+      })
+    )
+
+    await expect(
+      resolveWindowsUpdateFeedUrl('https://api.omi.me/', 'beta', fetchImpl as typeof fetch)
+    ).resolves.toBe('https://github.com/BasedHardware/omi/releases/download/v1.0.1-windows/')
+    expect(String(fetchImpl.mock.calls[0][0])).toBe(
+      'https://api.omi.me/v2/desktop/update-feed/windows?channel=beta'
+    )
+    expect(fetchImpl.mock.calls[0][1]).toMatchObject({
+      headers: { Accept: 'application/json' },
+      cache: 'no-store'
+    })
+  })
+
+  it('rejects stable-to-beta, wrong-platform, and untrusted feeds', async () => {
+    const betaForStable = vi.fn(async () =>
+      jsonResponse({
+        requested_channel: 'stable',
+        served_channel: 'beta',
+        feed_url: 'https://github.com/BasedHardware/omi/releases/download/v1.0.19-windows/'
+      })
+    ) as typeof fetch
+    await expect(
+      resolveWindowsUpdateFeedUrl('https://api.omi.me', 'stable', betaForStable)
+    ).rejects.toThrow('Stable Windows updates cannot fall through to beta')
+
+    const macFeed = vi.fn(async () =>
+      jsonResponse({
+        requested_channel: 'stable',
+        served_channel: 'stable',
+        feed_url: 'https://github.com/BasedHardware/omi/releases/download/v0.12.123+12123-macos/'
+      })
+    ) as typeof fetch
+    await expect(
+      resolveWindowsUpdateFeedUrl('https://api.omi.me', 'stable', macFeed)
+    ).rejects.toThrow('untrusted feed_url')
+
+    const untrusted = vi.fn(async () =>
+      jsonResponse({
+        requested_channel: 'beta',
+        served_channel: 'beta',
+        feed_url: 'https://example.com/v1.0.19-windows/'
+      })
+    ) as typeof fetch
+    await expect(
+      resolveWindowsUpdateFeedUrl('https://api.omi.me', 'beta', untrusted)
+    ).rejects.toThrow('untrusted feed_url')
+  })
+
+  it('surfaces resolution failures without reading an error body', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ detail: 'internal' }, 503)) as typeof fetch
+    await expect(
+      resolveWindowsUpdateFeedUrl('https://api.omi.me', 'stable', fetchImpl)
+    ).rejects.toThrow('Windows update feed resolution failed (503)')
+  })
+})
+
+describe('WindowsUpdateFeedSelector', () => {
+  it('refreshes before later checks but does not reapply an unchanged feed', async () => {
+    const resolveFeed = vi.fn(async () => {
+      return 'https://github.com/BasedHardware/omi/releases/download/v1.0.1-windows/'
+    })
+    const applyFeed = vi.fn()
+    const selector = new WindowsUpdateFeedSelector('stable', resolveFeed, applyFeed)
+
+    await selector.prepareSelected()
+    await selector.prepareSelected()
+
+    expect(resolveFeed).toHaveBeenCalledTimes(2)
+    expect(applyFeed).toHaveBeenCalledTimes(1)
+  })
+
+  it('never applies a stale channel response after a live channel switch', async () => {
+    const stable = deferred<string>()
+    const beta = deferred<string>()
+    const resolveFeed = vi.fn((channel: WindowsUpdateChannel) => {
+      return channel === 'stable' ? stable.promise : beta.promise
+    })
+    const applyFeed = vi.fn()
+    const selector = new WindowsUpdateFeedSelector('stable', resolveFeed, applyFeed)
+
+    const staleCheck = selector.prepareSelected()
+    selector.select('beta')
+    const betaCheck = selector.prepareSelected()
+
+    beta.resolve('https://github.com/BasedHardware/omi/releases/download/v1.0.19-windows/')
+    await betaCheck
+    stable.resolve('https://github.com/BasedHardware/omi/releases/download/v1.0.1-windows/')
+    await staleCheck
+
+    expect(applyFeed).toHaveBeenCalledTimes(1)
+    expect(applyFeed).toHaveBeenCalledWith(
+      'https://github.com/BasedHardware/omi/releases/download/v1.0.19-windows/'
+    )
+  })
+})

--- a/desktop/windows/src/main/windowsUpdateFeed.ts
+++ b/desktop/windows/src/main/windowsUpdateFeed.ts
@@ -1,0 +1,123 @@
+export type WindowsUpdateChannel = 'stable' | 'beta'
+type FetchUpdateFeed = (input: string, init?: RequestInit) => Promise<Response>
+
+type WindowsUpdateFeedResponse = {
+  requested_channel?: unknown
+  served_channel?: unknown
+  feed_url?: unknown
+}
+
+const WINDOWS_FEED_PATH =
+  /^\/BasedHardware\/omi\/releases\/download\/v?\d+\.\d+(?:\.\d+)?(?:\+\d+)?-windows\/$/
+
+function parseFeedResponse(payload: unknown, requestedChannel: WindowsUpdateChannel): string {
+  if (typeof payload !== 'object' || payload === null) {
+    throw new Error('Windows update feed response is not an object')
+  }
+  const response = payload as WindowsUpdateFeedResponse
+  if (response.requested_channel !== requestedChannel) {
+    throw new Error('Windows update feed response does not match the requested channel')
+  }
+  if (response.served_channel !== 'stable' && response.served_channel !== 'beta') {
+    throw new Error('Windows update feed response has an invalid served channel')
+  }
+  if (requestedChannel === 'stable' && response.served_channel !== 'stable') {
+    throw new Error('Stable Windows updates cannot fall through to beta')
+  }
+  if (typeof response.feed_url !== 'string') {
+    throw new Error('Windows update feed response is missing feed_url')
+  }
+
+  let feedUrl: URL
+  try {
+    feedUrl = new URL(response.feed_url)
+  } catch {
+    throw new Error('Windows update feed response contains an invalid feed_url')
+  }
+  if (
+    feedUrl.origin !== 'https://github.com' ||
+    feedUrl.username !== '' ||
+    feedUrl.password !== '' ||
+    feedUrl.search !== '' ||
+    feedUrl.hash !== '' ||
+    !WINDOWS_FEED_PATH.test(feedUrl.pathname)
+  ) {
+    throw new Error('Windows update feed response contains an untrusted feed_url')
+  }
+  return feedUrl.toString()
+}
+
+export async function resolveWindowsUpdateFeedUrl(
+  apiBase: string,
+  channel: WindowsUpdateChannel,
+  fetchImpl: FetchUpdateFeed = fetch
+): Promise<string> {
+  const endpoint = new URL(`${apiBase.replace(/\/+$/, '')}/v2/desktop/update-feed/windows`)
+  endpoint.searchParams.set('channel', channel)
+  const response = await fetchImpl(endpoint.toString(), {
+    headers: { Accept: 'application/json' },
+    cache: 'no-store'
+  })
+  if (!response.ok) {
+    throw new Error(`Windows update feed resolution failed (${response.status})`)
+  }
+  return parseFeedResponse(await response.json(), channel)
+}
+
+type ResolveFeed = (channel: WindowsUpdateChannel) => Promise<string>
+type ApplyFeed = (feedUrl: string) => void
+
+/**
+ * Resolves an immutable feed before every update check. Concurrent checks share
+ * one resolution request, and a response for a channel the user just left can
+ * never overwrite the newly selected channel.
+ */
+export class WindowsUpdateFeedSelector {
+  private selectedChannel: WindowsUpdateChannel
+  private configuredChannel: WindowsUpdateChannel | null = null
+  private configuredUrl: string | null = null
+  private readonly inFlight = new Map<WindowsUpdateChannel, Promise<string>>()
+
+  constructor(
+    initialChannel: WindowsUpdateChannel,
+    private readonly resolveFeed: ResolveFeed,
+    private readonly applyFeed: ApplyFeed
+  ) {
+    this.selectedChannel = initialChannel
+  }
+
+  select(channel: WindowsUpdateChannel): void {
+    this.selectedChannel = channel
+  }
+
+  async prepareSelected(): Promise<void> {
+    while (true) {
+      const channel = this.selectedChannel
+      const feedUrl = await this.resolveOnce(channel)
+
+      if (this.selectedChannel !== channel) {
+        if (this.configuredChannel === this.selectedChannel) return
+        continue
+      }
+      if (this.configuredChannel !== channel || this.configuredUrl !== feedUrl) {
+        this.applyFeed(feedUrl)
+        this.configuredChannel = channel
+        this.configuredUrl = feedUrl
+      }
+      return
+    }
+  }
+
+  private async resolveOnce(channel: WindowsUpdateChannel): Promise<string> {
+    const existing = this.inFlight.get(channel)
+    if (existing) return existing
+
+    const request = this.resolveFeed(channel)
+    this.inFlight.set(channel, request)
+    try {
+      return await request
+    } finally {
+      if (this.inFlight.get(channel) === request) this.inFlight.delete(channel)
+    }
+  }
+}


### PR DESCRIPTION
## What changed and why

Fixes #10508.

The Windows app now resolves a channel-scoped Windows release directory through the backend and points `electron-updater`'s generic provider at that immutable feed before every check. This avoids GitHubProvider's repository-wide `/releases/latest`, which can select a macOS release in this multi-platform repository.

Stable never falls through to beta; beta may fall back to stable while no beta release is available. The client validates the returned GitHub repository, Windows tag, and channel relationship, fails closed on resolver errors, and serializes checks across live channel changes. `OMI_UPDATER_DEV=1` continues to use the developer-supplied feed.

Each check, download, and staged installer is also bound to an immutable channel generation. Changing channels cancels or fences in-flight work, clears an installer staged by the previous channel, disables install-on-quit, and accepts `update-downloaded` only from the current version/channel attempt.

Rollout note: deploy the backend endpoint before publishing a Windows build that contains the client change. Until then, that build intentionally fails closed instead of falling back to the broken repository-wide provider.

## Product invariants affected

- `INV-BETA-1` is preserved. This route is Windows-only and does not change the macOS beta identity, artifacts, or identity-aware appcast/download behavior; the full desktop update router regression suite remains green.

## How it was verified

- `python -m pytest tests/unit/test_desktop_updates.py -q` -> 124 passed.
- `npm test -- updater.test.ts updaterChannel.test.ts windowsUpdateFeed.test.ts` -> 13 passed.
- Targeted ESLint on the six updater TypeScript files -> passed.
- `npm run build` in `desktop/windows` -> node/web typecheck, Electron main/preload/renderer build, bytecode verification, and extension bundle passed.
- Applying the updated updater regression test to prior head `512af596e` fails because beta `2.0.0` remains staged after opt-out; current head clears it and rejects both pre-settlement and post-settlement delayed events.
- `PYTHONUTF8=1 scripts/pr-preflight --pr-body-file ...` in a Windows integration worktree with #10594 and #10595 applied -> all 22 selected checks passed.
- A live backend probe inspected 67 GitHub Windows releases and selected `v1.0.1-windows` for stable and `v1.0.19-windows` for beta.
- A real `electron-updater` GenericProvider probe read versions `1.0.1` and `1.0.19` from those immutable release feeds without selecting a macOS tag.

The full Windows Vitest suite was also attempted. Its unrelated baseline failures were reproduced on a clean main worktree: the bundled Node SQLite lacks FTS5, and a date-label assertion assumes an English locale while this machine uses `zh-CN`.

## Tests

- `backend/tests/unit/test_desktop_updates.py` covers immutable trusted feed construction, stable/beta selection, beta-to-stable fallback telemetry, strict stable behavior, and non-cacheable success/error responses.
- `desktop/windows/src/main/windowsUpdateFeed.test.ts` covers endpoint requests, trust-boundary validation, failure handling, refresh behavior, and stale-channel races.
- `desktop/windows/src/main/updater.test.ts` covers the Windows-only production path, live channel switches, generation-fenced in-flight checks/downloads, beta opt-out after staging, delayed download events, fail-closed resolution, and the staged-install flow.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

The violated contract was that a Windows update check must resolve metadata from a Windows release in the requested channel. GitHubProvider's repository-wide latest-release lookup encoded neither platform nor Omi's release-channel semantics.

The new class is `FC-platform-unscoped-update-feed`. Its canonical guard is the backend's existing paginated, cached platform/channel release resolver combined with a client-side trusted-feed validator before the generic provider runs. Regression tests exercise both sides, and live probes verify the currently published stable and beta Windows feeds.


