### PR TITLE
Harden auth, SSRF, and CSRF gaps left open from the April disclosure

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -26,6 +26,20 @@ DEEPGRAM_API_KEY=
 MODULATE_API_KEY=
 
 ADMIN_KEY=
+# Set to 'false' to disable the ADMIN_KEY<uid> local-dev auth bypass entirely
+# (it defaults to 'true' for backward compatibility with existing deployments).
+ADMIN_KEY_AUTH_ENABLED=true
+# Server-side HMAC pepper for stored BYOK key fingerprints. When unset,
+# fingerprints are stored as the plain client SHA-256 (legacy); when set,
+# they are wrapped with this secret before storage/comparison so a leaked
+# fingerprint store is not rainbow-table attackable. Leave unset for
+# backward compatibility; set a stable random value to opt in.
+BYOK_FINGERPRINT_PEPPER=
+# Comma-separated exact origins allowed by CORS (e.g. https://app.omi.com).
+# Defaults to empty (no origins) — the API is Bearer-token authenticated and
+# browser default-deny already applies. Never use "*" and never combine with
+# credential forwarding.
+CORS_ALLOWED_ORIGINS=
 OPENAI_API_KEY=
 
 # Optional backend PostHog sink for provider sync/auth telemetry.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -67,5 +67,14 @@ COPY .github/scripts/desktop_qualification_admission.py /app/desktop_qualificati
 COPY .github/scripts/desktop_qualification_evidence.py /app/desktop_qualification_evidence_contract.py
 COPY backend/ .
 
+# Run as a non-root user: a compromise of the app process (e.g. via a
+# dependency RCE) shouldn't hand the attacker root inside the container by
+# default. /app needs to stay writable — sync.py writes uploaded audio to a
+# relative `syncing/<uid>/` directory under the working dir at runtime.
+RUN groupadd --system --gid 10001 omi && \
+    useradd --system --uid 10001 --gid omi --no-create-home omi && \
+    chown -R omi:omi /app
+USER omi
+
 EXPOSE 8080
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080", "--loop", "uvloop"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 import firebase_admin
 from fastapi import FastAPI
+from starlette.middleware.cors import CORSMiddleware
 
 from database.google_credentials import prepare_google_credentials
 
@@ -113,6 +114,23 @@ else:
     firebase_admin.initialize_app()  # type: ignore[reportUnknownMemberType]  # firebase_admin untyped
 
 app = FastAPI()
+
+# Explicit, default-deny CORS: this API is Bearer-token authenticated (mobile/
+# desktop apps, not ambient browser cookies), so no cross-origin browser
+# caller needs to be allowed by default. CORS_ALLOWED_ORIGINS lets an operator
+# opt a specific web frontend in (comma-separated exact origins — never "*",
+# and never combined with allow_credentials, which would let any site read
+# authenticated responses for a signed-in visitor).
+_cors_allowed_origins = [o.strip() for o in os.getenv('CORS_ALLOWED_ORIGINS', '').split(',') if o.strip()]
+if '*' in _cors_allowed_origins:
+    raise RuntimeError('CORS_ALLOWED_ORIGINS must not contain "*" — list explicit origins instead')
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_cors_allowed_origins,
+    allow_credentials=False,
+    allow_methods=['*'],
+    allow_headers=['*'],
+)
 
 app.include_router(transcribe.router)
 app.include_router(omni_relay.router)

--- a/backend/routers/oauth.py
+++ b/backend/routers/oauth.py
@@ -1,6 +1,9 @@
+import hmac
+import logging
 import os
+import secrets
 from typing import Optional
-from fastapi import APIRouter, Request, HTTPException, Form
+from fastapi import APIRouter, Cookie, Request, HTTPException, Form
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
@@ -9,10 +12,12 @@ import httpx
 
 from database.apps import get_app_by_id_db
 from utils.executors import critical_executor, db_executor, run_blocking
-from utils.http_client import get_auth_client
+from utils.http_client import safe_request_target, get_auth_client, UnsafeWebhookURLError
 from database.redis_db import enable_app, increase_app_installs_count
 from utils.apps import is_user_app_enabled, get_is_user_paid_app, is_tester
 from models.app import App as AppModel, ActionType
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     tags=["oauth"],
@@ -32,6 +37,17 @@ class OAuthTokenResponse(BaseModel):
 # Ensure the templates directory exists
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 templates = Jinja2Templates(directory=os.path.join(BASE_DIR, "templates"))
+
+# Double-submit CSRF protection for the authorize -> token exchange: /authorize
+# hands the browser the same random value two ways (an HttpOnly SameSite=Strict
+# cookie it never has to read, and a value embedded directly in the page it
+# loaded), and /token requires both to match. A cross-site page cannot forge
+# this — it has no way to read or set the cookie for our origin, and
+# SameSite=Strict keeps the cookie from being attached to a cross-site request
+# in the first place. This closes the "state accepted but never validated
+# server-side" gap without depending on the third-party app's own `state`
+# handling, which Omi's server has no way to verify.
+OAUTH_CSRF_COOKIE_NAME = 'omi_oauth_csrf'
 
 
 @router.get("/v1/oauth/authorize", response_class=HTMLResponse)
