### PR TITLE
fix(desktop): keep the thinking signature when continuing a paused turn

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/chat/streaming.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/streaming.rs
@@ -69,6 +69,16 @@ impl StreamedContentBlocks {
                     append_string_field(block, "thinking", thinking);
                 }
             }
+            // The signature is what makes a replayed thinking block valid. A
+            // pause_turn continuation resends this assistant turn to Anthropic,
+            // and a thinking block whose signature is missing or truncated is
+            // rejected upstream — dropping it here would fail the very turn the
+            // continuation exists to finish.
+            Some("signature_delta") => {
+                if let Some(signature) = delta.get("signature").and_then(Value::as_str) {
+                    append_string_field(block, "signature", signature);
+                }
+            }
             Some("input_json_delta") => {
                 if let Some(partial_json) = delta.get("partial_json").and_then(Value::as_str) {
                     self.input_json

--- a/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
@@ -1103,6 +1103,50 @@ fn test_pause_turn_stream_accumulator_preserves_raw_content_for_continuation() {
     );
 }
 
+/// Regression: a thinking block replayed on a `pause_turn` continuation must carry the
+/// signature Anthropic streamed for it. The accumulator handled `text_delta`,
+/// `thinking_delta` and `input_json_delta` but dropped `signature_delta`, so an adaptive
+/// (typed-chat) turn that paused mid web search was resent with an unsigned thinking block
+/// and rejected upstream — the user saw the partial answer end in an "Upstream provider
+/// error" instead of the searched answer.
+#[test]
+fn test_pause_turn_stream_accumulator_preserves_thinking_signature() {
+    let mut blocks = StreamedContentBlocks::default();
+    blocks.start_block(0, json!({"type": "thinking", "thinking": ""}));
+    blocks.append_delta(0, &json!({"type": "thinking_delta", "thinking": "Check "}));
+    blocks.append_delta(0, &json!({"type": "thinking_delta", "thinking": "the web"}));
+    blocks.append_delta(0, &json!({"type": "signature_delta", "signature": "ErrU"}));
+    blocks.append_delta(0, &json!({"type": "signature_delta", "signature": "hd8="}));
+    blocks.stop_block(0);
+    blocks.start_block(
+        1,
+        json!({
+            "type": "server_tool_use",
+            "id": "srvtoolu_123",
+            "name": "web_search",
+            "input": {}
+        }),
+    );
+    blocks.append_delta(
+        1,
+        &json!({"type": "input_json_delta", "partial_json": "{\"query\":\"NYC weather\"}"}),
+    );
+    blocks.stop_block(1);
+
+    assert_eq!(
+        blocks.into_value(),
+        json!([
+            {"type": "thinking", "thinking": "Check the web", "signature": "ErrUhd8="},
+            {
+                "type": "server_tool_use",
+                "id": "srvtoolu_123",
+                "name": "web_search",
+                "input": {"query": "NYC weather"}
+            }
+        ])
+    );
+}
+
 #[test]
 fn test_pause_turn_continuation_preserves_raw_assistant_content_and_tools() {
     let req = test_request(vec![user_message(


### PR DESCRIPTION
## What changed and why

`pause_turn` continuations rebuild the paused assistant turn from the streamed
content blocks and resend it to Anthropic. The rebuilder (`StreamedContentBlocks`,
added with the web-search streaming change #10537) handled `text_delta`,
`thinking_delta` and `input_json_delta` but ignored `signature_delta`, so a
thinking block was replayed **unsigned** — and Anthropic rejects an unsigned
thinking block.

Typed chat is exactly where both halves meet:

- adaptive thinking is enabled for the first model call of a user turn
  (`use_adaptive_thinking`, `request_translation.rs`), and
- the server-side `web_search` tool is exposed whenever the client sends tools
  (`inject_web_search`).

So a typed-chat turn that paused mid web search failed its own continuation:
`complete_anthropic_server_tool_turn` returned `Err`, and the user saw the
partial answer end in `"Upstream provider error"` instead of the searched
answer — the failure mode #10537 exists to remove. The same file already
documents this class one function up: *"a thinking-enabled request whose
assistant tool_use turn lacks its thinking block is rejected upstream."*

The fix is the missing arm: capture `signature_delta` into the rebuilt block,
via the same `append_string_field` helper the other text-bearing deltas use
(signatures may arrive across several deltas, so it appends).

No changelog fragment: #10537 has not shipped in a release yet
(`desktop/macos/changelog/unreleased/20260725-web-search-streaming.json` is
still unreleased), so this repairs an unreleased change rather than adding a
user-visible line of its own.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

## How it was verified

- `cargo test` — **378 passed**, 0 failed.
- The new regression test
  `test_pause_turn_stream_accumulator_preserves_thinking_signature` **fails on
  the pre-fix accumulator** (`git stash` of `streaming.rs` only) with the
  signature absent from the rebuilt block, and passes with the fix:
  ```
  left:  [{"thinking":"Check the web","type":"thinking"}, ...]
  right: [{"signature":"ErrUhd8=","thinking":"Check the web","type":"thinking"}, ...]
  ```
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean.
- `make preflight` green.

**Not reproduced end to end against live Anthropic:** `pause_turn` is upstream's
choice and cannot be forced, and `ANTHROPIC_API_URL` is a `const` with no test
seam, so the continuation request body was verified through the production
accumulator that builds it, not over the wire.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

