### PR TITLE
fix(windows/rewind): let users raise screen-capture quality for readable OCR

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-07-rewind-capture-quality.json
+++ b/desktop/windows/changelog/unreleased/2026-07-rewind-capture-quality.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Rewind can now capture at 1080p or 1440p — Settings → Rewind → Capture quality — so small on-screen text stays readable for search and OCR."
+  ]
+}

--- a/desktop/windows/src/main/rewind/captureService.ts
+++ b/desktop/windows/src/main/rewind/captureService.ts
@@ -36,7 +36,8 @@ let settings: RewindSettings = {
   captureEnabled: true,
   intervalMs: 1000,
   retentionDays: 14,
-  excludedApps: []
+  excludedApps: [],
+  captureQuality: 'standard'
 }
 
 function bindPowerListeners(): void {

--- a/desktop/windows/src/main/rewind/rewindSettings.quality.test.ts
+++ b/desktop/windows/src/main/rewind/rewindSettings.quality.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// Real read/write against a throwaway userData dir — the persisted round trip is
+// the behavior that matters (#10489: an existing install has no captureQuality
+// in its settings file and must still land on a valid tier).
+const dir = mkdtempSync(join(tmpdir(), 'rewind-settings-'))
+vi.mock('electron', () => ({ app: { getPath: () => dir } }))
+
+import { getPersistedRewindSettings, persistRewindSettings } from './rewindSettings'
+
+const base = { captureEnabled: true, intervalMs: 1000, retentionDays: 14, excludedApps: [] }
+
+describe('rewind capture quality', () => {
+  it('defaults to standard when nothing is persisted', () => {
+    expect(getPersistedRewindSettings().captureQuality).toBe('standard')
+  })
+
+  it('persists a chosen tier', () => {
+    persistRewindSettings({ ...base, captureQuality: 'max' })
+    expect(getPersistedRewindSettings().captureQuality).toBe('max')
+  })
+
+  it('falls back to standard for a settings file written before the tier existed', () => {
+    persistRewindSettings({ ...base, captureQuality: undefined } as never)
+    expect(getPersistedRewindSettings().captureQuality).toBe('standard')
+  })
+
+  it('falls back to standard for an unknown tier', () => {
+    persistRewindSettings({ ...base, captureQuality: 'ultra' } as never)
+    expect(getPersistedRewindSettings().captureQuality).toBe('standard')
+  })
+})

--- a/desktop/windows/src/main/rewind/rewindSettings.ts
+++ b/desktop/windows/src/main/rewind/rewindSettings.ts
@@ -1,7 +1,7 @@
 import { app } from 'electron'
 import { join } from 'path'
 import { readFileSync, writeFileSync } from 'fs'
-import type { RewindSettings } from '../../shared/types'
+import type { RewindCaptureQuality, RewindSettings } from '../../shared/types'
 
 // Rewind capture is ON by default — screen history is a core feature, so a fresh
 // install (no settings file yet) starts capturing. Once the user changes a
@@ -12,8 +12,13 @@ const DEFAULTS: RewindSettings = {
   captureEnabled: true,
   intervalMs: 1000,
   retentionDays: 14,
-  excludedApps: []
+  excludedApps: [],
+  // 720p — the resolution the capture path was tuned at. Sharper tiers cost CPU
+  // and disk continuously, so they are opt-in.
+  captureQuality: 'standard'
 }
+
+const QUALITIES: RewindCaptureQuality[] = ['standard', 'high', 'max']
 
 function file(): string {
   return join(app.getPath('userData'), 'rewind-settings.json')
@@ -51,7 +56,12 @@ function sanitize(raw: Partial<RewindSettings>): RewindSettings {
     captureEnabled: raw.captureEnabled !== false,
     intervalMs,
     retentionDays,
-    excludedApps
+    excludedApps,
+    // An unknown tier (older settings file, hand-edited value) falls back to the
+    // default rather than reaching the capture host as an undefined constraint.
+    captureQuality: QUALITIES.includes(raw.captureQuality as RewindCaptureQuality)
+      ? (raw.captureQuality as RewindCaptureQuality)
+      : DEFAULTS.captureQuality
   }
 }
 

--- a/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.test.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.test.tsx
@@ -152,7 +152,122 @@ describe('RewindCaptureHost — dead capture track', () => {
     await tick(INTERVAL_MS)
     expect(saveFrame).toHaveBeenCalledTimes(1)
   })
+})
 
