### PR TITLE
fix(backend): give each event loop its own shared HTTP client

### DIFF
--- a/.github/failure-classes/FC-loop-bound-resource-shared-process-wide.json
+++ b/.github/failure-classes/FC-loop-bound-resource-shared-process-wide.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "id": "FC-loop-bound-resource-shared-process-wide",
+  "violated_contract": "A resource bound to one event loop (connection pool, semaphore, queue) must be owned by that loop and never reused from another.",
+  "canonical_prevention": "Hand out loop-bound resources through one per-loop registry that keys on the running loop and drops a finished loop's entry, instead of a module-level singleton.",
+  "evidence_prs": [
+    6377
+  ],
+  "scope_hints": [
+    "backend/**"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_async_http_infrastructure.py
+++ b/backend/tests/unit/test_async_http_infrastructure.py
@@ -390,35 +390,79 @@ class TestWebhookClientConfig:
 
     def test_webhook_client_read_timeout_is_30s(self):
         """Webhook client must use 30s read timeout to match previous per-call behavior."""
-        from utils.http_client import get_webhook_client, _webhook_client
 
-        # Force fresh client creation
-        import utils.http_client as hc
+        async def _read_timeout():
+            from utils.http_client import close_all_clients, get_webhook_client
 
-        old_client = hc._webhook_client
-        hc._webhook_client = None
-        try:
-            client = get_webhook_client()
-            assert client.timeout.read == 30.0
-        finally:
-            if hc._webhook_client is not None and hc._webhook_client is not old_client:
-                asyncio.run(hc._webhook_client.aclose())
-            hc._webhook_client = old_client
+            try:
+                return get_webhook_client().timeout.read
+            finally:
+                await close_all_clients()
+
+        assert asyncio.run(_read_timeout()) == 30.0
 
     def test_webhook_client_connect_timeout_is_2s(self):
         """Webhook client must use aggressive 2s connect timeout."""
-        from utils.http_client import get_webhook_client as gwc
+
+        async def _connect_timeout():
+            from utils.http_client import close_all_clients, get_webhook_client
+
+            try:
+                return get_webhook_client().timeout.connect
+            finally:
+                await close_all_clients()
+
+        assert asyncio.run(_connect_timeout()) == 2.0
+
+
+class TestClientEventLoopOwnership:
+    """A shared client belongs to the event loop that opened its connections.
+
+    Regression for the prod failure where one process-wide client outlived the
+    `asyncio.run()` loop that pooled its keep-alive connections: the next live
+    loop made the pool discard one, uvloop raised `RuntimeError: ... the
+    handler is closed` from `write_eof()` on the freed handle, and httpcore
+    re-raised it at the caller — intermittent HTTP 500s on `/v1/apps/enable`
+    and dropped app-integration webhook deliveries.
+    """
+
+    def test_each_event_loop_gets_its_own_client(self):
+        """The surviving client of a finished loop is never handed to the next one."""
         import utils.http_client as hc
 
-        old_client = hc._webhook_client
-        hc._webhook_client = None
+        async def _client_id():
+            return id(hc.get_webhook_client())
+
+        # No close in between: this is the prod shape, where the process-wide
+        # client outlived the asyncio.run() loop that pooled its connections.
+        first = asyncio.run(_client_id())
+        second = asyncio.run(_client_id())
         try:
-            client = gwc()
-            assert client.timeout.connect == 2.0
+            assert first != second
         finally:
-            if hc._webhook_client is not None and hc._webhook_client is not old_client:
-                asyncio.run(hc._webhook_client.aclose())
-            hc._webhook_client = old_client
+            asyncio.run(hc.close_all_clients())
+
+    def test_one_loop_reuses_a_single_pooled_client(self):
+        import utils.http_client as hc
+
+        async def _same_client():
+            try:
+                return hc.get_webhook_client() is hc.get_webhook_client()
+            finally:
+                await hc.close_all_clients()
+
+        assert asyncio.run(_same_client()) is True
+
+    def test_finished_loops_do_not_accumulate_clients(self):
+        import utils.http_client as hc
+
+        async def _touch():
+            hc.get_webhook_client()
+
+        for _ in range(5):
+            asyncio.run(_touch())
+
+        assert len(hc._clients) == 1  # only the most recent loop's entry survives
 
 
 class TestExecutorConfiguration:

--- a/backend/utils/http_client.py
+++ b/backend/utils/http_client.py
@@ -14,6 +14,7 @@ import asyncio
 import logging
 import time
 from collections import defaultdict
+from collections.abc import Callable
 
 import httpx
 
@@ -40,8 +41,8 @@ class WebhookCircuitBreaker:
     no asyncio primitives.  Safe to call from multiple threads / event loops
     (e.g. asyncio.run() in sync FastAPI endpoints, executor threads).
     httpx.AsyncClient instances are likewise thread-safe (httpcore is
-    thread-safe).  Per-loop semaphores are keyed by loop ID so they work
-    correctly across different event loops.
+    thread-safe), but their pooled connections are not portable across event
+    loops, so both they and the semaphores are keyed by loop ID.
     """
 
     __slots__ = ('_failures', '_last_failure_time', '_last_access_time', '_state', '_half_open_in_flight', '_url')
@@ -233,13 +234,51 @@ def get_llm_gateway_semaphore() -> asyncio.Semaphore:
 # Shared httpx.AsyncClient instances
 # ---------------------------------------------------------------------------
 
-_webhook_client: httpx.AsyncClient | None = None
-_maps_client: httpx.AsyncClient | None = None
-_auth_client: httpx.AsyncClient | None = None
-_stt_client: httpx.AsyncClient | None = None
-_tts_client: httpx.AsyncClient | None = None
-_web_fetch_client: httpx.AsyncClient | None = None
-_llm_gateway_client: httpx.AsyncClient | None = None
+_clients: dict[int, tuple[asyncio.AbstractEventLoop, dict[str, httpx.AsyncClient]]] = {}
+_loopless_clients: dict[str, httpx.AsyncClient] = {}
+
+
+def _get_client(name: str, factory: Callable[[], httpx.AsyncClient]) -> httpx.AsyncClient:
+    """Get or create a shared client owned by the current event loop.
+
+    Clients are per-loop for the same reason as `_get_semaphore`: a pooled
+    keep-alive connection belongs to the event loop that opened it. Sync
+    FastAPI endpoints run `asyncio.run()`, which closes its loop on return, so
+    a process-wide client ends up holding connections whose loop is gone. The
+    next request on a live loop makes the pool discard one, and closing it
+    calls `write_eof()` on a freed uvloop handle — `RuntimeError: unable to
+    perform operation on <TCPTransport closed=True ...>; the handler is
+    closed`, which httpcore re-raises at the caller. In prod that surfaced as
+    intermittent HTTP 500s on `/v1/apps/enable` and dropped app-integration
+    webhook deliveries (~270/day).
+
+    A finished loop's entry is dropped when the next loop appears — its
+    clients cannot be closed (that is the same dead-handle error) and its
+    sockets went down with the loop. Each entry keeps the loop itself, both to
+    recognise that moment and so no two live entries can share an id.
+
+    The main FastAPI event loop keeps one stable entry, so async callers — the
+    hot paths — reuse their pool exactly as before.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop: configuration inspection, not requests.
+        by_name = _loopless_clients
+    else:
+        entry = _clients.get(id(loop))
+        if entry is None or entry[0] is not loop:
+            for cached_id, (cached_loop, _) in list(_clients.items()):
+                if cached_loop.is_closed():
+                    del _clients[cached_id]
+            entry = (loop, {})
+            _clients[id(loop)] = entry
+        by_name = entry[1]
+    client = by_name.get(name)
+    if client is None:
+        client = factory()
+        by_name[name] = client
+    return client
 
 
 def get_webhook_client() -> httpx.AsyncClient:
