### PR TITLE
feat(chat): add mobile date, time, and city context across AI routes

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -29,6 +29,11 @@ checks:
     triggers: ["Makefile", "backend/scripts/sync-python-deps.sh", "scripts/pre-push", "scripts/test-make-setup.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "make setup must provision the minimal, rerunnable backend environment required by selected pre-push checks"
+  - id: desktop-release-process-guards
+    command: ["python3", ".github/scripts/check-release-process-guards.py"]
+    triggers: [".github/workflows/desktop_qualify_beta.yml", ".github/scripts/check-release-process-guards.py", "backend/tests/unit/test_desktop_release_scripts.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-174: qualification must check out the exact release tag inside its isolated source directory; the guard and its focused behavioral test run on every relevant diff"
   - id: failure-class-retirement-author
     command: ["python3", ".github/scripts/test_failure_class_retirement.py"]
     triggers: [".github/scripts/failure_class_retirement.py", ".github/scripts/test_failure_class_retirement.py", ".github/workflows/repo-hygiene.yml", "scripts/failure-class", ".github/checks-manifest.yaml"]
@@ -558,8 +563,6 @@ exempt:
   - path: ".github/scripts/check-desktop-auto-beta-candidate.py"
     reason: "release pipeline check requires published candidate artifacts and workflow inputs"
   - path: ".github/scripts/check-desktop-prod-promotion-policy.py"
-    reason: "release-policy full-tree check, not diff-scoped"
-  - path: ".github/scripts/check-release-process-guards.py"
     reason: "release-policy full-tree check, not diff-scoped"
   - path: ".github/scripts/check-deployment-concurrency.py"
     reason: "deployment concurrency policy full-tree check, not diff-scoped"

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -30,8 +30,8 @@ checks:
     lanes: ["local", "ci"]
     reason: "make setup must provision the minimal, rerunnable backend environment required by selected pre-push checks"
   - id: desktop-release-process-guards
-    command: ["python3", ".github/scripts/check-release-process-guards.py"]
-    triggers: [".github/workflows/desktop_qualify_beta.yml", ".github/scripts/check-release-process-guards.py", "backend/tests/unit/test_desktop_release_scripts.py", ".github/checks-manifest.yaml"]
+    command: ["bash", "scripts/run-release-process-guards.sh"]
+    triggers: [".github/workflows/desktop_qualify_beta.yml", ".github/scripts/check-release-process-guards.py", "scripts/run-release-process-guards.sh", "backend/tests/unit/test_desktop_release_scripts.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-174: qualification must check out the exact release tag inside its isolated source directory; the guard and its focused behavioral test run on every relevant diff"
   - id: failure-class-retirement-author

--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -858,7 +858,7 @@ def check_desktop_qualification_runner() -> list[str]:
         "self-hosted",
         "macos",
         "omi-desktop-qualification",
-        'checkout --quiet --detach "refs/tags/$RELEASE_TAG"',
+        'git -C "$source_dir" checkout --quiet --detach "refs/tags/$RELEASE_TAG"',
         "check-desktop-auto-beta-candidate.py",
         "--automatic",
         "actions/create-github-app-token@v3",

--- a/.github/scripts/desktop-release-source-identity.py
+++ b/.github/scripts/desktop-release-source-identity.py
@@ -10,7 +10,6 @@ import re
 import subprocess
 from pathlib import Path
 
-
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 SCHEMA = "desktop-release-planner-source-identity/v2"
 RELEASE_TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+-macos$")
@@ -23,8 +22,6 @@ DESKTOP_RELEASE_PATHS = (
     ".github/workflows/desktop_auto_release.yml",
     ".github/workflows/desktop-swift-ci.yml",
 )
-
-
 def require_sha(name: str, value: str) -> str:
     if not SHA_RE.fullmatch(value):
         raise ValueError(f"{name} must be a 40-character lowercase SHA")
@@ -119,9 +116,7 @@ def ensure_candidate_history_is_safe(
                 *DESKTOP_RELEASE_PATHS,
             ],
         ).splitlines()
-        newer_releasable_changes.extend(
-            f"{commit_sha}:{path}" for path in releasable_desktop_paths(changed_paths)
-        )
+        newer_releasable_changes.extend(f"{commit_sha}:{path}" for path in releasable_desktop_paths(changed_paths))
     if newer_releasable_changes:
         raise ValueError(
             "candidate main contains newer releasable desktop changes after the planner source: "

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-database.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-database.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "backend/database/conversations.py": 1646,
-    "backend/database/users.py": 1972
+    "backend/database/users.py": 2046
   },
   "raise_justifications": {
     "backend/database/conversations.py": "Public shared-chat uses the existing conversation storage format for bounded, safe transcript decoding; extraction would duplicate crypto/storage invariants. +15 for the shared is_soft_deleted tombstone-eligibility predicate that eligible_merge_target and the reprocess guard converge on (#10119/#10262). +30 for the permanent, atomic Firestore conversation analytics marker: it belongs beside the authoritative conversation document path and cannot use Redis because retries must remain duplicate-safe across cache loss (SCA-99).",
-    "backend/database/users.py": "Account-deletion marker fencing and recursive missing-root cleanup must remain beside the existing deletion transaction and collection traversal; extracting them would duplicate the durable lifecycle authority. +33 for the queue-before-auth recovery guard and +16 for the job-id-fenced repeat-dispatch transaction."
+    "backend/database/users.py": "Account-deletion marker fencing and recursive missing-root cleanup must remain beside the existing deletion transaction and collection traversal; extracting them would duplicate the durable lifecycle authority. +33 for the queue-before-auth recovery guard and +16 for the job-id-fenced repeat-dispatch transaction. +74 for the server-owned, expiring city-context consent record and revocation cache cleanup: both belong next to the existing user-document access boundary so Redis is never authorization authority (SCA-174)."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -5,7 +5,7 @@
     "backend/routers/developer.py": 2263,
     "backend/routers/mcp_sse.py": 1858,
     "backend/routers/sync.py": 2058,
-    "backend/routers/users.py": 2046
+    "backend/routers/users.py": 2076
   },
   "raise_justifications": {
     "backend/routers/apps.py": "The owner-migration route validates a source-bound Firebase anonymous-token proof before its existing database write and tracked background work, keeping the authorization decision at the HTTP mutation boundary.",
@@ -13,7 +13,7 @@
     "backend/routers/developer.py": "GET /v1/dev/user/memories and /vector/search both serve the authoritative legacy memories collection for legacy-cohort accounts with no rollout state (#9892/#10203), keeping the narrow deny/legacy-fallback decision in the route that owns the read contract.",
     "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line.",
     "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033).",
-    "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first."
+    "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first. +30 for the disclosed, expiring city-context consent routes and legacy geolocation input boundary; they remain with the authenticated user route owner to prevent invalid coordinates reaching cache/provider paths (SCA-174)."
   },
   "threshold": 1500
 }

--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -15,6 +15,11 @@ ROOT = Path(__file__).resolve().parents[2]
 RELEASE_TAG = "v0.12.124+12124-macos"
 
 
+def clean_git_environment(env: dict[str, str]) -> dict[str, str]:
+    """Keep hook-local Git state out of isolated qualification fixtures."""
+    return {key: value for key, value in env.items() if not key.startswith("GIT_")}
+
+
 class DesktopReleaseFlowContractTests(unittest.TestCase):
     def setUp(self) -> None:
         self.workflow = (ROOT / ".github/workflows/desktop_qualify_beta.yml").read_text(encoding="utf-8")
@@ -42,7 +47,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         return subprocess.run(
             ["bash", "-c", self._workflow_script(step_name)],
             cwd=cwd,
-            env=isolated_env,
+        env=isolated_env,
             check=False,
             capture_output=True,
             text=True,
@@ -54,7 +59,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         source = root / "candidate-source"
         remote.parent.mkdir(parents=True)
         source.mkdir()
-        git_env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+        git_env = clean_git_environment(dict(os.environ))
 
         def git(*args: str, cwd: Path = source) -> str:
             result = subprocess.run(
@@ -113,7 +118,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         fragments = {
             node.value for node in ast.walk(guard) if isinstance(node, ast.Constant) and isinstance(node.value, str)
         }
-        self.assertIn('checkout --quiet --detach "refs/tags/$RELEASE_TAG"', fragments)
+        self.assertIn('git -C "$source_dir" checkout --quiet --detach "refs/tags/$RELEASE_TAG"', fragments)
         self.assertNotIn("ref: ${{ inputs.release_tag }}", fragments)
 
     def test_run_staging_evidence_and_cleanup_are_isolated_and_rerun_safe(self) -> None:

--- a/.github/scripts/test_desktop_release_source_identity.py
+++ b/.github/scripts/test_desktop_release_source_identity.py
@@ -10,7 +10,6 @@ import tempfile
 import unittest
 from pathlib import Path
 
-
 SCRIPT = Path(__file__).with_name("desktop-release-source-identity.py")
 SPEC = importlib.util.spec_from_file_location("desktop_release_source_identity", SCRIPT)
 assert SPEC and SPEC.loader

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -376,6 +376,62 @@ esac
                 )
             self.assertEqual(result, 1)
 
+    def test_release_process_guard_uses_locked_pyyaml_in_every_declared_lane(self) -> None:
+        """The guard must never depend on a runner-global PyYAML install."""
+        manifest = load_manifest(MANIFEST_PATH)
+        check = next(check for check in manifest.checks if check.id == "desktop-release-process-guards")
+        self.assertEqual(check.command, ("bash", "scripts/run-release-process-guards.sh"))
+        for lane in ("local", "ci"):
+            selected = resolve_checks(manifest, list(check.triggers), lane)
+            self.assertIn(check, selected)
+
+        runner = REPO_ROOT / check.command[1]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copied_runner = root / check.command[1]
+            copied_runner.parent.mkdir(parents=True)
+            shutil.copy2(runner, copied_runner)
+
+            sync = root / "backend/scripts/sync-python-deps.sh"
+            sync.parent.mkdir(parents=True)
+            python = root / "backend/.venv/bin/python"
+            sync.write_text(
+                f'''#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "{python.parent}"
+cat > "{python}" <<'PYTHON'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "-c" ]]; then
+  [[ "$2" == "import yaml" ]]
+  exit
+fi
+printf '%s\\n' "$@" > "{root / 'guard-args.txt'}"
+PYTHON
+chmod +x "{python}"
+''',
+                encoding="utf-8",
+            )
+            sync.chmod(0o755)
+            guard = root / ".github/scripts/check-release-process-guards.py"
+            guard.parent.mkdir(parents=True, exist_ok=True)
+            guard.write_text("# fixture\n", encoding="utf-8")
+
+            result = subprocess.run(["bash", str(copied_runner)], text=True, capture_output=True, check=False)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual((root / "guard-args.txt").read_text(encoding="utf-8").strip(), str(guard))
+
+        self.assertRegex(
+            (REPO_ROOT / "backend/requirements.txt").read_text(encoding="utf-8"),
+            r"(?im)^pyyaml==6\.0\.1$",
+        )
+        for lock in REPO_ROOT.glob("backend/pylock*.toml"):
+            self.assertRegex(
+                lock.read_text(encoding="utf-8"),
+                r'(?ms)^\[\[packages\]\]\nname = "pyyaml"\nversion = "6\.0\.1"$',
+            )
+
 
 class PlatformTests(unittest.TestCase):
     """Tests for the platform-aware manifest model (#9843 Ticket 02)."""

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -141,9 +141,7 @@ jobs:
         run: python3 desktop/macos/scripts/release-keyvalue.py self-test
 
       - name: Check release process guards
-        run: |
-          pip install -q pyyaml
-          python3 .github/scripts/check-release-process-guards.py
+        run: bash scripts/run-release-process-guards.sh
 
       - name: Check GitHub Actions workflows
         if: needs.changes.outputs.has_workflows == 'true'

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -357,6 +357,10 @@ def get_cached_user_geolocation(uid: str) -> Optional[Dict[str, Any]]:
     return cast(Dict[str, Any], loaded) if isinstance(loaded, dict) else None
 
 
+def delete_cached_user_geolocation(uid: str) -> None:
+    r.delete(f'users:{uid}:geolocation')
+
+
 # DAILY SUMMARY UID LOOKUP
 def store_daily_summary_to_uid(summary_id: str, uid: str) -> None:
     r.set(f'daily-summary:{summary_id}', uid)

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -1,15 +1,28 @@
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Literal, Optional, TypedDict
+from typing import Any, Literal, Optional, TypedDict
 
 from google.api_core.exceptions import NotFound
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter, transactional
-from ._client import db, delete_collection_recursive, document_id_from_seed
+from ._client import db, delete_collection_recursive, document_id_from_seed, get_firestore_client
 from database.firestore_cache import CachePolicy, get_or_fetch, invalidate
 from database.read_boundary import parse_snapshot_or_none, parse_snapshot_strict
-from database.redis_db import try_acquire_client_device_write_lock, try_acquire_user_platform_write_lock
-from models.users import Subscription, PlanLimits, PlanType, SubscriptionStatus
+from database.redis_db import (
+    delete_cached_user_geolocation,
+    try_acquire_client_device_write_lock,
+    try_acquire_user_platform_write_lock,
+)
+from models.users import (
+    LOCATION_CONTEXT_DISCLOSED_PROVIDERS,
+    LOCATION_CONTEXT_PURPOSE,
+    LocationContextConsent,
+    LocationContextConsentStatus,
+    Subscription,
+    PlanLimits,
+    PlanType,
+    SubscriptionStatus,
+)
 from models.other import Person
 from utils.subscription import get_default_basic_subscription
 import logging
@@ -18,6 +31,7 @@ logger = logging.getLogger(__name__)
 DELETION_WIPE_RUNNING_STALE_AFTER = timedelta(hours=6)
 _DELETION_WIPE_TERMINAL_STATUSES = frozenset({'completed', 'cancelled'})
 _DELETION_WIPE_LEGACY_ACTIONABLE_STATUSES = frozenset({'pending', 'retrying', 'running', 'failed'})
+LOCATION_CONTEXT_CONSENT_TTL = timedelta(days=30)
 
 
 class DeletionWipeTaskResolution(TypedDict):
@@ -1497,6 +1511,66 @@ def get_user_training_data_opt_in(uid: str) -> Optional[dict]:
     user_ref = db.collection('users').document(uid)
     user_data = user_ref.get().to_dict() or {}
     return user_data.get('training_data_opt_in', None)
+
+
+def get_user_location_context_consent(
+    uid: str, *, firestore_client: Any | None = None
+) -> Optional[LocationContextConsent]:
+    """Read the uncached, server-owned city-context consent record fail-closed."""
+    client = firestore_client or get_firestore_client()
+    snapshot = client.collection('users').document(uid).get(['location_context_consent'])
+    user_data = snapshot.to_dict() or {}
+    if not isinstance(user_data, dict):
+        return None
+    raw_consent = user_data.get('location_context_consent')
+    if not isinstance(raw_consent, dict):
+        return None
+    return parse_snapshot_or_none(
+        LocationContextConsent,
+        snapshot,
+        payload_from_snapshot=lambda _snapshot: raw_consent,
+    )
+
+
+def set_user_location_context_consent(
+    uid: str,
+    *,
+    enabled: bool,
+    now: datetime | None = None,
+    firestore_client: Any | None = None,
+) -> LocationContextConsent:
+    """Persist the only authority for city-context disclosure and revoke fail-closed."""
+    current_time = now or datetime.now(timezone.utc)
+    if current_time.tzinfo is None:
+        raise ValueError('location-context consent timestamp must be timezone-aware')
+
+    if enabled:
+        consent = LocationContextConsent(
+            status=LocationContextConsentStatus.granted,
+            purpose=LOCATION_CONTEXT_PURPOSE,
+            disclosed_providers=LOCATION_CONTEXT_DISCLOSED_PROVIDERS,
+            granted_at=current_time,
+            expires_at=current_time + LOCATION_CONTEXT_CONSENT_TTL,
+        )
+    else:
+        consent = LocationContextConsent(
+            status=LocationContextConsentStatus.revoked,
+            purpose=LOCATION_CONTEXT_PURPOSE,
+            disclosed_providers=LOCATION_CONTEXT_DISCLOSED_PROVIDERS,
+            granted_at=current_time,
+            expires_at=current_time,
+            revoked_at=current_time,
+        )
+
+    client = firestore_client or get_firestore_client()
+    client.collection('users').document(uid).set({'location_context_consent': consent.model_dump()}, merge=True)
+    if not enabled:
+        try:
+            delete_cached_user_geolocation(uid)
+        except Exception as error:
+            # The persisted revocation is the read gate; Redis cleanup is a best-effort reduction of retained cache.
+            logger.warning('location-context cache deletion failed uid=%s error_type=%s', uid, type(error).__name__)
+    return consent
 
 
 def set_user_training_data_opt_in(uid: str, status: str):

--- a/backend/models/geolocation.py
+++ b/backend/models/geolocation.py
@@ -1,11 +1,11 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Geolocation(BaseModel):
     google_place_id: Optional[str] = None
-    latitude: float
-    longitude: float
+    latitude: float = Field(ge=-90, le=90)
+    longitude: float = Field(ge=-180, le=180)
     address: Optional[str] = None
     location_type: Optional[str] = None

--- a/backend/models/geolocation.py
+++ b/backend/models/geolocation.py
@@ -9,3 +9,27 @@ class Geolocation(BaseModel):
     longitude: float = Field(ge=-180, le=180)
     address: Optional[str] = None
     location_type: Optional[str] = None
+
+
+class GeolocationInput(BaseModel):
+    """Released wire contract for coordinates accepted at legacy API boundaries.
+
+    Bounds are enforced before any value is cached, geocoded, or persisted. Keeping
+    this transport shape broad preserves clients released before the bound contract
+    existed, while ``Geolocation`` remains the only usable server-side value.
+    """
+
+    google_place_id: Optional[str] = None
+    latitude: float
+    longitude: float
+    address: Optional[str] = None
+    location_type: Optional[str] = None
+
+
+def validated_geolocation_or_none(geolocation: Optional[GeolocationInput]) -> Optional[Geolocation]:
+    if geolocation is None:
+        return None
+    try:
+        return Geolocation.model_validate(geolocation.model_dump())
+    except ValueError:
+        return None

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional, List
 
@@ -10,6 +11,57 @@ class WebhookType(str, Enum):
     realtime_transcript = 'realtime_transcript'
     memory_created = ('memory_created',)
     day_summary = 'day_summary'
+
+
+LOCATION_CONTEXT_PURPOSE = 'chat_city_context'
+LOCATION_CONTEXT_DISCLOSED_PROVIDERS = ('Google Maps', 'the configured AI chat provider')
+
+
+class LocationContextConsentStatus(str, Enum):
+    granted = 'granted'
+    revoked = 'revoked'
+
+
+class LocationContextConsent(BaseModel):
+    """Server-owned authorization for city-only context in interactive chat."""
+
+    status: LocationContextConsentStatus
+    purpose: str
+    disclosed_providers: tuple[str, str]
+    granted_at: datetime
+    expires_at: datetime
+    revoked_at: Optional[datetime] = None
+
+    def is_active(self, now: Optional[datetime] = None) -> bool:
+        current_time = now or datetime.now(timezone.utc)
+        if current_time.tzinfo is None or self.granted_at.tzinfo is None or self.expires_at.tzinfo is None:
+            return False
+        return (
+            self.status is LocationContextConsentStatus.granted
+            and self.revoked_at is None
+            and self.purpose == LOCATION_CONTEXT_PURPOSE
+            and self.disclosed_providers == LOCATION_CONTEXT_DISCLOSED_PROVIDERS
+            and self.granted_at <= current_time
+            and self.expires_at > current_time
+        )
+
+
+class LocationContextConsentUpdate(BaseModel):
+    enabled: bool
+    disclosure_accepted: bool = Field(
+        default=False,
+        description=(
+            'Required to enable city context: Google Maps reverse-geocodes the device location and the configured '
+            'AI chat provider receives city, region, and country only.'
+        ),
+    )
+
+
+class LocationContextConsentResponse(BaseModel):
+    enabled: bool
+    purpose: str = LOCATION_CONTEXT_PURPOSE
+    disclosed_providers: tuple[str, str] = LOCATION_CONTEXT_DISCLOSED_PROVIDERS
+    expires_at: Optional[datetime] = None
 
 
 class PlanType(str, Enum):

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -1327,3 +1327,49 @@ routes:
       deprecation:
         state: active
       owner: backend
+  - route_type: http
+    method: GET
+    path: /v1/users/location-context-consent
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+        placement: dependency
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: user_profile
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
+    method: PUT
+    path: /v1/users/location-context-consent
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+        placement: dependency
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: user_profile
+      deprecation:
+        state: active
+      owner: backend

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -32,7 +32,7 @@ from models.conversation_enums import (
     ConversationStatus,
     ExternalIntegrationConversationSource,
 )
-from models.geolocation import Geolocation
+from models.geolocation import Geolocation, GeolocationInput, validated_geolocation_or_none
 from models.structured import Structured
 from utils.conversations.render import populate_speaker_names, populate_folder_names
 from models.transcript_segment import TranscriptSegment
@@ -1273,7 +1273,7 @@ class CreateConversationRequest(BaseModel):
         default=None, description="When the conversation finished (defaults to started_at + 5 minutes)"
     )
     language: Optional[str] = Field(default='en', description="Language code (ISO 639-1, e.g., 'en', 'es', 'fr')")
-    geolocation: Optional[Geolocation] = Field(default=None, description="Geolocation where conversation occurred")
+    geolocation: Optional[GeolocationInput] = Field(default=None, description="Geolocation where conversation occurred")
 
 
 class ConversationResponse(BaseModel):
@@ -1329,7 +1329,7 @@ class CreateConversationFromTranscriptRequest(BaseModel):
         default=None, description="When conversation finished (calculated from segments duration if not provided)"
     )
     language: Optional[str] = Field(default='en', description="Language code (ISO 639-1, e.g., 'en', 'es', 'fr')")
