### PR TITLE
SCA-149: restore native Codemagic tag delivery

### DIFF
--- a/.github/scripts/publish-desktop-candidate-tag.py
+++ b/.github/scripts/publish-desktop-candidate-tag.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 from datetime import datetime, timezone
@@ -19,11 +20,16 @@ SECRET_PATTERNS = (
     re.compile(r"(?i)(bearer\s+)\S+"),
     re.compile(r"\b(?:gh[oprsu]_[A-Za-z0-9]+|github_pat_[A-Za-z0-9_]+)\b"),
     re.compile(r"(?i)((?:access_)?token=)[^&\s]+"),
+    re.compile(r"(?i)(https?://[^:/\s]+:)[^@/\s]+(@)"),
 )
 
 
 class GitHubApiError(RuntimeError):
     """A bounded, credential-safe GitHub CLI failure."""
+
+
+class GitTransportError(RuntimeError):
+    """A bounded, credential-safe native Git publication failure."""
 
 
 def sanitize_api_diagnostic(value: str) -> str:
@@ -66,6 +72,27 @@ def run_gh_json(args: list[str], payload: dict[str, object] | None = None) -> di
     return decoded
 
 
+def run_git(
+    args: list[str], *, stdin: str | None = None, environment: dict[str, str] | None = None
+) -> str:
+    """Run the native Git transport without exposing credentials in failures."""
+    if environment is None:
+        environment = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    result = subprocess.run(
+        ["git", *args],
+        check=False,
+        input=stdin,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=environment,
+    )
+    if result.returncode:
+        detail = sanitize_api_diagnostic(result.stderr or result.stdout)
+        raise GitTransportError(f"Git tag publication failed (exit {result.returncode}): {detail}")
+    return result.stdout
+
+
 def validate_inputs(repository: str, release_tag: str, candidate_sha: str) -> None:
     owner, separator, name = repository.partition("/")
     if not owner or not separator or not name or "/" in name:
@@ -76,23 +103,24 @@ def validate_inputs(repository: str, release_tag: str, candidate_sha: str) -> No
         raise ValueError("candidate_sha must be a 40-character lowercase SHA")
 
 
