### PR TITLE
fix(desktop): count the paused leg's tokens and web searches

### DIFF
--- a/desktop/macos/Backend-Rust/src/routes/chat/streaming.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/streaming.rs
@@ -16,7 +16,8 @@ use super::request_translation::{compute_cost, response_text_content};
 use super::response_or_500;
 use super::sse::{drain_sse_events, make_chunk, sse_line, stream_termination_chunks};
 use super::transport::{
-    append_pause_turn_continuation, complete_anthropic_server_tool_turn, send_anthropic_with_retry,
+    accumulate_anthropic_usage, append_pause_turn_continuation,
+    complete_anthropic_server_tool_turn, send_anthropic_with_retry,
 };
 
 /// How long a streaming turn may go without a single byte from Anthropic before we end it.
@@ -165,6 +166,28 @@ pub(super) fn continuation_delta_chunks(
     }
 
     chunks
+}
+
+/// Total the usage of a turn that paused: the streamed leg plus the continuation.
+///
+/// The paused leg is the leg that ran the server tool — it holds the output tokens
+/// generated before the pause *and* the `web_search_requests` Anthropic bills per
+/// request. Reporting only the continuation's usage drops both, so a paused turn is
+/// billed as if its first half never happened. The non-streaming lane already sums
+/// every leg (`accumulate_anthropic_usage`); the streaming splice totals the same way.
+pub(super) fn paused_turn_total_usage(
+    initial: Option<&AnthropicUsage>,
+    streamed_final: Option<&AnthropicUsage>,
+    continuation: &AnthropicUsage,
+) -> AnthropicUsage {
+    // `message_start` carries the input side, `message_delta` the output side, so the
+    // streamed leg is only whole once the two are merged.
+    let mut total = match streamed_final {
+        Some(final_usage) => merge_stream_usage(initial, final_usage),
+        None => initial.cloned().unwrap_or_default(),
+    };
+    accumulate_anthropic_usage(&mut total, continuation);
+    total
 }
 
 fn append_string_field(block: &mut Value, key: &str, suffix: &str) {
@@ -547,7 +570,11 @@ where
                     );
                     yield Ok(sse_line(&chunk_val));
 
-                    let merged = merge_stream_usage(initial_usage.as_ref(), &anthropic_resp.usage);
+                    let merged = paused_turn_total_usage(
+                        initial_usage.as_ref(),
+                        final_usage.as_ref(),
+                        &anthropic_resp.usage,
+                    );
                     let openai_usage = anthropic_usage_to_openai(&merged);
                     let usage_chunk = ChatCompletionChunk {
                         id: stream_id.clone(),

--- a/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/tests/all.rs
@@ -1329,6 +1329,63 @@ fn pause_turn_continuation_tool_ordinals_continue_from_the_streamed_prefix() {
     );
 }
 
