### PR TITLE
SCA-153: fail closed on M1 runner capacity

### DIFF
--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -107,6 +107,9 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
             "Finalize only this authenticated qualification lease",
             "if: always()",
             "qualification-lease release",
+            "runner-capacity.json",
+            "M1 qualification runner capacity guard refused to start",
+            "33554432",
             "desktop-qualification-evidence-${{ inputs.release_tag }}-m1-${{ github.run_id }}-${{ github.run_attempt }}",
             "overwrite: false",
             "qualification-evidence-${TARGET_SHA}-${digest}.json",
@@ -142,6 +145,8 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
                 "GITHUB_SERVER_URL": server.as_uri(),
                 "GITHUB_REPOSITORY": "BasedHardware/omi",
                 "RELEASE_TAG": RELEASE_TAG,
+                "OMI_QUALIFICATION_MINIMUM_FREE_KIB": "1",
+                "OMI_QUALIFICATION_MINIMUM_FREE_INODES": "1",
             }
             stage_result = self._run_workflow_script(
                 "Create run-isolated qualification staging",
@@ -188,6 +193,8 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
                 "GITHUB_RUN_ID": run_id,
                 "GITHUB_RUN_ATTEMPT": run_attempt,
                 "QUALIFICATION_STAGE": str(stage),
+                "OMI_QUALIFICATION_MINIMUM_FREE_KIB": "1",
+                "OMI_QUALIFICATION_MINIMUM_FREE_INODES": "1",
             }
             stage_result = self._run_workflow_script(
                 "Create run-isolated qualification staging",
@@ -215,6 +222,47 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
             )
             self.assertNotEqual(unsafe_result.returncode, 0)
             self.assertFalse((unsafe_stage / "cleanup-evidence.json").exists())
+
+    def test_low_runner_capacity_fails_before_checkout_with_durable_cleanup_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            runner_temp = root / "runner-temp"
+            runner_temp.mkdir()
+            run_id = "30185755794"
+            run_attempt = "1"
+            stage = runner_temp / "desktop-beta-qualification" / f"{run_id}-{run_attempt}"
+            env = {
+                **os.environ,
+                "RUNNER_TEMP": str(runner_temp),
+                "GITHUB_RUN_ID": run_id,
+                "GITHUB_RUN_ATTEMPT": run_attempt,
+                "QUALIFICATION_STAGE": str(stage),
+                "OMI_QUALIFICATION_MINIMUM_FREE_KIB": str(2**63 - 1),
+                "OMI_QUALIFICATION_MINIMUM_FREE_INODES": "1",
+            }
+
+            capacity_result = self._run_workflow_script(
+                "Create run-isolated qualification staging",
+                cwd=runner_temp,
+                env=env,
+            )
+            self.assertNotEqual(capacity_result.returncode, 0)
+            self.assertIn("M1 qualification runner capacity guard refused to start", capacity_result.stdout)
+            self.assertFalse((stage / "source").exists(), "capacity failure must precede candidate checkout")
+            capacity = json.loads((stage / "runner-capacity.json").read_text(encoding="utf-8"))
+            self.assertEqual(capacity["status"], "failed")
+            self.assertEqual(capacity["failure_class"], "runner-filesystem-capacity")
+            self.assertIn("insufficient-free-kib", capacity["failure_reasons"])
+            self.assertEqual(capacity["minimum_free_kib"], 2**63 - 1)
+
+            finalize_result = self._run_workflow_script(
+                "Finalize only this authenticated qualification lease",
+                cwd=runner_temp,
+                env=env,
+            )
+            self.assertEqual(finalize_result.returncode, 0, finalize_result.stderr)
+            cleanup = json.loads((stage / "cleanup-evidence.json").read_text(encoding="utf-8"))
+            self.assertEqual(cleanup, {"cleanup_status": "no-lease-acquired"})
 
     def test_normal_codemagic_candidate_build_still_dispatches_m1_workflow(self) -> None:
         self.assertIn("omi-desktop-swift-release:", self.codemagic)

--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -251,7 +251,8 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
             self.assertFalse((stage / "source").exists(), "capacity failure must precede candidate checkout")
             capacity = json.loads((stage / "runner-capacity.json").read_text(encoding="utf-8"))
             self.assertEqual(capacity["status"], "failed")
-            self.assertEqual(capacity["failure_class"], "runner-filesystem-capacity")
+            self.assertEqual(capacity["guard"], "runner-capacity-preflight")
+            self.assertNotIn("failure_class", capacity)
             self.assertIn("insufficient-free-kib", capacity["failure_reasons"])
             self.assertEqual(capacity["minimum_free_kib"], 2**63 - 1)
 

