### PR TITLE
fix: recover dead unproven qualification leases

### DIFF
--- a/scripts/dev-harness/dev_harness/qualification.py
+++ b/scripts/dev-harness/dev_harness/qualification.py
@@ -23,6 +23,7 @@ LEASE_OWNER = "omi-desktop-qualification"
 DEFAULT_RETAINED_RUNS = 3
 DEFAULT_RETENTION_MAX_AGE_SECONDS = 14 * 24 * 60 * 60
 COMPLETION_FILENAME = "qualification-completed.json"
+QUARANTINE_DIRNAME = "quarantined-lease-pointers"
 STOP_PHASES: tuple[tuple[signal.Signals, float], ...] = (
     (signal.SIGINT, 8),
     (signal.SIGTERM, 5),
@@ -84,6 +85,26 @@ def _write_lease(path: Path, payload: dict[str, object]) -> None:
     temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     temporary.replace(path)
+
+
+def _quarantine_stale_lease_pointer(path: Path, root: Path, lease: dict[str, object]) -> Path:
+    """Retire only a dead lease pointer when its state cannot prove safe cleanup.
+
+    The active pointer is moved under the root lock to preserve its exact diagnostic
+    contents. The associated state and logs remain untouched: without a valid
+    ownership sentinel, neither deletion nor process signalling is authorized.
+    """
+
+    lease_id = safety.validate_instance_name(str(lease["lease_id"]))
+    token_digest = hashlib.sha256(str(lease["token"]).encode("utf-8")).hexdigest()
+    quarantine = root / QUARANTINE_DIRNAME
+    quarantine.mkdir(mode=0o700, parents=True, exist_ok=True)
+    destination = quarantine / f"{lease_id}-{int(time.time_ns())}-{token_digest}.json"
+    if destination.exists():
+        raise QualificationLeaseError(f"Refusing to overwrite quarantined qualification lease evidence: {destination}")
+    path.replace(destination)
+    destination.chmod(0o400)
+    return destination
 
 
 def _lease_provenance(lease: dict[str, object], root: Path) -> tuple[str, Path, Path, int, str]:
@@ -364,13 +385,17 @@ def acquire(
                 raise QualificationLeaseError(
                     f"Qualification lease {old_id!r} is held by live PID {old_owner}; refusing concurrent stack use"
                 )
-            records, process_manifest, port_manifest = _validated_owned_records(old_state, old_repo, old_id, old_token)
-            _stop_owned_records(records, process_manifest, port_manifest, old_id)
-            _safe_remove_state(old_state, old_repo, old_id)
-            old_logs = root / "logs" / old_id
-            if old_logs.is_dir():
-                shutil.rmtree(old_logs)
-            path.unlink(missing_ok=True)
+            try:
+                records, process_manifest, port_manifest = _validated_owned_records(old_state, old_repo, old_id, old_token)
+            except safety.SafetyError:
+                _quarantine_stale_lease_pointer(path, root, existing)
+            else:
+                _stop_owned_records(records, process_manifest, port_manifest, old_id)
+                _safe_remove_state(old_state, old_repo, old_id)
+                old_logs = root / "logs" / old_id
+                if old_logs.is_dir():
+                    shutil.rmtree(old_logs)
+                path.unlink(missing_ok=True)
 
         state_root = _real(root / "state" / lease_id)
         if state_root.exists():

--- a/scripts/dev-harness/tests/test_qualification_lease.py
+++ b/scripts/dev-harness/tests/test_qualification_lease.py
@@ -81,6 +81,33 @@ def test_stale_owned_stack_is_reclaimed_without_touching_foreign_listener(
                 proc.wait(timeout=10)
 
 
+def test_dead_lease_with_missing_sentinel_is_quarantined_before_a_fresh_lease_acquires(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "qualification"
+    monkeypatch.setenv("OMI_QUALIFICATION_LEASE_ROOT", str(root))
+    stale_id = "qualification-missing-sentinel"
+    qualification.acquire(repo_root=REPO_ROOT, lease_id=stale_id, owner_pid=os.getpid(), port_offset=1000)
+    stale_pointer = json.loads((root / "qualification-lease.json").read_text(encoding="utf-8"))
+    stale_state = root / "state" / stale_id
+    (stale_state / safety.HARNESS_SENTINEL_FILENAME).unlink()
+    stale_pointer["owner_pid"] = 999999
+    (root / "qualification-lease.json").write_text(json.dumps(stale_pointer), encoding="utf-8")
+
+    replacement = qualification.acquire(
+        repo_root=REPO_ROOT, lease_id="qualification-replacement", owner_pid=os.getpid(), port_offset=1001
+    )
+
+    quarantined = list((root / qualification.QUARANTINE_DIRNAME).glob("*.json"))
+    assert len(quarantined) == 1
+    assert json.loads(quarantined[0].read_text(encoding="utf-8")) == stale_pointer
+    assert stale_state.exists()
+    assert not (stale_state / safety.HARNESS_SENTINEL_FILENAME).exists()
+    assert json.loads((root / "qualification-lease.json").read_text(encoding="utf-8"))["lease_id"] == "qualification-replacement"
+
+    qualification.release(repo_root=REPO_ROOT, lease_id="qualification-replacement", token=str(replacement["token"]))
+
+
 def test_retention_prunes_only_completed_sentinel_proven_qualification_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     root = tmp_path / "qualification"
     monkeypatch.setenv("OMI_QUALIFICATION_LEASE_ROOT", str(root))


### PR DESCRIPTION
## Summary
- Quarantine only a dead qualification lease pointer when its ownership sentinel is missing or unproven.
- Preserve the unproven state and logs untouched; do not signal processes or delete state.
- Allow a fresh M1 qualification lease and cover the stale-sentinel recovery path.

## Verification
- `scripts/dev-harness/run-tests.sh` — 59 passed
- `make preflight` — passing with this PR body

## Release impact
- The change repairs M1 runner qualification lifecycle only. A fresh immutable candidate is still required before Beta promotion; Stable is excluded.
- Real M1 qualification will be exercised by that fresh candidate after merge.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

