### PR TITLE
SCA-163: report M1 qualification lease failures

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -519,15 +519,21 @@ checks:
     reason: "#10163 mutation-sensitive Stable retry and default-channel feed fixtures"
   - id: desktop-release-one-path-contract
     command: ["python3", ".github/scripts/test_desktop_release_flow_contract.py"]
-    triggers: ["codemagic.yaml", ".github/workflows/desktop_auto_release.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_beta.yml", ".github/workflows/desktop_recover_beta.yml", ".github/workflows/desktop_rollback_beta.yml", ".github/workflows/desktop_breakglass_rollout_beta.yml", ".github/workflows/desktop_beta_admission_control.yml", ".github/workflows/desktop_promote_prod.yml", ".github/workflows/gcp_backend.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", ".github/scripts/test_desktop_release_flow_contract.py", ".github/checks-manifest.yaml"]
+    triggers: ["codemagic.yaml", ".github/workflows/desktop_auto_release.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_beta.yml", ".github/workflows/desktop_recover_beta.yml", ".github/workflows/desktop_rollback_beta.yml", ".github/workflows/desktop_breakglass_rollout_beta.yml", ".github/workflows/desktop_beta_admission_control.yml", ".github/workflows/desktop_promote_prod.yml", ".github/workflows/gcp_backend.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/qualification-lease-command.sh", ".github/scripts/test_desktop_release_flow_contract.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-17 prevents duplicate desktop promotion authorities and requires post-traffic production release-vector verification"
   - id: desktop-qualification-bootstrap-contract
     command: ["bash", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh"]
-    triggers: ["desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/prepare-qualification-profile.sh", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh", ".github/checks-manifest.yaml"]
+    triggers: ["desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/prepare-qualification-profile.sh", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     platforms: ["macos"]
     reason: "Trusted qualification requires an exact-SHA persistent source, isolated named-bundle, unchanged gates, and phase-bound bootstrap contracts"
+  - id: desktop-qualification-lease-command
+    command: ["bash", "desktop/macos/tests/test-qualification-lease-command.sh"]
+    triggers: ["desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/tests/test-qualification-lease-command.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    platforms: ["macos"]
+    reason: "SCA-163 keeps lease command failures actionable while stdout remains reserved for the JSON lease capability"
   - id: desktop-qualification-swift-cache
     command: ["bash", "desktop/macos/tests/test-qualification-swift-cache.sh"]
     triggers: ["desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/tests/test-qualification-swift-cache.sh", ".github/checks-manifest.yaml"]

--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -20,6 +20,9 @@ EXEMPT_DESKTOP_PATHS = {
     # Sibling qualification-runner helper to qualify-desktop-beta.sh: internal
     # release infrastructure with no user-facing app surface.
     "desktop/macos/scripts/qualification-swift-cache.sh",
+    # Lease transport for the same qualification runner: it only moves
+    # machine-readable lease evidence and never ships in the desktop app.
+    "desktop/macos/scripts/qualification-lease-command.sh",
     # Pre-tag readiness gate script: internal release infrastructure (runs on the
     # trusted M1 before tagging), no user-facing app surface.
     "desktop/macos/scripts/pre-tag-readiness.sh",

--- a/.github/scripts/test_desktop_changelog.py
+++ b/.github/scripts/test_desktop_changelog.py
@@ -74,6 +74,7 @@ class ChangelogRequirementTests(unittest.TestCase):
             "desktop/macos/scripts/qualify-desktop-beta.sh",
             # Sibling qualification-runner helper (EXEMPT_DESKTOP_PATHS).
             "desktop/macos/scripts/qualification-swift-cache.sh",
+            "desktop/macos/scripts/qualification-lease-command.sh",
             # CI-only flow validation and its shared source inventory do not
             # alter the desktop application users receive.
             "desktop/macos/scripts/desktop-flow-lint.py",

--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -91,7 +91,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
 
     def test_m1_qualification_binds_the_immutable_tag(self) -> None:
         for fragment in (
-            'checkout --quiet --detach "refs/tags/$ref"',
+            'checkout --quiet --detach "refs/tags/$RELEASE_TAG"',
             "ref: ${{ inputs.release_tag }}",
             'test "$ref" = "$RELEASE_TAG"',
             'git rev-parse "$RELEASE_TAG^{commit}"',
@@ -123,7 +123,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
             "OMI_QUALIFICATION_CLEANUP_CONTEXT",
             "Finalize only this authenticated qualification lease",
             "if: always()",
-            "qualification-lease release",
+            "qualification-lease-command.sh\" release",
             "runner-capacity.json",
             "M1 qualification runner capacity guard refused to start",
             "33554432",

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -97,7 +97,7 @@ jobs:
           git init --quiet "$source_dir"
           git -C "$source_dir" remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           GIT_TERMINAL_PROMPT=0 git -C "$source_dir" fetch --force --prune --tags origin
-          git -C "$source_dir" checkout --quiet --detach "refs/tags/$ref"
+          git -C "$source_dir" checkout --quiet --detach "refs/tags/$RELEASE_TAG"
       - id: app-token
         uses: actions/create-github-app-token@v3
         with:
@@ -208,7 +208,7 @@ jobs:
             worktree=$(jq -r .worktree "$context"); lease_id=$(jq -r .lease_id "$context"); token=$(jq -r .token "$context")
             retained=$(jq -r .retained_runs "$context"); age=$(jq -r .retention_age_seconds "$context")
             echo "::add-mask::$token"
-            (cd "$worktree" && OMI_HARNESS_OWNERSHIP_TOKEN="$token" PYTHONPATH=scripts/dev-harness python3 -m dev_harness.cli qualification-lease release --lease-id "$lease_id" --token "$token" --retained-runs "$retained" --retention-age-seconds "$age")
+            OMI_HARNESS_OWNERSHIP_TOKEN="$token" "$worktree/desktop/macos/scripts/qualification-lease-command.sh" release "$worktree" "$lease_id" "$token" "$retained" "$age"
             jq -n --arg lease_id "$lease_id" '{lease_id: $lease_id, cleanup_status: "released"}' > "$cleanup"
           else
             printf '%s\n' '{"cleanup_status":"no-lease-acquired"}' > "$cleanup"

--- a/desktop/macos/scripts/qualification-lease-command.sh
+++ b/desktop/macos/scripts/qualification-lease-command.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Run the qualification lease CLI through the exact backend interpreter that
+# qualification just provisioned. Lease errors are deliberately relayed to
+# stderr: callers reserve stdout for the successful lease JSON capability.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  qualification-lease-command.sh acquire <worktree> <lease-id> <owner-pid> <port-offset> <retained-runs>
+  qualification-lease-command.sh release <worktree> <lease-id> <token> <retained-runs> <retention-age-seconds>
+USAGE
+  exit 2
+}
+
+[[ $# -ge 1 ]] || usage
+action="$1"
+shift
+lease_token=""
+
+run_lease_command() {
+  local worktree="$1"
+  shift
+  local lease_python="$worktree/backend/.venv/bin/python"
+  local output status detail stderr_file
+  if [[ ! -x "$lease_python" ]]; then
+    echo "qualification failed: backend virtualenv is missing at $lease_python; lease ${action} cannot run" >&2
+    return 127
+  fi
+
+  stderr_file="$(mktemp "${TMPDIR:-/tmp}/omi-qualification-lease-command.XXXXXX")" || {
+    echo "qualification failed: could not capture lease ${action} diagnostics" >&2
+    return 1
+  }
+
+  # The harness resolves its repo root from cwd, so run it inside the exact
+  # tag-pinned cache worktree. Stdout remains the acquire capability channel;
+  # stderr is retained only for an actionable failure diagnostic.
+  if output="$(
+    (
+      cd "$worktree" || exit $?
+      PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$lease_python" -m dev_harness.cli qualification-lease "$action" "$@"
+    ) 2>"$stderr_file"
+  )"; then
+    rm -f "$stderr_file"
+    if [[ "$action" == "acquire" ]]; then
+      printf '%s\n' "$output"
+    fi
+    return 0
+  else
+    status=$?
+  fi
+
+  detail="${output//$'\n'/ } $(tr '\n' ' ' < "$stderr_file")"
+  rm -f "$stderr_file"
+  if [[ -n "$lease_token" ]]; then
+    detail="${detail//"$lease_token"/[redacted]}"
+  fi
+  detail="${detail:0:500}"
+  if [[ -n "$detail" ]]; then
+    echo "qualification failed: lease ${action} exited ${status}: ${detail}" >&2
+  else
+    echo "qualification failed: lease ${action} exited ${status} without a diagnostic" >&2
+  fi
+  return "$status"
+}
+
+case "$action" in
+  acquire)
+    [[ $# -eq 5 ]] || usage
+    worktree="$1"
+    run_lease_command "$worktree" --lease-id "$2" --owner-pid "$3" --port-offset "$4" --retained-runs "$5"
+    ;;
+  release)
+    [[ $# -eq 5 ]] || usage
+    worktree="$1"
+    lease_token="$3"
+    run_lease_command "$worktree" --lease-id "$2" --token "$3" --retained-runs "$4" --retention-age-seconds "$5"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -11,6 +11,7 @@ DESKTOP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$DESKTOP_DIR/../.." && pwd)"
 KEYVALUE_PY="$SCRIPT_DIR/release-keyvalue.py"
 STAGE_HELPER="$SCRIPT_DIR/qualification-stage.sh"
+LEASE_COMMAND="$SCRIPT_DIR/qualification-lease-command.sh"
 # shellcheck source=qualification-stage.sh
 source "$STAGE_HELPER"
 
@@ -219,30 +220,31 @@ provision_backend_venv() {
 if command -v uv >/dev/null 2>&1; then
   provision_backend_venv "$WORKTREE"
 else
-  echo "uv not found; dev-harness python resolves via global python3"
+  echo "uv not found; qualification lease requires the backend virtualenv" >&2
 fi
 
-LEASE_JSON="$(
-  cd "$WORKTREE"
-  PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" python3 -m dev_harness.cli qualification-lease acquire \
-    --lease-id "$QUALIFICATION_LEASE_ID" \
-    --owner-pid "$$" \
-    --port-offset "$QUALIFICATION_PORT_OFFSET" \
-    --retained-runs "$QUALIFICATION_RETAINED_RUNS"
-)"
-QUALIFICATION_LEASE_TOKEN="$(python3 - "$LEASE_JSON" <<'PY'
+qualification_lease_field() {
+  local field="$1" lease_json="$2" value
+  if value="$(printf '%s' "$lease_json" | python3 -c '
 import json
 import sys
-print(json.loads(sys.argv[1])["token"])
-PY
-)"
-QUALIFICATION_LOG_DIR="$(python3 - "$LEASE_JSON" <<'PY'
-import json
-import sys
-from pathlib import Path
-print(Path(json.loads(sys.argv[1])["log_dir"]))
-PY
-)"
+
+field = sys.argv[1]
+value = json.loads(sys.stdin.read()).get(field)
+if not isinstance(value, str) or not value:
+    raise SystemExit(1)
+print(value)
+' "$field" 2>/dev/null)"; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  echo "qualification failed: lease acquisition returned no valid ${field}" >&2
+  return 1
+}
+
+LEASE_JSON="$("$LEASE_COMMAND" acquire "$WORKTREE" "$QUALIFICATION_LEASE_ID" "$$" "$QUALIFICATION_PORT_OFFSET" "$QUALIFICATION_RETAINED_RUNS")"
+QUALIFICATION_LEASE_TOKEN="$(qualification_lease_field token "$LEASE_JSON")"
+QUALIFICATION_LOG_DIR="$(qualification_lease_field log_dir "$LEASE_JSON")"
 # This capability is distinct from the lease token. It is passed only to the
 # launched named app and binds the detached LaunchServices process to this run.
 DESKTOP_LAUNCH_TOKEN="$(python3 -c 'import secrets; print(secrets.token_urlsafe(24))')"
@@ -540,15 +542,7 @@ run_qualification_cleanup() {
     fi
   fi
   if [[ "$KEEP_STACK" -eq 0 && -n "$QUALIFICATION_LEASE_TOKEN" && -d "$WORKTREE" ]]; then
-    if ! (
-      cd "$WORKTREE"
-      export OMI_HARNESS_OWNERSHIP_TOKEN="$QUALIFICATION_LEASE_TOKEN"
-      PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" python3 -m dev_harness.cli qualification-lease release \
-        --lease-id "$QUALIFICATION_LEASE_ID" \
-        --token "$QUALIFICATION_LEASE_TOKEN" \
-        --retained-runs "$QUALIFICATION_RETAINED_RUNS" \
-        --retention-age-seconds "$QUALIFICATION_RETENTION_AGE_SECONDS"
-    ) >/dev/null 2>&1; then
+    if ! "$LEASE_COMMAND" release "$WORKTREE" "$QUALIFICATION_LEASE_ID" "$QUALIFICATION_LEASE_TOKEN" "$QUALIFICATION_RETAINED_RUNS" "$QUALIFICATION_RETENTION_AGE_SECONDS"; then
       QUALIFICATION_CLEANUP_STATUS="release-failed"
       return 1
     fi

--- a/desktop/macos/tests/test-qualification-lease-command.sh
+++ b/desktop/macos/tests/test-qualification-lease-command.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LEASE_COMMAND="$SCRIPT_DIR/../scripts/qualification-lease-command.sh"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/omi-qualification-lease-command-test.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+FIXTURE_WORKTREE="$TMP_ROOT/worktree"
+FIXTURE_PYTHON="$FIXTURE_WORKTREE/backend/.venv/bin/python"
+WORKFLOW_SOURCE="$TMP_ROOT/workflow-source"
+mkdir -p "$(dirname "$FIXTURE_PYTHON")"
+mkdir -p "$WORKFLOW_SOURCE"
+cat > "$FIXTURE_PYTHON" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == '-m' && "${2:-}" == 'dev_harness.cli' && "${3:-}" == 'qualification-lease' && "${5:-}" == '--lease-id' ]] || {
+  echo "unexpected qualification lease command shape" >&2
+  exit 65
+}
+expected_worktree="${QUALIFICATION_LEASE_EXPECTED_WORKTREE:-}"
+actual_worktree="$(pwd -P)"
+expected_worktree="$(cd "$expected_worktree" && pwd -P)"
+[[ "$actual_worktree" == "$expected_worktree" ]] || {
+  echo "qualification lease ran from $actual_worktree instead of $expected_worktree" >&2
+  exit 66
+}
+case "${QUALIFICATION_LEASE_FIXTURE_MODE:-}" in
+  acquire-failure)
+    printf '%s\n' 'Safety check failed: Qualification lease owner PID is not running: 424242'
+    exit 2
+    ;;
+  release-failure)
+    printf '%s\n' 'Safety check failed: Qualification lease token test-release-token does not match the active lease'
+    exit 2
+    ;;
+  acquire-success)
+    printf '%s\n' '{"log_dir":"/tmp/qualification-log","token":"test-token"}'
+    ;;
+  acquire-success-with-stderr)
+    printf '%s\n' 'benign harness warning' >&2
+    printf '%s\n' '{"log_dir":"/tmp/qualification-log","token":"test-token"}'
+    ;;
+  *)
+    echo "unexpected fixture mode: ${QUALIFICATION_LEASE_FIXTURE_MODE:-unset}" >&2
+    exit 64
+    ;;
+esac
+SH
+chmod +x "$FIXTURE_PYTHON"
+
+if QUALIFICATION_LEASE_EXPECTED_WORKTREE="$FIXTURE_WORKTREE" QUALIFICATION_LEASE_FIXTURE_MODE=acquire-failure "$LEASE_COMMAND" acquire "$FIXTURE_WORKTREE" qualification-test 424242 1000 3 >"$TMP_ROOT/acquire.out" 2>"$TMP_ROOT/acquire.err"; then
+  fail "lease acquire unexpectedly succeeded"
+fi
+grep -Fq 'qualification failed: lease acquire exited 2: Safety check failed: Qualification lease owner PID is not running: 424242' "$TMP_ROOT/acquire.err" \
+  || fail "lease acquire failure was not relayed to stderr"
+[[ ! -s "$TMP_ROOT/acquire.out" ]] || fail "failed lease acquire wrote a JSON capability to stdout"
+
+if QUALIFICATION_LEASE_EXPECTED_WORKTREE="$FIXTURE_WORKTREE" QUALIFICATION_LEASE_FIXTURE_MODE=release-failure "$LEASE_COMMAND" release "$FIXTURE_WORKTREE" qualification-test test-release-token 3 1209600 >"$TMP_ROOT/release.out" 2>"$TMP_ROOT/release.err"; then
+  fail "lease release unexpectedly succeeded"
+fi
+grep -Fq 'qualification failed: lease release exited 2: Safety check failed: Qualification lease token [redacted] does not match the active lease' "$TMP_ROOT/release.err" \
+  || fail "lease release failure was not relayed to stderr"
+if grep -Fq 'test-release-token' "$TMP_ROOT/release.err"; then
+  fail "lease release diagnostic leaked its capability token"
+fi
+
+QUALIFICATION_LEASE_EXPECTED_WORKTREE="$FIXTURE_WORKTREE" QUALIFICATION_LEASE_FIXTURE_MODE=acquire-success "$LEASE_COMMAND" acquire "$FIXTURE_WORKTREE" qualification-test $$ 1000 3 >"$TMP_ROOT/success.out"
+grep -Fxq '{"log_dir":"/tmp/qualification-log","token":"test-token"}' "$TMP_ROOT/success.out" \
+  || fail "successful lease acquire did not preserve its JSON capability"
+
+(
+  cd "$WORKFLOW_SOURCE"
+  QUALIFICATION_LEASE_EXPECTED_WORKTREE="$FIXTURE_WORKTREE" QUALIFICATION_LEASE_FIXTURE_MODE=acquire-success-with-stderr "$LEASE_COMMAND" acquire "$FIXTURE_WORKTREE" qualification-test $$ 1000 3
+) >"$TMP_ROOT/success-with-stderr.out" 2>"$TMP_ROOT/success-with-stderr.err"
+grep -Fxq '{"log_dir":"/tmp/qualification-log","token":"test-token"}' "$TMP_ROOT/success-with-stderr.out" \
+  || fail "successful lease acquire with stderr did not preserve its JSON capability"
+[[ ! -s "$TMP_ROOT/success-with-stderr.err" ]] \
+  || fail "successful lease acquire relayed diagnostics instead of isolating its JSON capability"
+
+echo "qualification lease command behavioral regression tests passed"

--- a/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
+++ b/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
@@ -6,6 +6,7 @@ QUALIFIER="$SCRIPT_DIR/../scripts/qualify-desktop-beta.sh"
 CORE_HARNESS="$SCRIPT_DIR/../scripts/desktop-core-harness.sh"
 PROFILE_PREP="$SCRIPT_DIR/../scripts/prepare-qualification-profile.sh"
 SWIFT_CACHE="$SCRIPT_DIR/../scripts/qualification-swift-cache.sh"
+LEASE_COMMAND="$SCRIPT_DIR/../scripts/qualification-lease-command.sh"
 APP_CONFIG="$SCRIPT_DIR/../scripts/app-config.sh"
 RUN_SH="$SCRIPT_DIR/../run.sh"
 
@@ -75,8 +76,10 @@ require_order "$QUALIFIER" \
 require_text 'terminate_qualification_desktop "$BUNDLE"'
 require_text '--json tagName,isDraft,isPrerelease,publishedAt,assets,body'
 require_text 'WORKTREE="$("$SCRIPT_DIR/qualification-swift-cache.sh" prepare "$SHA" "$REPO_ROOT")"'
-require_text 'qualification-lease acquire'
-require_text 'qualification-lease release'
+require_text 'qualification-lease "$action"' "$LEASE_COMMAND"
+require_text 'acquire)' "$LEASE_COMMAND"
+require_text 'release)' "$LEASE_COMMAND"
+require_text 'qualification-lease-command.sh' "$QUALIFIER"
 require_text 'OMI_HARNESS_PORT_OFFSET="$QUALIFICATION_PORT_OFFSET"'
 require_text 'OMI_AUTOMATION_PORT="$((47777 + QUALIFICATION_PORT_OFFSET))"'
 require_text 'QUALIFICATION_RETAINED_RUNS="${OMI_QUALIFICATION_RETAINED_RUNS:-3}"'
@@ -137,6 +140,10 @@ if [[ ! -x "$PROFILE_PREP" ]]; then
 fi
 if [[ ! -x "$SWIFT_CACHE" ]]; then
   echo "FAIL: missing executable exact-source qualification Swift cache helper" >&2
+  exit 1
+fi
+if [[ ! -x "$LEASE_COMMAND" ]]; then
+  echo "FAIL: missing executable qualification lease command helper" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Route M1 qualification lease acquire/release through the tag-pinned backend virtualenv and cached worktree.
- Keep successful acquire stdout capability-only even when the harness emits stderr; relay concise diagnostics only when a lease command fails.
- Add behavioral regression coverage for cached-worktree cwd binding, success-with-stderr JSON isolation, failure diagnostics, and release-token redaction.
- Preserve the existing exact-tag checkout contract used by the qualification guard.

## Incident evidence

The immutable `v0.12.129+12129-macos` candidate (`b07851f438dac10ebeec3dac90c318423498f390`) failed its sole M1 Studio qualification run (`30194590936`) immediately after backend dependency sync with exit 2. The runner-capacity preflight passed, no lease was acquired, and the raw log contained no diagnostic because the lease CLI's stdout failure was captured as expected JSON.

## Verification

- `bash desktop/macos/tests/test-qualification-lease-command.sh`
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh`
- `python3 .github/scripts/test_desktop_release_flow_contract.py`
- `python3 .github/scripts/test_desktop_changelog.py`
- `python3 .github/scripts/check-release-process-guards.py`
- `make preflight`

## Failure class

Failure-Class: none