--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -89,7 +89,9 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
 
     def test_m1_qualification_binds_the_immutable_tag(self) -> None:
         for fragment in (
-            'checkout --quiet --detach "refs/tags/$RELEASE_TAG"',
+            'checkout --quiet --detach "refs/tags/$ref"',
+            "ref: ${{ inputs.release_tag }}",
+            'test "$ref" = "$RELEASE_TAG"',
             'git rev-parse "$RELEASE_TAG^{commit}"',
             "git rev-parse 'HEAD^{commit}'",
             "check-desktop-auto-beta-candidate.py",
@@ -145,6 +147,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
                 "GITHUB_SERVER_URL": server.as_uri(),
                 "GITHUB_REPOSITORY": "BasedHardware/omi",
                 "RELEASE_TAG": RELEASE_TAG,
+                "ref": RELEASE_TAG,
                 "OMI_QUALIFICATION_MINIMUM_FREE_KIB": "1",
                 "OMI_QUALIFICATION_MINIMUM_FREE_INODES": "1",
             }

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -35,8 +35,9 @@ jobs:
           (umask 077; mkdir -p "$QUALIFICATION_STAGE/assets")
           test ! -L "$QUALIFICATION_STAGE"
           test "$(python3 -c 'import os, stat, sys; print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode))[2:])' "$QUALIFICATION_STAGE")" = 700
-          # This must run before the candidate checkout: an ENOSPC while the Actions
-          # worker writes its own trace aborts the worker before `always()` can run.
+          # This must run before the candidate checkout: a terminal runner loss can
+          # prevent later `always()` steps from producing cleanup evidence.
+          # Detect constrained capacity early enough to preserve a per-run report.
           # Keep the guard here instead of a checked-in helper because this workflow
           # deliberately has no repository checkout before its candidate binding.
           python3 - "$RUNNER_TEMP" "$QUALIFICATION_STAGE/runner-capacity.json" <<'PY'
@@ -61,8 +62,8 @@ jobs:
           report = {
               "available_inodes": available_inodes,
               "available_kib": available_kib,
-              "failure_class": "runner-filesystem-capacity",
               "failure_reasons": failures,
+              "guard": "runner-capacity-preflight",
               "minimum_free_inodes": minimum_free_inodes,
               "minimum_free_kib": minimum_free_kib,
               "schema_version": 1,

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -35,6 +35,51 @@ jobs:
           (umask 077; mkdir -p "$QUALIFICATION_STAGE/assets")
           test ! -L "$QUALIFICATION_STAGE"
           test "$(python3 -c 'import os, stat, sys; print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode))[2:])' "$QUALIFICATION_STAGE")" = 700
+          # This must run before the candidate checkout: an ENOSPC while the Actions
+          # worker writes its own trace aborts the worker before `always()` can run.
+          # Keep the guard here instead of a checked-in helper because this workflow
+          # deliberately has no repository checkout before its candidate binding.
+          python3 - "$RUNNER_TEMP" "$QUALIFICATION_STAGE/runner-capacity.json" <<'PY'
+          import json
+          import os
+          import sys
+
+          path, report_path = sys.argv[1:]
+          minimum_free_kib = int(os.environ.get("OMI_QUALIFICATION_MINIMUM_FREE_KIB", "33554432"))
+          minimum_free_inodes = int(os.environ.get("OMI_QUALIFICATION_MINIMUM_FREE_INODES", "65536"))
+          if minimum_free_kib < 1 or minimum_free_inodes < 1:
+              raise SystemExit("Qualification capacity minimums must be positive")
+
+          filesystem = os.statvfs(path)
+          available_kib = (filesystem.f_bavail * filesystem.f_frsize) // 1024
+          available_inodes = filesystem.f_favail
+          failures = []
+          if available_kib < minimum_free_kib:
+              failures.append("insufficient-free-kib")
+          if available_inodes < minimum_free_inodes:
+              failures.append("insufficient-free-inodes")
+          report = {
+              "available_inodes": available_inodes,
+              "available_kib": available_kib,
+              "failure_class": "runner-filesystem-capacity",
+              "failure_reasons": failures,
+              "minimum_free_inodes": minimum_free_inodes,
+              "minimum_free_kib": minimum_free_kib,
+              "schema_version": 1,
+              "status": "failed" if failures else "passed",
+          }
+          with open(report_path, "w", encoding="utf-8") as handle:
+              json.dump(report, handle, sort_keys=True)
+              handle.write("\n")
+
+          if failures:
+              print(
+                  "::error::M1 qualification runner capacity guard refused to start "
+                  f"(available_kib={available_kib}, required_kib={minimum_free_kib}, "
+                  f"available_inodes={available_inodes}, required_inodes={minimum_free_inodes})"
+              )
+              raise SystemExit(1)
+          PY
       - name: Checkout candidate into this run only
         working-directory: ${{ runner.temp }}
         env:
@@ -168,7 +213,9 @@ jobs:
         if: always()
         with:
           name: desktop-qualification-cleanup-${{ inputs.release_tag }}-m1-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/cleanup-evidence.json
+          path: |
+            ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/runner-capacity.json
+            ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/cleanup-evidence.json
           if-no-files-found: error
           overwrite: false
 

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -86,15 +86,18 @@ jobs:
         env:
           QUALIFICATION_STAGE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}
           RELEASE_TAG: ${{ inputs.release_tag }}
