### PR TITLE
fix(desktop): allow cold fault bundle readiness

### DIFF
--- a/.github/failure-classes/FC-gate-timeout-below-cold-cost.json
+++ b/.github/failure-classes/FC-gate-timeout-below-cold-cost.json
@@ -3,6 +3,10 @@
   "id": "FC-gate-timeout-below-cold-cost",
   "violated_contract": "A release gate's fixed time budget must exceed the worst-case cost of the healthy work it bounds (a cold, from-scratch rebuild), and a timed-out attempt must not poison the cache that would let the retry run warm.",
   "canonical_prevention": "Size the qualification cold-preparation budget to the observed cold-build duration with headroom (env-overridable), and keep the static timing-contract test asserting the current budget plus its recurrence history so the value cannot silently regress below the cold cost again.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/scripts/desktop-core-harness.sh",
+    "desktop/macos/tests/test-fault-suite-launch-env.sh"
+  ],
   "evidence_prs": [10374],
   "scope_hints": [
     "desktop/macos/scripts/qualify-desktop-beta.sh",

--- a/desktop/macos/changelog/unreleased/20260726-cold-fault-bundle-readiness.json
+++ b/desktop/macos/changelog/unreleased/20260726-cold-fault-bundle-readiness.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved reliability of macOS Beta qualification on cold build runners."
+}

--- a/desktop/macos/scripts/desktop-core-harness.sh
+++ b/desktop/macos/scripts/desktop-core-harness.sh
@@ -876,8 +876,17 @@ start_fault_stack() {
   FAULT_RUN_STARTED=1
   FAULT_APP_LAUNCH_REQUESTED=1
   local expected_bundle="com.omi.${FAULT_BUNDLE}"
+  # A cold qualification cache can spend several minutes creating the named
+  # fault bundle before the bridge exists. Do not turn that bounded build time
+  # into a false fault-suite failure; an explicit override keeps local probes
+  # fast while the qualification default covers a clean SwiftPM build.
+  local bridge_ready_attempts="${OMI_FAULT_BRIDGE_READY_ATTEMPTS:-210}"
+  [[ "$bridge_ready_attempts" =~ ^[1-9][0-9]*$ ]] || {
+    echo "desktop-core-harness: OMI_FAULT_BRIDGE_READY_ATTEMPTS must be a positive integer" >&2
+    return 1
+  }
   local attempt
-  for attempt in $(seq 1 90); do
+  for attempt in $(seq 1 "$bridge_ready_attempts"); do
     if verify_fault_bundle_health "$PORT" "$expected_bundle" 2>/dev/null; then
       OMI_AUTOMATION_PORT="$PORT" "$SCRIPT_DIR/omi-ctl" wait-ready 90
       record_owned_fault_app

--- a/desktop/macos/tests/test-fault-suite-launch-env.sh
+++ b/desktop/macos/tests/test-fault-suite-launch-env.sh
@@ -208,6 +208,21 @@ PY
   if kill -0 "$app_pid" 2>/dev/null; then
     fail "fault suite cleanup left its owned detached app running"
   fi
+
+  set +e
+  PATH="$bin_dir:$PATH" \
+    OMI_FAULT_RUN_TOKEN="$fault_run_token" \
+    OMI_FAULT_APP_PID_FILE="$fixture/fault-app.pid" \
+    OMI_FAULT_TEST_PORT="$fault_port" \
+    OMI_FAULT_ENV_CAPTURE="$capture" \
+    OMI_FAULT_READY_CAPTURE="$ready_capture" \
+    OMI_FAULT_BRIDGE_READY_ATTEMPTS=not-a-number \
+    "$fixture/scripts/desktop-core-harness.sh" --fault-suite --port "$bridge_port" >"$output" 2>&1
+  status=$?
+  set -e
+  [[ "$status" -ne 0 ]] || fail "fault suite accepted a non-numeric bridge readiness attempt budget"
+  grep -Fq 'OMI_FAULT_BRIDGE_READY_ATTEMPTS must be a positive integer' "$output" \
+    || fail "fault suite did not report the invalid bridge readiness attempt budget"
 }
 
 exercise_fault_launcher_without_backend_env() {


### PR DESCRIPTION
## Summary
- Extend the M1 qualification fault-bundle bridge readiness budget from three to seven minutes for a cold SwiftPM build.
- Validate the environment override and reject malformed readiness budgets.

## Evidence
- Failed M1 qualification run: https://github.com/BasedHardware/omi/actions/runs/30202464340
- Candidate: `v0.12.130+12130-macos` / `50b51083593563f11241d9f59de17415ab6469b0`
- The signed artifact and candidate-evidence checks passed; the fault suite timed out waiting for its named test bundle bridge while cold setup was still running.
- Verified locally: `bash -n desktop/macos/scripts/desktop-core-harness.sh desktop/macos/tests/test-fault-suite-launch-env.sh && bash desktop/macos/tests/test-fault-suite-launch-env.sh`

## Failure class
Failure-Class: FC-gate-timeout-below-cold-cost


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