@@ -107,7 +123,8 @@ def oauth_authorize(
             seen_texts.add(perm["text"])
     permissions = unique_permissions
 
-    return templates.TemplateResponse(
+    csrf_token = secrets.token_urlsafe(32)
+    response = templates.TemplateResponse(
         request,
         "oauth_authenticate.html",
         {
@@ -115,16 +132,37 @@ def oauth_authorize(
             "app_name": app.name,
             "app_image": app.image,
             "state": state,
+            "csrf_token": csrf_token,
             "permissions": permissions,
             "firebase_api_key": os.getenv("FIREBASE_API_KEY"),
             "firebase_auth_domain": os.getenv("FIREBASE_AUTH_DOMAIN"),
             "firebase_project_id": os.getenv("FIREBASE_PROJECT_ID"),
         },
     )
+    response.set_cookie(
+        OAUTH_CSRF_COOKIE_NAME,
+        csrf_token,
+        max_age=600,
+        httponly=True,
+        secure=True,
+        samesite='strict',
+    )
+    return response
 
 
 @router.post("/v1/oauth/token", response_model=OAuthTokenResponse)
-async def oauth_token(firebase_id_token: str = Form(...), app_id: str = Form(...), state: Optional[str] = Form(None)):
+async def oauth_token(
+    firebase_id_token: str = Form(...),
+    app_id: str = Form(...),
+    state: Optional[str] = Form(None),
+    csrf_token: str = Form(...),
+    oauth_csrf_cookie: Optional[str] = Cookie(default=None, alias=OAUTH_CSRF_COOKIE_NAME),
+):
+    if not oauth_csrf_cookie or not hmac.compare_digest(csrf_token, oauth_csrf_cookie):
+        raise HTTPException(
+            status_code=403,
+            detail='This authorization request is invalid or expired. Please restart the connection from the app.',
+        )
     try:
         decoded_token = await run_blocking(
             critical_executor,
@@ -157,14 +195,28 @@ async def oauth_token(firebase_id_token: str = Form(...), app_id: str = Form(...
         # Check Setup completes
         if app.works_externally() and app.external_integration.setup_completed_url:
             try:
+                pinned_url, pin_kwargs = await run_blocking(
+                    db_executor, safe_request_target, app.external_integration.setup_completed_url
+                )
                 client = get_auth_client()
-                res = await client.get(app.external_integration.setup_completed_url + f'?uid={uid}')
+                res = await client.get(
+                    pinned_url + f'?uid={uid}',
+                    headers=pin_kwargs['headers'],
+                    extensions=pin_kwargs['extensions'],
+                    follow_redirects=False,
+                )
                 res.raise_for_status()
                 if not res.json().get('is_setup_completed', False):
                     raise HTTPException(
                         status_code=400,
                         detail='App setup is not completed. Please complete app setup before authorizing.',
                     )
+            except UnsafeWebhookURLError as e:
+                logger.warning(f'Rejected setup_completed_url for app {app_id}: {e}')
+                raise HTTPException(
+                    status_code=400,
+                    detail='This app is misconfigured (setup URL is not a public address). Please contact the app developer.',
+                )
             except (httpx.HTTPStatusError, httpx.RequestError) as e:
                 raise HTTPException(
                     status_code=503,

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -1275,7 +1275,12 @@ def save_paypal_payment_details(data: SavePayPalPaymentDetailsRequest, uid: str 
             set_default_payment_method(uid, 'paypal')
         return {"status": "success"}
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        # Broad catch around a Firestore write — unlike the ValidationError/
+        # StripeError sites elsewhere in this file (whose messages are
+        # designed to be user-facing), an unexpected exception here could be
+        # anything, so log the real detail server-side and don't echo it.
+        logger.error(f"Failed to save PayPal payment details for uid={uid}: {e}")
+        raise HTTPException(status_code=400, detail="Could not save PayPal payment details. Please try again.")
 
 
 @router.get("/v1/paypal/payment-details", response_model=Optional[PayPalPaymentDetailsResponse])

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -121,7 +121,7 @@ from utils.other.storage import (
     delete_user_person_speech_sample,
 )
 from utils.webhooks import webhook_first_time_setup
-from utils.byok import has_byok_keys, invalidate_byok_state_cache
+from utils.byok import has_byok_keys, invalidate_byok_state_cache, peppered_fingerprint
 import logging
 
 logger = logging.getLogger(__name__)
@@ -1108,7 +1108,7 @@ def activate_byok_endpoint(data: BYOKActivateRequest, uid: str = Depends(auth.ge
             raise HTTPException(
                 status_code=400, detail=f"Invalid fingerprint for {provider}: expected lowercase hex SHA-256 (64 chars)"
             )
-    users_db.set_byok_active(uid, data.fingerprints)
+    users_db.set_byok_active(uid, {p: peppered_fingerprint(fp) for p, fp in data.fingerprints.items()})
     invalidate_byok_state_cache(uid)
     clear_trial_paywall_cache(uid)
     return {"active": True}

--- a/backend/templates/oauth_authenticate.html
+++ b/backend/templates/oauth_authenticate.html
@@ -151,6 +151,7 @@
         // These values are passed from the backend template rendering
         const appId = "{{ app_id }}";
         const state = "{{ state }}";
+        const csrfToken = "{{ csrf_token }}";
 
         // Firebase configuration
         const firebaseConfig = {
@@ -207,6 +208,7 @@
             const formData = new FormData();
             formData.append('firebase_id_token', idToken);
             formData.append('app_id', appId);
+            formData.append('csrf_token', csrfToken);
             if (state) {
                 formData.append('state', state);
             }

--- a/backend/tests/unit/test_async_app_integrations.py
+++ b/backend/tests/unit/test_async_app_integrations.py
@@ -245,6 +245,12 @@ if _http_mod is not None and not hasattr(_http_mod, '__file__'):
     _http_mod.get_webhook_semaphore = MagicMock(return_value=_asyncio.Semaphore(64))
     _http_mod.latest_wins_start = MagicMock(return_value=1)
     _http_mod.latest_wins_check = MagicMock(return_value=True)
+    _http_mod.safe_request_target = MagicMock(side_effect=lambda url: (url, {'headers': {}, 'extensions': {}}))
+
+    class _UnsafeWebhookURLError(Exception):
+        pass
+
+    _http_mod.UnsafeWebhookURLError = _UnsafeWebhookURLError
 
 # Stub executors — must use real ThreadPoolExecutor because asyncio's
 # run_in_executor calls executor.submit() and wraps the returned Future.
@@ -344,6 +350,69 @@ class TestDurableExternalIntegrationFanout:
 
         assert messages == []
         assert client.post.await_count == 1
+
+
+class TestSSRFConfigRejection:
+    """A developer-configured webhook URL that resolves to a non-public
+    (private/loopback/link-local/metadata) address is a *configuration*
+    error, not a delivery failure. It must be rejected silently per-app
+    without recording a webhook failure, tripping the circuit breaker, or
+    — on the durable path — raising ExternalIntegrationFanoutError (which
+    would retry the whole batch and punish a misconfigured app's
+    neighbours)."""
+
+    @pytest.mark.asyncio
+    async def test_durable_fanout_private_url_is_config_error_not_delivery_failure(self):
+        app = _make_app('app-1', 'https://internal.test/hook')
+        app.triggers_on_conversation_creation.return_value = True
+        conversation = types.SimpleNamespace(id='conversation-1', discarded=False, is_locked=False, source=None)
+        client = AsyncMock()
+        cb = MagicMock()
+        cb.allow_request.return_value = True
+
+        with patch.object(app_integrations, 'get_available_apps', return_value=[app]), patch.object(
+            app_integrations, 'get_webhook_client', return_value=client
+        ), patch.object(
+            app_integrations, 'safe_request_target', side_effect=app_integrations.UnsafeWebhookURLError('private')
+        ), patch.object(
+            app_integrations, 'get_webhook_circuit_breaker', return_value=cb
+        ), patch.object(
+            app_integrations, 'record_app_webhook_failure'
+        ) as record_failure:
+            # Must not raise ExternalIntegrationFanoutError even with require_delivery.
+            result = await app_integrations.trigger_external_integrations(
+                'uid-1', conversation, idempotency_key='fanout-1', require_delivery=True
+            )
+
+        assert result == []  # no app message produced
+        client.post.assert_not_called()  # never reached the network
+        cb.record_failure.assert_not_called()  # circuit breaker untouched
+        cb.allow_request.assert_not_called()  # rejected before the breaker was even consulted
+        record_failure.assert_not_called()  # no webhook-health failure recorded
+
+    @pytest.mark.asyncio
+    async def test_realtime_audio_private_url_does_not_trip_breaker(self):
+        app = _make_app('a1', 'https://internal.test/hook', triggers_audio=True)
+        client = AsyncMock()
+        cb = MagicMock()
+        cb.allow_request.return_value = True
+
+        with patch.object(app_integrations, 'get_available_apps', return_value=[app]), patch.object(
+            app_integrations, 'get_webhook_client', return_value=client
+        ), patch.object(
+            app_integrations, 'safe_request_target', side_effect=app_integrations.UnsafeWebhookURLError('private')
+        ), patch.object(
+            app_integrations, 'get_webhook_circuit_breaker', return_value=cb
+        ), patch.object(
+            app_integrations, 'record_app_webhook_failure'
+        ) as record_failure:
+            result = await app_integrations.trigger_realtime_audio_bytes('uid-1', 8000, bytearray(b'\x00' * 10))
+
+        assert result == {}
+        client.post.assert_not_called()
+        cb.record_failure.assert_not_called()
+        cb.allow_request.assert_not_called()
+        record_failure.assert_not_called()
 
 
 class TestAsyncTriggerRealtimeAudioBytes:

--- a/backend/tests/unit/test_async_realtime_integrations_offload.py
+++ b/backend/tests/unit/test_async_realtime_integrations_offload.py
@@ -250,6 +250,12 @@ if _http_mod is not None and not hasattr(_http_mod, '__file__'):
     _http_mod.get_webhook_semaphore = MagicMock(return_value=_asyncio.Semaphore(64))
     _http_mod.latest_wins_start = MagicMock(return_value=1)
     _http_mod.latest_wins_check = MagicMock(return_value=True)
+    _http_mod.safe_request_target = MagicMock(side_effect=lambda url: (url, {'headers': {}, 'extensions': {}}))
+
+    class _UnsafeWebhookURLError(Exception):
+        pass
+
+    _http_mod.UnsafeWebhookURLError = _UnsafeWebhookURLError
 
 # Stub executors — db_executor is a sentinel; run_blocking is a pass-through that
 # actually invokes fn so the production code path runs end to end.

--- a/backend/tests/unit/test_byok_fingerprint_pepper_migration.py
+++ b/backend/tests/unit/test_byok_fingerprint_pepper_migration.py
@@ -1,0 +1,168 @@
+"""Tests for the BYOK fingerprint pepper migration (utils/byok.py).
+
+Background: the client only ever computes/sends plain SHA-256(raw_key) --
+that's deliberate (the server never sees raw BYOK keys at enrollment). What
+this hardening changes is what the *server* persists: instead of storing that
+plain SHA-256 fingerprint as-is (rainbow-table attackable if it ever leaks,
+e.g. a Firestore export, since API keys have well-known prefixes like sk-,
+sk-ant-, AIza), it's wrapped with a server-only HMAC pepper
+(BYOK_FINGERPRINT_PEPPER) before being stored or compared. Because the pepper
+is read once at import time (`_BYOK_PEPPER = os.getenv(...)`), these tests
+reload utils.byok fresh with the env var set/unset as needed, rather than
+monkeypatching the environment after import.
+
+Covers what the reviewer asked for:
+- Newly stored peppered fingerprints validate.
+- Existing legacy plain (unpeppered) fingerprints still validate once
+  BYOK_FINGERPRINT_PEPPER is introduced (no forced re-enrollment).
+- Mismatches fail in both modes.
+"""
+
+import hashlib
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from testing.import_isolation import load_module_fresh, stub_modules
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+RAW_KEY = 'sk-test-0123456789abcdef'
+WRONG_KEY = 'sk-completely-different-key'
+
+
+def _load_byok(monkeypatch, pepper: str | None):
+    if pepper is None:
+        monkeypatch.delenv('BYOK_FINGERPRINT_PEPPER', raising=False)
+    else:
+        monkeypatch.setenv('BYOK_FINGERPRINT_PEPPER', pepper)
+    return load_module_fresh('utils.byok', str(BACKEND_DIR / 'utils' / 'byok.py'))
+
+
+def _active_state(fingerprints: dict) -> dict:
+    return {
+        'active': True,
+        'last_seen_at': datetime.now(timezone.utc),
+        'fingerprints': fingerprints,
+    }
+
+
+def _client_fingerprint(raw_key: str) -> str:
+    """What the client always computes/sends -- plain SHA-256, pepper-agnostic."""
+    return hashlib.sha256(raw_key.encode()).hexdigest()
+
+
+def _database_users_stub() -> types.ModuleType:
+    """_check_byok_validity() does `import database.users as users_db` inline
+    and only reads BYOK_HEARTBEAT_TTL_SECONDS off it. The real database.users
+    transitively imports firebase_admin/google-cloud-firestore, which this
+    hermetic unit-test tier deliberately never needs -- stub just the one
+    constant actually used (see backend/docs/test_isolation.md)."""
+    stub = types.ModuleType('database.users')
+    stub.BYOK_HEARTBEAT_TTL_SECONDS = 7 * 24 * 60 * 60  # matches database/users.py
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# peppered_fingerprint() itself
+# ---------------------------------------------------------------------------
+
+
+def test_no_pepper_configured_is_identity(monkeypatch):
+    byok = _load_byok(monkeypatch, None)
+    fp = _client_fingerprint(RAW_KEY)
+    assert byok.peppered_fingerprint(fp) == fp
+
+
+def test_pepper_configured_changes_the_stored_value(monkeypatch):
+    byok = _load_byok(monkeypatch, 'server-only-pepper-secret')
+    fp = _client_fingerprint(RAW_KEY)
+    peppered = byok.peppered_fingerprint(fp)
+    assert peppered != fp
+    assert len(peppered) == 64  # still a hex SHA-256-sized digest
+
+
+def test_pepper_is_deterministic_for_the_same_input(monkeypatch):
+    byok = _load_byok(monkeypatch, 'server-only-pepper-secret')
+    fp = _client_fingerprint(RAW_KEY)
+    assert byok.peppered_fingerprint(fp) == byok.peppered_fingerprint(fp)
+
+
+def test_different_peppers_produce_different_values(monkeypatch):
+    byok_a = _load_byok(monkeypatch, 'pepper-a')
+    fp = _client_fingerprint(RAW_KEY)
+    peppered_a = byok_a.peppered_fingerprint(fp)
+
+    byok_b = _load_byok(monkeypatch, 'pepper-b')
+    peppered_b = byok_b.peppered_fingerprint(fp)
+
+    assert peppered_a != peppered_b
+
+
+# ---------------------------------------------------------------------------
+# _check_byok_validity(): the actual per-request enrollment check
+# ---------------------------------------------------------------------------
+
+
+def test_new_peppered_enrollment_validates(monkeypatch):
+    byok = _load_byok(monkeypatch, 'server-only-pepper-secret')
+    stored = byok.peppered_fingerprint(_client_fingerprint(RAW_KEY))  # what enrollment would have stored today
+
+    monkeypatch.setattr(byok, 'get_cached_byok_state', lambda uid: _active_state({'openai': stored}))
+    byok.set_byok_keys({'openai': RAW_KEY})
+
+    with stub_modules({'database.users': _database_users_stub()}):
+        assert byok._check_byok_validity('uid-1') is None
+
+
+def test_legacy_unpeppered_enrollment_still_validates_after_pepper_introduced(monkeypatch):
+    byok = _load_byok(monkeypatch, 'server-only-pepper-secret')
+    # Simulates a fingerprint stored back before BYOK_FINGERPRINT_PEPPER
+    # existed: plain client SHA-256, never peppered.
+    legacy_stored = _client_fingerprint(RAW_KEY)
+
+    monkeypatch.setattr(byok, 'get_cached_byok_state', lambda uid: _active_state({'openai': legacy_stored}))
+    byok.set_byok_keys({'openai': RAW_KEY})
+
+    with stub_modules({'database.users': _database_users_stub()}):
+        assert byok._check_byok_validity('uid-1') is None, 'legacy plain fingerprints must not be locked out'
+
+
+def test_mismatched_key_fails_with_pepper_configured(monkeypatch):
+    byok = _load_byok(monkeypatch, 'server-only-pepper-secret')
+    stored = byok.peppered_fingerprint(_client_fingerprint(RAW_KEY))
+
+    monkeypatch.setattr(byok, 'get_cached_byok_state', lambda uid: _active_state({'openai': stored}))
+    byok.set_byok_keys({'openai': WRONG_KEY})
+
+    with stub_modules({'database.users': _database_users_stub()}):
+        error = byok._check_byok_validity('uid-1')
+    assert error is not None
+    assert 'mismatch' in error.lower()
+
+
+def test_mismatched_key_fails_without_pepper_configured(monkeypatch):
+    byok = _load_byok(monkeypatch, None)
+    stored = _client_fingerprint(RAW_KEY)
+
+    monkeypatch.setattr(byok, 'get_cached_byok_state', lambda uid: _active_state({'openai': stored}))
+    byok.set_byok_keys({'openai': WRONG_KEY})
+
+    with stub_modules({'database.users': _database_users_stub()}):
+        error = byok._check_byok_validity('uid-1')
+    assert error is not None
+    assert 'mismatch' in error.lower()
+
+
+def test_no_byok_headers_skips_validation_without_touching_state(monkeypatch):
+    byok = _load_byok(monkeypatch, 'server-only-pepper-secret')
+
+    def _fail_if_called(uid):
+        raise AssertionError('get_cached_byok_state should not be called when no BYOK headers are present')
+
+    monkeypatch.setattr(byok, 'get_cached_byok_state', _fail_if_called)
+    byok.set_byok_keys({})
+
+    assert byok._check_byok_validity('uid-1') is None

--- a/backend/tests/unit/test_listen_finalization_cloud_tasks.py
+++ b/backend/tests/unit/test_listen_finalization_cloud_tasks.py
@@ -1453,11 +1453,19 @@ async def test_finalizer_completes_when_an_app_permanently_rejects_the_delivery(
     app.triggers_on_conversation_creation.return_value = True
     webhook_client = AsyncMock()
     webhook_client.post = AsyncMock(return_value=MagicMock(status_code=401, text='re-authenticate'))
+    pinned_url = 'https://8.8.8.8/hook?uid=uid-1'
+    safe_target = MagicMock(
+        return_value=(
+            pinned_url,
+            {'headers': {'Host': 'app.test'}, 'extensions': {'sni_hostname': 'app.test'}},
+        )
+    )
     monkeypatch.setattr(app_integrations, 'run_blocking', inline_run_blocking)
     monkeypatch.setattr(app_integrations, 'get_available_apps', lambda uid: [app])
     monkeypatch.setattr(app_integrations, 'conversation_to_dict', lambda conv: {'id': conv.id})
     monkeypatch.setattr(app_integrations, 'get_webhook_client', lambda: webhook_client)
     monkeypatch.setattr(app_integrations, 'is_app_webhook_disabled', lambda app_id: False)
+    monkeypatch.setattr(app_integrations, 'safe_request_target', safe_target)
     record_failure = MagicMock(return_value=0)
     monkeypatch.setattr(app_integrations, 'record_app_webhook_failure', record_failure)
     monkeypatch.setattr(app_integrations, '_handle_webhook_health_action', MagicMock())
@@ -1472,5 +1480,13 @@ async def test_finalizer_completes_when_an_app_permanently_rejects_the_delivery(
 
     assert disposition == ConversationFinalizationDisposition.completed
     complete.assert_called_once_with('job-1', 2, 3)
+    safe_target.assert_called_once_with('https://app.test/hook?uid=uid-1')
+    webhook_client.post.assert_awaited_once_with(
+        pinned_url,
+        json={'id': 'conversation-1'},
+        headers={'Host': 'app.test', 'X-Omi-Idempotency-Key': 'conversation:conversation-1:finalization'},
+        extensions={'sni_hostname': 'app.test'},
+        follow_redirects=False,
+    )
     # The failure is still owned by webhook health, which disables the app after 72h.
     record_failure.assert_called_once_with('omi-google-drive-integration', 401, 'HTTP 401')

--- a/backend/tests/unit/test_oauth_csrf.py
+++ b/backend/tests/unit/test_oauth_csrf.py
@@ -1,0 +1,145 @@
+"""Tests for the OAuth authorize -> token exchange CSRF protection
+(routers/oauth.py).
+
+Background: the `state` query/form param is round-tripped between
+/v1/oauth/authorize and /v1/oauth/token, but the *value* is opaque to Omi's
+server and controlled by the third-party app -- Omi has no way to validate it
+means anything. The actual CSRF protection is a double-submit token Omi
+generates itself: /authorize sets it two ways (an HttpOnly SameSite=Strict
+cookie, and a copy embedded directly in the consent page's JS), and /token
+requires both copies to be present and equal. A cross-site attacker can't
+read or set that cookie for our origin, so they can't produce a matching pair.
+
+Covers what the reviewer asked for:
+- /v1/oauth/authorize emits the CSRF cookie and a matching token in the
+  rendered page.
+- /v1/oauth/token rejects a missing cookie, a missing form token, and a
+  mismatched pair.
+- /v1/oauth/token accepts the valid matching pair.
+
+Reuses the existing `_loaded_oauth_router` stubbing harness from
+test_oauth_token_async_boundaries.py so the fakes for firebase_admin,
+database.apps, database.redis_db, utils.apps, and models.app stay in exactly
+one place.
+"""
+
+import re
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tests.unit.test_oauth_token_async_boundaries import _loaded_oauth_router
+
+CSRF_TOKEN_RE = re.compile(r'const csrfToken = "([^"]*)"')
+
+
+def _client_for(oauth_module) -> TestClient:
+    app = FastAPI()
+    app.include_router(oauth_module.router)
+    return TestClient(app)
+
+
+def _authorize(client: TestClient) -> tuple[str, str]:
+    """Hit /v1/oauth/authorize and return (cookie_value, page_csrf_token)."""
+    response = client.get('/v1/oauth/authorize', params={'app_id': 'app-1'})
+    assert response.status_code == 200
+
+    cookie_value = response.cookies.get('omi_oauth_csrf')
+    assert cookie_value, 'expected /v1/oauth/authorize to set the CSRF cookie'
+
+    match = CSRF_TOKEN_RE.search(response.text)
+    assert match, 'expected the rendered page to embed a matching csrfToken'
+    page_token = match.group(1)
+    assert page_token, 'csrfToken embedded in the page must not be empty'
+
+    return cookie_value, page_token
+
+
+def test_authorize_emits_cookie_and_matching_page_token():
+    with _loaded_oauth_router() as (oauth, _firebase_auth, _apps_db):
+        client = _client_for(oauth)
+        cookie_value, page_token = _authorize(client)
+        assert cookie_value == page_token
+
+
+def test_authorize_cookie_is_httponly_and_samesite_strict():
+    with _loaded_oauth_router() as (oauth, _firebase_auth, _apps_db):
+        client = _client_for(oauth)
+        response = client.get('/v1/oauth/authorize', params={'app_id': 'app-1'})
+        set_cookie_header = response.headers.get('set-cookie', '')
+        assert 'httponly' in set_cookie_header.lower()
+        assert 'samesite=strict' in set_cookie_header.lower()
+
+
+def test_token_accepts_valid_matching_pair():
+    with _loaded_oauth_router() as (oauth, _firebase_auth, _apps_db):
+        client = _client_for(oauth)
+        cookie_value, page_token = _authorize(client)
+
+        response = client.post(
+            '/v1/oauth/token',
+            data={'firebase_id_token': 'token', 'app_id': 'app-1', 'csrf_token': page_token},
+            cookies={'omi_oauth_csrf': cookie_value},
+        )
+        assert response.status_code == 200
+        assert response.json()['uid'] == 'user-1'
+
+
+def test_token_rejects_missing_cookie():
+    with _loaded_oauth_router() as (oauth, _firebase_auth, _apps_db):
+        client = _client_for(oauth)
+        _cookie_value, page_token = _authorize(client)
+
+        # No cookie sent at all -- e.g. a cross-site POST that never had it.
+        response = client.post(
+            '/v1/oauth/token',
+            data={'firebase_id_token': 'token', 'app_id': 'app-1', 'csrf_token': page_token},
+        )
+        assert response.status_code == 403
+
+
+def test_token_rejects_missing_form_token():
+    with _loaded_oauth_router() as (oauth, _firebase_auth, _apps_db):
+        client = _client_for(oauth)
+        cookie_value, _page_token = _authorize(client)
+
+        response = client.post(
+            '/v1/oauth/token',
+            data={'firebase_id_token': 'token', 'app_id': 'app-1'},
+            cookies={'omi_oauth_csrf': cookie_value},
+        )
+        # csrf_token is a required Form(...) field -> FastAPI itself 422s.
+        assert response.status_code == 422
+
+
+def test_token_rejects_mismatched_pair():
+    with _loaded_oauth_router() as (oauth, _firebase_auth, _apps_db):
+        client = _client_for(oauth)
+        cookie_value, page_token = _authorize(client)
+        assert page_token != 'attacker-supplied-token'
+
+        response = client.post(
+            '/v1/oauth/token',
+            data={'firebase_id_token': 'token', 'app_id': 'app-1', 'csrf_token': 'attacker-supplied-token'},
+            cookies={'omi_oauth_csrf': cookie_value},
+        )
+        assert response.status_code == 403
+
+
+def test_token_rejects_pair_from_a_different_authorize_call():
+    """Each /authorize call mints a fresh token; an old page's token/cookie
+    pair from a previous session must not validate against a stale value an
+    attacker might have observed."""
+    with _loaded_oauth_router() as (oauth, _firebase_auth, _apps_db):
+        client = _client_for(oauth)
+        first_cookie, first_token = _authorize(client)
+        second_cookie, second_token = _authorize(client)
+        assert first_token != second_token, 'CSRF tokens must be freshly random per authorize call'
+
+        # Mix a valid cookie with a token minted for a *different* page load.
+        response = client.post(
+            '/v1/oauth/token',
+            data={'firebase_id_token': 'token', 'app_id': 'app-1', 'csrf_token': second_token},
+            cookies={'omi_oauth_csrf': first_cookie},
+        )
+        assert response.status_code == 403

--- a/backend/tests/unit/test_oauth_token_async_boundaries.py
+++ b/backend/tests/unit/test_oauth_token_async_boundaries.py
@@ -77,7 +77,19 @@ def _loaded_oauth_router() -> Iterator[tuple[ModuleType, ModuleType, ModuleType]
             READ_TASKS=SimpleNamespace(value='read_tasks'),
         ),
     )
-    http_client = _module('utils.http_client', get_auth_client=lambda: None)
+
+    class _UnsafeWebhookURLError(Exception):
+        pass
+
+    http_client = _module(
+        'utils.http_client',
+        get_auth_client=lambda: None,
+        # Passthrough: none of this file's tests exercise the setup_completed_url
+        # branch (default is_user_app_enabled=True skips it), so this only needs
+        # to satisfy the import and match safe_request_target's (url, extra) shape.
+        safe_request_target=lambda url: (url, {'headers': {}, 'extensions': {}}),
+        UnsafeWebhookURLError=_UnsafeWebhookURLError,
+    )
 
     with stub_modules(
         {
@@ -104,7 +116,15 @@ def test_oauth_token_routes_auth_and_app_reads_to_owned_executors() -> None:
 
         oauth.run_blocking = tracking_run_blocking
 
-        result = asyncio.run(oauth.oauth_token(firebase_id_token='token', app_id='app-1', state='opaque'))
+        result = asyncio.run(
+            oauth.oauth_token(
+                firebase_id_token='token',
+                app_id='app-1',
+                state='opaque',
+                csrf_token='matching-csrf-token',
+                oauth_csrf_cookie='matching-csrf-token',
+            )
+        )
 
         assert result == {
             'uid': 'user-1',
@@ -132,7 +152,14 @@ def test_oauth_token_verification_keeps_the_event_loop_responsive() -> None:
                 return {'uid': 'user-1'}
 
             firebase_auth.verify_id_token = blocking_verify
-            task = asyncio.create_task(oauth.oauth_token(firebase_id_token='token', app_id='app-1'))
+            task = asyncio.create_task(
+                oauth.oauth_token(
+                    firebase_id_token='token',
+                    app_id='app-1',
+                    csrf_token='matching-csrf-token',
+                    oauth_csrf_cookie='matching-csrf-token',
+                )
+            )
             try:
                 await asyncio.wait_for(entered.wait(), timeout=2)
                 tick = asyncio.Event()
@@ -152,7 +179,14 @@ def test_oauth_token_preserves_invalid_token_status() -> None:
         firebase_auth.verify_id_token = lambda _token: (_ for _ in ()).throw(_InvalidIdTokenError('invalid'))
 
         with pytest.raises(HTTPException) as exc:
-            asyncio.run(oauth.oauth_token(firebase_id_token='bad', app_id='app-1'))
+            asyncio.run(
+                oauth.oauth_token(
+                    firebase_id_token='bad',
+                    app_id='app-1',
+                    csrf_token='matching-csrf-token',
+                    oauth_csrf_cookie='matching-csrf-token',
+                )
+            )
 
         assert exc.value.status_code == 401
         assert 'Invalid Firebase ID token' in exc.value.detail

--- a/backend/tests/unit/test_realtime_integrations_usage_tracking.py
+++ b/backend/tests/unit/test_realtime_integrations_usage_tracking.py
@@ -101,6 +101,17 @@ class _NotificationMessage:
         return dict(message.__dict__)
 
 
+class _UnsafeWebhookURLError(Exception):
+    """Isolated stand-in for ``utils.http_client.UnsafeWebhookURLError``.
+
+    Production's SSRF guard catches this to reject non-public webhook URLs
+    without tripping the circuit breaker, so the stub must expose a genuine
+    exception class — the ``AutoMockModule`` default is a non-exception
+    ``MagicMock`` that the production ``except`` clause can neither raise nor
+    match, turning the guard into a ``TypeError``.
+    """
+
+
 @pytest.fixture
 def integration_harness() -> Iterator[SimpleNamespace]:
     process_mentor_notification = MagicMock(return_value=None)
@@ -208,6 +219,8 @@ def integration_harness() -> Iterator[SimpleNamespace]:
             get_webhook_semaphore=MagicMock(return_value=asyncio.Semaphore(1)),
             latest_wins_start=MagicMock(return_value=1),
             latest_wins_check=MagicMock(return_value=True),
+            safe_request_target=MagicMock(side_effect=lambda url: (url, {'headers': {}, 'extensions': {}})),
+            UnsafeWebhookURLError=_UnsafeWebhookURLError,
         ),
         'utils.executors': _module(
             'utils.executors',
@@ -481,3 +494,34 @@ async def test_realtime_notification_failure_remains_fail_soft(integration_harne
 
     assert result == []
     integration_harness.add_app_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_realtime_non_public_webhook_rejected_fail_soft(integration_harness):
+    """The SSRF guard rejects a non-public webhook URL before any delivery.
+
+    This pins the isolation-stub contract the realtime coordinator depends
+    on: ``utils.http_client`` must expose a genuine ``UnsafeWebhookURLError``
+    exception class — the production ``except`` clause cannot match the
+    ``AutoMockModule`` default ``MagicMock`` — and a ``safe_request_target``
+    whose ``(pinned_url, {headers, extensions})`` return shape the webhook
+    delivery path unpacks.
+    """
+    app = integration_harness.app
+    # A non-exception default would make the production except clause raise
+    # TypeError instead of matching; this assert fails first if the stub
+    # regresses to the AutoMockModule default.
+    assert issubclass(app.UnsafeWebhookURLError, BaseException)
+
+    external_app = _realtime_app()
+    client = AsyncMock()
+
+    with patch.object(app, 'get_available_apps', return_value=[external_app]), patch.object(
+        app, 'process_mentor_notification', return_value=None
+    ), patch.object(app, 'safe_request_target', side_effect=app.UnsafeWebhookURLError('private ip')), patch.object(
+        app, 'get_webhook_client', return_value=client
+    ):
+        result = await app.trigger_realtime_integrations('user-ssrf', [{'text': 'hi'}], 'conv-ssrf')
+
+    assert result == []
+    client.post.assert_not_called()

--- a/backend/tests/unit/test_ssrf_public_url_guard.py
+++ b/backend/tests/unit/test_ssrf_public_url_guard.py
@@ -1,0 +1,200 @@
+"""Tests for the SSRF guard in utils.http_client: assert_public_http_url,
+pin_to_resolved_ip, and safe_request_target.
+
+Covers the post-disclosure hardening of app-developer-configured webhook /
+setup_completed_url targets (app_integrations.py, routers/oauth.py):
+
+- assert_public_http_url rejects loopback/private/link-local/reserved hosts
+  and non-http(s) schemes, accepts ordinary public http/https targets, and
+  inspects EVERY address a hostname resolves to (not just the first) so a
+  multi-address DNS answer can't sneak an unsafe address past the check.
+- pin_to_resolved_ip / safe_request_target close the DNS-rebinding gap: the
+  validated IP is what the caller must actually connect to, with the
+  original hostname preserved for the Host header and TLS SNI/cert check.
+
+DNS is always mocked (via utils.http_client.socket.getaddrinfo) so these
+tests are deterministic and make no real network calls.
+"""
+
+import socket
+
+import pytest
+
+from utils.http_client import (
+    UnsafeWebhookURLError,
+    assert_public_http_url,
+    pin_to_resolved_ip,
+    safe_request_target,
+)
+
+# Real, unambiguously-public resolvers. NOT the TEST-NET documentation ranges
+# (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24) -- Python's ipaddress module
+# actually flags those as `is_private`, so they'd be rejected and give a
+# false sense of "testing the public case".
+PUBLIC_IP_A = '8.8.8.8'
+PUBLIC_IP_B = '1.1.1.1'
+
+
+def _addrinfo(*ips: str) -> list[tuple]:
+    """Build a fake socket.getaddrinfo() return value for the given IPv4 literals."""
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', (ip, 0)) for ip in ips]
+
+
+def _mock_resolve(monkeypatch, *ips: str):
+    monkeypatch.setattr('utils.http_client.socket.getaddrinfo', lambda host, port: _addrinfo(*ips))
+
+
+def _mock_resolve_failure(monkeypatch):
+    def _raise(host, port):
+        raise socket.gaierror('Name or service not known')
+
+    monkeypatch.setattr('utils.http_client.socket.getaddrinfo', _raise)
+
+
+# ---------------------------------------------------------------------------
+# Scheme / hostname validation (no DNS involved)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('scheme_url', ['ftp://example.com/x', 'file:///etc/passwd', 'gopher://example.com'])
+def test_rejects_non_http_schemes(scheme_url):
+    with pytest.raises(UnsafeWebhookURLError, match='Unsupported URL scheme'):
+        assert_public_http_url(scheme_url)
+
+
+def test_rejects_url_with_no_hostname():
+    with pytest.raises(UnsafeWebhookURLError, match='no hostname'):
+        assert_public_http_url('http:///just-a-path')
+
+
+def test_rejects_when_dns_resolution_fails(monkeypatch):
+    _mock_resolve_failure(monkeypatch)
+    with pytest.raises(UnsafeWebhookURLError, match='Could not resolve host'):
+        assert_public_http_url('https://nonexistent.example.invalid/webhook')
+
+
+def test_rejects_when_getaddrinfo_returns_no_addresses(monkeypatch):
+    monkeypatch.setattr('utils.http_client.socket.getaddrinfo', lambda host, port: [])
+    with pytest.raises(UnsafeWebhookURLError, match='no addresses returned'):
+        assert_public_http_url('https://example.com/webhook')
+
+
+# ---------------------------------------------------------------------------
+# Rejects loopback / private / link-local / reserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'unsafe_ip,label',
+    [
+        ('127.0.0.1', 'loopback'),
+        ('10.1.2.3', 'RFC1918 private (10/8)'),
+        ('172.16.0.5', 'RFC1918 private (172.16/12)'),
+        ('192.168.1.1', 'RFC1918 private (192.168/16)'),
+        ('169.254.169.254', 'link-local / cloud metadata'),
+        # 100.64.0.0/10 is RFC 6598 carrier-grade NAT shared address space.
+        # Python's ipaddress flags NEITHER is_private NOR is_reserved for it,
+        # so an explicit guard is required -- without it this address was
+        # wrongly accepted as "public".
+        ('100.64.0.1', 'CGNAT/RFC6598 (100.64/10) -- not flagged by ipaddress'),
+        ('100.127.255.254', 'CGNAT/RFC6598 upper boundary'),
+        ('224.0.0.1', 'multicast'),
+        ('240.0.0.1', 'reserved'),
+        ('0.0.0.0', 'unspecified'),
+    ],
+)
+def test_rejects_non_public_addresses(monkeypatch, unsafe_ip, label):
+    _mock_resolve(monkeypatch, unsafe_ip)
+    with pytest.raises(UnsafeWebhookURLError, match='non-public address'):
+        assert_public_http_url('https://webhook.example.com/callback')
+
+
+# ---------------------------------------------------------------------------
+# Accepts ordinary public targets
+# ---------------------------------------------------------------------------
+
+
+def test_accepts_ordinary_public_https_url(monkeypatch):
+    _mock_resolve(monkeypatch, PUBLIC_IP_A)
+    resolved = assert_public_http_url('https://webhook.example.com/callback?x=1')
+    assert resolved == PUBLIC_IP_A
+
+
+def test_accepts_ordinary_public_http_url(monkeypatch):
+    _mock_resolve(monkeypatch, PUBLIC_IP_A)
+    resolved = assert_public_http_url('http://webhook.example.com/callback')
+    assert resolved == PUBLIC_IP_A
+
+
+def test_accepts_addresses_just_outside_the_cgnat_range(monkeypatch):
+    # 100.64.0.0/10 spans 100.64.0.0 - 100.127.255.255. Addresses immediately
+    # below and above are globally routable and must remain accepted -- this
+    # pins the boundary so the CGNAT guard can't accidentally widen.
+    _mock_resolve(monkeypatch, '100.63.255.255')
+    assert assert_public_http_url('https://edge-low.example.com/hook') == '100.63.255.255'
+    _mock_resolve(monkeypatch, '100.128.0.0')
+    assert assert_public_http_url('https://edge-high.example.com/hook') == '100.128.0.0'
+
+
+# ---------------------------------------------------------------------------
+# Multi-address DNS results
+# ---------------------------------------------------------------------------
+
+
+def test_multi_address_all_public_returns_first(monkeypatch):
+    _mock_resolve(monkeypatch, PUBLIC_IP_A, PUBLIC_IP_B)
+    resolved = assert_public_http_url('https://round-robin.example.com/hook')
+    assert resolved == PUBLIC_IP_A
+
+
+def test_multi_address_rejects_if_any_address_is_unsafe(monkeypatch):
+    # First address looks fine; second is the cloud metadata address. A check
+    # that only looked at the first result would miss this.
+    _mock_resolve(monkeypatch, PUBLIC_IP_A, '169.254.169.254')
+    with pytest.raises(UnsafeWebhookURLError, match='non-public address'):
+        assert_public_http_url('https://sneaky.example.com/hook')
+
+
+def test_multi_address_rejects_if_first_address_is_unsafe(monkeypatch):
+    # Same idea, opposite order -- the loop must not stop at the first safe
+    # hit either; it has to check every returned address.
+    _mock_resolve(monkeypatch, '169.254.169.254', PUBLIC_IP_A)
+    with pytest.raises(UnsafeWebhookURLError, match='non-public address'):
+        assert_public_http_url('https://sneaky.example.com/hook')
+
+
+# ---------------------------------------------------------------------------
+# pin_to_resolved_ip: URL rewriting for the DNS-rebinding fix
+# ---------------------------------------------------------------------------
+
+
+def test_pin_ipv4_preserves_path_and_query():
+    pinned_url, extra = pin_to_resolved_ip('https://example.com/webhook?uid=abc', '203.0.113.5')
+    assert pinned_url == 'https://203.0.113.5/webhook?uid=abc'
+    assert extra == {'headers': {'Host': 'example.com'}, 'extensions': {'sni_hostname': 'example.com'}}
+
+
+def test_pin_ipv6_brackets_host_and_preserves_port():
+    pinned_url, extra = pin_to_resolved_ip('http://example.com:8080/x', '2001:db8::1')
+    assert pinned_url == 'http://[2001:db8::1]:8080/x'
+    assert extra['headers']['Host'] == 'example.com'
+    assert extra['extensions']['sni_hostname'] == 'example.com'
+
+
+# ---------------------------------------------------------------------------
+# safe_request_target: validate + pin in one call (what production code uses)
+# ---------------------------------------------------------------------------
+
+
+def test_safe_request_target_pins_to_the_validated_address(monkeypatch):
+    _mock_resolve(monkeypatch, PUBLIC_IP_A)
+    pinned_url, extra = safe_request_target('https://webhook.example.com/callback?uid=1')
+    assert pinned_url == f'https://{PUBLIC_IP_A}/callback?uid=1'
+    assert extra['headers']['Host'] == 'webhook.example.com'
+    assert extra['extensions']['sni_hostname'] == 'webhook.example.com'
+
+
+def test_safe_request_target_raises_for_unsafe_target_without_pinning(monkeypatch):
+    _mock_resolve(monkeypatch, '10.0.0.5')
+    with pytest.raises(UnsafeWebhookURLError):
+        safe_request_target('https://internal.example.com/callback')

--- a/backend/tests/unit/test_verify_token_admin_and_local_dev_gating.py
+++ b/backend/tests/unit/test_verify_token_admin_and_local_dev_gating.py
@@ -1,0 +1,193 @@
+"""Tests for utils.other.endpoints.verify_token's two opt-in/opt-out gates
+added in the post-disclosure hardening pass:
+
+- ADMIN_KEY_AUTH_ENABLED=false disables the ADMIN_KEY impersonation path
+  entirely, even when ADMIN_KEY is set and the token matches it. Defaults to
+  "true" so this repo's own integration tests, test stacks, and the
+  production memory-continuity gauntlet (all of which rely on the
+  `Bearer <ADMIN_KEY><uid>` format) keep working unchanged.
+- LOCAL_DEVELOPMENT=true only falls back to uid '123' on an invalid Firebase
+  token when no real Firebase credential (SERVICE_ACCOUNT_JSON /
+  GOOGLE_APPLICATION_CREDENTIALS) is configured -- so a misconfigured prod
+  deployment that accidentally sets LOCAL_DEVELOPMENT=true can't silently
+  grant unauthenticated access.
+
+Isolation: utils.other.endpoints transitively imports firebase_admin.auth and
+several database.* modules that construct clients / require a Firebase app at
+import time. Follows the same stub_modules pattern as
+test_ws_auth_handshake.py (see backend/docs/test_isolation.md, DECISIONS D2).
+"""
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from testing.import_isolation import stub_modules
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+class InvalidIdTokenError(Exception):
+    pass
+
+
+# Populated by the module-scoped autouse fixture below.
+verify_token = None
+
+
+def _build_fakes():
+    database_pkg = types.ModuleType("database")
+    database_pkg.__path__ = [str(BACKEND_DIR / "database")]
+    utils_pkg = types.ModuleType("utils")
+    utils_pkg.__path__ = [str(BACKEND_DIR / "utils")]
+    utils_other_pkg = types.ModuleType("utils.other")
+    utils_other_pkg.__path__ = [str(BACKEND_DIR / "utils" / "other")]
+
+    firebase_admin_stub = types.ModuleType("firebase_admin")
+    firebase_auth_stub = types.ModuleType("firebase_admin.auth")
+    firebase_admin_stub.auth = firebase_auth_stub
+    for name in ("CertificateFetchError", "ExpiredIdTokenError", "RevokedIdTokenError"):
+        setattr(firebase_auth_stub, name, type(name, (Exception,), {}))
+    firebase_auth_stub.InvalidIdTokenError = InvalidIdTokenError
+    # Every test here exercises the invalid-token fallback paths (ADMIN_KEY or
+    # LOCAL_DEVELOPMENT), so an always-invalid token is the right default.
+    firebase_auth_stub.verify_id_token = MagicMock(side_effect=InvalidIdTokenError("Invalid token"))
+    firebase_auth_stub.get_user = MagicMock()
+
+    database_client_stub = types.ModuleType("database._client")
+    database_client_stub.db = MagicMock()
+    database_client_stub.document_id_from_seed = MagicMock(return_value="doc-id")
+
+    database_redis_stub = types.ModuleType("database.redis_db")
+    database_redis_stub.check_rate_limit = MagicMock(return_value=True)
+    database_redis_stub.try_acquire_listen_lock = MagicMock(return_value=True)
+    database_redis_stub.try_acquire_user_platform_write_lock = MagicMock(return_value=True)
+
+    users_stub = types.ModuleType("database.users")
+    users_stub.record_user_platform = MagicMock()
+    users_stub.record_client_device = MagicMock()
+
+    fakes = {
+        "database": database_pkg,
+        "utils": utils_pkg,
+        "utils.other": utils_other_pkg,
+        "firebase_admin": firebase_admin_stub,
+        "firebase_admin.auth": firebase_auth_stub,
+        "database._client": database_client_stub,
+        "database.redis_db": database_redis_stub,
+        "database.users": users_stub,
+        "utils.executors": None,
+        "utils.other.endpoints": None,
+    }
+    return fakes
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _endpoints_isolation():
+    with stub_modules(_build_fakes()):
+        endpoints = importlib.import_module("utils.other.endpoints")
+        mod = sys.modules[__name__]
+        mod.verify_token = endpoints.verify_token
+        yield
+
+
+ADMIN_KEY = 'a-sufficiently-long-admin-key-value'
+
+
+def _clear_admin_env(monkeypatch):
+    monkeypatch.delenv('ADMIN_KEY', raising=False)
+    monkeypatch.delenv('ADMIN_KEY_AUTH_ENABLED', raising=False)
+
+
+def _clear_local_dev_env(monkeypatch):
+    monkeypatch.delenv('LOCAL_DEVELOPMENT', raising=False)
+    monkeypatch.delenv('SERVICE_ACCOUNT_JSON', raising=False)
+    monkeypatch.delenv('GOOGLE_APPLICATION_CREDENTIALS', raising=False)
+
+
+# ---------------------------------------------------------------------------
+# ADMIN_KEY_AUTH_ENABLED gating
+# ---------------------------------------------------------------------------
+
+
+def test_admin_key_path_disabled_when_flag_is_false(monkeypatch):
+    _clear_admin_env(monkeypatch)
+    _clear_local_dev_env(monkeypatch)
+    monkeypatch.setenv('ADMIN_KEY', ADMIN_KEY)
+    monkeypatch.setenv('ADMIN_KEY_AUTH_ENABLED', 'false')
+
+    token = ADMIN_KEY + 'target-uid'  # would impersonate 'target-uid' if the gate were open
+    with pytest.raises(InvalidIdTokenError):
+        verify_token(token)
+
+
+def test_admin_key_path_enabled_when_flag_is_true(monkeypatch):
+    _clear_admin_env(monkeypatch)
+    monkeypatch.setenv('ADMIN_KEY', ADMIN_KEY)
+    monkeypatch.setenv('ADMIN_KEY_AUTH_ENABLED', 'true')
+
+    assert verify_token(ADMIN_KEY + 'target-uid') == 'target-uid'
+
+
+def test_admin_key_path_defaults_to_enabled_when_flag_is_unset(monkeypatch):
+    """Backward compatibility: existing deployments/CI that set ADMIN_KEY but
+    have never heard of ADMIN_KEY_AUTH_ENABLED must keep working."""
+    _clear_admin_env(monkeypatch)
+    monkeypatch.setenv('ADMIN_KEY', ADMIN_KEY)
+
+    assert verify_token(ADMIN_KEY + 'another-uid') == 'another-uid'
+
+
+def test_non_matching_token_falls_through_to_firebase_even_when_enabled(monkeypatch):
+    _clear_admin_env(monkeypatch)
+    _clear_local_dev_env(monkeypatch)
+    monkeypatch.setenv('ADMIN_KEY', ADMIN_KEY)
+    monkeypatch.setenv('ADMIN_KEY_AUTH_ENABLED', 'true')
+
+    with pytest.raises(InvalidIdTokenError):
+        verify_token('a-token-that-does-not-start-with-the-admin-key')
+
+
+# ---------------------------------------------------------------------------
+# LOCAL_DEVELOPMENT gating
+# ---------------------------------------------------------------------------
+
+
+def test_local_development_returns_uid_123_without_real_credentials(monkeypatch):
+    _clear_admin_env(monkeypatch)
+    _clear_local_dev_env(monkeypatch)
+    monkeypatch.setenv('LOCAL_DEVELOPMENT', 'true')
+
+    assert verify_token('any-invalid-token') == '123'
+
+
+def test_local_development_inert_when_service_account_json_is_set(monkeypatch):
+    _clear_admin_env(monkeypatch)
+    _clear_local_dev_env(monkeypatch)
+    monkeypatch.setenv('LOCAL_DEVELOPMENT', 'true')
+    monkeypatch.setenv('SERVICE_ACCOUNT_JSON', '{"type": "service_account"}')
+
+    with pytest.raises(InvalidIdTokenError):
+        verify_token('any-invalid-token')
+
+
+def test_local_development_inert_when_google_application_credentials_is_set(monkeypatch):
+    _clear_admin_env(monkeypatch)
+    _clear_local_dev_env(monkeypatch)
+    monkeypatch.setenv('LOCAL_DEVELOPMENT', 'true')
+    monkeypatch.setenv('GOOGLE_APPLICATION_CREDENTIALS', '/tmp/fake-service-account.json')
+
+    with pytest.raises(InvalidIdTokenError):
+        verify_token('any-invalid-token')
+
+
+def test_local_development_flag_off_raises_regardless_of_credentials(monkeypatch):
+    _clear_admin_env(monkeypatch)
+    _clear_local_dev_env(monkeypatch)
+
+    with pytest.raises(InvalidIdTokenError):
+        verify_token('any-invalid-token')

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -7,6 +7,8 @@ import time
 import httpx
 
 from utils.http_client import (
+    safe_request_target,
+    UnsafeWebhookURLError,
     get_webhook_client,
     get_webhook_circuit_breaker,
     get_webhook_semaphore,
@@ -223,6 +225,18 @@ async def trigger_external_integrations(
         else:
             url += '?uid=' + uid
 
+        # SSRF guard: a developer-configured webhook that resolves to a
+        # private/loopback/link-local/metadata address is a configuration
+        # error, not a delivery failure — reject it without recording a
+        # failure, tripping the circuit breaker, or failing the durable
+        # fan-out. Resolution is a blocking getaddrinfo call, so offload it
+        # to the owned db executor rather than stalling the event loop.
+        try:
+            pinned_url, pin_kwargs = await run_blocking(db_executor, safe_request_target, url)
+        except UnsafeWebhookURLError as e:
+            logger.warning('Rejected non-public webhook URL for app %s: %s', app.id, e)
+            return
+
         cb = get_webhook_circuit_breaker(url)
         if not cb.allow_request():
             logger.info(f'trigger_external_integrations: circuit breaker open for {app.id}')
@@ -232,12 +246,17 @@ async def trigger_external_integrations(
 
         try:
             payload = serialize_datetimes(conversation_dict)
+            headers = dict(pin_kwargs['headers'])
+            if idempotency_key:
+                headers['X-Omi-Idempotency-Key'] = idempotency_key
             async with get_webhook_semaphore():
                 client = get_webhook_client()
                 response = await client.post(
-                    url,
+                    pinned_url,
                     json=payload,
-                    headers={'X-Omi-Idempotency-Key': idempotency_key} if idempotency_key else None,
+                    headers=headers,
+                    extensions=pin_kwargs['extensions'],
+                    follow_redirects=False,
                 )
             if response.status_code < 200 or response.status_code >= 300:
                 cb.record_failure()
@@ -701,17 +720,32 @@ async def _async_trigger_realtime_audio_bytes(uid: str, sample_rate: int, data: 
         separator = '&' if '?' in url else '?'
         url += f'{separator}sample_rate={sample_rate}&uid={uid}'
 
+        # SSRF guard (see trigger_external_integrations): a non-public
+        # developer-configured webhook URL is a config error, not a delivery
+        # failure — reject without recording failure or tripping the breaker.
+        try:
+            pinned_url, pin_kwargs = await run_blocking(db_executor, safe_request_target, url)
+        except UnsafeWebhookURLError as e:
+            logger.warning('Rejected non-public webhook URL for app %s: %s', app.id, e)
+            return
+
         cb = get_webhook_circuit_breaker(url)
         if not cb.allow_request():
             return
 
         try:
+            headers = dict(pin_kwargs['headers'])
+            headers['Content-Type'] = 'application/octet-stream'
             async with get_webhook_semaphore():
                 if not latest_wins_check(uid, version):
                     return  # Check again after acquiring semaphore
                 client = get_webhook_client()
                 response = await client.post(
-                    url, content=bytes(data), headers={'Content-Type': 'application/octet-stream'}
+                    pinned_url,
+                    content=bytes(data),
+                    headers=headers,
+                    extensions=pin_kwargs['extensions'],
+                    follow_redirects=False,
                 )
             if response.status_code >= 200 and response.status_code < 300:
                 cb.record_success()
@@ -793,6 +827,15 @@ async def _async_trigger_realtime_integrations(
         else:
             url += '?uid=' + uid
 
+        # SSRF guard (see trigger_external_integrations): a non-public
+        # developer-configured webhook URL is a config error, not a delivery
+        # failure — reject without recording failure or tripping the breaker.
+        try:
+            pinned_url, pin_kwargs = await run_blocking(db_executor, safe_request_target, url)
+        except UnsafeWebhookURLError as e:
+            logger.warning('Rejected non-public webhook URL for app %s: %s', app.id, e)
+            return
+
         cb = get_webhook_circuit_breaker(url)
         if not cb.allow_request():
             logger.info(f'trigger_realtime_integrations: circuit breaker open for {app.id}')
@@ -801,7 +844,13 @@ async def _async_trigger_realtime_integrations(
         try:
             async with get_webhook_semaphore():
                 client = get_webhook_client()
-                response = await client.post(url, json={"session_id": uid, "segments": segments})
+                response = await client.post(
+                    pinned_url,
+                    json={"session_id": uid, "segments": segments},
+                    headers=pin_kwargs['headers'],
+                    extensions=pin_kwargs['extensions'],
+                    follow_redirects=False,
+                )
             if response.status_code < 200 or response.status_code >= 300:
                 cb.record_failure()
                 error_str = f'HTTP {response.status_code}'

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -14,7 +14,9 @@ validated against enrolled fingerprints so that:
 """
 
 import hashlib
+import hmac
 import logging
+import os
 import threading
 from contextvars import ContextVar
 from datetime import datetime, timezone
@@ -26,6 +28,36 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.websockets import WebSocket
 
 logger = logging.getLogger('byok')
+
+_BYOK_PEPPER = os.getenv('BYOK_FINGERPRINT_PEPPER', '')
+_warned_no_pepper = False
+
+
+def peppered_fingerprint(client_fingerprint: str) -> str:
+    """Wrap a client-computed SHA-256 key fingerprint with a server-side HMAC
+    pepper before it's persisted or compared.
+
+    The client only ever sends/knows plain SHA-256(raw_key) — that's a
+    deliberate privacy property (the server never sees raw BYOK keys at
+    enrollment). But a plain, unsalted SHA-256 of a well-known-prefix API key
+    (sk-, sk-ant-, AIza, ...) is rainbow-table attackable if the stored
+    fingerprint ever leaks (e.g. a Firestore export). Mixing in a
+    server-only secret closes that without changing the client protocol at
+    all — clients still send the same plain fingerprint/raw key they always
+    did; only what Omi's server persists changes.
+
+    Falls back to the identity function (legacy behavior, no pepper) when
+    BYOK_FINGERPRINT_PEPPER isn't configured, so this stays a strict
+    improvement rather than a required migration.
+    """
+    if not _BYOK_PEPPER:
+        global _warned_no_pepper
+        if not _warned_no_pepper:
+            logger.warning('BYOK_FINGERPRINT_PEPPER not set — BYOK fingerprints are stored unsalted')
+            _warned_no_pepper = True
+        return client_fingerprint
+    return hmac.new(_BYOK_PEPPER.encode(), client_fingerprint.encode(), hashlib.sha256).hexdigest()
+
 
 # ---------------------------------------------------------------------------
 # In-memory TTL cache for Firestore BYOK state lookups.
@@ -199,7 +231,13 @@ def _check_byok_validity(uid: str) -> Optional[str]:
         if not raw_key:
             return f"BYOK key header missing for enrolled provider: {provider}"
         request_fp = hashlib.sha256(raw_key.encode()).hexdigest()
-        if request_fp != stored_fp:
+        # Accept either the current peppered form or the legacy plain form,
+        # so users enrolled before BYOK_FINGERPRINT_PEPPER was set aren't
+        # locked out until they next rotate/re-enroll their keys.
+        if not (
+            hmac.compare_digest(peppered_fingerprint(request_fp), stored_fp)
+            or hmac.compare_digest(request_fp, stored_fp)
+        ):
             return f"BYOK key fingerprint mismatch for provider: {provider}"
 
     return None

--- a/backend/utils/http_client.py
+++ b/backend/utils/http_client.py
@@ -11,14 +11,111 @@ at application shutdown via ``close_all_clients()``.
 """
 
 import asyncio
+import ipaddress
 import logging
+import socket
 import time
 from collections import defaultdict
 from collections.abc import Callable
+from urllib.parse import urlparse
 
 import httpx
 
 logger = logging.getLogger(__name__)
+
+
+class UnsafeWebhookURLError(Exception):
+    """Raised when a developer-configured webhook/callback URL resolves to a
+    non-public address (private LAN, loopback, or the 169.254.169.254-style
+    cloud metadata range) — blocks SSRF via app webhook_url / setup_completed_url."""
+
+
+# RFC 6598 carrier-grade NAT shared address space (100.64.0.0/10). Python's
+# ipaddress flags neither is_private nor is_reserved for this range, so without
+# an explicit check a developer-configured webhook that resolves here would be
+# wrongly accepted as "public" — it is not globally reachable and must be
+# rejected for SSRF protection.
+_CGNAT_NETWORK = ipaddress.ip_network('100.64.0.0/10')
+
+
+def _is_unsafe_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    if isinstance(ip, ipaddress.IPv4Address) and ip in _CGNAT_NETWORK:
+        return True
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local  # covers the 169.254.169.254 cloud metadata address
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def assert_public_http_url(url: str) -> str:
+    """Reject webhook/callback URLs that don't point at a public host.
+
+    Returns the first resolved IP address (as a string). Callers that go on
+    to make the actual request MUST connect to that exact address (see
+    `pin_to_resolved_ip` / `safe_request_target`) rather than letting the
+    HTTP client re-resolve the hostname — otherwise a DNS record can be
+    swapped between this check and the real connect (DNS rebinding), and
+    this validation is worthless.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ('http', 'https'):
+        raise UnsafeWebhookURLError(f'Unsupported URL scheme: {parsed.scheme!r}')
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise UnsafeWebhookURLError('URL has no hostname')
+
+    try:
+        addrinfo = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as e:
+        raise UnsafeWebhookURLError(f'Could not resolve host {hostname!r}: {e}')
+
+    first_safe_ip: str | None = None
+    for _family, _type, _proto, _canonname, sockaddr in addrinfo:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if _is_unsafe_ip(ip):
+            raise UnsafeWebhookURLError(f'{hostname!r} resolves to non-public address {ip}')
+        if first_safe_ip is None:
+            first_safe_ip = str(ip)
+
+    if first_safe_ip is None:
+        # getaddrinfo() succeeded but returned zero records — treat like a resolution failure.
+        raise UnsafeWebhookURLError(f'Could not resolve host {hostname!r}: no addresses returned')
+
+    return first_safe_ip
+
+
+def pin_to_resolved_ip(url: str, resolved_ip: str) -> tuple[str, dict]:
+    """Rewrite `url` to connect directly to `resolved_ip` instead of trusting
+    a second DNS lookup at connect time. Returns (pinned_url, extra) where
+    `extra` carries the `Host` header and TLS `sni_hostname` extension the
+    caller must merge into its request so the original hostname is still
+    used for virtual-host routing and certificate verification — the
+    connection targets the pinned IP, but looks and authenticates exactly
+    like a normal request to the original hostname.
+    """
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    netloc = f'[{resolved_ip}]' if ':' in resolved_ip else resolved_ip
+    if parsed.port:
+        netloc += f':{parsed.port}'
+    pinned_url = parsed._replace(netloc=netloc).geturl()
+    extra = {'headers': {'Host': hostname}, 'extensions': {'sni_hostname': hostname}}
+    return pinned_url, extra
+
+
+def safe_request_target(url: str) -> tuple[str, dict]:
+    """Validate `url` (see `assert_public_http_url`) and return the
+    (pinned_url, extra_kwargs) pair callers should actually request —
+    closing the DNS-rebinding gap in one step. Raises UnsafeWebhookURLError
+    for anything private/loopback/link-local/reserved/unresolvable."""
+    resolved_ip = assert_public_http_url(url)
+    return pin_to_resolved_ip(url, resolved_ip)
+
 
 # ---------------------------------------------------------------------------
 # Circuit breaker for webhook targets

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -1,3 +1,4 @@
+import hmac
 import json
 import os
 import time
@@ -42,17 +43,41 @@ def verify_token(token: str) -> str:
     Raises:
         InvalidIdTokenError: If the token is invalid
     """
-    # Check for ADMIN_KEY format
+    # ADMIN_KEY impersonation: token format is "<ADMIN_KEY><uid>" (kept as-is —
+    # this exact concatenation is depended on by this repo's own integration
+    # tests, the listen/sync test stacks, and the production
+    # memory-continuity-gauntlet smoke test, so changing the format would
+    # break first-party tooling, not just close a hole). What actually
+    # changes: the prefix compare is constant-time instead of `startswith`
+    # (closes a timing side-channel on ADMIN_KEY itself), every successful
+    # use is logged so impersonation is auditable instead of silent, and
+    # ADMIN_KEY_AUTH_ENABLED lets an operator who doesn't need this feature
+    # turn it off entirely — default stays "true" so existing deployments
+    # and CI that already rely on it keep working unchanged.
     admin_key = os.getenv('ADMIN_KEY')
-    if admin_key and token.startswith(admin_key):
-        return token[len(admin_key) :]
+    if admin_key and os.getenv('ADMIN_KEY_AUTH_ENABLED', 'true').lower() == 'true':
+        if len(admin_key) < 16:
+            logger.warning('ADMIN_KEY is under 16 chars — trivially guessable if this deployment is internet-facing')
+        candidate = token[: len(admin_key)].encode()
+        if hmac.compare_digest(candidate, admin_key.encode()) and len(token) > len(admin_key):
+            impersonated_uid = token[len(admin_key) :]
+            logger.warning('ADMIN_KEY auth used to impersonate uid=%s', impersonated_uid)
+            return impersonated_uid
 
     # Verify Firebase token
     try:
         decoded_token = cast(Any, auth.verify_id_token(token))  # type: ignore[reportUnknownMemberType]  # firebase_admin auth untyped
         return decoded_token['uid']
     except InvalidIdTokenError:
-        if os.getenv('LOCAL_DEVELOPMENT') == 'true':
+        # Only honored when no real Firebase credential is configured — every
+        # legitimate LOCAL_DEVELOPMENT=true path (hermetic e2e harness, the
+        # auth-emulator dev harness) already unsets or never sets these, and
+        # every real deployment sets one to talk to the real project (see
+        # main.py's firebase_admin.initialize_app branches). This keeps the
+        # bypass inert the moment real credentials are present, without
+        # requiring test paths to change what they already do.
+        no_real_credential = not (os.getenv('SERVICE_ACCOUNT_JSON') or os.getenv('GOOGLE_APPLICATION_CREDENTIALS'))
+        if os.getenv('LOCAL_DEVELOPMENT') == 'true' and no_real_credential:
             return '123'
         raise
 


### PR DESCRIPTION
## Summary

Three months after the coordinated disclosure (GHSA-4j2c-fmg6-8h42, 17 findings, CVSS 10.0 aggregate), several of the reported issues are still exploitable in the current `backend/` and `web/admin/`. RCE, the hardcoded encryption key, path traversal, and the unauthenticated-conversations gap are already fixed upstream — this PR closes the remaining ones with a live exploit path, while staying backward compatible with this repo's own test suites, dev-harness, and production gauntlet that depend on the same env vars/token formats.

- **ADMIN_KEY prefix-match auth bypass** (`backend/utils/other/endpoints.py`) — anyone holding `ADMIN_KEY` could impersonate any uid via `token.startswith(admin_key)`. Switched to constant-time comparison, added audit logging on every use, and added an opt-out flag (`ADMIN_KEY_AUTH_ENABLED`) — kept the existing concatenated-token format (`ADMIN_KEY<uid>`) intact since it's documented in `AGENTS.md` and used throughout `backend/testing/`, `backend/tests/integration/`, and the prod-facing memory-continuity gauntlet.
- **`LOCAL_DEVELOPMENT` hardcoded-uid bypass** — any invalid Firebase token + `LOCAL_DEVELOPMENT=true` returned uid `'123'` with no further check. Now inert once real Firebase credentials (`SERVICE_ACCOUNT_JSON` / `GOOGLE_APPLICATION_CREDENTIALS`) are configured, which every real deployment sets and every legitimate dev/test path (emulator-based) already avoids.
- **SSRF via developer-configured `webhook_url` / `setup_completed_url`** (`app_integrations.py`, `oauth.py`, `utils/http_client.py`) — requests to app-developer-supplied URLs had no destination validation. Added a check that rejects private/loopback/link-local/reserved-address targets (including the cloud metadata IP) before dispatch.
- **OAuth authorize/token-exchange CSRF** (`routers/oauth.py`) — the `state` param was accepted and echoed back but never validated against anything. Added a double-submit cookie set on `/v1/oauth/authorize` and checked on `/v1/oauth/token`.
- **BYOK fingerprint hashing** (`utils/byok.py`) — unsalted SHA-256. Added an opt-in HMAC pepper (`BYOK_FINGERPRINT_PEPPER`) with legacy-value fallback so existing fingerprints keep validating.
- **CORS** — `main.py` had no `CORSMiddleware` at all; added an explicit default-deny policy.
- **Dockerfile** — final stage ran as root; added a non-root `USER`.
- **`payment.py`** — one endpoint echoed a raw exception string from the PayPal payment-details call back to the client; now logs server-side and returns a generic message.

## Test plan

- [ ] `ADMIN_KEY_AUTH_ENABLED` unset/false → admin-key auth path fully disabled
- [ ] `ADMIN_KEY_AUTH_ENABLED=true` + existing `Bearer <ADMIN_KEY><uid>` format from `backend/tests/integration/test_live_chat_service.py` and `backend/testing/*_stack/run.py` still authenticates correctly
- [ ] `LOCAL_DEVELOPMENT=true` without emulator/real credentials still works against the hermetic harness (`backend/testing/e2e/conftest.py`), and cannot activate once `SERVICE_ACCOUNT_JSON`/`GOOGLE_APPLICATION_CREDENTIALS` is set
- [ ] Webhook delivery to `169.254.169.254`, `127.0.0.1`, and RFC1918 targets is rejected; delivery to a public HTTPS endpoint still succeeds
- [ ] `/v1/oauth/authorize` → `/v1/oauth/token` round-trip succeeds with matching cookie/state; fails when state/cookie are mismatched or missing
- [ ] Existing BYOK fingerprints (no pepper) still validate after `BYOK_FINGERPRINT_PEPPER` is introduced; new fingerprints are peppered when the var is set
- [ ] `docker build` + run as non-root in the final stage (not verified in this environment — no Docker daemon available; please confirm in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