+          ref: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
           source_dir="$QUALIFICATION_STAGE/source"
           test -d "$QUALIFICATION_STAGE"
           test ! -e "$source_dir"
+          test -n "$ref"
+          test "$ref" = "$RELEASE_TAG"
           git init --quiet "$source_dir"
           git -C "$source_dir" remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           GIT_TERMINAL_PROMPT=0 git -C "$source_dir" fetch --force --prune --tags origin
-          git -C "$source_dir" checkout --quiet --detach "refs/tags/$RELEASE_TAG"
+          git -C "$source_dir" checkout --quiet --detach "refs/tags/$ref"
       - id: app-token
         uses: actions/create-github-app-token@v3
         with:

--- a/desktop/macos/changelog/unreleased/20260726-m1-qualification-runner-capacity.json
+++ b/desktop/macos/changelog/unreleased/20260726-m1-qualification-runner-capacity.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved reliability of macOS Beta qualification on the dedicated M1 Studio"
+}

--- a/desktop/macos/docs/qualification-environment.md
+++ b/desktop/macos/docs/qualification-environment.md
@@ -21,6 +21,18 @@ The offset applies to Firestore, Firebase Auth, backend, desktop backend,
 Redis, and Typesense. The script also derives `OMI_AUTOMATION_PORT`; invalid
 ports fail before launch.
 
+## Runner capacity preflight
+
+Before the candidate checkout, the M1-only workflow writes
+`runner-capacity.json` in its run-isolated stage and requires at least 32 GiB
+of free filesystem blocks plus 65,536 free inodes. This is intentionally ahead
+of the checkout because an `ENOSPC` while the Actions worker writes its own
+diagnostic trace can terminate that worker before later `always()` steps run.
+On a controlled capacity failure, the workflow fails closed before fetching
+candidate assets, then its normal finalizer writes cleanup evidence and uploads
+both evidence files. The guard only observes capacity; it never deletes shared
+runner state or prior qualification evidence.
+
 ## Cleanup safety
 
 On normal exit, `INT`, `TERM`, `HUP`, or the workflow `always()` finalizer,

--- a/desktop/macos/docs/qualification-environment.md
+++ b/desktop/macos/docs/qualification-environment.md
@@ -26,8 +26,9 @@ ports fail before launch.
 Before the candidate checkout, the M1-only workflow writes
 `runner-capacity.json` in its run-isolated stage and requires at least 32 GiB
 of free filesystem blocks plus 65,536 free inodes. This is intentionally ahead
-of the checkout because an `ENOSPC` while the Actions worker writes its own
-diagnostic trace can terminate that worker before later `always()` steps run.
+of the checkout because a terminal runner loss can prevent later `always()`
+steps from producing cleanup evidence. The report records only capacity observed
+by this guard; it does not attribute a prior incident to a runner or host cause.
 On a controlled capacity failure, the workflow fails closed before fetching
 candidate assets, then its normal finalizer writes cleanup evidence and uploads
 both evidence files. The guard only observes capacity; it never deletes shared


### PR DESCRIPTION
## What changed and why

Closes SCA-153.

This change adds a capacity guard before the M1 candidate checkout. When the
guard observes fewer than 32 GiB free or fewer than 65,536 free inodes, it
fails closed before candidate input retrieval, writes a run-isolated capacity
report, and preserves that report with normal cleanup evidence. The isolated
checkout is explicitly bound to `ref: ${{ inputs.release_tag }}`, checks that
binding against `RELEASE_TAG`, and detaches the run-local source from that tag.
It does not delete runner state, retry a candidate, alter a release, call
Codemagic, or change Beta or Stable behavior.

## Product invariants affected

none

## Observed incident boundary

- Candidate `v0.12.126+12126-macos` remains immutable and non-live.
- [Qualification run 30185755794](https://github.com/BasedHardware/omi/actions/runs/30185755794)
  publicly shows the first five `qualify-m1-studio` steps succeeding, then
  `Fetch candidate release inputs into this run only` remaining in progress
  without a completion timestamp or visible job log; later steps are pending,
  no run artifacts exist, and the verdict fails for missing M1 evidence.
- Those observable facts establish a terminal loss boundary, not its underlying
  host cause. This PR intentionally makes no ENOSPC, filesystem, or runner
  root-cause claim about that incident.

## Failure class

Unclassified terminal runner loss; the preflight is a fail-closed guard for an
independently observable low-capacity condition, not incident self-attestation.

Failure-Class: none

## How it was verified

- `python3 .github/scripts/check-release-process-guards.py` — passed; verifies
  the required release-tag ref contract.
- `python3 .github/scripts/test_desktop_release_flow_contract.py` — 7 passed;
  verifies the isolated source checks out the explicit tag ref and preserves the
  low-capacity cleanup boundary.
- `actionlint -config-file .github/actionlint.yaml .github/workflows/desktop_qualify_beta.yml` — passed.
- `scripts/pr-preflight --pr-body-file pr-body.md` — passed.
- `OMI_PR_BODY_FILE=pr-body.md make preflight` — passed.
