### PR TITLE
SCA-168: authenticate fault listener cleanup

### DIFF
--- a/desktop/macos/changelog/unreleased/20260726-owned-fault-listener-cleanup.json
+++ b/desktop/macos/changelog/unreleased/20260726-owned-fault-listener-cleanup.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved reliability of macOS Beta qualification cleanup."
+}

--- a/desktop/macos/docs/qualification-environment.md
+++ b/desktop/macos/docs/qualification-environment.md
@@ -45,6 +45,13 @@ unrecorded processes are never killed. `--keep-stack` intentionally leaves the
 recorded lease for later safe reclamation. Retention removes only completed,
 sentinel-proven state and paired logs, never a live/incomplete or foreign root.
 
+The automatic fault suite keeps its fault-inject state under the same
+sentinel-protected lease root. Normal harness cleanup stops that token-bearing
+process first; lease release is the fail-closed fallback for interruption paths.
+Before signaling it, release revalidates the owner-only state files, lease token,
+PID/process group, command marker, loopback URL, and exact listener PID. A
+listener that fails any check is retained and never signaled.
+
 The main qualification app receives a separate run-unique launch token. `run.sh`
 writes an owner-only launch signal, which the qualifier verifies against exactly
 one token-bearing app process before writing a `0600` launch record. Cleanup

--- a/desktop/macos/scripts/desktop-core-harness.sh
+++ b/desktop/macos/scripts/desktop-core-harness.sh
@@ -975,7 +975,10 @@ if [[ "$FAULT_SUITE" -eq 1 ]]; then
   mkdir -p "$RUN_DIR"
   chmod 700 "$RUN_DIR"
   FAULT_RUN_DIR="$RUN_DIR"
-  FAULT_STATE_DIR="$RUN_DIR/fault-inject"
+  # Qualification binds this state to its sentinel-protected lease root. Honor
+  # that handoff so authenticated lease release can reclaim the exact tokened
+  # listener if this harness is interrupted before its normal stop path.
+  FAULT_STATE_DIR="${OMI_FAULT_STATE_DIR:-$RUN_DIR/fault-inject}"
   mkdir -p "$FAULT_STATE_DIR"
   chmod 700 "$FAULT_STATE_DIR"
   FAULT_RUN_TOKEN="$(fault_token_for_run)"

--- a/desktop/macos/tests/test-fault-suite-launch-env.sh
+++ b/desktop/macos/tests/test-fault-suite-launch-env.sh
@@ -38,12 +38,14 @@ exercise_fault_suite_launch_command() {
   local fixture="$TMP_ROOT/fault-suite"
   local bin_dir="$TMP_ROOT/fault-suite-bin"
   local bridge_port fault_port fault_run_token capture ready_capture output
+  local qualification_fault_state
   bridge_port="47791"
   fault_port="19081"
   fault_run_token="faultsuitefixturetoken123456"
   capture="$fixture/fault-run.env"
   ready_capture="$fixture/fault-ready.env"
   output="$fixture/fault-suite.out"
+  qualification_fault_state="$fixture/qualification-state/fault"
 
   mkdir -p "$fixture/scripts" "$fixture/e2e/flows"
   ln -s "$CORE_HARNESS" "$fixture/scripts/desktop-core-harness.sh"
@@ -139,6 +141,7 @@ SH
 
   PATH="$bin_dir:$PATH" \
     OMI_FAULT_RUN_TOKEN="$fault_run_token" \
+    OMI_FAULT_STATE_DIR="$qualification_fault_state" \
     OMI_FAULT_APP_PID_FILE="$fixture/fault-app.pid" \
     OMI_FAULT_TEST_PORT="$fault_port" \
     OMI_FAULT_ENV_CAPTURE="$capture" \
@@ -148,6 +151,8 @@ SH
       cat "$output" >&2
       fail "fault suite fixture did not complete"
     }
+  [[ -d "$qualification_fault_state" ]] \
+    || fail "fault suite ignored the qualification-owned fault state directory"
 
   python3 - "$capture" "$ready_capture" "$bridge_port" "$fault_port" "$fault_run_token" "$fixture" <<'PY'
 import json
@@ -212,6 +217,7 @@ PY
   set +e
   PATH="$bin_dir:$PATH" \
     OMI_FAULT_RUN_TOKEN="$fault_run_token" \
+    OMI_FAULT_STATE_DIR="$qualification_fault_state" \
     OMI_FAULT_APP_PID_FILE="$fixture/fault-app.pid" \
     OMI_FAULT_TEST_PORT="$fault_port" \
     OMI_FAULT_ENV_CAPTURE="$capture" \

--- a/scripts/dev-harness/dev_harness/qualification.py
+++ b/scripts/dev-harness/dev_harness/qualification.py
@@ -9,6 +9,7 @@ import os
 import secrets
 import shutil
 import signal
