### PR TITLE
SCA-135: isolate dev Pusher telemetry evidence

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -43,7 +43,11 @@ podAnnotations:
   prometheus.io/path: "/metrics"
 # This is for setting Kubernetes Labels to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-podLabels: {}
+podLabels:
+  env: dev
+  # Reconnect and circuit-breaker aggregates are emitted by backend-listen.
+  # Keep those scrape targets in the same development-only evidence plane as
+  # the Pusher targets.
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/backend/charts/monitoring/dashboards/gke/pusher.json
+++ b/backend/charts/monitoring/dashboards/gke/pusher.json
@@ -1708,7 +1708,145 @@
           "refId": "B"
         }
       ],
-      "title": "Reconnect circuit breaker",
+      "title": "Reconnect / recovery circuit breaker",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 51
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(pusher_sessions_degraded{job=\"backend-listen-metrics\"})",
+          "legendFormat": "sessions reconnecting / degraded",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconnect / recovery aggregate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 51
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "up{job=~\"pusher-metrics|backend-listen-metrics\"}",
+          "legendFormat": "{{job}} {{namespace}}/{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Metrics scrape target health",
       "type": "timeseries"
     }
   ],

--- a/backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml
+++ b/backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml
@@ -117,7 +117,18 @@ prometheus:
           credentials_file: /etc/prometheus/secrets/metrics-scrape-token/token
         kubernetes_sd_configs:
         - role: pod
+          namespaces:
+            names:
+              - dev-omi-backend
         relabel_configs:
+          # Scope the development Prometheus instance to development targets
+          # even if a future discovery change widens its Kubernetes RBAC.
+          - source_labels: [__meta_kubernetes_namespace]
+            action: keep
+            regex: dev-omi-backend
+          - source_labels: [__meta_kubernetes_pod_label_env]
+            action: keep
+            regex: dev
           - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
             action: keep
             regex: "true"
@@ -135,6 +146,8 @@ prometheus:
             target_label: __address__
           - source_labels: [__meta_kubernetes_namespace]
             target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_label_env]
+            target_label: environment
           - source_labels: [__meta_kubernetes_pod_name]
             target_label: pod
       - job_name: pusher-metrics
@@ -146,7 +159,19 @@ prometheus:
           credentials_file: /etc/prometheus/secrets/metrics-scrape-token/token
         kubernetes_sd_configs:
         - role: pod
+          namespaces:
+            names:
+              - dev-omi-backend
         relabel_configs:
+          # The development job must never discover a production Pusher pod.
+          # Namespace and immutable dev workload-label checks are deliberately
+          # both retained as independent isolation boundaries.
+          - source_labels: [__meta_kubernetes_namespace]
+            action: keep
+            regex: dev-omi-backend
+          - source_labels: [__meta_kubernetes_pod_label_env]
+            action: keep
+            regex: dev
           - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
             action: keep
             regex: "true"
@@ -164,6 +189,8 @@ prometheus:
             target_label: __address__
           - source_labels: [__meta_kubernetes_namespace]
             target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_label_env]
+            target_label: environment
           - source_labels: [__meta_kubernetes_pod_name]
             target_label: pod
       - job_name: llm-gateway-metrics

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -49,7 +49,10 @@ podAnnotations:
   prometheus.io/path: "/metrics"
 # This is for setting Kubernetes Labels to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-podLabels: {}
+podLabels:
+  env: dev
+  # The development Prometheus job keeps this target in the development
+  # evidence plane as a second boundary alongside its namespace selector.
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/backend/docs/pusher_rolling_update_operations.md
+++ b/backend/docs/pusher_rolling_update_operations.md
@@ -223,9 +223,36 @@ tolerations. This is capacity evidence, not a claim that the rollout has product
 traffic or user-success proof.
 
 The dev Pusher dashboard is backed by the isolated dev Prometheus scrape. It
-shows existing connection, readiness/drain, and backend-listen reconnect-circuit
-signals without creating traffic. Pod health alone is not product-success
-evidence.
+shows existing connection, readiness/drain, reconnect/recovery and
+backend-listen circuit-breaker aggregates, plus target health, without creating
+traffic. Pod health alone is not product-success evidence.
+
+#### Read-only development evidence boundary
+
+The development Prometheus jobs discover only `dev-omi-backend` pods carrying
+the `env=dev` workload label. They retain the existing bearer-token file
+reference; do not fetch `/metrics` directly, inspect the token, copy headers, or
+weaken authentication. The dashboard contains only low-cardinality aggregates
+and target labels (`job`, `namespace`, and `pod`), never connection IDs, user
+data, or request payloads.
+
+For a passive development-bake check in the permitted read-only operator plane,
+use the Pusher dashboard or these equivalent PromQL expressions:
+
+- active Pusher WebSockets: `sum(pusher_active_ws_connections{job="pusher-metrics"})`
+- sessions currently reconnecting or degraded:
+  `sum(pusher_sessions_degraded{job="backend-listen-metrics"})`
+- reconnect circuit state and rejected attempts:
+  `pusher_circuit_breaker_state{job="backend-listen-metrics"}` and
+  `sum(rate(pusher_circuit_breaker_rejections_total{job="backend-listen-metrics"}[5m]))`
+- authenticated scrape target health:
+  `up{job=~"pusher-metrics|backend-listen-metrics"}`
+
+`up == 1` proves only that Prometheus authenticated and scraped a target; it is
+not connection, drain, or recovery proof. A recovery aggregate can move only
+when a real client reconnects. If no real connection exists during the passive
+window, record reconnect/recovery as **unproven**—do not generate synthetic
+traffic to turn the signal non-zero.
 
 ### 4. Shared ConfigMap/Secret migration guard (required on key changes)
 

