### PR TITLE
fix(release): ignore docs-only Windows release history

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -529,6 +529,11 @@ checks:
     triggers: [".github/scripts/desktop-release-source-identity.py", ".github/scripts/test_desktop_release_source_identity.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "issue #11936: a candidate stays on the exact release source (or changelog-only child) while later desktop merges queue for the next train"
+  - id: desktop-windows-release-paths
+    command: ["python3", ".github/scripts/test_windows_release_paths.py"]
+    triggers: [".github/scripts/windows_release_paths.py", ".github/scripts/test_windows_release_paths.py", ".github/workflows/desktop_windows_release.yml", "desktop/windows/docs/release-pipeline.md", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#10240: a default manual Windows release must not cut an installer from docs-only history; the planner uses an executable path-classification contract"
   - id: desktop-candidate-tag-transaction
     command: ["python3", ".github/scripts/test_publish_desktop_candidate_tag.py"]
     triggers: [".github/scripts/publish-desktop-candidate-tag.py", ".github/scripts/test_publish_desktop_candidate_tag.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -418,7 +418,7 @@ checks:
     command: ["python3", ".github/scripts/test_windows_release_paths.py"]
     triggers: [".github/scripts/windows_release_paths.py", ".github/scripts/test_windows_release_paths.py", ".github/workflows/desktop_windows_release.yml", "desktop/windows/docs/release-pipeline.md", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "#10240: Windows docs-only changes must not cut installers; the push trigger and tag planner share an executable path-classification contract"
+    reason: "#10240: a default manual Windows release must not cut an installer from docs-only history; the planner uses an executable path-classification contract"
   - id: desktop-candidate-tag-transaction
     command: ["python3", ".github/scripts/test_publish_desktop_candidate_tag.py"]
     triggers: [".github/scripts/publish-desktop-candidate-tag.py", ".github/scripts/test_publish_desktop_candidate_tag.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -414,6 +414,11 @@ checks:
     triggers: [".github/scripts/desktop-release-source-identity.py", ".github/scripts/test_desktop_release_source_identity.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-129 keeps a current-main candidate bound to the checked desktop source while rejecting a newer releasable desktop change"
+  - id: desktop-windows-release-paths
+    command: ["python3", ".github/scripts/test_windows_release_paths.py"]
+    triggers: [".github/scripts/windows_release_paths.py", ".github/scripts/test_windows_release_paths.py", ".github/workflows/desktop_windows_release.yml", "desktop/windows/docs/release-pipeline.md", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#10240: Windows docs-only changes must not cut installers; the push trigger and tag planner share an executable path-classification contract"
   - id: desktop-candidate-tag-transaction
     command: ["python3", ".github/scripts/test_publish_desktop_candidate_tag.py"]
     triggers: [".github/scripts/publish-desktop-candidate-tag.py", ".github/scripts/test_publish_desktop_candidate_tag.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]

--- a/.github/failure-classes/FC-release-input-path-scope.json
+++ b/.github/failure-classes/FC-release-input-path-scope.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-release-input-path-scope",
+  "violated_contract": "An automatic release must be cut only when the selected history contains an artifact-bearing input; release-neutral documentation changes must not mint a new version, tag, or installer.",
+  "canonical_prevention": "Keep release-bearing and release-neutral path classes explicit in an executable classifier, mirror release-neutral exclusions in the event trigger, and test both trigger wiring and planner behavior against real Git histories.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/test_windows_release_paths.py"
+  ],
+  "evidence_prs": [10622],
+  "scope_hints": [
+    ".github/workflows/desktop_windows_release.yml",
+    ".github/scripts/windows_release_paths.py",
+    "desktop/windows/docs/"
+  ],
+  "status": "open"
+}

--- a/.github/failure-classes/FC-release-input-path-scope.json
+++ b/.github/failure-classes/FC-release-input-path-scope.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "id": "FC-release-input-path-scope",
-  "violated_contract": "An automatic release must be cut only when the selected history contains an artifact-bearing input; release-neutral documentation changes must not mint a new version, tag, or installer.",
-  "canonical_prevention": "Keep release-bearing and release-neutral path classes explicit in an executable classifier, mirror release-neutral exclusions in the event trigger, and test both trigger wiring and planner behavior against real Git histories.",
+  "violated_contract": "A default release must be cut only when the selected history contains an artifact-bearing input; release-neutral documentation changes must not mint a new version, tag, or installer.",
+  "canonical_prevention": "Keep release-bearing and release-neutral path classes explicit in an executable classifier invoked by the release planner, preserve force_release as the explicit override, and test the planner wiring and classifier behavior against real Git histories.",
   "canonical_prevention_artifact": [
     ".github/scripts/test_windows_release_paths.py"
   ],

--- a/.github/scripts/test_windows_release_paths.py
+++ b/.github/scripts/test_windows_release_paths.py
@@ -90,9 +90,10 @@ class WindowsReleasePathTests(unittest.TestCase):
                 ["desktop/windows/src/runtime.md"],
             )
 
-    def test_workflow_filters_docs_and_uses_the_tested_classifier(self) -> None:
+    def test_manual_workflow_uses_the_tested_classifier(self) -> None:
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
-        self.assertIn("- '!desktop/windows/docs/**'", workflow)
+        self.assertIn("\non:\n  workflow_dispatch:\n", workflow)
+        self.assertNotIn("\n  push:\n", workflow)
         self.assertIn(
             'HAS_CHANGES=$(python3 .github/scripts/windows_release_paths.py --base "$LATEST")',
             workflow,
@@ -105,8 +106,7 @@ class WindowsReleasePathTests(unittest.TestCase):
             ["git", *args],
             cwd=root,
             check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
             encoding="utf-8",
         )
@@ -130,8 +130,7 @@ class WindowsReleasePathTests(unittest.TestCase):
         return subprocess.run(
             [sys.executable, str(MODULE_PATH), "--root", str(root), "--base", base],
             check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
             encoding="utf-8",
         )

--- a/.github/scripts/test_windows_release_paths.py
+++ b/.github/scripts/test_windows_release_paths.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Regression tests for Windows desktop release path classification."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+MODULE_PATH = SCRIPT_DIR / "windows_release_paths.py"
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/desktop_windows_release.yml"
+SPEC = importlib.util.spec_from_file_location("windows_release_paths", MODULE_PATH)
+assert SPEC and SPEC.loader
+release_paths = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release_paths)
+
+
+class WindowsReleasePathTests(unittest.TestCase):
+    def test_docs_are_release_neutral_but_runtime_and_changelog_are_releasable(self) -> None:
+        self.assertFalse(release_paths.is_releasable_windows_path("desktop/windows/docs/release-pipeline.md"))
+        self.assertTrue(release_paths.is_releasable_windows_path("desktop/windows/src/main/index.ts"))
+        self.assertTrue(
+            release_paths.is_releasable_windows_path("desktop/windows/changelog/unreleased/2026-07-runtime-fix.json")
+        )
+        self.assertFalse(release_paths.is_releasable_windows_path("desktop/macos/README.md"))
+
+    def test_real_git_history_ignores_docs_only_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.git(root, "init", "--quiet")
+            source = root / "desktop/windows/src/main/index.ts"
+            docs = root / "desktop/windows/docs/release-pipeline.md"
+            source.parent.mkdir(parents=True)
+            docs.parent.mkdir(parents=True)
+            source.write_text("export const version = 1\n", encoding="utf-8")
+            docs.write_text("# Release\n", encoding="utf-8")
+            self.commit_all(root, "initial")
+            base = self.git(root, "rev-parse", "HEAD").stdout.strip()
+
+            docs.write_text("# Release\n\nDocs only.\n", encoding="utf-8")
+            self.commit_all(root, "docs")
+            self.assertEqual(release_paths.releasable_paths(root, base), [])
+            self.assertEqual(self.run_cli(root, base).stdout.strip(), "false")
+
+            source.write_text("export const version = 2\n", encoding="utf-8")
+            self.commit_all(root, "runtime")
+            self.assertEqual(
+                release_paths.releasable_paths(root, base),
+                ["desktop/windows/src/main/index.ts"],
+            )
+            self.assertEqual(self.run_cli(root, base).stdout.strip(), "true")
+
+    def test_first_release_still_requires_non_docs_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.git(root, "init", "--quiet")
+            docs = root / "desktop/windows/docs/release-pipeline.md"
+            docs.parent.mkdir(parents=True)
+            docs.write_text("# Release\n", encoding="utf-8")
+            self.commit_all(root, "docs")
+            self.assertEqual(release_paths.releasable_paths(root), [])
+
+            source = root / "desktop/windows/package.json"
+            source.write_text("{}\n", encoding="utf-8")
+            self.commit_all(root, "package")
+            self.assertEqual(release_paths.releasable_paths(root), ["desktop/windows/package.json"])
+
+    def test_moving_runtime_content_into_docs_is_still_releasable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.git(root, "init", "--quiet")
+            source = root / "desktop/windows/src/runtime.md"
+            destination = root / "desktop/windows/docs/runtime.md"
+            source.parent.mkdir(parents=True)
+            source.write_text("runtime content\n", encoding="utf-8")
+            self.commit_all(root, "runtime")
+            base = self.git(root, "rev-parse", "HEAD").stdout.strip()
+
+            destination.parent.mkdir(parents=True)
+            self.git(root, "mv", str(source.relative_to(root)), str(destination.relative_to(root)))
+            self.commit_all(root, "move")
+
+            self.assertEqual(
+                release_paths.releasable_paths(root, base),
+                ["desktop/windows/src/runtime.md"],
+            )
+
+    def test_workflow_filters_docs_and_uses_the_tested_classifier(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn("- '!desktop/windows/docs/**'", workflow)
+        self.assertIn(
+            'HAS_CHANGES=$(python3 .github/scripts/windows_release_paths.py --base "$LATEST")',
+            workflow,
+        )
+        self.assertNotIn("git diff --quiet --diff-filter=ACDMR", workflow)
+
+    @staticmethod
+    def git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=root,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+        )
+
+    def commit_all(self, root: Path, message: str) -> None:
+        self.git(root, "add", ".")
+        self.git(
+            root,
+            "-c",
+            "user.name=Omi release path test",
+            "-c",
+            "user.email=release-paths@example.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            message,
+        )
+
+    @staticmethod
+    def run_cli(root: Path, base: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(MODULE_PATH), "--root", str(root), "--base", base],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/windows_release_paths.py
+++ b/.github/scripts/windows_release_paths.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Classify changes that should cut a Windows desktop release."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+WINDOWS_ROOT = "desktop/windows/"
+RELEASE_NEUTRAL_PREFIXES = ("desktop/windows/docs/",)
+
+
+def normalize_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    return normalized[2:] if normalized.startswith("./") else normalized
+
+
+def is_releasable_windows_path(path: str) -> bool:
+    normalized = normalize_path(path)
+    return normalized.startswith(WINDOWS_ROOT) and not any(
+        normalized.startswith(prefix) for prefix in RELEASE_NEUTRAL_PREFIXES
+    )
+
+
+def git_paths(root: Path, *args: str) -> list[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def releasable_paths(root: Path, base: str = "") -> list[str]:
+    if base:
+        paths = git_paths(
+            root,
+            "diff",
+            "--name-only",
+            "--no-renames",
+            "--diff-filter=ACDMR",
+            f"{base}..HEAD",
+            "--",
+            WINDOWS_ROOT,
+        )
+    else:
+        paths = git_paths(root, "ls-files", "--", WINDOWS_ROOT)
+    return sorted({normalize_path(path) for path in paths if is_releasable_windows_path(path)})
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="", help="Latest Windows release tag; empty means the first release.")
+    parser.add_argument("--root", type=Path, default=Path("."), help="Repository root.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        paths = releasable_paths(args.root.resolve(), args.base.strip())
+    except subprocess.CalledProcessError as exc:
+        print(f"FAIL: could not classify Windows release paths: {exc.stderr.strip()}", file=sys.stderr)
+        return 1
+    if paths:
+        print(f"Windows release paths ({len(paths)}): {', '.join(paths)}", file=sys.stderr)
+    else:
+        print("Windows release paths: none", file=sys.stderr)
+    print(str(bool(paths)).lower())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/windows_release_paths.py
+++ b/.github/scripts/windows_release_paths.py
@@ -14,7 +14,7 @@ RELEASE_NEUTRAL_PREFIXES = ("desktop/windows/docs/",)
 
 def normalize_path(path: str) -> str:
     normalized = path.replace("\\", "/")
-    return normalized[2:] if normalized.startswith("./") else normalized
+    return normalized.removeprefix("./")
 
 
 def is_releasable_windows_path(path: str) -> bool:
@@ -29,8 +29,7 @@ def git_paths(root: Path, *args: str) -> list[str]:
         ["git", *args],
         cwd=root,
         check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
         encoding="utf-8",
     )

--- a/.github/workflows/desktop_windows_release.yml
+++ b/.github/workflows/desktop_windows_release.yml
@@ -118,14 +118,10 @@ jobs:
           echo "Latest windows tag: ${LATEST:-none}"
 
           # --- Is there a releasable desktop/windows change since that tag? ---
-          # (git diff --quiet exits 1 on differences; keep it out of a `head`
-          # pipe so pipefail+SIGPIPE can't abort the step.)
-          HAS_CHANGES=false
-          if [ -z "$LATEST" ]; then
-            [ -n "$(git ls-files desktop/windows)" ] && HAS_CHANGES=true
-          elif ! git diff --quiet --diff-filter=ACDMR "${LATEST}..HEAD" -- desktop/windows; then
-            HAS_CHANGES=true
-          fi
+          # A default manual release still needs a runtime change since the
+          # latest tag. The tested classifier excludes docs-only history;
+          # force_release remains the explicit override.
+          HAS_CHANGES=$(python3 .github/scripts/windows_release_paths.py --base "$LATEST")
 
           if [ "$HAS_CHANGES" != "true" ] && [ "$RELEASE_MODE" != "force_release" ]; then
             echo "No releasable desktop/windows changes since ${LATEST:-repo start}."

--- a/.github/workflows/desktop_windows_release.yml
+++ b/.github/workflows/desktop_windows_release.yml
@@ -85,14 +85,10 @@ jobs:
           echo "Latest windows tag: ${LATEST:-none}"
 
           # --- Is there a releasable desktop/windows change since that tag? ---
-          # (git diff --quiet exits 1 on differences; keep it out of a `head`
-          # pipe so pipefail+SIGPIPE can't abort the step.)
-          HAS_CHANGES=false
-          if [ -z "$LATEST" ]; then
-            [ -n "$(git ls-files desktop/windows)" ] && HAS_CHANGES=true
-          elif ! git diff --quiet --diff-filter=ACDMR "${LATEST}..HEAD" -- desktop/windows; then
-            HAS_CHANGES=true
-          fi
+          # A default manual release still needs a runtime change since the
+          # latest tag. The tested classifier excludes docs-only history;
+          # force_release remains the explicit override.
+          HAS_CHANGES=$(python3 .github/scripts/windows_release_paths.py --base "$LATEST")
 
           if [ "$HAS_CHANGES" != "true" ] && [ "$RELEASE_MODE" != "force_release" ]; then
             echo "No releasable desktop/windows changes since ${LATEST:-repo start}."

--- a/desktop/windows/docs/release-pipeline.md
+++ b/desktop/windows/docs/release-pipeline.md
@@ -1,20 +1,21 @@
 # Windows release pipeline
 
 The Windows desktop app ships through `.github/workflows/desktop_windows_release.yml`.
-It mirrors the macOS auto-release shape (`.github/workflows/desktop_auto_release.yml`):
-a merge to `main` cuts a version, tags it, and publishes a beta build — the
-difference is Windows has no external CI (no Codemagic), so the same workflow also
-builds the installer on a `windows-latest` runner with electron-builder (NSIS).
+Maintainers cut releases deliberately with `workflow_dispatch`; merges to `main`
+do not tag or publish automatically. Windows has no external CI (no Codemagic),
+so the same workflow plans the version and builds the installer on a
+`windows-latest` runner with electron-builder (NSIS).
 
 ## What it does
 
-On every push to `main` that touches `desktop/windows/**` (or a manual
-`workflow_dispatch`):
+When a maintainer starts `workflow_dispatch`, a default `release_now` run:
 
 1. **plan-and-tag** (Ubuntu)
    - Finds the latest `v*-windows` tag (the version source of truth).
    - Skips if there is no releasable `desktop/windows` change since that tag
-     (unless `release_mode: force_release`).
+     (unless `release_mode: force_release`). Changes confined to
+     `desktop/windows/docs/**` are release-neutral; mixed documentation and app
+     changes still release normally.
    - Computes the next **patch** version (from the latest tag, or the checked-in
      `package.json` version for the very first release).
    - Stamps `desktop/windows/package.json` to that version, commits it, tags the
@@ -71,16 +72,12 @@ every auto-update would 404.
   time and synced back to `main` for humans; even if that sync PR never merges,
   the next release still computes correctly from the tag.
 
-### Loop prevention
+### Release input guard
 
-The bump must not re-trigger the workflow. Three independent guards:
-
-1. Every git write uses `GITHUB_TOKEN`; GitHub does not start new workflow runs
-   for pushes made with `GITHUB_TOKEN`.
-2. The plan job skips any commit whose message starts with
-   `chore(windows): release v`.
-3. The plan job skips when there is no releasable `desktop/windows` change since
-   the latest tag.
+The tested release-path classifier keeps a default manual run from minting a
+new version for docs-only or empty history. `release_mode: force_release` is the
+explicit override when a maintainer needs to publish without a release-bearing
+Windows change.
 
 ### Auto-update
 

--- a/desktop/windows/docs/release-pipeline.md
+++ b/desktop/windows/docs/release-pipeline.md
@@ -9,12 +9,14 @@ runner with electron-builder (NSIS).
 
 ## What it does
 
-On a manual `workflow_dispatch`:
+When a maintainer starts `workflow_dispatch`, a default `release_now` run:
 
 1. **plan-and-tag** (Ubuntu)
    - Finds the latest `v*-windows` tag (the version source of truth).
    - Skips if there is no releasable `desktop/windows` change since that tag
-     (unless `release_mode: force_release`).
+     (unless `release_mode: force_release`). Changes confined to
+     `desktop/windows/docs/**` are release-neutral; mixed documentation and app
+     changes still release normally.
    - Computes the next **patch** version (from the latest tag, or the checked-in
      `package.json` version for the very first release).
    - Stamps `desktop/windows/package.json` to that version, commits it, tags the
@@ -71,16 +73,12 @@ every auto-update would 404.
   time and synced back to `main` for humans; even if that sync PR never merges,
   the next release still computes correctly from the tag.
 
-### Loop prevention
+### Release input guard
 
-The bump must not re-trigger the workflow. Three independent guards:
-
-1. Every git write uses `GITHUB_TOKEN`; GitHub does not start new workflow runs
-   for pushes made with `GITHUB_TOKEN`.
-2. The plan job skips any commit whose message starts with
-   `chore(windows): release v`.
-3. The plan job skips when there is no releasable `desktop/windows` change since
-   the latest tag.
+The tested release-path classifier keeps a default manual run from minting a
+new version for docs-only or empty history. `release_mode: force_release` is the
+explicit override when a maintainer needs to publish without a release-bearing
+Windows change.
 
 ### Auto-update
 


### PR DESCRIPTION
## What changed and why

Keeps the Windows docs-only release guard from #10240 aligned with current `main`.

Automatic push-to-`main` Windows tagging has been retired. The remaining manual `release_now` path still examines changes since the latest `v*-windows` tag, however, and its old broad `desktop/windows/**` diff treats documentation-only history as an installer input.

This PR routes that decision through a tested classifier:

- `desktop/windows/docs/**` alone is release-neutral;
- mixed documentation and app changes remain releasable;
- moving runtime content into docs remains releasable because the runtime deletion is artifact-bearing;
- `force_release` remains the explicit maintainer override; and
- the release runbook describes the manual-only workflow and its input guard.

## Product invariants affected

No locked product invariant requires citation for the current diff. `INV-DATA-1` remains unchanged: this modifies only Windows release-input classification and documentation, not production endpoints or data-plane authority.

## How it was verified

- `.github/scripts/test_windows_release_paths.py`: 5/5 passed against disposable real Git histories.
- `.github/scripts/test_plan_desktop_release.py`: 31/31 passed.
- `.github/scripts/test_run_checks.py ManifestContractTests`: 9/9 passed.
- `scripts/test_failure_class.py`: 24/24 passed.
- Full PR preflight passed all 98 selected contracts; 20 applicable checks executed on Windows in 284.06s.
- `actionlint .github/workflows/desktop_windows_release.yml` passed.
- Black 26.5.1, Python bytecode compilation, and `git diff --check` passed.
- Standard architecture review found no remaining issue.

## Tests

The classifier suite covers docs-only and mixed histories, first-release behavior, runtime-to-docs moves, exact CLI output, manual-only workflow wiring, and replacement of the old broad `git diff` test.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

`FC-release-input-path-scope` records the contract that a default release may mint a version, tag, and installer only when its selected history contains an artifact-bearing input. The canonical guard is the executable Windows release-path classifier invoked by the planner; `force_release` is the explicit override.

## New guards (only when adding a check or ratchet)

The classifier would have prevented the docs-only Windows release recorded in #10240 and remains effective after the workflow's transition to manual-only releases. It stays Windows-specific because this workflow owns the Windows tag, version-sync PR, and NSIS installer lifecycle.