### PR TITLE
SCA-146: replan desktop candidate after changelog sync

### DIFF
--- a/.github/scripts/desktop-release-source-identity.py
+++ b/.github/scripts/desktop-release-source-identity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -48,12 +49,17 @@ def releasable_desktop_paths(paths: list[str]) -> list[str]:
 
 
 def git(repository_root: Path, args: list[str], *, check: bool = True) -> str:
+    # The caller can be a Git hook or another repository-scoped tool. Do not
+    # inherit its GIT_DIR/index/worktree state when proving a different,
+    # explicit repository root.
+    environment = {name: value for name, value in os.environ.items() if not name.startswith("GIT_")}
     result = subprocess.run(
         ["git", "-C", str(repository_root), *args],
         check=check,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=environment,
     )
     return result.stdout.strip()
 
@@ -126,6 +132,19 @@ def ensure_candidate_history_is_safe(
         actual_parent = git(repository_root, ["rev-parse", f"{changelog_commit}^1"])
         if actual_parent != changelog_parent_sha:
             raise ValueError("merged changelog parent does not match its recorded source SHA")
+        if changelog_parent_sha != planned_source_sha:
+            # A changelog merge may race a newer releasable desktop merge. The
+            # workflow is allowed to replan in that narrow case, but only from
+            # a source descended from the immutable changelog parent. This
+            # keeps the original source evidence intact without allowing an
+            # unrelated or stale changelog branch to be repurposed.
+            try:
+                git(
+                    repository_root,
+                    ["merge-base", "--is-ancestor", changelog_parent_sha, planned_source_sha],
+                )
+            except subprocess.CalledProcessError as error:
+                raise ValueError("replanned source must descend from the changelog parent SHA") from error
 
 
 def build_evidence(
@@ -143,7 +162,10 @@ def build_evidence(
     later non-desktop commits, which are admitted only after the caller proves
     ancestry and confirms there is no newer releasable desktop input. A
     consolidated changelog records its own parent, not the merge commit's first
-    parent: concurrent non-desktop main commits are valid merge parents.
+    parent: concurrent non-desktop main commits are valid merge parents. If a
+    newer releasable desktop change races that merge, the workflow replans from
+    the newer checked source and preserves the changelog's original parent in
+    a distinct evidence mode.
     """
     planned_source_sha = require_sha("planned_source_sha", planned_source_sha)
     candidate_source_sha = require_sha("candidate_source_sha", candidate_source_sha)
@@ -157,13 +179,11 @@ def build_evidence(
             raise ValueError("merged changelog evidence requires commit, PR URL, and first parent")
         changelog_commit = require_sha("changelog_commit", changelog_commit)
         changelog_parent_sha = require_sha("changelog_parent_sha", changelog_parent_sha)
-        if changelog_parent_sha != planned_source_sha:
-            raise ValueError("merged changelog parent must match the planner source SHA")
         if not re.fullmatch(r"https://github\.com/[^/]+/[^/]+/pull/[1-9][0-9]*", changelog_pr):
             raise ValueError("changelog_pr must be a canonical GitHub pull request URL")
-        return {
+        evidence = {
             "schema": SCHEMA,
-            "mode": "merged-changelog",
+            "mode": "merged-changelog" if changelog_parent_sha == planned_source_sha else "replanned-changelog",
             "planned_source_sha": planned_source_sha,
             "candidate_source_sha": candidate_source_sha,
             "origin_main_sha": origin_main_sha,
@@ -171,6 +191,9 @@ def build_evidence(
             "changelog_pr": changelog_pr,
             "changelog_parent_sha": changelog_parent_sha,
         }
+        if changelog_parent_sha != planned_source_sha:
+            evidence["replanned_from_source_sha"] = changelog_parent_sha
+        return evidence
 
     return {
         "schema": SCHEMA,

--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -33,10 +33,14 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         cwd: Path,
         env: dict[str, str],
     ) -> subprocess.CompletedProcess[str]:
+        # Git invokes hooks with repository-scoped GIT_* variables. This test
+        # runs workflow commands in an independent disposable repository, so
+        # do not let the hook's index/worktree leak into that shell.
+        isolated_env = {name: value for name, value in env.items() if not name.startswith("GIT_")}
         return subprocess.run(
             ["bash", "-c", self._workflow_script(step_name)],
             cwd=cwd,
-            env=env,
+            env=isolated_env,
             check=False,
             capture_output=True,
             text=True,
@@ -156,6 +160,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
                 check=True,
                 capture_output=True,
                 text=True,
+                env={name: value for name, value in os.environ.items() if not name.startswith("GIT_")},
             ).stdout.strip()
             self.assertEqual(checked_out_sha, candidate_sha)
             self.assertEqual(sentinel.read_text(encoding="utf-8"), "must remain untouched\n")

--- a/.github/scripts/test_desktop_release_source_identity.py
+++ b/.github/scripts/test_desktop_release_source_identity.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import subprocess
 import tempfile
 import unittest
@@ -49,17 +50,6 @@ class DesktopReleaseSourceIdentityTests(unittest.TestCase):
                 changelog_pr=PR_URL,
             )
 
-    def test_rejects_changelog_commit_with_a_different_recorded_parent(self) -> None:
-        with self.assertRaisesRegex(ValueError, "changelog parent must match the planner source SHA"):
-            identity.build_evidence(
-                planned_source_sha=PLANNED_SHA,
-                candidate_source_sha=CANDIDATE_SHA,
-                origin_main_sha=CANDIDATE_SHA,
-                changelog_parent_sha="d" * 40,
-                changelog_commit=CHANGELOG_SHA,
-                changelog_pr=PR_URL,
-            )
-
     def test_direct_path_records_current_main_after_non_desktop_commits(self) -> None:
         evidence = identity.build_evidence(
             planned_source_sha=PLANNED_SHA,
@@ -70,12 +60,17 @@ class DesktopReleaseSourceIdentityTests(unittest.TestCase):
         self.assertEqual(evidence["candidate_source_sha"], CANDIDATE_SHA)
 
     def _git(self, repository: Path, *args: str) -> str:
+        # The repository-wide pre-push hook exports GIT_* state while running
+        # selected checks. Test repositories must not inherit that state from
+        # their caller or their commits can target the wrong index/worktree.
+        environment = {name: value for name, value in os.environ.items() if not name.startswith("GIT_")}
         return subprocess.run(
             ["git", "-C", str(repository), *args],
             check=True,
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=environment,
         ).stdout.strip()
 
     def _commit(self, repository: Path, path: str, contents: str, message: str) -> str:
@@ -177,6 +172,65 @@ class DesktopReleaseSourceIdentityTests(unittest.TestCase):
                     changelog_parent_sha=planned_source_sha,
                 )
             self.assertNotEqual(stale_parent_sha, planned_source_sha)
+
+    def test_replans_after_concurrent_desktop_change_without_losing_changelog_evidence(self) -> None:
+        """Model SCA-146: a newer desktop merge races a regular changelog merge."""
+        directory, repository, original_planned_source_sha = self._repository_with_planned_source()
+        with directory:
+            main_branch = self._git(repository, "branch", "--show-current")
+            replanned_source_sha = self._commit(
+                repository,
+                "desktop/macos/Desktop/Sources/Newer.swift",
+                "let newerDesktopChange = true\n",
+                "newer desktop source",
+            )
+            self._git(repository, "checkout", "-b", "changelog", original_planned_source_sha)
+            changelog_commit = self._commit(
+                repository,
+                "desktop/macos/changelog/2026-07-25.json",
+                "{}\n",
+                "consolidate changelog",
+            )
+            self._git(repository, "checkout", main_branch)
+            self._git(
+                repository,
+                "merge",
+                "--no-ff",
+                "changelog",
+                "-m",
+                "regular changelog merge",
+            )
+            candidate_source_sha = self._git(repository, "rev-parse", "HEAD")
+
+            with self.assertRaisesRegex(ValueError, "newer releasable desktop changes"):
+                identity.ensure_candidate_history_is_safe(
+                    repository_root=repository,
+                    planned_source_sha=original_planned_source_sha,
+                    candidate_source_sha=candidate_source_sha,
+                    changelog_commit=changelog_commit,
+                    changelog_parent_sha=original_planned_source_sha,
+                )
+
+            identity.ensure_candidate_history_is_safe(
+                repository_root=repository,
+                planned_source_sha=replanned_source_sha,
+                candidate_source_sha=candidate_source_sha,
+                changelog_commit=changelog_commit,
+                changelog_parent_sha=original_planned_source_sha,
+            )
+            evidence = identity.build_evidence(
+                planned_source_sha=replanned_source_sha,
+                candidate_source_sha=candidate_source_sha,
+                origin_main_sha=candidate_source_sha,
+                changelog_parent_sha=original_planned_source_sha,
+                changelog_commit=changelog_commit,
+                changelog_pr=PR_URL,
+            )
+
+        self.assertEqual(evidence["mode"], "replanned-changelog")
+        self.assertEqual(evidence["planned_source_sha"], replanned_source_sha)
+        self.assertEqual(evidence["replanned_from_source_sha"], original_planned_source_sha)
+        self.assertEqual(evidence["changelog_commit"], changelog_commit)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -397,12 +397,17 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertIn("source_sha: ${{ steps.plan.outputs.source_sha }}", workflow)
         self.assertIn("ref: ${{ steps.recheck.outputs.source_sha }}", workflow)
         self.assertEqual(planner.SOURCE_CHECK_WAIT_SECONDS, 20 * 60)
-        self.assertEqual(workflow.count("--source-check-wait-seconds 1200"), 2)
-        self.assertEqual(workflow.count("--source-check-poll-seconds 30"), 2)
+        self.assertEqual(workflow.count("--source-check-wait-seconds 1200"), 3)
+        self.assertEqual(workflow.count("--source-check-poll-seconds 30"), 3)
         self.assertLess(
             workflow.index("Create and regular-merge PR to sync changelog back to main"),
             workflow.index("Publish immutable tag from exact live main source"),
         )
+        self.assertIn("Replan release source after changelog sync", workflow)
+        self.assertIn("git checkout --detach origin/main", workflow)
+        self.assertIn('SHOULD_RELEASE="${{ steps.replan.outputs.should_release }}"', workflow)
+        self.assertIn('PLANNED_SOURCE_SHA="${{ steps.final-plan.outputs.source_sha }}"', workflow)
+        self.assertIn("if: steps.final-plan.outputs.should_release == 'true'", workflow)
         self.assertIn('git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main', workflow)
         self.assertEqual(workflow.count('CANDIDATE_SHA="$MAIN_SHA"'), 2)
         self.assertIn('BRANCH="changelog/v${VERSION}-${PLANNED_SOURCE_SHA:0:12}"', workflow)

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -270,12 +270,57 @@ jobs:
             echo "merged_main_sha=$MERGED_MAIN_SHA"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Bind immutable planner evidence to fresh main
+      - name: Replan release source after changelog sync
+        # A newer releasable desktop change may merge while the changelog branch
+        # is being prepared. The regular changelog merge must remain intact, but
+        # its original planner source is then intentionally stale. Replan from
+        # fresh main before binding evidence so this run either tags the newly
+        # qualified source or defers cleanly without a stale-source failure.
+        if: steps.recheck.outputs.should_release == 'true' && steps.changelog.outputs.changed == 'true'
+        id: replan
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "Omi Bot token not available; cannot replan after changelog sync."
+            exit 1
+          fi
+
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git checkout --detach origin/main
+          test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+
+          python3 .github/scripts/plan-desktop-release.py \
+            --repository "${{ github.repository }}" \
+            --source-check-wait-seconds 1200 \
+            --source-check-poll-seconds 30
+
+      - name: Select final release plan
         if: steps.recheck.outputs.should_release == 'true'
+        id: final-plan
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.changelog.outputs.changed }}" = "true" ]; then
+            # The merge above can advance main. Always use the post-merge plan,
+            # even when it defers, so a stale initial plan cannot reach tagging.
+            SHOULD_RELEASE="${{ steps.replan.outputs.should_release }}"
+            SOURCE_SHA="${{ steps.replan.outputs.source_sha }}"
+          else
+            SHOULD_RELEASE="${{ steps.recheck.outputs.should_release }}"
+            SOURCE_SHA="${{ steps.recheck.outputs.source_sha }}"
+          fi
+          {
+            echo "should_release=$SHOULD_RELEASE"
+            echo "source_sha=$SOURCE_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Bind immutable planner evidence to fresh main
+        if: steps.final-plan.outputs.should_release == 'true'
         id: identity
         run: |
           set -euo pipefail
-          PLANNED_SOURCE_SHA="${{ steps.recheck.outputs.source_sha }}"
+          PLANNED_SOURCE_SHA="${{ steps.final-plan.outputs.source_sha }}"
           CHANGELOG_CHANGED="${{ steps.changelog.outputs.changed }}"
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           MAIN_SHA="$(git rev-parse 'origin/main^{commit}')"
@@ -308,7 +353,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Retain immutable planner source evidence
-        if: steps.recheck.outputs.should_release == 'true'
+        if: steps.final-plan.outputs.should_release == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: desktop-release-planner-source-identity-${{ steps.version.outputs.release_tag }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -317,7 +362,7 @@ jobs:
           overwrite: false
 
       - name: Publish immutable tag from exact live main source
-        if: steps.recheck.outputs.should_release == 'true'
+        if: steps.final-plan.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |


### PR DESCRIPTION
## Summary

- replan from freshly fetched `origin/main` after a regular changelog PR merge
- bind tagging only to that final exact-SHA plan, deferring safely when its checks are not ready
- preserve immutable evidence for the original changelog parent in a `replanned-changelog` mode

## Root cause and safety

A newer releasable desktop merge could arrive while the workflow was preparing and regular-merging a changelog PR. The existing source-identity guard correctly rejected the stale initial plan, but only after the changelog mutation, leaving that candidate run terminally failed. The post-merge planner pass retains the fail-closed identity check and will either select the newer exact-SHA-qualified source or skip tagging. It creates no direct Codemagic builds and does not change qualification, release, Beta, or Stable behavior.

## Verification

- `python3 .github/scripts/test_desktop_release_source_identity.py`
- `python3 .github/scripts/test_plan_desktop_release.py`
- `python3 .github/scripts/test_desktop_release_flow_contract.py`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/desktop_auto_release.yml`
- `make preflight`

## Product invariants affected

None.

Failure-Class: FC-release-build-config-source-binding


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