@@ -248,24 +287,24 @@ def get_webhook_client() -> httpx.AsyncClient:
     Uses aggressive connect timeout (2s) and 30s read timeout to match
     the previous per-call timeout=30 that partner webhooks relied on.
     """
-    global _webhook_client
-    if _webhook_client is None:
-        _webhook_client = httpx.AsyncClient(
+    return _get_client(
+        'webhook',
+        lambda: httpx.AsyncClient(
             timeout=httpx.Timeout(30.0, connect=2.0),
             limits=httpx.Limits(max_connections=64, max_keepalive_connections=16),
-        )
-    return _webhook_client
+        ),
+    )
 
 
 def get_maps_client() -> httpx.AsyncClient:
     """Return a shared async HTTP client for Google Maps geocoding."""
-    global _maps_client
-    if _maps_client is None:
-        _maps_client = httpx.AsyncClient(
+    return _get_client(
+        'maps',
+        lambda: httpx.AsyncClient(
             timeout=httpx.Timeout(10.0, connect=2.0),
             limits=httpx.Limits(max_connections=8, max_keepalive_connections=4),
-        )
-    return _maps_client
+        ),
+    )
 
 
 def get_auth_client() -> httpx.AsyncClient:
@@ -281,24 +320,24 @@ def get_auth_client() -> httpx.AsyncClient:
     client). Auth token-exchange volume is low, so paying a TLS handshake per
     request is a fine trade for eliminating the stale-socket failures.
     """
