### PR TITLE
SCA-136: repair macOS candidate tag publication

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -378,7 +378,7 @@ checks:
     command: ["python3", ".github/scripts/test_publish_desktop_candidate_tag.py"]
     triggers: [".github/scripts/publish-desktop-candidate-tag.py", ".github/scripts/test_publish_desktop_candidate_tag.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "SCA-129 requires GitHub to atomically verify live main before creating an immutable candidate tag"
+    reason: "SCA-136 requires a fresh authoritative main check plus create-only immutable candidate tag publication"
   - id: desktop-manifest-routes
     command: ["python3", ".github/scripts/test_desktop_manifest_routes.py"]
     triggers: [".github/workflows/desktop-swift-ci.yml", ".github/checks-manifest.yaml", ".github/scripts/run_checks.py", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_desktop_manifest_routes.py"]

--- a/.github/scripts/publish-desktop-candidate-tag.py
+++ b/.github/scripts/publish-desktop-candidate-tag.py
@@ -1,93 +1,79 @@
 #!/usr/bin/env python3
-"""Atomically publish an annotated macOS candidate tag against live main."""
+"""Publish an immutable annotated macOS candidate tag from exact live main."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
-
-ZERO_OID = "0" * 40
 TAGGER_NAME = "github-actions[bot]"
 TAGGER_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
-
-REPOSITORY_ID_QUERY = """
-query RepositoryId($owner: String!, $name: String!) {
-  repository(owner: $owner, name: $name) { id }
-}
-"""
-
-UPDATE_REFS_MUTATION = """
-mutation PublishCandidateTag(
-  $repositoryId: ID!,
-  $mainBefore: GitObjectID!,
-  $mainAfter: GitObjectID!,
-  $tagName: GitRefname!,
-  $tagObject: GitObjectID!,
-  $zeroOid: GitObjectID!
-) {
-  updateRefs(input: {
-    repositoryId: $repositoryId,
-    refUpdates: [
-      {
-        name: "refs/heads/main",
-        beforeOid: $mainBefore,
-        afterOid: $mainAfter,
-        force: false
-      },
-      {
-        name: $tagName,
-        beforeOid: $zeroOid,
-        afterOid: $tagObject,
-        force: false
-      }
-    ]
-  }) {
-    clientMutationId
-  }
-}
-"""
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+RELEASE_TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+-macos$")
+SECRET_PATTERNS = (
+    re.compile(r"(?i)(authorization:\s*bearer\s+)\S+"),
+    re.compile(r"(?i)(bearer\s+)\S+"),
+    re.compile(r"\b(?:gh[oprsu]_[A-Za-z0-9]+|github_pat_[A-Za-z0-9_]+)\b"),
+    re.compile(r"(?i)((?:access_)?token=)[^&\s]+"),
+)
 
 
-def run_gh_json(args: list[str], payload: dict[str, object]) -> dict[str, object]:
-    """Call the authenticated GitHub CLI without exposing structured input to a shell."""
+class GitHubApiError(RuntimeError):
+    """A bounded, credential-safe GitHub CLI failure."""
+
+
+def sanitize_api_diagnostic(value: str) -> str:
+    """Retain actionable API context without echoing credentials."""
+    sanitized = " ".join(value.split())
+    for pattern in SECRET_PATTERNS:
+        replacement = r"\1<redacted>" if pattern.groups else "<redacted>"
+        sanitized = pattern.sub(replacement, sanitized)
+    return sanitized[:1000] or "no diagnostic text returned"
+
+
+def run_gh_json(args: list[str], payload: dict[str, object] | None = None) -> dict[str, object]:
+    """Call the authenticated GitHub CLI without exposing input to a shell."""
+    command = ["gh", *args]
+    stdin = None
+    if payload is not None:
+        command.extend(["--input", "-"])
+        stdin = json.dumps(payload)
     result = subprocess.run(
-        ["gh", *args, "--input", "-"],
-        check=True,
-        input=json.dumps(payload),
+        command,
+        check=False,
+        input=stdin,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+    if result.returncode:
+        detail = sanitize_api_diagnostic(result.stderr or result.stdout)
+        raise GitHubApiError(f"GitHub API request failed (exit {result.returncode}): {detail}")
     try:
         decoded = json.loads(result.stdout)
     except json.JSONDecodeError as error:
-        raise ValueError("GitHub API returned invalid JSON") from error
+        detail = sanitize_api_diagnostic(result.stdout)
+        raise GitHubApiError(f"GitHub API returned invalid JSON: {detail}") from error
     if not isinstance(decoded, dict):
         raise ValueError("GitHub API returned an unexpected JSON payload")
     if decoded.get("errors"):
-        raise ValueError(f"GitHub GraphQL rejected the ref transaction: {decoded['errors']}")
+        detail = sanitize_api_diagnostic(json.dumps(decoded["errors"], sort_keys=True))
+        raise GitHubApiError(f"GitHub API rejected the request: {detail}")
     return decoded
 
 
-def repository_id(repository: str) -> str:
+def validate_inputs(repository: str, release_tag: str, candidate_sha: str) -> None:
     owner, separator, name = repository.partition("/")
     if not owner or not separator or not name or "/" in name:
         raise ValueError("repository must be in owner/name form")
-    response = run_gh_json(
-        ["api", "graphql"],
-        {"query": REPOSITORY_ID_QUERY, "variables": {"owner": owner, "name": name}},
-    )
-    data = response.get("data")
-    if not isinstance(data, dict) or not isinstance(data.get("repository"), dict):
-        raise ValueError("GitHub did not return a repository node")
-    identifier = data["repository"].get("id")
-    if not isinstance(identifier, str) or not identifier:
-        raise ValueError("GitHub did not return a repository ID")
-    return identifier
+    if not RELEASE_TAG_RE.fullmatch(release_tag):
+        raise ValueError("release_tag must be an exact v<version>+<build>-macos tag")
+    if not SHA_RE.fullmatch(candidate_sha):
+        raise ValueError("candidate_sha must be a 40-character lowercase SHA")
 
 
 def create_annotated_tag_object(
@@ -104,40 +90,50 @@ def create_annotated_tag_object(
         },
     )
     tag_object_sha = response.get("sha")
-    if not isinstance(tag_object_sha, str) or len(tag_object_sha) != 40:
+    if not isinstance(tag_object_sha, str) or not SHA_RE.fullmatch(tag_object_sha):
         raise ValueError("GitHub did not return the annotated tag object SHA")
     return tag_object_sha
 
 
-def atomic_publish_tag_ref(
-    *, repository_id_value: str, release_tag: str, candidate_sha: str, tag_object_sha: str
-) -> None:
-    """Publish only if live main still points at the identity-validated SHA.
+def live_main_sha(repository: str) -> str:
+    response = run_gh_json(["api", "--method", "GET", f"repos/{repository}/git/ref/heads/main"])
+    target = response.get("object")
+    if not isinstance(target, dict):
+        raise ValueError("GitHub did not return the live main ref target")
+    sha = target.get("sha")
+    if not isinstance(sha, str) or not SHA_RE.fullmatch(sha):
+        raise ValueError("GitHub did not return the live main commit SHA")
+    return sha
 
-    GitHub's `updateRefs` mutation evaluates every `beforeOid` and applies all
-    ref updates as one transaction. Keeping main unchanged still makes its
-    current OID a server-enforced precondition for adding the immutable tag.
-    """
-    run_gh_json(
-        ["api", "graphql"],
+
+def create_immutable_tag_ref(*, repository: str, release_tag: str, tag_object_sha: str) -> None:
+    """Create the candidate ref once; conflicts fail without rewriting a tag."""
+    expected_ref = f"refs/tags/{release_tag}"
+    response = run_gh_json(
+        ["api", "--method", "POST", f"repos/{repository}/git/refs"],
         {
-            "query": UPDATE_REFS_MUTATION,
-            "variables": {
-                "repositoryId": repository_id_value,
-                "mainBefore": candidate_sha,
-                "mainAfter": candidate_sha,
-                "tagName": f"refs/tags/{release_tag}",
-                "tagObject": tag_object_sha,
-                "zeroOid": ZERO_OID,
-            },
+            "ref": expected_ref,
+            "sha": tag_object_sha,
         },
     )
+    target = response.get("object")
+    if response.get("ref") != expected_ref or not isinstance(target, dict):
+        raise ValueError("GitHub returned an unexpected candidate tag ref")
+    if target.get("sha") != tag_object_sha:
+        raise ValueError("GitHub candidate tag ref does not target the annotated tag object")
 
 
-def publish_candidate_tag(*, repository: str, release_tag: str, candidate_sha: str, evidence: str, timestamp: str) -> None:
-    repo_id = repository_id(repository)
+def publish_candidate_tag(
+    *,
+    repository: str,
+    release_tag: str,
+    candidate_sha: str,
+    evidence: str,
+    timestamp: str,
+) -> None:
+    validate_inputs(repository, release_tag, candidate_sha)
     # A tag object alone is unreachable and is not a candidate. The only
-    # candidate-creating action is the atomic ref transaction below.
+    # candidate-creating action is the create-only ref request below.
     tag_object_sha = create_annotated_tag_object(
         repository=repository,
         release_tag=release_tag,
@@ -145,10 +141,15 @@ def publish_candidate_tag(*, repository: str, release_tag: str, candidate_sha: s
         evidence=evidence,
         timestamp=timestamp,
     )
-    atomic_publish_tag_ref(
-        repository_id_value=repo_id,
+    observed_main_sha = live_main_sha(repository)
+    if observed_main_sha != candidate_sha:
+        raise ValueError(
+            "GitHub main moved before candidate publication; "
+            f"expected {candidate_sha}, observed {observed_main_sha}; tag ref was not created"
+        )
+    create_immutable_tag_ref(
+        repository=repository,
         release_tag=release_tag,
-        candidate_sha=candidate_sha,
         tag_object_sha=tag_object_sha,
     )
 

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -363,7 +363,7 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertEqual(workflow.count("--source-check-poll-seconds 30"), 2)
         self.assertLess(
             workflow.index("Create and regular-merge PR to sync changelog back to main"),
-            workflow.index("Atomically tag exact live main source"),
+            workflow.index("Publish immutable tag from exact live main source"),
         )
         self.assertIn('git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main', workflow)
         self.assertEqual(workflow.count('CANDIDATE_SHA="$MAIN_SHA"'), 2)

--- a/.github/scripts/test_publish_desktop_candidate_tag.py
+++ b/.github/scripts/test_publish_desktop_candidate_tag.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Behavioral contract tests for atomic macOS candidate-tag publication."""
+"""Behavioral contract tests for fail-closed macOS candidate-tag publication."""
 
 from __future__ import annotations
 
@@ -9,7 +9,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-
 SCRIPT = Path(__file__).with_name("publish-desktop-candidate-tag.py")
 SPEC = importlib.util.spec_from_file_location("publish_desktop_candidate_tag", SCRIPT)
 assert SPEC and SPEC.loader
@@ -17,58 +16,20 @@ publisher = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(publisher)
 
 REPOSITORY = "BasedHardware/omi"
-REPOSITORY_ID = "R_kgDOGHExample"
 CANDIDATE_SHA = "a" * 40
 TAG_OBJECT_SHA = "b" * 40
 RELEASE_TAG = "v1.2.3+10203-macos"
 
 
 class PublishDesktopCandidateTagTests(unittest.TestCase):
-    def test_ref_transaction_requires_live_main_and_an_unused_tag(self) -> None:
-        with patch.object(publisher, "run_gh_json", return_value={"data": {"updateRefs": {}}}) as run_gh:
-            publisher.atomic_publish_tag_ref(
-                repository_id_value=REPOSITORY_ID,
-                release_tag=RELEASE_TAG,
-                candidate_sha=CANDIDATE_SHA,
-                tag_object_sha=TAG_OBJECT_SHA,
-            )
-
-        args, payload = run_gh.call_args.args
-        self.assertEqual(args, ["api", "graphql"])
-        self.assertIn("updateRefs", payload["query"])
-        self.assertEqual(
-            payload["variables"],
+    def test_publishes_only_after_refetching_exact_live_main(self) -> None:
+        responses = [
+            {"sha": TAG_OBJECT_SHA},
+            {"object": {"sha": CANDIDATE_SHA}},
             {
-                "repositoryId": REPOSITORY_ID,
-                "mainBefore": CANDIDATE_SHA,
-                "mainAfter": CANDIDATE_SHA,
-                "tagName": f"refs/tags/{RELEASE_TAG}",
-                "tagObject": TAG_OBJECT_SHA,
-                "zeroOid": publisher.ZERO_OID,
+                "ref": f"refs/tags/{RELEASE_TAG}",
+                "object": {"sha": TAG_OBJECT_SHA},
             },
-        )
-
-    def test_main_advance_rejection_cannot_report_a_published_candidate(self) -> None:
-        responses = [
-            {"data": {"repository": {"id": REPOSITORY_ID}}},
-            {"sha": TAG_OBJECT_SHA},
-            subprocess.CalledProcessError(1, ["gh", "api", "graphql"], stderr="main beforeOid mismatch"),
-        ]
-        with patch.object(publisher, "run_gh_json", side_effect=responses):
-            with self.assertRaises(subprocess.CalledProcessError):
-                publisher.publish_candidate_tag(
-                    repository=REPOSITORY,
-                    release_tag=RELEASE_TAG,
-                    candidate_sha=CANDIDATE_SHA,
-                    evidence="immutable planner evidence\n",
-                    timestamp="2026-07-25T00:00:00Z",
-                )
-
-    def test_annotated_tag_carries_the_identity_evidence_before_the_ref_transaction(self) -> None:
-        responses = [
-            {"data": {"repository": {"id": REPOSITORY_ID}}},
-            {"sha": TAG_OBJECT_SHA},
-            {"data": {"updateRefs": {}}},
         ]
         with patch.object(publisher, "run_gh_json", side_effect=responses) as run_gh:
             publisher.publish_candidate_tag(
@@ -79,13 +40,93 @@ class PublishDesktopCandidateTagTests(unittest.TestCase):
                 timestamp="2026-07-25T00:00:00Z",
             )
 
-        tag_args, tag_payload = run_gh.call_args_list[1].args
+        main_args = run_gh.call_args_list[1].args
+        self.assertEqual(
+            main_args,
+            (
+                [
+                    "api",
+                    "--method",
+                    "GET",
+                    f"repos/{REPOSITORY}/git/ref/heads/main",
+                ],
+            ),
+        )
+        ref_args, ref_payload = run_gh.call_args_list[2].args
+        self.assertEqual(
+            ref_args,
+            ["api", "--method", "POST", f"repos/{REPOSITORY}/git/refs"],
+        )
+        self.assertEqual(
+            ref_payload,
+            {
+                "ref": f"refs/tags/{RELEASE_TAG}",
+                "sha": TAG_OBJECT_SHA,
+            },
+        )
+
+    def test_main_advance_rejection_never_creates_the_tag_ref(self) -> None:
+        responses = [
+            {"sha": TAG_OBJECT_SHA},
+            {"object": {"sha": "c" * 40}},
+        ]
+        with patch.object(publisher, "run_gh_json", side_effect=responses) as run_gh:
+            with self.assertRaisesRegex(ValueError, "GitHub main moved before candidate publication"):
+                publisher.publish_candidate_tag(
+                    repository=REPOSITORY,
+                    release_tag=RELEASE_TAG,
+                    candidate_sha=CANDIDATE_SHA,
+                    evidence="immutable planner evidence\n",
+                    timestamp="2026-07-25T00:00:00Z",
+                )
+        self.assertEqual(run_gh.call_count, 2)
+
+    def test_annotated_tag_carries_identity_evidence_before_ref_creation(self) -> None:
+        responses = [
+            {"sha": TAG_OBJECT_SHA},
+            {"object": {"sha": CANDIDATE_SHA}},
+            {
+                "ref": f"refs/tags/{RELEASE_TAG}",
+                "object": {"sha": TAG_OBJECT_SHA},
+            },
+        ]
+        with patch.object(publisher, "run_gh_json", side_effect=responses) as run_gh:
+            publisher.publish_candidate_tag(
+                repository=REPOSITORY,
+                release_tag=RELEASE_TAG,
+                candidate_sha=CANDIDATE_SHA,
+                evidence="immutable planner evidence\n",
+                timestamp="2026-07-25T00:00:00Z",
+            )
+
+        tag_args, tag_payload = run_gh.call_args_list[0].args
         self.assertEqual(tag_args, ["api", "--method", "POST", f"repos/{REPOSITORY}/git/tags"])
         self.assertEqual(tag_payload["object"], CANDIDATE_SHA)
         self.assertEqual(tag_payload["message"], "immutable planner evidence\n")
         self.assertEqual(tag_payload["tagger"]["name"], publisher.TAGGER_NAME)
         self.assertEqual(tag_payload["tagger"]["date"], "2026-07-25T00:00:00Z")
-        self.assertEqual(run_gh.call_args_list[2].args[1]["variables"]["mainBefore"], CANDIDATE_SHA)
+
+    def test_existing_tag_api_failure_is_actionable_and_credential_safe(self) -> None:
+        result = subprocess.CompletedProcess(
+            ["gh", "api"],
+            1,
+            stdout="",
+            stderr=(
+                "HTTP 422: Reference already exists " "(Request ID: A50A:19CD13) Authorization: Bearer ghp_supersecret"
+            ),
+        )
+        with patch.object(publisher.subprocess, "run", return_value=result):
+            with self.assertRaisesRegex(
+                publisher.GitHubApiError,
+                r"HTTP 422: Reference already exists .*Request ID: A50A:19CD13",
+            ) as raised:
+                publisher.run_gh_json(
+                    ["api", "--method", "POST", f"repos/{REPOSITORY}/git/refs"],
+                    {"ref": f"refs/tags/{RELEASE_TAG}", "sha": TAG_OBJECT_SHA},
+                )
+
+        self.assertNotIn("ghp_supersecret", str(raised.exception))
+        self.assertIn("<redacted>", str(raised.exception))
 
 
 if __name__ == "__main__":

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -316,7 +316,7 @@ jobs:
           if-no-files-found: error
           overwrite: false
 
-      - name: Atomically tag exact live main source
+      - name: Publish immutable tag from exact live main source
         if: steps.recheck.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -327,12 +327,12 @@ jobs:
           EVIDENCE_PATH="${{ steps.identity.outputs.evidence_path }}"
 
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "Omi Bot token not available; cannot atomically publish a candidate tag." >&2
+            echo "Omi Bot token not available; cannot publish a candidate tag." >&2
             exit 1
           fi
-          # `updateRefs` publishes the tag only when GitHub still observes
-          # main at CANDIDATE_SHA; its `beforeOid` check and tag creation are
-          # one server-side atomic transaction, not a cached-ref comparison.
+          # The publisher refetches GitHub's authoritative main immediately
+          # before the documented create-only ref request. A moved main or an
+          # existing tag fails without creating or rewriting a candidate ref.
           python3 .github/scripts/publish-desktop-candidate-tag.py \
             --repository "${{ github.repository }}" \
             --release-tag "$RELEASE_TAG" \


### PR DESCRIPTION
## Summary

- replace the unsupported GraphQL `updateRefs` no-op on `main` with GitHub's documented create-only REST tag-ref endpoint
- refetch GitHub's authoritative `heads/main` immediately before publication and fail before creating the tag ref if it no longer matches the identity-validated candidate SHA
- preserve the annotated tag's source-identity evidence and reject any existing candidate tag instead of rewriting it
- surface bounded GitHub API diagnostics, including request IDs, while redacting bearer and token-shaped credential material

## Root cause and immutable evidence

The publisher attempted to use an unchanged `mainBefore == mainAfter` update as a precondition in a multi-ref GraphQL transaction. GitHub rejected that no-op server-side, so the evidence-bearing tag object remained unreachable and the candidate tag was never created.

- failed planner/tag run: https://github.com/BasedHardware/omi/actions/runs/30180632104
- immutable source-identity artifact: https://github.com/BasedHardware/omi/actions/runs/30180632104/artifacts/8625475335
- artifact SHA-256: `5c03c680a027cebc30b924097b6a528851ac679613dc1460d4a5213502106319`
- independent read-only reproduction request ID: `A50A:19CD13:59A7ACA:139D4E77:6A655193`
- separately failed planner run: https://github.com/BasedHardware/omi/actions/runs/30180787122

## Safety

- Beta-only candidate publication controls changed; Stable, Beta pointers, production, and promotion workflows are untouched
- no tag, Codemagic dispatch, candidate build, release pointer, or deployment was created or mutated during this repair
- native tag-triggered Codemagic behavior, exact-SHA planner identity, one-candidate gating, M1-only qualification, and evidence-gated promotion remain unchanged

## Verification

- `python3 .github/scripts/test_publish_desktop_candidate_tag.py` — 4 passed
- `python3 .github/scripts/test_desktop_release_source_identity.py` — 8 passed
- `python3 .github/scripts/test_plan_desktop_release.py` — 14 passed
- `actionlint -config-file .github/actionlint.yaml .github/workflows/desktop_auto_release.yml` — passed
- real read-only `live_main_sha("BasedHardware/omi")` call matched `git ls-remote origin refs/heads/main`
- `git diff --check` — passed
- `OMI_PR_BODY_FILE=./pr-body.md make preflight` — 64 selected checks passed

## Product invariants affected

None.

Failure-Class: FC-release-build-config-source-binding


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

