### PR TITLE
SCA-134: isolate M1 qualification checkout

### DIFF
--- a/.github/failure-classes/FC-shared-runner-checkout-residue.json
+++ b/.github/failure-classes/FC-shared-runner-checkout-residue.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-shared-runner-checkout-residue",
+  "violated_contract": "A self-hosted release gate must not inspect or reuse mutable repository state from an earlier run before it has established a run-isolated source and cleanup boundary.",
+  "canonical_prevention": "Create an owner-only run stage before repository access, fetch the immutable candidate into a fresh source tree outside the shared Actions workspace, bind always-path cleanup evidence to that deterministic stage, and exercise checkout plus pre-checkout failure behavior against stale shared-workspace residue.",
+  "canonical_prevention_artifact": [
+    ".github/workflows/desktop_qualify_beta.yml",
+    ".github/scripts/test_desktop_release_flow_contract.py"
+  ],
+  "evidence_prs": [
+    10611
+  ],
+  "scope_hints": [
+    ".github/workflows/**",
+    ".github/scripts/test_*release*contract.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -3,16 +3,76 @@
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
+RELEASE_TAG = "v0.12.124+12124-macos"
 
 
 class DesktopReleaseFlowContractTests(unittest.TestCase):
     def setUp(self) -> None:
         self.workflow = (ROOT / ".github/workflows/desktop_qualify_beta.yml").read_text(encoding="utf-8")
         self.codemagic = (ROOT / "codemagic.yaml").read_text(encoding="utf-8")
+
+    def _workflow_script(self, step_name: str) -> str:
+        marker = f"      - name: {step_name}\n"
+        self.assertEqual(self.workflow.count(marker), 1)
+        block = self.workflow.split(marker, 1)[1].split("\n      - ", 1)[0]
+        script = block.split("        run: |\n", 1)[1]
+        return "\n".join(line[10:] if line.startswith("          ") else line for line in script.splitlines())
+
+    def _run_workflow_script(
+        self,
+        step_name: str,
+        *,
+        cwd: Path,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", "-c", self._workflow_script(step_name)],
+            cwd=cwd,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def _create_candidate_remote(self, root: Path) -> tuple[Path, str]:
+        server = root / "git-server"
+        remote = server / "BasedHardware" / "omi.git"
+        source = root / "candidate-source"
+        remote.parent.mkdir(parents=True)
+        source.mkdir()
+        git_env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+        def git(*args: str, cwd: Path = source) -> str:
+            result = subprocess.run(
+                ["git", *args],
+                cwd=cwd,
+                env=git_env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return result.stdout.strip()
+
+        git("init", "--quiet")
+        git("config", "user.name", "Qualification Contract")
+        git("config", "user.email", "qualification-contract@example.com")
+        (source / "candidate.txt").write_text("immutable candidate\n", encoding="utf-8")
+        git("add", "candidate.txt")
+        git("-c", "core.hooksPath=/dev/null", "commit", "--quiet", "-m", "candidate")
+        candidate_sha = git("rev-parse", "HEAD")
+        git("tag", "-a", RELEASE_TAG, "-m", "candidate")
+        git("init", "--quiet", "--bare", str(remote), cwd=root)
+        git("remote", "add", "origin", remote.as_uri())
+        git("push", "--quiet", "origin", "HEAD:refs/heads/main", f"refs/tags/{RELEASE_TAG}")
+        return server, candidate_sha
 
     def test_only_m1_studio_can_qualify(self) -> None:
         self.assertIn("qualify-m1-studio:", self.workflow)
@@ -25,7 +85,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
 
     def test_m1_qualification_binds_the_immutable_tag(self) -> None:
         for fragment in (
-            "ref: ${{ inputs.release_tag }}",
+            'checkout --quiet --detach "refs/tags/$RELEASE_TAG"',
             'git rev-parse "$RELEASE_TAG^{commit}"',
             "git rev-parse 'HEAD^{commit}'",
             "check-desktop-auto-beta-candidate.py",
@@ -38,7 +98,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
     def test_run_staging_evidence_and_cleanup_are_isolated_and_rerun_safe(self) -> None:
         for fragment in (
             "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}",
-            "Refusing reused staging directory",
+            "Refusing reused qualification staging directory",
             "OMI_QUALIFICATION_CLEANUP_CONTEXT",
             "Finalize only this authenticated qualification lease",
             "if: always()",
@@ -48,6 +108,108 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
             "qualification-evidence-${TARGET_SHA}-${digest}.json",
         ):
             self.assertIn(fragment, self.workflow)
+
+    def test_checkout_ignores_stale_shared_workspace_and_uses_fresh_run_source(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            server, candidate_sha = self._create_candidate_remote(root)
+            runner_temp = root / "runner-temp"
+            runner_temp.mkdir()
+            stale_workspace = root / "shared-workspace"
+            stale_gitlink = stale_workspace / "omiGlass/firmware/.pio/libdeps/seeed_xiao_esp32s3/libopus"
+            stale_gitlink.mkdir(parents=True)
+            sentinel = stale_gitlink / "stale-runner-residue"
+            sentinel.write_text("must remain untouched\n", encoding="utf-8")
+            (stale_workspace / ".gitmodules").write_text(
+                '[submodule "stale"]\n\tpath = omiGlass/firmware/.pio/libdeps/seeed_xiao_esp32s3/libopus\n'
+                "\turl = https://invalid.example/stale.git\n",
+                encoding="utf-8",
+            )
+
+            run_id = "30179386741"
+            run_attempt = "2"
+            stage = runner_temp / "desktop-beta-qualification" / f"{run_id}-{run_attempt}"
+            env = {
+                **os.environ,
+                "RUNNER_TEMP": str(runner_temp),
+                "GITHUB_RUN_ID": run_id,
+                "GITHUB_RUN_ATTEMPT": run_attempt,
+                "QUALIFICATION_STAGE": str(stage),
+                "GITHUB_SERVER_URL": server.as_uri(),
+                "GITHUB_REPOSITORY": "BasedHardware/omi",
+                "RELEASE_TAG": RELEASE_TAG,
+            }
+            stage_result = self._run_workflow_script(
+                "Create run-isolated qualification staging",
+                cwd=stale_workspace,
+                env=env,
+            )
+            self.assertEqual(stage_result.returncode, 0, stage_result.stderr)
+            checkout_result = self._run_workflow_script(
+                "Checkout candidate into this run only",
+                cwd=stale_workspace,
+                env=env,
+            )
+            self.assertEqual(checkout_result.returncode, 0, checkout_result.stderr)
+            checked_out_sha = subprocess.run(
+                ["git", "-C", str(stage / "source"), "rev-parse", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            self.assertEqual(checked_out_sha, candidate_sha)
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "must remain untouched\n")
+            self.assertNotIn("actions/checkout@", self.workflow)
+
+            reused_result = self._run_workflow_script(
+                "Create run-isolated qualification staging",
+                cwd=stale_workspace,
+                env=env,
+            )
+            self.assertNotEqual(reused_result.returncode, 0)
+            self.assertIn("Refusing reused qualification staging directory", reused_result.stderr)
+
+    def test_pre_checkout_failure_writes_cleanup_evidence_only_under_run_stage(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            runner_temp = root / "runner-temp"
+            runner_temp.mkdir()
+            run_id = "30179386741"
+            run_attempt = "3"
+            stage = runner_temp / "desktop-beta-qualification" / f"{run_id}-{run_attempt}"
+            env = {
+                **os.environ,
+                "RUNNER_TEMP": str(runner_temp),
+                "GITHUB_RUN_ID": run_id,
+                "GITHUB_RUN_ATTEMPT": run_attempt,
+                "QUALIFICATION_STAGE": str(stage),
+            }
+            stage_result = self._run_workflow_script(
+                "Create run-isolated qualification staging",
+                cwd=runner_temp,
+                env=env,
+            )
+            self.assertEqual(stage_result.returncode, 0, stage_result.stderr)
+            self.assertFalse((stage / "source").exists(), "test seam must stop before checkout")
+
+            finalize_result = self._run_workflow_script(
+                "Finalize only this authenticated qualification lease",
+                cwd=runner_temp,
+                env=env,
+            )
+            self.assertEqual(finalize_result.returncode, 0, finalize_result.stderr)
+            cleanup = stage / "cleanup-evidence.json"
+            self.assertEqual(json.loads(cleanup.read_text(encoding="utf-8")), {"cleanup_status": "no-lease-acquired"})
+
+            unsafe_stage = root / "outside-run-stage"
+            unsafe_env = {**env, "QUALIFICATION_STAGE": str(unsafe_stage)}
+            unsafe_result = self._run_workflow_script(
+                "Finalize only this authenticated qualification lease",
+                cwd=runner_temp,
+                env=unsafe_env,
+            )
+            self.assertNotEqual(unsafe_result.returncode, 0)
+            self.assertFalse((unsafe_stage / "cleanup-evidence.json").exists())
 
     def test_normal_codemagic_candidate_build_still_dispatches_m1_workflow(self) -> None:
         self.assertIn("omi-desktop-swift-release:", self.codemagic)

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -23,25 +23,40 @@ jobs:
     outputs:
       qualified: ${{ steps.publish.outputs.qualified }}
     steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.release_tag }}
-          fetch-depth: 0
+      - name: Create run-isolated qualification staging
+        working-directory: ${{ runner.temp }}
+        env:
+          QUALIFICATION_STAGE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          expected="$RUNNER_TEMP/desktop-beta-qualification/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$QUALIFICATION_STAGE" = "$expected"
+          test ! -e "$QUALIFICATION_STAGE" || { echo "Refusing reused qualification staging directory" >&2; exit 1; }
+          (umask 077; mkdir -p "$QUALIFICATION_STAGE/assets")
+          test ! -L "$QUALIFICATION_STAGE"
+          test "$(python3 -c 'import os, stat, sys; print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode))[2:])' "$QUALIFICATION_STAGE")" = 700
+      - name: Checkout candidate into this run only
+        working-directory: ${{ runner.temp }}
+        env:
+          QUALIFICATION_STAGE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          source_dir="$QUALIFICATION_STAGE/source"
+          test -d "$QUALIFICATION_STAGE"
+          test ! -e "$source_dir"
+          git init --quiet "$source_dir"
+          git -C "$source_dir" remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+          GIT_TERMINAL_PROMPT=0 git -C "$source_dir" fetch --force --prune --tags origin
+          git -C "$source_dir" checkout --quiet --detach "refs/tags/$RELEASE_TAG"
       - id: app-token
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.OMI_BOT_APP_ID }}
           private-key: ${{ secrets.OMI_BOT_PRIVATE_KEY }}
-      - name: Create run-isolated qualification staging
-        id: stage
-        run: |
-          set -euo pipefail
-          stage_dir="$RUNNER_TEMP/desktop-beta-qualification/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          test ! -e "$stage_dir" || { echo "Refusing reused staging directory" >&2; exit 1; }
-          mkdir -p "$stage_dir/assets"
-          echo "stage_dir=$stage_dir" >> "$GITHUB_OUTPUT"
       - name: Bind tag and checkout to the same immutable commit
         id: candidate
+        working-directory: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/source
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
@@ -51,9 +66,10 @@ jobs:
           test "$TARGET_SHA" = "$(git rev-parse 'HEAD^{commit}')"
           echo "target_sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
       - name: Fetch candidate release inputs into this run only
+        working-directory: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/source
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          QUALIFICATION_STAGE: ${{ steps.stage.outputs.stage_dir }}
+          QUALIFICATION_STAGE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           REPO: ${{ github.repository }}
         run: |
@@ -68,8 +84,9 @@ jobs:
             gh release download "$RELEASE_TAG" --repo "$REPO" --pattern Omi.Beta.zip --pattern omi-beta.dmg --dir "$QUALIFICATION_STAGE/assets"
           fi
       - name: Validate candidate evidence
+        working-directory: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/source
         env:
-          QUALIFICATION_STAGE: ${{ steps.stage.outputs.stage_dir }}
+          QUALIFICATION_STAGE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           TARGET_SHA: ${{ steps.candidate.outputs.target_sha }}
         run: |
@@ -78,18 +95,20 @@ jobs:
           python3 .github/scripts/check-desktop-auto-beta-candidate.py --release-json "$QUALIFICATION_STAGE/release.json" --smoke-result "$QUALIFICATION_STAGE/desktop-smoke-result.json" --beta-smoke-result "$QUALIFICATION_STAGE/desktop-smoke-result-beta.json" --release-tag "$RELEASE_TAG" --latest-tag "$LATEST_TAG" --tag-sha "$TARGET_SHA" --checkout-sha "$TARGET_SHA" --output "$QUALIFICATION_STAGE/candidate-gate.json"
       - name: Qualify exact candidate on the M1 Studio hermetic stack
         id: qualify
+        working-directory: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/source
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_TAG: ${{ inputs.release_tag }}
-          QUALIFICATION_STAGE: ${{ steps.stage.outputs.stage_dir }}
-          OMI_QUALIFICATION_CLEANUP_CONTEXT: ${{ steps.stage.outputs.stage_dir }}/lease-context.json
+          QUALIFICATION_STAGE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}
+          OMI_QUALIFICATION_CLEANUP_CONTEXT: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/lease-context.json
         run: |
           set -euo pipefail
           desktop/macos/scripts/qualify-desktop-beta.sh --automatic --github-actions-artifact --signed-smoke-result "$QUALIFICATION_STAGE/desktop-smoke-result.json" --candidate-gate-result "$QUALIFICATION_STAGE/candidate-gate.json" "$RELEASE_TAG"
       - name: Create immutable qualification evidence
         id: evidence
+        working-directory: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/source
         env:
-          QUALIFICATION_STAGE: ${{ steps.stage.outputs.stage_dir }}
+          QUALIFICATION_STAGE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           TARGET_SHA: ${{ steps.candidate.outputs.target_sha }}
         run: |
@@ -102,14 +121,15 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: desktop-qualification-evidence-${{ inputs.release_tag }}-m1-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ steps.stage.outputs.stage_dir }}/qualification-evidence.json
+          path: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/qualification-evidence.json
           if-no-files-found: error
           overwrite: false
       - name: Attach immutable qualification evidence
         id: publish
