### PR TITLE
fix(desktop): forward client tool calls from a paused turn continuation

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/chat/streaming.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/streaming.rs
@@ -106,6 +106,67 @@ impl StreamedContentBlocks {
     }
 }
 
+/// Translate a completed `pause_turn` continuation into the OpenAI chunks the
+/// streaming client is still waiting for.
+///
+/// A continuation answers in text *and* may decide to call a client-side tool:
+/// web search is only ever exposed alongside the client's own tools
+/// (`inject_web_search`), so "search, then act" is the ordinary shape of a
+/// paused turn. Forwarding only the text would hand the client
+/// `finish_reason: tool_calls` with nothing to run.
+pub(super) fn continuation_delta_chunks(
+    resp: &AnthropicResponse,
+    stream_id: &str,
+    created: i64,
+    model: &str,
+    first_tool_ordinal: u32,
+) -> Vec<Value> {
+    let mut chunks = Vec::new();
+
+    if let Some(text) = response_text_content(resp) {
+        chunks.push(make_chunk(
+            stream_id,
+            created,
+            model,
+            ChunkDelta {
+                content: Some(text),
+                ..ChunkDelta::default()
+            },
+            None,
+            None,
+        ));
+    }
+
+    let mut ordinal = first_tool_ordinal;
+    for block in &resp.content {
+        let AnthropicContentBlock::ToolUse { id, name, input } = block else {
+            continue;
+        };
+        chunks.push(make_chunk(
+            stream_id,
+            created,
+            model,
+            ChunkDelta {
+                tool_calls: Some(vec![ChunkToolCall {
+                    index: ordinal,
+                    id: Some(id.clone()),
+                    call_type: Some("function".to_string()),
+                    function: Some(ChunkFunctionCall {
+                        name: Some(name.clone()),
+                        arguments: Some(serde_json::to_string(input).unwrap_or_default()),
+                    }),
+                }]),
+                ..ChunkDelta::default()
+            },
+            None,
+            None,
+        ));
+        ordinal += 1;
+    }
+
+    chunks
+}
+
 fn append_string_field(block: &mut Value, key: &str, suffix: &str) {
     if let Some(current) = block.get_mut(key).and_then(|value| value.as_str()) {
         let mut combined = current.to_string();
@@ -466,20 +527,13 @@ where
             .await
             {
                 Ok(anthropic_resp) => {
-                    if let Some(text) = response_text_content(&anthropic_resp) {
-                        let chunk_val = make_chunk(
-                            &stream_id,
-                            created,
-                            &model,
-                            ChunkDelta {
-                                role: None,
-                                content: Some(text),
-                                reasoning_content: None,
-                                tool_calls: None,
-                            },
-                            None,
-                            None,
-                        );
+                    for chunk_val in continuation_delta_chunks(
+                        &anthropic_resp,
+                        &stream_id,
+                        created,
+                        &model,
+                        next_tool_ordinal,
+                    ) {
                         yield Ok(sse_line(&chunk_val));
                     }
                     let finish = map_stop_reason(anthropic_resp.stop_reason.as_deref());

--- a/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
@@ -1234,6 +1234,101 @@ fn test_pause_turn_server_tool_response_decodes_and_preserves_raw_content() {
     );
 }
 
+/// Regression: a `pause_turn` continuation used to forward only its text, so a
+/// continuation that decided to call a client-side tool reached the client as
+/// `finish_reason: tool_calls` with no tool call to run — the requested action
+/// silently never happened. Web search is only injected when the client sends
+/// its own tools, so "search the web, then act on it" is the ordinary shape of
+/// a paused streaming turn.
+#[test]
+fn pause_turn_continuation_forwards_client_tool_calls() {
+    let resp: AnthropicResponse = serde_json::from_value(json!({
+        "id": "msg_cont",
+        "type": "message",
+        "model": "claude-sonnet-4-6",
+        "role": "assistant",
+        "content": [
+            {
+                "type": "server_tool_use",
+                "id": "srvtoolu_1",
+                "name": "web_search",
+                "input": {"query": "Hanoi weather"}
+            },
+            {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_1",
+                "content": [{"type": "web_search_result", "title": "Weather"}]
+            },
+            {"type": "text", "text": "It is raining in Hanoi. Adding a reminder."},
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "create_task",
+                "input": {"title": "Pack an umbrella"}
+            }
+        ],
+        "stop_reason": "tool_use",
+        "usage": {"input_tokens": 11, "output_tokens": 5}
+    }))
+    .expect("continuation response must decode");
+
+    let chunks = continuation_delta_chunks(&resp, "chatcmpl-msg_cont", 4200, "omi-sonnet", 0);
+
+    assert_eq!(chunks.len(), 2, "expected one text chunk and one tool call");
+    assert_eq!(
+        chunks[0]["choices"][0]["delta"]["content"],
+        "It is raining in Hanoi. Adding a reminder."
+    );
+
+    let tool_call = &chunks[1]["choices"][0]["delta"]["tool_calls"][0];
+    assert_eq!(tool_call["index"], 0);
+    assert_eq!(tool_call["id"], "toolu_1");
+    assert_eq!(tool_call["type"], "function");
+    assert_eq!(tool_call["function"]["name"], "create_task");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(
+            tool_call["function"]["arguments"].as_str().unwrap()
+        )
+        .unwrap(),
+        json!({"title": "Pack an umbrella"})
+    );
+    // Anthropic's own server-tool blocks stay gateway-side.
+    assert!(!chunks
+        .iter()
+        .any(|chunk| chunk.to_string().contains("web_search")));
+}
+
+/// Tool ordinals continue past any tool call already streamed before the pause,
+/// so a client accumulating by `index` never overwrites an earlier call.
+#[test]
+fn pause_turn_continuation_tool_ordinals_continue_from_the_streamed_prefix() {
+    let resp: AnthropicResponse = serde_json::from_value(json!({
+        "id": "msg_cont",
+        "type": "message",
+        "model": "claude-sonnet-4-6",
+        "role": "assistant",
+        "content": [
+            {"type": "tool_use", "id": "toolu_2", "name": "create_task", "input": {}},
+            {"type": "tool_use", "id": "toolu_3", "name": "send_email", "input": {}}
+        ],
+        "stop_reason": "tool_use",
+        "usage": {"input_tokens": 3, "output_tokens": 2}
+    }))
+    .expect("continuation response must decode");
+
+    let chunks = continuation_delta_chunks(&resp, "chatcmpl-msg_cont", 4200, "omi-sonnet", 1);
+
+    assert_eq!(chunks.len(), 2);
+    assert_eq!(
+        chunks[0]["choices"][0]["delta"]["tool_calls"][0]["index"],
+        1
+    );
+    assert_eq!(
+        chunks[1]["choices"][0]["delta"]["tool_calls"][0]["index"],
+        2
+    );
+}
+
 #[test]
 fn test_translate_request_degrades_when_web_search_disabled() {
     let mut req = test_request(vec![user_message("Search the web for HumanPost")]);

--- a/desktop/macos/changelog/unreleased/20260726-paused-web-search-tool-calls.json
+++ b/desktop/macos/changelog/unreleased/20260726-paused-web-search-tool-calls.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed chat silently skipping the action it promised after a web search — the follow-up tool call was dropped, so nothing happened"
+}


### PR DESCRIPTION
## What changed and why

A `pause_turn` continuation is completed **non-streaming** at the gateway
(`complete_anthropic_server_tool_turn`) and its result is spliced back into the
open SSE body. That splice forwarded only `response_text_content()`, which
deliberately drops `tool_use` blocks — so a continuation that decided to call a
**client-side** tool reached the desktop agent as `finish_reason: "tool_calls"`
with no tool call attached. Nothing to run, no error: the action the answer
promised silently never happened.

This is the main path, not an edge. Web search is injected only when the client
already sends its own tools:

```rust
let inject_web_search = web_search_supported && !client_tools.is_empty();
```

so **every turn that can pause is a turn where the model can also call a client
tool**. "Search the web, then add it to my notes / create a task" is the
ordinary shape of a paused turn.

The non-streaming lane already does this correctly (`translate_response` maps
`ToolUse` → `tool_calls`); only the streaming continuation splice was missing
it. This is the second defect in the same splice after #10616 (dropped
`signature_delta`), both introduced with #10537.

## The fix

Extract `continuation_delta_chunks()` and emit the continuation's text **and**
its `tool_use` blocks as OpenAI chunks. Tool ordinals continue from
`next_tool_ordinal`, so a call streamed before the pause is never overwritten by
a client accumulating tool calls by `index`. Anthropic's own `server_tool_use` /
`web_search_tool_result` blocks stay gateway-side, unchanged.

## Product invariants affected

- INV-CHAT-1

## How it was verified

- `cargo test` — **380 passed**, 0 failed.
- Two new regression tests (`pause_turn_continuation_forwards_client_tool_calls`,
  `pause_turn_continuation_tool_ordinals_continue_from_the_streamed_prefix`)
  **fail on the pre-fix behaviour** (continuation forwards text only:
  `expected one text chunk and one tool call, left: 1 right: 2`) and pass on the
  fix.
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean.
- `make preflight` green.

**Not verified against the live provider:** an Anthropic `pause_turn` cannot be
forced on demand, so the fix is proven through the production translation seam
rather than a real round trip.

## Follow-up noticed, not fixed here

The same continuation branch bills only the continuation's usage
(`merge_stream_usage(initial_usage, &anthropic_resp.usage)`), so the paused
segment's `output_tokens` from its `message_delta` are dropped from
`record_llm_usage`. Cost accounting only, no user impact — left out to keep this
fix surgical.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