+import stat
 import subprocess
 import tempfile
 import time
@@ -24,6 +25,7 @@ DEFAULT_RETAINED_RUNS = 3
 DEFAULT_RETENTION_MAX_AGE_SECONDS = 14 * 24 * 60 * 60
 COMPLETION_FILENAME = "qualification-completed.json"
 QUARANTINE_DIRNAME = "quarantined-lease-pointers"
+FAULT_STATE_DIRNAME = "fault"
 STOP_PHASES: tuple[tuple[signal.Signals, float], ...] = (
     (signal.SIGINT, 8),
     (signal.SIGTERM, 5),
@@ -181,6 +183,146 @@ def _validated_owned_records(
             )
         validated.append(record)
     return validated, process_manifest, port_manifest
+
+
+def _read_fault_metadata(path: Path) -> dict[str, str]:
+    try:
+        file_stat = path.stat()
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise QualificationLeaseError(f"Cannot validate qualification fault-inject state: {exc}") from exc
+    if path.is_symlink() or not path.is_file() or file_stat.st_uid != os.getuid():
+        raise QualificationLeaseError("Qualification fault-inject state is not an owner-controlled regular file")
+    if stat.S_IMODE(file_stat.st_mode) & 0o077:
+        raise QualificationLeaseError("Qualification fault-inject state is not owner-only")
+    fields: dict[str, str] = {}
+    for line in lines:
+        if "=" not in line:
+            raise QualificationLeaseError("Qualification fault-inject state is malformed")
+        key, value = line.split("=", 1)
+        if not key or key in fields:
+            raise QualificationLeaseError("Qualification fault-inject state is malformed")
+        fields[key] = value
+    return fields
+
+
+def _validated_fault_record(state_root: Path, ownership_token: str) -> dict[str, object] | None:
+    """Authenticate the optional fault listener rooted inside this exact lease."""
+
+    fault_state = state_root / FAULT_STATE_DIRNAME
+    if not fault_state.exists():
+        return None
+    if (
+        fault_state.is_symlink()
+        or not fault_state.is_dir()
+        or _real(fault_state) != _real(state_root) / FAULT_STATE_DIRNAME
+    ):
+        raise QualificationLeaseError("Qualification fault-inject state escaped its recorded lease root")
+    try:
+        directory_stat = fault_state.stat()
+    except OSError as exc:
+        raise QualificationLeaseError(f"Cannot validate qualification fault-inject state: {exc}") from exc
+    if directory_stat.st_uid != os.getuid() or stat.S_IMODE(directory_stat.st_mode) & 0o077:
+        raise QualificationLeaseError("Qualification fault-inject state directory is not owner-only")
+
+    pid_path, meta_path = fault_state / "pid", fault_state / "meta"
+    if not pid_path.exists() and not meta_path.exists():
+        return None
+    if not pid_path.is_file() or not meta_path.is_file():
+        raise QualificationLeaseError("Qualification fault-inject state is incomplete")
+    fields = _read_fault_metadata(meta_path)
+    try:
+        pid_stat = pid_path.stat()
+        pid_text = pid_path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise QualificationLeaseError(f"Cannot validate qualification fault-inject PID: {exc}") from exc
+    if pid_path.is_symlink() or pid_stat.st_uid != os.getuid() or stat.S_IMODE(pid_stat.st_mode) & 0o077:
+        raise QualificationLeaseError("Qualification fault-inject PID is not owner-only")
+    try:
+        pid = int(pid_text)
+        recorded_pid = int(fields.get("pid", "-1"))
+        process_group = int(fields.get("pgid", "-1"))
+        port = int(fields.get("port", "-1"))
+    except ValueError as exc:
+        raise QualificationLeaseError("Qualification fault-inject state has invalid numeric provenance") from exc
+    if pid <= 0 or recorded_pid != pid or process_group != pid:
+        raise QualificationLeaseError("Qualification fault-inject process lineage is invalid")
+    if not 1 <= port <= 65535:
+        raise QualificationLeaseError("Qualification fault-inject port is invalid")
+    if fields.get("token") != ownership_token:
+        raise QualificationLeaseError("Qualification fault-inject token does not match the active lease")
+    if fields.get("url") != f"http://127.0.0.1:{port}":
+        raise QualificationLeaseError("Qualification fault-inject endpoint is not the recorded loopback port")
+
+    record: dict[str, object] = {
+        "service": "fault-inject",
+        "pid": pid,
+        "process_group": process_group,
+        "port": port,
+        "ownership_marker": f"omi-fault-inject:{ownership_token}",
+    }
+    _validate_fault_process(record)
+    return record
+
+
+def _validate_fault_process(record: dict[str, object]) -> tuple[bool, tuple[int, ...]]:
+    """Re-prove the exact token-bound fault process and its current listener."""
+
+    pid = int(record["pid"])
+    process_group = int(record["process_group"])
+    port = int(record["port"])
+    marker = str(record["ownership_marker"])
+    listeners = safety.listening_pids(port)
+    alive = safety.process_exists(pid)
+    if listeners and listeners != (pid,):
+        raise QualificationLeaseError(
+            "Refusing to signal a qualification fault-inject listener whose lease lineage is unproven"
+        )
+    if alive:
+        if marker not in safety.command_line_for_pid(pid) or os.getpgid(pid) != process_group or process_group != pid:
+            raise QualificationLeaseError(
+                "Refusing to signal a qualification fault-inject process whose lease lineage is unproven"
+            )
+    elif listeners:
+        raise QualificationLeaseError(
+            "Refusing to signal a qualification fault-inject listener whose lease lineage is unproven"
+        )
+    return alive, listeners
+
+
+def _stop_owned_fault_record(record: dict[str, object] | None) -> None:
+    if record is None:
+        return
+    process_group = int(record["process_group"])
+    service, port = str(record["service"]), int(record["port"])
+    for sig, wait_seconds in STOP_PHASES:
+        alive, listeners = _validate_fault_process(record)
+        if not alive and not listeners:
+            return
+        if alive:
+            try:
+                os.killpg(process_group, sig)
+            except (ProcessLookupError, PermissionError) as exc:
+                raise QualificationLeaseError(
+                    f"Cannot signal recorded qualification fault-inject group: {exc}"
+                ) from exc
+        deadline = time.monotonic() + wait_seconds
+        while time.monotonic() < deadline:
+            alive, listeners = _validate_fault_process(record)
+            if not alive and not listeners:
+                return
+            time.sleep(0.2)
+    alive, listeners = _validate_fault_process(record)
+    if listeners:
+        raise QualificationLeaseError(
+            f"Qualification fault-inject port still open after cleanup; retaining incomplete lease state: "
+            f"{service}:{port} (listeners {','.join(map(str, listeners))})"
+        )
+    if alive:
+        raise QualificationLeaseError(
+            f"Qualification fault-inject process still running after cleanup; retaining incomplete lease state: "
+            f"{service} pid={record['pid']}"
+        )
 
 
 def _is_exact_typesense_docker_proxy(record: dict[str, object], lease_id: str | None) -> bool:
@@ -387,9 +529,11 @@ def acquire(
                 )
             try:
                 records, process_manifest, port_manifest = _validated_owned_records(old_state, old_repo, old_id, old_token)
+                fault_record = _validated_fault_record(old_state, old_token)
             except safety.SafetyError:
                 _quarantine_stale_lease_pointer(path, root, existing)
             else:
+                _stop_owned_fault_record(fault_record)
                 _stop_owned_records(records, process_manifest, port_manifest, old_id)
                 _safe_remove_state(old_state, old_repo, old_id)
                 old_logs = root / "logs" / old_id
@@ -448,6 +592,8 @@ def release(
         records, process_manifest, port_manifest = _validated_owned_records(
             state_root, recorded_repo, recorded_id, recorded_token
         )
+        fault_record = _validated_fault_record(state_root, recorded_token)
+        _stop_owned_fault_record(fault_record)
         _stop_owned_records(records, process_manifest, port_manifest, recorded_id)
         path.unlink(missing_ok=True)
         _mark_completed(state_root, recorded_repo, recorded_id, recorded_token)

--- a/scripts/dev-harness/tests/test_qualification_lease.py
+++ b/scripts/dev-harness/tests/test_qualification_lease.py
@@ -17,6 +17,7 @@ from dev_harness import qualification, safety
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+FAULT_INJECTOR = REPO_ROOT / "desktop" / "macos" / "scripts" / "omi-fault-inject.sh"
 
 
 def _stale_lease(root: Path, lease_id: str, pid: int, port: int) -> None:
@@ -35,6 +36,31 @@ def _stale_lease(root: Path, lease_id: str, pid: int, port: int) -> None:
     lease_path.write_text(json.dumps(lease), encoding="utf-8")
 
 
+def _free_port() -> int:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    port = int(listener.getsockname()[1])
+    listener.close()
+    return port
+
+
+def _start_fault_injector(state: Path, token: str, port: int) -> int:
+    env = {
+        **os.environ,
+        "OMI_FAULT_STATE_DIR": str(state),
+        "OMI_FAULT_OWNERSHIP_TOKEN": token,
+    }
+    subprocess.run(
+        ["bash", str(FAULT_INJECTOR), "start", "error", "--port", str(port)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    return int((state / "pid").read_text(encoding="utf-8"))
+
+
 def test_active_lease_serializes_qualification_runs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     root = tmp_path / "qualification"
     monkeypatch.setenv("OMI_QUALIFICATION_LEASE_ROOT", str(root))
@@ -44,6 +70,71 @@ def test_active_lease_serializes_qualification_runs(monkeypatch: pytest.MonkeyPa
         qualification.acquire(repo_root=REPO_ROOT, lease_id="qualification-two", owner_pid=os.getpid(), port_offset=1001)
 
     qualification.release(repo_root=REPO_ROOT, lease_id="qualification-one", token=str(first["token"]))
+
+
+def test_release_stops_the_exact_lease_owned_fault_inject_listener(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "qualification"
+    lease_id = "qualification-owned-fault"
+    monkeypatch.setenv("OMI_QUALIFICATION_LEASE_ROOT", str(root))
+    monkeypatch.setattr(qualification, "STOP_PHASES", ((signal.SIGTERM, 2), (signal.SIGKILL, 1)))
+    acquired = qualification.acquire(repo_root=REPO_ROOT, lease_id=lease_id, owner_pid=os.getpid(), port_offset=1000)
+    state = root / "state" / lease_id / qualification.FAULT_STATE_DIRNAME
+    state.mkdir(mode=0o700)
+    port = _free_port()
+    pid = _start_fault_injector(state, str(acquired["token"]), port)
+
+    qualification.release(repo_root=REPO_ROOT, lease_id=lease_id, token=str(acquired["token"]))
+
+    assert not safety.listening_pids(port)
+    deadline = time.monotonic() + 2
+    while safety.process_exists(pid) and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert not safety.process_exists(pid)
+    assert not (root / "qualification-lease.json").exists()
+    assert (root / "state" / lease_id / qualification.COMPLETION_FILENAME).is_file()
+
+
+def test_release_refuses_and_retains_an_unproven_listener_on_the_recorded_fault_port(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "qualification"
+    lease_id = "qualification-foreign-fault"
+    monkeypatch.setenv("OMI_QUALIFICATION_LEASE_ROOT", str(root))
+    acquired = qualification.acquire(repo_root=REPO_ROOT, lease_id=lease_id, owner_pid=os.getpid(), port_offset=1000)
+    state = root / "state" / lease_id / qualification.FAULT_STATE_DIRNAME
+    state.mkdir(mode=0o700)
+    port = _free_port()
+    owned_pid = _start_fault_injector(state, str(acquired["token"]), port)
+    os.killpg(owned_pid, signal.SIGTERM)
+    deadline = time.monotonic() + 5
+    while safety.process_exists(owned_pid) and time.monotonic() < deadline:
+        time.sleep(0.05)
+    foreign = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import socket,time; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); "
+            "s.bind(('127.0.0.1',int(__import__('sys').argv[1]))); s.listen(); time.sleep(60)",
+            str(port),
+        ],
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while foreign.pid not in safety.listening_pids(port) and time.monotonic() < deadline:
+            time.sleep(0.05)
+        with pytest.raises(qualification.QualificationLeaseError, match="lease lineage is unproven"):
+            qualification.release(repo_root=REPO_ROOT, lease_id=lease_id, token=str(acquired["token"]))
+        assert foreign.poll() is None
+        assert (root / "qualification-lease.json").is_file()
+        assert (state / "meta").is_file()
+        assert not (root / "state" / lease_id / qualification.COMPLETION_FILENAME).exists()
+    finally:
+        if foreign.poll() is None:
+            foreign.terminate()
+            foreign.wait(timeout=10)
 
 
 def test_stale_owned_stack_is_reclaimed_without_touching_foreign_listener(


### PR DESCRIPTION
## Summary

- preserve the qualification-provided fault state directory under the sentinel-protected lease root
- authenticate a retained fault listener by exact state path, owner-only files, lease token, PID/process group, command marker, loopback URL, port, and listener PID before bounded cleanup
- keep fail-closed behavior: an unproven replacement listener is not signaled and the incomplete lease is retained

This is a qualification-specific guard rather than a shared process primitive because it joins the existing `omi-fault-inject` state record to the qualification lease capability. It would have caught and safely finalized the owned listener in M1 qualification run 30202464340, whose cleanup failure became diagnosable through #10644.

## Verification

- `bash scripts/dev-harness/run-tests.sh` — 61 passed
- `bash desktop/macos/tests/test-qualification-lease-command.sh` — passed
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh` — passed
- `bash desktop/macos/tests/test-fault-suite-launch-env.sh` — passed
- `bash desktop/macos/tests/test-fault-suite-owned-app-cleanup.sh` — passed
- `python3 .github/scripts/test_desktop_release_flow_contract.py` — 8 passed

Failure-Class: none

Closes SCA-168


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

