### PR TITLE
fix(desktop-windows): detect current Google Meet titles

### DIFF
--- a/.github/failure-classes/FC-meeting-trigger-title-identity-drift.json
+++ b/.github/failure-classes/FC-meeting-trigger-title-identity-drift.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-meeting-trigger-title-identity-drift",
+  "violated_contract": "Event-triggered meeting detection must recognize a provider in the browser-title form present when microphone use first triggers evaluation; it must not depend only on a later title form whose transition emits no detector event.",
+  "canonical_prevention": "Keep provider join and in-call title identities together in tested pattern data, scope title matching to known browser processes, and retain negative near-prefix cases so broader coverage does not create generic-title false positives.",
+  "canonical_prevention_artifact": [
+    "desktop/windows/src/main/meeting/patterns.test.ts"
+  ],
+  "evidence_prs": [
+    10628
+  ],
+  "scope_hints": [
+    "desktop/windows/src/main/meeting/patterns.json",
+    "desktop/windows/src/main/meeting/patterns.test.ts"
+  ],
+  "status": "open"
+}

--- a/desktop/windows/src/main/meeting/patterns.json
+++ b/desktop/windows/src/main/meeting/patterns.json
@@ -30,7 +30,11 @@
     "arc.exe"
   ],
   "titles": [
-    { "id": "meet-web", "name": "Google Meet", "pattern": "^Meet\\s+[-–—]\\s" },
+    {
+      "id": "meet-web",
+      "name": "Google Meet",
+      "pattern": "^(?:Google\\s+)?Meet(?:\\s+[-–—]\\s|$)"
+    },
     { "id": "zoom-web", "name": "Zoom", "pattern": "Zoom Meeting" },
     { "id": "teams-web", "name": "Microsoft Teams", "pattern": "\\| Microsoft Teams" },
     { "id": "webex-web", "name": "Webex", "pattern": "\\bWebex\\b" }

--- a/desktop/windows/src/main/meeting/patterns.test.ts
+++ b/desktop/windows/src/main/meeting/patterns.test.ts
@@ -44,21 +44,24 @@ describe('meeting patterns', () => {
     expect(m).toEqual([{ id: 'zoom', name: 'Zoom', exe: 'zoom.exe', via: 'process' }])
   })
 
-  it('matches browser meeting titles only for known browsers', () => {
-    const meet = matchTier1(
-      [],
-      { exePath: 'C:\\Program Files\\Google\\Chrome\\chrome.exe', title: 'Meet - abc-defg-hij' },
-      p
-    )
-    expect(meet[0]).toMatchObject({ id: 'meet-web', exe: 'chrome.exe', via: 'title' })
+  it('matches current Google Meet join and in-call titles only for known browsers', () => {
+    const chrome = 'C:\\Program Files\\Google\\Chrome\\chrome.exe'
+    for (const title of [
+      'Meet',
+      'Google Meet',
+      'Meet - abc-defg-hij',
+      'Google Meet - abc-defg-hij'
+    ]) {
+      const meet = matchTier1([], { exePath: chrome, title }, p)
+      expect(meet[0]).toMatchObject({ id: 'meet-web', exe: 'chrome.exe', via: 'title' })
+    }
 
     // Same title in a non-browser (an editor with a weird filename) — no match.
-    const editor = matchTier1(
-      [],
-      { exePath: 'C:\\tools\\notepad.exe', title: 'Meet - notes.txt' },
-      p
-    )
+    const editor = matchTier1([], { exePath: 'C:\\tools\\notepad.exe', title: 'Meet' }, p)
     expect(editor).toEqual([])
+
+    // Do not broaden the exact-title form into ordinary "meeting" documents.
+    expect(matchTier1([], { exePath: chrome, title: 'Meeting notes' }, p)).toEqual([])
   })
 
   it('matches Teams / Zoom / Webex browser titles', () => {
@@ -66,9 +69,9 @@ describe('meeting patterns', () => {
       exePath: 'C:\\x\\msedge.exe',
       title
     })
-    expect(matchTier1([], fg('Standup | Microsoft Teams - Profile 1 - Microsoft Edge'), p)[0].id).toBe(
-      'teams-web'
-    )
+    expect(
+      matchTier1([], fg('Standup | Microsoft Teams - Profile 1 - Microsoft Edge'), p)[0].id
+    ).toBe('teams-web')
     expect(matchTier1([], fg('Zoom Meeting - Google Chrome'), p)[0].id).toBe('zoom-web')
     expect(matchTier1([], fg('Cisco Webex Meetings'), p)[0].id).toBe('webex-web')
   })


### PR DESCRIPTION
Fixes #10553

## Summary

- Recognize the current Google Meet join-page titles `Meet` and `Google Meet`.
- Preserve support for the existing `Meet - <meeting code>` title form.
- Keep matching browser-scoped and reject ordinary titles such as `Meeting notes`.

## Root cause

The bundled matcher required a separator after `Meet`, but the current Google Meet join page reports the exact document title `Meet`. The browser starts using the microphone on that join surface, so the ConsentStore trigger can run before the title ever has a meeting-code suffix. A later document-title change does not emit the foreground-window event the detector watches, leaving both ask and auto modes silent.

## Product invariants affected

none

## Failure class

Failure-Class: new

The event-triggered detector accepted only a later presentation of the same provider identity. The behavioral pattern test now covers the join and in-call title forms at the trigger boundary.

## Validation

- `node node_modules/vitest/vitest.mjs run src/main/meeting/patterns.test.ts src/main/meeting/detector.test.ts` (26 passed)
- `node node_modules/typescript/bin/tsc --noEmit -p tsconfig.node.json --composite false`
- `node node_modules/prettier/bin/prettier.cjs --check src/main/meeting/patterns.json src/main/meeting/patterns.test.ts`
- `git diff --check`
- Live page probe: `https://meet.google.com/abc-defg-hij` reported the title `Meet`.
- Native Windows probe: an actual Chrome microphone stream appeared in ConsentStore as active `chrome.exe`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