-def create_annotated_tag_object(
-    *, repository: str, release_tag: str, candidate_sha: str, evidence: str, timestamp: str
-) -> str:
-    response = run_gh_json(
-        ["api", "--method", "POST", f"repos/{repository}/git/tags"],
-        {
-            "tag": release_tag,
-            "message": evidence,
-            "object": candidate_sha,
-            "type": "commit",
-            "tagger": {"name": TAGGER_NAME, "email": TAGGER_EMAIL, "date": timestamp},
-        },
+def create_local_annotated_tag(
+    *, release_tag: str, candidate_sha: str, evidence: str, timestamp: str
+) -> None:
+    """Create an evidence-bearing tag locally; it is not a candidate until pushed."""
+    tagger_environment = {
+        # Git hooks export repository-scoped GIT_* variables. The publisher
+        # can be tested from a disposable repository, so never inherit a
+        # caller's index, directory, or worktree into local tag creation.
+        **{key: value for key, value in os.environ.items() if not key.startswith("GIT_")},
+        "GIT_COMMITTER_NAME": TAGGER_NAME,
+        "GIT_COMMITTER_EMAIL": TAGGER_EMAIL,
+        "GIT_COMMITTER_DATE": timestamp,
+    }
+    run_git(
+        ["tag", "--annotate", "--file=-", release_tag, candidate_sha],
+        stdin=evidence,
+        environment=tagger_environment,
     )
-    tag_object_sha = response.get("sha")
-    if not isinstance(tag_object_sha, str) or not SHA_RE.fullmatch(tag_object_sha):
-        raise ValueError("GitHub did not return the annotated tag object SHA")
-    return tag_object_sha
 
 
 def live_main_sha(repository: str) -> str:
@@ -106,21 +134,12 @@ def live_main_sha(repository: str) -> str:
     return sha
 
 
-def create_immutable_tag_ref(*, repository: str, release_tag: str, tag_object_sha: str) -> None:
-    """Create the candidate ref once; conflicts fail without rewriting a tag."""
-    expected_ref = f"refs/tags/{release_tag}"
-    response = run_gh_json(
-        ["api", "--method", "POST", f"repos/{repository}/git/refs"],
-        {
-            "ref": expected_ref,
-            "sha": tag_object_sha,
-        },
-    )
-    target = response.get("object")
-    if response.get("ref") != expected_ref or not isinstance(target, dict):
-        raise ValueError("GitHub returned an unexpected candidate tag ref")
-    if target.get("sha") != tag_object_sha:
-        raise ValueError("GitHub candidate tag ref does not target the annotated tag object")
+def publish_immutable_tag_ref(release_tag: str) -> None:
+    """Publish through Git's tag push so Codemagic sees its native tag trigger."""
+    tag_ref = f"refs/tags/{release_tag}"
+    # No force refspec: an existing remote candidate makes Git fail rather
+    # than rewriting immutable tag evidence or retrying a stale candidate.
+    run_git(["push", "origin", f"{tag_ref}:{tag_ref}"])
 
 
 def publish_candidate_tag(
@@ -132,10 +151,9 @@ def publish_candidate_tag(
     timestamp: str,
 ) -> None:
     validate_inputs(repository, release_tag, candidate_sha)
-    # A tag object alone is unreachable and is not a candidate. The only
-    # candidate-creating action is the create-only ref request below.
-    tag_object_sha = create_annotated_tag_object(
-        repository=repository,
+    # A local tag is not a candidate. It becomes one only through the native
+    # Git tag push below, which is the provider-visible Codemagic boundary.
+    create_local_annotated_tag(
         release_tag=release_tag,
         candidate_sha=candidate_sha,
         evidence=evidence,
@@ -145,13 +163,9 @@ def publish_candidate_tag(
     if observed_main_sha != candidate_sha:
         raise ValueError(
             "GitHub main moved before candidate publication; "
-            f"expected {candidate_sha}, observed {observed_main_sha}; tag ref was not created"
+            f"expected {candidate_sha}, observed {observed_main_sha}; tag was not pushed"
         )
-    create_immutable_tag_ref(
-        repository=repository,
-        release_tag=release_tag,
-        tag_object_sha=tag_object_sha,
-    )
+    publish_immutable_tag_ref(release_tag)
 
 
 def main() -> int:

--- a/.github/scripts/test_publish_desktop_candidate_tag.py
+++ b/.github/scripts/test_publish_desktop_candidate_tag.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 SCRIPT = Path(__file__).with_name("publish-desktop-candidate-tag.py")
 SPEC = importlib.util.spec_from_file_location("publish_desktop_candidate_tag", SCRIPT)
@@ -17,21 +19,63 @@ SPEC.loader.exec_module(publisher)
 
 REPOSITORY = "BasedHardware/omi"
 CANDIDATE_SHA = "a" * 40
-TAG_OBJECT_SHA = "b" * 40
 RELEASE_TAG = "v1.2.3+10203-macos"
 
 
 class PublishDesktopCandidateTagTests(unittest.TestCase):
-    def test_publishes_only_after_refetching_exact_live_main(self) -> None:
-        responses = [
-            {"sha": TAG_OBJECT_SHA},
-            {"object": {"sha": CANDIDATE_SHA}},
-            {
-                "ref": f"refs/tags/{RELEASE_TAG}",
-                "object": {"sha": TAG_OBJECT_SHA},
-            },
-        ]
-        with patch.object(publisher, "run_gh_json", side_effect=responses) as run_gh:
+    def test_native_git_transport_preserves_annotated_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            remote = root / "remote.git"
+            source.mkdir()
+            git_environment = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+            def git(*args: str, cwd: Path = source) -> str:
+                result = subprocess.run(
+                    ["git", *args],
+                    cwd=cwd,
+                    env=git_environment,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                return result.stdout.strip()
+
+            git("init", "--quiet")
+            git("config", "user.name", "Candidate contract")
+            git("config", "user.email", "candidate-contract@example.com")
+            (source / "candidate.txt").write_text("candidate source\n", encoding="utf-8")
+            git("add", "candidate.txt")
+            git("commit", "--quiet", "-m", "candidate")
+            candidate_sha = git("rev-parse", "HEAD")
+            git("init", "--bare", "--quiet", str(remote), cwd=root)
+            git("remote", "add", "origin", str(remote))
+            git("push", "--quiet", "origin", "HEAD:refs/heads/main")
+
+            original_directory = Path.cwd()
+            try:
+                os.chdir(source)
+                publisher.create_local_annotated_tag(
+                    release_tag=RELEASE_TAG,
+                    candidate_sha=candidate_sha,
+                    evidence="immutable planner evidence\n",
+                    timestamp="2026-07-25T00:00:00Z",
+                )
+                publisher.publish_immutable_tag_ref(RELEASE_TAG)
+            finally:
+                os.chdir(original_directory)
+
+            self.assertEqual(git("cat-file", "-t", f"refs/tags/{RELEASE_TAG}", cwd=remote), "tag")
+            evidence = git("cat-file", "-p", f"refs/tags/{RELEASE_TAG}", cwd=remote)
+            self.assertIn(f"object {candidate_sha}", evidence)
+            self.assertIn("immutable planner evidence", evidence)
+
+    def test_publishes_only_after_refetching_exact_live_main_via_native_tag_push(self) -> None:
+        with (
+            patch.object(publisher, "run_gh_json", return_value={"object": {"sha": CANDIDATE_SHA}}) as run_gh,
+            patch.object(publisher, "run_git") as run_git,
+        ):
             publisher.publish_candidate_tag(
                 repository=REPOSITORY,
                 release_tag=RELEASE_TAG,
@@ -40,37 +84,31 @@ class PublishDesktopCandidateTagTests(unittest.TestCase):
                 timestamp="2026-07-25T00:00:00Z",
             )
 
-        main_args = run_gh.call_args_list[1].args
         self.assertEqual(
-            main_args,
-            (
-                [
-                    "api",
-                    "--method",
-                    "GET",
-                    f"repos/{REPOSITORY}/git/ref/heads/main",
-                ],
-            ),
-        )
-        ref_args, ref_payload = run_gh.call_args_list[2].args
-        self.assertEqual(
-            ref_args,
-            ["api", "--method", "POST", f"repos/{REPOSITORY}/git/refs"],
+            run_gh.call_args_list,
+            [call(["api", "--method", "GET", f"repos/{REPOSITORY}/git/ref/heads/main"])],
         )
         self.assertEqual(
-            ref_payload,
-            {
-                "ref": f"refs/tags/{RELEASE_TAG}",
-                "sha": TAG_OBJECT_SHA,
-            },
+            run_git.call_args_list[0].args,
+            (["tag", "--annotate", "--file=-", RELEASE_TAG, CANDIDATE_SHA],),
+        )
+        self.assertEqual(run_git.call_args_list[0].kwargs["stdin"], "immutable planner evidence\n")
+        self.assertEqual(
+            run_git.call_args_list[0].kwargs["environment"]["GIT_COMMITTER_NAME"], publisher.TAGGER_NAME
+        )
+        self.assertEqual(
+            run_git.call_args_list[0].kwargs["environment"]["GIT_COMMITTER_DATE"], "2026-07-25T00:00:00Z"
+        )
+        self.assertEqual(
+            run_git.call_args_list[1],
+            call(["push", "origin", f"refs/tags/{RELEASE_TAG}:refs/tags/{RELEASE_TAG}"]),
         )
 
-    def test_main_advance_rejection_never_creates_the_tag_ref(self) -> None:
-        responses = [
-            {"sha": TAG_OBJECT_SHA},
-            {"object": {"sha": "c" * 40}},
-        ]
-        with patch.object(publisher, "run_gh_json", side_effect=responses) as run_gh:
+    def test_main_advance_rejection_never_pushes_the_tag(self) -> None:
+        with (
+            patch.object(publisher, "run_gh_json", return_value={"object": {"sha": "c" * 40}}) as run_gh,
+            patch.object(publisher, "run_git") as run_git,
+        ):
             with self.assertRaisesRegex(ValueError, "GitHub main moved before candidate publication"):
                 publisher.publish_candidate_tag(
                     repository=REPOSITORY,
@@ -79,51 +117,32 @@ class PublishDesktopCandidateTagTests(unittest.TestCase):
                     evidence="immutable planner evidence\n",
                     timestamp="2026-07-25T00:00:00Z",
                 )
-        self.assertEqual(run_gh.call_count, 2)
+        self.assertEqual(
+            run_gh.call_args_list,
+            [call(["api", "--method", "GET", f"repos/{REPOSITORY}/git/ref/heads/main"])],
+        )
+        self.assertEqual(run_git.call_count, 1)
+        self.assertEqual(
+            run_git.call_args_list[0].args,
+            (["tag", "--annotate", "--file=-", RELEASE_TAG, CANDIDATE_SHA],),
+        )
 
-    def test_annotated_tag_carries_identity_evidence_before_ref_creation(self) -> None:
-        responses = [
-            {"sha": TAG_OBJECT_SHA},
-            {"object": {"sha": CANDIDATE_SHA}},
-            {
-                "ref": f"refs/tags/{RELEASE_TAG}",
-                "object": {"sha": TAG_OBJECT_SHA},
-            },
-        ]
-        with patch.object(publisher, "run_gh_json", side_effect=responses) as run_gh:
-            publisher.publish_candidate_tag(
-                repository=REPOSITORY,
-                release_tag=RELEASE_TAG,
-                candidate_sha=CANDIDATE_SHA,
-                evidence="immutable planner evidence\n",
-                timestamp="2026-07-25T00:00:00Z",
-            )
-
-        tag_args, tag_payload = run_gh.call_args_list[0].args
-        self.assertEqual(tag_args, ["api", "--method", "POST", f"repos/{REPOSITORY}/git/tags"])
-        self.assertEqual(tag_payload["object"], CANDIDATE_SHA)
-        self.assertEqual(tag_payload["message"], "immutable planner evidence\n")
-        self.assertEqual(tag_payload["tagger"]["name"], publisher.TAGGER_NAME)
-        self.assertEqual(tag_payload["tagger"]["date"], "2026-07-25T00:00:00Z")
-
-    def test_existing_tag_api_failure_is_actionable_and_credential_safe(self) -> None:
+    def test_transport_failure_is_actionable_and_credential_safe(self) -> None:
         result = subprocess.CompletedProcess(
-            ["gh", "api"],
+            ["git", "push"],
             1,
             stdout="",
             stderr=(
-                "HTTP 422: Reference already exists " "(Request ID: A50A:19CD13) Authorization: Bearer ghp_supersecret"
+                "remote: cannot lock ref 'refs/tags/v1.2.3+10203-macos': reference already exists "
+                "https://x-access-token:ghp_supersecret@github.com/BasedHardware/omi.git"
             ),
         )
         with patch.object(publisher.subprocess, "run", return_value=result):
             with self.assertRaisesRegex(
-                publisher.GitHubApiError,
-                r"HTTP 422: Reference already exists .*Request ID: A50A:19CD13",
+                publisher.GitTransportError,
+                r"cannot lock ref 'refs/tags/v1.2.3\+10203-macos': reference already exists",
             ) as raised:
-                publisher.run_gh_json(
-                    ["api", "--method", "POST", f"repos/{REPOSITORY}/git/refs"],
-                    {"ref": f"refs/tags/{RELEASE_TAG}", "sha": TAG_OBJECT_SHA},
-                )
+                publisher.run_git(["push", "origin", f"refs/tags/{RELEASE_TAG}:refs/tags/{RELEASE_TAG}"])
 
         self.assertNotIn("ghp_supersecret", str(raised.exception))
         self.assertIn("<redacted>", str(raised.exception))


### PR DESCRIPTION
## What changed and why

Fixes SCA-149. Candidate tags created through GitHub's REST git-ref API reached
the Codemagic webhook but did not produce the native release check/build. The
publisher now creates the same evidence-bearing annotated tag locally, rechecks
the authoritative `main` SHA, and publishes one non-forced `git push` tag
ref—the known-good provider-visible trigger boundary. It never posts to
Codemagic's builds API.

Closes SCA-149

## Product invariants affected

none

## How it was verified

- `python3 .github/scripts/test_publish_desktop_candidate_tag.py` — 4 passed
- `python3 .github/scripts/test_plan_desktop_release.py` — 15 passed
- `python3 .github/scripts/test_desktop_release_source_identity.py` — 8 passed
- `backend/.venv/bin/python -m pytest -q .github/scripts/test_check_release_process_guards.py -k 'desktop_candidate_trigger'` — 3 passed
- `actionlint -config-file .github/actionlint.yaml .github/workflows/desktop_auto_release.yml` — passed
- `python3 -m compileall -q .github/scripts/publish-desktop-candidate-tag.py .github/scripts/test_publish_desktop_candidate_tag.py` — passed
- `git diff --check` — passed

The unrelated full `test_check_release_process_guards.py` suite has 9 existing
reviewed-parent fixture failures (`canonical workflow must retain exactly 21
approved script steps`); this change does not modify `codemagic.yaml` or that
guard's fixtures.

## Tests

`test_native_git_transport_preserves_annotated_evidence` pushes an annotated
tag to a disposable Git remote and verifies its source SHA and identity
evidence. The publisher contract also proves the authoritative-main read occurs
before the sole non-forced native tag push, and that a moved main prevents that
push.

## Failure class (fixes)

Failure-Class: FC-release-build-config-source-binding


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

