### PR TITLE
SCA-140: extend planner exact-SHA check wait

### DIFF
--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -20,7 +20,10 @@ REQUIRED_SOURCE_CHECK_NAMES = (
     "Desktop Swift Release Compile",
 )
 RECENT_TAG_WITHOUT_CHECK_SECONDS = 10 * 60
-SOURCE_CHECK_WAIT_SECONDS = 12 * 60
+# The exact-SHA aggregate can complete after the former 12-minute boundary on
+# a healthy run. Give the normal 20-minute CI budget time to settle while
+# retaining a bounded, fail-closed source-check gate.
+SOURCE_CHECK_WAIT_SECONDS = 20 * 60
 SOURCE_CHECK_POLL_SECONDS = 30
 MAX_SOURCE_STATUS_POLLS = 20
 # Short debounce so a merge is tagged within ~a minute instead of waiting ten.

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -246,6 +246,43 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertIn("timed out after 20s", gate.reason or "")
         sleep.assert_called_once_with(10)
 
+    def test_extended_wait_admits_observed_late_exact_sha_success(self) -> None:
+        # Run 30179919353 timed out at the former 12-minute boundary, then its
+        # final exact-SHA aggregate completed successfully 5m40s later. Model
+        # that state transition through the production polling seam: a failed
+        # check would still return "blocked" immediately (covered above).
+        observed_success_after_seconds = 12 * 60 + 5 * 60 + 40
+        elapsed_seconds = 0
+
+        def monotonic() -> int:
+            return elapsed_seconds
+
+        def sleep(seconds: int) -> None:
+            nonlocal elapsed_seconds
+            elapsed_seconds += seconds
+
+        def source_checks(_repository: str, _sha: str) -> planner.SourceCheckGate:
+            if elapsed_seconds >= observed_success_after_seconds:
+                return planner.SourceCheckGate("ready")
+            return planner.SourceCheckGate("waiting", "Desktop Swift Build & Tests is in_progress")
+
+        with (
+            patch.object(planner, "required_source_checks_gate", side_effect=source_checks),
+            patch.object(planner.time, "monotonic", side_effect=monotonic),
+            patch.object(planner.time, "sleep", side_effect=sleep) as poll,
+        ):
+            gate = planner.wait_for_required_source_checks(
+                REPOSITORY,
+                SOURCE_SHA,
+                wait_seconds=planner.SOURCE_CHECK_WAIT_SECONDS,
+                poll_seconds=planner.SOURCE_CHECK_POLL_SECONDS,
+            )
+
+        self.assertEqual(gate.state, "ready")
+        self.assertGreater(elapsed_seconds, observed_success_after_seconds)
+        self.assertLess(elapsed_seconds, planner.SOURCE_CHECK_WAIT_SECONDS)
+        self.assertEqual(poll.call_args_list[-1].args, (planner.SOURCE_CHECK_POLL_SECONDS,))
+
     def test_existing_exact_source_tag_preserves_active_or_published_candidate(self) -> None:
         for lifecycle in ("active", "published"):
             with self.subTest(lifecycle=lifecycle):
@@ -359,7 +396,8 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertNotIn("break_glass", workflow)
         self.assertIn("source_sha: ${{ steps.plan.outputs.source_sha }}", workflow)
         self.assertIn("ref: ${{ steps.recheck.outputs.source_sha }}", workflow)
-        self.assertEqual(workflow.count("--source-check-wait-seconds 720"), 2)
+        self.assertEqual(planner.SOURCE_CHECK_WAIT_SECONDS, 20 * 60)
+        self.assertEqual(workflow.count("--source-check-wait-seconds 1200"), 2)
         self.assertEqual(workflow.count("--source-check-poll-seconds 30"), 2)
         self.assertLess(
             workflow.index("Create and regular-merge PR to sync changelog back to main"),

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           python3 .github/scripts/plan-desktop-release.py \
             --repository "${{ github.repository }}" \
-            --source-check-wait-seconds 720 \
+            --source-check-wait-seconds 1200 \
             --source-check-poll-seconds 30
 
       - name: Show release plan
@@ -114,7 +114,7 @@ jobs:
 
           python3 .github/scripts/plan-desktop-release.py \
             --repository "${{ github.repository }}" \
-            --source-check-wait-seconds 720 \
+            --source-check-wait-seconds 1200 \
             --source-check-poll-seconds 30
 
       - name: Checkout exact releasable desktop source


### PR DESCRIPTION
## Summary

- Extends both desktop planner exact-SHA check waits from 12 to 20 minutes.
- Preserves fail-closed behavior for missing, non-success, and identity-mismatched source checks.
- Covers the healthy aggregate success observed 5m40s after the former timeout boundary.

## Failure class

Failure-Class: FC-gate-timeout-below-cold-cost

## Verification

- `python3 .github/scripts/test_plan_desktop_release.py` — 15 tests passed.
- `make preflight` — passed with this PR body.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