--- a/backend/scripts/verify_pusher_dev_observability.py
+++ b/backend/scripts/verify_pusher_dev_observability.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Keep Pusher dev-bake telemetry visible without treating health as success.
 
-This source-only gate proves the development Prometheus instance has an
-environment-isolated Pusher scrape and that its dashboard exposes connection,
-drain, and backend-listen reconnect-circuit signals.  It deliberately does not
-query a live Prometheus API or generate traffic.
+This source-only gate proves the development Prometheus instance has
+namespace- and environment-isolated Pusher and backend-listen scrapes.  Its
+dashboard must expose connection, drain, reconnect/recovery, circuit-breaker,
+and scrape-target health aggregates. It deliberately does not query a live
+Prometheus API or generate traffic.
 """
 
 from __future__ import annotations
@@ -24,11 +25,22 @@ EXPECTED_METRICS = (
     "pusher_drain_in_progress",
     "pusher_circuit_breaker_state",
     "pusher_circuit_breaker_rejections_total",
+    "pusher_sessions_degraded",
 )
+DEV_NAMESPACE = "dev-omi-backend"
+DEV_ENVIRONMENT = "dev"
+SCRAPE_JOBS = {
+    "pusher-metrics": "pusher",
+    "backend-listen-metrics": "backend-listen",
+}
+DEV_WORKLOAD_VALUES = {
+    PUSHER_VALUES: "pusher",
+    ROOT / "backend/charts/backend-listen/dev_omi_backend_listen_values.yaml": "backend-listen",
+}
 
 
-def pusher_scrape_block(values: str) -> str | None:
-    match = re.search(r"(?ms)^\s*- job_name: pusher-metrics\n(?P<block>.*?)(?=^\s*- job_name:|\Z)", values)
+def scrape_block(values: str, job_name: str) -> str | None:
+    match = re.search(rf"(?ms)^\s*- job_name: {re.escape(job_name)}\n(?P<block>.*?)(?=^\s*- job_name:|\Z)", values)
     return match.group(0) if match else None
 
 
@@ -45,22 +57,36 @@ def dashboard_expressions(payload: dict) -> set[str]:
 
 def validate(root: Path = ROOT) -> list[str]:
     errors: list[str] = []
-    pusher_values = (root / PUSHER_VALUES.relative_to(ROOT)).read_text(encoding="utf-8")
-    for annotation in ('prometheus.io/scrape: "true"', 'prometheus.io/port: "8080"', 'prometheus.io/path: "/metrics"'):
-        if annotation not in pusher_values:
-            errors.append(f"dev Pusher chart must keep {annotation} for the isolated development scrape")
+    for values_path, workload in DEV_WORKLOAD_VALUES.items():
+        workload_values = (root / values_path.relative_to(ROOT)).read_text(encoding="utf-8")
+        for annotation in (
+            'prometheus.io/scrape: "true"',
+            'prometheus.io/port: "8080"',
+            'prometheus.io/path: "/metrics"',
+        ):
+            if annotation not in workload_values:
+                errors.append(f"dev {workload} chart must keep {annotation} for the isolated development scrape")
+        if f"podLabels:\n  env: {DEV_ENVIRONMENT}" not in workload_values:
+            errors.append(f"dev {workload} chart must label its scrape target env: {DEV_ENVIRONMENT}")
 
-    scrape = pusher_scrape_block((root / DEV_VALUES.relative_to(ROOT)).read_text(encoding="utf-8"))
-    if scrape is None:
-        errors.append("development Prometheus must define the pusher-metrics scrape job")
-    else:
+    monitoring_values = (root / DEV_VALUES.relative_to(ROOT)).read_text(encoding="utf-8")
+    for job_name, workload in SCRAPE_JOBS.items():
+        scrape = scrape_block(monitoring_values, job_name)
+        if scrape is None:
+            errors.append(f"development Prometheus must define the {job_name} scrape job")
+            continue
         for fragment in (
             "credentials_file: /etc/prometheus/secrets/metrics-scrape-token/token",
-            "__meta_kubernetes_pod_annotation_prometheus_io_scrape",
-            "regex: pusher",
+            f"names:\n              - {DEV_NAMESPACE}",
+            "__meta_kubernetes_namespace",
+            f"regex: {DEV_NAMESPACE}",
+            "__meta_kubernetes_pod_label_env",
+            f"regex: {DEV_ENVIRONMENT}",
+            "target_label: environment",
+            f"regex: {workload}",
         ):
             if fragment not in scrape:
-                errors.append(f"development pusher-metrics scrape must include {fragment!r}")
+                errors.append(f"development {job_name} scrape must include {fragment!r}")
 
     metric_text = (root / METRICS.relative_to(ROOT)).read_text(encoding="utf-8")
     for metric in EXPECTED_METRICS:
@@ -76,6 +102,8 @@ def validate(root: Path = ROOT) -> list[str]:
         for metric in EXPECTED_METRICS:
             if metric not in expressions:
                 errors.append(f"Pusher dashboard must expose development-visible {metric!r}")
+        if 'up{job=~"pusher-metrics|backend-listen-metrics"}' not in expressions:
+            errors.append("Pusher dashboard must expose the isolated scrape target health aggregate")
     return errors
 
 

--- a/backend/tests/unit/test_verify_pusher_dev_observability.py
+++ b/backend/tests/unit/test_verify_pusher_dev_observability.py
@@ -14,6 +14,7 @@ SCRIPT = ROOT / "backend/scripts/verify_pusher_dev_observability.py"
 FILES = (
     "backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml",
     "backend/charts/pusher/dev_omi_pusher_values.yaml",
+    "backend/charts/backend-listen/dev_omi_backend_listen_values.yaml",
     "backend/charts/monitoring/dashboards/gke/pusher.json",
     "backend/utils/metrics.py",
 )
@@ -59,10 +60,28 @@ def test_dev_pusher_bake_observability_contract_passes(verifier: SimpleNamespace
             "isolated development scrape",
         ),
         (
+            "backend/charts/pusher/dev_omi_pusher_values.yaml",
+            "podLabels:\n  env: dev",
+            "podLabels:\n  env: prod",
+            "dev pusher chart must label its scrape target env: dev",
+        ),
+        (
+            "backend/charts/backend-listen/dev_omi_backend_listen_values.yaml",
+            "podLabels:\n  env: dev",
+            "podLabels:\n  env: prod",
+            "dev backend-listen chart must label its scrape target env: dev",
+        ),
+        (
             "backend/charts/monitoring/dashboards/gke/pusher.json",
             "pusher_drain_in_progress",
             "removed_drain_metric",
             "development-visible 'pusher_drain_in_progress'",
+        ),
+        (
+            "backend/charts/monitoring/dashboards/gke/pusher.json",
+            'up{job=~\\"pusher-metrics|backend-listen-metrics\\"}',
+            "removed_scrape_target_health",
+            "must expose the isolated scrape target health aggregate",
         ),
     ],
 )
@@ -72,3 +91,17 @@ def test_rejects_missing_scrape_or_bake_signal(
     replace_once(fixture_root / relative, before, after)
 
     assert any(expected in error for error in verifier.validate(fixture_root))
+
+
+def test_rejects_pusher_scrape_outside_the_development_namespace(verifier: SimpleNamespace, fixture_root: Path) -> None:
+    monitoring_values = fixture_root / "backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml"
+    source = monitoring_values.read_text(encoding="utf-8")
+    pusher_job = verifier.scrape_block(source, "pusher-metrics")
+    assert pusher_job is not None
+    tampered_job = pusher_job.replace("regex: dev-omi-backend", "regex: prod-omi-backend", 1)
+    monitoring_values.write_text(source.replace(pusher_job, tampered_job, 1), encoding="utf-8")
+
+    assert any(
+        "development pusher-metrics scrape must include 'regex: dev-omi-backend'" in error
+        for error in verifier.validate(fixture_root)
+    )


### PR DESCRIPTION
## Summary

- Restrict the dev-only Pusher and backend-listen Prometheus jobs to `dev-omi-backend` targets labelled `env=dev`, retaining the existing mounted bearer-token reference.
- Add aggregate reconnect/recovery and scrape-target-health panels to the Pusher dashboard; no connection identifiers, user data, raw metrics, or credentials are exposed.
- Extend the deterministic dev-observability contract and operations guide with the read-only evidence boundary and the requirement to record recovery as unproven when no real connection occurs.

## Scope and evidence plan

This changes only development chart and monitoring wiring; it performs no cluster mutation, traffic generation, secret read, authentication bypass, production workload change, or deployment. After an approved dev monitoring rollout, a read-only operator can confirm `up`, active Pusher WebSocket aggregates, current reconnect/degraded sessions, and circuit state from the dev Pusher dashboard. A healthy scrape does not prove a reconnect; without a real client connection, reconnect/recovery remains unproven.

## Verification

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_verify_pusher_dev_observability.py -q` — 8 passed.
- `backend/scripts/run-unit-ci.sh --changed-files <changed-file-list>` — 6 selected Pusher deployment test files passed; type checking reported 0 errors.
- `backend/.venv/bin/python backend/scripts/verify_pusher_dev_observability.py` — passed.
- `jq empty backend/charts/monitoring/dashboards/gke/pusher.json` and Helm renders for dev Pusher and backend-listen — passed.
- `make preflight` — 26 deterministic checks passed.

Closes SCA-135


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