-    global _auth_client
-    if _auth_client is None:
-        _auth_client = httpx.AsyncClient(
+    return _get_client(
+        'auth',
+        lambda: httpx.AsyncClient(
             timeout=httpx.Timeout(10.0, connect=2.0),
             limits=httpx.Limits(max_connections=20, max_keepalive_connections=0),
-        )
-    return _auth_client
+        ),
+    )
 
 
 def get_stt_client() -> httpx.AsyncClient:
     """Return a shared async HTTP client for STT/ML services (long timeout)."""
-    global _stt_client
-    if _stt_client is None:
-        _stt_client = httpx.AsyncClient(
+    return _get_client(
+        'stt',
+        lambda: httpx.AsyncClient(
             timeout=httpx.Timeout(300.0, connect=5.0),
             limits=httpx.Limits(max_connections=8, max_keepalive_connections=4),
-        )
-    return _stt_client
+        ),
+    )
 
 
 def get_tts_client() -> httpx.AsyncClient:
@@ -311,13 +350,13 @@ def get_tts_client() -> httpx.AsyncClient:
     volume is low enough that paying a TLS handshake per request is fine,
     and the correctness win is worth it.
     """
-    global _tts_client
-    if _tts_client is None:
-        _tts_client = httpx.AsyncClient(
+    return _get_client(
+        'tts',
+        lambda: httpx.AsyncClient(
             timeout=httpx.Timeout(60.0, connect=5.0),
             limits=httpx.Limits(max_connections=32, max_keepalive_connections=0),
-        )
-    return _tts_client
+        ),
+    )
 
 
 def get_web_fetch_client() -> httpx.AsyncClient:
@@ -326,50 +365,45 @@ def get_web_fetch_client() -> httpx.AsyncClient:
     Isolated from the webhook pool so slow/stalled external pages don't
     compete with partner webhook delivery slots.
     """
-    global _web_fetch_client
-    if _web_fetch_client is None:
-        _web_fetch_client = httpx.AsyncClient(
+    return _get_client(
+        'web_fetch',
+        lambda: httpx.AsyncClient(
             timeout=httpx.Timeout(15.0, connect=5.0),
             limits=httpx.Limits(max_connections=16, max_keepalive_connections=4),
-        )
-    return _web_fetch_client
+        ),
+    )
 
 
 def get_llm_gateway_client() -> httpx.AsyncClient:
     """Return the shared async client for the internal LLM gateway."""
-    global _llm_gateway_client
-    if _llm_gateway_client is None:
-        _llm_gateway_client = httpx.AsyncClient(
+    return _get_client(
+        'llm_gateway',
+        lambda: httpx.AsyncClient(
             timeout=httpx.Timeout(20.0, connect=3.0),
             limits=httpx.Limits(max_connections=24, max_keepalive_connections=12),
-        )
-    return _llm_gateway_client
+        ),
+    )
 
 
 async def close_all_clients():
