### PR TITLE
SCA-132: reserve dev Pusher pool capacity

### DIFF
--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -398,7 +398,13 @@ volumeMounts: []
 
 nodeSelector: {}
 
-tolerations: []
+# The dedicated dev Pusher pool is tainted to keep other workloads out. The
+# existing affinity below still confines this workload to matching Pusher nodes.
+tolerations:
+  - key: dedicated
+    operator: Equal
+    value: pusher
+    effect: NoSchedule
 
 affinity:
   nodeAffinity:

--- a/backend/docs/pusher_rolling_update_operations.md
+++ b/backend/docs/pusher_rolling_update_operations.md
@@ -100,6 +100,22 @@ rebuilt (verified against `{dev,prod}_omi_pusher_values.yaml`):
   `activeConnectionsPerPod: 30`; dev `minReplicas: 1`, `maxReplicas: 3`.
 - `podDisruptionBudget.minAvailable: 80%` in both charts.
 
+### Dedicated development Pusher capacity
+
+Development Pusher alone tolerates `dedicated=pusher:NoSchedule`. Its existing
+required node affinity still requires matching `service=pusher` and `env=dev`
+labels, so that toleration does not admit LLM Gateway, Agent Proxy, or other
+workloads to the pool. Production deliberately retains no corresponding
+toleration; it is a separate configuration boundary.
+
+Before a dev Pusher rollout, an external approved GKE operation must provide
+**two Ready, schedulable Pusher-capable nodes** matching that affinity, each
+tainted `dedicated=pusher:NoSchedule`. Two matching nodes leave room for the
+single serving pod and its `maxSurge: 1` replacement during a rolling update.
+Helm only renders the workload toleration: it does not create, label, taint, or
+scale GKE node capacity. Dev HPA remains `minReplicas: 1`, `maxReplicas: 3`,
+and its rolling-update settings remain `maxSurge: 1`, `maxUnavailable: 0`.
+
 Fail-closed rollout gates (preflight scripts that must pass before a deploy) are
 listed in [Operator runbook](#operator-runbook) and the blocking signals in
 [Rollout quality gates (fail-closed)](#rollout-quality-gates-fail-closed).
@@ -172,7 +188,8 @@ helm template pusher backend/charts/pusher \
 Confirm in the rendered output: `readinessProbe.httpGet.path: /ready`,
 `livenessProbe`/`startupProbe` on `/health`, the BackendConfig `healthCheck` on
 `/health` plus `connectionDraining`, `preStop` calling `/__internal/drain`, and
-`progressDeadlineSeconds: 9600`.
+`progressDeadlineSeconds: 9600`. Confirm the dev Deployment has the
+`dedicated=pusher:NoSchedule` toleration and the prod Deployment does not.
 
 ### 2. Run the fail-closed preflight
 

--- a/backend/tests/unit/test_rendered_deployment_contract.py
+++ b/backend/tests/unit/test_rendered_deployment_contract.py
@@ -142,6 +142,24 @@ def test_dev_pusher_rollout_preserves_the_existing_replica(contracts: SimpleName
     assert rolling_update["maxSurge"] == 1
 
 
+def test_pusher_dedicated_pool_toleration_is_dev_only(contracts: SimpleNamespace):
+    helm = shutil.which("helm")
+    assert helm is not None, "helm must be installed for the rendered deployment contract"
+    contract = next(contract for contract in contracts.CONTRACTS if contract.service == "pusher")
+
+    dev_documents = contracts.render_chart(contract, "dev", helm)
+    dev_deployment = contracts.deployment_for(dev_documents, contracts.release_name(contract, "dev"))
+    prod_documents = contracts.render_chart(contract, "prod", helm)
+    prod_deployment = contracts.deployment_for(prod_documents, contracts.release_name(contract, "prod"))
+
+    assert dev_deployment is not None
+    assert prod_deployment is not None
+    assert dev_deployment["spec"]["template"]["spec"].get("tolerations") == [
+        {"key": "dedicated", "operator": "Equal", "value": "pusher", "effect": "NoSchedule"}
+    ]
+    assert prod_deployment["spec"]["template"]["spec"].get("tolerations") is None
+
+
 @pytest.mark.parametrize("environment", ("dev", "prod"))
 def test_pusher_explicit_zero_min_ready_seconds_renders(contracts: SimpleNamespace, environment: str):
     helm = shutil.which("helm")


### PR DESCRIPTION
## What changed and why

Development Pusher now tolerates only `dedicated=pusher:NoSchedule`, while retaining its required `service=pusher`, `env=dev` node affinity. The matching regression coverage and rollout documentation make the external two-node GKE prerequisite explicit; production values remain unchanged.

## Product invariants affected

none

## How it was verified

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_rendered_deployment_contract.py -q` — 13 passed.
- Real local `helm template` renders with an immutable test tag: dev Deployment rendered exactly `dedicated=pusher:NoSchedule`; prod Deployment rendered no tolerations.
- `git diff --check origin/main...HEAD` — passed.
- `make preflight` — passed all 26 selected checks.

No GCP/Kubernetes mutation, deployment, or synthetic traffic was performed.

## Tests

`test_pusher_dedicated_pool_toleration_is_dev_only` renders both Pusher environments and asserts the dedicated taint toleration exists only in development.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

