### PR TITLE
SCA-156: harden replay oracle and private web-search policy

### DIFF
--- a/backend/testing/replay_harness_llm_gateway_fake_upstream/README.md
+++ b/backend/testing/replay_harness_llm_gateway_fake_upstream/README.md
@@ -18,7 +18,7 @@ routing remain unchanged outside this test process.
 The fake upstream proves only that:
 
 1. the real provider adapter uses the expected chat-completions path;
-2. a routed gateway request completes exactly one bounded local round trip;
+2. a routed gateway request completes exactly one proxy-isolated, bounded local round trip;
 3. gateway and upstream event ordering remains stable; and
 4. an incoming request cannot choose or redirect the upstream target.
 

--- a/backend/testing/replay_harness_llm_gateway_fake_upstream/oracle.py
+++ b/backend/testing/replay_harness_llm_gateway_fake_upstream/oracle.py
@@ -15,7 +15,6 @@ import json
 import logging
 import os
 import threading
-import time
 import warnings
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
@@ -23,12 +22,10 @@ from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
+import httpx
+
 # The pinned Starlette/httpx combination emits an import-time warning. The
 # oracle's stdout is reserved for its structural evidence JSON.
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    from starlette.testclient import TestClient
-
 from llm_gateway.gateway.executor import ProviderRegistry
 from llm_gateway.gateway.providers import OpenAICompatibleChatCompletionProvider
 from llm_gateway.main import app
@@ -162,39 +159,64 @@ def _valid_gateway_request() -> dict[str, object]:
     return {"model": "omi:auto:chat-structured", "messages": [{"role": "user", "content": ""}]}
 
 
-def run_oracle() -> dict[str, Any]:
-    """Run the gateway against its controlled loopback upstream."""
+def _loopback_http_client(**kwargs: Any) -> httpx.AsyncClient:
+    """Construct a client that cannot read ambient proxy settings.
+
+    This harness owns both endpoints.  Inheriting a developer or CI proxy here
+    could route the fake provider request outside the process instead of to
+    127.0.0.1, so every harness-owned client opts out explicitly.
+    """
+
+    return httpx.AsyncClient(trust_env=False, **kwargs)
+
+
+async def _post_with_deadline(
+    client: Any,
+    *,
+    path: str,
+    payload: dict[str, object],
+    headers: dict[str, str],
+    deadline_seconds: float = ROUND_TRIP_DEADLINE_SECONDS,
+) -> httpx.Response:
+    """Bound the request itself, rather than checking elapsed time afterward."""
+
+    try:
+        async with asyncio.timeout(deadline_seconds):
+            return await client.post(path, json=payload, headers=headers)
+    except TimeoutError as error:
+        raise OracleFailure("gateway loopback round trip exceeded its bounded deadline") from error
+
+
+async def _run_gateway_oracle(upstream: _LoopbackOpenAI) -> dict[str, Any]:
+    """Drive the real ASGI app and fake provider while both clients are live."""
 
     previous_overrides = dict(app.dependency_overrides)
     registry: ProviderRegistry | None = None
     try:
-        with _temporary_environment(
-            {
-                "OMI_LLM_GATEWAY_SERVICE_TOKEN": "loopback-test-token",
-                "OPENAI_API_KEY": "loopback-test-key",
-            }
-        ), _bounded_evidence_logging(), _LoopbackOpenAI() as upstream:
+        async with _loopback_http_client() as provider_http_client:
             registry = ProviderRegistry(
                 {
-                    "openai": OpenAICompatibleChatCompletionProvider(base_url=upstream.base_url),
+                    "openai": OpenAICompatibleChatCompletionProvider(
+                        base_url=upstream.base_url,
+                        http_client=provider_http_client,
+                    ),
                 }
             )
             # This override is test-owned. Production construction remains the
             # cached registry in llm_gateway.routers.dependencies.
             app.dependency_overrides[dependencies.get_provider_registry] = lambda: registry
 
