### PR TITLE
refactor(windows): retire agent identity compatibility shims

### DIFF
--- a/desktop/windows/src/main/agentKernel/controlTools.test.ts
+++ b/desktop/windows/src/main/agentKernel/controlTools.test.ts
@@ -502,6 +502,36 @@ describe('dispatch create/resolve — the consent gate', () => {
     expect((event.payload as Record<string, unknown>).grantId).toBe(grant.grantId)
   })
 
+  it('rejects the retired legacy_default grant source at the control boundary', async () => {
+    const { kernel, store } = newKernel()
+    const session = store.insertSession({
+      ownerId: OWNER,
+      surfaceKind: 'main_chat',
+      defaultAdapterId: 'acp'
+    })
+    const dispatchId = await createApproval(kernel, { sourceSessionId: session.sessionId })
+
+    const result = await call(coordinatorContext(kernel), 'resolve_desktop_dispatch', {
+      dispatchId,
+      status: 'resolved',
+      resolution: { decision: 'allow' },
+      grant: {
+        capability: 'desktop.context.screenshot_image',
+        operation: 'get_screenshot',
+        resourcePattern: 'display:1',
+        source: 'legacy_default',
+        expiresAtMs: Date.now() + 60_000
+      }
+    })
+
+    expect(result.ok).toBe(false)
+    expect(store.allRows('SELECT COUNT(*) AS n FROM grants')[0].n).toBe(0)
+    expect(
+      store.getRow('SELECT status FROM desktop_dispatches WHERE dispatch_id = ?', [dispatchId])
+        .status
+    ).toBe('pending')
+  })
+
   const grantRejections: Array<[string, Record<string, unknown>, RegExp]> = [
     [
       'a grant for a capability the user was never asked about',

--- a/desktop/windows/src/main/agentKernel/controlTools.ts
+++ b/desktop/windows/src/main/agentKernel/controlTools.ts
@@ -209,7 +209,7 @@ const resolveDesktopDispatchSchema = strictObject({
     operation: z.string().min(1),
     resourcePattern: z.string().min(1),
     effect: z.enum(['allow', 'deny']).default('allow'),
-    source: z.enum(['legacy_default', 'policy', 'user', 'system']).default('user'),
+    source: z.enum(['policy', 'user', 'system']).default('user'),
     constraintsJson: z.string().default('{}'),
     expiresAtMs: z.coerce.number().int().positive().nullable().optional()
   }).optional()

--- a/desktop/windows/src/main/agentKernel/store.test.ts
+++ b/desktop/windows/src/main/agentKernel/store.test.ts
@@ -26,6 +26,25 @@ import {
 const nodeSqliteFactory = DatabaseSync as unknown as DatabaseFactory
 
 const createdDirs: string[] = []
+const WINDOWS_SESSION_COLUMNS = [
+  'session_id',
+  'owner_id',
+  'agent_definition_id',
+  'title',
+  'status',
+  'surface_kind',
+  'external_ref_kind',
+  'external_ref_id',
+  'default_adapter_id',
+  'default_cwd',
+  'model_profile',
+  'metadata_json',
+  'created_at_ms',
+  'updated_at_ms',
+  'last_activity_at_ms',
+  'execution_role',
+  'provider_boundary'
+]
 
 afterEach(() => {
   for (const dir of createdDirs.splice(0)) {
@@ -40,7 +59,7 @@ describe('SqliteAgentStore', () => {
     store.migrate()
     store.migrate()
 
-    expect(store.getRow('SELECT COUNT(*) AS count FROM schema_migrations').count).toBe(14)
+    expect(store.getRow('SELECT COUNT(*) AS count FROM schema_migrations').count).toBe(15)
     expect(tableNames(store)).toEqual([
       'adapter_bindings',
       'artifacts',
@@ -67,6 +86,146 @@ describe('SqliteAgentStore', () => {
     ])
     expect(tableNames(store)).not.toContain('desktop_action_queue')
 
+    store.close()
+  })
+
+  it('retires v14 identity shims without losing sessions, runs, or grants', () => {
+    const databasePath = newDatabasePath()
+    let store = openStore({ databasePath, reconcileOnOpen: false })
+    const session = store.insertSession({
+      sessionId: 'ses_legacy_identity',
+      ownerId: 'owner',
+      surfaceKind: 'main_chat',
+      defaultAdapterId: 'acp'
+    })
+    const run = store.insertRun({
+      runId: 'run_legacy_identity',
+      sessionId: session.sessionId,
+      clientId: 'client',
+      requestId: 'request',
+      status: 'succeeded',
+      mode: 'ask'
+    })
+    store.insertGrant({
+      grantId: 'grant_legacy_identity',
+      sessionId: session.sessionId,
+      runId: run.runId,
+      capability: 'filesystem',
+      operation: 'read',
+      resourcePattern: 'C:\\workspace\\**',
+      effect: 'allow',
+      source: 'user',
+      constraintsJson: '{"scope":"legacy"}'
+    })
+    store.close()
+
+    makeDatabaseLookLikeV14(databasePath)
+
+    store = openStore({ databasePath, reconcileOnOpen: false })
+    expect(store.allRows('PRAGMA table_info(sessions)').map((row) => String(row.name))).toEqual([
+      ...WINDOWS_SESSION_COLUMNS,
+      'current_profile_generation'
+    ])
+    expect(
+      String(
+        store.getRow("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'grants'").sql
+      )
+    ).not.toContain('legacy_default')
+    const migratedGrant = store.getRow(
+      `SELECT source, constraints_json, revoked_at_ms
+       FROM grants
+       WHERE grant_id = ?`,
+      ['grant_legacy_identity']
+    )
+    expect(migratedGrant.source).toBe('system')
+    expect(Number(migratedGrant.revoked_at_ms)).toBeGreaterThan(0)
+    expect(JSON.parse(String(migratedGrant.constraints_json))).toMatchObject({
+      _omiLegacyIdentityCleanup: {
+        originalSource: 'legacy_default',
+        action: 'revoked',
+        version: 29
+      },
+      originalConstraints: { scope: 'legacy' }
+    })
+    expect(
+      store.getRow('SELECT current_profile_generation FROM sessions WHERE session_id = ?', [
+        'ses_legacy_identity'
+      ]).current_profile_generation
+    ).toBe(3)
+    expect(
+      store.getRow('SELECT session_id FROM runs WHERE run_id = ?', ['run_legacy_identity'])
+        .session_id
+    ).toBe('ses_legacy_identity')
+    expect(store.allRows('PRAGMA foreign_key_check')).toEqual([])
+    expect(Number(store.getPragma('foreign_keys'))).toBe(1)
+
+    store.execute('DELETE FROM sessions WHERE session_id = ?', ['ses_legacy_identity'])
+    expect(store.getRow('SELECT COUNT(*) AS count FROM runs').count).toBe(0)
+    expect(store.getRow('SELECT COUNT(*) AS count FROM grants').count).toBe(0)
+
+    store.migrate()
+    expect(
+      store.getRow('SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 29').count
+    ).toBe(1)
+    store.close()
+  })
+
+  it('refuses to rebuild the sessions parent table inside an active transaction', () => {
+    const store = newStore({ reconcileOnOpen: false })
+    const session = store.insertSession({
+      ownerId: 'owner',
+      surfaceKind: 'main_chat',
+      defaultAdapterId: 'acp'
+    })
+    store.execute('ALTER TABLE sessions ADD COLUMN legacy_client_scope TEXT')
+    store.execute('DELETE FROM schema_migrations WHERE version = 29')
+
+    expect(() => store.withTransaction(() => store.migrate())).toThrow(
+      /must run outside an active transaction/
+    )
+    expect(Number(store.getPragma('foreign_keys'))).toBe(1)
+    expect(
+      store.getRow('SELECT session_id FROM sessions WHERE session_id = ?', [session.sessionId])
+        .session_id
+    ).toBe(session.sessionId)
+    expect(
+      store.getRow('SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 29').count
+    ).toBe(0)
+    store.close()
+  })
+
+  it('rolls back the cleanup and restores foreign keys when schema recreation fails', () => {
+    const store = newStore({ reconcileOnOpen: false })
+    store.insertSession({
+      ownerId: 'owner',
+      surfaceKind: 'main_chat',
+      externalRefKind: 'task',
+      externalRefId: 'duplicate',
+      defaultAdapterId: 'acp'
+    })
+    store.execute('DROP INDEX sessions_external_ref_uq')
+    store.insertSession({
+      ownerId: 'owner',
+      surfaceKind: 'main_chat',
+      externalRefKind: 'task',
+      externalRefId: 'duplicate',
+      defaultAdapterId: 'acp'
+    })
+    store.execute('ALTER TABLE sessions ADD COLUMN legacy_client_scope TEXT')
+    store.execute('DELETE FROM schema_migrations WHERE version = 29')
+
+    expect(() => store.migrate()).toThrow(/UNIQUE constraint failed/)
+    expect(Number(store.getPragma('foreign_keys'))).toBe(1)
+    expect(store.getRow('SELECT COUNT(*) AS count FROM sessions').count).toBe(2)
+    expect(
+      store
+        .allRows('PRAGMA table_info(sessions)')
+        .map((row) => String(row.name))
+        .includes('legacy_client_scope')
+    ).toBe(true)
+    expect(
+      store.getRow('SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 29').count
+    ).toBe(0)
     store.close()
   })
 
@@ -1471,12 +1630,17 @@ describe('SqliteAgentStore', () => {
     ).toBe(true)
   })
 
-  it('stores no legacy_default grant rows in a fresh database', () => {
+  it('creates fresh databases without retired identity columns or grant sources', () => {
     const store = newStore({ reconcileOnOpen: false })
-    const count = Number(
-      store.getRow("SELECT COUNT(*) AS count FROM grants WHERE source = 'legacy_default'").count
+    const sessionColumns = store
+      .allRows('PRAGMA table_info(sessions)')
+      .map((row) => String(row.name))
+    const grantsSql = String(
+      store.getRow("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'grants'").sql
     )
-    expect(count).toBe(0)
+
+    expect(sessionColumns).toEqual(WINDOWS_SESSION_COLUMNS)
+    expect(grantsSql).not.toContain('legacy_default')
     store.close()
   })
 
@@ -1581,4 +1745,92 @@ function tableNames(store: SqliteAgentStore): string[] {
       "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
     )
     .map((row) => String(row.name))
+}
+
+function makeDatabaseLookLikeV14(databasePath: string): void {
+  const db = new DatabaseSync(databasePath)
+  try {
+    db.exec('PRAGMA foreign_keys = OFF')
+    db.exec('BEGIN IMMEDIATE')
+
+    const sessionColumns = db.prepare('PRAGMA table_info(sessions)').all() as Array<{
+      name: string
+    }>
+    if (!sessionColumns.some((column) => column.name === 'legacy_client_scope')) {
+      db.exec('ALTER TABLE sessions ADD COLUMN legacy_client_scope TEXT')
+      db.exec('ALTER TABLE sessions ADD COLUMN legacy_session_key TEXT')
+      db.exec(`
+        CREATE UNIQUE INDEX sessions_legacy_alias_uq
+          ON sessions(owner_id, legacy_client_scope, legacy_session_key)
+          WHERE legacy_client_scope IS NOT NULL
+      `)
+    }
+    db.exec(`
+      UPDATE sessions
+      SET legacy_client_scope = 'desktop',
+          legacy_session_key = 'legacy-session'
+      WHERE session_id = 'ses_legacy_identity'
+    `)
+    if (!sessionColumns.some((column) => column.name === 'current_profile_generation')) {
+      db.exec(`
+        ALTER TABLE sessions
+          ADD COLUMN current_profile_generation INTEGER NOT NULL DEFAULT 1
+          CHECK (current_profile_generation > 0)
+      `)
+    }
+    db.exec(`
+      UPDATE sessions
+      SET current_profile_generation = 3
+      WHERE session_id = 'ses_legacy_identity';
+      INSERT OR IGNORE INTO schema_migrations (version, applied_at_ms)
+      VALUES (16, 1);
+    `)
+
+    const grantsSql = String(
+      (
+        db
+          .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'grants'")
+          .get() as { sql: string }
+      ).sql
+    )
+    if (!grantsSql.includes('legacy_default')) {
+      db.exec(`
+        CREATE TABLE grants_v14 (
+          grant_id TEXT PRIMARY KEY,
+          session_id TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+          run_id TEXT REFERENCES runs(run_id) ON DELETE CASCADE,
+          capability TEXT NOT NULL,
+          operation TEXT NOT NULL,
+          resource_pattern TEXT NOT NULL,
+          effect TEXT NOT NULL CHECK (effect IN ('allow', 'deny')),
+          source TEXT NOT NULL CHECK (source IN ('legacy_default', 'policy', 'user', 'system')),
+          constraints_json TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(constraints_json)),
+          created_at_ms INTEGER NOT NULL,
+          expires_at_ms INTEGER,
+          revoked_at_ms INTEGER
+        ) STRICT;
+
+        INSERT INTO grants_v14
+        SELECT * FROM grants;
+
+        DROP TABLE grants;
+        ALTER TABLE grants_v14 RENAME TO grants;
+        CREATE INDEX grants_lookup_idx
+          ON grants(session_id, run_id, capability, operation, created_at_ms DESC);
+      `)
+    }
+    db.exec(`
+      UPDATE grants
+      SET source = 'legacy_default'
+      WHERE grant_id = 'grant_legacy_identity';
+      DELETE FROM schema_migrations WHERE version = 29;
+    `)
+    db.exec('COMMIT')
+  } catch (error) {
+    if (db.isTransaction) db.exec('ROLLBACK')
+    throw error
+  } finally {
+    db.exec('PRAGMA foreign_keys = ON')
+    db.close()
+  }
 }

--- a/desktop/windows/src/main/agentKernel/store.ts
+++ b/desktop/windows/src/main/agentKernel/store.ts
@@ -78,6 +78,9 @@ const CONVERSATION_TURNS_MIGRATION_VERSION = 11
 const BINDING_TURN_DELIVERY_MIGRATION_VERSION = 12
 const WORKSTREAM_CONTINUITY_MIGRATION_VERSION = 13
 const SESSION_EXECUTION_POLICY_MIGRATION_VERSION = 14
+// 15-28 are already occupied by the canonical macOS runtime. Keep this shared
+// migration namespace collision-free so Windows can port those steps later.
+const LEGACY_IDENTITY_CLEANUP_MIGRATION_VERSION = 29
 
 const ACTIVE_ATTEMPT_STATUSES = [
   'queued',
@@ -148,9 +151,6 @@ CREATE TABLE sessions (
   surface_kind TEXT NOT NULL,
   external_ref_kind TEXT,
   external_ref_id TEXT,
-  -- TODO(#10240 desktop-agent-platonic-gap-closure G6): drop legacy_client_scope + legacy_session_key two desktop releases after platonic ships.
-  legacy_client_scope TEXT,
-  legacy_session_key TEXT,
   default_adapter_id TEXT NOT NULL,
   default_cwd TEXT,
   model_profile TEXT,
@@ -158,17 +158,12 @@ CREATE TABLE sessions (
   created_at_ms INTEGER NOT NULL,
   updated_at_ms INTEGER NOT NULL,
   last_activity_at_ms INTEGER NOT NULL,
-  CHECK ((external_ref_kind IS NULL) = (external_ref_id IS NULL)),
-  CHECK ((legacy_client_scope IS NULL) = (legacy_session_key IS NULL))
+  CHECK ((external_ref_kind IS NULL) = (external_ref_id IS NULL))
 ) STRICT;
 
 CREATE UNIQUE INDEX sessions_external_ref_uq
   ON sessions(owner_id, external_ref_kind, external_ref_id)
   WHERE external_ref_kind IS NOT NULL;
-
-CREATE UNIQUE INDEX sessions_legacy_alias_uq
-  ON sessions(owner_id, legacy_client_scope, legacy_session_key)
-  WHERE legacy_client_scope IS NOT NULL;
 
 CREATE INDEX sessions_recent_idx
   ON sessions(owner_id, last_activity_at_ms DESC);
@@ -358,8 +353,7 @@ CREATE TABLE grants (
   operation TEXT NOT NULL,
   resource_pattern TEXT NOT NULL,
   effect TEXT NOT NULL CHECK (effect IN ('allow', 'deny')),
-  -- TODO(#10240 desktop-agent-platonic-gap-closure G6): drop legacy_default from CHECK after ship+2 releases post-platonic.
-  source TEXT NOT NULL CHECK (source IN ('legacy_default', 'policy', 'user', 'system')),
+  source TEXT NOT NULL CHECK (source IN ('policy', 'user', 'system')),
   constraints_json TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(constraints_json)),
   created_at_ms INTEGER NOT NULL,
   expires_at_ms INTEGER,
@@ -439,6 +433,7 @@ export function probeSqliteRuntime(options: SqliteProbeOptions = {}): void {
     runBindingTurnDeliveryMigration(db, Date.now())
     runWorkstreamContinuityMigration(db, Date.now())
     runSessionExecutionPolicyMigration(db, Date.now())
+    runLegacyIdentityCleanupMigration(db, Date.now())
     runTransaction(db, () => {
       db?.prepare(
         'INSERT INTO sessions (session_id, owner_id, status, surface_kind, default_adapter_id, created_at_ms, updated_at_ms, last_activity_at_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
@@ -523,6 +518,9 @@ export class SqliteAgentStore implements AgentStore {
     }
     if (!this.hasMigration(SESSION_EXECUTION_POLICY_MIGRATION_VERSION)) {
       runSessionExecutionPolicyMigration(this.db, this.nowMs())
+    }
+    if (!this.hasMigration(LEGACY_IDENTITY_CLEANUP_MIGRATION_VERSION)) {
+      runLegacyIdentityCleanupMigration(this.db, this.nowMs())
     }
   }
 
@@ -876,10 +874,9 @@ export class SqliteAgentStore implements AgentStore {
       .prepare(
         `INSERT INTO sessions (
         session_id, owner_id, agent_definition_id, title, status, surface_kind, execution_role, provider_boundary,
-        external_ref_kind, external_ref_id, legacy_client_scope, legacy_session_key,
-        default_adapter_id, default_cwd, model_profile, metadata_json,
+        external_ref_kind, external_ref_id, default_adapter_id, default_cwd, model_profile, metadata_json,
         created_at_ms, updated_at_ms, last_activity_at_ms
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .run(...sessionValues(session))
     return session
@@ -1699,6 +1696,18 @@ function tableHasColumn(db: KernelDatabase, tableName: string, columnName: strin
   return rows.some((row) => String(row.name) === columnName)
 }
 
+function tableDefinitionSql(db: KernelDatabase, tableName: string): string {
+  const row = db
+    .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName) as Row | undefined
+  return typeof row?.sql === 'string' ? row.sql : ''
+}
+
+function foreignKeysEnabled(db: KernelDatabase): boolean {
+  const row = db.prepare('PRAGMA foreign_keys').get() as Row | undefined
+  return Number(row?.foreign_keys) === 1
+}
+
 function runDesktopContextPacketsMigration(db: KernelDatabase, appliedAtMs: number): void {
   runTransaction(db, () => {
     db.exec(`
@@ -2229,6 +2238,183 @@ function runSessionExecutionPolicyMigration(db: KernelDatabase, appliedAtMs: num
   })
 }
 
+/**
+ * Burn down the two-release compatibility shims tracked by #10240. Rebuilding
+ * the parent sessions table requires foreign-key enforcement to be disabled
+ * before the transaction starts; the in-transaction foreign_key_check is the
+ * guard that prevents committing a broken child graph.
+ */
+function runLegacyIdentityCleanupMigration(db: KernelDatabase, appliedAtMs: number): void {
+  const rebuildSessions =
+    tableHasColumn(db, 'sessions', 'legacy_client_scope') ||
+    tableHasColumn(db, 'sessions', 'legacy_session_key')
+  const rebuildGrants = tableDefinitionSql(db, 'grants').includes('legacy_default')
+  const preserveCurrentProfileGeneration = tableHasColumn(
+    db,
+    'sessions',
+    'current_profile_generation'
+  )
+  const profileColumnDefinition = preserveCurrentProfileGeneration
+    ? `,
+            current_profile_generation INTEGER NOT NULL DEFAULT 1
+              CHECK (current_profile_generation > 0)`
+    : ''
+  const profileColumnProjection = preserveCurrentProfileGeneration
+    ? ', current_profile_generation'
+    : ''
+
+  if (!rebuildSessions && !rebuildGrants) {
+    db.prepare('INSERT INTO schema_migrations (version, applied_at_ms) VALUES (?, ?)').run(
+      LEGACY_IDENTITY_CLEANUP_MIGRATION_VERSION,
+      appliedAtMs
+    )
+    return
+  }
+
+  db.exec('PRAGMA foreign_keys = OFF')
+  if (foreignKeysEnabled(db)) {
+    throw new Error('Legacy identity cleanup must run outside an active transaction')
+  }
+  let migrationFailure: { error: unknown } | undefined
+  try {
+    runTransaction(db, () => {
+      if (rebuildSessions) {
+        db.exec(`
+          CREATE TABLE sessions_v29 (
+            session_id TEXT PRIMARY KEY,
+            owner_id TEXT NOT NULL,
+            agent_definition_id TEXT NOT NULL DEFAULT 'omi.generalist@1',
+            title TEXT,
+            status TEXT NOT NULL CHECK (status IN ('open', 'archived', 'closed')),
+            surface_kind TEXT NOT NULL,
+            external_ref_kind TEXT,
+            external_ref_id TEXT,
+            default_adapter_id TEXT NOT NULL,
+            default_cwd TEXT,
+            model_profile TEXT,
+            metadata_json TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(metadata_json)),
+            created_at_ms INTEGER NOT NULL,
+            updated_at_ms INTEGER NOT NULL,
+            last_activity_at_ms INTEGER NOT NULL,
+            execution_role TEXT NOT NULL DEFAULT 'coordinator'
+              CHECK (execution_role IN ('coordinator', 'leaf')),
+            provider_boundary TEXT NOT NULL DEFAULT 'local_user:acp'${profileColumnDefinition},
+            CHECK ((external_ref_kind IS NULL) = (external_ref_id IS NULL))
+          ) STRICT;
+
+          INSERT INTO sessions_v29 (
+            session_id, owner_id, agent_definition_id, title, status, surface_kind,
+            external_ref_kind, external_ref_id, default_adapter_id, default_cwd,
+            model_profile, metadata_json, created_at_ms, updated_at_ms,
+            last_activity_at_ms, execution_role, provider_boundary${profileColumnProjection}
+          )
+          SELECT
+            session_id, owner_id, agent_definition_id, title, status, surface_kind,
+            external_ref_kind, external_ref_id, default_adapter_id, default_cwd,
+            model_profile, metadata_json, created_at_ms, updated_at_ms,
+            last_activity_at_ms, execution_role, provider_boundary${profileColumnProjection}
+          FROM sessions;
+
+          DROP TABLE sessions;
+          ALTER TABLE sessions_v29 RENAME TO sessions;
+
+          CREATE UNIQUE INDEX sessions_external_ref_uq
+            ON sessions(owner_id, external_ref_kind, external_ref_id)
+            WHERE external_ref_kind IS NOT NULL;
+          CREATE INDEX sessions_recent_idx
+            ON sessions(owner_id, last_activity_at_ms DESC);
+        `)
+      }
+
+      if (rebuildGrants) {
+        db.exec(`
+          CREATE TABLE grants_v29 (
+            grant_id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+            run_id TEXT REFERENCES runs(run_id) ON DELETE CASCADE,
+            capability TEXT NOT NULL,
+            operation TEXT NOT NULL,
+            resource_pattern TEXT NOT NULL,
+            effect TEXT NOT NULL CHECK (effect IN ('allow', 'deny')),
+            source TEXT NOT NULL CHECK (source IN ('policy', 'user', 'system')),
+            constraints_json TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(constraints_json)),
+            created_at_ms INTEGER NOT NULL,
+            expires_at_ms INTEGER,
+            revoked_at_ms INTEGER
+          ) STRICT;
+        `)
+        db.prepare(
+          `
+          INSERT INTO grants_v29 (
+            grant_id, session_id, run_id, capability, operation, resource_pattern,
+            effect, source, constraints_json, created_at_ms, expires_at_ms, revoked_at_ms
+          )
+          SELECT
+            grant_id, session_id, run_id, capability, operation, resource_pattern,
+            effect,
+            CASE source WHEN 'legacy_default' THEN 'system' ELSE source END,
+            CASE source
+              WHEN 'legacy_default' THEN json_object(
+                '_omiLegacyIdentityCleanup',
+                json_object('originalSource', 'legacy_default', 'action', 'revoked', 'version', 29),
+                'originalConstraints',
+                json(constraints_json)
+              )
+              ELSE constraints_json
+            END,
+            created_at_ms,
+            expires_at_ms,
+            CASE source
+              WHEN 'legacy_default' THEN COALESCE(revoked_at_ms, ?)
+              ELSE revoked_at_ms
+            END
+          FROM grants;
+        `
+        ).run(appliedAtMs)
+        db.exec(`
+          DROP TABLE grants;
+          ALTER TABLE grants_v29 RENAME TO grants;
+          CREATE INDEX grants_lookup_idx
+            ON grants(session_id, run_id, capability, operation, created_at_ms DESC);
+        `)
+      }
+
+      const foreignKeyViolations = db.prepare('PRAGMA foreign_key_check').all() as Row[]
+      if (foreignKeyViolations.length > 0) {
+        const summary = foreignKeyViolations
+          .slice(0, 3)
+          .map((row) => `${String(row.table)}:${String(row.rowid)}->${String(row.parent)}`)
+          .join(', ')
+        throw new Error(`Legacy identity cleanup would break foreign keys: ${summary}`)
+      }
+
+      db.prepare('INSERT INTO schema_migrations (version, applied_at_ms) VALUES (?, ?)').run(
+        LEGACY_IDENTITY_CLEANUP_MIGRATION_VERSION,
+        appliedAtMs
+      )
+    })
+  } catch (error) {
+    migrationFailure = { error }
+  }
+
+  let foreignKeyRestoreFailure: { error: unknown } | undefined
+  try {
+    db.exec('PRAGMA foreign_keys = ON')
+    if (!foreignKeysEnabled(db)) {
+      throw new Error('Legacy identity cleanup could not restore foreign-key enforcement')
+    }
+  } catch (error) {
+    foreignKeyRestoreFailure = { error }
+  }
+
+  if (migrationFailure) {
+    throw migrationFailure.error
+  }
+  if (foreignKeyRestoreFailure) {
+    throw foreignKeyRestoreFailure.error
+  }
+}
+
 // Migration/probe-level transaction helper. Distinct from the store's
 // `withTransaction` (hand-tracked depth): migrations run at construction time,
 // never nested and never inside `withTransaction`, so a best-effort open-tx check
@@ -2291,8 +2477,6 @@ function sessionValues(session: AgentSession): SqlBind[] {
     session.providerBoundary,
     session.externalRefKind,
     session.externalRefId,
-    null,
-    null,
     session.defaultAdapterId,
     session.defaultCwd,
     session.modelProfile,

--- a/desktop/windows/src/main/agentKernel/types.ts
+++ b/desktop/windows/src/main/agentKernel/types.ts
@@ -68,9 +68,8 @@ export type DelegationStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 
 /** Whether a grant allows or denies a capability. */
 export type GrantEffect = 'allow' | 'deny'
 
-/** Origin of a grant. `legacy_default` is legacy debt slated for removal. */
-// TODO(#10240 desktop-agent-platonic-gap-closure G6): delete legacy_default after ship+2 releases post-platonic.
-export type GrantSource = 'legacy_default' | 'policy' | 'user' | 'system'
+/** Origin of a grant. */
+export type GrantSource = 'policy' | 'user' | 'system'
 
 /** Speaker role of a conversation turn. */
 export type ConversationTurnRole = 'user' | 'assistant'

--- a/docs/doc/developer/agent-control-plane.mdx
+++ b/docs/doc/developer/agent-control-plane.mdx
@@ -489,7 +489,7 @@ CREATE TABLE grants (
   operation TEXT NOT NULL,
   resource_pattern TEXT NOT NULL,
   effect TEXT NOT NULL CHECK (effect IN ('allow', 'deny')),
-  source TEXT NOT NULL CHECK (source IN ('legacy_default', 'policy', 'user', 'system')),
+  source TEXT NOT NULL CHECK (source IN ('policy', 'user', 'system')),
   constraints_json TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(constraints_json)),
   created_at_ms INTEGER NOT NULL,
   expires_at_ms INTEGER,
@@ -499,6 +499,11 @@ CREATE TABLE grants (
 CREATE INDEX grants_lookup_idx
   ON grants(session_id, run_id, capability, operation, created_at_ms DESC);
 ```
+
+Portable grant writers MUST use `policy`, `user`, or `system`. Older runtimes may
+still recognize `legacy_default` while migrating existing databases, but clients
+MUST NOT send it and cleanup migrations MUST revoke those rows without presenting
+them as current policy grants.
 
 ### 8.3 Intentionally omitted Phase 1 tables
 
@@ -1180,7 +1185,7 @@ For the initial release it MAY preserve:
 However:
 
 - every automatic ACP decision MUST emit an `approval.resolved` or equivalent audit event;
-- once the store is present, each run MUST receive an explicit `legacy_default` grant record describing the broad legacy authority;
+- automatic legacy/high-trust decisions MUST NOT synthesize a durable broad grant;
 - new adapters MUST explicitly opt into this policy rather than inheriting it accidentally;
 - no code outside the policy module may make ad hoc approval decisions;
 - the product MUST label this mode as legacy/high-trust internally.

--- a/docs/doc/developer/agent-grants-approval-ux.mdx
+++ b/docs/doc/developer/agent-grants-approval-ux.mdx
@@ -17,13 +17,13 @@ The Phase 2 runtime has a durable `grants` schema and TypeScript grant types:
 - `operation`
 - `resource_pattern`
 - `effect`: `allow` or `deny`
-- `source`: `legacy_default`, `policy`, `user`, or `system`
+- `source`: `policy`, `user`, or `system`
 - `constraints_json`
 - `created_at_ms`
 - optional `expires_at_ms`
 - optional `revoked_at_ms`
 
-That schema is present, but grants are currently dormant state. There is no live insertion path for `legacy_default`, `policy`, `user`, or `system` grants in the merged Phase 2 runtime.
+That schema is present, but grants are currently dormant state. There is no live insertion path for `policy`, `user`, or `system` grants in the merged Phase 2 runtime.
 
 The intended meaning remains section 6.8: a grant is a recorded capability decision scoped to a session or run. Until implementation work explicitly activates grant writes, UI must not imply that Omi already has user-managed grant records.
 
@@ -55,7 +55,10 @@ That audit payload is logged, but it is not currently appended as a canonical ke
 
 `legacy_high_trust` names the temporary policy mode that auto-resolves ACP permission prompts. It is policy identity and UX copy must not present it as an end-user trust grant.
 
-`legacy_default` is the planned grant source for run-scoped records that describe broad legacy authority once grant writes are implemented. It is not the same thing as `legacy_high_trust`: one is stored grant provenance, the other is the current policy mode.
+`legacy_default` is a retired database provenance value, not a valid source for
+new grant writes. Older runtimes may parse it only long enough to migrate an
+existing row into revoked history. `legacy_high_trust` remains the temporary
+policy mode name and does not imply a stored grant.
 
 ## Design Goals
 
@@ -126,7 +129,7 @@ Approval requests and resolutions remain events as required by section 11.2.
 }
 ```
 
-Legacy automatic ACP approvals should use the same event name when persisted, but with `policy: "legacy_high_trust"`, `automatic: true`, `resolvedBy: "policy"`, and no `grantId` unless a matching `legacy_default` row is actually inserted in the same transaction.
+Legacy automatic ACP approvals should use the same event name when persisted, but with `policy: "legacy_high_trust"`, `automatic: true`, `resolvedBy: "policy"`, and no `grantId`.
 
 ## Grant Write Rules
 
@@ -134,7 +137,7 @@ When grant writes are pulled into implementation scope:
 
 - only the policy module may create, renew, revoke, or consume grants;
 - adapter code may describe a requested capability, but may not choose allow or deny;
-- `legacy_default` rows should be run-scoped and describe existing broad legacy authority;
+- new writes must never use `legacy_default`; any existing rows are migration-only history and must remain revoked;
 - user choices should use `source: "user"`;
 - automatic non-legacy decisions should use `source: "policy"`;
 - operating-system or managed-admin decisions should use `source: "system"`;


### PR DESCRIPTION
## What changed and why

Completes the Windows agent-kernel identity cleanup tracked in #10240 after the two-release compatibility window. Fresh databases and control-tool inputs no longer expose the legacy session aliases or `legacy_default`; migration 29 atomically rebuilds existing tables, preserves the canonical v16 session field when present, and revokes legacy grants while retaining their original provenance.

## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1

## How it was verified

- `node_modules\.bin\vitest.cmd run src/main/agentKernel` -> 547 passed, 1 existing e2e test skipped
- `npm.cmd run typecheck:node` -> passed
- ESLint and Prettier on the five changed TypeScript files -> passed
- `git diff --check` -> passed
- 9 change-specific manifest checks -> passed through the Windows-portable runner from #10574

The migration path was exercised through the repository's `node:sqlite` `DatabaseFactory` test seam. Production `better-sqlite3` is built for Electron's ABI and cannot be loaded by the plain-Node Vitest process.

The remaining local `check-manifest-contract` invocation is blocked by the
`python3`/Windows platform handling fixed in #10574; GitHub CI exercises that
contract on Linux.

## Tests

`store.test.ts` covers a v14-shaped database with the canonical v16 session field, grant provenance preservation and revocation, foreign-key/cascade integrity, idempotency, nested-transaction rejection, rollback on schema recreation failure, and fresh-schema parity. `controlTools.test.ts` verifies that `legacy_default` is rejected without resolving the dispatch or writing a grant.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