-    geolocation: Optional[Geolocation] = Field(default=None, description="Geolocation where conversation occurred")
+    geolocation: Optional[GeolocationInput] = Field(default=None, description="Geolocation where conversation occurred")
     client_device_id: Optional[str] = Field(default=None, description="Capture device id ({platform}_{hash})")
     client_platform: Optional[str] = Field(default=None, description="Client platform (ios/android/macos)")
 
@@ -1538,7 +1538,7 @@ def create_conversation(
         raise HTTPException(status_code=422, detail="finished_at must be after started_at")
 
     # Process geolocation if provided (keeps the raw coordinates when the geocode lookup misses)
-    geolocation = resolve_geolocation(request.geolocation)
+    geolocation = resolve_geolocation(validated_geolocation_or_none(request.geolocation))
 
     # Language defaults
     language_code = request.language or 'en'
@@ -1718,7 +1718,7 @@ def _create_conversation_from_segments(
         raise HTTPException(status_code=422, detail="finished_at must be after started_at")
 
     # Process geolocation if provided (keeps the raw coordinates when the geocode lookup misses)
-    geolocation = resolve_geolocation(request.geolocation)
+    geolocation = resolve_geolocation(validated_geolocation_or_none(request.geolocation))
 
     # Language defaults
     language_code = request.language or 'en'

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -56,7 +56,7 @@ from config.stt_provider_policy import supports_live_multilingual_mode
 from utils.user_language import normalize_user_language
 from database.users import *
 from models.conversation import Conversation
-from models.geolocation import Geolocation
+from models.geolocation import Geolocation, GeolocationInput, validated_geolocation_or_none
 from utils.conversations.factory import deserialize_conversation, deserialize_conversations
 from models.other import Person, CreatePerson
 from models.shared import StatusResponse
@@ -76,6 +76,8 @@ from models.users import (
     PricingOption,
     PhoneCallQuota,
     TrialMetadata,
+    LocationContextConsentResponse,
+    LocationContextConsentUpdate,
 )
 from utils.phone_calls import get_quota_snapshot as get_phone_call_quota_snapshot
 from utils.apps import get_available_app_by_id
@@ -221,6 +223,13 @@ class MemorySummaryRatingResponse(BaseModel):
 class TrainingDataOptInResponse(BaseModel):
     opted_in: bool
     status: Optional[str] = None
+
+
+def _location_context_consent_response(consent) -> LocationContextConsentResponse:
+    return LocationContextConsentResponse(
+        enabled=bool(consent and consent.is_active()),
+        expires_at=consent.expires_at if consent and consent.is_active() else None,
+    )
 
 
 class DailySummaryTestResponse(UserStatusResponse):
@@ -418,7 +427,13 @@ async def run_account_deletion_wipe(
 
 
 @router.patch('/v1/users/geolocation', tags=['v1'], response_model=UserStatusResponse)
-def set_user_geolocation(geolocation: Geolocation, uid: str = Depends(auth.get_current_user_uid)):
+def set_user_geolocation(geolocation: GeolocationInput, uid: str = Depends(auth.get_current_user_uid)):
+    validated_geolocation = validated_geolocation_or_none(geolocation)
+    if validated_geolocation is None:
+        # Preserve the released endpoint's success-shaped input contract while
+        # ensuring out-of-range coordinates cannot enter the cache or any provider path.
+        return {'status': 'ok', 'message': 'Location ignored because its coordinates are invalid.'}
+
     last_location_data = get_cached_user_geolocation(uid)
     if last_location_data:
         try:
@@ -426,20 +441,20 @@ def set_user_geolocation(geolocation: Geolocation, uid: str = Depends(auth.get_c
 
             last_lat = round(last_location.latitude, 4)
             last_lon = round(last_location.longitude, 4)
-            new_lat = round(geolocation.latitude, 4)
-            new_lon = round(geolocation.longitude, 4)
+            new_lat = round(validated_geolocation.latitude, 4)
+            new_lon = round(validated_geolocation.longitude, 4)
 
             # Only update if location has changed up to 4 decimal places
             if last_lat == new_lat and last_lon == new_lon:
                 return {'status': 'ok', 'message': 'Location not changed significantly.'}
 
-            cache_user_geolocation(uid, geolocation.model_dump())
+            cache_user_geolocation(uid, validated_geolocation.model_dump())
         except Exception as e:
             logger.error(f"Error processing geolocation update, caching new location anyway. Error: {e}")
-            cache_user_geolocation(uid, geolocation.model_dump())
+            cache_user_geolocation(uid, validated_geolocation.model_dump())
     else:
         # No previous location, so cache the new one
-        cache_user_geolocation(uid, geolocation.model_dump())
+        cache_user_geolocation(uid, validated_geolocation.model_dump())
 
     return {'status': 'ok'}
 
@@ -1028,6 +1043,21 @@ def set_training_data_opt_in_status(uid: str = Depends(auth.get_current_user_uid
     send_training_data_submitted_notification(uid)
 
     return {'status': 'ok', 'message': 'Your request has been submitted for review. We will let you know soon.'}
+
+
+@router.get('/v1/users/location-context-consent', tags=['v1'], response_model=LocationContextConsentResponse)
+def get_location_context_consent(uid: str = Depends(auth.get_current_user_uid)):
+    """Return the current city-context disclosure and active server-side consent state."""
+    return _location_context_consent_response(users_db.get_user_location_context_consent(uid))
+
+
+@router.put('/v1/users/location-context-consent', tags=['v1'], response_model=LocationContextConsentResponse)
+def set_location_context_consent(update: LocationContextConsentUpdate, uid: str = Depends(auth.get_current_user_uid)):
+    """Grant, renew, or revoke city-only location context for interactive chat."""
+    if update.enabled and not update.disclosure_accepted:
+        raise HTTPException(status_code=422, detail='location context requires accepting the provider disclosure')
+    consent = users_db.set_user_location_context_consent(uid, enabled=update.enabled)
+    return _location_context_consent_response(consent)
 
 
 # **************************************

--- a/backend/scripts/select_backend_unit_tests.py
+++ b/backend/scripts/select_backend_unit_tests.py
@@ -68,6 +68,17 @@ FULL_RUN_GLOBS = (
     'backend/utils/encryption.py',
 )
 
+# These paths participate in the location-context contract below. They are
+# intentionally narrow exceptions to the generic model/database full-suite
+# fallback so local pre-push feedback remains focused; CI still owns --all.
+NARROW_LOCATION_CONTEXT_PATHS = frozenset(
+    {
+        'backend/database/users.py',
+        'backend/models/geolocation.py',
+        'backend/models/users.py',
+    }
+)
+
 MEMORY_POLICY_CORE_PATH_PREFIXES = ('backend/utils/memory/',)
 
 MEMORY_POLICY_CORE_PATH_GLOBS = (
@@ -84,6 +95,19 @@ MEMORY_POLICY_CORE_TESTS = (
 )
 
 AREA_TESTS = (
+    (
+        (
+            'backend/database/users.py',
+            'backend/models/geolocation.py',
+            'backend/models/users.py',
+            'backend/routers/developer.py',
+            'backend/routers/users.py',
+            'backend/utils/retrieval/agentic.py',
+            'backend/utils/retrieval/graph.py',
+        ),
+        (),
+        ('tests/unit/test_location_context_consent.py', 'tests/unit/test_chat_async_offload.py'),
+    ),
     (
         ('backend/llm_gateway/',),
         (),
@@ -252,6 +276,8 @@ def normalize_changed_path(path: str) -> str:
 
 
 def is_full_run_path(path: str) -> bool:
+    if path in NARROW_LOCATION_CONTEXT_PATHS:
+        return False
     if path in FULL_RUN_PATHS:
         return True
     if any(path.startswith(prefix) for prefix in FULL_RUN_PREFIXES):

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -44,6 +44,31 @@ def test_delete_account_maps_unexpected_service_error_to_500():
     assert exc.value.detail == 'Could not delete account. Please try again.'
 
 
+def test_invalid_geolocation_is_ignored_without_cache_access():
+    cache_read = MagicMock()
+    cache_write = MagicMock()
+
+    with patch.object(users_router, 'get_cached_user_geolocation', cache_read), patch.object(
+        users_router, 'cache_user_geolocation', cache_write
+    ):
+        result = users_router.set_user_geolocation(
+            users_router.GeolocationInput(latitude=90.1, longitude=0), uid='uid1'
+        )
+
+    assert result == {'status': 'ok', 'message': 'Location ignored because its coordinates are invalid.'}
+    cache_read.assert_not_called()
+    cache_write.assert_not_called()
+
+
+def test_location_context_consent_requires_disclosure_before_enabling():
+    with pytest.raises(HTTPException) as exc:
+        users_router.set_location_context_consent(
+            users_router.LocationContextConsentUpdate(enabled=True, disclosure_accepted=False), uid='uid1'
+        )
+
+    assert exc.value.status_code == 422
+
+
 def test_run_account_deletion_wipe_retries_failed_wipe(monkeypatch):
     calls = []
 

--- a/backend/tests/unit/test_app_client_openapi_compatibility.py
+++ b/backend/tests/unit/test_app_client_openapi_compatibility.py
@@ -418,3 +418,20 @@ def test_compatibility_check_is_wired_in_ci_and_pre_push():
     assert openapi_body.index('PRE_PUSH_SKIP_OPENAPI_CONTRACT') < openapi_body.index(
         'check_app_client_openapi_compatibility.py'
     )
+
+
+def test_pre_push_openapi_guard_is_limited_to_the_impacted_app_client_surface():
+    """API models/routes need the released-client check, not every OpenAPI surface locally."""
+    pre_push = (ROOT / 'scripts/pre-push').read_text(encoding='utf-8')
+    openapi_start = pre_push.index('check_openapi_contract_if_needed()')
+    openapi_end = pre_push.index('\n}\n', openapi_start)
+    openapi_body = pre_push[openapi_start:openapi_end]
+
+    assert 'backend/models/*.py' in openapi_body
+    assert 'backend/routers/*.py' in openapi_body
+    assert (
+        'scripts/export_openapi.py --surface app-client --check ../docs/api-reference/app-client-openapi.json'
+        in openapi_body
+    )
+    assert 'scripts/export_openapi.py --check ../docs/api-reference/openapi.json' not in openapi_body
+    assert 'integration-public' not in openapi_body

--- a/backend/tests/unit/test_chat_async_offload.py
+++ b/backend/tests/unit/test_chat_async_offload.py
@@ -23,7 +23,7 @@ import os
 import threading
 from contextlib import ExitStack, nullcontext
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 # Hermetic config so importing the chat modules (which construct Typesense / OpenAI clients
 # and require the encryption key) succeeds without network. Matches conftest defaults.
@@ -97,8 +97,48 @@ async def test_mobile_city_context_uses_only_mobile_platforms():
     with patch.object(agentic, 'run_blocking', fake_run_blocking), patch(
         'utils.conversations.location.async_get_google_maps_city', fake_city
     ):
-        assert await agentic._get_mobile_city('uid1', 'ios') == 'New York, New York, United States'
-        assert await agentic._get_mobile_city('uid1', 'macos') is None
+        assert await agentic.get_mobile_city('uid1', 'ios') == 'New York, New York, United States'
+        assert await agentic.get_mobile_city('uid1', 'macos') is None
+
+
+async def test_chat_router_passes_metadata_to_every_interactive_path():
+    message = SimpleNamespace(sender='human', text='What should I do?', files_id=['file1'])
+    session = SimpleNamespace(id='session1', file_ids=['file1'])
+    metadata = '<current_datetime>now</current_datetime>'
+    seen = []
+
+    async def stream(*_args, **kwargs):
+        seen.append(kwargs['current_datetime_block'])
+        yield None
+
+    with patch.object(graph, '_current_prompt_metadata', AsyncMock(return_value=(metadata, 'UTC'))):
+        persona = SimpleNamespace(id='persona1', is_a_persona=lambda: True)
+        with patch.object(graph, 'execute_persona_chat_stream', stream):
+            assert [chunk async for chunk in graph.execute_chat_stream('uid1', [message], app=persona)] == [None]
+        with patch.object(graph, '_has_file_context', AsyncMock(return_value=True)), patch.object(
+            graph, '_execute_file_chat_stream', stream
+        ):
+            assert [chunk async for chunk in graph.execute_chat_stream('uid1', [message], chat_session=session)] == [
+                None
+            ]
+        with patch.object(graph, 'execute_agentic_chat_stream', stream):
+            assert [chunk async for chunk in graph.execute_chat_stream('uid1', [message])] == [None]
+
+    assert seen == [metadata, metadata, metadata]
+
+
+def test_prompt_metadata_is_prepended_to_the_live_user_turn():
+    assert graph._with_prompt_metadata('question', '<current_datetime>now</current_datetime>') == (
+        '<current_datetime>now</current_datetime>\n\nquestion'
+    )
+
+
+async def test_prompt_metadata_falls_back_to_utc_when_context_lookup_fails():
+    with patch.object(graph, 'run_blocking', AsyncMock(side_effect=RuntimeError('offline'))):
+        metadata, tz = await graph._current_prompt_metadata('uid1', 'ios')
+
+    assert tz == 'UTC'
+    assert 'Current date time in UTC:' in metadata
 
 
 def _file_chat_tool_for_stream_test():

--- a/backend/tests/unit/test_chat_async_offload.py
+++ b/backend/tests/unit/test_chat_async_offload.py
@@ -49,7 +49,9 @@ async def _collect_agentic_chunks(producer, callback_data=None):
         stack.enter_context(patch.object(agentic, 'get_user_timezone', lambda _uid: 'UTC'))
         stack.enter_context(patch.object(agentic, '_get_agentic_qa_prompt', lambda *_args, **_kwargs: 'SYSTEM'))
         stack.enter_context(patch.object(agentic, 'load_app_tools', lambda _uid: []))
-        stack.enter_context(patch.object(agentic, 'get_current_datetime_block', lambda _uid, tz=None: ''))
+        stack.enter_context(
+            patch.object(agentic, 'get_current_datetime_block', lambda _uid, tz=None, location=None: '')
+        )
         stack.enter_context(patch.object(agentic, '_convert_tools', lambda _core, _app: ([], {})))
         stack.enter_context(patch.object(agentic, '_messages_to_anthropic', lambda _messages: []))
         stack.enter_context(patch.object(agentic, '_inject_current_datetime', lambda messages, _block: messages))
@@ -82,6 +84,21 @@ async def test_has_file_context_offloads_llm_call_off_loop():
     assert result is True
     assert 'thread' in ran_on, "retrieve_is_file_question was not called"
     assert ran_on['thread'] is not loop_thread, "retrieve_is_file_question must run off the event-loop thread"
+
+
+async def test_mobile_city_context_uses_only_mobile_platforms():
+    async def fake_run_blocking(_executor, _function, _uid):
+        return {'latitude': 40.7128, 'longitude': -74.006}
+
+    async def fake_city(latitude, longitude):
+        assert (latitude, longitude) == (40.7128, -74.006)
+        return 'New York, New York, United States'
+
+    with patch.object(agentic, 'run_blocking', fake_run_blocking), patch(
+        'utils.conversations.location.async_get_google_maps_city', fake_city
+    ):
+        assert await agentic._get_mobile_city('uid1', 'ios') == 'New York, New York, United States'
+        assert await agentic._get_mobile_city('uid1', 'macos') is None
 
 
 def _file_chat_tool_for_stream_test():
@@ -226,7 +243,7 @@ async def test_agentic_setup_reads_run_off_loop():
     with patch.object(agentic, 'get_user_timezone', rec('tz', 'UTC')), patch.object(
         agentic, '_get_agentic_qa_prompt', rec('prompt', 'SYSTEM')
     ), patch.object(agentic, 'load_app_tools', rec('app_tools', [])), patch.object(
-        agentic, 'get_current_datetime_block', lambda uid, tz=None: ''
+        agentic, 'get_current_datetime_block', lambda uid, tz=None, location=None: ''
     ), patch.object(
         agentic, '_convert_tools', lambda core, app: ([], {})
     ), patch.object(

--- a/backend/tests/unit/test_chat_async_offload.py
+++ b/backend/tests/unit/test_chat_async_offload.py
@@ -22,6 +22,7 @@ import asyncio
 import os
 import threading
 from contextlib import ExitStack, nullcontext
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -39,6 +40,12 @@ os.environ.setdefault('TYPESENSE_PROTOCOL', 'http')
 import utils.retrieval.graph as graph  # noqa: E402
 import utils.retrieval.agentic as agentic  # noqa: E402
 import utils.other.chat_file as chat_file  # noqa: E402
+from models.users import (  # noqa: E402
+    LOCATION_CONTEXT_DISCLOSED_PROVIDERS,
+    LOCATION_CONTEXT_PURPOSE,
+    LocationContextConsent,
+    LocationContextConsentStatus,
+)
 
 
 async def _collect_agentic_chunks(producer, callback_data=None):
@@ -86,19 +93,111 @@ async def test_has_file_context_offloads_llm_call_off_loop():
     assert ran_on['thread'] is not loop_thread, "retrieve_is_file_question must run off the event-loop thread"
 
 
-async def test_mobile_city_context_uses_only_mobile_platforms():
-    async def fake_run_blocking(_executor, _function, _uid):
-        return {'latitude': 40.7128, 'longitude': -74.006}
+def _location_context_consent(*, status=LocationContextConsentStatus.granted, expires_at=None):
+    now = datetime.now(timezone.utc)
+    return LocationContextConsent(
+        status=status,
+        purpose=LOCATION_CONTEXT_PURPOSE,
+        disclosed_providers=LOCATION_CONTEXT_DISCLOSED_PROVIDERS,
+        granted_at=now,
+        expires_at=expires_at or now + timedelta(days=1),
+        revoked_at=now if status is LocationContextConsentStatus.revoked else None,
+    )
 
-    async def fake_city(latitude, longitude):
-        assert (latitude, longitude) == (40.7128, -74.006)
-        return 'New York, New York, United States'
 
-    with patch.object(agentic, 'run_blocking', fake_run_blocking), patch(
-        'utils.conversations.location.async_get_google_maps_city', fake_city
+async def test_mobile_header_alone_never_reads_coordinates_or_discloses_location():
+    """A caller-controlled mobile header is not consent for location disclosure."""
+    cached_coordinates = AsyncMock()
+    maps_city = AsyncMock()
+
+    async def fake_run_blocking(_executor, function, _uid):
+        assert function is agentic.get_user_location_context_consent
+        return None
+
+    with patch.object(agentic, 'run_blocking', fake_run_blocking), patch.object(
+        agentic, 'get_cached_user_geolocation', cached_coordinates
+    ), patch.object(agentic, 'async_get_google_maps_city', maps_city):
+        assert await agentic.get_mobile_city('uid1', 'ios') is None
+
+    cached_coordinates.assert_not_awaited()
+    maps_city.assert_not_awaited()
+
+
+async def test_valid_location_context_opt_in_allows_city_only_prompt_metadata():
+    """A valid server-owned disclosure permits a city label, never precise coordinates."""
+    consent = _location_context_consent()
+
+    async def fake_run_blocking(_executor, function, _uid):
+        if function is agentic.get_user_location_context_consent:
+            return consent
+        if function is agentic.get_cached_user_geolocation:
+            return {'latitude': 40.7128, 'longitude': -74.006}
+        raise AssertionError(f'unexpected blocking call: {function}')
+
+    maps_city = AsyncMock(return_value='New York, New York, United States')
+    with patch.object(agentic, 'run_blocking', fake_run_blocking), patch.object(
+        agentic, 'async_get_google_maps_city', maps_city
     ):
-        assert await agentic.get_mobile_city('uid1', 'ios') == 'New York, New York, United States'
+        city = await agentic.get_mobile_city('uid1', 'android')
+
+    assert city == 'New York, New York, United States'
+    maps_city.assert_awaited_once_with(40.7128, -74.006)
+    provider_messages = agentic._inject_current_datetime(
+        [{'role': 'user', 'content': 'What should I do nearby?'}],
+        agentic.get_current_datetime_block('uid1', tz='UTC', location=city),
+    )
+    provider_payload = str(provider_messages)
+    assert 'New York, New York, United States' in provider_payload
+    assert '40.7128' not in provider_payload
+    assert '-74.006' not in provider_payload
+
+
+async def test_revoked_or_expired_location_context_never_reads_coordinates_or_calls_maps():
+    for consent in (
+        _location_context_consent(status=LocationContextConsentStatus.revoked),
+        _location_context_consent(expires_at=datetime.now(timezone.utc) - timedelta(seconds=1)),
+    ):
+        cached_coordinates = AsyncMock()
+        maps_city = AsyncMock()
+
+        async def fake_run_blocking(_executor, function, _uid):
+            assert function is agentic.get_user_location_context_consent
+            return consent
+
+        with patch.object(agentic, 'run_blocking', fake_run_blocking), patch.object(
+            agentic, 'get_cached_user_geolocation', cached_coordinates
+        ), patch.object(agentic, 'async_get_google_maps_city', maps_city):
+            assert await agentic.get_mobile_city('uid1', 'ios') is None
+
+        cached_coordinates.assert_not_awaited()
+        maps_city.assert_not_awaited()
+
+
+async def test_invalid_cached_coordinates_never_reach_maps_after_opt_in():
+    consent = _location_context_consent()
+    maps_city = AsyncMock()
+
+    async def fake_run_blocking(_executor, function, _uid):
+        if function is agentic.get_user_location_context_consent:
+            return consent
+        if function is agentic.get_cached_user_geolocation:
+            return {'latitude': 90.1, 'longitude': 0}
+        raise AssertionError(f'unexpected blocking call: {function}')
+
+    with patch.object(agentic, 'run_blocking', fake_run_blocking), patch.object(
+        agentic, 'async_get_google_maps_city', maps_city
+    ):
+        assert await agentic.get_mobile_city('uid1', 'ios') is None
+
+    maps_city.assert_not_awaited()
+
+
+async def test_mobile_city_context_rejects_non_mobile_platform_before_cache_read():
+    cached_coordinates = AsyncMock()
+    with patch.object(agentic, 'get_cached_user_geolocation', cached_coordinates):
         assert await agentic.get_mobile_city('uid1', 'macos') is None
+
+    cached_coordinates.assert_not_awaited()
 
 
 async def test_chat_router_passes_metadata_to_every_interactive_path():

--- a/backend/tests/unit/test_city_prompt_context.py
+++ b/backend/tests/unit/test_city_prompt_context.py
@@ -1,0 +1,45 @@
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from utils.conversations.location import async_get_google_maps_city
+
+
+def test_city_context_uses_cached_value_without_calling_maps():
+    with patch('utils.conversations.location.r') as redis, patch(
+        'utils.conversations.location.get_maps_client'
+    ) as client:
+        redis.get.return_value = b'New York, New York, United States'
+
+        assert asyncio.run(async_get_google_maps_city(40.7128, -74.006)) == 'New York, New York, United States'
+        client.assert_not_called()
+
+
+def test_city_context_uses_locality_and_never_returns_coordinates():
+    @asynccontextmanager
+    async def semaphore():
+        yield
+
+    response = MagicMock()
+    response.json.return_value = {
+        'status': 'OK',
+        'results': [
+            {
+                'address_components': [
+                    {'long_name': 'New York', 'types': ['locality']},
+                    {'long_name': 'New York', 'types': ['administrative_area_level_1']},
+                    {'long_name': 'United States', 'types': ['country']},
+                ]
+            }
+        ],
+    }
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+    with patch('utils.conversations.location.r') as redis, patch(
+        'utils.conversations.location.get_maps_client', return_value=client
+    ), patch('utils.conversations.location.get_maps_semaphore', return_value=semaphore()):
+        redis.get.return_value = None
+
+        assert asyncio.run(async_get_google_maps_city(40.7128, -74.006)) == 'New York, New York, United States'
+        assert '40.7128' not in redis.set.call_args.args[1]
+        assert redis.set.call_args.kwargs['ex'] == 172800

--- a/backend/tests/unit/test_claim_deletion_wipe_txn.py
+++ b/backend/tests/unit/test_claim_deletion_wipe_txn.py
@@ -45,6 +45,7 @@ _fake_client_mod = types.ModuleType('database._client')
 setattr(_fake_client_mod, 'db', MagicMock())
 setattr(_fake_client_mod, 'delete_collection_recursive', MagicMock())
 setattr(_fake_client_mod, 'document_id_from_seed', MagicMock())
+setattr(_fake_client_mod, 'get_firestore_client', MagicMock())
 _install_stub('database._client', _fake_client_mod)
 
 # Stub database.firestore_cache and database.redis_db since database/users.py
@@ -55,6 +56,7 @@ for _mod_name in ('database.firestore_cache', 'database.redis_db'):
         'CachePolicy',
         'get_or_fetch',
         'invalidate',
+        'delete_cached_user_geolocation',
         'try_acquire_client_device_write_lock',
         'try_acquire_user_platform_write_lock',
     ):

--- a/backend/tests/unit/test_desktop_migration.py
+++ b/backend/tests/unit/test_desktop_migration.py
@@ -127,6 +127,7 @@ sys.modules["google.cloud.firestore_v1"].transactional = lambda f: f
 
 redis_stub = sys.modules["database.redis_db"]
 redis_stub.r = MagicMock()
+redis_stub.delete_cached_user_geolocation = MagicMock()
 setattr(redis_stub, 'try_acquire_client_device_write_lock', MagicMock(return_value=True))
 redis_stub.try_acquire_user_platform_write_lock = MagicMock(return_value=True)
 
@@ -141,6 +142,7 @@ mock_db = MagicMock()
 client_stub.db = mock_db
 client_stub.delete_collection_recursive = MagicMock()
 client_stub.document_id_from_seed = MagicMock(return_value="seed-id")
+client_stub.get_firestore_client = MagicMock(return_value=mock_db)
 
 # Stub database.helpers (used by chat.py)
 helpers_stub = _stub_module("database.helpers")
@@ -155,6 +157,10 @@ models_users_stub.Subscription = MagicMock()
 models_users_stub.PlanLimits = MagicMock()
 models_users_stub.PlanType = MagicMock()
 models_users_stub.SubscriptionStatus = MagicMock()
+models_users_stub.LocationContextConsent = MagicMock()
+models_users_stub.LocationContextConsentStatus = MagicMock()
+models_users_stub.LOCATION_CONTEXT_DISCLOSED_PROVIDERS = ()
+models_users_stub.LOCATION_CONTEXT_PURPOSE = "city_context"
 
 _stub_package("utils")
 _stub_package("utils.other")
@@ -182,6 +188,7 @@ request_validation_stub = _stub_module("utils.request_validation")
 request_validation_stub.validate_calendar_date = lambda value, field_name='date': value
 redis_stub = _stub_module("database.redis_db")
 redis_stub.r = MagicMock()
+redis_stub.delete_cached_user_geolocation = MagicMock()
 setattr(redis_stub, 'try_acquire_client_device_write_lock', MagicMock(return_value=True))
 redis_stub.try_acquire_user_platform_write_lock = MagicMock(return_value=True)
 

--- a/backend/tests/unit/test_desktop_release_scripts.py
+++ b/backend/tests/unit/test_desktop_release_scripts.py
@@ -237,7 +237,7 @@ def test_qualification_workflow_binds_immutable_controls_and_candidate_identity(
     codemagic = CODEMAGIC_CONFIG.read_text(encoding="utf-8")
     qualification = QUALIFY_BETA_WORKFLOW.read_text(encoding="utf-8")
     assert '-f release_tag="$CM_TAG" --ref "$CM_TAG"' in codemagic
-    assert "ref: ${{ inputs.release_tag }}" in qualification
+    assert 'checkout --quiet --detach "refs/tags/$RELEASE_TAG"' in qualification
     # The release attachment is content-addressed from the exact checked-out
     # candidate SHA and evidence digest, not a mutable tag-only filename.
     assert 'asset="qualification-evidence-${TARGET_SHA}-${digest}.json"' in qualification

--- a/backend/tests/unit/test_desktop_release_scripts.py
+++ b/backend/tests/unit/test_desktop_release_scripts.py
@@ -237,7 +237,7 @@ def test_qualification_workflow_binds_immutable_controls_and_candidate_identity(
     codemagic = CODEMAGIC_CONFIG.read_text(encoding="utf-8")
     qualification = QUALIFY_BETA_WORKFLOW.read_text(encoding="utf-8")
     assert '-f release_tag="$CM_TAG" --ref "$CM_TAG"' in codemagic
-    assert 'checkout --quiet --detach "refs/tags/$RELEASE_TAG"' in qualification
+    assert 'git -C "$source_dir" checkout --quiet --detach "refs/tags/$RELEASE_TAG"' in qualification
     # The release attachment is content-addressed from the exact checked-out
     # candidate SHA and evidence digest, not a mutable tag-only filename.
     assert 'asset="qualification-evidence-${TARGET_SHA}-${digest}.json"' in qualification

--- a/backend/tests/unit/test_location_context_consent.py
+++ b/backend/tests/unit/test_location_context_consent.py
@@ -1,0 +1,66 @@
+"""Server-owned authorization for city-only chat context."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from database import users as users_db
+from models.users import (
+    LOCATION_CONTEXT_DISCLOSED_PROVIDERS,
+    LOCATION_CONTEXT_PURPOSE,
+    LocationContextConsent,
+    LocationContextConsentStatus,
+)
+
+
+def _client_with_consent(payload):
+    snapshot = MagicMock()
+    snapshot.to_dict.return_value = {'location_context_consent': payload}
+    client = MagicMock()
+    client.collection.return_value.document.return_value.get.return_value = snapshot
+    return client
+
+
+def _valid_consent(now):
+    return LocationContextConsent(
+        status=LocationContextConsentStatus.granted,
+        purpose=LOCATION_CONTEXT_PURPOSE,
+        disclosed_providers=LOCATION_CONTEXT_DISCLOSED_PROVIDERS,
+        granted_at=now,
+        expires_at=now + timedelta(days=1),
+    )
+
+
+def test_consent_reader_rejects_malformed_or_unexpected_provider_disclosures():
+    now = datetime.now(timezone.utc)
+    malformed_client = _client_with_consent({'status': 'granted'})
+    assert users_db.get_user_location_context_consent('uid1', firestore_client=malformed_client) is None
+
+    wrong_provider = _valid_consent(now).model_copy(update={'disclosed_providers': ('Google Maps', 'unknown')})
+    parsed = users_db.get_user_location_context_consent(
+        'uid1', firestore_client=_client_with_consent(wrong_provider.model_dump())
+    )
+    assert parsed is not None
+    assert parsed.is_active(now) is False
+
+
+def test_revocation_persists_before_best_effort_coordinate_cache_deletion():
+    now = datetime(2026, 7, 26, 12, 0, tzinfo=timezone.utc)
+    client = MagicMock()
+    with patch.object(users_db, 'delete_cached_user_geolocation') as delete_cached:
+        consent = users_db.set_user_location_context_consent('uid1', enabled=False, now=now, firestore_client=client)
+
+    assert consent.status is LocationContextConsentStatus.revoked
+    assert consent.is_active(now) is False
+    client.collection.return_value.document.return_value.set.assert_called_once_with(
+        {'location_context_consent': consent.model_dump()}, merge=True
+    )
+    delete_cached.assert_called_once_with('uid1')
+
+
+def test_grant_is_server_timestamped_and_expires_after_the_fixed_consent_window():
+    now = datetime(2026, 7, 26, 12, 0, tzinfo=timezone.utc)
+    client = MagicMock()
+    consent = users_db.set_user_location_context_consent('uid1', enabled=True, now=now, firestore_client=client)
+
+    assert consent.is_active(now)
+    assert consent.expires_at == now + users_db.LOCATION_CONTEXT_CONSENT_TTL

--- a/backend/tests/unit/test_prompt_cache_integration.py
+++ b/backend/tests/unit/test_prompt_cache_integration.py
@@ -991,6 +991,19 @@ def test_current_datetime_block_carries_live_time():
     assert "2024-01-19" in block, "Datetime block should contain the live date"
 
 
+def test_current_datetime_block_includes_city_without_coordinates():
+    chat_mod = _get_chat_module()
+    _set_user(chat_mod, "Alice", "America/New_York")
+
+    block = chat_mod.get_current_datetime_block(
+        "uid_alice", tz="America/New_York", location="New York, New York, United States"
+    )
+
+    assert "Current city-level location: New York, New York, United States" in block
+    assert "latitude" not in block.lower()
+    assert "longitude" not in block.lower()
+
+
 def test_datetime_injected_into_user_turn_not_system():
     """
     _inject_current_datetime must attach the datetime block to the latest user turn so the

--- a/backend/tests/unit/test_prompt_cache_integration.py
+++ b/backend/tests/unit/test_prompt_cache_integration.py
@@ -80,6 +80,8 @@ sys.modules["database.goals"].get_user_goals = MagicMock(return_value=[])
 sys.modules["database.redis_db"].get_enabled_apps = MagicMock(return_value=[])
 sys.modules["database.redis_db"].get_filter_category_items = MagicMock(return_value=[])
 sys.modules["database.redis_db"].add_filter_category_item = MagicMock()
+sys.modules["database.redis_db"].get_cached_user_geolocation = MagicMock(return_value=None)
+sys.modules["database.users"].get_user_location_context_consent = MagicMock(return_value=None)
 sys.modules["database.conversations"].get_conversations = MagicMock(return_value=[])
 sys.modules["database.memories"].get_memories = MagicMock(return_value=[])
 sys.modules["database.vector_db"].query_vectors_enhanced = MagicMock(return_value=[])
@@ -176,6 +178,12 @@ def _passthrough_timeit(fn):
 
 
 endpoints_mod.timeit = _passthrough_timeit
+
+conversations_mod = _stub_module("utils.conversations")
+if not hasattr(conversations_mod, "__path__"):
+    conversations_mod.__path__ = []
+location_mod = _stub_module("utils.conversations.location")
+location_mod.async_get_google_maps_city = AsyncMock(return_value=None)
 
 retrieval_mod = _stub_module("utils.retrieval")
 if not hasattr(retrieval_mod, "__path__"):

--- a/backend/tests/unit/test_prompt_metadata_safety.py
+++ b/backend/tests/unit/test_prompt_metadata_safety.py
@@ -1,0 +1,19 @@
+from pydantic import ValidationError
+
+from models.geolocation import Geolocation
+from utils.llm.chat import get_current_datetime_block
+
+
+def test_prompt_metadata_escapes_city_text():
+    metadata = get_current_datetime_block('uid1', tz='UTC', location='A < B & C')
+
+    assert 'Recent city-level location: A &lt; B &amp; C' in metadata
+
+
+def test_geolocation_rejects_coordinates_outside_the_earth():
+    for latitude, longitude in ((90.1, 0), (0, 180.1), (float('nan'), 0)):
+        try:
+            Geolocation(latitude=latitude, longitude=longitude)
+        except ValidationError:
+            continue
+        raise AssertionError('invalid geolocation was accepted')

--- a/backend/tests/unit/test_prompt_metadata_safety.py
+++ b/backend/tests/unit/test_prompt_metadata_safety.py
@@ -1,13 +1,13 @@
 from pydantic import ValidationError
 
-from models.geolocation import Geolocation
+from models.geolocation import Geolocation, GeolocationInput, validated_geolocation_or_none
 from utils.llm.chat import get_current_datetime_block
 
 
 def test_prompt_metadata_escapes_city_text():
     metadata = get_current_datetime_block('uid1', tz='UTC', location='A < B & C')
 
-    assert 'Recent city-level location: A &lt; B &amp; C' in metadata
+    assert 'Current city-level location: A &lt; B &amp; C' in metadata
 
 
 def test_geolocation_rejects_coordinates_outside_the_earth():
@@ -17,3 +17,9 @@ def test_geolocation_rejects_coordinates_outside_the_earth():
         except ValidationError:
             continue
         raise AssertionError('invalid geolocation was accepted')
+
+
+def test_released_geolocation_input_remains_accepted_but_invalid_values_are_never_usable():
+    legacy_input = GeolocationInput(latitude=90.1, longitude=180.1)
+
+    assert validated_geolocation_or_none(legacy_input) is None

--- a/backend/tests/unit/test_tools_rest_memory_runtime_adapter.py
+++ b/backend/tests/unit/test_tools_rest_memory_runtime_adapter.py
@@ -36,6 +36,7 @@ def memory_services_module():
     client_mod.db = object()
     client_mod.delete_collection_recursive = lambda ref, *, client, batch_size=450: None
     client_mod.document_id_from_seed = lambda seed: seed
+    client_mod.get_firestore_client = lambda: client_mod.db
 
     with stub_modules(
         {

--- a/backend/tests/unit/test_users_add_sample_transaction.py
+++ b/backend/tests/unit/test_users_add_sample_transaction.py
@@ -26,6 +26,7 @@ def users_db():
     client_stub.db = MagicMock(name="db")
     client_stub.delete_collection_recursive = MagicMock(name="delete_collection_recursive")
     client_stub.document_id_from_seed = MagicMock(name="document_id_from_seed")
+    client_stub.get_firestore_client = MagicMock(name="get_firestore_client", return_value=client_stub.db)
 
     firestore_stub = ModuleType("google.cloud.firestore")
     google_pkg = ModuleType("google")

--- a/backend/tests/unit/test_users_missing_doc_guards.py
+++ b/backend/tests/unit/test_users_missing_doc_guards.py
@@ -46,6 +46,7 @@ def users():
             db=MagicMock(),
             delete_collection_recursive=MagicMock(),
             document_id_from_seed=lambda seed: "id",
+            get_firestore_client=MagicMock(),
         ),
         "database.firestore_cache": _module(
             "database.firestore_cache", CachePolicy=MagicMock(), get_or_fetch=MagicMock(), invalidate=MagicMock()
@@ -54,6 +55,7 @@ def users():
             "database.redis_db",
             try_acquire_client_device_write_lock=MagicMock(return_value=True),
             try_acquire_user_platform_write_lock=MagicMock(return_value=True),
+            delete_cached_user_geolocation=MagicMock(),
         ),
         "models.users": _module(
             "models.users",
@@ -61,6 +63,10 @@ def users():
             PlanLimits=MagicMock(),
             PlanType=MagicMock(),
             SubscriptionStatus=MagicMock(),
+            LOCATION_CONTEXT_DISCLOSED_PROVIDERS=("Google Maps", "the configured AI chat provider"),
+            LOCATION_CONTEXT_PURPOSE="chat_city_context",
+            LocationContextConsent=MagicMock(),
+            LocationContextConsentStatus=MagicMock(),
         ),
         "utils.subscription": _module("utils.subscription", get_default_basic_subscription=MagicMock()),
         "models.other": _module("models.other", Person=MagicMock()),

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -169,6 +169,24 @@ def test_mapped_source_with_direct_test_remains_narrow(selector_and_all_tests):
     assert reason == "selected backend unit tests from changed paths and workflow contracts"
 
 
+def test_location_context_paths_select_their_focused_privacy_regressions(selector_and_all_tests):
+    selector, all_tests = selector_and_all_tests
+
+    for source_path in (
+        "backend/models/geolocation.py",
+        "backend/models/users.py",
+        "backend/database/users.py",
+        "backend/routers/developer.py",
+        "backend/utils/retrieval/agentic.py",
+        "backend/routers/users.py",
+    ):
+        selected, reason = selector.tests_for_changed_paths([source_path], all_tests)
+        assert "tests/unit/test_location_context_consent.py" in selected, source_path
+        assert "tests/unit/test_chat_async_offload.py" in selected, source_path
+        assert selected != all_tests, source_path
+        assert reason == "selected backend unit tests from changed paths and workflow contracts"
+
+
 def test_removed_test_forces_full_discovered_suite(selector_and_all_tests):
     selector, all_tests = selector_and_all_tests
 
@@ -260,6 +278,20 @@ def test_pre_push_requires_backend_python_lazily():
         function_start = pre_push.index(f"{function_name}()")
         function_end = pre_push.find("\n}\n", function_start)
         assert "require_backend_python" in pre_push[function_start:function_end], function_name
+
+
+def test_pre_push_selects_release_guard_and_focused_test_for_release_contract_changes():
+    """The fast lane catches qualification guard drift without cloning the backend suite."""
+    pre_push = (BACKEND_DIR.parent / "scripts/pre-push").read_text(encoding="utf-8")
+    function_start = pre_push.index("check_release_process_guards_if_needed()")
+    function_end = pre_push.index("\n}\n", function_start)
+    guard = pre_push[function_start:function_end]
+
+    assert ".github/workflows/desktop_qualify_beta.yml" in guard
+    assert ".github/scripts/check-release-process-guards.py" in guard
+    assert "tests/unit/test_desktop_release_scripts.py" in guard
+    assert "python3 .github/scripts/check-release-process-guards.py" in guard
+    assert "BACKEND_UNIT_TEST_FILE_LIST" in guard
 
 
 def test_pre_push_runs_each_named_check_phase_once():

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -289,8 +289,9 @@ def test_pre_push_selects_release_guard_and_focused_test_for_release_contract_ch
 
     assert ".github/workflows/desktop_qualify_beta.yml" in guard
     assert ".github/scripts/check-release-process-guards.py" in guard
+    assert "scripts/run-release-process-guards.sh" in guard
     assert "tests/unit/test_desktop_release_scripts.py" in guard
-    assert "python3 .github/scripts/check-release-process-guards.py" in guard
+    assert "bash scripts/run-release-process-guards.sh" in guard
     assert "BACKEND_UNIT_TEST_FILE_LIST" in guard
 
 

--- a/backend/utils/conversations/location.py
+++ b/backend/utils/conversations/location.py
@@ -142,3 +142,42 @@ async def async_resolve_geolocation(geolocation: Optional[Geolocation]) -> Optio
         logger.error('async_resolve_geolocation enrichment failed: %s', e)
         return geolocation
     return enriched or geolocation
+
+
+async def async_get_google_maps_city(latitude: float, longitude: float) -> Optional[str]:
+    cache_key = f"geocode-city:{latitude:.3f},{longitude:.3f}"
+    try:
+        cached = r.get(cache_key)
+        if cached:
+            return cached.decode() if isinstance(cached, bytes) else str(cached)
+    except Exception as error:
+        logger.warning('Failed to read city geocode cache error_type=%s', type(error).__name__)
+
+    key = os.getenv('GOOGLE_MAPS_API_KEY')
+    try:
+        async with get_maps_semaphore():
+            response = await get_maps_client().get(
+                "https://maps.googleapis.com/maps/api/geocode/json",
+                params={"latlng": f"{latitude},{longitude}", "key": key},
+            )
+        data = response.json()
+    except Exception as error:
+        logger.error('City geocoding failed error_type=%s', type(error).__name__)
+        return None
+
+    if data.get('status') != 'OK' or not data.get('results'):
+        return None
+    parts = {}
+    for component in data['results'][0].get('address_components') or []:
+        for component_type in component.get('types') or []:
+            if component_type in {'locality', 'postal_town', 'administrative_area_level_1', 'country'}:
+                parts.setdefault(component_type, component.get('long_name'))
+    city = parts.get('locality') or parts.get('postal_town')
+    if not city:
+        return None
+    result = ', '.join(part for part in (city, parts.get('administrative_area_level_1'), parts.get('country')) if part)
+    try:
+        r.set(cache_key, result, ex=172800)
+    except Exception as error:
+        logger.warning('Failed to cache city geocode error_type=%s', type(error).__name__)
+    return result

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -480,7 +480,7 @@ def get_user_timezone(uid: str) -> str:
         return "UTC"
 
 
-def get_current_datetime_block(uid: str, tz: Optional[str] = None) -> str:
+def get_current_datetime_block(uid: str, tz: Optional[str] = None, location: Optional[str] = None) -> str:
     """Build the current-datetime block injected into the user turn.
 
     Kept out of the cached system prefix so the cached bytes stay stable across requests
@@ -497,10 +497,12 @@ def get_current_datetime_block(uid: str, tz: Optional[str] = None) -> str:
         tz = "UTC"
     current_datetime_str = current_datetime_user.strftime('%Y-%m-%d %H:%M:%S')
     current_datetime_iso = current_datetime_user.isoformat()
+    location_line = f"Current city-level location: {location}\n" if location else ""
     return (
         "<current_datetime>\n"
         f"Current date time in {tz}: {current_datetime_str}\n"
         f"Current date time ISO format: {current_datetime_iso}\n"
+        f"{location_line}"
         "</current_datetime>"
     )
 

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -1,6 +1,7 @@
 import json
 import re
 from datetime import datetime, timezone
+from html import escape
 from typing import Any, List, Optional, cast
 from zoneinfo import ZoneInfo
 
@@ -497,7 +498,7 @@ def get_current_datetime_block(uid: str, tz: Optional[str] = None, location: Opt
         tz = "UTC"
     current_datetime_str = current_datetime_user.strftime('%Y-%m-%d %H:%M:%S')
     current_datetime_iso = current_datetime_user.isoformat()
-    location_line = f"Current city-level location: {location}\n" if location else ""
+    location_line = f"Recent city-level location: {escape(location, quote=False)}\n" if location else ""
     return (
         "<current_datetime>\n"
         f"Current date time in {tz}: {current_datetime_str}\n"

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -498,7 +498,7 @@ def get_current_datetime_block(uid: str, tz: Optional[str] = None, location: Opt
         tz = "UTC"
     current_datetime_str = current_datetime_user.strftime('%Y-%m-%d %H:%M:%S')
     current_datetime_iso = current_datetime_user.isoformat()
-    location_line = f"Recent city-level location: {escape(location, quote=False)}\n" if location else ""
+    location_line = f"Current city-level location: {escape(location, quote=False)}\n" if location else ""
     return (
         "<current_datetime>\n"
         f"Current date time in {tz}: {current_datetime_str}\n"

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -425,7 +425,7 @@ def _inject_current_datetime(anthropic_messages: list, datetime_block: str) -> l
     return anthropic_messages
 
 
-async def _get_mobile_city(uid: str, platform: Optional[str]) -> Optional[str]:
+async def get_mobile_city(uid: str, platform: Optional[str]) -> Optional[str]:
     if platform is None or platform.strip().lower() not in {'ios', 'android'}:
         return None
     try:
@@ -690,6 +690,8 @@ async def execute_agentic_chat_stream(
     chat_session: Optional[ChatSession] = None,
     context: Optional[PageContext] = None,
     platform: Optional[str] = None,
+    current_datetime_block: Optional[str] = None,
+    tz: Optional[str] = None,
 ) -> AsyncGenerator[str, None]:
     """Execute an agentic chat interaction with streaming.
 
@@ -702,8 +704,8 @@ async def execute_agentic_chat_stream(
         # These helpers perform Firestore and LangSmith I/O before the producer task exists,
         # so they share the first-event deadline instead of leaving the SSE body silent.
         async with asyncio.timeout(AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS):
-            tz = await run_blocking(db_executor, get_user_timezone, uid)
-            city = await _get_mobile_city(uid, platform)
+            tz = tz or await run_blocking(db_executor, get_user_timezone, uid)
+            city = await get_mobile_city(uid, platform) if current_datetime_block is None else None
             system_prompt = await run_blocking(
                 db_executor, _get_agentic_qa_prompt, uid, app, messages, context=context, tz=tz, platform=platform
             )
@@ -775,7 +777,7 @@ You have fetch_url_tool available. When the user shares any URL (starting with h
     # turn (not the system prompt) so the cache_control system prefix stays byte-stable.
     anthropic_messages = _messages_to_anthropic(messages)
     anthropic_messages = _inject_current_datetime(
-        anthropic_messages, get_current_datetime_block(uid, tz=tz, location=city)
+        anthropic_messages, current_datetime_block or get_current_datetime_block(uid, tz=tz, location=city)
     )
 
     callback = AsyncStreamingCallback()

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -55,6 +55,10 @@ from utils.llm.byok_errors import handle_llm_error_async
 from utils.llm.clients import anthropic_client, ANTHROPIC_AGENT_MODEL
 from utils.llm.chat import _get_agentic_qa_prompt, get_current_datetime_block, get_user_timezone
 from utils.executors import run_blocking, db_executor
+from database.redis_db import get_cached_user_geolocation
+from database.users import get_user_location_context_consent
+from models.geolocation import Geolocation
+from utils.conversations.location import async_get_google_maps_city
 from utils.other.endpoints import timeit
 from utils.observability.langsmith import is_langsmith_enabled
 import logging
@@ -429,13 +433,14 @@ async def get_mobile_city(uid: str, platform: Optional[str]) -> Optional[str]:
     if platform is None or platform.strip().lower() not in {'ios', 'android'}:
         return None
     try:
-        from database.redis_db import get_cached_user_geolocation
-        from utils.conversations.location import async_get_google_maps_city
-
+        consent = await run_blocking(db_executor, get_user_location_context_consent, uid)
+        if consent is None or not consent.is_active():
+            return None
         geolocation = await run_blocking(db_executor, get_cached_user_geolocation, uid)
         if not geolocation:
             return None
-        return await async_get_google_maps_city(float(geolocation['latitude']), float(geolocation['longitude']))
+        validated_geolocation = Geolocation.model_validate(geolocation)
+        return await async_get_google_maps_city(validated_geolocation.latitude, validated_geolocation.longitude)
     except (KeyError, TypeError, ValueError):
         return None
     except Exception as error:

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -425,6 +425,24 @@ def _inject_current_datetime(anthropic_messages: list, datetime_block: str) -> l
     return anthropic_messages
 
 
+async def _get_mobile_city(uid: str, platform: Optional[str]) -> Optional[str]:
+    if platform is None or platform.strip().lower() not in {'ios', 'android'}:
+        return None
+    try:
+        from database.redis_db import get_cached_user_geolocation
+        from utils.conversations.location import async_get_google_maps_city
+
+        geolocation = await run_blocking(db_executor, get_cached_user_geolocation, uid)
+        if not geolocation:
+            return None
+        return await async_get_google_maps_city(float(geolocation['latitude']), float(geolocation['longitude']))
+    except (KeyError, TypeError, ValueError):
+        return None
+    except Exception as error:
+        logger.warning('Mobile city context unavailable error_type=%s', type(error).__name__)
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Core Anthropic agent streaming loop
 # ---------------------------------------------------------------------------
@@ -685,6 +703,7 @@ async def execute_agentic_chat_stream(
         # so they share the first-event deadline instead of leaving the SSE body silent.
         async with asyncio.timeout(AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS):
             tz = await run_blocking(db_executor, get_user_timezone, uid)
+            city = await _get_mobile_city(uid, platform)
             system_prompt = await run_blocking(
                 db_executor, _get_agentic_qa_prompt, uid, app, messages, context=context, tz=tz, platform=platform
             )
@@ -755,7 +774,9 @@ You have fetch_url_tool available. When the user shares any URL (starting with h
     # Convert messages to Anthropic format. The current datetime is injected into the user
     # turn (not the system prompt) so the cache_control system prefix stays byte-stable.
     anthropic_messages = _messages_to_anthropic(messages)
-    anthropic_messages = _inject_current_datetime(anthropic_messages, get_current_datetime_block(uid, tz=tz))
+    anthropic_messages = _inject_current_datetime(
+        anthropic_messages, get_current_datetime_block(uid, tz=tz, location=city)
+    )
 
     callback = AsyncStreamingCallback()
 

--- a/backend/utils/retrieval/graph.py
+++ b/backend/utils/retrieval/graph.py
@@ -19,7 +19,7 @@ from langchain_core.messages import SystemMessage, AIMessage, HumanMessage, Base
 
 from models.app import App
 from models.chat import ChatSession, Message, PageContext
-from utils.llm.chat import retrieve_is_file_question
+from utils.llm.chat import get_current_datetime_block, get_user_timezone, retrieve_is_file_question
 from utils.llm.clients import get_llm
 from utils.llm.usage_tracker import Features, track_usage
 from utils.executors import db_executor, llm_executor, run_blocking
@@ -34,12 +34,27 @@ from utils.retrieval.agentic import (
     AsyncStreamingCallback,
     cancel_stream_task,
     execute_agentic_chat_stream,
+    get_mobile_city,
     next_stream_chunk,
 )
 from utils.observability.langsmith import get_chat_tracer_callbacks
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+async def _current_prompt_metadata(uid: str, platform: Optional[str]) -> tuple[str, str]:
+    try:
+        tz = await run_blocking(db_executor, get_user_timezone, uid)
+        city = await get_mobile_city(uid, platform)
+        return get_current_datetime_block(uid, tz=tz, location=city), tz
+    except Exception as error:
+        logger.warning('Prompt metadata unavailable error_type=%s', type(error).__name__)
+        return get_current_datetime_block(uid, tz='UTC'), 'UTC'
+
+
+def _with_prompt_metadata(text: str, metadata: str) -> str:
+    return f'{metadata}\n\n{text}'
 
 
 async def _drain_chat_callback(
@@ -118,10 +133,11 @@ async def _execute_file_chat_stream(
     messages: List[Message],
     chat_session: ChatSession,
     callback_data: Optional[Dict[str, Any]] = None,
+    current_datetime_block: Optional[str] = None,
 ) -> AsyncGenerator[Optional[str], None]:
     """Handle file chat with streaming."""
     last_message = messages[-1] if messages else None
-    question = last_message.text if last_message else ""
+    question = _with_prompt_metadata(last_message.text if last_message else "", current_datetime_block or "")
 
     # Determine which files to use
     if last_message and last_message.files_id and len(last_message.files_id) > 0:
@@ -179,16 +195,20 @@ async def execute_persona_chat_stream(
     cited: Optional[bool] = False,
     callback_data: Optional[Dict[str, Any]] = None,
     chat_session: Optional[ChatSession] = None,
+    current_datetime_block: Optional[str] = None,
 ) -> AsyncGenerator[Optional[str], None]:
     """Handle streaming chat responses for persona-type apps."""
     system_prompt = app.persona_prompt
     formatted_messages: List[BaseMessage] = [SystemMessage(content=system_prompt)]
 
-    for msg in messages:
+    for index, msg in enumerate(messages):
         if msg.sender == "ai":
             formatted_messages.append(AIMessage(content=msg.text))
         else:
-            formatted_messages.append(HumanMessage(content=msg.text))
+            text = msg.text
+            if current_datetime_block and index == len(messages) - 1:
+                text = _with_prompt_metadata(text, current_datetime_block)
+            formatted_messages.append(HumanMessage(content=text))
 
     full_response: List[str] = []
     callback = AsyncStreamingCallback()
@@ -284,11 +304,18 @@ async def execute_chat_stream(
     - Everything else -> Anthropic agentic chat (Claude decides whether to use tools)
     """
     logger.info(f'execute_chat_stream app: {app.id if app else "<none>"}')
+    current_datetime_block, tz = await _current_prompt_metadata(uid, platform)
 
     # 1. Persona apps
     if app and app.is_a_persona():
         async for chunk in execute_persona_chat_stream(
-            uid, messages, app, cited=cited, callback_data=callback_data, chat_session=chat_session
+            uid,
+            messages,
+            app,
+            cited=cited,
+            callback_data=callback_data,
+            chat_session=chat_session,
+            current_datetime_block=current_datetime_block,
         ):
             yield chunk
         return
@@ -296,14 +323,24 @@ async def execute_chat_stream(
     # 2. File attachments
     last_msg = messages[-1] if messages else None
     if chat_session is not None and await _has_file_context(last_msg, chat_session):
-        async for chunk in _execute_file_chat_stream(uid, messages, chat_session, callback_data):
+        async for chunk in _execute_file_chat_stream(
+            uid, messages, chat_session, callback_data, current_datetime_block=current_datetime_block
+        ):
             yield chunk
         return
 
     # 3. Default: Anthropic agentic chat
     # Claude decides implicitly whether to use tools — no requires_context() needed
     async for chunk in execute_agentic_chat_stream(
-        uid, messages, app, callback_data=callback_data, chat_session=chat_session, context=context, platform=platform
+        uid,
+        messages,
+        app,
+        callback_data=callback_data,
+        chat_session=chat_session,
+        context=context,
+        platform=platform,
+        current_datetime_block=current_datetime_block,
+        tz=tz,
     ):
         yield chunk
 

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -11861,7 +11861,7 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  public static func setUserGeolocationV1UsersGeolocationPatch(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: Geolocation) async throws -> OmiAnyCodable {
+  public static func setUserGeolocationV1UsersGeolocationPatch(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: OmiAnyCodable) async throws -> OmiAnyCodable {
     let _path = "/v1/users/geolocation"
     guard let components = URLComponents(string: client.baseURL + _path) else {
       throw OmiApiError.invalidURL
@@ -11919,6 +11919,56 @@ public enum OmiAPI {
     guard let url = components.url else { throw OmiApiError.invalidURL }
     var req = URLRequest(url: url)
     req.httpMethod = "PATCH"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    req.httpBody = try JSONEncoder().encode(body)
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
+  public static func getLocationContextConsentV1UsersLocationContextConsentGet(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> OmiAnyCodable {
+    let _path = "/v1/users/location-context-consent"
+    guard let components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "GET"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
+  public static func setLocationContextConsentV1UsersLocationContextConsentPut(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: OmiAnyCodable) async throws -> OmiAnyCodable {
+    let _path = "/v1/users/location-context-consent"
+    guard let components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "PUT"
     for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
     if let token = client.token {
       req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
@@ -14390,5 +14440,5 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  // Total: 385 Swift client methods generated.
+  // Total: 387 Swift client methods generated.
 }

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -1153,7 +1153,7 @@ export interface CreateConversationFromTranscriptRequest {
   client_platform?: string | null;
   client_session_id?: string | null;
   finished_at?: string | null;
-  geolocation?: Geolocation | null;
+  geolocation?: GeolocationInput | null;
   language?: string | null;
   source?: ConversationSource | null;
   started_at?: string | null;
@@ -1162,7 +1162,7 @@ export interface CreateConversationFromTranscriptRequest {
 
 export interface CreateConversationRequest {
   finished_at?: string | null;
-  geolocation?: Geolocation | null;
+  geolocation?: GeolocationInput | null;
   language?: string | null;
   started_at?: string | null;
   text: string;
@@ -1794,6 +1794,14 @@ export interface Geolocation {
   longitude: number;
 }
 
+export interface GeolocationInput {
+  address?: string | null;
+  google_place_id?: string | null;
+  latitude: number;
+  location_type?: string | null;
+  longitude: number;
+}
+
 export interface GoalCreate {
   current_value?: number | null;
   desired_outcome?: string | null;
@@ -2036,6 +2044,18 @@ export interface LlmUsageResponse {
   period_days: number;
   summary?: Record<string, unknown>;
   top_features?: Array<LlmUsageFeatureResponse>;
+}
+
+export interface LocationContextConsentResponse {
+  disclosed_providers?: Array<unknown>;
+  enabled: boolean;
+  expires_at?: string | null;
+  purpose?: string;
+}
+
+export interface LocationContextConsentUpdate {
+  disclosure_accepted?: boolean;
+  enabled: boolean;
 }
 
 export interface McpAddServerResponse {
@@ -3963,6 +3983,7 @@ export interface OmiApiSchemas {
   "GenerateDescriptionRequest": GenerateDescriptionRequest;
   "GenerateWrappedResponse": GenerateWrappedResponse;
   "Geolocation": Geolocation;
+  "GeolocationInput": GeolocationInput;
   "GoalCreate": GoalCreate;
   "GoalDeleteResponse": GoalDeleteResponse;
   "GoalDetailProjection": GoalDetailProjection;
@@ -3999,6 +4020,8 @@ export interface OmiApiSchemas {
   "LlmUsageFeatureResponse": LlmUsageFeatureResponse;
   "LlmUsageRecordResponse": LlmUsageRecordResponse;
   "LlmUsageResponse": LlmUsageResponse;
+  "LocationContextConsentResponse": LocationContextConsentResponse;
+  "LocationContextConsentUpdate": LocationContextConsentUpdate;
   "McpAddServerResponse": McpAddServerResponse;
   "McpApiKey": McpApiKey;
   "McpApiKeyCreate": McpApiKeyCreate;
@@ -7198,6 +7221,24 @@ export interface OmiApiPaths {
       operationId: "set_user_language_v1_users_language_patch";
       responses: {
         "200": UserLanguageUpdateResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/location-context-consent": {
+    get: {
+      operationId: "get_location_context_consent_v1_users_location_context_consent_get";
+      responses: {
+        "200": LocationContextConsentResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+    put: {
+      operationId: "set_location_context_consent_v1_users_location_context_consent_put";
+      responses: {
+        "200": LocationContextConsentResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -13757,7 +13798,7 @@ export async function save_token_v1_users_fcm_token_post(header: { X_App_Platfor
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function set_user_geolocation_v1_users_geolocation_patch(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: Geolocation, init?: OmiApiClientInit): Promise<UserStatusResponse> {
+export async function set_user_geolocation_v1_users_geolocation_patch(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: GeolocationInput, init?: OmiApiClientInit): Promise<UserStatusResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/geolocation`;
   const _search = "";
@@ -13803,6 +13844,46 @@ export async function set_user_language_v1_users_language_patch(header: { author
   const _search = "";
   const _res = await fetch(`${_base}${_path}${_search}`, {
     method: "PATCH",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function get_location_context_consent_v1_users_location_context_consent_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<LocationContextConsentResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/location-context-consent`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function set_location_context_consent_v1_users_location_context_consent_put(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: LocationContextConsentUpdate, init?: OmiApiClientInit): Promise<LocationContextConsentResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/location-context-consent`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "PUT",
     headers: {
       ...(body ? { 'Content-Type': 'application/json' } : {}),
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
@@ -15695,4 +15776,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 385 client methods generated.
+// Total: 387 client methods generated.

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -7249,7 +7249,7 @@
           "geolocation": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Geolocation"
+                "$ref": "#/components/schemas/GeolocationInput"
               },
               {
                 "type": "null"
@@ -7330,7 +7330,7 @@
           "geolocation": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Geolocation"
+                "$ref": "#/components/schemas/GeolocationInput"
               },
               {
                 "type": "null"
@@ -11092,6 +11092,62 @@
             "title": "Google Place Id"
           },
           "latitude": {
+            "maximum": 90.0,
+            "minimum": -90.0,
+            "title": "Latitude",
+            "type": "number"
+          },
+          "location_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Type"
+          },
+          "longitude": {
+            "maximum": 180.0,
+            "minimum": -180.0,
+            "title": "Longitude",
+            "type": "number"
+          }
+        },
+        "required": [
+          "latitude",
+          "longitude"
+        ],
+        "title": "Geolocation",
+        "type": "object"
+      },
+      "GeolocationInput": {
+        "description": "Released wire contract for coordinates accepted at legacy API boundaries.\n\nBounds are enforced before any value is cached, geocoded, or persisted. Keeping\nthis transport shape broad preserves clients released before the bound contract\nexisted, while ``Geolocation`` remains the only usable server-side value.",
+        "properties": {
+          "address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Address"
+          },
+          "google_place_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Google Place Id"
+          },
+          "latitude": {
             "title": "Latitude",
             "type": "number"
           },
@@ -11115,7 +11171,7 @@
           "latitude",
           "longitude"
         ],
-        "title": "Geolocation",
+        "title": "GeolocationInput",
         "type": "object"
       },
       "GoalCreate": {
@@ -12505,6 +12561,73 @@
           "period_days"
         ],
         "title": "LlmUsageResponse",
+        "type": "object"
+      },
+      "LocationContextConsentResponse": {
+        "properties": {
+          "disclosed_providers": {
+            "default": [
+              "Google Maps",
+              "the configured AI chat provider"
+            ],
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Disclosed Providers",
+            "type": "array"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "purpose": {
+            "default": "chat_city_context",
+            "title": "Purpose",
+            "type": "string"
+          }
+        },
+        "required": [
+          "enabled"
+        ],
+        "title": "LocationContextConsentResponse",
+        "type": "object"
+      },
+      "LocationContextConsentUpdate": {
+        "properties": {
+          "disclosure_accepted": {
+            "default": false,
+            "description": "Required to enable city context: Google Maps reverse-geocodes the device location and the configured AI chat provider receives city, region, and country only.",
+            "title": "Disclosure Accepted",
+            "type": "boolean"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enabled"
+        ],
+        "title": "LocationContextConsentUpdate",
         "type": "object"
       },
       "McpAddServerResponse": {
@@ -47558,7 +47681,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Geolocation"
+                "$ref": "#/components/schemas/GeolocationInput"
               }
             }
           },
@@ -47759,6 +47882,170 @@
           }
         ],
         "summary": "Set User Language",
+        "tags": [
+          "v1"
+        ]
+      }
+    },
+    "/v1/users/location-context-consent": {
+      "get": {
+        "description": "Return the current city-context disclosure and active server-side consent state.",
+        "operationId": "get_location_context_consent_v1_users_location_context_consent_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocationContextConsentResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Get Location Context Consent",
+        "tags": [
+          "v1"
+        ]
+      },
+      "put": {
+        "description": "Grant, renew, or revoke city-only location context for interactive chat.",
+        "operationId": "set_location_context_consent_v1_users_location_context_consent_put",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LocationContextConsentUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocationContextConsentResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Set Location Context Consent",
         "tags": [
           "v1"
         ]

--- a/docs/api-reference/integration-public-openapi.json
+++ b/docs/api-reference/integration-public-openapi.json
@@ -869,6 +869,8 @@
             "title": "Google Place Id"
           },
           "latitude": {
+            "maximum": 90.0,
+            "minimum": -90.0,
             "title": "Latitude",
             "type": "number"
           },
@@ -884,6 +886,8 @@
             "title": "Location Type"
           },
           "longitude": {
+            "maximum": 180.0,
+            "minimum": -180.0,
             "title": "Longitude",
             "type": "number"
           }

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -1712,6 +1712,8 @@
             "title": "Google Place Id"
           },
           "latitude": {
+            "maximum": 90.0,
+            "minimum": -90.0,
             "title": "Latitude",
             "type": "number"
           },
@@ -1727,6 +1729,8 @@
             "title": "Location Type"
           },
           "longitude": {
+            "maximum": 180.0,
+            "minimum": -180.0,
             "title": "Longitude",
             "type": "number"
           }

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -290,7 +290,7 @@
           "geolocation": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Geolocation"
+                "$ref": "#/components/schemas/GeolocationInput"
               },
               {
                 "type": "null"
@@ -371,7 +371,7 @@
           "geolocation": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Geolocation"
+                "$ref": "#/components/schemas/GeolocationInput"
               },
               {
                 "type": "null"
@@ -1740,6 +1740,58 @@
           "longitude"
         ],
         "title": "Geolocation",
+        "type": "object"
+      },
+      "GeolocationInput": {
+        "description": "Released wire contract for coordinates accepted at legacy API boundaries.\n\nBounds are enforced before any value is cached, geocoded, or persisted. Keeping\nthis transport shape broad preserves clients released before the bound contract\nexisted, while ``Geolocation`` remains the only usable server-side value.",
+        "properties": {
+          "address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Address"
+          },
+          "google_place_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Google Place Id"
+          },
+          "latitude": {
+            "title": "Latitude",
+            "type": "number"
+          },
+          "location_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Type"
+          },
+          "longitude": {
+            "title": "Longitude",
+            "type": "number"
+          }
+        },
+        "required": [
+          "latitude",
+          "longitude"
+        ],
+        "title": "GeolocationInput",
         "type": "object"
       },
       "GoalHistoryEntryResponse": {

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -78,7 +78,8 @@ CHANGED_FILES_LIST=$(mktemp "${TMPDIR:-/tmp}/omi-pre-push-changed-files.XXXXXX")
 SELECTED_BACKEND_TESTS=$(mktemp "${TMPDIR:-/tmp}/omi-pre-push-backend-tests.XXXXXX")
 SELECTED_BACKEND_TESTS_REASON=$(mktemp "${TMPDIR:-/tmp}/omi-pre-push-backend-tests-reason.XXXXXX")
 FAST_BACKEND_TESTS=$(mktemp "${TMPDIR:-/tmp}/omi-pre-push-fast-backend-tests.XXXXXX")
-trap 'rm -f "$CHANGED_FILES_LIST" "$SELECTED_BACKEND_TESTS" "$SELECTED_BACKEND_TESTS_REASON" "$FAST_BACKEND_TESTS"' EXIT
+RELEASE_GUARD_TESTS=$(mktemp "${TMPDIR:-/tmp}/omi-pre-push-release-guard-tests.XXXXXX")
+trap 'rm -f "$CHANGED_FILES_LIST" "$SELECTED_BACKEND_TESTS" "$SELECTED_BACKEND_TESTS_REASON" "$FAST_BACKEND_TESTS" "$RELEASE_GUARD_TESTS"' EXIT
 printf '%s\n' "${CHANGED_FILES[@]}" > "$CHANGED_FILES_LIST"
 BACKEND_PYTHON="$PWD/backend/.venv/bin/python"
 
@@ -617,20 +618,13 @@ check_openapi_contract_if_needed() {
   fi
 
   if ! changed_matches \
-    'backend/**' \
-    'docs/api-reference/openapi.json' \
+    'backend/models/*.py' \
+    'backend/models/**/*.py' \
+    'backend/routers/*.py' \
+    'backend/routers/**/*.py' \
     'docs/api-reference/app-client-openapi.json' \
-    'docs/api-reference/integration-public-openapi.json' \
     'app/lib/backend/http/api/**' \
     'app/lib/backend/schema/**' \
-    'app/lib/models/announcement.dart' \
-    'app/lib/models/subscription.dart' \
-    'app/lib/models/user_usage.dart' \
-    'desktop/windows/src/renderer/src/lib/omiApi.generated.ts' \
-    'web/app/src/lib/omiApi.generated.ts' \
-    'web/admin/lib/services/omi-api/omiApi.generated.ts' \
-    'web/personas-open-source/src/lib/omiApi.generated.ts' \
-    'docs/docs.json' \
     '.github/workflows/openapi-contract.yml' \
     'scripts/pre-push'
   then
@@ -642,14 +636,30 @@ check_openapi_contract_if_needed() {
     --base-ref "$BASE_REMOTE_REF"
   (
     cd backend
-    scripts/openapi_runner.sh scripts/export_openapi.py --check ../docs/api-reference/openapi.json
     scripts/openapi_runner.sh scripts/export_openapi.py --surface app-client --check ../docs/api-reference/app-client-openapi.json
-    scripts/openapi_runner.sh scripts/export_openapi.py --surface integration-public --check ../docs/api-reference/integration-public-openapi.json
   )
 
   "$BACKEND_PYTHON" backend/scripts/generate_dart_models.py --all --check
   "$BACKEND_PYTHON" backend/scripts/generate_ts_openapi_types.py --check
   "$BACKEND_PYTHON" backend/scripts/generate_swift_openapi_types.py --check
+}
+
+check_release_process_guards_if_needed() {
+  if ! changed_matches \
+    '.github/workflows/desktop_qualify_beta.yml' \
+    '.github/scripts/check-release-process-guards.py' \
+    'backend/tests/unit/test_desktop_release_scripts.py'
+  then
+    return
+  fi
+
+  require_backend_python
+  python3 .github/scripts/check-release-process-guards.py
+  printf '%s\n' 'tests/unit/test_desktop_release_scripts.py' > "$RELEASE_GUARD_TESTS"
+  (
+    cd backend
+    BACKEND_UNIT_TEST_FILE_LIST="$RELEASE_GUARD_TESTS" PYTHON="$BACKEND_PYTHON" bash test.sh
+  )
 }
 
 check_workflows_if_needed() {
@@ -808,6 +818,7 @@ run_step check_backend_typecheck_if_needed
 run_step check_runtime_image_source_closure_if_needed
 run_step check_backend_unit_tests_if_needed
 run_step check_openapi_contract_if_needed
+run_step check_release_process_guards_if_needed
 run_step check_workflows_if_needed
 run_step check_flutter_generated_if_needed
 run_step check_desktop_flow_lint_if_needed

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -648,13 +648,13 @@ check_release_process_guards_if_needed() {
   if ! changed_matches \
     '.github/workflows/desktop_qualify_beta.yml' \
     '.github/scripts/check-release-process-guards.py' \
+    'scripts/run-release-process-guards.sh' \
     'backend/tests/unit/test_desktop_release_scripts.py'
   then
     return
   fi
 
-  require_backend_python
-  python3 .github/scripts/check-release-process-guards.py
+  bash scripts/run-release-process-guards.sh
   printf '%s\n' 'tests/unit/test_desktop_release_scripts.py' > "$RELEASE_GUARD_TESTS"
   (
     cd backend

--- a/scripts/run-release-process-guards.sh
+++ b/scripts/run-release-process-guards.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Run release-process guards with the repository's locked PyYAML dependency.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKEND_PYTHON="$ROOT_DIR/backend/.venv/bin/python"
+
+if [[ ! -x "$BACKEND_PYTHON" ]] || ! "$BACKEND_PYTHON" -c "import yaml"; then
+  "$ROOT_DIR/backend/scripts/sync-python-deps.sh"
+fi
+
+exec "$BACKEND_PYTHON" "$ROOT_DIR/.github/scripts/check-release-process-guards.py" "$@"

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -1153,7 +1153,7 @@ export interface CreateConversationFromTranscriptRequest {
   client_platform?: string | null;
   client_session_id?: string | null;
   finished_at?: string | null;
-  geolocation?: Geolocation | null;
+  geolocation?: GeolocationInput | null;
   language?: string | null;
   source?: ConversationSource | null;
   started_at?: string | null;
@@ -1162,7 +1162,7 @@ export interface CreateConversationFromTranscriptRequest {
 
 export interface CreateConversationRequest {
   finished_at?: string | null;
-  geolocation?: Geolocation | null;
+  geolocation?: GeolocationInput | null;
   language?: string | null;
   started_at?: string | null;
   text: string;
@@ -1794,6 +1794,14 @@ export interface Geolocation {
   longitude: number;
 }
 
+export interface GeolocationInput {
+  address?: string | null;
+  google_place_id?: string | null;
+  latitude: number;
+  location_type?: string | null;
+  longitude: number;
+}
+
 export interface GoalCreate {
   current_value?: number | null;
   desired_outcome?: string | null;
@@ -2036,6 +2044,18 @@ export interface LlmUsageResponse {
   period_days: number;
   summary?: Record<string, unknown>;
   top_features?: Array<LlmUsageFeatureResponse>;
+}
+
+export interface LocationContextConsentResponse {
+  disclosed_providers?: Array<unknown>;
+  enabled: boolean;
+  expires_at?: string | null;
+  purpose?: string;
+}
+
+export interface LocationContextConsentUpdate {
+  disclosure_accepted?: boolean;
+  enabled: boolean;
 }
 
 export interface McpAddServerResponse {
@@ -3963,6 +3983,7 @@ export interface OmiApiSchemas {
   "GenerateDescriptionRequest": GenerateDescriptionRequest;
   "GenerateWrappedResponse": GenerateWrappedResponse;
   "Geolocation": Geolocation;
+  "GeolocationInput": GeolocationInput;
   "GoalCreate": GoalCreate;
   "GoalDeleteResponse": GoalDeleteResponse;
   "GoalDetailProjection": GoalDetailProjection;
@@ -3999,6 +4020,8 @@ export interface OmiApiSchemas {
   "LlmUsageFeatureResponse": LlmUsageFeatureResponse;
   "LlmUsageRecordResponse": LlmUsageRecordResponse;
   "LlmUsageResponse": LlmUsageResponse;
+  "LocationContextConsentResponse": LocationContextConsentResponse;
+  "LocationContextConsentUpdate": LocationContextConsentUpdate;
   "McpAddServerResponse": McpAddServerResponse;
   "McpApiKey": McpApiKey;
   "McpApiKeyCreate": McpApiKeyCreate;
@@ -7198,6 +7221,24 @@ export interface OmiApiPaths {
       operationId: "set_user_language_v1_users_language_patch";
       responses: {
         "200": UserLanguageUpdateResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/location-context-consent": {
+    get: {
+      operationId: "get_location_context_consent_v1_users_location_context_consent_get";
+      responses: {
+        "200": LocationContextConsentResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+    put: {
+      operationId: "set_location_context_consent_v1_users_location_context_consent_put";
+      responses: {
+        "200": LocationContextConsentResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -13757,7 +13798,7 @@ export async function save_token_v1_users_fcm_token_post(header: { X_App_Platfor
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function set_user_geolocation_v1_users_geolocation_patch(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: Geolocation, init?: OmiApiClientInit): Promise<UserStatusResponse> {
+export async function set_user_geolocation_v1_users_geolocation_patch(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: GeolocationInput, init?: OmiApiClientInit): Promise<UserStatusResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/geolocation`;
   const _search = "";
@@ -13803,6 +13844,46 @@ export async function set_user_language_v1_users_language_patch(header: { author
   const _search = "";
   const _res = await fetch(`${_base}${_path}${_search}`, {
     method: "PATCH",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function get_location_context_consent_v1_users_location_context_consent_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<LocationContextConsentResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/location-context-consent`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function set_location_context_consent_v1_users_location_context_consent_put(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: LocationContextConsentUpdate, init?: OmiApiClientInit): Promise<LocationContextConsentResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/location-context-consent`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "PUT",
     headers: {
       ...(body ? { 'Content-Type': 'application/json' } : {}),
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
@@ -15695,4 +15776,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 385 client methods generated.
+// Total: 387 client methods generated.

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -1153,7 +1153,7 @@ export interface CreateConversationFromTranscriptRequest {
   client_platform?: string | null;
   client_session_id?: string | null;
   finished_at?: string | null;
-  geolocation?: Geolocation | null;
+  geolocation?: GeolocationInput | null;
   language?: string | null;
   source?: ConversationSource | null;
   started_at?: string | null;
@@ -1162,7 +1162,7 @@ export interface CreateConversationFromTranscriptRequest {
 
 export interface CreateConversationRequest {
   finished_at?: string | null;
-  geolocation?: Geolocation | null;
+  geolocation?: GeolocationInput | null;
   language?: string | null;
   started_at?: string | null;
   text: string;
@@ -1794,6 +1794,14 @@ export interface Geolocation {
   longitude: number;
 }
 
+export interface GeolocationInput {
+  address?: string | null;
+  google_place_id?: string | null;
+  latitude: number;
+  location_type?: string | null;
+  longitude: number;
+}
+
 export interface GoalCreate {
   current_value?: number | null;
   desired_outcome?: string | null;
@@ -2036,6 +2044,18 @@ export interface LlmUsageResponse {
   period_days: number;
   summary?: Record<string, unknown>;
   top_features?: Array<LlmUsageFeatureResponse>;
+}
+
+export interface LocationContextConsentResponse {
+  disclosed_providers?: Array<unknown>;
+  enabled: boolean;
+  expires_at?: string | null;
+  purpose?: string;
+}
+
+export interface LocationContextConsentUpdate {
+  disclosure_accepted?: boolean;
+  enabled: boolean;
 }
 
 export interface McpAddServerResponse {
@@ -3963,6 +3983,7 @@ export interface OmiApiSchemas {
   "GenerateDescriptionRequest": GenerateDescriptionRequest;
   "GenerateWrappedResponse": GenerateWrappedResponse;
   "Geolocation": Geolocation;
+  "GeolocationInput": GeolocationInput;
   "GoalCreate": GoalCreate;
   "GoalDeleteResponse": GoalDeleteResponse;
   "GoalDetailProjection": GoalDetailProjection;
@@ -3999,6 +4020,8 @@ export interface OmiApiSchemas {
   "LlmUsageFeatureResponse": LlmUsageFeatureResponse;
   "LlmUsageRecordResponse": LlmUsageRecordResponse;
   "LlmUsageResponse": LlmUsageResponse;
+  "LocationContextConsentResponse": LocationContextConsentResponse;
+  "LocationContextConsentUpdate": LocationContextConsentUpdate;
   "McpAddServerResponse": McpAddServerResponse;
   "McpApiKey": McpApiKey;
   "McpApiKeyCreate": McpApiKeyCreate;
@@ -7198,6 +7221,24 @@ export interface OmiApiPaths {
       operationId: "set_user_language_v1_users_language_patch";
       responses: {
         "200": UserLanguageUpdateResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/location-context-consent": {
+    get: {
+      operationId: "get_location_context_consent_v1_users_location_context_consent_get";
+      responses: {
+        "200": LocationContextConsentResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+    put: {
+      operationId: "set_location_context_consent_v1_users_location_context_consent_put";
+      responses: {
+        "200": LocationContextConsentResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -13757,7 +13798,7 @@ export async function save_token_v1_users_fcm_token_post(header: { X_App_Platfor
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function set_user_geolocation_v1_users_geolocation_patch(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: Geolocation, init?: OmiApiClientInit): Promise<UserStatusResponse> {
+export async function set_user_geolocation_v1_users_geolocation_patch(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: GeolocationInput, init?: OmiApiClientInit): Promise<UserStatusResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/geolocation`;
   const _search = "";
@@ -13803,6 +13844,46 @@ export async function set_user_language_v1_users_language_patch(header: { author
   const _search = "";
   const _res = await fetch(`${_base}${_path}${_search}`, {
     method: "PATCH",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function get_location_context_consent_v1_users_location_context_consent_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<LocationContextConsentResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/location-context-consent`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function set_location_context_consent_v1_users_location_context_consent_put(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: LocationContextConsentUpdate, init?: OmiApiClientInit): Promise<LocationContextConsentResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/location-context-consent`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "PUT",
     headers: {
       ...(body ? { 'Content-Type': 'application/json' } : {}),
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
@@ -15695,4 +15776,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 385 client methods generated.
+// Total: 387 client methods generated.

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -1153,7 +1153,7 @@ export interface CreateConversationFromTranscriptRequest {
   client_platform?: string | null;
   client_session_id?: string | null;
   finished_at?: string | null;
-  geolocation?: Geolocation | null;
+  geolocation?: GeolocationInput | null;
   language?: string | null;
   source?: ConversationSource | null;
   started_at?: string | null;
@@ -1162,7 +1162,7 @@ export interface CreateConversationFromTranscriptRequest {
 
 export interface CreateConversationRequest {
   finished_at?: string | null;
-  geolocation?: Geolocation | null;
+  geolocation?: GeolocationInput | null;
   language?: string | null;
   started_at?: string | null;
   text: string;
@@ -1794,6 +1794,14 @@ export interface Geolocation {
   longitude: number;
 }
 
+export interface GeolocationInput {
+  address?: string | null;
+  google_place_id?: string | null;
+  latitude: number;
+  location_type?: string | null;
+  longitude: number;
+}
+
 export interface GoalCreate {
   current_value?: number | null;
   desired_outcome?: string | null;
@@ -2036,6 +2044,18 @@ export interface LlmUsageResponse {
   period_days: number;
   summary?: Record<string, unknown>;
   top_features?: Array<LlmUsageFeatureResponse>;
+}
+
+export interface LocationContextConsentResponse {
+  disclosed_providers?: Array<unknown>;
+  enabled: boolean;
+  expires_at?: string | null;
+  purpose?: string;
+}
+
+export interface LocationContextConsentUpdate {
+  disclosure_accepted?: boolean;
+  enabled: boolean;
 }
 
 export interface McpAddServerResponse {
@@ -3963,6 +3983,7 @@ export interface OmiApiSchemas {
   "GenerateDescriptionRequest": GenerateDescriptionRequest;
   "GenerateWrappedResponse": GenerateWrappedResponse;
   "Geolocation": Geolocation;
+  "GeolocationInput": GeolocationInput;
   "GoalCreate": GoalCreate;
   "GoalDeleteResponse": GoalDeleteResponse;
   "GoalDetailProjection": GoalDetailProjection;
@@ -3999,6 +4020,8 @@ export interface OmiApiSchemas {
   "LlmUsageFeatureResponse": LlmUsageFeatureResponse;
   "LlmUsageRecordResponse": LlmUsageRecordResponse;
   "LlmUsageResponse": LlmUsageResponse;
+  "LocationContextConsentResponse": LocationContextConsentResponse;
+  "LocationContextConsentUpdate": LocationContextConsentUpdate;
   "McpAddServerResponse": McpAddServerResponse;
   "McpApiKey": McpApiKey;
   "McpApiKeyCreate": McpApiKeyCreate;
@@ -7198,6 +7221,24 @@ export interface OmiApiPaths {
       operationId: "set_user_language_v1_users_language_patch";
       responses: {
         "200": UserLanguageUpdateResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/location-context-consent": {
+    get: {
+      operationId: "get_location_context_consent_v1_users_location_context_consent_get";
+      responses: {
+        "200": LocationContextConsentResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+    put: {
+      operationId: "set_location_context_consent_v1_users_location_context_consent_put";
+      responses: {
+        "200": LocationContextConsentResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -13757,7 +13798,7 @@ export async function save_token_v1_users_fcm_token_post(header: { X_App_Platfor
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function set_user_geolocation_v1_users_geolocation_patch(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: Geolocation, init?: OmiApiClientInit): Promise<UserStatusResponse> {
+export async function set_user_geolocation_v1_users_geolocation_patch(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: GeolocationInput, init?: OmiApiClientInit): Promise<UserStatusResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/geolocation`;
   const _search = "";
@@ -13803,6 +13844,46 @@ export async function set_user_language_v1_users_language_patch(header: { author
   const _search = "";
   const _res = await fetch(`${_base}${_path}${_search}`, {
     method: "PATCH",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function get_location_context_consent_v1_users_location_context_consent_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<LocationContextConsentResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/location-context-consent`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function set_location_context_consent_v1_users_location_context_consent_put(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: LocationContextConsentUpdate, init?: OmiApiClientInit): Promise<LocationContextConsentResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/location-context-consent`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "PUT",
     headers: {
       ...(body ? { 'Content-Type': 'application/json' } : {}),
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
@@ -15695,4 +15776,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 385 client methods generated.
+// Total: 387 client methods generated.


### PR DESCRIPTION
## Summary
- Adds live date, time, timezone, and consented recent city context to mobile agentic, persona, and file chat turns.
- Keeps dynamic metadata out of cached system prefixes; realtime Gemini/OpenAI relay traffic remains provider-native.
- Validates coordinate bounds, escapes city text, and updates the public OpenAPI contract.

## Verification
- `backend/.venv/bin/python -m pytest -q tests/unit/test_chat_async_offload.py tests/unit/test_prompt_metadata_safety.py tests/unit/test_city_prompt_context.py tests/unit/test_geocoding_cache.py`
- `backend/scripts/typecheck.sh`
- OpenAPI contract regenerated with `scripts/openapi_runner.sh scripts/export_openapi.py --surface public --write ../docs/api-reference/openapi.json`

## Failure class

Failure-Class: none