-    """Close all shared HTTP clients. Call at app shutdown."""
-    global _webhook_client, _maps_client, _auth_client, _stt_client, _tts_client, _web_fetch_client, _llm_gateway_client
-    for client in (
-        _webhook_client,
-        _maps_client,
-        _auth_client,
-        _stt_client,
-        _tts_client,
-        _web_fetch_client,
-        _llm_gateway_client,
-    ):
-        if client is not None:
-            try:
-                await client.aclose()
-            except Exception as e:
-                logger.warning(f"Error closing HTTP client: {e}")
-    _webhook_client = None
-    _maps_client = None
-    _auth_client = None
-    _tts_client = None
-    _stt_client = None
-    _web_fetch_client = None
-    _llm_gateway_client = None
+    """Close all shared HTTP clients. Call at app shutdown.
+
+    Only this loop's clients can be closed: another loop's connections are
+    already gone with it, and awaiting aclose() on them raises the dead-handle
+    RuntimeError described in `_get_client`.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    _, own_clients = _clients.pop(id(loop), (None, {})) if loop is not None else (None, {})
+    for client in own_clients.values():
+        try:
+            await client.aclose()
+        except Exception as e:
+            logger.warning(f"Error closing HTTP client: {e}")
+    _clients.clear()
+    _loopless_clients.clear()
     # Reset stateful registries
     _semaphores.clear()
     _webhook_circuit_breakers.clear()


### PR DESCRIPTION
## Bug (live in prod, ~270/day)

`backend/utils/http_client.py` hands out process-wide `httpx.AsyncClient`
singletons, but a pooled keep-alive connection belongs to the event loop that
opened it. Sync FastAPI endpoints run `asyncio.run()`, which closes its loop on
return, so the shared client keeps connections whose loop is gone. The next
request on a live loop makes httpcore discard one, and closing it calls
`write_eof()` on a freed uvloop handle:

```
File "httpcore/_async/connection_pool.py", line 229, in handle_async_request
  await self._close_connections(closing)
...
File "anyio/_backends/_asyncio.py", line 1198, in aclose
  self._transport.write_eof()
File "uvloop/handles/handle.pyx", line 159, in uvloop.loop.UVHandle._ensure_alive
RuntimeError: unable to perform operation on <TCPTransport closed=True reading=False 0x...>; the handler is closed
```

`connection_pool.py:256` re-raises it at the caller, so the request fails
before anything reaches the wire. In `based-hardware` over the last 24h that is
~270 occurrences: unhandled **HTTP 500s on `POST /v1/apps/enable`**
(`routers/apps.py:2098`, the `external_integration.setup_completed_url` check —
the user is told the app failed to enable) and **dropped app-integration
webhook deliveries** logged as `App integration error: ... the handler is
closed`. It is uvloop-specific: stdlib asyncio's `write_eof()` on a closed
transport is a no-op, and prod runs `uvicorn --loop uvloop`.

The module already solved this exact ownership problem for semaphores
(`_get_semaphore`, keyed by loop id, with the comment explaining that
`asyncio.run()` in sync endpoints creates a fresh loop per call); the clients
were left process-wide, and the class docstring asserted they were safe to
share because httpcore is thread-safe. Thread-safe is not loop-portable.

## Fix

One per-loop registry (`_get_client`) behind the seven unchanged getters. It
keys on the running loop and drops a finished loop's entry when the next loop
appears — those clients cannot be closed (that is the same dead-handle error)
and their sockets died with the loop. Entries hold the loop itself so two live
entries can never share an id. `close_all_clients()` closes only the current
loop's clients.

Timeouts and limits are untouched. The long-lived FastAPI loop keeps a single
entry, so the hot async paths pool exactly as before; only `asyncio.run()`
callers pay a fresh connection, which is the cost of not reusing a dead one.

## Verified

- **Reproduced the prod error verbatim** under uvloop with a real keep-alive
  server and the real `get_webhook_client()`: request 1 on loop A → 200,
  request 2 on loop B → `RuntimeError: unable to perform operation on
  <TCPTransport closed=True reading=False 0x...>; the handler is closed`,
  request 3 → 200 (the poisoned connection had been evicted) — the exact
  alternating shape seen in prod logs.
- **After the fix**: 200/200 sequential `uvloop.run()` loops return 200, the
  registry holds 1 entry (finished loops pruned, no growth), the long-lived
  loop reuses one client, `close_all_clients()` empties the registry.
- Three new `TestClientEventLoopOwnership` tests fail against the unfixed
  module and pass here. `tests/unit/test_async_http_infrastructure.py`: 48
  passed.
- `test_async_webhooks`, `test_webhook_auto_disable`,
  `test_webhook_health_cache_cap`, `test_auth_redirect_uri`: identical results
  to `origin/main` (the 16 `test_auth_redirect_uri` failures in a combined run
  are pre-existing cross-file stub pollution, reproduced on `origin/main`).
- `make preflight`: 10 checks green.

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