+/// Regression: a paused turn used to report only its continuation's usage, so the
+/// leg that actually ran the web search — its output tokens and its billed
+/// `web_search_requests` — was never recorded. Every paused turn under-billed.
+#[test]
+fn paused_turn_usage_totals_the_streamed_leg_and_the_continuation() {
+    let initial: AnthropicUsage = serde_json::from_value(json!({
+        "input_tokens": 100,
+        "cache_read_input_tokens": 20
+    }))
+    .expect("message_start usage must decode");
+    let streamed_final: AnthropicUsage = serde_json::from_value(json!({
+        "output_tokens": 40,
+        "server_tool_use": {"web_search_requests": 1}
+    }))
+    .expect("message_delta usage must decode");
+    let continuation: AnthropicUsage = serde_json::from_value(json!({
+        "input_tokens": 130,
+        "output_tokens": 25,
+        "server_tool_use": {"web_search_requests": 1}
+    }))
+    .expect("continuation usage must decode");
+
+    let total = paused_turn_total_usage(Some(&initial), Some(&streamed_final), &continuation);
+
+    assert_eq!(total.input_tokens, 230);
+    assert_eq!(total.cache_read_input_tokens, 20);
+    assert_eq!(
+        total.output_tokens, 65,
+        "the paused leg's output is billable"
+    );
+    assert_eq!(
+        total
+            .server_tool_use
+            .as_ref()
+            .map(|tool_use| tool_use.web_search_requests),
+        Some(2),
+        "both legs' web searches are billed per request"
+    );
+}
+
+/// A `message_delta` may carry no usage at all. The turn then totals what
+/// `message_start` reported plus the continuation, never less than before.
+#[test]
+fn paused_turn_usage_falls_back_to_message_start_when_the_pause_reported_none() {
+    let initial: AnthropicUsage =
+        serde_json::from_value(json!({"input_tokens": 90})).expect("usage must decode");
+    let continuation: AnthropicUsage =
+        serde_json::from_value(json!({"input_tokens": 110, "output_tokens": 7}))
+            .expect("usage must decode");
+
+    let total = paused_turn_total_usage(Some(&initial), None, &continuation);
+
+    assert_eq!(total.input_tokens, 200);
+    assert_eq!(total.output_tokens, 7);
+    assert!(total.server_tool_use.is_none());
+}
+
 #[test]
 fn test_translate_request_degrades_when_web_search_disabled() {
     let mut req = test_request(vec![user_message("Search the web for HumanPost")]);

--- a/desktop/macos/Backend-Rust/src/routes/chat/transport.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/transport.rs
@@ -153,7 +153,7 @@ async fn receive_anthropic_response(
     })
 }
 
-fn accumulate_anthropic_usage(total: &mut AnthropicUsage, usage: &AnthropicUsage) {
+pub(super) fn accumulate_anthropic_usage(total: &mut AnthropicUsage, usage: &AnthropicUsage) {
     total.input_tokens += usage.input_tokens;
     total.output_tokens += usage.output_tokens;
     total.cache_creation_input_tokens += usage.cache_creation_input_tokens;


### PR DESCRIPTION
## Bug

A streaming chat turn that Anthropic pauses (`stop_reason: pause_turn`) is finished by a non-streaming continuation whose result is spliced back into the open SSE body. The splice reported the turn's usage as `merge_stream_usage(message_start_usage, continuation_usage)` — and `merge_stream_usage` takes `output_tokens` from its second argument alone. The streamed leg was therefore dropped from both the client's usage chunk and the Firestore `record_llm_usage` row.

## Why it matters

The dropped leg is the leg that ran the web search. A turn pauses *because* a server tool ran, so the pausing `message_delta` is exactly where `usage.server_tool_use.web_search_requests` lives — and those are billed per request (`compute_cost` → `WEB_SEARCH_COST_PER_REQUEST`), on top of every output token spent before the pause (thinking plus the search query). Every paused turn was accounted for as if its first half never happened: cost under-reported per turn, and the user-visible `usage` chunk under-reported `completion_tokens`.

`AnthropicUsage::server_tool_use` even carries the comment "billed per request, so it must survive into cost computation" — the streaming splice was the one path where it did not.

## Root cause / fix

The non-streaming lane already sums every leg (`accumulate_anthropic_usage` in `transport.rs`, used across `complete_anthropic_server_tool_turn`'s own continuations). Only the streaming splice had its own, lossy totalling rule.

Extract `paused_turn_total_usage()` so the splice totals the same way:

1. merge `message_start` with the pausing `message_delta` to make the streamed leg whole (input side comes from the former, output side from the latter);
2. accumulate the continuation's usage on top, reusing `accumulate_anthropic_usage`.

A pause that reported no usage at all falls back to `message_start`, so the fix can never report less than before.

## Tested

- `cargo test` — 382 passed, 0 failed.
- Both new regression tests fail on the pre-fix expression (`input 130` vs `230`, `110` vs `200`) and pass on the fix.
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.
- The live Anthropic `pause_turn` round trip is not driveable on demand and `ANTHROPIC_API_URL` is a constant with no test seam, so the fix is proven through the production usage-totalling function rather than against the provider.

## Product invariants

none

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