+// #10489: every frame was captured at 720p and encoded at 0.6 no matter the
+// display, so OCR could not read normal on-screen text — and nothing in the app
+// could raise it. Quality is now a setting, and each tier has to reach the
+// stream, the sampled canvas AND the encode to be worth anything.
+describe('RewindCaptureHost — capture quality', () => {
+  /** Sample a 1440p display, so a tier that downscales is visible in the canvas. */
+  function displayIs1440p(): void {
+    Object.defineProperty(HTMLVideoElement.prototype, 'videoWidth', {
+      configurable: true,
+      get: () => 2560
+    })
+    Object.defineProperty(HTMLVideoElement.prototype, 'videoHeight', {
+      configurable: true,
+      get: () => 1440
+    })
+  }
+
+  function setQuality(captureQuality: string): void {
+    ;(
+      window as unknown as { omi: { rewindGetSettings: () => Promise<unknown> } }
+    ).omi.rewindGetSettings = async () => ({
+      captureEnabled: true,
+      intervalMs: INTERVAL_MS,
+      captureQuality
+    })
+  }
+
+  /** The stream constraints of the nth getUserMedia call. */
+  function constraints(call: number): { maxWidth: number; maxHeight: number } {
+    return (
+      getUserMedia.mock.calls[call][0] as {
+        video: { mandatory: { maxWidth: number; maxHeight: number } }
+      }
+    ).video.mandatory
+  }
+
+  /** Canvas size + JPEG quality of each encode. */
+  let encodes: { width: number; height: number; quality: number }[]
+  beforeEach(() => {
+    encodes = []
+    vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(function (
+      this: HTMLCanvasElement,
+      cb,
+      _type,
+      quality
+    ) {
+      encodes.push({ width: this.width, height: this.height, quality: quality as number })
+      cb({ arrayBuffer: async () => new ArrayBuffer(8) } as Blob)
+    })
+  })
+
+  it('defaults to the proven 720p tier when no quality is persisted', async () => {
+    displayIs1440p()
+    render(<RewindCaptureHost />)
+    await settle()
+    await tick(INTERVAL_MS)
+
+    expect(constraints(0)).toMatchObject({ maxWidth: 1280, maxHeight: 720 })
+    expect(encodes[0]).toEqual({ width: 1600, height: 900, quality: 0.6 })
+  })
+
+  it('captures a 1440p display at full size and a higher JPEG quality on "max"', async () => {
+    displayIs1440p()
+    setQuality('max')
+    render(<RewindCaptureHost />)
+    await settle()
+    await tick(INTERVAL_MS)
+
+    expect(constraints(0)).toMatchObject({ maxWidth: 2560, maxHeight: 1440 })
+    // Not downscaled by the sampler either — the whole point is readable text.
+    expect(encodes[0]).toEqual({ width: 2560, height: 1440, quality: 0.82 })
+  })
+
+  it('raises the stream to 1080p on "high"', async () => {
+    setQuality('high')
+    render(<RewindCaptureHost />)
+    await settle()
+
+    expect(constraints(0)).toMatchObject({ maxWidth: 1920, maxHeight: 1080 })
+  })
+
+  it('re-opens the stream when the quality setting changes', async () => {
+    // Resolution is a stream constraint, so a live change has to tear the stream
+    // down — otherwise the new tier would only apply at the next launch.
+    let push: (s: unknown) => void = () => undefined
+    ;(
+      window as unknown as { omi: { onRewindSettings: (cb: (s: unknown) => void) => () => void } }
+    ).omi.onRewindSettings = (cb) => {
+      push = cb
+      return () => undefined
+    }
+    render(<RewindCaptureHost />)
+    await settle()
+    expect(getUserMedia).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      push({ captureEnabled: true, intervalMs: INTERVAL_MS, captureQuality: 'high' })
+    })
+    await settle()
+
+    expect(getUserMedia).toHaveBeenCalledTimes(2)
+    expect(constraints(1)).toMatchObject({ maxWidth: 1920, maxHeight: 1080 })
+  })
+
+  it('falls back to the default tier for an unknown persisted value', async () => {
+    setQuality('ultra')
+    render(<RewindCaptureHost />)
+    await settle()
+
+    expect(constraints(0)).toMatchObject({ maxWidth: 1280, maxHeight: 720 })
+  })
+})
+
+describe('RewindCaptureHost — unmount', () => {
   it('does not reopen the stream after unmount', async () => {
     const view = render(<RewindCaptureHost />)
     await settle()

--- a/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
@@ -1,10 +1,25 @@
 import { useEffect, useRef, useState } from 'react'
-import type { RewindSettings, RewindCaptureDirective } from '../../../../shared/types'
+import type {
+  RewindSettings,
+  RewindCaptureDirective,
+  RewindCaptureQuality
+} from '../../../../shared/types'
 
-// Cap the longest sampled edge — plenty for a timeline + OCR, and keeps each
-// canvas grab + JPEG encode cheap.
-const MAX_EDGE = 1600
-const JPEG_QUALITY = 0.6
+// What each quality tier costs and buys. `maxWidth`/`maxHeight` cap the live
+// stream (the steady-state cost of having capture on); `maxEdge` caps the
+// sampled canvas and `jpegQuality` the encode — both raised with the tier, since
+// a sharper stream re-compressed at 0.6 into a 1600px canvas would be spent for
+// nothing. 720p at 0.6 is unreadable for small on-screen text, which is why OCR
+// misses it (#10489); the sharper tiers are the fix, opt-in because they decode
+// and store more all day long.
+const QUALITY_TIERS: Record<
+  RewindCaptureQuality,
+  { maxWidth: number; maxHeight: number; maxEdge: number; jpegQuality: number }
+> = {
+  standard: { maxWidth: 1280, maxHeight: 720, maxEdge: 1600, jpegQuality: 0.6 },
+  high: { maxWidth: 1920, maxHeight: 1080, maxEdge: 1920, jpegQuality: 0.72 },
+  max: { maxWidth: 2560, maxHeight: 1440, maxEdge: 2560, jpegQuality: 0.82 }
+}
 // Wait before re-opening a stream whose track died, so a source that is
 // unavailable in bursts (display asleep, GPU reset) can't spin getUserMedia.
 const RESTART_DELAY_MS = 2000
@@ -56,10 +71,12 @@ export function RewindCaptureHost(): React.JSX.Element {
   // stream down (sleep/lock). Fall back to the base interval before first directive.
   const effectiveIntervalMs = directive?.intervalMs ?? settings?.intervalMs ?? 1000
   const paused = directive?.paused ?? false
+  const quality = settings?.captureQuality ?? 'standard'
 
   useEffect(() => {
     const enabled = !!settings?.captureEnabled && !paused
     const intervalMs = effectiveIntervalMs
+    const tier = QUALITY_TIERS[quality] ?? QUALITY_TIERS.standard
     let cancelled = false
     // Bumped on every teardown so a grab still in flight (a save is an IPC
     // round-trip) can't reschedule itself onto a stream that is already gone —
@@ -99,18 +116,17 @@ export function RewindCaptureHost(): React.JSX.Element {
       try {
         const v = videoRef.current
         if (v && isLive() && v.videoWidth && v.videoHeight && !savingRef.current) {
-          const scale = Math.min(1, MAX_EDGE / Math.max(v.videoWidth, v.videoHeight))
+          const scale = Math.min(1, tier.maxEdge / Math.max(v.videoWidth, v.videoHeight))
           const w = Math.round(v.videoWidth * scale)
           const h = Math.round(v.videoHeight * scale)
-          const canvas =
-            canvasRef.current ?? (canvasRef.current = document.createElement('canvas'))
+          const canvas = canvasRef.current ?? (canvasRef.current = document.createElement('canvas'))
           if (canvas.width !== w) canvas.width = w
           if (canvas.height !== h) canvas.height = h
           const ctx = canvas.getContext('2d')
           if (ctx) {
             ctx.drawImage(v, 0, 0, w, h)
             const blob = await new Promise<Blob | null>((r) =>
-              canvas.toBlob(r, 'image/jpeg', JPEG_QUALITY)
+              canvas.toBlob(r, 'image/jpeg', tier.jpegQuality)
             )
             if (blob && !cancelled && gen === generation) {
               savingRef.current = true
@@ -147,11 +163,12 @@ export function RewindCaptureHost(): React.JSX.Element {
               chromeMediaSourceId: sourceId,
               // The live stream is decoded continuously in the renderer, so its
               // resolution + frame rate set the steady-state cost of having
-              // capture on. Keep both low: 720p is enough for a timeline + OCR of
-              // normal-size text, and we only sample every few seconds, so 1fps
-              // capture is plenty. (Was 1080p@30fps → froze; 1080p@2fps → laggy.)
-              maxWidth: 1280,
-              maxHeight: 720,
+              // capture on. Resolution follows the user's quality tier (720p by
+              // default); the frame rate stays at 1fps regardless — we sample
+              // every few seconds, and frame rate is what made this expensive
+              // before (1080p@30fps → froze; 1080p@2fps → laggy).
+              maxWidth: tier.maxWidth,
+              maxHeight: tier.maxHeight,
               maxFrameRate: 1
             }
           }
@@ -181,7 +198,9 @@ export function RewindCaptureHost(): React.JSX.Element {
       cancelled = true
       stop()
     }
-  }, [settings?.captureEnabled, effectiveIntervalMs, paused])
+    // `quality` is a stream constraint, so changing it re-opens the stream —
+    // otherwise the new tier would only take effect at the next app launch.
+  }, [settings?.captureEnabled, effectiveIntervalMs, paused, quality])
 
   return (
     <video

--- a/desktop/windows/src/renderer/src/components/settings/tabs/RewindTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/RewindTab.tsx
@@ -9,14 +9,20 @@ import {
   X,
   Mic,
   Trash2,
-  Target
+  Target,
+  ScanText
 } from 'lucide-react'
 import { runScreenSynthesisOnce } from '../../../lib/screenSynthesis'
 import { BUILT_IN_EXCLUDED_APPS } from '../../../../../shared/rewindExclusions'
 import { SettingRow } from '../SettingRow'
 import { Toggle } from '../Toggle'
 import { getPreferences, setPreferences } from '../../../lib/preferences'
-import type { RewindSettings, ScreenSynthState, InsightSettings } from '../../../../../shared/types'
+import type {
+  RewindSettings,
+  RewindCaptureQuality,
+  ScreenSynthState,
+  InsightSettings
+} from '../../../../../shared/types'
 
 // Preset cadences offered for proactive insights (minutes). Each run is a Gemini
 // call via Omi's proxy, so longer intervals mean less backend cost.
@@ -166,6 +172,33 @@ export function RewindTab(): React.JSX.Element {
             </option>
             <option value={10000} className="bg-neutral-900">
               Every 10s
+            </option>
+          </select>
+        }
+      />
+      <SettingRow
+        icon={ScanText}
+        title="Capture quality"
+        subtitle="Higher quality makes small on-screen text readable (better search and OCR), and uses more CPU and disk."
+        keywords="rewind resolution quality ocr sharpness readable text"
+        control={
+          <select
+            value={rewind?.captureQuality ?? 'standard'}
+            onChange={(e) =>
+              rewind &&
+              saveRewind({ ...rewind, captureQuality: e.target.value as RewindCaptureQuality })
+            }
+            disabled={!rewind}
+            className="rounded-md bg-white/10 px-2 py-1.5 text-sm text-white focus:outline-none disabled:opacity-40"
+          >
+            <option value="standard" className="bg-neutral-900">
+              Standard (720p)
+            </option>
+            <option value="high" className="bg-neutral-900">
+              High (1080p)
+            </option>
+            <option value="max" className="bg-neutral-900">
+              Maximum (1440p)
             </option>
           </select>
         }

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -2046,6 +2046,11 @@ export type RewindSearchGroup = {
  *  treat 'unknown' as not-granted — never as a grant. */
 export type MicPermissionState = 'granted' | 'denied' | 'unknown'
 
+/** Resolution/JPEG tier the capture host samples at. The live stream is decoded
+ *  continuously while capture is on, so this is the one setting that trades CPU
+ *  and disk for OCR-readable small text. 'standard' is the proven 720p default. */
+export type RewindCaptureQuality = 'standard' | 'high' | 'max'
+
 export type RewindSettings = {
   captureEnabled: boolean
   intervalMs: number
@@ -2053,6 +2058,7 @@ export type RewindSettings = {
   /** App names to never screenshot (case-insensitive substring match against the
    *  foreground app/process name). Empty = capture everything. */
   excludedApps: string[]
+  captureQuality: RewindCaptureQuality
 }
 
 /** Runtime capture directive pushed main→renderer, derived from OS power/lock state.


### PR DESCRIPTION
## What

Adds a **Capture quality** setting to Rewind on Windows (Settings → Rewind) with three tiers — Standard (720p, today's default), High (1080p), Maximum (1440p) — and makes the tier drive the whole capture path.

## Why

From #10489:

> The screenshots captured by Omi Desktop are too low resolution for OCR to read properly. […] At the same time, there is no usable setting or control to make screenshots better quality.

That is exactly what the code did. `RewindCaptureHost` opened its `getUserMedia` desktop stream with `maxWidth: 1280, maxHeight: 720` hard-coded, on every display, and encoded each frame at JPEG `0.6`. On a 1440p or 4K screen that is a >2× downscale *before* OCR runs, so normal on-screen text comes back unreadable and screen search misses it. Nothing in the app could change it. `MAX_EDGE = 1600` in the sampler was dead code — the stream could never exceed 1280 wide.

## How

- `RewindSettings.captureQuality` (`'standard' | 'high' | 'max'`), persisted and sanitized in `rewindSettings.ts`; an old settings file with no tier, or an unknown value, falls back to `standard`.
- One tier table in `RewindCaptureHost` drives all three stages that decide how readable a frame is: the stream constraints, the sampled-canvas cap, and the JPEG quality. Frame rate stays at 1fps for every tier — that was what made capture expensive before, not resolution.
- Changing the tier re-opens the stream, so it applies immediately instead of at the next launch.
- The **default is unchanged**: stream resolution is the steady-state cost of having capture on, so the sharper tiers are opt-in.

## Tested

- `npx vitest run src/renderer/src/components/rewind src/main/rewind` — RewindCaptureHost 8/8, new `rewindSettings.quality` 4/4, rest of the rewind suite green. Reverting `RewindCaptureHost.tsx` fails 3 of the new tests (tier never reaches the constraints, the canvas, or the re-open).
- `npm run typecheck` (node + web) and `eslint` on the touched files: clean.
- **Real built app** (`electron-vite build` + Playwright `_electron`, fake-auth profile): Settings → Rewind renders the Capture quality row defaulting to Standard; selecting High then Maximum *through the UI* wrote `captureQuality: "high"` then `"max"` into `rewind-settings.json` through the real IPC:

  ```
  [verify] capture-quality options: ["standard:Standard (720p)","high:High (1080p)","max:Maximum (1440p)"] value: standard
  [verify] rewind-settings.json after "high": {…,"captureQuality":"high"}
  [verify] rewind-settings.json after "max":  {…,"captureQuality":"max"}
  ```

- **Not verified:** a real higher-resolution frame written to disk. The verification ran on macOS, where the dev Electron binary has no screen-recording grant (`desktopCapturer` → "Failed to get sources"), so the capture host never opens a stream; there was no Windows machine in this session. The tier → stream/canvas/JPEG mapping is covered by the unit tests above.

Failure-Class: none

fixes #10489

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