-            with TestClient(app) as client:
-                started_at = time.monotonic()
-                response = client.post(
-                    GATEWAY_PATH,
-                    json=_valid_gateway_request(),
+            transport = httpx.ASGITransport(app=app, raise_app_exceptions=True)
+            async with _loopback_http_client(transport=transport, base_url="http://gateway.test") as client:
+                response = await _post_with_deadline(
+                    client,
+                    path=GATEWAY_PATH,
+                    payload=_valid_gateway_request(),
                     headers={
                         "Authorization": "Bearer loopback-test-token",
                         "X-Omi-Service-Caller": "backend",
                     },
                 )
-                if time.monotonic() - started_at > ROUND_TRIP_DEADLINE_SECONDS:
-                    raise OracleFailure("gateway loopback round trip exceeded its bounded deadline")
                 if _status_class(response.status_code) != "2xx":
                     raise OracleFailure("gateway did not return a successful status class")
                 response_body = response.json()
@@ -207,9 +229,10 @@ def run_oracle() -> dict[str, Any]:
 
                 # An external caller cannot change the provider target. The router
                 # rejects this unknown field before the provider terminal path runs.
-                redirect_response = client.post(
-                    GATEWAY_PATH,
-                    json={**_valid_gateway_request(), "upstream_url": upstream.base_url},
+                redirect_response = await _post_with_deadline(
+                    client,
+                    path=GATEWAY_PATH,
+                    payload={**_valid_gateway_request(), "upstream_url": upstream.base_url},
                     headers={
                         "Authorization": "Bearer loopback-test-token",
                         "X-Omi-Service-Caller": "backend",
@@ -245,7 +268,19 @@ def run_oracle() -> dict[str, Any]:
         app.dependency_overrides.clear()
         app.dependency_overrides.update(previous_overrides)
         if registry is not None:
-            asyncio.run(registry.aclose())
+            await registry.aclose()
+
+
+def run_oracle() -> dict[str, Any]:
+    """Run the gateway against its controlled loopback upstream."""
+
+    with _temporary_environment(
+        {
+            "OMI_LLM_GATEWAY_SERVICE_TOKEN": "loopback-test-token",
+            "OPENAI_API_KEY": "loopback-test-key",
+        }
+    ), _bounded_evidence_logging(), _LoopbackOpenAI() as upstream:
+        return asyncio.run(_run_gateway_oracle(upstream))
 
 
 def main() -> int:

--- a/backend/tests/unit/test_replay_llm_gateway_fake_upstream_oracle.py
+++ b/backend/tests/unit/test_replay_llm_gateway_fake_upstream_oracle.py
@@ -1,0 +1,52 @@
+import asyncio
+
+import pytest
+
+from testing.replay_harness_llm_gateway_fake_upstream import oracle
+
+
+def test_loopback_oracle_bypasses_ambient_proxy_configuration(monkeypatch) -> None:
+    """A poisoned proxy must not intercept the local fake-upstream request."""
+
+    for name in ("ALL_PROXY", "HTTP_PROXY", "HTTPS_PROXY", "all_proxy", "http_proxy", "https_proxy"):
+        monkeypatch.setenv(name, "http://127.0.0.1:1")
+    monkeypatch.setenv("NO_PROXY", "")
+    monkeypatch.setenv("no_proxy", "")
+
+    evidence = oracle.run_oracle()
+
+    assert evidence["provider_request_count"] == 1
+    assert evidence["status_classes"] == ["2xx", "4xx"]
+
+
+def test_stalled_in_process_request_is_cancelled_by_the_deadline() -> None:
+    """Exercise cancellation without using a wall-clock wait in the regression."""
+
+    class StalledClient:
+        def __init__(self) -> None:
+            self.started = False
+            self.cancelled = False
+
+        async def post(self, *_args, **_kwargs) -> None:
+            self.started = True
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.cancelled = True
+                raise
+
+    client = StalledClient()
+
+    with pytest.raises(oracle.OracleFailure, match="bounded deadline"):
+        asyncio.run(
+            oracle._post_with_deadline(
+                client,
+                path=oracle.GATEWAY_PATH,
+                payload=oracle._valid_gateway_request(),
+                headers={},
+                deadline_seconds=0,
+            )
+        )
+
+    assert client.started
+    assert client.cancelled

--- a/desktop/macos/Backend-Rust/src/routes/chat/ARCHITECTURE.md
+++ b/desktop/macos/Backend-Rust/src/routes/chat/ARCHITECTURE.md
@@ -14,8 +14,9 @@ shape conversion and its retrieval-policy injection points.
 
 Provider translation must not reach SSE framing. Public-web prompt routing for
 the agent runtime lives in `desktop/macos/agent`; this gateway exposes
-`web_search` as a normal server tool on supported agentic turns and lets the
-model choose it instead of keyword-injecting retrieval instructions here.
+`web_search` as a normal server tool on supported agentic turns. Request
+translation is the enforcement boundary for explicit private/no-web context,
+including client-tool continuations, and must omit the external tool there.
 
 ## Tests
 

--- a/desktop/macos/Backend-Rust/src/routes/chat/request_translation.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/request_translation.rs
@@ -58,6 +58,77 @@ const WEB_SEARCH_MAX_USES: u32 = 5;
 /// Anthropic web search pricing: $10 per 1,000 searches.
 const WEB_SEARCH_COST_PER_REQUEST: f64 = 10.0 / 1_000.0;
 
+// The agent runtime owns positive public-web routing. The gateway remains the
+// authority that prevents an explicitly private or no-web turn from receiving
+// the external server tool, including after a client tool result is replayed.
+const EXPLICIT_WEB_REQUESTS: &[&str] = &[
+    "search the web",
+    "search web",
+    "search the internet",
+    "search online",
+    "look it up online",
+    "look this up online",
+    "look that up online",
+    "find it online",
+    "find this online",
+    "find that online",
+    "google it",
+    "google this",
+    "google that",
+    "browse the web",
+    "web search",
+    "internet search",
+];
+const EXPLICIT_WEB_PROHIBITIONS: &[&str] = &[
+    "don't call web search",
+    "do not call web search",
+    "don't call the web search",
+    "do not call the web search",
+    "don't call internet search",
+    "do not call internet search",
+    "don't call the internet search",
+    "do not call the internet search",
+    "don't use web search",
+    "do not use web search",
+    "don't use the web search",
+    "do not use the web search",
+    "don't use internet search",
+    "do not use internet search",
+    "don't use the internet search",
+    "do not use the internet search",
+    "don't search the web",
+    "do not search the web",
+    "don't search the internet",
+    "do not search the internet",
+    "without web search",
+];
+const EXPLICIT_PRIVATE_CONTEXT: &[&str] = &[
+    "my conversations",
+    "our conversations",
+    "my memories",
+    "your memory of me",
+    "my screen history",
+    "my screen activity",
+    "my calendar",
+    "your calendar",
+    "my email",
+    "your email",
+    "my files",
+    "your files",
+    "my tasks",
+    "your tasks",
+    "my action items",
+    "my notes",
+    "your notes",
+    "what did i say",
+    "what have i said",
+    "what did i do",
+    "when did i",
+    "what was i doing",
+    "what do you remember about me",
+];
+const CURRENT_USER_MESSAGE_DELIMITER: &str = "\n# User Message\n";
+
 fn web_search_tool_def() -> AnthropicToolDef {
     AnthropicToolDef::Server(json!({
         "type": WEB_SEARCH_TOOL_TYPE,
@@ -228,16 +299,16 @@ pub(super) fn translate_request_inner(
         }
     }
 
-    // Web search is a normal tool the model chooses to use, not a keyword-routed
-    // pre-decision. The desktop system prompt already states when public web
-    // search is appropriate, so expose the server-side tool on every supported
-    // agentic turn and let the model select it with its normal tool choice.
-    // This keeps public-web turns on the incremental streaming path instead of
-    // buffering an entire server-tool continuation before the client sees a byte.
-    // Haiku is excluded because it does not support this web-search tool.
+    // Web search is a normal tool on supported public agentic turns, keeping
+    // streaming incremental rather than pre-routing into a buffered path. The
+    // current user instruction is still a hard privacy boundary: an explicit
+    // private or no-web turn must not receive this external server tool, even
+    // when this request resumes after a client tool result.
     let web_search_supported = enable_web_search && !upstream_model.starts_with("claude-haiku");
     let client_tools = req.tools.as_deref().unwrap_or(&[]);
-    let inject_web_search = web_search_supported && !client_tools.is_empty();
+    let public_web_prohibited = public_web_is_prohibited(&req.messages);
+    let inject_web_search =
+        web_search_supported && !public_web_prohibited && !client_tools.is_empty();
     let anthropic_tools = if client_tools.is_empty() && !inject_web_search {
         req.tools.as_ref().map(|_| Vec::new())
     } else {
@@ -262,6 +333,7 @@ pub(super) fn translate_request_inner(
     tracing::info!(
         event = "retrieval_policy",
         web_search_exposed = inject_web_search,
+        public_web_prohibited,
         "chat_retrieval_policy"
     );
 
@@ -571,6 +643,65 @@ pub(super) fn extract_text_content(content: &Option<serde_json::Value>) -> Strin
     }
 }
 
+fn public_web_is_prohibited(messages: &[ChatMessage]) -> bool {
+    // A tool-result continuation ends in `tool`, but must retain the privacy
+    // policy selected by the fresh user instruction that began the turn.
+    let Some(latest_user) = messages.iter().rev().find(|message| message.role == "user") else {
+        return false;
+    };
+    let rendered_prompt = extract_text_content(&latest_user.content);
+    let instruction = rendered_prompt
+        .rsplit_once(CURRENT_USER_MESSAGE_DELIMITER)
+        .map_or(rendered_prompt.as_str(), |(_, current)| current);
+    let instruction = strip_public_web_routing_instruction(instruction);
+    let normalized = normalize_policy_text(instruction);
+    if normalized.is_empty() {
+        return false;
+    }
+
+    let explicitly_mentions_web = contains_policy_phrase(&normalized, EXPLICIT_WEB_REQUESTS);
+    let explicit_private_context = contains_policy_phrase(&normalized, EXPLICIT_PRIVATE_CONTEXT);
+    (explicitly_mentions_web && explicitly_prohibits_public_web(&normalized))
+        || (explicit_private_context && !explicitly_mentions_web)
+}
+
+fn strip_public_web_routing_instruction(text: &str) -> &str {
+    const OPEN: &str = "<omi_retrieval_policy>";
+    const CLOSE: &str = "</omi_retrieval_policy>";
+
+    let trimmed = text.trim_start();
+    if !trimmed.starts_with(OPEN) {
+        return text;
+    }
+    trimmed
+        .split_once(CLOSE)
+        .map_or(text, |(_, remainder)| remainder.trim_start())
+}
+
+fn normalize_policy_text(text: &str) -> String {
+    text.trim()
+        .trim_matches(|ch: char| !ch.is_alphanumeric())
+        .replace(['\u{2018}', '\u{2019}'], "'")
+        .to_ascii_lowercase()
+}
+
+fn contains_policy_phrase(text: &str, phrases: &[&str]) -> bool {
+    phrases.iter().any(|phrase| text.contains(phrase))
+}
+
+fn explicitly_prohibits_public_web(text: &str) -> bool {
+    EXPLICIT_WEB_PROHIBITIONS.iter().any(|phrase| {
+        text.match_indices(phrase).any(|(start, _)| {
+            let suffix = text[start + phrase.len()..].trim_start();
+            !["result", "results"].iter().any(|noun| {
+                suffix
+                    .strip_prefix(noun)
+                    .is_some_and(|tail| tail.chars().next().is_none_or(|ch| !ch.is_alphanumeric()))
+            })
+        })
+    })
+}
+
 // ── Anthropic non-streaming response → OpenAI format ────────────────────────
 
 pub(super) fn translate_response(
@@ -663,7 +794,9 @@ pub(super) fn should_record_web_search_fallback(
     req: &ChatCompletionRequest,
     web_search_supported: bool,
 ) -> bool {
-    !web_search_supported && req.tools.as_ref().is_some_and(|tools| !tools.is_empty())
+    !web_search_supported
+        && !public_web_is_prohibited(&req.messages)
+        && req.tools.as_ref().is_some_and(|tools| !tools.is_empty())
 }
 
 pub(super) fn server_tool_available_from(tools: &Option<Vec<AnthropicToolDef>>) -> &'static str {

--- a/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
@@ -869,12 +869,12 @@ fn test_translate_request_tool_result() {
 }
 
 #[test]
-fn test_translate_request_with_tools() {
+fn test_translate_request_public_lookup_keeps_web_search_available() {
     let req = ChatCompletionRequest {
         model: "omi-sonnet".to_string(),
         messages: vec![ChatMessage {
             role: "user".to_string(),
-            content: Some(json!("Hi")),
+            content: Some(json!("Search the web for current HumanPost news")),
             name: None,
             tool_calls: None,
             tool_call_id: None,
@@ -909,9 +909,8 @@ fn test_translate_request_with_tools() {
     )
     .unwrap();
     let tools = result.tools.unwrap();
-    // The model chooses web_search from the normal tool set. This keeps the
-    // stream incremental instead of pre-routing a turn to the buffered
-    // server-tool continuation path.
+    // An allowed public turn keeps web_search in the normal incremental tool
+    // set instead of pre-routing the request to a buffered continuation path.
     assert_eq!(tools.len(), 2);
     assert_eq!(
         serde_json::to_value(&tools[0]).unwrap()["name"],
@@ -1379,7 +1378,7 @@ fn test_translate_request_guessed_freshness_answers_without_web_search() {
 }
 
 #[test]
-fn test_translate_request_private_lookup_keeps_web_search_available_to_the_model() {
+fn test_translate_request_private_lookup_excludes_web_search() {
     let mut req = test_request(vec![user_message("Search my conversations for HumanPost")]);
     req.tools = Some(vec![ToolDefinition {
         tool_type: "function".to_string(),
@@ -1398,16 +1397,80 @@ fn test_translate_request_private_lookup_keeps_web_search_available_to_the_model
     )
     .unwrap();
     let tools = result.tools.unwrap();
-    assert_eq!(tools.len(), 2);
+    assert_eq!(tools.len(), 1);
     assert_eq!(
         serde_json::to_value(&tools[0]).unwrap()["name"],
-        "web_search"
-    );
-    assert_eq!(
-        serde_json::to_value(&tools[1]).unwrap()["name"],
         "search_conversations"
     );
     assert!(result.tool_choice.is_none());
+}
+
+#[test]
+fn test_private_context_policy_survives_mixed_tool_continuation() {
+    // The follow-up request replays a client tool result. It must retain the
+    // original private/no-web boundary instead of treating the `tool` tail as
+    // a fresh unrestricted agentic turn.
+    let mut req = test_request(vec![
+        user_message("Search my conversations for HumanPost"),
+        ChatMessage {
+            role: "assistant".to_string(),
+            content: None,
+            name: None,
+            tool_calls: Some(vec![ToolCall {
+                id: "call_private".to_string(),
+                call_type: "function".to_string(),
+                function: FunctionCall {
+                    name: "search_conversations".to_string(),
+                    arguments: r#"{"query":"HumanPost"}"#.to_string(),
+                },
+            }]),
+            tool_call_id: None,
+        },
+        ChatMessage {
+            role: "tool".to_string(),
+            content: Some(json!("private conversation result")),
+            name: None,
+            tool_calls: None,
+            tool_call_id: Some("call_private".to_string()),
+        },
+    ]);
+    req.tools = Some(vec![
+        ToolDefinition {
+            tool_type: "function".to_string(),
+            function: FunctionDefinition {
+                name: "search_conversations".to_string(),
+                description: Some("Search private conversations".to_string()),
+                parameters: None,
+            },
+        },
+        ToolDefinition {
+            tool_type: "function".to_string(),
+            function: FunctionDefinition {
+                name: "create_task".to_string(),
+                description: Some("Create a private follow-up task".to_string()),
+                parameters: None,
+            },
+        },
+    ]);
+
+    let result = translate_request_inner(
+        &req,
+        "claude-sonnet-4-6",
+        true,
+        ReasoningEffort::Unspecified,
+    )
+    .unwrap();
+    let tools = result.tools.unwrap();
+    let tool_names = tools
+        .iter()
+        .map(|tool| serde_json::to_value(tool).unwrap()["name"].clone())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        tool_names,
+        vec![json!("search_conversations"), json!("create_task")]
+    );
+    assert!(!tool_names.contains(&json!("web_search")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- harden the replay LLM-gateway fake-upstream oracle: its in-process and provider clients ignore ambient proxy settings, and the request itself is cancelled at the five-second deadline;
- add deterministic proxy-isolation and stalled-request regression coverage;
- preserve the desktop gateway's normal public `web_search` behavior while making explicit private/no-web context a hard tool-exposure boundary, including client-tool continuations.

## Follow-ups

- Follow-up to [#10592 — test: add replay LLM gateway fake-upstream seam](https://github.com/BasedHardware/omi/pull/10592).
- Follow-up to [#10537 — fix(desktop): stream public web-search turns](https://github.com/BasedHardware/omi/pull/10537).

## Verification

- `PYTHONPATH=backend backend/.venv/bin/python -m pytest backend/tests/unit/test_replay_llm_gateway_fake_upstream_oracle.py -q` — 2 passed.
- `npm run test:replay-llm-fake-upstream` — passed; one proxy-isolated loopback request and expected 2xx/4xx structure.
- `cargo fmt --check` — passed.
- `cargo test` in `desktop/macos/Backend-Rust` — 381 passed.
- `cargo clippy --bin omi-desktop-backend -- -D warnings` — blocked by five pre-existing diagnostics outside this change: four unused Anthropic model declarations and `unnecessary_sort_by` in `desktop_releases_repository.rs`.
- `OMI_PR_BODY_FILE=<this body> make preflight` — passed the diff-scoped local manifest.
- `OMI_PR_BODY_FILE=<this body> .github/scripts/run-pre-push.sh origin` — passed the normal bounded pre-push gate against `origin/main`.

No deployment, configuration, IAM, secret, credential, or traffic mutation was made.

Closes SCA-156

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

