### PR TITLE
fix(release): align qualification guard with isolated checkout

### DIFF
--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -858,7 +858,7 @@ def check_desktop_qualification_runner() -> list[str]:
         "self-hosted",
         "macos",
         "omi-desktop-qualification",
-        "ref: ${{ inputs.release_tag }}",
+        'checkout --quiet --detach "refs/tags/$RELEASE_TAG"',
         "check-desktop-auto-beta-candidate.py",
         "--automatic",
         "actions/create-github-app-token@v3",

--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import subprocess
@@ -18,6 +19,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
     def setUp(self) -> None:
         self.workflow = (ROOT / ".github/workflows/desktop_qualify_beta.yml").read_text(encoding="utf-8")
         self.codemagic = (ROOT / "codemagic.yaml").read_text(encoding="utf-8")
+        self.release_guard = (ROOT / ".github/scripts/check-release-process-guards.py").read_text(encoding="utf-8")
 
     def _workflow_script(self, step_name: str) -> str:
         marker = f"      - name: {step_name}\n"
@@ -98,6 +100,19 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
             "cancel-in-progress: false",
         ):
             self.assertIn(fragment, self.workflow)
+
+    def test_release_process_guard_accepts_the_run_isolated_tag_checkout(self) -> None:
+        tree = ast.parse(self.release_guard)
+        guard = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "check_desktop_qualification_runner"
+        )
+        fragments = {
+            node.value for node in ast.walk(guard) if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        }
+        self.assertIn('checkout --quiet --detach "refs/tags/$RELEASE_TAG"', fragments)
+        self.assertNotIn("ref: ${{ inputs.release_tag }}", fragments)
 
     def test_run_staging_evidence_and_cleanup_are_isolated_and_rerun_safe(self) -> None:
         for fragment in (


### PR DESCRIPTION
## What changed and why

Align the release-process guard with the run-isolated detached-tag checkout introduced by #10611, and make the desktop release flow contract verify that the guard tracks that checkout boundary. The stale guard still required the removed `actions/checkout` `ref:` field and has reddened `main` since run 30182385274.

## Product invariants affected

None.

## How it was verified

- Direct `check_desktop_qualification_runner()` reproduction changed from the stale-fragment error to `[]`
- Five host-portable `DesktopReleaseFlowContractTests` cases passed, including the new guard/workflow alignment regression
- `python -m py_compile .github/scripts/check-release-process-guards.py .github/scripts/test_desktop_release_flow_contract.py` - passed
- `git diff --check` - passed

The two shell-execution cases in the same suite were not run locally because Windows resolves the system WSL `bash.exe` before Git Bash for child processes; Linux CI exercises the complete suite.

## Tests

`test_release_process_guard_accepts_the_run_isolated_tag_checkout` fails against the current `main` guard and passes only when the guard requires the detached immutable-tag checkout used by the qualification workflow.

## Failure class (fixes)

Failure-Class: FC-shared-runner-checkout-residue

## New guards (only when adding a check or ratchet)

The cross-file contract would have caught the guard drift introduced when #10611 replaced shared-workspace `actions/checkout` with an isolated source tree. It extends the existing shared desktop release-flow primitive instead of creating another checker.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