+        working-directory: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/source
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          QUALIFICATION_STAGE: ${{ steps.stage.outputs.stage_dir }}
+          QUALIFICATION_STAGE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           REPO: ${{ github.repository }}
           TARGET_SHA: ${{ steps.candidate.outputs.target_sha }}
@@ -123,10 +143,16 @@ jobs:
           echo "qualified=true" >> "$GITHUB_OUTPUT"
       - name: Finalize only this authenticated qualification lease
         if: always()
+        working-directory: ${{ runner.temp }}
         env:
-          QUALIFICATION_STAGE: ${{ steps.stage.outputs.stage_dir }}
+          QUALIFICATION_STAGE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          expected="$RUNNER_TEMP/desktop-beta-qualification/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test -n "$QUALIFICATION_STAGE"
+          test "$QUALIFICATION_STAGE" = "$expected"
+          test -d "$QUALIFICATION_STAGE"
+          test ! -L "$QUALIFICATION_STAGE"
           context="$QUALIFICATION_STAGE/lease-context.json"
           cleanup="$QUALIFICATION_STAGE/cleanup-evidence.json"
           if [ -f "$context" ]; then
@@ -142,7 +168,7 @@ jobs:
         if: always()
         with:
           name: desktop-qualification-cleanup-${{ inputs.release_tag }}-m1-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ steps.stage.outputs.stage_dir }}/cleanup-evidence.json
+          path: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/cleanup-evidence.json
           if-no-files-found: error
           overwrite: false
 


### PR DESCRIPTION
## Summary

- create the M1 qualification's owner-only run stage before any repository inspection
- replace `actions/checkout` on this reused self-hosted runner with a fresh full-history/tag fetch under `RUNNER_TEMP`, while retaining the exact tag/HEAD binding
- bind always-path cleanup evidence directly to the deterministic run path so a checkout failure cannot expand an empty stage output to `/cleanup-evidence.json`
- behaviorally execute the workflow's staging, checkout, and finalizer scripts against stale shared-workspace gitlink residue and a checkout-never-started boundary

## Root cause

`actions/checkout@v7` prepares an existing checkout by running `git submodule status` before its clean/reset, and its auth cleanup also traverses submodules. The M1 runner reused `_work/omi/omi`, so stale PlatformIO gitlink residue could block those pre-checkout operations even though qualification does not request submodules. Run [30179386741](https://github.com/BasedHardware/omi/actions/runs/30179386741) was cancelled in that boundary before candidate validation or lease acquisition.

The repair avoids evaluating the shared checkout at all. The workflow creates a unique `${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}` stage under `RUNNER_TEMP`, initializes a new repository inside it, fetches all refs/tags, checks out the requested tag detached, and then re-validates the peeled tag commit against `HEAD` as before.

## Safety

- `runs-on` remains M1 Studio-only with `omi-qual-m1-studio`
- non-cancelling single-flight concurrency remains `desktop-beta-qualification-m1`
- immutable tag/SHA binding, candidate evidence validation, content-addressed evidence, automatic Beta handoff, and Stable non-mutation are unchanged
- no release, tag, qualification dispatch, promotion, deployment, pointer, secret, IAM, or production mutation was performed
- no changelog fragment: this is internal release-control repair

## Verification

- `python3 .github/scripts/test_desktop_release_flow_contract.py` — 6 passed
- `actionlint -config-file .github/actionlint.yaml .github/workflows/desktop_qualify_beta.yml` — passed
- `bash desktop/macos/tests/test-qualification-stage-isolation.sh` — passed
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh` — passed
- `python3 .github/scripts/test_desktop_release_source_identity.py` — 8 passed
- `python3 -m py_compile .github/scripts/test_desktop_release_flow_contract.py` — passed
- `git diff --check` — passed
- `make setup` — passed with the Multica checkout's `/dev/null` hook path overridden for this command to the repository's shared hooks directory
- `OMI_PR_BODY_FILE=./pr-body.md make preflight` — 15 selected checks passed

## Product invariants

None.

Failure-Class: new
